### PR TITLE
test(eos): cover crash atomicity

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1826,6 +1826,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     transactionToComplete.ProducerId,
                     transactionToComplete.ProducerEpoch,
                     applyResponseProducerState,
+                    afterRequestWrittenAsync: null,
                     cancellationToken)
                 .ConfigureAwait(false);
 
@@ -2253,6 +2254,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _producerId,
             _producerEpoch,
             applyResponseProducerState: true,
+            afterRequestWrittenAsync: null,
+            cancellationToken);
+
+    internal ValueTask EndTransactionAsync(
+        bool committed,
+        Func<ValueTask>? afterRequestWrittenAsync,
+        CancellationToken cancellationToken)
+        => EndTransactionAsync(
+            committed,
+            _producerId,
+            _producerEpoch,
+            applyResponseProducerState: true,
+            afterRequestWrittenAsync,
             cancellationToken);
 
     private async ValueTask EndTransactionAsync(
@@ -2260,6 +2274,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         long producerId,
         short producerEpoch,
         bool applyResponseProducerState,
+        Func<ValueTask>? afterRequestWrittenAsync,
         CancellationToken cancellationToken)
     {
         const int maxRetries = 5;
@@ -2283,10 +2298,31 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 Committed = committed
             };
 
-            var response = (EndTxnResponse)await connection
-                .SendAsync<EndTxnRequest, EndTxnResponse>(
-                    request, apiVersion, cancellationToken)
-                .ConfigureAwait(false);
+            EndTxnResponse response;
+            if (afterRequestWrittenAsync is null)
+            {
+                response = await connection
+                    .SendAsync<EndTxnRequest, EndTxnResponse>(
+                        request, apiVersion, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
+                {
+                    throw new InvalidOperationException(
+                        "The transaction coordinator connection cannot report request write completion.");
+                }
+
+                var responseTask = await writeCompletionConnection
+                    .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
+                        request, apiVersion, cancellationToken)
+                    .ConfigureAwait(false);
+                var requestWrittenCallback = afterRequestWrittenAsync;
+                afterRequestWrittenAsync = null;
+                await requestWrittenCallback().ConfigureAwait(false);
+                response = await responseTask.ConfigureAwait(false);
+            }
 
             if (response.ErrorCode == ErrorCode.None)
             {
@@ -4065,7 +4101,20 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         return await _producer.ProduceAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default) =>
+        CommitCoreAsync(afterRequestWrittenAsync: null, cancellationToken);
+
+    internal ValueTask CommitAfterRequestWrittenAsync(
+        Func<ValueTask> afterRequestWrittenAsync,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(afterRequestWrittenAsync);
+        return CommitCoreAsync(afterRequestWrittenAsync, cancellationToken);
+    }
+
+    private async ValueTask CommitCoreAsync(
+        Func<ValueTask>? afterRequestWrittenAsync,
+        CancellationToken cancellationToken)
     {
         ThrowIfProducerDisposed();
         _producer.ThrowIfFatalTransactionError("Cannot commit transaction");
@@ -4080,7 +4129,11 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             // Flush all pending messages before committing
             await _producer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
-            await _producer.EndTransactionAsync(committed: true, cancellationToken).ConfigureAwait(false);
+            await _producer.EndTransactionAsync(
+                    committed: true,
+                    afterRequestWrittenAsync,
+                    cancellationToken)
+                .ConfigureAwait(false);
             _committed = true;
         }
         finally

