### PR TITLE
Coordinate cold Schema Registry image startup

### DIFF
--- a/tests/Dekaf.Tests.Integration/ContainerImageBootstrapCoordinator.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerImageBootstrapCoordinator.cs
@@ -1,0 +1,35 @@
+namespace Dekaf.Tests.Integration;
+
+internal sealed class ContainerImageBootstrapCoordinator
+{
+    private readonly SemaphoreSlim _bootstrapGate = new(1, 1);
+    private bool _bootstrapCompleted;
+
+    internal async Task RunAsync(Func<Task> startupAsync)
+    {
+        ArgumentNullException.ThrowIfNull(startupAsync);
+
+        if (Volatile.Read(ref _bootstrapCompleted))
+        {
+            await startupAsync().ConfigureAwait(false);
+            return;
+        }
+
+        await _bootstrapGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!Volatile.Read(ref _bootstrapCompleted))
+            {
+                await startupAsync().ConfigureAwait(false);
+                Volatile.Write(ref _bootstrapCompleted, true);
+                return;
+            }
+        }
+        finally
+        {
+            _bootstrapGate.Release();
+        }
+
+        await startupAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ContainerImageBootstrapCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerImageBootstrapCoordinatorTests.cs
@@ -1,0 +1,85 @@
+namespace Dekaf.Tests.Integration;
+
+[Category("Retry")]
+public sealed class ContainerImageBootstrapCoordinatorTests
+{
+    [Test]
+    public async Task RunAsync_ColdStart_BlocksFollowersUntilBootstrapCompletes()
+    {
+        var coordinator = new ContainerImageBootstrapCoordinator();
+        var bootstrapStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBootstrap = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startupCount = 0;
+
+        Task StartAsync()
+        {
+            if (Interlocked.Increment(ref startupCount) == 1)
+                bootstrapStarted.SetResult();
+
+            return releaseBootstrap.Task;
+        }
+
+        var startupTasks = Enumerable.Range(0, 3)
+            .Select(_ => coordinator.RunAsync(StartAsync))
+            .ToArray();
+
+        await bootstrapStarted.Task;
+        await Assert.That(startupCount).IsEqualTo(1);
+
+        releaseBootstrap.SetResult();
+        await Task.WhenAll(startupTasks);
+
+        await Assert.That(startupCount).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task RunAsync_AfterBootstrap_RunsStartupsConcurrently()
+    {
+        var coordinator = new ContainerImageBootstrapCoordinator();
+        await coordinator.RunAsync(() => Task.CompletedTask);
+
+        var bothStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStartups = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startupCount = 0;
+
+        Task StartAsync()
+        {
+            if (Interlocked.Increment(ref startupCount) == 2)
+                bothStarted.SetResult();
+
+            return releaseStartups.Task;
+        }
+
+        var first = coordinator.RunAsync(StartAsync);
+        var second = coordinator.RunAsync(StartAsync);
+
+        await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        releaseStartups.SetResult();
+        await Task.WhenAll(first, second);
+
+        await Assert.That(startupCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RunAsync_FailedBootstrap_AllowsNextStartupToRetry()
+    {
+        var coordinator = new ContainerImageBootstrapCoordinator();
+        var startupCount = 0;
+
+        var failedBootstrap = async () => await coordinator.RunAsync(() =>
+        {
+            startupCount++;
+            return Task.FromException(new InvalidOperationException("bootstrap failed"));
+        });
+
+        await Assert.That(failedBootstrap).Throws<InvalidOperationException>();
+
+        await coordinator.RunAsync(() =>
+        {
+            startupCount++;
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(startupCount).IsEqualTo(2);
+    }
+}

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -14,6 +14,8 @@ namespace Dekaf.Tests.Integration;
 /// </summary>
 public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposable
 {
+    private static readonly ContainerImageBootstrapCoordinator ImageBootstrapCoordinator = new();
+
     private KafkaContainer? _kafkaContainer;
     private IContainer? _schemaRegistryContainer;
     private INetwork? _network;
@@ -52,6 +54,12 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
             return;
         }
 
+        // A complete first startup guarantees Testcontainers has pulled both images.
+        await ImageBootstrapCoordinator.RunAsync(StartLocalContainersAsync).ConfigureAwait(false);
+    }
+
+    private async Task StartLocalContainersAsync()
+    {
         Console.WriteLine("[KafkaWithSchemaRegistry] Creating Docker network...");
 
         // Create a shared network for the containers


### PR DESCRIPTION
## Summary

- gate the first local Kafka and Schema Registry fixture startup until both Testcontainers images exist
- let every follower start concurrently after the first successful bootstrap
- cover cold followers, warm concurrency, and retry after bootstrap failure

## Tests

- net8.0 and net10.0 integration project builds
- coordinator regression tests: 3/3 on net8.0 and net10.0
- Schema Registry integration tests: 22/22 on net8.0 and net10.0

Closes #1685