### PR TITLE
fix(consumer): isolate shared-pool scale-down

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -138,7 +138,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyList<ClientMetricsResourceListing>>(async () =>
         {
-            var connection = await GetAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
             var request = new ListClientMetricsResourcesRequest();
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
@@ -202,7 +203,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var isRetryAttempt = createMayHaveApplied;
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new CreateTopicsRequest
             {
@@ -335,7 +337,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var isRetryAttempt = deleteMayHaveApplied;
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.DeleteTopics,
@@ -518,7 +521,9 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+            var connection = connectionLease.Connection;
             var request = new DescribeTopicPartitionsRequest
             {
                 Topics = topicList.Select(static name => new DescribeTopicPartitionsRequestTopic
@@ -695,7 +700,8 @@ public sealed class AdminClient : IAdminClient
 
         foreach (var (coordinatorId, groups) in groupsByCoordinator)
         {
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new ConsumerGroupDescribeRequest
             {
@@ -780,7 +786,8 @@ public sealed class AdminClient : IAdminClient
 
         foreach (var (coordinatorId, groups) in groupsByCoordinator)
         {
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new DescribeGroupsRequest
             {
@@ -859,7 +866,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var broker in brokers)
             {
-                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -943,7 +951,8 @@ public sealed class AdminClient : IAdminClient
 
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
                 var response = await connection.SendAsync<ListTransactionsRequest, ListTransactionsResponse>(
                     request,
                     apiVersion,
@@ -1035,7 +1044,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var (coordinatorId, ids) in idsByCoordinator)
             {
-                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
                 var request = new DescribeTransactionsRequest
                 {
                     TransactionalIds = ids
@@ -1136,7 +1146,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var (leaderId, topics) in partitionsByLeader)
             {
-                var connection = await _connectionPool.GetConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
                 var request = new DescribeProducersRequest
                 {
                     Topics = topics
@@ -1230,7 +1241,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var (coordinatorId, ids) in idsByCoordinator)
             {
-                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 foreach (var transactionalId in ids)
                 {
@@ -1328,7 +1340,9 @@ public sealed class AdminClient : IAdminClient
                 ]
             };
 
-            var connection = await _connectionPool.GetConnectionAsync(leaderNode.NodeId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderNode.NodeId, cancellationToken).ConfigureAwait(false);
+
+            var connection = connectionLease.Connection;
             var response = await connection.SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
                 request,
                 apiVersion,
@@ -1384,7 +1398,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var (coordinatorId, groups) in groupsByCoordinator)
             {
-                var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var request = new DeleteGroupsRequest
                 {
@@ -1431,7 +1446,8 @@ public sealed class AdminClient : IAdminClient
         {
             // Find group coordinator
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new OffsetFetchRequest
             {
@@ -1505,7 +1521,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new OffsetCommitRequest
             {
@@ -1580,7 +1597,8 @@ public sealed class AdminClient : IAdminClient
 
             foreach (var (leaderId, leaderOffsets) in partitionsByLeader)
             {
-                var connection = await _connectionPool.GetConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 // Build topics array from offsets grouped by topic
                 var topics = leaderOffsets
@@ -1642,7 +1660,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var isRetryAttempt = createPartitionsMayHaveApplied;
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new CreatePartitionsRequest
             {
@@ -1713,7 +1732,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var isRetryAttempt = alterMayHaveApplied;
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new AlterPartitionReassignmentsRequest
             {
@@ -1782,7 +1802,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<TopicPartition, PartitionReassignment>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new ListPartitionReassignmentsRequest
             {
@@ -1893,7 +1914,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<string, IReadOnlyList<ScramCredentialInfo>>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new DescribeUserScramCredentialsRequest
             {
@@ -1987,7 +2009,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new AlterUserScramCredentialsRequest
             {
@@ -2029,7 +2052,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<ClientQuotaEntity, IReadOnlyDictionary<string, double>>>(async () =>
         {
-            var connection = await GetAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new DescribeClientQuotasRequest
             {
@@ -2084,7 +2108,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var connection = await GetAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new AlterClientQuotasRequest
             {
@@ -2198,7 +2223,7 @@ public sealed class AdminClient : IAdminClient
             }).ToList()
         };
 
-    private async ValueTask<IKafkaConnection> GetAnyBrokerConnectionAsync(CancellationToken cancellationToken)
+    private async ValueTask<KafkaConnectionLease> LeaseAnyBrokerConnectionAsync(CancellationToken cancellationToken)
     {
         var brokers = _metadataManager.Metadata.GetBrokers();
         if (brokers.Count == 0)
@@ -2206,7 +2231,7 @@ public sealed class AdminClient : IAdminClient
             throw new InvalidOperationException("No brokers available");
         }
 
-        return await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+        return await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask<DelegationToken> CreateDelegationTokenAsync(
@@ -2223,7 +2248,8 @@ public sealed class AdminClient : IAdminClient
         var maxLifetimeMs = ToKafkaMilliseconds(maxLifetime, nameof(maxLifetime));
 
         // CreateDelegationToken has no client idempotency key; do not auto-retry after the broker may have minted a token.
-        var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+        using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+        var controller = controllerLease.Connection;
         var request = new CreateDelegationTokenRequest
         {
             Owner = ownerPrincipal,
@@ -2266,7 +2292,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<DateTimeOffset>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var request = new RenewDelegationTokenRequest
             {
                 Hmac = hmac,
@@ -2304,7 +2331,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<DateTimeOffset>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var request = new ExpireDelegationTokenRequest
             {
                 Hmac = hmac,
@@ -2340,7 +2368,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyList<DelegationToken>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var request = new DescribeDelegationTokenRequest
             {
                 Owners = ownerList
@@ -2466,7 +2495,9 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+            var connection = connectionLease.Connection;
 
             var request = new DescribeConfigsRequest
             {
@@ -2549,7 +2580,9 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+            var connection = connectionLease.Connection;
 
             var request = new AlterConfigsRequest
             {
@@ -2607,7 +2640,9 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+            var connection = connectionLease.Connection;
 
             var request = new IncrementalAlterConfigsRequest
             {
@@ -2672,7 +2707,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new CreateAclsRequest
             {
@@ -2727,7 +2763,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyList<AclBinding>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new DeleteAclsRequest
             {
@@ -2795,7 +2832,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyList<AclBinding>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new DescribeAclsRequest
             {
@@ -2882,7 +2920,8 @@ public sealed class AdminClient : IAdminClient
         {
             var isRetryAttempt = deleteMayHaveApplied;
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new OffsetDeleteRequest
             {
@@ -2995,7 +3034,8 @@ public sealed class AdminClient : IAdminClient
             // Send requests to each leader
             foreach (var (leaderId, topics) in partitionsByLeader)
             {
-                var connection = await _connectionPool.GetConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var request = new ListOffsetsRequest
                 {
@@ -3082,7 +3122,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<TopicPartition, ElectLeadersResultInfo>>(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
 
             var request = new ElectLeadersRequest
             {
@@ -3143,7 +3184,8 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.DescribeQuorum,
                 DescribeQuorumRequest.LowestSupportedVersion,
@@ -3231,7 +3273,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.AddRaftVoter,
                 AddRaftVoterRequest.LowestSupportedVersion,
@@ -3288,7 +3331,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.RemoveRaftVoter,
                 RemoveRaftVoterRequest.LowestSupportedVersion,
@@ -3328,7 +3372,8 @@ public sealed class AdminClient : IAdminClient
 
         await WithRetryAsync(async () =>
         {
-            var controller = await GetControllerAsync(cancellationToken).ConfigureAwait(false);
+            using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
+            var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.UnregisterBroker,
                 UnregisterBrokerRequest.LowestSupportedVersion,
@@ -3382,7 +3427,8 @@ public sealed class AdminClient : IAdminClient
             // Fan out to all requested brokers in parallel.
             var brokerResults = await Task.WhenAll(brokerIdList.Select(async brokerId =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
                 var response = await connection.SendAsync<DescribeLogDirsRequest, DescribeLogDirsResponse>(
                     new DescribeLogDirsRequest { Topics = topicFilters },
                     apiVersion,
@@ -3473,7 +3519,8 @@ public sealed class AdminClient : IAdminClient
             var brokerResults = await Task.WhenAll(assignmentsByBroker.Select(async brokerAssignments =>
             {
                 var brokerId = brokerAssignments.Key;
-                var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
                 var request = new AlterReplicaLogDirsRequest
                 {
                     Dirs = BuildAlterReplicaLogDirsRequestDirs(brokerAssignments)
@@ -3638,7 +3685,8 @@ public sealed class AdminClient : IAdminClient
 
             var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var request = new StreamsGroupDescribeRequest
                 {
@@ -3704,7 +3752,8 @@ public sealed class AdminClient : IAdminClient
 
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -3903,7 +3952,8 @@ public sealed class AdminClient : IAdminClient
             // Fan out ShareGroupDescribe requests to all coordinators in parallel
             var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var request = new ShareGroupDescribeRequest
                 {
@@ -3991,7 +4041,8 @@ public sealed class AdminClient : IAdminClient
             // Fan out to all brokers in parallel
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
-                var connection = await _connectionPool.GetConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -4054,7 +4105,8 @@ public sealed class AdminClient : IAdminClient
         return await WithRetryAsync<IReadOnlyList<ShareGroupOffsetDescription>>(async () =>
         {
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             // Build topics filter from partitions list, or null for all
             IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? requestTopics = null;
@@ -4151,7 +4203,8 @@ public sealed class AdminClient : IAdminClient
         await WithRetryAsync(async () =>
         {
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new AlterShareGroupOffsetsRequest
             {
@@ -4212,7 +4265,8 @@ public sealed class AdminClient : IAdminClient
         {
             var isRetryAttempt = deleteMayHaveApplied;
             var coordinatorId = await FindGroupCoordinatorAsync(groupId, cancellationToken).ConfigureAwait(false);
-            var connection = await _connectionPool.GetConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new DeleteShareGroupOffsetsRequest
             {
@@ -4344,7 +4398,7 @@ public sealed class AdminClient : IAdminClient
             $"WriteTxnMarkers response did not include {topicPartition.Topic}-{topicPartition.Partition} for producer {transaction.ProducerId}.");
     }
 
-    private async ValueTask<IKafkaConnection> GetControllerAsync(CancellationToken cancellationToken)
+    private async ValueTask<KafkaConnectionLease> LeaseControllerAsync(CancellationToken cancellationToken)
     {
         var controllerId = _metadataManager.Metadata.ControllerId;
         if (controllerId < 0)
@@ -4352,7 +4406,7 @@ public sealed class AdminClient : IAdminClient
             throw new InvalidOperationException("No controller available");
         }
 
-        return await _connectionPool.GetConnectionAsync(controllerId, cancellationToken).ConfigureAwait(false);
+        return await _connectionPool.LeaseConnectionAsync(controllerId, cancellationToken).ConfigureAwait(false);
     }
 
     private static QuorumReplicaState MapQuorumReplicaState(DescribeQuorumReplicaState state) =>
@@ -4418,7 +4472,9 @@ public sealed class AdminClient : IAdminClient
             throw new InvalidOperationException("No brokers available");
         }
 
-        var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+        using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+        var connection = connectionLease.Connection;
 
         var request = new FindCoordinatorRequest
         {
@@ -4460,7 +4516,9 @@ public sealed class AdminClient : IAdminClient
             throw new InvalidOperationException("No brokers available");
         }
 
-        var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+        using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
+
+        var connection = connectionLease.Connection;
 
         var request = new FindCoordinatorRequest
         {

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -162,7 +162,19 @@ internal sealed class ConsumerConnectionScaler
             _logError?.Invoke(task.Exception.InnerException ?? task.Exception);
     }
 
-    internal async ValueTask StopAndDrainAsync()
+    internal async ValueTask StopAndDrainAsync(TimeSpan timeout)
+    {
+        try
+        {
+            await StopAndDrainCoreAsync().AsTask().WaitAsync(timeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            // Core drain continues observing the pending operations after disposal moves on.
+        }
+    }
+
+    private async ValueTask StopAndDrainCoreAsync()
     {
         Task[] pendingOperations;
         lock (_operationLock)

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -25,12 +25,15 @@ internal sealed class ConsumerConnectionScaler
     private readonly Func<CancellationToken, ValueTask> _scaleUpAsync;
     private readonly Func<CancellationToken, ValueTask> _scaleDownAsync;
     private readonly Action<Exception>? _logError;
+    private readonly object _operationLock = new();
+    private readonly HashSet<Task> _pendingOperations = [];
 
     private int _currentConnectionCount;
     private long _saturationStartTimestamp;
     private long _lowUtilizationStartTimestamp;
     private long _lastScaleTimestamp;
     private long _testTimeOffsetTicks;
+    private int _stopping;
 
     public int CurrentConnectionCount => Interlocked.CompareExchange(ref _currentConnectionCount, 0, 0);
 
@@ -88,6 +91,9 @@ internal sealed class ConsumerConnectionScaler
     /// </summary>
     public void MaybeScale()
     {
+        if (Volatile.Read(ref _stopping) != 0)
+            return;
+
         var now = GetTimestamp();
 
         if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
@@ -125,15 +131,57 @@ internal sealed class ConsumerConnectionScaler
 
     private void FireAndObserve(Func<CancellationToken, ValueTask> action)
     {
-        var task = action(CancellationToken.None);
-        if (task.IsCompletedSuccessfully)
+        Task operationTask;
+        lock (_operationLock)
+        {
+            if (_stopping != 0)
+                return;
+
+            var operation = action(CancellationToken.None);
+            if (operation.IsCompletedSuccessfully)
+                return;
+
+            operationTask = operation.AsTask();
+            _pendingOperations.Add(operationTask);
+        }
+
+        _ = operationTask.ContinueWith(
+            static (task, state) => ((ConsumerConnectionScaler)state!).ObserveCompletedOperation(task),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ObserveCompletedOperation(Task task)
+    {
+        lock (_operationLock)
+            _pendingOperations.Remove(task);
+
+        if (task.Exception is not null)
+            _logError?.Invoke(task.Exception.InnerException ?? task.Exception);
+    }
+
+    internal async ValueTask StopAndDrainAsync()
+    {
+        Task[] pendingOperations;
+        lock (_operationLock)
+        {
+            Volatile.Write(ref _stopping, 1);
+            pendingOperations = [.. _pendingOperations];
+        }
+
+        if (pendingOperations.Length == 0)
             return;
 
-        task.AsTask().ContinueWith(static (t, state) =>
+        try
         {
-            if (t.Exception is not null)
-                ((Action<Exception>?)state)?.Invoke(t.Exception.InnerException ?? t.Exception);
-        }, _logError, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+            await Task.WhenAll(pendingOperations).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Each operation's continuation observes and logs its exception.
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -228,6 +228,8 @@ internal sealed class ConsumerConnectionScaler
         }
     }
 
+    internal ValueTask StopAndDrainAsync() => StopAndDrainCoreAsync();
+
     private async ValueTask StopAndDrainCoreAsync()
     {
         Task[] pendingOperations;

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Consumer;
 /// Scale-down: when utilization is below 30% for >120 seconds.
 /// Cooldown: 5 seconds between any scale operations.
 /// </summary>
-internal sealed class ConsumerConnectionScaler
+internal sealed class ConsumerConnectionScaler : IDisposable
 {
     /// <summary>
     /// Maximum number of fetch connections per broker. Used for stackalloc sizing
@@ -256,6 +256,8 @@ internal sealed class ConsumerConnectionScaler
             // Each operation's continuation observes and logs its exception.
         }
     }
+
+    public void Dispose() => _operationCancellationSource.Dispose();
 
     /// <summary>
     /// Splits partitions across fetch connections using chunked distribution.

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -132,17 +132,25 @@ internal sealed class ConsumerConnectionScaler
     private void FireAndObserve(Func<CancellationToken, ValueTask> action)
     {
         Task operationTask;
-        lock (_operationLock)
+        try
         {
-            if (_stopping != 0)
-                return;
+            lock (_operationLock)
+            {
+                if (_stopping != 0)
+                    return;
 
-            var operation = action(CancellationToken.None);
-            if (operation.IsCompletedSuccessfully)
-                return;
+                var operation = action(CancellationToken.None);
+                if (operation.IsCompletedSuccessfully)
+                    return;
 
-            operationTask = operation.AsTask();
-            _pendingOperations.Add(operationTask);
+                operationTask = operation.AsTask();
+                _pendingOperations.Add(operationTask);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logError?.Invoke(ex);
+            return;
         }
 
         _ = operationTask.ContinueWith(

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -35,6 +35,8 @@ internal sealed class ConsumerConnectionScaler
     private long _testTimeOffsetTicks;
     private int _stopping;
 
+    internal Action? BeforeScaleOperationLockForTest { get; set; }
+
     public int CurrentConnectionCount => Interlocked.CompareExchange(ref _currentConnectionCount, 0, 0);
 
     public ConsumerConnectionScaler(
@@ -91,34 +93,44 @@ internal sealed class ConsumerConnectionScaler
     /// </summary>
     public void MaybeScale()
     {
-        if (Volatile.Read(ref _stopping) != 0)
-            return;
+        BeforeScaleOperationLockForTest?.Invoke();
 
         var now = GetTimestamp();
-
-        if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
-            return;
-
-        if (_saturationStartTimestamp != 0
-            && _currentConnectionCount < _maxConnectionCount
-            && Stopwatch.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
+        Task? operationTask = null;
+        Exception? operationError = null;
+        lock (_operationLock)
         {
-            Interlocked.Increment(ref _currentConnectionCount);
-            _saturationStartTimestamp = 0;
-            _lastScaleTimestamp = now;
-            FireAndObserve(_scaleUpAsync);
-            return;
+            if (_stopping != 0)
+                return;
+
+            if (_lastScaleTimestamp != 0 && Stopwatch.GetElapsedTime(_lastScaleTimestamp, now) < Cooldown)
+                return;
+
+            if (_saturationStartTimestamp != 0
+                && _currentConnectionCount < _maxConnectionCount
+                && Stopwatch.GetElapsedTime(_saturationStartTimestamp, now) >= ScaleUpSustained)
+            {
+                Interlocked.Increment(ref _currentConnectionCount);
+                _saturationStartTimestamp = 0;
+                _lastScaleTimestamp = now;
+                operationTask = StartAndTrackOperation(_scaleUpAsync, out operationError);
+            }
+            else if (_lowUtilizationStartTimestamp != 0
+                && _currentConnectionCount > _initialConnectionCount
+                && Stopwatch.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
+            {
+                Interlocked.Decrement(ref _currentConnectionCount);
+                _lowUtilizationStartTimestamp = 0;
+                _lastScaleTimestamp = now;
+                operationTask = StartAndTrackOperation(_scaleDownAsync, out operationError);
+            }
         }
 
-        if (_lowUtilizationStartTimestamp != 0
-            && _currentConnectionCount > _initialConnectionCount
-            && Stopwatch.GetElapsedTime(_lowUtilizationStartTimestamp, now) >= ScaleDownSustained)
-        {
-            Interlocked.Decrement(ref _currentConnectionCount);
-            _lowUtilizationStartTimestamp = 0;
-            _lastScaleTimestamp = now;
-            FireAndObserve(_scaleDownAsync);
-        }
+        if (operationError is not null)
+            _logError?.Invoke(operationError);
+
+        if (operationTask is not null)
+            ObserveOperation(operationTask);
     }
 
     /// <summary>
@@ -129,30 +141,31 @@ internal sealed class ConsumerConnectionScaler
     internal static int GetFetchConnectionCount(int connectionsPerBroker)
         => connectionsPerBroker > 1 ? connectionsPerBroker - 1 : 1;
 
-    private void FireAndObserve(Func<CancellationToken, ValueTask> action)
+    private Task? StartAndTrackOperation(
+        Func<CancellationToken, ValueTask> action,
+        out Exception? operationError)
     {
-        Task operationTask;
+        Debug.Assert(Monitor.IsEntered(_operationLock));
+        operationError = null;
         try
         {
-            lock (_operationLock)
-            {
-                if (_stopping != 0)
-                    return;
+            var operation = action(CancellationToken.None);
+            if (operation.IsCompletedSuccessfully)
+                return null;
 
-                var operation = action(CancellationToken.None);
-                if (operation.IsCompletedSuccessfully)
-                    return;
-
-                operationTask = operation.AsTask();
-                _pendingOperations.Add(operationTask);
-            }
+            var operationTask = operation.AsTask();
+            _pendingOperations.Add(operationTask);
+            return operationTask;
         }
         catch (Exception ex)
         {
-            _logError?.Invoke(ex);
-            return;
+            operationError = ex;
+            return null;
         }
+    }
 
+    private void ObserveOperation(Task operationTask)
+    {
         _ = operationTask.ContinueWith(
             static (task, state) => ((ConsumerConnectionScaler)state!).ObserveCompletedOperation(task),
             this,

--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -27,6 +27,7 @@ internal sealed class ConsumerConnectionScaler
     private readonly Action<Exception>? _logError;
     private readonly object _operationLock = new();
     private readonly HashSet<Task> _pendingOperations = [];
+    private readonly CancellationTokenSource _operationCancellationSource = new();
 
     private int _currentConnectionCount;
     private long _saturationStartTimestamp;
@@ -96,8 +97,8 @@ internal sealed class ConsumerConnectionScaler
         BeforeScaleOperationLockForTest?.Invoke();
 
         var now = GetTimestamp();
-        Task? operationTask = null;
-        Exception? operationError = null;
+        Func<CancellationToken, ValueTask>? operation = null;
+        TaskCompletionSource? operationReservation = null;
         lock (_operationLock)
         {
             if (_stopping != 0)
@@ -113,7 +114,7 @@ internal sealed class ConsumerConnectionScaler
                 Interlocked.Increment(ref _currentConnectionCount);
                 _saturationStartTimestamp = 0;
                 _lastScaleTimestamp = now;
-                operationTask = StartAndTrackOperation(_scaleUpAsync, out operationError);
+                operation = _scaleUpAsync;
             }
             else if (_lowUtilizationStartTimestamp != 0
                 && _currentConnectionCount > _initialConnectionCount
@@ -122,15 +123,22 @@ internal sealed class ConsumerConnectionScaler
                 Interlocked.Decrement(ref _currentConnectionCount);
                 _lowUtilizationStartTimestamp = 0;
                 _lastScaleTimestamp = now;
-                operationTask = StartAndTrackOperation(_scaleDownAsync, out operationError);
+                operation = _scaleDownAsync;
+            }
+
+            if (operation is not null)
+            {
+                operationReservation = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _pendingOperations.Add(operationReservation.Task);
             }
         }
 
-        if (operationError is not null)
-            _logError?.Invoke(operationError);
-
-        if (operationTask is not null)
-            ObserveOperation(operationTask);
+        if (operationReservation is not null)
+        {
+            ObserveOperation(operationReservation.Task);
+            StartReservedOperation(operation!, operationReservation);
+        }
     }
 
     /// <summary>
@@ -141,26 +149,51 @@ internal sealed class ConsumerConnectionScaler
     internal static int GetFetchConnectionCount(int connectionsPerBroker)
         => connectionsPerBroker > 1 ? connectionsPerBroker - 1 : 1;
 
-    private Task? StartAndTrackOperation(
+    private void StartReservedOperation(
         Func<CancellationToken, ValueTask> action,
-        out Exception? operationError)
+        TaskCompletionSource operationReservation)
     {
-        Debug.Assert(Monitor.IsEntered(_operationLock));
-        operationError = null;
         try
         {
-            var operation = action(CancellationToken.None);
+            var cancellationToken = _operationCancellationSource.Token;
+            cancellationToken.ThrowIfCancellationRequested();
+            var operation = action(cancellationToken);
             if (operation.IsCompletedSuccessfully)
-                return null;
+            {
+                operationReservation.TrySetResult();
+                return;
+            }
 
-            var operationTask = operation.AsTask();
-            _pendingOperations.Add(operationTask);
-            return operationTask;
+            _ = CompleteReservedOperationAsync(operation, operationReservation);
+        }
+        catch (OperationCanceledException ex)
+        {
+            operationReservation.TrySetCanceled(ex.CancellationToken);
         }
         catch (Exception ex)
         {
-            operationError = ex;
-            return null;
+            // Preserve synchronous delegate semantics: report before MaybeScale returns.
+            _logError?.Invoke(ex);
+            operationReservation.TrySetResult();
+        }
+    }
+
+    private static async Task CompleteReservedOperationAsync(
+        ValueTask operation,
+        TaskCompletionSource operationReservation)
+    {
+        try
+        {
+            await operation.ConfigureAwait(false);
+            operationReservation.TrySetResult();
+        }
+        catch (OperationCanceledException ex)
+        {
+            operationReservation.TrySetCanceled(ex.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            operationReservation.TrySetException(ex);
         }
     }
 
@@ -198,11 +231,16 @@ internal sealed class ConsumerConnectionScaler
     private async ValueTask StopAndDrainCoreAsync()
     {
         Task[] pendingOperations;
+        bool cancelOperations;
         lock (_operationLock)
         {
+            cancelOperations = _stopping == 0;
             Volatile.Write(ref _stopping, 1);
             pendingOperations = [.. _pendingOperations];
         }
+
+        if (cancelOperations)
+            _operationCancellationSource.Cancel();
 
         if (pendingOperations.Length == 0)
             return;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -317,8 +317,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             // Cycle through brokers on retries to avoid wasting all attempts on one slow broker.
             var broker = brokers[attempt % brokers.Count];
-            var connection = await _connectionPool.GetConnectionByIndexAsync(broker.NodeId, _getCoordinationConnectionIndex(), cancellationToken)
+            using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                broker.NodeId,
+                _getCoordinationConnectionIndex(),
+                cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             // Use negotiated API version
             var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
@@ -485,8 +489,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             await RetryHelper.WithRetryAsync(async () =>
             {
-                var connection = await _connectionPool.GetConnectionByIndexAsync(_coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                    _coordinatorId,
+                    _getCoordinationConnectionIndex(),
+                    cancellationToken)
                     .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 // Group offsets by topic using pooled dictionary to avoid allocations
                 // Clear existing Lists before clearing the dictionary to reuse List instances
@@ -587,8 +595,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             return await RetryHelper.WithRetryAsync(async () =>
             {
-                var connection = await _connectionPool.GetConnectionByIndexAsync(_coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                    _coordinatorId,
+                    _getCoordinationConnectionIndex(),
+                    cancellationToken)
                     .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 // Group partitions by topic using pooled dictionary to avoid allocations
                 // Clear existing Lists before clearing the dictionary to reuse List instances
@@ -814,9 +826,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         bool isInitial,
         CancellationToken cancellationToken)
     {
-        var connection = await _connectionPool.GetConnectionByIndexAsync(
+        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
             _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
             .ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         var version = _metadataManager.GetNegotiatedApiVersion(
             ApiKey.ConsumerGroupHeartbeat,
@@ -1280,9 +1293,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         try
         {
-            var connection = await _connectionPool.GetConnectionByIndexAsync(
+            using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
                 _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new ConsumerGroupHeartbeatRequest
             {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2165,14 +2165,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 continue;
             }
 
-            if (key.ConnectionIndex >= fetchConnectionCount)
+            var isScaledDownConnection = key.ConnectionIndex >= fetchConnectionCount;
+            if (isScaledDownConnection)
             {
-                _fetchSessions.TryRemove(key, out _);
+                if (_ownsInfrastructure)
+                {
+                    _fetchSessions.TryRemove(key, out _);
+                    continue;
+                }
+
+                // Shared consumers retain the physical connection after logical scale-down.
+                // Fall through so an empty fetch closes the now-unused session.
+            }
+            else if (scheduledFetchSessions is not null && scheduledFetchSessions.Contains(key))
+            {
                 continue;
             }
-
-            if (scheduledFetchSessions is not null && scheduledFetchSessions.Contains(key))
-                continue;
 
             targetCount++;
             if (TryStartBrokerPrefetch(
@@ -2386,7 +2394,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int fetchBufferEpoch,
         CancellationToken cancellationToken)
     {
-        var connection = await _connectionPool.GetConnectionByIndexAsync(brokerId, connectionIndex, cancellationToken).ConfigureAwait(false);
+        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+            brokerId,
+            connectionIndex,
+            cancellationToken).ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         // Ensure API version is negotiated (thread-safe initialization)
         var apiVersion = _fetchApiVersion;
@@ -3950,9 +3962,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         return await RetryHelper.WithRetryAsync(async () =>
         {
-            var connection = await GetPartitionLeaderControlConnectionAsync(topicPartition, cancellationToken).ConfigureAwait(false);
-            if (connection is null)
+            var connectionLease = await GetPartitionLeaderControlConnectionAsync(topicPartition, cancellationToken)
+                .ConfigureAwait(false);
+            if (connectionLease is null)
                 throw new KafkaException(ErrorCode.LeaderNotAvailable, $"No leader found for partition {topicPartition}");
+            using var lease = connectionLease.Value;
+            var connection = lease.Connection;
 
             var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.ListOffsets,
@@ -4399,9 +4414,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         return RetryHelper.WithRetryAsync(async () =>
         {
-            var connection = await GetPartitionLeaderControlConnectionAsync(partition, cancellationToken).ConfigureAwait(false);
-            if (connection is null)
+            var connectionLease = await GetPartitionLeaderControlConnectionAsync(partition, cancellationToken)
+                .ConfigureAwait(false);
+            if (connectionLease is null)
                 return 0;
+            using var lease = connectionLease.Value;
+            var connection = lease.Connection;
 
             var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.ListOffsets,
@@ -4462,7 +4480,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }, _metadataManager, cancellationToken);
     }
 
-    private async ValueTask<IKafkaConnection?> GetPartitionLeaderControlConnectionAsync(
+    private async ValueTask<KafkaConnectionLease?> GetPartitionLeaderControlConnectionAsync(
         TopicPartition partition,
         CancellationToken cancellationToken)
     {
@@ -4476,7 +4494,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // block assignment position initialization or watermark queries during a rebalance.
         var connectionCount = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
         var connectionIndex = ConsumerCoordinator.GetCoordinationConnectionIndex(connectionCount);
-        return await _connectionPool.GetConnectionByIndexAsync(leader.NodeId, connectionIndex, cancellationToken).ConfigureAwait(false);
+        return await _connectionPool.LeaseConnectionByIndexAsync(leader.NodeId, connectionIndex, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async ValueTask FetchRecordsAsync(CancellationToken cancellationToken)
@@ -4994,7 +5013,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int fetchBufferEpoch,
         CancellationToken cancellationToken)
     {
-        var connection = await _connectionPool.GetConnectionByIndexAsync(brokerId, 0, cancellationToken).ConfigureAwait(false);
+        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+            brokerId,
+            0,
+            cancellationToken).ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         // Ensure API version is negotiated (thread-safe initialization)
         var apiVersion = _fetchApiVersion;
@@ -6173,7 +6196,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         List<TopicPartitionTimestamp> partitions,
         CancellationToken cancellationToken)
     {
-        var connection = await _connectionPool.GetConnectionByIndexAsync(brokerId, 0, cancellationToken).ConfigureAwait(false);
+        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+            brokerId,
+            0,
+            cancellationToken).ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
             ApiKey.ListOffsets,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1072,9 +1072,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (removedConnection is null)
             return;
 
+        // Once detached from the pool, the retired connection must finish draining even if
+        // consumer shutdown cancels further pool operations; otherwise it has no remaining owner.
         await RetiredConnectionDisposer.DrainAndDisposeAsync(
             removedConnection,
-            cancellationToken).ConfigureAwait(false);
+            CancellationToken.None).ConfigureAwait(false);
     }
 
     public StringSet Subscription => _subscriptionSnapshot;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2166,22 +2166,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             var isScaledDownConnection = key.ConnectionIndex >= fetchConnectionCount;
-            if (isScaledDownConnection)
-            {
-                if (_ownsInfrastructure)
-                {
-                    _fetchSessions.TryRemove(key, out _);
-                    continue;
-                }
-
-                // Shared consumers retain the physical connection after logical scale-down.
-                // Fall through so an empty fetch closes the now-unused session.
-            }
-            else if (scheduledFetchSessions is not null && scheduledFetchSessions.Contains(key))
+            if (!isScaledDownConnection
+                && scheduledFetchSessions is not null
+                && scheduledFetchSessions.Contains(key))
             {
                 continue;
             }
 
+            // Shared consumers retain every physical connection. Owned consumers remove the
+            // old coordination connection, so the former highest fetch connection also remains
+            // open as the new coordination connection. Close either stale session explicitly.
             targetCount++;
             if (TryStartBrokerPrefetch(
                 key.BrokerId,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6347,6 +6347,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 await _connectionScaler.StopAndDrainAsync().ConfigureAwait(false);
             else
                 await _connectionScaler.StopAndDrainAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            _connectionScaler.Dispose();
         }
 
         autoCommitCts?.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6354,7 +6354,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         if (_connectionScaler is not null)
-            await _connectionScaler.StopAndDrainAsync().ConfigureAwait(false);
+            await _connectionScaler.StopAndDrainAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
         autoCommitCts?.Dispose();
         prefetchCts?.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1070,9 +1070,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         try
         {
-            // Shrink removed the connection from pool routing. Let requests that already
-            // hold its reference finish before transferring final disposal ownership.
-            while (connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 })
+            // Pool routing is already closed. Existing leases may still start more sends,
+            // so seal retirement only after every lease has been returned.
+            if (connection is IRetirableKafkaConnection retirableConnection)
+            {
+                while (retirableConnection.LeaseCount > 0)
+                    await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+
+                retirableConnection.CompleteRetirement();
+            }
+
+            // A send may have entered immediately before retirement was sealed.
+            while (HasRetiredConnectionWork(connection))
                 await Task.Delay(10, cancellationToken).ConfigureAwait(false);
         }
         finally
@@ -1080,6 +1089,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await connection.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    private static bool HasRetiredConnectionWork(IKafkaConnection connection)
+        => connection is IRetirableKafkaConnection { ActiveOperationCount: > 0 }
+            || connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 };
 
     public StringSet Subscription => _subscriptionSnapshot;
     public string? SubscriptionPattern => _topicPattern;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -998,6 +998,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Initialize adaptive connection scaler if configured (before coordinator, which needs the connection count)
         if (options.EnableAdaptiveConnections && options.MaxConnectionsPerBroker > options.ConnectionsPerBroker)
         {
+            // Shared consumers may narrow local fetch routing, but cannot retire sockets
+            // that sibling clients still use from the shared connection pool.
             _connectionScaler = new ConsumerConnectionScaler(
                 initialConnectionCount: options.ConnectionsPerBroker,
                 maxConnectionCount: options.MaxConnectionsPerBroker,
@@ -1007,12 +1009,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     foreach (var broker in _metadataManager.Metadata.GetBrokers())
                         await _connectionPool.ScaleConnectionGroupAsync(broker.NodeId, newCount, ct).ConfigureAwait(false);
                 },
-                scaleDownAsync: async ct =>
-                {
-                    var newCount = _connectionScaler!.CurrentConnectionCount;
-                    foreach (var broker in _metadataManager.Metadata.GetBrokers())
-                        await _connectionPool.ShrinkConnectionGroupAsync(broker.NodeId, newCount, ct).ConfigureAwait(false);
-                },
+                scaleDownAsync: ownsInfrastructure
+                    ? ScaleDownOwnedConnectionGroupsAsync
+                    : static _ => ValueTask.CompletedTask,
                 logError: ex => _logger.LogWarning(ex, "Adaptive connection scaling operation failed"));
         }
 
@@ -1045,6 +1044,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Register this instance's lag callback with the shared static gauge.
         // The callback is invoked only during metric collection (~every 5-60s), not on the hot path.
         Diagnostics.DekafMetrics.RegisterConsumerLagCallback(ObserveConsumerLag);
+    }
+
+    private async ValueTask ScaleDownOwnedConnectionGroupsAsync(CancellationToken cancellationToken)
+    {
+        var newCount = _connectionScaler!.CurrentConnectionCount;
+        foreach (var broker in _metadataManager.Metadata.GetBrokers())
+        {
+            var removedConnection = await _connectionPool.ShrinkConnectionGroupAsync(
+                broker.NodeId,
+                newCount,
+                cancellationToken).ConfigureAwait(false);
+            if (removedConnection is null)
+                continue;
+
+            await DrainAndDisposeRetiredConnectionAsync(
+                removedConnection,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask DrainAndDisposeRetiredConnectionAsync(
+        IKafkaConnection connection,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Shrink removed the connection from pool routing. Let requests that already
+            // hold its reference finish before transferring final disposal ownership.
+            while (connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 })
+                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
     }
 
     public StringSet Subscription => _subscriptionSnapshot;
@@ -6278,6 +6312,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // Ignore — task may not exit promptly after cancellation
             }
         }
+
+        if (_connectionScaler is not null)
+            await _connectionScaler.StopAndDrainAsync().ConfigureAwait(false);
 
         autoCommitCts?.Dispose();
         prefetchCts?.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1058,41 +1058,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (removedConnection is null)
                 continue;
 
-            await DrainAndDisposeRetiredConnectionAsync(
+            await RetiredConnectionDisposer.DrainAndDisposeAsync(
                 removedConnection,
                 cancellationToken).ConfigureAwait(false);
         }
     }
-
-    private static async ValueTask DrainAndDisposeRetiredConnectionAsync(
-        IKafkaConnection connection,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            // Pool routing is already closed. Existing leases may still start more sends,
-            // so seal retirement only after every lease has been returned.
-            if (connection is IRetirableKafkaConnection retirableConnection)
-            {
-                while (retirableConnection.LeaseCount > 0)
-                    await Task.Delay(10, cancellationToken).ConfigureAwait(false);
-
-                retirableConnection.CompleteRetirement();
-            }
-
-            // A send may have entered immediately before retirement was sealed.
-            while (HasRetiredConnectionWork(connection))
-                await Task.Delay(10, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
-    private static bool HasRetiredConnectionWork(IKafkaConnection connection)
-        => connection is IRetirableKafkaConnection { ActiveOperationCount: > 0 }
-            || connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 };
 
     public StringSet Subscription => _subscriptionSnapshot;
     public string? SubscriptionPattern => _topicPattern;
@@ -2170,6 +2140,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 && scheduledFetchSessions is not null
                 && scheduledFetchSessions.Contains(key))
             {
+                continue;
+            }
+
+            // Owned consumers physically removed indices beyond the current group, so
+            // asking the pool for one would modulo-wrap the close onto a live connection.
+            // Shared consumers only narrow local routing and retain those physical slots.
+            if (_ownsInfrastructure && key.ConnectionIndex >= currentConnections)
+            {
+                _fetchSessions.TryRemove(key, out _);
                 continue;
             }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6342,7 +6342,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         if (_connectionScaler is not null)
-            await _connectionScaler.StopAndDrainAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        {
+            if (_ownsInfrastructure)
+                await _connectionScaler.StopAndDrainAsync().ConfigureAwait(false);
+            else
+                await _connectionScaler.StopAndDrainAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
 
         autoCommitCts?.Dispose();
         prefetchCts?.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1049,19 +1049,32 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private async ValueTask ScaleDownOwnedConnectionGroupsAsync(CancellationToken cancellationToken)
     {
         var newCount = _connectionScaler!.CurrentConnectionCount;
-        foreach (var broker in _metadataManager.Metadata.GetBrokers())
-        {
-            var removedConnection = await _connectionPool.ShrinkConnectionGroupAsync(
-                broker.NodeId,
+        var brokers = _metadataManager.Metadata.GetBrokers();
+        var scaleDownTasks = new Task[brokers.Count];
+        for (var i = 0; i < brokers.Count; i++)
+            scaleDownTasks[i] = ScaleDownOwnedConnectionGroupAsync(
+                brokers[i].NodeId,
                 newCount,
-                cancellationToken).ConfigureAwait(false);
-            if (removedConnection is null)
-                continue;
+                cancellationToken).AsTask();
 
-            await RetiredConnectionDisposer.DrainAndDisposeAsync(
-                removedConnection,
-                cancellationToken).ConfigureAwait(false);
-        }
+        await Task.WhenAll(scaleDownTasks).ConfigureAwait(false);
+    }
+
+    private async ValueTask ScaleDownOwnedConnectionGroupAsync(
+        int brokerId,
+        int newCount,
+        CancellationToken cancellationToken)
+    {
+        var removedConnection = await _connectionPool.ShrinkConnectionGroupAsync(
+            brokerId,
+            newCount,
+            cancellationToken).ConfigureAwait(false);
+        if (removedConnection is null)
+            return;
+
+        await RetiredConnectionDisposer.DrainAndDisposeAsync(
+            removedConnection,
+            cancellationToken).ConfigureAwait(false);
     }
 
     public StringSet Subscription => _subscriptionSnapshot;

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -549,6 +549,9 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             // Remove the last connection from the group
             var removedConnection = currentGroup[^1];
+            if (removedConnection is IRetirableKafkaConnection retirableConnection)
+                retirableConnection.BeginRetirement();
+
             var shrunkGroup = new IKafkaConnection[currentGroup.Length - 1];
             Array.Copy(currentGroup, shrunkGroup, shrunkGroup.Length);
 

--- a/src/Dekaf/Networking/IRetirableKafkaConnection.cs
+++ b/src/Dekaf/Networking/IRetirableKafkaConnection.cs
@@ -1,0 +1,19 @@
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Coordinates pool leases and active sends while a connection leaves pool routing.
+/// </summary>
+internal interface IRetirableKafkaConnection
+{
+    int LeaseCount { get; }
+
+    int ActiveOperationCount { get; }
+
+    bool TryAcquireLease();
+
+    void ReleaseLease();
+
+    void BeginRetirement();
+
+    void CompleteRetirement();
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -134,6 +134,7 @@ internal static class ConnectionHelper
 public sealed partial class KafkaConnection :
     IKafkaConnection,
     IIdleTrackedKafkaConnection,
+    IRetirableKafkaConnection,
     IKafkaPipelinedWriteCompletionConnection
 {
     private readonly string _host;
@@ -185,6 +186,9 @@ public sealed partial class KafkaConnection :
     private int _pendingRequestSlotOperationCount;
     private int _pendingRequestSlotsClosed;
     private int _pendingRequestCount;
+    private int _leaseCount;
+    private int _activeOperationCount;
+    private int _retirementState;
     private readonly CancelledCorrelationIdTracker _cancelledCorrelationIds = new(MaxCancelledCorrelationIds);
     private readonly PendingRequestPool _pendingRequestPool;
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
@@ -229,6 +233,19 @@ public sealed partial class KafkaConnection :
     int IIdleTrackedKafkaConnection.PendingRequestCount => GetPendingRequestCount();
 
     void IIdleTrackedKafkaConnection.Touch() => Touch();
+
+    int IRetirableKafkaConnection.LeaseCount => Volatile.Read(ref _leaseCount);
+
+    int IRetirableKafkaConnection.ActiveOperationCount => Volatile.Read(ref _activeOperationCount);
+
+    bool IRetirableKafkaConnection.TryAcquireLease() => TryAcquireLease();
+
+    void IRetirableKafkaConnection.ReleaseLease() => ReleaseLease();
+
+    void IRetirableKafkaConnection.BeginRetirement()
+        => Interlocked.CompareExchange(ref _retirementState, 1, 0);
+
+    void IRetirableKafkaConnection.CompleteRetirement() => Volatile.Write(ref _retirementState, 2);
 
     /// <summary>
     /// Gets the current SASL session state, if SASL authentication was performed.
@@ -567,6 +584,8 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        using var operation = TrackOperation();
+
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
 
@@ -662,6 +681,8 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        using var operation = TrackOperation();
+
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
 
@@ -764,6 +785,8 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        using var operation = TrackOperation();
+
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
 
@@ -1619,6 +1642,46 @@ public sealed partial class KafkaConnection :
     private int GetPendingRequestCount() => Volatile.Read(ref _pendingRequestCount);
 
     private bool HasPendingRequests() => Volatile.Read(ref _pendingRequestCount) != 0;
+
+    private bool TryAcquireLease()
+    {
+        if (Volatile.Read(ref _retirementState) != 0 || Volatile.Read(ref _disposed) != 0)
+            return false;
+
+        Interlocked.Increment(ref _leaseCount);
+        if (Volatile.Read(ref _retirementState) == 0 && Volatile.Read(ref _disposed) == 0)
+            return true;
+
+        ReleaseLease();
+        return false;
+    }
+
+    private void ReleaseLease()
+    {
+        var remaining = Interlocked.Decrement(ref _leaseCount);
+        Debug.Assert(remaining >= 0);
+    }
+
+    private TrackedOperation TrackOperation()
+    {
+        Interlocked.Increment(ref _activeOperationCount);
+        if (Volatile.Read(ref _retirementState) < 2 && Volatile.Read(ref _disposed) == 0)
+            return new TrackedOperation(this);
+
+        EndTrackedOperation();
+        throw new ObjectDisposedException(nameof(KafkaConnection), "Connection has been retired");
+    }
+
+    private void EndTrackedOperation()
+    {
+        var remaining = Interlocked.Decrement(ref _activeOperationCount);
+        Debug.Assert(remaining >= 0);
+    }
+
+    private readonly struct TrackedOperation(KafkaConnection connection) : IDisposable
+    {
+        public void Dispose() => connection.EndTrackedOperation();
+    }
 
     private void RefreshReceiveTimeout()
     {

--- a/src/Dekaf/Networking/KafkaConnectionLease.cs
+++ b/src/Dekaf/Networking/KafkaConnectionLease.cs
@@ -7,6 +7,24 @@ internal readonly struct KafkaConnectionLease(
     public IKafkaConnection Connection { get; } = connection;
 
     public void Dispose() => retirableConnection?.ReleaseLease();
+
+    internal static bool TryAcquire(IKafkaConnection connection, out KafkaConnectionLease lease)
+    {
+        if (connection is IRetirableKafkaConnection retirableConnection)
+        {
+            if (!retirableConnection.TryAcquireLease())
+            {
+                lease = default;
+                return false;
+            }
+
+            lease = new KafkaConnectionLease(connection, retirableConnection);
+            return true;
+        }
+
+        lease = new KafkaConnectionLease(connection, null);
+        return true;
+    }
 }
 
 internal static class ConnectionPoolLeaseExtensions
@@ -22,7 +40,7 @@ internal static class ConnectionPoolLeaseExtensions
         {
             var connection = await connectionPool.GetConnectionAsync(brokerId, cancellationToken)
                 .ConfigureAwait(false);
-            if (TryLease(connection, out var lease))
+            if (KafkaConnectionLease.TryAcquire(connection, out var lease))
                 return lease;
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -40,7 +58,7 @@ internal static class ConnectionPoolLeaseExtensions
         {
             var connection = await connectionPool.GetConnectionByIndexAsync(brokerId, index, cancellationToken)
                 .ConfigureAwait(false);
-            if (TryLease(connection, out var lease))
+            if (KafkaConnectionLease.TryAcquire(connection, out var lease))
                 return lease;
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -48,21 +66,4 @@ internal static class ConnectionPoolLeaseExtensions
         }
     }
 
-    private static bool TryLease(IKafkaConnection connection, out KafkaConnectionLease lease)
-    {
-        if (connection is IRetirableKafkaConnection retirableConnection)
-        {
-            if (!retirableConnection.TryAcquireLease())
-            {
-                lease = default;
-                return false;
-            }
-
-            lease = new KafkaConnectionLease(connection, retirableConnection);
-            return true;
-        }
-
-        lease = new KafkaConnectionLease(connection, null);
-        return true;
-    }
 }

--- a/src/Dekaf/Networking/KafkaConnectionLease.cs
+++ b/src/Dekaf/Networking/KafkaConnectionLease.cs
@@ -1,0 +1,66 @@
+namespace Dekaf.Networking;
+
+internal readonly struct KafkaConnectionLease(
+    IKafkaConnection connection,
+    IRetirableKafkaConnection? retirableConnection) : IDisposable
+{
+    public IKafkaConnection Connection { get; } = connection;
+
+    public void Dispose() => retirableConnection?.ReleaseLease();
+}
+
+internal static class ConnectionPoolLeaseExtensions
+{
+    public static async ValueTask<KafkaConnectionLease> LeaseConnectionAsync(
+        this IConnectionPool connectionPool,
+        int brokerId,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var connection = await connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+            if (TryLease(connection, out var lease))
+                return lease;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
+    public static async ValueTask<KafkaConnectionLease> LeaseConnectionByIndexAsync(
+        this IConnectionPool connectionPool,
+        int brokerId,
+        int index,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var connection = await connectionPool.GetConnectionByIndexAsync(brokerId, index, cancellationToken)
+                .ConfigureAwait(false);
+            if (TryLease(connection, out var lease))
+                return lease;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
+    private static bool TryLease(IKafkaConnection connection, out KafkaConnectionLease lease)
+    {
+        if (connection is IRetirableKafkaConnection retirableConnection)
+        {
+            if (!retirableConnection.TryAcquireLease())
+            {
+                lease = default;
+                return false;
+            }
+
+            lease = new KafkaConnectionLease(connection, retirableConnection);
+            return true;
+        }
+
+        lease = new KafkaConnectionLease(connection, null);
+        return true;
+    }
+}

--- a/src/Dekaf/Networking/KafkaConnectionLease.cs
+++ b/src/Dekaf/Networking/KafkaConnectionLease.cs
@@ -11,6 +11,8 @@ internal readonly struct KafkaConnectionLease(
 
 internal static class ConnectionPoolLeaseExtensions
 {
+    private static readonly TimeSpan LeaseRetryDelay = TimeSpan.FromMilliseconds(1);
+
     public static async ValueTask<KafkaConnectionLease> LeaseConnectionAsync(
         this IConnectionPool connectionPool,
         int brokerId,
@@ -24,7 +26,7 @@ internal static class ConnectionPoolLeaseExtensions
                 return lease;
 
             cancellationToken.ThrowIfCancellationRequested();
-            await Task.Yield();
+            await Task.Delay(LeaseRetryDelay, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -42,7 +44,7 @@ internal static class ConnectionPoolLeaseExtensions
                 return lease;
 
             cancellationToken.ThrowIfCancellationRequested();
-            await Task.Yield();
+            await Task.Delay(LeaseRetryDelay, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Dekaf/Networking/RetiredConnectionDisposer.cs
+++ b/src/Dekaf/Networking/RetiredConnectionDisposer.cs
@@ -11,26 +11,21 @@ internal static class RetiredConnectionDisposer
         IKafkaConnection connection,
         CancellationToken cancellationToken)
     {
-        try
+        // Existing lease holders may still start operations while retirement is open.
+        // Seal retirement only after every holder has returned its lease.
+        if (connection is IRetirableKafkaConnection retirableConnection)
         {
-            // Existing lease holders may still start operations while retirement is open.
-            // Seal retirement only after every holder has returned its lease.
-            if (connection is IRetirableKafkaConnection retirableConnection)
-            {
-                while (retirableConnection.LeaseCount > 0)
-                    await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
-
-                retirableConnection.CompleteRetirement();
-            }
-
-            // A send may have entered immediately before retirement was sealed.
-            while (HasActiveWork(connection))
+            while (retirableConnection.LeaseCount > 0)
                 await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+
+            retirableConnection.CompleteRetirement();
         }
-        finally
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-        }
+
+        // A send may have entered immediately before retirement was sealed.
+        while (HasActiveWork(connection))
+            await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+
+        await connection.DisposeAsync().ConfigureAwait(false);
     }
 
     private static bool HasActiveWork(IKafkaConnection connection)

--- a/src/Dekaf/Networking/RetiredConnectionDisposer.cs
+++ b/src/Dekaf/Networking/RetiredConnectionDisposer.cs
@@ -1,0 +1,39 @@
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Drains a connection after pool routing has removed it, then disposes it.
+/// </summary>
+internal static class RetiredConnectionDisposer
+{
+    private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(10);
+
+    public static async ValueTask DrainAndDisposeAsync(
+        IKafkaConnection connection,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Existing lease holders may still start operations while retirement is open.
+            // Seal retirement only after every holder has returned its lease.
+            if (connection is IRetirableKafkaConnection retirableConnection)
+            {
+                while (retirableConnection.LeaseCount > 0)
+                    await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+
+                retirableConnection.CompleteRetirement();
+            }
+
+            // A send may have entered immediately before retirement was sealed.
+            while (HasActiveWork(connection))
+                await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool HasActiveWork(IKafkaConnection connection)
+        => connection is IRetirableKafkaConnection { ActiveOperationCount: > 0 }
+            || connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 };
+}

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -481,6 +481,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // disposal. The list is expected to already be empty when parked; a non-empty list
     // means a request slipped in against the width-reduction invariant and is logged.
     private IKafkaConnection? _retiringConnection;
+    private readonly ConcurrentDictionary<Task, byte> _retirementDrainTasks = new();
+
+    internal Action? RetirementDrainStartedForTest { get; set; }
 
     // Set at send-loop finally entry so IsAlive turns false before surviving batches are
     // reroute-redelivered — GetOrCreateBrokerSender must build a replacement, not return
@@ -3929,6 +3932,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             LogBatchCleanupStepFailed(ex, _brokerId);
         }
 
+        // A final send-loop iteration may have already detached a retirement drain after
+        // clearing the raw connection fields. Wait for every such drain before inspecting
+        // the remaining scale-down state.
+        var retirementDrainTasks = _retirementDrainTasks.Keys.ToArray();
+        if (retirementDrainTasks.Length > 0)
+        {
+            await WaitForDisposalDrainAsync(
+                Task.WhenAll(retirementDrainTasks)).ConfigureAwait(false);
+        }
+
         // Observe any in-flight shrink task and dispose the draining connection.
         // After the send loop exits, these won't be polled by MaybeScaleConnections.
         if (_pendingShrinkTask is { } pendingShrinkTask)
@@ -4354,14 +4367,28 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         // This sender's pending list is empty. The shared retirement helper also waits for
         // any leases or operations held by other pool users before disposing in the background.
-        _ = RetiredConnectionDisposer.DrainAndDisposeAsync(
+        StartRetirementDrain(connection);
+    }
+
+    private void StartRetirementDrain(IKafkaConnection connection)
+    {
+        var drainTask = RetiredConnectionDisposer.DrainAndDisposeAsync(
             connection,
-            CancellationToken.None).AsTask().ContinueWith(
-            static (t, _) => { /* Observe exception — best-effort disposal */ },
-            null,
+            CancellationToken.None).AsTask();
+        _retirementDrainTasks.TryAdd(drainTask, 0);
+        RetirementDrainStartedForTest?.Invoke();
+        _ = drainTask.ContinueWith(
+            static (task, state) => ((BrokerSender)state!).ObserveCompletedRetirementDrain(task),
+            this,
             CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
+    }
+
+    private void ObserveCompletedRetirementDrain(Task task)
+    {
+        _retirementDrainTasks.TryRemove(task, out _);
+        _ = task.Exception;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -483,8 +483,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private IKafkaConnection? _retiringConnection;
     private readonly ConcurrentDictionary<Task, byte> _retirementDrainTasks = new();
 
-    internal Action? RetirementDrainStartedForTest { get; set; }
-
     // Set at send-loop finally entry so IsAlive turns false before surviving batches are
     // reroute-redelivered — GetOrCreateBrokerSender must build a replacement, not return
     // this instance whose event channel is already completed.
@@ -4376,7 +4374,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             connection,
             CancellationToken.None).AsTask();
         _retirementDrainTasks.TryAdd(drainTask, 0);
-        RetirementDrainStartedForTest?.Invoke();
         _ = drainTask.ContinueWith(
             static (task, state) => ((BrokerSender)state!).ObserveCompletedRetirementDrain(task),
             this,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4023,7 +4023,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         try
         {
-            await drainTask.WaitAsync(DisposalDrainTimeout).ConfigureAwait(false);
+            if (_canPhysicallyShrinkConnections)
+                await drainTask.ConfigureAwait(false);
+            else
+                await drainTask.WaitAsync(DisposalDrainTimeout).ConfigureAwait(false);
         }
         catch (TimeoutException ex)
         {

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4356,7 +4356,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // any leases or operations held by other pool users before disposing in the background.
         _ = RetiredConnectionDisposer.DrainAndDisposeAsync(
             connection,
-            _cts.Token).AsTask().ContinueWith(
+            CancellationToken.None).AsTask().ContinueWith(
             static (t, _) => { /* Observe exception — best-effort disposal */ },
             null,
             CancellationToken.None,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -93,6 +93,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private const int SendCoalescedTimeoutMs = 1500;
 
     private const int ResponsePollIntervalMs = 100;
+    private static readonly TimeSpan DisposalDrainTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Micro-linger: when coalesced batch count is at or below this threshold,
@@ -3935,7 +3936,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _pendingShrinkTask = null;
             if (pendingShrinkTask.IsCompleted)
             {
-                await DisposeShrinkResultAsync(pendingShrinkTask).ConfigureAwait(false);
+                await WaitForDisposalDrainAsync(
+                    DisposeShrinkResultAsync(pendingShrinkTask)).ConfigureAwait(false);
             }
             else
             {
@@ -3947,25 +3949,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         if (_drainingConnection is not null)
         {
-            try
-            {
-                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+            await WaitForDisposalDrainAsync(
+                RetiredConnectionDisposer.DrainAndDisposeAsync(
                     _drainingConnection,
-                    _cts.Token).ConfigureAwait(false);
-            }
-            catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
+                    CancellationToken.None).AsTask()).ConfigureAwait(false);
             _drainingConnection = null;
         }
 
         if (_retiringConnection is not null)
         {
-            try
-            {
-                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+            await WaitForDisposalDrainAsync(
+                RetiredConnectionDisposer.DrainAndDisposeAsync(
                     _retiringConnection,
-                    _cts.Token).ConfigureAwait(false);
-            }
-            catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
+                    CancellationToken.None).AsTask()).ConfigureAwait(false);
             _retiringConnection = null;
         }
 
@@ -4004,9 +4000,32 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _anyResponseCompleted.Dispose();
     }
 
+    private async ValueTask WaitForDisposalDrainAsync(Task drainTask)
+    {
+        try
+        {
+            await drainTask.WaitAsync(DisposalDrainTimeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            LogBatchCleanupStepFailed(ex, _brokerId);
+            // WaitAsync bounds DisposeAsync only. The drain retains connection ownership
+            // and must continue until sibling leases and operations finish.
+            _ = drainTask.ContinueWith(
+                static (task, _) => { _ = task.Exception; },
+                null,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            LogBatchCleanupStepFailed(ex, _brokerId);
+        }
+    }
+
     private async Task DisposeShrinkResultAsync(Task<IKafkaConnection?> shrinkTask)
     {
-        var cancellationToken = _cts.Token;
         try
         {
             var removedConnection = await shrinkTask.ConfigureAwait(false);
@@ -4014,7 +4033,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 await RetiredConnectionDisposer.DrainAndDisposeAsync(
                     removedConnection,
-                    cancellationToken).ConfigureAwait(false);
+                    CancellationToken.None).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3947,14 +3947,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         if (_drainingConnection is not null)
         {
-            try { await _drainingConnection.DisposeAsync().ConfigureAwait(false); }
+            try
+            {
+                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+                    _drainingConnection,
+                    _cts.Token).ConfigureAwait(false);
+            }
             catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
             _drainingConnection = null;
         }
 
         if (_retiringConnection is not null)
         {
-            try { await _retiringConnection.DisposeAsync().ConfigureAwait(false); }
+            try
+            {
+                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+                    _retiringConnection,
+                    _cts.Token).ConfigureAwait(false);
+            }
             catch (Exception ex) { LogBatchCleanupStepFailed(ex, _brokerId); }
             _retiringConnection = null;
         }
@@ -3996,11 +4006,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private async Task DisposeShrinkResultAsync(Task<IKafkaConnection?> shrinkTask)
     {
+        var cancellationToken = _cts.Token;
         try
         {
             var removedConnection = await shrinkTask.ConfigureAwait(false);
             if (removedConnection is not null)
-                await removedConnection.DisposeAsync().ConfigureAwait(false);
+            {
+                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+                    removedConnection,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -4318,10 +4333,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var connection = _drainingConnection;
         _drainingConnection = null;
 
-        // Fire-and-forget disposal with exception observation to prevent UnobservedTaskException.
-        // The connection has no in-flight requests (its pending list was empty when it was
-        // promoted to draining).
-        _ = connection.DisposeAsync().AsTask().ContinueWith(
+        // This sender's pending list is empty. The shared retirement helper also waits for
+        // any leases or operations held by other pool users before disposing in the background.
+        _ = RetiredConnectionDisposer.DrainAndDisposeAsync(
+            connection,
+            _cts.Token).AsTask().ContinueWith(
             static (t, _) => { /* Observe exception — best-effort disposal */ },
             null,
             CancellationToken.None,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2839,8 +2839,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
             }
 
-            var connection = await GetConnectionAtIndexAsync(connectionIndex, cancellationToken)
+            using var connectionLease = await GetConnectionLeaseAtIndexAsync(connectionIndex, cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             count = CompactCurrentBatches(batches, generations, count);
             if (count == 0)
@@ -2851,7 +2852,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             // Diagnostic: mark batches as having acquired a connection.
             // If orphan trace shows 'S' but no 'G' (Got connection), the hang is at
-            // GetConnectionAtIndexAsync (connection creation or write lock contention).
+            // GetConnectionLeaseAtIndexAsync (connection creation or write lock contention).
             for (var i = 0; i < count; i++)
                 batches[i].AppendDiag('G');
 
@@ -3583,26 +3584,33 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Returns the pinned connection for the given connection index.
-    /// Each connection slot caches a healthy connection for reuse.
+    /// Leases and returns the pinned connection for the given connection index.
+    /// Each connection slot caches a healthy connection for reuse, while the lease bridges
+    /// selection to request registration so shared-pool retirement cannot dispose it between them.
     /// </summary>
-    private async ValueTask<IKafkaConnection> GetConnectionAtIndexAsync(int connIdx, CancellationToken cancellationToken)
+    private async ValueTask<KafkaConnectionLease> GetConnectionLeaseAtIndexAsync(
+        int connIdx,
+        CancellationToken cancellationToken)
     {
         var conn = _pinnedConnections[connIdx];
-        if (conn is not null && conn.IsConnected)
-            return conn;
+        if (conn is not null
+            && conn.IsConnected
+            && KafkaConnectionLease.TryAcquire(conn, out var pinnedLease))
+        {
+            return pinnedLease;
+        }
 
         // Shared pools may retain an expanded group owned by another client. An owning
         // sender also retains a one-slot group after scaling back down. Keep those slots
         // indexed, while preserving the singleton path before this sender first scales up.
-        var connection = _connectionCount > 1 || !_canPhysicallyShrinkConnections || _hasScaledConnectionGroup
-            ? await _connectionPool.GetConnectionByIndexAsync(_brokerId, connIdx, cancellationToken)
+        var connectionLease = _connectionCount > 1 || !_canPhysicallyShrinkConnections || _hasScaledConnectionGroup
+            ? await _connectionPool.LeaseConnectionByIndexAsync(_brokerId, connIdx, cancellationToken)
                 .ConfigureAwait(false)
-            : await _connectionPool.GetConnectionAsync(_brokerId, cancellationToken)
+            : await _connectionPool.LeaseConnectionAsync(_brokerId, cancellationToken)
                 .ConfigureAwait(false);
 
-        _pinnedConnections[connIdx] = connection;
-        return connection;
+        _pinnedConnections[connIdx] = connectionLease.Connection;
+        return connectionLease;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1963,6 +1963,23 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         throw CreateTransactionException(errorCode, classification, $"{operation} failed: {errorCode}");
     }
 
+    private async ValueTask<TResponse> SendWithConnectionLeaseAsync<TRequest, TResponse>(
+        int brokerId,
+        TRequest request,
+        short apiVersion,
+        CancellationToken cancellationToken)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        using var connectionLease = await _connectionPool.LeaseConnectionAsync(
+            brokerId,
+            cancellationToken).ConfigureAwait(false);
+        return await connectionLease.Connection.SendAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     internal async ValueTask ReinitializeProducerIdAsync(
         CancellationToken cancellationToken,
         bool keepPreparedTransaction = false)
@@ -1972,9 +1989,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var connection = await _connectionPool.GetConnectionAsync(_transactionCoordinatorId, cancellationToken)
-                .ConfigureAwait(false);
-
             var initProducerIdVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.InitProducerId,
                 InitProducerIdRequest.LowestSupportedVersion,
@@ -1996,9 +2010,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 KeepPreparedTransaction = keepPreparedTransaction
             };
 
-            var response = (InitProducerIdResponse)await connection
-                .SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
-                    request, initProducerIdVersion, cancellationToken)
+            var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                    _transactionCoordinatorId,
+                    request,
+                    initProducerIdVersion,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             if (response.ErrorCode != ErrorCode.None)
@@ -2080,16 +2096,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken)
-                .ConfigureAwait(false);
-
             var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.FindCoordinator,
                 FindCoordinatorRequest.LowestSupportedVersion,
                 FindCoordinatorRequest.HighestSupportedVersion);
 
-            var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-                request, findCoordinatorVersion, cancellationToken).ConfigureAwait(false);
+            var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                brokers[0].NodeId,
+                request,
+                findCoordinatorVersion,
+                cancellationToken).ConfigureAwait(false);
 
             if (response.Coordinators.Count == 0)
             {
@@ -2179,12 +2195,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var connection = await _connectionPool.GetConnectionAsync(_transactionCoordinatorId, cancellationToken)
-                .ConfigureAwait(false);
-
-            var response = (AddPartitionsToTxnResponse)await connection
-                .SendAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
-                    request, apiVersion, cancellationToken)
+            var response = await SendWithConnectionLeaseAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
+                    _transactionCoordinatorId,
+                    request,
+                    apiVersion,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             // Check for retriable errors in the response
@@ -2282,9 +2297,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var connection = await _connectionPool.GetConnectionAsync(_transactionCoordinatorId, cancellationToken)
-                .ConfigureAwait(false);
-
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.EndTxn,
                 EndTxnRequest.LowestSupportedVersion,
@@ -2299,29 +2311,35 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             };
 
             EndTxnResponse response;
-            if (afterRequestWrittenAsync is null)
+            using (var connectionLease = await _connectionPool.LeaseConnectionAsync(
+                       _transactionCoordinatorId,
+                       cancellationToken).ConfigureAwait(false))
             {
-                response = await connection
-                    .SendAsync<EndTxnRequest, EndTxnResponse>(
-                        request, apiVersion, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
+                var connection = connectionLease.Connection;
+                if (afterRequestWrittenAsync is null)
                 {
-                    throw new InvalidOperationException(
-                        "The transaction coordinator connection cannot report request write completion.");
+                    response = await connection
+                        .SendAsync<EndTxnRequest, EndTxnResponse>(
+                            request, apiVersion, cancellationToken)
+                        .ConfigureAwait(false);
                 }
+                else
+                {
+                    if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
+                    {
+                        throw new InvalidOperationException(
+                            "The transaction coordinator connection cannot report request write completion.");
+                    }
 
-                var responseTask = await writeCompletionConnection
-                    .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
-                        request, apiVersion, cancellationToken)
-                    .ConfigureAwait(false);
-                var requestWrittenCallback = afterRequestWrittenAsync;
-                afterRequestWrittenAsync = null;
-                await requestWrittenCallback().ConfigureAwait(false);
-                response = await responseTask.ConfigureAwait(false);
+                    var responseTask = await writeCompletionConnection
+                        .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
+                            request, apiVersion, cancellationToken)
+                        .ConfigureAwait(false);
+                    var requestWrittenCallback = afterRequestWrittenAsync;
+                    afterRequestWrittenAsync = null;
+                    await requestWrittenCallback().ConfigureAwait(false);
+                    response = await responseTask.ConfigureAwait(false);
+                }
             }
 
             if (response.ErrorCode == ErrorCode.None)
@@ -2387,9 +2405,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             // Step 1: Add offsets to the transaction via the transaction coordinator
-            var connection = await _connectionPool.GetConnectionAsync(_transactionCoordinatorId, cancellationToken)
-                .ConfigureAwait(false);
-
             var addOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.AddOffsetsToTxn,
                 AddOffsetsToTxnRequest.LowestSupportedVersion,
@@ -2403,9 +2418,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 GroupId = consumerGroupId
             };
 
-            var addOffsetsResponse = (AddOffsetsToTxnResponse)await connection
-                .SendAsync<AddOffsetsToTxnRequest, AddOffsetsToTxnResponse>(
-                    addOffsetsRequest, addOffsetsVersion, cancellationToken)
+            var addOffsetsResponse = await SendWithConnectionLeaseAsync<AddOffsetsToTxnRequest, AddOffsetsToTxnResponse>(
+                    _transactionCoordinatorId,
+                    addOffsetsRequest,
+                    addOffsetsVersion,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             if (addOffsetsResponse.ErrorCode != ErrorCode.None)
@@ -2421,9 +2438,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             // Step 2: Find the group coordinator
             var brokers = _metadataManager.Metadata.GetBrokers();
-            var brokerConnection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken)
-                .ConfigureAwait(false);
-
             var findCoordVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.FindCoordinator,
                 FindCoordinatorRequest.LowestSupportedVersion,
@@ -2435,9 +2449,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 KeyType = CoordinatorType.Group
             };
 
-            var findCoordResponse = await brokerConnection
-                .SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-                    findCoordRequest, findCoordVersion, cancellationToken)
+            var findCoordResponse = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                    brokers[0].NodeId,
+                    findCoordRequest,
+                    findCoordVersion,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             if (findCoordResponse.Coordinators.Count == 0)
@@ -2461,9 +2477,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             // Step 3: Send TxnOffsetCommit to the group coordinator
-            var groupConnection = await _connectionPool.GetConnectionAsync(coord.NodeId, cancellationToken)
-                .ConfigureAwait(false);
-
             var txnOffsetCommitVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.TxnOffsetCommit,
                 TxnOffsetCommitRequest.LowestSupportedVersion,
@@ -2505,9 +2518,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 Topics = txnTopics
             };
 
-            var txnOffsetCommitResponse = (TxnOffsetCommitResponse)await groupConnection
-                .SendAsync<TxnOffsetCommitRequest, TxnOffsetCommitResponse>(
-                    txnOffsetCommitRequest, txnOffsetCommitVersion, cancellationToken)
+            var txnOffsetCommitResponse = await SendWithConnectionLeaseAsync<TxnOffsetCommitRequest, TxnOffsetCommitResponse>(
+                    coord.NodeId,
+                    txnOffsetCommitRequest,
+                    txnOffsetCommitVersion,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             // Check for errors across all partitions
@@ -3383,9 +3398,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     throw new InvalidOperationException("No brokers available for idempotent producer initialization");
                 }
 
-                var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken)
-                    .ConfigureAwait(false);
-
                 var request = new InitProducerIdRequest
                 {
                     TransactionalId = null,
@@ -3394,9 +3406,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     ProducerEpoch = _producerEpoch
                 };
 
-                var response = (InitProducerIdResponse)await connection
-                    .SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
-                        request, initProducerIdVersion, cancellationToken)
+                var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                        brokers[0].NodeId,
+                        request,
+                        initProducerIdVersion,
+                        cancellationToken)
                     .ConfigureAwait(false);
 
                 if (response.ErrorCode == ErrorCode.None)
@@ -3510,9 +3524,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     throw new InvalidOperationException("No brokers available for epoch bump");
                 }
 
-                var connection = await _connectionPool.GetConnectionAsync(brokers[0].NodeId, cancellationToken)
-                    .ConfigureAwait(false);
-
                 var request = new InitProducerIdRequest
                 {
                     TransactionalId = null,
@@ -3521,9 +3532,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     ProducerEpoch = _producerEpoch
                 };
 
-                var response = (InitProducerIdResponse)await connection
-                    .SendAsync<InitProducerIdRequest, InitProducerIdResponse>(
-                        request, initProducerIdVersion, cancellationToken)
+                var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                        brokers[0].NodeId,
+                        request,
+                        initProducerIdVersion,
+                        cancellationToken)
                     .ConfigureAwait(false);
 
                 if (response.ErrorCode == ErrorCode.None)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3845,9 +3845,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 // so under normal parallel disposal the aggregate completes quickly.
                 // This outer deadline only fires if something beyond the per-sender
                 // timeout hangs (e.g., CancelAsync blocking on a slow callback).
-                await Task.WhenAll(disposeTasks)
-                    .WaitAsync(TimeSpan.FromMilliseconds(brokerDisposeMs))
-                    .ConfigureAwait(false);
+                var disposeSendersTask = Task.WhenAll(disposeTasks);
+                if (_ownsInfrastructure)
+                    await disposeSendersTask.ConfigureAwait(false);
+                else
+                    await disposeSendersTask
+                        .WaitAsync(TimeSpan.FromMilliseconds(brokerDisposeMs))
+                        .ConfigureAwait(false);
             }
             catch (TimeoutException)
             {

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -578,8 +578,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     {
         try
         {
-            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
             var response = (ShareFetchResponse)await connection
                 .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
                 .ConfigureAwait(false);
@@ -638,8 +639,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     {
         try
         {
-            var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
             await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
         }
@@ -666,8 +668,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             Topics = topics
         };
 
-        var connection = await _connectionPool.GetConnectionAsync(brokerId, cancellationToken)
+        using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
             .ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         var response = (ShareAcknowledgeResponse)await connection
             .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -135,9 +135,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             var broker = brokers[attempt % brokers.Count];
-            var connection = await _connectionPool.GetConnectionByIndexAsync(
+            using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
                 broker.NodeId, _getCoordinationConnectionIndex(), cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
                 ApiKey.FindCoordinator,
@@ -251,9 +252,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         bool isInitial,
         CancellationToken cancellationToken)
     {
-        var connection = await _connectionPool.GetConnectionByIndexAsync(
+        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
             _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
             .ConfigureAwait(false);
+        var connection = connectionLease.Connection;
 
         var version = _metadataManager.GetNegotiatedApiVersion(
             ApiKey.ShareGroupHeartbeat,
@@ -553,9 +555,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
 
         try
         {
-            var connection = await _connectionPool.GetConnectionByIndexAsync(
+            using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
                 _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
                 .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
 
             var request = new ShareGroupHeartbeatRequest
             {

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -266,11 +266,14 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
         try
         {
-            var connection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
-            if (connection is null)
+            var leasedConnection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
+            if (leasedConnection is null)
             {
                 return null;
             }
+
+            using var connectionLease = leasedConnection.Value;
+            var connection = connectionLease.Connection;
 
             var response = await connection.SendAsync<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(
                 new GetTelemetrySubscriptionsRequest { ClientInstanceId = clientInstanceId },
@@ -342,11 +345,14 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
         try
         {
-            var connection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
-            if (connection is null)
+            var leasedConnection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
+            if (leasedConnection is null)
             {
                 return ErrorCode.BrokerNotAvailable;
             }
+
+            using var connectionLease = leasedConnection.Value;
+            var connection = connectionLease.Connection;
 
             var metricSnapshot = _metricCollector?.Collect(subscription) ??
                 ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
@@ -429,12 +435,12 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         errorCode == ErrorCode.InvalidRequest ||
         errorCode == ErrorCode.InvalidRecord;
 
-    private async ValueTask<IKafkaConnection?> GetTelemetryConnectionAsync(CancellationToken cancellationToken)
+    private async ValueTask<KafkaConnectionLease?> GetTelemetryConnectionAsync(CancellationToken cancellationToken)
     {
         var brokerId = SelectBrokerId();
         return brokerId is null
             ? null
-            : await _connectionPool.GetConnectionAsync(brokerId.Value, cancellationToken).ConfigureAwait(false);
+            : await _connectionPool.LeaseConnectionAsync(brokerId.Value, cancellationToken).ConfigureAwait(false);
     }
 
     private int? SelectBrokerId()

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientClientMetricsResourcesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientClientMetricsResourcesTests.cs
@@ -4,6 +4,7 @@ using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Tests.Unit.Producer;
 using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Admin;
@@ -60,13 +61,35 @@ public sealed class AdminClientClientMetricsResourcesTests
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.ClusterAuthorizationFailed);
     }
 
-    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection()
+    [Test]
+    public async Task ListClientMetricsResourcesAsync_HoldsConnectionLeaseThroughResponse()
     {
-        var connection = Substitute.For<IKafkaConnection>();
-        connection.BrokerId.Returns(1);
-        connection.Host.Returns("localhost");
-        connection.Port.Returns(9092);
-        connection.IsConnected.Returns(true);
+        var connection = new TestKafkaConnection
+        {
+            SendResponse = static requestType => requestType == typeof(ListClientMetricsResourcesRequest)
+                ? new ListClientMetricsResourcesResponse { ErrorCode = ErrorCode.None }
+                : throw new NotSupportedException()
+        };
+        var (admin, _) = CreateAdminWithMockConnection(connection);
+        var retirableConnection = (IRetirableKafkaConnection)connection;
+
+        await admin.ListClientMetricsResourcesAsync();
+
+        await Assert.That(connection.LeaseCountDuringRequest).IsEqualTo(1);
+        await Assert.That(retirableConnection.LeaseCount).IsEqualTo(0);
+    }
+
+    private static (AdminClient Admin, IKafkaConnection Connection) CreateAdminWithMockConnection(
+        IKafkaConnection? suppliedConnection = null)
+    {
+        var connection = suppliedConnection ?? Substitute.For<IKafkaConnection>();
+        if (suppliedConnection is null)
+        {
+            connection.BrokerId.Returns(1);
+            connection.Host.Returns("localhost");
+            connection.Port.Returns(9092);
+            connection.IsConnected.Returns(true);
+        }
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -79,25 +102,28 @@ public sealed class AdminClientClientMetricsResourcesTests
         metadataManager.SetApiVersion(ApiKey.ListClientMetricsResources, 0, 0);
         metadataManager.SetApiVersion(ApiKey.Metadata, 9, 13);
 
-        connection.SendAsync<MetadataRequest, MetadataResponse>(
-                Arg.Any<MetadataRequest>(),
-                Arg.Any<short>(),
-                Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(CreateMetadataResponse()));
+        if (suppliedConnection is null)
+        {
+            connection.SendAsync<MetadataRequest, MetadataResponse>(
+                    Arg.Any<MetadataRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ValueTask.FromResult(CreateMetadataResponse()));
 
-        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-                Arg.Any<ApiVersionsRequest>(),
-                Arg.Any<short>(),
-                Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(new ApiVersionsResponse
-            {
-                ErrorCode = ErrorCode.None,
-                ApiKeys =
-                [
-                    new ApiVersion(ApiKey.Metadata, 9, 13),
-                    new ApiVersion(ApiKey.ListClientMetricsResources, 0, 0)
-                ]
-            }));
+            connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    Arg.Any<ApiVersionsRequest>(),
+                    Arg.Any<short>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ValueTask.FromResult(new ApiVersionsResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    ApiKeys =
+                    [
+                        new ApiVersion(ApiKey.Metadata, 9, 13),
+                        new ApiVersion(ApiKey.ListClientMetricsResources, 0, 0)
+                    ]
+                }));
+        }
 
         var admin = new AdminClient(
             new AdminClientOptions { BootstrapServers = ["localhost:9092"] },

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -284,6 +284,41 @@ public sealed class ConsumerConnectionOwnershipTests
         _ = pool.Received(1).DisposeAsync();
     }
 
+    [Test]
+    public async Task StandaloneConsumer_Dispose_KeepsPoolAliveUntilRetiredLeaseReleases()
+    {
+        var pool = CreatePool();
+        var removedConnection = new TrackedConnection(
+            hasPendingRequest: false,
+            hasLease: true);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(removedConnection));
+        var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+        var leaseReleased = false;
+
+        TriggerScaleDown(consumer);
+        var disposeTask = consumer.DisposeAsync().AsTask();
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5.2));
+            _ = pool.DidNotReceive().DisposeAsync();
+
+            removedConnection.ReleaseLease();
+            leaseReleased = true;
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            if (!leaseReleased)
+                removedConnection.ReleaseLease();
+            await consumer.DisposeAsync();
+        }
+
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(1);
+        _ = pool.Received(1).DisposeAsync();
+    }
+
     private static IConnectionPool CreatePool()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -44,10 +44,14 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
-    [Arguments(false)]
-    [Arguments(true)]
-    public async Task Consumer_ScaleDown_ClosesStaleFetchSessionOnRetainedConnection(
-        bool ownsInfrastructure)
+    [Arguments(false, 1, true)]
+    [Arguments(true, 1, true)]
+    [Arguments(false, 2, true)]
+    [Arguments(true, 2, false)]
+    public async Task Consumer_ScaleDown_ClosesOnlyReachableStaleFetchSession(
+        bool ownsInfrastructure,
+        int sessionConnectionIndex,
+        bool expectsCloseRequest)
     {
         var pool = CreatePool();
         var closeRequest = new TaskCompletionSource<(int SessionId, int SessionEpoch)>(
@@ -55,7 +59,7 @@ public sealed class ConsumerConnectionOwnershipTests
         var connection = new TrackedConnection(
             hasPendingRequest: false,
             onFetchRequest: request => closeRequest.TrySetResult((request.SessionId, request.SessionEpoch)));
-        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+        pool.GetConnectionByIndexAsync(1, sessionConnectionIndex, Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
 
         var metadataManager = CreateMetadataManager(pool);
@@ -78,7 +82,7 @@ public sealed class ConsumerConnectionOwnershipTests
                 ErrorCode = ErrorCode.None,
                 SessionId = 42
             });
-            fetchSessions[(1, 1)] = handler;
+            fetchSessions[(1, sessionConnectionIndex)] = handler;
 
             var dispatchMethod = typeof(KafkaConsumer<string, string>).GetMethod(
                 "DispatchReadyBrokerPrefetchesAsync",
@@ -89,13 +93,24 @@ public sealed class ConsumerConnectionOwnershipTests
                 [CancellationToken.None])!;
 
             var result = await dispatch;
-            var close = await closeRequest.Task.WaitAsync(TimeSpan.FromSeconds(1));
-
-            await Assert.That(result.Started).IsEqualTo(1);
-            await Assert.That(close.SessionId).IsEqualTo(42);
-            await Assert.That(close.SessionEpoch).IsEqualTo(-1);
-            await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
-            await Assert.That(connection.LeaseCount).IsEqualTo(0);
+            if (expectsCloseRequest)
+            {
+                var close = await closeRequest.Task.WaitAsync(TimeSpan.FromSeconds(1));
+                await Assert.That(result.Started).IsEqualTo(1);
+                await Assert.That(close.SessionId).IsEqualTo(42);
+                await Assert.That(close.SessionEpoch).IsEqualTo(-1);
+                await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+                await Assert.That(connection.LeaseCount).IsEqualTo(0);
+            }
+            else
+            {
+                await Assert.That(result.Started).IsEqualTo(0);
+                await pool.DidNotReceive().GetConnectionByIndexAsync(
+                    1,
+                    sessionConnectionIndex,
+                    Arg.Any<CancellationToken>());
+                await Assert.That(fetchSessions.ContainsKey((1, sessionConnectionIndex))).IsFalse();
+            }
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -66,6 +66,48 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
+    public async Task StandaloneConsumer_ScaleDown_WaitsForLeasedHolderBeforeDisposal()
+    {
+        var pool = CreatePool();
+        var removedConnection = new TrackedConnection(
+            hasPendingRequest: false,
+            hasLease: true);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(removedConnection));
+        await using var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+
+        TriggerScaleDown(consumer);
+
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(0);
+
+        removedConnection.ReleaseLease();
+        await TestWait.UntilAsync(
+            () => removedConnection.DisposeCount == 1,
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task StandaloneConsumer_ScaleDown_WaitsForActiveOperationBeforeDisposal()
+    {
+        var pool = CreatePool();
+        var removedConnection = new TrackedConnection(
+            hasPendingRequest: false,
+            activeOperationCount: 1);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(removedConnection));
+        await using var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+
+        TriggerScaleDown(consumer);
+
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(0);
+
+        removedConnection.CompleteOperation();
+        await TestWait.UntilAsync(
+            () => removedConnection.DisposeCount == 1,
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task StandaloneConsumer_Dispose_WaitsForLateShrinkAndDisposesReturnedConnection()
     {
         var pool = CreatePool();
@@ -194,13 +236,19 @@ public sealed class ConsumerConnectionOwnershipTests
         scaler.MaybeScale();
     }
 
-    private sealed class TrackedConnection(bool hasPendingRequest) :
+    private sealed class TrackedConnection(
+        bool hasPendingRequest,
+        bool hasLease = false,
+        int activeOperationCount = 0) :
         IKafkaConnection,
-        IIdleTrackedKafkaConnection
+        IIdleTrackedKafkaConnection,
+        IRetirableKafkaConnection
     {
         private readonly TaskCompletionSource _activeRequest = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
         private int _pendingRequestCount = hasPendingRequest ? 1 : 0;
+        private int _leaseCount = hasLease ? 1 : 0;
+        private int _activeOperationCount = activeOperationCount;
         private int _disposeCount;
 
         public int BrokerId => 1;
@@ -211,6 +259,8 @@ public sealed class ConsumerConnectionOwnershipTests
         public int DisposeCount => Volatile.Read(ref _disposeCount);
         public long LastUsedTimestampMs => 0;
         public int PendingRequestCount => Volatile.Read(ref _pendingRequestCount);
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int ActiveOperationCount => Volatile.Read(ref _activeOperationCount);
 
         public void CompleteRequest()
         {
@@ -218,7 +268,25 @@ public sealed class ConsumerConnectionOwnershipTests
             _activeRequest.TrySetResult();
         }
 
+        public void CompleteOperation() => Interlocked.Decrement(ref _activeOperationCount);
+
         public void Touch()
+        {
+        }
+
+        public bool TryAcquireLease()
+        {
+            Interlocked.Increment(ref _leaseCount);
+            return true;
+        }
+
+        public void ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+        public void BeginRetirement()
+        {
+        }
+
+        public void CompleteRetirement()
         {
         }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -186,6 +186,47 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
+    public async Task StandaloneConsumer_ScaleDown_DrainsBrokerConnectionsConcurrently()
+    {
+        var pool = CreatePool();
+        var firstConnection = new TrackedConnection(
+            hasPendingRequest: false,
+            hasLease: true);
+        var secondConnection = new TrackedConnection(hasPendingRequest: false);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(firstConnection));
+        pool.ShrinkConnectionGroupAsync(2, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(secondConnection));
+        var consumer = CreateStandaloneConsumer(
+            pool,
+            CreateMetadataManager(pool, includeSecondBroker: true));
+        var firstLeaseReleased = false;
+
+        try
+        {
+            TriggerScaleDown(consumer);
+
+            await TestWait.UntilAsync(
+                () => secondConnection.DisposeCount == 1,
+                TimeSpan.FromSeconds(5));
+            _ = pool.Received(1).ShrinkConnectionGroupAsync(2, 2, Arg.Any<CancellationToken>());
+            await Assert.That(firstConnection.DisposeCount).IsEqualTo(0);
+
+            firstConnection.ReleaseLease();
+            firstLeaseReleased = true;
+            await TestWait.UntilAsync(
+                () => firstConnection.DisposeCount == 1,
+                TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            if (!firstLeaseReleased)
+                firstConnection.ReleaseLease();
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task StandaloneConsumer_Dispose_WaitsForLateShrinkAndDisposesReturnedConnection()
     {
         var pool = CreatePool();
@@ -250,19 +291,23 @@ public sealed class ConsumerConnectionOwnershipTests
         return pool;
     }
 
-    private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+    private static MetadataManager CreateMetadataManager(IConnectionPool pool, bool includeSecondBroker = false)
     {
         var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        var brokers = new List<BrokerMetadata>
+        {
+            new() { NodeId = 1, Host = "localhost", Port = 9092 }
+        };
+        if (includeSecondBroker)
+            brokers.Add(new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 });
+
         metadataManager.SetApiVersion(
             ApiKey.Fetch,
             FetchRequest.LowestSupportedVersion,
             FetchRequest.HighestSupportedVersion);
         metadataManager.Metadata.Update(new MetadataResponse
         {
-            Brokers =
-            [
-                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
-            ],
+            Brokers = brokers,
             Topics = []
         });
         return metadataManager;

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -1,0 +1,287 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerConnectionOwnershipTests
+{
+    [Test]
+    public async Task SharedConsumer_ScaleDown_DoesNotShrinkSiblingConnection()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var siblingConnection = new TrackedConnection(hasPendingRequest: true);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(siblingConnection));
+        var metadataManager = CreateMetadataManager(pool);
+        var consumer = CreateSharedConsumer(pool, metadataManager);
+
+        try
+        {
+            TriggerScaleDown(consumer);
+
+            _ = pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+
+            siblingConnection.CompleteRequest();
+            await siblingConnection.ActiveRequest;
+            await Assert.That(siblingConnection.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task StandaloneConsumer_ScaleDown_DrainsAndDisposesRemovedConnectionOnce()
+    {
+        var pool = CreatePool();
+        var removedConnection = new TrackedConnection(hasPendingRequest: true);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(removedConnection));
+        await using var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+
+        TriggerScaleDown(consumer);
+
+        _ = pool.Received(1).ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>());
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(0);
+
+        removedConnection.CompleteRequest();
+        await TestWait.UntilAsync(
+            () => removedConnection.DisposeCount == 1,
+            TimeSpan.FromSeconds(5));
+
+        await consumer.DisposeAsync();
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task StandaloneConsumer_Dispose_WaitsForLateShrinkAndDisposesReturnedConnection()
+    {
+        var pool = CreatePool();
+        var shrinkCompletion = new TaskCompletionSource<IKafkaConnection?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var removedConnection = new TrackedConnection(hasPendingRequest: false);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection?>(shrinkCompletion.Task));
+        var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+
+        TriggerScaleDown(consumer);
+        var disposeTask = consumer.DisposeAsync().AsTask();
+
+        try
+        {
+            _ = pool.DidNotReceive().DisposeAsync();
+            shrinkCompletion.SetResult(removedConnection);
+            await disposeTask;
+        }
+        finally
+        {
+            shrinkCompletion.TrySetResult(removedConnection);
+            await consumer.DisposeAsync();
+        }
+
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(1);
+        _ = pool.Received(1).DisposeAsync();
+    }
+
+    [Test]
+    public async Task StandaloneConsumer_Dispose_WaitsForFaultedShrinkBeforeDisposingPool()
+    {
+        var pool = CreatePool();
+        var shrinkCompletion = new TaskCompletionSource<IKafkaConnection?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection?>(shrinkCompletion.Task));
+        var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+
+        TriggerScaleDown(consumer);
+        var disposeTask = consumer.DisposeAsync().AsTask();
+
+        try
+        {
+            _ = pool.DidNotReceive().DisposeAsync();
+            shrinkCompletion.SetException(new IOException("shrink failed"));
+            await disposeTask;
+        }
+        finally
+        {
+            shrinkCompletion.TrySetException(new IOException("shrink failed"));
+            await consumer.DisposeAsync();
+        }
+
+        _ = pool.Received(1).DisposeAsync();
+    }
+
+    private static IConnectionPool CreatePool()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.DisposeAsync().Returns(ValueTask.CompletedTask);
+        return pool;
+    }
+
+    private static MetadataManager CreateMetadataManager(IConnectionPool pool)
+    {
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }
+            ],
+            Topics = []
+        });
+        return metadataManager;
+    }
+
+    private static KafkaConsumer<string, string> CreateStandaloneConsumer(
+        IConnectionPool pool,
+        MetadataManager metadataManager)
+        => new(
+            CreateOptions(),
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+    private static KafkaConsumer<string, string> CreateSharedConsumer(
+        IConnectionPool pool,
+        MetadataManager metadataManager)
+        => new(
+            CreateOptions(),
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager,
+            new TestMemoryBudget());
+
+    private static ConsumerOptions CreateOptions() =>
+        new()
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "connection-ownership-test",
+            ConnectionsPerBroker = 2,
+            MaxConnectionsPerBroker = 4,
+            EnableAdaptiveConnections = true,
+            QueuedMaxMessagesKbytes = 1,
+            IsAutoTuned = false
+        };
+
+    private static void TriggerScaleDown(KafkaConsumer<string, string> consumer)
+    {
+        var scalerField = typeof(KafkaConsumer<string, string>).GetField(
+            "_connectionScaler",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_connectionScaler field not found");
+        var scaler = (ConsumerConnectionScaler?)scalerField.GetValue(consumer)
+            ?? throw new InvalidOperationException("Connection scaler was not created");
+
+        scaler.TestSetConnectionCount(3);
+        scaler.ReportPipelineUtilization(0, pipelineDepth: 3);
+        scaler.MaybeScale();
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(121));
+        scaler.ReportPipelineUtilization(0, pipelineDepth: 3);
+        scaler.MaybeScale();
+    }
+
+    private sealed class TrackedConnection(bool hasPendingRequest) :
+        IKafkaConnection,
+        IIdleTrackedKafkaConnection
+    {
+        private readonly TaskCompletionSource _activeRequest = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _pendingRequestCount = hasPendingRequest ? 1 : 0;
+        private int _disposeCount;
+
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public Task ActiveRequest => _activeRequest.Task;
+        public int DisposeCount => Volatile.Read(ref _disposeCount);
+        public long LastUsedTimestampMs => 0;
+        public int PendingRequestCount => Volatile.Read(ref _pendingRequestCount);
+
+        public void CompleteRequest()
+        {
+            Volatile.Write(ref _pendingRequestCount, 0);
+            _activeRequest.TrySetResult();
+        }
+
+        public void Touch()
+        {
+        }
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse =>
+            throw new NotSupportedException();
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _disposeCount);
+            _activeRequest.TrySetException(new ObjectDisposedException(nameof(TrackedConnection)));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TestMemoryBudget : IDekafMemoryBudget
+    {
+        public ulong PreviewProducerLimit() => 1;
+        public ulong PreviewConsumerLimit() => 1;
+        public void RegisterProducer(IBudgetedInstance instance) { }
+        public void UnregisterProducer(IBudgetedInstance instance) { }
+        public void RegisterConsumer(IBudgetedInstance instance) { }
+        public void UnregisterConsumer(IBudgetedInstance instance) { }
+        public void ReserveExplicit(ulong bytes) { }
+        public void ReleaseExplicit(ulong bytes) { }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -44,7 +44,10 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
-    public async Task SharedConsumer_ScaleDown_ClosesStaleFetchSessionOnSharedConnection()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Consumer_ScaleDown_ClosesStaleFetchSessionOnRetainedConnection(
+        bool ownsInfrastructure)
     {
         var pool = CreatePool();
         var closeRequest = new TaskCompletionSource<(int SessionId, int SessionEpoch)>(
@@ -56,7 +59,9 @@ public sealed class ConsumerConnectionOwnershipTests
             .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
 
         var metadataManager = CreateMetadataManager(pool);
-        var consumer = CreateSharedConsumer(pool, metadataManager);
+        var consumer = ownsInfrastructure
+            ? CreateStandaloneConsumer(pool, metadataManager)
+            : CreateSharedConsumer(pool, metadataManager);
 
         try
         {
@@ -95,7 +100,8 @@ public sealed class ConsumerConnectionOwnershipTests
         finally
         {
             await consumer.DisposeAsync();
-            await metadataManager.DisposeAsync();
+            if (!ownsInfrastructure)
+                await metadataManager.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Internal;
@@ -34,6 +35,62 @@ public sealed class ConsumerConnectionOwnershipTests
             siblingConnection.CompleteRequest();
             await siblingConnection.ActiveRequest;
             await Assert.That(siblingConnection.DisposeCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task SharedConsumer_ScaleDown_ClosesStaleFetchSessionOnSharedConnection()
+    {
+        var pool = CreatePool();
+        var closeRequest = new TaskCompletionSource<(int SessionId, int SessionEpoch)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new TrackedConnection(
+            hasPendingRequest: false,
+            onFetchRequest: request => closeRequest.TrySetResult((request.SessionId, request.SessionEpoch)));
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+
+        var metadataManager = CreateMetadataManager(pool);
+        var consumer = CreateSharedConsumer(pool, metadataManager);
+
+        try
+        {
+            var fetchSessionsField = typeof(KafkaConsumer<string, string>).GetField(
+                "_fetchSessions",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("_fetchSessions field not found");
+            var fetchSessions = (ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler>)
+                fetchSessionsField.GetValue(consumer)!;
+            var handler = new FetchSessionHandler();
+            _ = handler.Build([], clusterMetadata: null);
+            _ = handler.HandleResponse(new FetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                SessionId = 42
+            });
+            fetchSessions[(1, 1)] = handler;
+
+            var dispatchMethod = typeof(KafkaConsumer<string, string>).GetMethod(
+                "DispatchReadyBrokerPrefetchesAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("DispatchReadyBrokerPrefetchesAsync method not found");
+            var dispatch = (ValueTask<(int Started, int TargetCount)>)dispatchMethod.Invoke(
+                consumer,
+                [CancellationToken.None])!;
+
+            var result = await dispatch;
+            var close = await closeRequest.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            await Assert.That(result.Started).IsEqualTo(1);
+            await Assert.That(close.SessionId).IsEqualTo(42);
+            await Assert.That(close.SessionEpoch).IsEqualTo(-1);
+            await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+            await Assert.That(connection.LeaseCount).IsEqualTo(0);
         }
         finally
         {
@@ -175,6 +232,10 @@ public sealed class ConsumerConnectionOwnershipTests
     private static MetadataManager CreateMetadataManager(IConnectionPool pool)
     {
         var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.SetApiVersion(
+            ApiKey.Fetch,
+            FetchRequest.LowestSupportedVersion,
+            FetchRequest.HighestSupportedVersion);
         metadataManager.Metadata.Update(new MetadataResponse
         {
             Brokers =
@@ -239,7 +300,8 @@ public sealed class ConsumerConnectionOwnershipTests
     private sealed class TrackedConnection(
         bool hasPendingRequest,
         bool hasLease = false,
-        int activeOperationCount = 0) :
+        int activeOperationCount = 0,
+        Action<FetchRequest>? onFetchRequest = null) :
         IKafkaConnection,
         IIdleTrackedKafkaConnection,
         IRetirableKafkaConnection
@@ -248,6 +310,7 @@ public sealed class ConsumerConnectionOwnershipTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         private int _pendingRequestCount = hasPendingRequest ? 1 : 0;
         private int _leaseCount = hasLease ? 1 : 0;
+        private int _leaseAcquisitionCount;
         private int _activeOperationCount = activeOperationCount;
         private int _disposeCount;
 
@@ -260,6 +323,7 @@ public sealed class ConsumerConnectionOwnershipTests
         public long LastUsedTimestampMs => 0;
         public int PendingRequestCount => Volatile.Read(ref _pendingRequestCount);
         public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int LeaseAcquisitionCount => Volatile.Read(ref _leaseAcquisitionCount);
         public int ActiveOperationCount => Volatile.Read(ref _activeOperationCount);
 
         public void CompleteRequest()
@@ -276,6 +340,7 @@ public sealed class ConsumerConnectionOwnershipTests
 
         public bool TryAcquireLease()
         {
+            Interlocked.Increment(ref _leaseAcquisitionCount);
             Interlocked.Increment(ref _leaseCount);
             return true;
         }
@@ -298,8 +363,16 @@ public sealed class ConsumerConnectionOwnershipTests
             short apiVersion,
             CancellationToken cancellationToken = default)
             where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse =>
+            where TResponse : IKafkaResponse
+        {
+            if (request is FetchRequest fetchRequest && typeof(TResponse) == typeof(FetchResponse))
+            {
+                onFetchRequest?.Invoke(fetchRequest);
+                return ValueTask.FromResult((TResponse)(object)new FetchResponse { ErrorCode = ErrorCode.None });
+            }
+
             throw new NotSupportedException();
+        }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
             TRequest request,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -314,6 +315,25 @@ public sealed class ConsumerConnectionScalerTests
         await scaler.StopAndDrainAsync(TimeSpan.FromSeconds(1));
 
         await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Dispose_DisposesOperationCancellationSource()
+    {
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ => ValueTask.CompletedTask,
+            scaleDownAsync: _ => ValueTask.CompletedTask);
+        var field = typeof(ConsumerConnectionScaler).GetField(
+            "_operationCancellationSource",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Cancellation source field not found");
+        var source = (CancellationTokenSource)field.GetValue(scaler)!;
+
+        scaler.Dispose();
+
+        await Assert.That(source.Cancel).Throws<ObjectDisposedException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -195,6 +195,48 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task MaybeScale_StopBeforeOperationLock_DoesNotChangeCountOrDispatch()
+    {
+        var scaleUpCount = 0;
+        var beforeOperationLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var continueScale = new ManualResetEventSlim();
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ =>
+            {
+                Interlocked.Increment(ref scaleUpCount);
+                return ValueTask.CompletedTask;
+            },
+            scaleDownAsync: _ => ValueTask.CompletedTask)
+        {
+            BeforeScaleOperationLockForTest = () =>
+            {
+                beforeOperationLock.TrySetResult();
+                continueScale.Wait();
+            }
+        };
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+
+        var scaleTask = Task.Run(scaler.MaybeScale);
+        try
+        {
+            await beforeOperationLock.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await scaler.StopAndDrainAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            continueScale.Set();
+        }
+
+        await scaleTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(scaleUpCount).IsEqualTo(0);
+        await Assert.That(scaler.CurrentConnectionCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task StopAndDrainAsync_PendingOperation_ReturnsAfterTimeout()
     {
         var scaleCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -263,6 +263,27 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task StopAndDrainAsync_WithoutTimeout_WaitsForPendingOperation()
+    {
+        var scaleCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ => new ValueTask(scaleCompletion.Task),
+            scaleDownAsync: _ => ValueTask.CompletedTask);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.MaybeScale();
+
+        var drainTask = scaler.StopAndDrainAsync().AsTask();
+        await Assert.That(drainTask.IsCompleted).IsFalse();
+
+        scaleCompletion.SetResult();
+        await drainTask.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
     public async Task StopAndDrainAsync_CancelsPendingOperation()
     {
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -263,6 +263,73 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task StopAndDrainAsync_CancelsPendingOperation()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: async cancellationToken =>
+            {
+                operationStarted.TrySetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationObserved.TrySetResult();
+                    throw;
+                }
+            },
+            scaleDownAsync: _ => ValueTask.CompletedTask);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.MaybeScale();
+
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await scaler.StopAndDrainAsync(TimeSpan.FromSeconds(1));
+
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task MaybeScale_SynchronousDelegatePrefix_DoesNotHoldOperationLock()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseOperation = new ManualResetEventSlim();
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ =>
+            {
+                operationStarted.TrySetResult();
+                releaseOperation.Wait(CancellationToken.None);
+                return ValueTask.CompletedTask;
+            },
+            scaleDownAsync: _ => ValueTask.CompletedTask);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+
+        var firstScale = Task.Run(scaler.MaybeScale);
+        await operationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var secondScale = Task.Run(scaler.MaybeScale);
+        try
+        {
+            await secondScale.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            releaseOperation.Set();
+            await firstScale.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
     public async Task SplitPartitions_SingleConnection_ReturnsSingleGroup()
     {
         var groups = new (int StartIndex, int Count)[1];

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -176,6 +176,32 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task StopAndDrainAsync_PendingOperation_ReturnsAfterTimeout()
+    {
+        var scaleCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ => new ValueTask(scaleCompletion.Task),
+            scaleDownAsync: _ => ValueTask.CompletedTask);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.MaybeScale();
+
+        try
+        {
+            await scaler.StopAndDrainAsync(TimeSpan.Zero);
+            await Assert.That(scaleCompletion.Task.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            scaleCompletion.TrySetResult();
+            await scaler.StopAndDrainAsync(TimeSpan.FromSeconds(1));
+        }
+    }
+
+    [Test]
     public async Task SplitPartitions_SingleConnection_ReturnsSingleGroup()
     {
         var groups = new (int StartIndex, int Count)[1];

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionScalerTests.cs
@@ -176,6 +176,25 @@ public sealed class ConsumerConnectionScalerTests
     }
 
     [Test]
+    public async Task MaybeScale_SynchronousDelegateThrow_LogsError()
+    {
+        var exception = new InvalidOperationException("scale failed synchronously");
+        Exception? logged = null;
+        var scaler = new ConsumerConnectionScaler(
+            initialConnectionCount: 2,
+            maxConnectionCount: 4,
+            scaleUpAsync: _ => throw exception,
+            scaleDownAsync: _ => ValueTask.CompletedTask,
+            logError: ex => logged = ex);
+
+        scaler.ReportPipelineUtilization(3, 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.MaybeScale();
+
+        await Assert.That(logged).IsSameReferenceAs(exception);
+    }
+
+    [Test]
     public async Task StopAndDrainAsync_PendingOperation_ReturnsAfterTimeout()
     {
         var scaleCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/QueryWatermarkOffsetsTests.cs
@@ -21,9 +21,9 @@ public sealed class QueryWatermarkOffsetsTests
     public async Task QueryWatermarkOffsetsAsync_UsesCoordinationConnectionAndStartsRequestsConcurrently()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
-        var connection = Substitute.For<IKafkaConnection>();
+        var connection = new LeaseTrackingConnection();
         connectionPool.GetConnectionByIndexAsync(0, 1, Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(connection));
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
         metadataManager.SetApiVersion(ApiKey.ListOffsets, ListOffsetsRequest.LowestSupportedVersion, ListOffsetsRequest.HighestSupportedVersion);
@@ -45,32 +45,29 @@ public sealed class QueryWatermarkOffsetsTests
         var latestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-                Arg.Any<ListOffsetsRequest>(),
-                Arg.Any<short>(),
-                Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var request = ci.Arg<ListOffsetsRequest>();
-                var timestamp = request.Topics[0].Partitions[0].Timestamp;
-                var currentLeaderEpoch = request.Topics[0].Partitions[0].CurrentLeaderEpoch;
+        connection.SendHandler = request =>
+        {
+            var timestamp = request.Topics[0].Partitions[0].Timestamp;
+            var currentLeaderEpoch = request.Topics[0].Partitions[0].CurrentLeaderEpoch;
 
-                if (currentLeaderEpoch != 3)
-                    throw new InvalidOperationException($"Unexpected CurrentLeaderEpoch {currentLeaderEpoch}");
+            if (currentLeaderEpoch != 3)
+                throw new InvalidOperationException($"Unexpected CurrentLeaderEpoch {currentLeaderEpoch}");
 
-                if (timestamp == EarliestOffsetTimestamp)
-                    earliestStarted.TrySetResult();
-                else if (timestamp == LatestOffsetTimestamp)
-                    latestStarted.TrySetResult();
-                else
-                    throw new InvalidOperationException($"Unexpected ListOffsets timestamp {timestamp}");
+            if (timestamp == EarliestOffsetTimestamp)
+                earliestStarted.TrySetResult();
+            else if (timestamp == LatestOffsetTimestamp)
+                latestStarted.TrySetResult();
+            else
+                throw new InvalidOperationException($"Unexpected ListOffsets timestamp {timestamp}");
 
-                return new ValueTask<ListOffsetsResponse>(CreateListOffsetsResponseAsync(timestamp, releaseResponses.Task));
-            });
+            return new ValueTask<ListOffsetsResponse>(CreateListOffsetsResponseAsync(timestamp, releaseResponses.Task));
+        };
 
         var queryTask = consumer.QueryWatermarkOffsetsAsync(new TopicPartition(Topic, Partition), CancellationToken.None).AsTask();
 
         await earliestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await Assert.That(connection.LeaseAcquisitionCount).IsEqualTo(1);
+        await Assert.That(connection.LeaseCount).IsEqualTo(1);
         try
         {
             await latestStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
@@ -91,6 +88,7 @@ public sealed class QueryWatermarkOffsetsTests
             0,
             1,
             Arg.Any<CancellationToken>());
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
     }
 
     private static async Task<ListOffsetsResponse> CreateListOffsetsResponseAsync(long timestamp, Task release)
@@ -159,5 +157,79 @@ public sealed class QueryWatermarkOffsetsTests
             ?? throw new InvalidOperationException("_initialized field not found - was it renamed?");
 
         initializedField.SetValue(consumer, true);
+    }
+
+    private sealed class LeaseTrackingConnection : IKafkaConnection, IRetirableKafkaConnection
+    {
+        private int _leaseCount;
+        private int _leaseAcquisitionCount;
+
+        public Func<ListOffsetsRequest, ValueTask<ListOffsetsResponse>>? SendHandler { get; set; }
+        public int BrokerId => 0;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int LeaseAcquisitionCount => Volatile.Read(ref _leaseAcquisitionCount);
+        public int ActiveOperationCount => 0;
+
+        public bool TryAcquireLease()
+        {
+            Interlocked.Increment(ref _leaseAcquisitionCount);
+            Interlocked.Increment(ref _leaseCount);
+            return true;
+        }
+
+        public void ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+        public void BeginRetirement() { }
+        public void CompleteRetirement() { }
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is not ListOffsetsRequest listOffsetsRequest
+                || typeof(TResponse) != typeof(ListOffsetsResponse)
+                || SendHandler is null)
+            {
+                throw new NotSupportedException();
+            }
+
+            var response = await SendHandler(listOffsetsRequest);
+            return (TResponse)(object)response;
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionLeaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionLeaseTests.cs
@@ -1,0 +1,44 @@
+using Dekaf.Networking;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class KafkaConnectionLeaseTests
+{
+    [Test]
+    public async Task LeaseConnectionByIndex_RetiredSelection_RetriesAndReleasesLease()
+    {
+        await using var retiredConnection = new KafkaConnection("localhost", 9092);
+        await using var activeConnection = new KafkaConnection("localhost", 9093);
+        ((IRetirableKafkaConnection)retiredConnection).BeginRetirement();
+        var pool = Substitute.For<IConnectionPool>();
+        var selectionCount = 0;
+        pool.GetConnectionByIndexAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult<IKafkaConnection>(
+                Interlocked.Increment(ref selectionCount) == 1
+                    ? retiredConnection
+                    : activeConnection));
+
+        using (var lease = await pool.LeaseConnectionByIndexAsync(1, 2, CancellationToken.None))
+        {
+            await Assert.That(lease.Connection).IsSameReferenceAs(activeConnection);
+            await Assert.That(((IRetirableKafkaConnection)activeConnection).LeaseCount).IsEqualTo(1);
+        }
+
+        _ = pool.Received(2).GetConnectionByIndexAsync(1, 2, Arg.Any<CancellationToken>());
+        await Assert.That(((IRetirableKafkaConnection)activeConnection).LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task LeaseConnection_NonRetirableConnection_ReturnsNoOpLease()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        using var lease = await pool.LeaseConnectionAsync(1, CancellationToken.None);
+
+        await Assert.That(lease.Connection).IsSameReferenceAs(connection);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -138,6 +138,26 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task SendAsync_AfterRetirementSealed_ThrowsObjectDisposedException()
+    {
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var retirableConnection = (IRetirableKafkaConnection)connection;
+
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+        await Assert.That(retirableConnection.TryAcquireLease()).IsFalse();
+        retirableConnection.ReleaseLease();
+        retirableConnection.CompleteRetirement();
+
+        Func<Task> act = () => connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+            apiVersion: 3).AsTask();
+
+        await Assert.That(act).Throws<ObjectDisposedException>();
+        await Assert.That(retirableConnection.ActiveOperationCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConnectAsync_AfterDispose_ThrowsObjectDisposedException()
     {
         var connection = new KafkaConnection("localhost", 9092);

--- a/tests/Dekaf.Tests.Unit/Networking/RetiredConnectionDisposerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/RetiredConnectionDisposerTests.cs
@@ -1,0 +1,27 @@
+using Dekaf.Networking;
+using Dekaf.Tests.Unit.Producer;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class RetiredConnectionDisposerTests
+{
+    [Test]
+    public async Task DrainAndDisposeAsync_CancelledWhileLeased_DoesNotDisposeConnection()
+    {
+        var connection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)connection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        var exception = await Assert.That(async () =>
+                await RetiredConnectionDisposer.DrainAndDisposeAsync(
+                    connection,
+                    cancellationSource.Token))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(connection.DisposeCalls).IsEqualTo(0);
+        retirableConnection.ReleaseLease();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -550,8 +550,6 @@ public sealed class AdaptiveScaleDownTests
         var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
         var removedConnection = new TestKafkaConnection();
         var retirableConnection = (IRetirableKafkaConnection)removedConnection;
-        var drainStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        sender.RetirementDrainStartedForTest = () => drainStarted.TrySetResult();
         await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
         retirableConnection.BeginRetirement();
 
@@ -560,7 +558,11 @@ public sealed class AdaptiveScaleDownTests
             BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(sender, removedConnection);
 
-        await drainStarted.Task.WaitAsync(cancellationToken);
+        typeof(BrokerSender).GetMethod(
+            "MaybeDrainAndDisposeConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(sender, null);
+
         await AssertDisposeWaitsForLeaseAsync(
             sender,
             removedConnection,

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -460,6 +460,50 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task DisposeShrinkResultAsync_WaitsForLeasedConnection(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        var disposeShrinkResultAsync = typeof(BrokerSender).GetMethod(
+            "DisposeShrinkResultAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("DisposeShrinkResultAsync method not found");
+        var disposalTask = (Task)disposeShrinkResultAsync.Invoke(
+            sender,
+            [Task.FromResult<IKafkaConnection?>(removedConnection)])!;
+
+        try
+        {
+            var firstSignal = await Task.WhenAny(
+                    removedConnection.LeaseCountObserved.Task,
+                    removedConnection.DisposeStarted.Task)
+                .WaitAsync(cancellationToken);
+
+            await Assert.That(firstSignal).IsSameReferenceAs(removedConnection.LeaseCountObserved.Task);
+            await Assert.That(disposalTask.IsCompleted).IsFalse();
+            await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(0);
+        }
+        finally
+        {
+            retirableConnection.ReleaseLease();
+            await disposalTask.WaitAsync(cancellationToken);
+            await sender.DisposeAsync();
+        }
+
+        await Assert.That(Volatile.Read(ref removedConnection.CompleteRetirementCalls)).IsEqualTo(1);
+        await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ApplyScaleDown_EmptyRemovedSlot_DisposesConnectionImmediately()
     {
         var options = CreateOptions(idempotent: false);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -540,6 +540,35 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task DisposeAsync_InFlightRetirementDrain_WaitsForLeasedConnection(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        var drainStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        sender.RetirementDrainStartedForTest = () => drainStarted.TrySetResult();
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        typeof(BrokerSender).GetField(
+            "_drainingConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, removedConnection);
+
+        await drainStarted.Task.WaitAsync(cancellationToken);
+        await AssertDisposeWaitsForLeaseAsync(
+            sender,
+            removedConnection,
+            retirableConnection,
+            cancellationToken);
+    }
+
+    [Test]
     [Timeout(15_000)]
     public async Task DisposeAsync_DrainTimeout_ContinuesWaitingForLease(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -115,6 +115,20 @@ public sealed class AdaptiveScaleDownTests
             logger: null,
             canPhysicallyShrinkConnections: canPhysicallyShrinkConnections);
 
+    private static IKafkaConnection?[] GetPinnedConnections(BrokerSender sender)
+        => (IKafkaConnection?[])typeof(BrokerSender).GetField(
+            "_pinnedConnections",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+
+    private static ValueTask<KafkaConnectionLease> GetConnectionLeaseAtIndexAsync(
+        BrokerSender sender,
+        int connectionIndex)
+        => (ValueTask<KafkaConnectionLease>)typeof(BrokerSender).GetMethod(
+            "GetConnectionLeaseAtIndexAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(
+                sender,
+                [connectionIndex, CancellationToken.None])!;
+
     private static async Task AssertDisposeWaitsForLeaseAsync(
         BrokerSender sender,
         TestKafkaConnection connection,
@@ -415,20 +429,11 @@ public sealed class AdaptiveScaleDownTests
                     .SetValue(sender, 1);
             }
 
-            var pinnedConnections = (IKafkaConnection?[])typeof(BrokerSender).GetField(
-                "_pinnedConnections",
-                BindingFlags.Instance | BindingFlags.NonPublic)!
-                .GetValue(sender)!;
+            var pinnedConnections = GetPinnedConnections(sender);
             pinnedConnections[0] = disconnectedConnection;
 
-            var getConnectionAtIndexAsync = typeof(BrokerSender).GetMethod(
-                "GetConnectionAtIndexAsync",
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
-            var pendingConnection = (ValueTask<IKafkaConnection>)getConnectionAtIndexAsync.Invoke(
-                sender,
-                [0, CancellationToken.None])!;
-
-            var connection = await pendingConnection;
+            using var connectionLease = await GetConnectionLeaseAtIndexAsync(sender, 0);
+            var connection = connectionLease.Connection;
 
             await Assert.That(connection).IsSameReferenceAs(
                 expectsIndexedConnection ? indexedConnection : unindexedConnection);
@@ -451,6 +456,82 @@ public sealed class AdaptiveScaleDownTests
         {
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task GetConnectionLeaseAtIndexAsync_PinnedConnection_HoldsLeaseUntilDisposed()
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = new TestKafkaConnection();
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            canPhysicallyShrinkConnections: false);
+
+        try
+        {
+            var pinnedConnections = GetPinnedConnections(sender);
+            pinnedConnections[0] = connection;
+
+            using (var connectionLease = await GetConnectionLeaseAtIndexAsync(sender, 0))
+            {
+                await Assert.That(connectionLease.Connection).IsSameReferenceAs(connection);
+                await Assert.That(((IRetirableKafkaConnection)connection).LeaseCount).IsEqualTo(1);
+            }
+
+            await Assert.That(((IRetirableKafkaConnection)connection).LeaseCount).IsEqualTo(0);
+            await pool.DidNotReceive().GetConnectionByIndexAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task GetConnectionLeaseAtIndexAsync_RetiredPinnedConnection_UsesCurrentPoolSlot()
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var retiredConnection = new TestKafkaConnection();
+        var replacementConnection = new TestKafkaConnection();
+        pool.GetConnectionByIndexAsync(1, 0, Arg.Any<CancellationToken>())
+            .Returns(replacementConnection);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            canPhysicallyShrinkConnections: false);
+
+        try
+        {
+            var pinnedConnections = GetPinnedConnections(sender);
+            pinnedConnections[0] = retiredConnection;
+            ((IRetirableKafkaConnection)retiredConnection).BeginRetirement();
+
+            using (var connectionLease = await GetConnectionLeaseAtIndexAsync(sender, 0))
+            {
+                await Assert.That(connectionLease.Connection).IsSameReferenceAs(replacementConnection);
+                await Assert.That(((IRetirableKafkaConnection)replacementConnection).LeaseCount).IsEqualTo(1);
+            }
+
+            await Assert.That(pinnedConnections[0]).IsSameReferenceAs(replacementConnection);
+            await Assert.That(((IRetirableKafkaConnection)retiredConnection).LeaseCount).IsEqualTo(0);
+            await Assert.That(((IRetirableKafkaConnection)replacementConnection).LeaseCount).IsEqualTo(0);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -115,6 +115,31 @@ public sealed class AdaptiveScaleDownTests
             logger: null,
             canPhysicallyShrinkConnections: canPhysicallyShrinkConnections);
 
+    private static async Task AssertDisposeWaitsForLeaseAsync(
+        BrokerSender sender,
+        TestKafkaConnection connection,
+        IRetirableKafkaConnection retirableConnection,
+        CancellationToken cancellationToken)
+    {
+        var disposalTask = sender.DisposeAsync().AsTask();
+        try
+        {
+            await connection.LeaseCountObserved.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(disposalTask.IsCompleted).IsFalse();
+            await Assert.That(connection.DisposeStarted.Task.IsCompleted).IsFalse();
+            await Assert.That(Volatile.Read(ref connection.DisposeCalls)).IsEqualTo(0);
+        }
+        finally
+        {
+            retirableConnection.ReleaseLease();
+            await disposalTask.WaitAsync(cancellationToken);
+        }
+
+        await Assert.That(Volatile.Read(ref connection.CompleteRetirementCalls)).IsEqualTo(1);
+        await Assert.That(Volatile.Read(ref connection.DisposeCalls)).IsEqualTo(1);
+    }
+
     /// <summary>
     /// Drives a full scale-up → scale-down cycle through the live send loop with an
     /// idempotent producer whose partitions span every connection slot, then keeps
@@ -461,7 +486,7 @@ public sealed class AdaptiveScaleDownTests
 
     [Test]
     [Timeout(10_000)]
-    public async Task DisposeShrinkResultAsync_WaitsForLeasedConnection(
+    public async Task DisposeAsync_CompletedShrinkResult_WaitsForLeasedConnection(
         CancellationToken cancellationToken)
     {
         var options = CreateOptions(idempotent: false);
@@ -473,30 +498,77 @@ public sealed class AdaptiveScaleDownTests
         await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
         retirableConnection.BeginRetirement();
 
-        var disposeShrinkResultAsync = typeof(BrokerSender).GetMethod(
-            "DisposeShrinkResultAsync",
-            BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("DisposeShrinkResultAsync method not found");
-        var disposalTask = (Task)disposeShrinkResultAsync.Invoke(
+        typeof(BrokerSender).GetField(
+            "_pendingShrinkTask",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, Task.FromResult<IKafkaConnection?>(removedConnection));
+
+        await AssertDisposeWaitsForLeaseAsync(
             sender,
-            [Task.FromResult<IKafkaConnection?>(removedConnection)])!;
+            removedConnection,
+            retirableConnection,
+            cancellationToken);
+    }
+
+    [Test]
+    [Arguments("_drainingConnection")]
+    [Arguments("_retiringConnection")]
+    [Timeout(10_000)]
+    public async Task DisposeAsync_ParkedConnection_WaitsForLeasedConnection(
+        string connectionFieldName,
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        typeof(BrokerSender).GetField(
+            connectionFieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, removedConnection);
+
+        await AssertDisposeWaitsForLeaseAsync(
+            sender,
+            removedConnection,
+            retirableConnection,
+            cancellationToken);
+    }
+
+    [Test]
+    [Timeout(15_000)]
+    public async Task DisposeAsync_DrainTimeout_ContinuesWaitingForLease(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        typeof(BrokerSender).GetField(
+            "_drainingConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, removedConnection);
 
         try
         {
-            var firstSignal = await Task.WhenAny(
-                    removedConnection.LeaseCountObserved.Task,
-                    removedConnection.DisposeStarted.Task)
-                .WaitAsync(cancellationToken);
+            await sender.DisposeAsync().AsTask().WaitAsync(cancellationToken);
 
-            await Assert.That(firstSignal).IsSameReferenceAs(removedConnection.LeaseCountObserved.Task);
-            await Assert.That(disposalTask.IsCompleted).IsFalse();
             await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(0);
+            await Assert.That(Volatile.Read(ref removedConnection.CompleteRetirementCalls)).IsEqualTo(0);
         }
         finally
         {
             retirableConnection.ReleaseLease();
-            await disposalTask.WaitAsync(cancellationToken);
-            await sender.DisposeAsync();
+            await removedConnection.DisposeStarted.Task.WaitAsync(cancellationToken);
         }
 
         await Assert.That(Volatile.Read(ref removedConnection.CompleteRetirementCalls)).IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -653,13 +653,18 @@ public sealed class AdaptiveScaleDownTests
 
     [Test]
     [Timeout(15_000)]
-    public async Task DisposeAsync_DrainTimeout_ContinuesWaitingForLease(
+    public async Task DisposeAsync_SharedDrainTimeout_ContinuesWaitingForLease(
         CancellationToken cancellationToken)
     {
         var options = CreateOptions(idempotent: false);
         await using var accumulator = new RecordAccumulator(options);
         var pool = Substitute.For<IConnectionPool>();
-        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            canPhysicallyShrinkConnections: false);
         var removedConnection = new TestKafkaConnection();
         var retirableConnection = (IRetirableKafkaConnection)removedConnection;
         await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
@@ -684,6 +689,43 @@ public sealed class AdaptiveScaleDownTests
         }
 
         await Assert.That(Volatile.Read(ref removedConnection.CompleteRetirementCalls)).IsEqualTo(1);
+        await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(15_000)]
+    public async Task DisposeAsync_OwnedDrainPastTimeout_WaitsForLease(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        await using var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        typeof(BrokerSender).GetField(
+            "_drainingConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(sender, removedConnection);
+
+        var dispose = sender.DisposeAsync().AsTask();
+        try
+        {
+            await removedConnection.LeaseCountObserved.Task.WaitAsync(cancellationToken);
+            await Assert.That(async () =>
+                    await dispose.WaitAsync(TimeSpan.FromMilliseconds(5_200), cancellationToken))
+                .Throws<TimeoutException>();
+            await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(0);
+        }
+        finally
+        {
+            retirableConnection.ReleaseLease();
+            await dispose.WaitAsync(cancellationToken);
+        }
+
         await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -576,6 +576,48 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task ApplyScaleDown_CancelledSender_KeepsRetirementDrainAlive(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(idempotent: false);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var removedConnection = new TestKafkaConnection();
+        var retirableConnection = (IRetirableKafkaConnection)removedConnection;
+        await Assert.That(retirableConnection.TryAcquireLease()).IsTrue();
+        retirableConnection.BeginRetirement();
+
+        var lifetimeCts = (CancellationTokenSource)typeof(BrokerSender).GetField(
+            "_cts",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+        lifetimeCts.Cancel();
+
+        typeof(BrokerSender).GetMethod(
+            "ApplyScaleDown",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(sender, [removedConnection]);
+
+        try
+        {
+            await removedConnection.LeaseCountObserved.Task.WaitAsync(cancellationToken);
+            await Assert.That(removedConnection.DisposeStarted.Task.IsCompleted).IsFalse();
+            await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(0);
+        }
+        finally
+        {
+            retirableConnection.ReleaseLease();
+            await removedConnection.DisposeStarted.Task.WaitAsync(cancellationToken);
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+
+        await Assert.That(Volatile.Read(ref removedConnection.CompleteRetirementCalls)).IsEqualTo(1);
+        await Assert.That(Volatile.Read(ref removedConnection.DisposeCalls)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ApplyScaleDown_EmptyRemovedSlot_DisposesConnectionImmediately()
     {
         var options = CreateOptions(idempotent: false);

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -24,6 +24,7 @@ internal sealed class TestKafkaConnection :
     public int SendFireAndForgetWithCallerTimeoutCalls;
     public int DisposeCalls;
     public int CompleteRetirementCalls;
+    public int LeaseCountDuringRequest;
 
     public TaskCompletionSource LeaseCountObserved { get; } = new(
         TaskCreationOptions.RunContinuationsAsynchronously);
@@ -33,6 +34,7 @@ internal sealed class TestKafkaConnection :
 
     public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
     public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
+    public Func<Type, object>? SendResponse { get; set; }
 
     public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
         TRequest request,
@@ -40,7 +42,13 @@ internal sealed class TestKafkaConnection :
         CancellationToken cancellationToken = default)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
-        => throw new NotSupportedException();
+    {
+        if (SendResponse is null)
+            throw new NotSupportedException();
+
+        LeaseCountDuringRequest = Volatile.Read(ref _leaseCount);
+        return ValueTask.FromResult((TResponse)SendResponse(typeof(TRequest)));
+    }
 
     public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
         TRequest request,

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -4,8 +4,14 @@ using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Unit.Producer;
 
-internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWriteCompletionConnection
+internal sealed class TestKafkaConnection :
+    IKafkaConnection,
+    IKafkaPipelinedWriteCompletionConnection,
+    IRetirableKafkaConnection
 {
+    private int _leaseCount;
+    private int _retirementState;
+
     public int BrokerId { get; init; } = 1;
     public string Host { get; init; } = "localhost";
     public int Port { get; init; } = 9092;
@@ -17,6 +23,13 @@ internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWri
     public int SendPipelinedWithCallerTimeoutAfterWriteCalls;
     public int SendFireAndForgetWithCallerTimeoutCalls;
     public int DisposeCalls;
+    public int CompleteRetirementCalls;
+
+    public TaskCompletionSource LeaseCountObserved { get; } = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public TaskCompletionSource DisposeStarted { get; } = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
 
     public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
     public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
@@ -74,8 +87,44 @@ internal sealed class TestKafkaConnection : IKafkaConnection, IKafkaPipelinedWri
 
     public ValueTask DisposeAsync()
     {
+        DisposeStarted.TrySetResult();
         Interlocked.Increment(ref DisposeCalls);
         return ValueTask.CompletedTask;
+    }
+
+    int IRetirableKafkaConnection.LeaseCount
+    {
+        get
+        {
+            LeaseCountObserved.TrySetResult();
+            return Volatile.Read(ref _leaseCount);
+        }
+    }
+
+    int IRetirableKafkaConnection.ActiveOperationCount => 0;
+
+    bool IRetirableKafkaConnection.TryAcquireLease()
+    {
+        if (Volatile.Read(ref _retirementState) != 0)
+            return false;
+
+        Interlocked.Increment(ref _leaseCount);
+        if (Volatile.Read(ref _retirementState) == 0)
+            return true;
+
+        ((IRetirableKafkaConnection)this).ReleaseLease();
+        return false;
+    }
+
+    void IRetirableKafkaConnection.ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+    void IRetirableKafkaConnection.BeginRetirement()
+        => Interlocked.CompareExchange(ref _retirementState, 1, 0);
+
+    void IRetirableKafkaConnection.CompleteRetirement()
+    {
+        Interlocked.Increment(ref CompleteRetirementCalls);
+        Volatile.Write(ref _retirementState, 2);
     }
 
     public async ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -479,6 +479,36 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task CompletePreparedTransactionAsync_HoldsConnectionLeaseDuringRequest()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+
+        await harness.Producer.CompletePreparedTransactionAsync(preparedState, committed: true);
+
+        await Assert.That(harness.LeaseCountDuringRequest).IsEqualTo(1);
+        await Assert.That(harness.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReinitializeProducerIdAsync_HoldsConnectionLeaseDuringRequest()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+
+        await harness.Producer.ReinitializeProducerIdAsync(CancellationToken.None);
+
+        await Assert.That(harness.LeaseCountDuringRequest).IsEqualTo(1);
+        await Assert.That(harness.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task CompletePreparedTransactionAsync_Abort_UsesPreparedTransactionProducerIdentity()
     {
         var preparedState = new PreparedTransactionState(1001, 4);
@@ -580,21 +610,11 @@ public sealed class TransactionTests
         short currentProducerEpoch,
         ErrorCode endTxnError = ErrorCode.None)
     {
-        EndTxnRequest? capturedRequest = null;
-        var connection = Substitute.For<IKafkaConnection>();
-        connection.IsConnected.Returns(true);
-        connection.BrokerId.Returns(1);
-        connection
-            .SendAsync<EndTxnRequest, EndTxnResponse>(
-                Arg.Do<EndTxnRequest>(request => capturedRequest = request),
-                Arg.Any<short>(),
-                Arg.Any<CancellationToken>())
-            .Returns(_ => new ValueTask<EndTxnResponse>(new EndTxnResponse
-            {
-                ErrorCode = endTxnError,
-                ProducerId = preparedState.ProducerId,
-                ProducerEpoch = (short)(preparedState.ProducerEpoch + 1)
-            }));
+        var connection = new LeaseTrackingConnection(
+            preparedState,
+            currentProducerId,
+            currentProducerEpoch,
+            endTxnError);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",
@@ -608,6 +628,10 @@ public sealed class TransactionTests
             ApiKey.EndTxn,
             EndTxnRequest.LowestSupportedVersion,
             EndTxnRequest.HighestSupportedVersion);
+        metadataManager.SetApiVersion(
+            ApiKey.InitProducerId,
+            InitProducerIdRequest.LowestSupportedVersion,
+            InitProducerIdRequest.HighestSupportedVersion);
 
         var producer = new KafkaProducer<string, string>(
             new ProducerOptions
@@ -631,10 +655,7 @@ public sealed class TransactionTests
         producer._preparedTransactionState = preparedState;
         producer._transactionState = TransactionState.PreparedTransaction;
 
-        return new PreparedCompletionHarness(
-            producer,
-            connectionPool,
-            () => capturedRequest ?? throw new InvalidOperationException("EndTxn request was not captured."));
+        return new PreparedCompletionHarness(producer, connectionPool, connection);
     }
 
     private static void SetFinalizedTransactionVersion(KafkaProducer<string, string> producer, short version)
@@ -665,16 +686,116 @@ public sealed class TransactionTests
     private sealed class PreparedCompletionHarness(
         KafkaProducer<string, string> producer,
         ConnectionPool connectionPool,
-        Func<EndTxnRequest> capturedRequest) : IAsyncDisposable
+        LeaseTrackingConnection connection) : IAsyncDisposable
     {
         public KafkaProducer<string, string> Producer { get; } = producer;
 
-        public EndTxnRequest CapturedRequest => capturedRequest();
+        public EndTxnRequest CapturedRequest => connection.CapturedEndTxnRequest
+            ?? throw new InvalidOperationException("EndTxn request was not captured.");
+        public int LeaseCountDuringRequest => connection.LeaseCountDuringRequest;
+        public int LeaseCount => connection.LeaseCount;
 
         public async ValueTask DisposeAsync()
         {
             await Producer.DisposeAsync().ConfigureAwait(false);
             await connectionPool.DisposeAsync().ConfigureAwait(false);
         }
+    }
+
+    private sealed class LeaseTrackingConnection(
+        PreparedTransactionState preparedState,
+        long producerId,
+        short producerEpoch,
+        ErrorCode endTxnError) : IKafkaConnection, IRetirableKafkaConnection
+    {
+        private int _leaseCount;
+        private int _leaseCountDuringRequest = -1;
+
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public EndTxnRequest? CapturedEndTxnRequest { get; private set; }
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int LeaseCountDuringRequest => Volatile.Read(ref _leaseCountDuringRequest);
+        public int ActiveOperationCount => 0;
+
+        public bool TryAcquireLease()
+        {
+            Interlocked.Increment(ref _leaseCount);
+            return true;
+        }
+
+        public void ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+        public void BeginRetirement() { }
+        public void CompleteRetirement() { }
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            Volatile.Write(ref _leaseCountDuringRequest, LeaseCount);
+            IKafkaResponse response = request switch
+            {
+                EndTxnRequest endTxnRequest => CreateEndTxnResponse(endTxnRequest),
+                InitProducerIdRequest => new InitProducerIdResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    ProducerId = producerId,
+                    ProducerEpoch = producerEpoch
+                },
+                _ => throw new NotSupportedException()
+            };
+
+            return ValueTask.FromResult((TResponse)response);
+        }
+
+        private EndTxnResponse CreateEndTxnResponse(EndTxnRequest request)
+        {
+            CapturedEndTxnRequest = request;
+            return new EndTxnResponse
+            {
+                ErrorCode = endTxnError,
+                ProducerId = preparedState.ProducerId,
+                ProducerEpoch = (short)(preparedState.ProducerEpoch + 1)
+            };
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -1,0 +1,190 @@
+using System.Reflection;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerConnectionOwnershipTests
+{
+    [Test]
+    public async Task LeaveGroupAsync_HoldsConnectionLeaseThroughRequest()
+    {
+        var options = CreateOptions();
+        var connection = new LeaseTrackingConnection();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
+            .Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.SetApiVersion(
+            ApiKey.ShareGroupHeartbeat,
+            ShareGroupHeartbeatRequest.LowestSupportedVersion,
+            ShareGroupHeartbeatRequest.HighestSupportedVersion);
+        await using var coordinator = new ShareConsumerCoordinator(
+            options,
+            pool,
+            metadataManager,
+            getConnectionCount: () => 2);
+
+        typeof(ShareConsumerCoordinator).GetField(
+            "_memberId",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, "member-1");
+        typeof(ShareConsumerCoordinator).GetField(
+            "_coordinatorId",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(coordinator, 1);
+
+        await coordinator.LeaveGroupAsync();
+
+        await Assert.That(connection.LeaseCountDuringSend).IsEqualTo(1);
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SendShareFetchAsync_HoldsConnectionLeaseThroughRequest()
+    {
+        var options = CreateOptions();
+        var connection = new LeaseTrackingConnection();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        await using var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+
+        var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
+            "SendShareFetchAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var sendTask = (Task)method.Invoke(
+            consumer,
+            [
+                1,
+                new ShareFetchRequest
+                {
+                    GroupId = options.GroupId,
+                    MemberId = "member-1",
+                    Topics = []
+                },
+                (short)0,
+                CancellationToken.None
+            ])!;
+
+        await sendTask;
+
+        await Assert.That(connection.LeaseCountDuringSend).IsEqualTo(1);
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    private static ShareConsumerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        GroupId = "share-group",
+        ConnectionsPerBroker = 2
+    };
+
+    private sealed class LeaseTrackingConnection : IKafkaConnection, IRetirableKafkaConnection
+    {
+        private int _leaseCount;
+        private int _retirementState;
+
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int LeaseCountDuringSend { get; private set; }
+
+        int IRetirableKafkaConnection.LeaseCount => LeaseCount;
+        int IRetirableKafkaConnection.ActiveOperationCount => 0;
+
+        bool IRetirableKafkaConnection.TryAcquireLease()
+        {
+            if (Volatile.Read(ref _retirementState) != 0)
+                return false;
+
+            Interlocked.Increment(ref _leaseCount);
+            if (Volatile.Read(ref _retirementState) == 0)
+                return true;
+
+            ((IRetirableKafkaConnection)this).ReleaseLease();
+            return false;
+        }
+
+        void IRetirableKafkaConnection.ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+        void IRetirableKafkaConnection.BeginRetirement()
+            => Interlocked.CompareExchange(ref _retirementState, 1, 0);
+
+        void IRetirableKafkaConnection.CompleteRetirement()
+            => Volatile.Write(ref _retirementState, 2);
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            LeaseCountDuringSend = LeaseCount;
+            IKafkaResponse response = request switch
+            {
+                ShareGroupHeartbeatRequest => new ShareGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None
+                },
+                ShareFetchRequest => new ShareFetchResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    Responses = [],
+                    NodeEndpoints = []
+                },
+                _ => throw new NotSupportedException(typeof(TRequest).Name)
+            };
+            return new ValueTask<TResponse>((TResponse)response);
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

- keep adaptive scale-down local when a consumer shares `KafkaClient` infrastructure
- drain and dispose standalone-consumer connections returned by physical shrink
- track scale operations so consumer teardown waits for late success or failure
- cover sibling in-flight ownership, exact disposal, and late/faulted completion

## Test plan

- [x] focused connection ownership/scaler tests, net8.0 and net10.0 (33/33 each)
- [x] consumer unit suite, net8.0 and net10.0 (551/551 each)
- [x] `dotnet format Dekaf.sln --verify-no-changes --no-restore --include ...`

Closes #1680