--- a/tests/Dekaf.Tests.Integration/ExactlyOnceCrashAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Integration/ExactlyOnceCrashAtomicityTests.cs
@@ -1,0 +1,241 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Transaction")]
+public sealed class ExactlyOnceCrashAtomicityTests(KafkaTestContainer kafka) : TransactionalKafkaIntegrationTest(kafka)
+{
+    private const int MessageCount = 4;
+
+    [Test]
+    [Timeout(180_000)]
+    [Arguments(TransactionalEosCrashPoint.AfterInputConsumed)]
+    [Arguments(TransactionalEosCrashPoint.AfterOutputProduced)]
+    [Arguments(TransactionalEosCrashPoint.AfterOffsetsSent)]
+    [Arguments(TransactionalEosCrashPoint.CommitAcknowledgementRace)]
+    [Arguments(TransactionalEosCrashPoint.AfterCommitAcknowledged)]
+    public async Task CrashAndRestart_CommitsEveryTransformationExactlyOnce(
+        TransactionalEosCrashPoint crashPoint,
+        CancellationToken cancellationToken)
+    {
+        var inputTopic = await KafkaContainer.CreateTestTopicAsync();
+        var outputTopic = await KafkaContainer.CreateTestTopicAsync();
+        var runId = Guid.NewGuid().ToString("N");
+        var consumerGroupId = $"eos-crash-group-{runId}";
+        var transactionId = $"eos-crash-txn-{runId}";
+
+        await SeedInputAsync(inputTopic, cancellationToken);
+        await using (var consumerGroupAnchor = await CreateConsumerGroupAnchorAsync(
+                         inputTopic,
+                         consumerGroupId,
+                         cancellationToken))
+        {
+            await using (var crashClient = TransactionalCrashClientProcess.StartExactlyOnce(
+                             KafkaContainer.BootstrapServers,
+                             inputTopic,
+                             outputTopic,
+                             consumerGroupId,
+                             transactionId,
+                             MessageCount,
+                             crashPoint))
+            {
+                await crashClient.WaitUntilReadyAsync(
+                    TransactionalCrashClientProcess.SignalFor(crashPoint),
+                    TimeSpan.FromSeconds(60));
+                await crashClient.TerminateAsync();
+            }
+
+            await RunRecoveryAsync(
+                inputTopic,
+                outputTopic,
+                consumerGroupId,
+                transactionId);
+        }
+
+        var committedOffset = await ReadBrokerCommittedOffsetAsync(
+            inputTopic,
+            consumerGroupId,
+            cancellationToken);
+        var output = await ReadCommittedOutputAsync(outputTopic, cancellationToken);
+
+        ThrowIfAtomicityViolated(crashPoint, committedOffset, output);
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateConsumerGroupAnchorAsync(
+        string inputTopic,
+        string consumerGroupId,
+        CancellationToken cancellationToken)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(consumerGroupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        try
+        {
+            consumer.Subscribe(inputTopic);
+            var firstMessage = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            if (firstMessage is null)
+            {
+                throw new TimeoutException("Could not establish the EOS consumer group before the crash run.");
+            }
+
+            await consumer.CommitAsync(
+                [new TopicPartitionOffset(inputTopic, 0, 0)],
+                cancellationToken);
+            var committedOffset = await consumer.GetCommittedOffsetAsync(
+                new TopicPartition(inputTopic, 0),
+                cancellationToken);
+            if (committedOffset != 0)
+            {
+                throw new InvalidOperationException(
+                    $"EOS consumer group bootstrap committed {committedOffset?.ToString() ?? "<null>"}, expected 0.");
+            }
+
+            return consumer;
+        }
+        catch
+        {
+            await consumer.DisposeAsync();
+            throw;
+        }
+    }
+
+    private async Task SeedInputAsync(string inputTopic, CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        for (var index = 0; index < MessageCount; index++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = inputTopic,
+                Partition = 0,
+                Key = InputKey(index),
+                Value = InputValue(index)
+            }, cancellationToken);
+        }
+    }
+
+    private async Task RunRecoveryAsync(
+        string inputTopic,
+        string outputTopic,
+        string consumerGroupId,
+        string transactionId)
+    {
+        await using var recoveryClient = TransactionalCrashClientProcess.StartExactlyOnce(
+            KafkaContainer.BootstrapServers,
+            inputTopic,
+            outputTopic,
+            consumerGroupId,
+            transactionId,
+            MessageCount,
+            crashPoint: null);
+        await recoveryClient.WaitForSuccessfulExitAsync(TimeSpan.FromSeconds(90));
+    }
+
+    private async Task<long?> ReadBrokerCommittedOffsetAsync(
+        string inputTopic,
+        string consumerGroupId,
+        CancellationToken cancellationToken)
+    {
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+        var offsets = await admin.ListConsumerGroupOffsetsAsync(consumerGroupId, cancellationToken);
+        return offsets.TryGetValue(new TopicPartition(inputTopic, 0), out var offset)
+            ? offset
+            : null;
+    }
+
+    private async Task<List<ConsumeResult<string, string>>> ReadCommittedOutputAsync(
+        string outputTopic,
+        CancellationToken cancellationToken)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"eos-crash-verify-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        consumer.Subscribe(outputTopic);
+        var messages = new List<ConsumeResult<string, string>>();
+
+        while (messages.Count <= MessageCount)
+        {
+            var timeout = messages.Count == 0
+                ? TimeSpan.FromSeconds(30)
+                : TimeSpan.FromSeconds(3);
+            var message = await consumer.ConsumeOneAsync(timeout, cancellationToken);
+            if (message is null)
+            {
+                break;
+            }
+
+            messages.Add(message.Value);
+        }
+
+        return messages;
+    }
+
+    private static void ThrowIfAtomicityViolated(
+        TransactionalEosCrashPoint crashPoint,
+        long? committedOffset,
+        IReadOnlyCollection<ConsumeResult<string, string>> output)
+    {
+        var expected = Enumerable.Range(0, MessageCount)
+            .ToDictionary(InputKey, InputValue, StringComparer.Ordinal);
+        var actualGroups = output
+            .GroupBy(message => message.Key ?? "<null>", StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var missingKeys = expected.Keys.Where(key => !actualGroups.ContainsKey(key)).ToArray();
+        var duplicateKeys = actualGroups
+            .Where(pair => pair.Value.Length > 1)
+            .Select(pair => $"{pair.Key} x{pair.Value.Length}")
+            .ToArray();
+        var unexpectedKeys = actualGroups.Keys.Where(key => !expected.ContainsKey(key)).ToArray();
+        var invalidValues = actualGroups
+            .Where(pair => expected.TryGetValue(pair.Key, out var inputValue)
+                           && pair.Value.Any(message => message.Value != Transform(inputValue)))
+            .Select(pair => pair.Key)
+            .ToArray();
+
+        if (committedOffset == MessageCount
+            && missingKeys.Length == 0
+            && duplicateKeys.Length == 0
+            && unexpectedKeys.Length == 0
+            && invalidValues.Length == 0
+            && output.Count == MessageCount)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"EOS crash point '{crashPoint}' violated commit-offset atomicity. " +
+            $"Committed offset: {committedOffset?.ToString() ?? "<null>"}; " +
+            $"output count: {output.Count}; " +
+            $"missing keys: [{string.Join(", ", missingKeys)}]; " +
+            $"duplicate keys: [{string.Join(", ", duplicateKeys)}]; " +
+            $"unexpected keys: [{string.Join(", ", unexpectedKeys)}]; " +
+            $"invalid values: [{string.Join(", ", invalidValues)}].");
+    }
+
+    internal static string InputKey(int index) => $"input-{index}";
+
+    internal static string InputValue(int index) => $"payload-{index}";
+
+    internal static string Transform(string value) => $"transformed-{value}";
+}

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -1,18 +1,35 @@
 using System.Diagnostics;
 using System.Text;
+using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Integration;
+
+public enum TransactionalEosCrashPoint
+{
+    AfterInputConsumed,
+    AfterOutputProduced,
+    AfterOffsetsSent,
+    CommitAcknowledgementRace,
+    AfterCommitAcknowledged
+}
 
 internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
 {
     internal const string EnabledVariable = "DEKAF_TRANSACTION_CRASH_CLIENT";
+    internal const string ExactlyOnceMode = "eos";
     internal const string BootstrapServersVariable = "DEKAF_TRANSACTION_CRASH_BOOTSTRAP_SERVERS";
     internal const string TopicVariable = "DEKAF_TRANSACTION_CRASH_TOPIC";
     internal const string TransactionIdVariable = "DEKAF_TRANSACTION_CRASH_ID";
     internal const string KeyVariable = "DEKAF_TRANSACTION_CRASH_KEY";
     internal const string ValueVariable = "DEKAF_TRANSACTION_CRASH_VALUE";
     internal const string ReadyPathVariable = "DEKAF_TRANSACTION_CRASH_READY_PATH";
+    internal const string InputTopicVariable = "DEKAF_TRANSACTION_CRASH_INPUT_TOPIC";
+    internal const string OutputTopicVariable = "DEKAF_TRANSACTION_CRASH_OUTPUT_TOPIC";
+    internal const string ConsumerGroupVariable = "DEKAF_TRANSACTION_CRASH_CONSUMER_GROUP";
+    internal const string ExpectedMessageCountVariable = "DEKAF_TRANSACTION_CRASH_EXPECTED_COUNT";
+    internal const string CrashPointVariable = "DEKAF_TRANSACTION_CRASH_POINT";
     internal const string BrokerAcknowledgedSignal = "broker-acknowledged";
     private const int MaximumDiagnosticCharacters = 16_384;
 
@@ -39,10 +56,47 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         string key,
         string value)
     {
-        var readyPath = Path.Combine(
+        var readyPath = CreateReadyPath();
+        var startInfo = CreateStartInfo(bootstrapServers, topic, transactionId, key, value, readyPath);
+        return StartProcess(startInfo, readyPath);
+    }
+
+    public static TransactionalCrashClientProcess StartExactlyOnce(
+        string bootstrapServers,
+        string inputTopic,
+        string outputTopic,
+        string consumerGroupId,
+        string transactionId,
+        int expectedMessageCount,
+        TransactionalEosCrashPoint? crashPoint)
+    {
+        var readyPath = CreateReadyPath();
+        var startInfo = CreateBaseStartInfo();
+        startInfo.Environment[EnabledVariable] = ExactlyOnceMode;
+        startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
+        startInfo.Environment[InputTopicVariable] = inputTopic;
+        startInfo.Environment[OutputTopicVariable] = outputTopic;
+        startInfo.Environment[ConsumerGroupVariable] = consumerGroupId;
+        startInfo.Environment[TransactionIdVariable] = transactionId;
+        startInfo.Environment[ExpectedMessageCountVariable] = expectedMessageCount.ToString(
+            System.Globalization.CultureInfo.InvariantCulture);
+        startInfo.Environment[CrashPointVariable] = crashPoint?.ToString() ?? string.Empty;
+        startInfo.Environment[ReadyPathVariable] = readyPath;
+        return StartProcess(startInfo, readyPath);
+    }
+
+    internal static string SignalFor(TransactionalEosCrashPoint crashPoint) =>
+        $"eos-crash-point:{crashPoint}";
+
+    private static string CreateReadyPath() =>
+        Path.Combine(
             Path.GetTempPath(),
             $"dekaf-transaction-crash-{Guid.NewGuid():N}.ready");
-        var startInfo = CreateStartInfo(bootstrapServers, topic, transactionId, key, value, readyPath);
+
+    private static TransactionalCrashClientProcess StartProcess(
+        ProcessStartInfo startInfo,
+        string readyPath)
+    {
         var process = new Process { StartInfo = startInfo };
         var diagnostics = new BoundedProcessDiagnostics(MaximumDiagnosticCharacters);
 
@@ -68,7 +122,10 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         }
     }
 
-    public async Task WaitUntilReadyAsync(TimeSpan timeout)
+    public Task WaitUntilReadyAsync(TimeSpan timeout) =>
+        WaitUntilReadyAsync(BrokerAcknowledgedSignal, timeout);
+
+    public async Task WaitUntilReadyAsync(string expectedSignal, TimeSpan timeout)
     {
         using var timeoutSource = new CancellationTokenSource(timeout);
 
@@ -81,10 +138,10 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
             }
 
             var signal = await File.ReadAllTextAsync(_readyPath, timeoutSource.Token);
-            if (!string.Equals(signal, BrokerAcknowledgedSignal, StringComparison.Ordinal))
+            if (!string.Equals(signal, expectedSignal, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
-                    $"Transactional crash client wrote an invalid readiness signal: '{signal}'.");
+                    $"Transactional crash client wrote readiness signal '{signal}', expected '{expectedSignal}'.");
             }
 
             ThrowIfExitedBeforeReady();
@@ -92,7 +149,29 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
         {
             throw new TimeoutException(
-                $"Transactional crash client did not acknowledge its open transaction within {timeout}." +
+                $"Transactional crash client did not write signal '{expectedSignal}' within {timeout}." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    public async Task WaitForSuccessfulExitAsync(TimeSpan timeout)
+    {
+        using var timeoutSource = new CancellationTokenSource(timeout);
+        try
+        {
+            await _process.WaitForExitAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Transactional crash client did not exit within {timeout}." +
+                Environment.NewLine + _diagnostics);
+        }
+
+        if (_process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Transactional crash client exited with code {_process.ExitCode}." +
                 Environment.NewLine + _diagnostics);
         }
     }
@@ -155,6 +234,19 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         string value,
         string readyPath)
     {
+        var startInfo = CreateBaseStartInfo();
+        startInfo.Environment[EnabledVariable] = "1";
+        startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
+        startInfo.Environment[TopicVariable] = topic;
+        startInfo.Environment[TransactionIdVariable] = transactionId;
+        startInfo.Environment[KeyVariable] = key;
+        startInfo.Environment[ValueVariable] = value;
+        startInfo.Environment[ReadyPathVariable] = readyPath;
+        return startInfo;
+    }
+
+    private static ProcessStartInfo CreateBaseStartInfo()
+    {
         var processPath = Environment.ProcessPath
             ?? throw new InvalidOperationException("Cannot locate the integration test executable.");
         var startInfo = new ProcessStartInfo(processPath)
@@ -175,14 +267,6 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         startInfo.ArgumentList.Add("/*/*/TransactionalCrashClient/*");
         startInfo.ArgumentList.Add("--maximum-parallel-tests");
         startInfo.ArgumentList.Add("1");
-
-        startInfo.Environment[EnabledVariable] = "1";
-        startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
-        startInfo.Environment[TopicVariable] = topic;
-        startInfo.Environment[TransactionIdVariable] = transactionId;
-        startInfo.Environment[KeyVariable] = key;
-        startInfo.Environment[ValueVariable] = value;
-        startInfo.Environment[ReadyPathVariable] = readyPath;
         return startInfo;
     }
 
@@ -287,13 +371,172 @@ public sealed class TransactionalCrashClient
             Value = value
         }, CancellationToken.None);
 
-        var temporaryReadyPath = readyPath + ".tmp";
-        await File.WriteAllTextAsync(
-            temporaryReadyPath,
+        await WriteSignalAsync(
+            readyPath,
             TransactionalCrashClientProcess.BrokerAcknowledgedSignal);
-        File.Move(temporaryReadyPath, readyPath);
 
         await Task.Delay(Timeout.InfiniteTimeSpan);
+    }
+
+    [Test]
+    public async Task ProcessExactlyOnceUntilComplete()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable(TransactionalCrashClientProcess.EnabledVariable),
+                TransactionalCrashClientProcess.ExactlyOnceMode,
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var bootstrapServers = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.BootstrapServersVariable);
+        var inputTopic = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.InputTopicVariable);
+        var outputTopic = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.OutputTopicVariable);
+        var consumerGroupId = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.ConsumerGroupVariable);
+        var transactionId = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.TransactionIdVariable);
+        var readyPath = GetRequiredEnvironmentVariable(
+            TransactionalCrashClientProcess.ReadyPathVariable);
+        var expectedMessageCount = int.Parse(
+            GetRequiredEnvironmentVariable(TransactionalCrashClientProcess.ExpectedMessageCountVariable),
+            System.Globalization.CultureInfo.InvariantCulture);
+        var crashPointText = Environment.GetEnvironmentVariable(
+            TransactionalCrashClientProcess.CrashPointVariable);
+        TransactionalEosCrashPoint? crashPoint = string.IsNullOrEmpty(crashPointText)
+            ? null
+            : Enum.Parse<TransactionalEosCrashPoint>(crashPointText, ignoreCase: false);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithTransactionalId(transactionId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        await producer.InitTransactionsAsync();
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithGroupId(consumerGroupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var inputPartition = new TopicPartition(inputTopic, 0);
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(bootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+        var committedOffsets = await admin.ListConsumerGroupOffsetsAsync(consumerGroupId);
+        var committedOffset = committedOffsets.GetValueOrDefault(inputPartition, 0);
+        if (committedOffset < 0 || committedOffset > expectedMessageCount)
+        {
+            throw new InvalidOperationException(
+                $"Committed input offset {committedOffset} is outside expected range 0..{expectedMessageCount}.");
+        }
+
+        if (committedOffset == expectedMessageCount)
+        {
+            return;
+        }
+
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(inputTopic, 0, committedOffset)
+        ]);
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(75));
+
+        while (committedOffset < expectedMessageCount)
+        {
+            var message = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(45), timeoutSource.Token)
+                ?? throw new TimeoutException(
+                    $"EOS recovery stopped at input offset {committedOffset}; expected {expectedMessageCount}.");
+
+            if (message.Partition != 0)
+            {
+                throw new InvalidOperationException(
+                    $"EOS crash client received unexpected input partition {message.Partition}.");
+            }
+
+            if (crashPoint == TransactionalEosCrashPoint.AfterInputConsumed)
+            {
+                await SignalAndWaitAsync(readyPath, crashPoint.Value);
+            }
+
+            await using var transaction = producer.BeginTransaction();
+            await transaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = outputTopic,
+                Partition = 0,
+                Key = message.Key,
+                Value = ExactlyOnceCrashAtomicityTests.Transform(message.Value)
+            }, timeoutSource.Token);
+
+            if (crashPoint == TransactionalEosCrashPoint.AfterOutputProduced)
+            {
+                await SignalAndWaitAsync(readyPath, crashPoint.Value);
+            }
+
+            var offsets = new[]
+            {
+                new TopicPartitionOffset(message.Topic, message.Partition, message.Offset + 1)
+            };
+            await transaction.SendOffsetsToTransactionAsync(
+                offsets,
+                consumerGroupId,
+                timeoutSource.Token);
+
+            if (crashPoint == TransactionalEosCrashPoint.AfterOffsetsSent)
+            {
+                await SignalAndWaitAsync(readyPath, crashPoint.Value);
+            }
+
+            if (crashPoint == TransactionalEosCrashPoint.CommitAcknowledgementRace)
+            {
+                var commitTask = transaction.CommitAsync(timeoutSource.Token).AsTask();
+                await Task.Yield();
+                await WriteSignalAsync(
+                    readyPath,
+                    TransactionalCrashClientProcess.SignalFor(crashPoint.Value));
+                await commitTask;
+                await Task.Delay(Timeout.InfiniteTimeSpan);
+            }
+            else
+            {
+                await transaction.CommitAsync(timeoutSource.Token);
+            }
+
+            if (crashPoint == TransactionalEosCrashPoint.AfterCommitAcknowledged)
+            {
+                await SignalAndWaitAsync(readyPath, crashPoint.Value);
+            }
+
+            committedOffset = message.Offset + 1;
+        }
+    }
+
+    private static async Task SignalAndWaitAsync(
+        string readyPath,
+        TransactionalEosCrashPoint crashPoint)
+    {
+        await WriteSignalAsync(
+            readyPath,
+            TransactionalCrashClientProcess.SignalFor(crashPoint));
+        await Task.Delay(Timeout.InfiniteTimeSpan);
+    }
+
+    private static async Task WriteSignalAsync(
+        string readyPath,
+        string signal)
+    {
+        var temporaryReadyPath = readyPath + ".tmp";
+        await File.WriteAllTextAsync(temporaryReadyPath, signal);
+        File.Move(temporaryReadyPath, readyPath);
     }
 
     private static string GetRequiredEnvironmentVariable(string name) =>

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -498,13 +498,15 @@ public sealed class TransactionalCrashClient
 
             if (crashPoint == TransactionalEosCrashPoint.CommitAcknowledgementRace)
             {
-                var commitTask = transaction.CommitAsync(timeoutSource.Token).AsTask();
-                await Task.Yield();
-                await WriteSignalAsync(
-                    readyPath,
-                    TransactionalCrashClientProcess.SignalFor(crashPoint.Value));
-                await commitTask;
-                await Task.Delay(Timeout.InfiniteTimeSpan);
+                await ((Transaction<string, string>)transaction).CommitAfterRequestWrittenAsync(
+                    async () =>
+                    {
+                        await WriteSignalAsync(
+                            readyPath,
+                            TransactionalCrashClientProcess.SignalFor(crashPoint.Value));
+                        await Task.Delay(Timeout.InfiniteTimeSpan);
+                    },
+                    timeoutSource.Token);
             }
             else
             {


### PR DESCRIPTION
## Summary
- extend the transactional child-process harness with a consume-transform-produce EOS mode
- force crashes after consumption, output acknowledgement, offset staging, commit race, and commit acknowledgement
- restart with stable group and transactional identities, then verify broker offsets and `read_committed` output for exact-once keys

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release`
- [x] focused EOS crash suite: 15/15 on net10.0
- [x] focused EOS crash suite: 15/15 on net8.0
- [x] net10.0 Transaction category: 130/130
- [x] `dotnet format Dekaf.sln --verify-no-changes --no-restore --include ...`

Closes #1622
