### PR TITLE
Enforce max poll interval eviction

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -817,8 +817,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         _memberId = null;
         _generationId = -1;
         _state = CoordinatorState.Unjoined;
-        Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
-
         ClearAssignment();
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1386,7 +1386,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         cancellationToken).ConfigureAwait(false);
 
                     _state = CoordinatorState.Stable;
-                    RefreshPollDeadline();
+                    if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
+                        RefreshPollDeadline();
 
                     Diagnostics.DekafMetrics.RebalanceDuration.Record(
                         Stopwatch.GetElapsedTime(startedAt).TotalSeconds,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -65,6 +65,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     // KIP-848 consumer protocol state
     private volatile int _heartbeatIntervalMs;
+    private readonly long _maxPollIntervalStopwatchTicks;
     private long _lastPollTimestamp;
     private long _pollVersion;
     private long _maxPollExpiredAtPollVersion = -1;
@@ -96,6 +97,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
             : () => GetCoordinationConnectionIndex(options.ConnectionsPerBroker);
         _heartbeatIntervalMs = options.HeartbeatIntervalMs;
+        _maxPollIntervalStopwatchTicks = options.MaxPollIntervalMs * Stopwatch.Frequency / 1000;
         _lastPollTimestamp = Stopwatch.GetTimestamp();
     }
 
@@ -107,7 +109,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal void RecordPoll()
     {
-        Volatile.Write(ref _lastPollTimestamp, Stopwatch.GetTimestamp());
+        var now = Stopwatch.GetTimestamp();
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
+            && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
+        {
+            // Preserve the overdue poll generation until the heartbeat records its expiry.
+            // A later foreground poll can advance it once the expiry marker is visible.
+            return;
+        }
+
+        Volatile.Write(ref _lastPollTimestamp, now);
         Interlocked.Increment(ref _pollVersion);
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -133,6 +133,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (expiration.Expired)
             await CompleteMaxPollExpirationAsync(expiration.Lost).ConfigureAwait(false);
 
+        // Another overdue foreground poll may have won _lock and started loss callbacks
+        // after this call passed RecordPollAsync's initial guard. Its expired generation
+        // must remain unchanged until those callbacks finish.
+        if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
+            return;
+
         cancellationToken.ThrowIfCancellationRequested();
         // Advance only after loss callbacks so prefetch cannot rejoin during notification.
         RecordPoll(Stopwatch.GetTimestamp());

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1052,7 +1052,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             // Validate and publish under the same lock used by expiry so it cannot clear
             // membership between this guard and the epoch/assignment writes below.
             if (_state != CoordinatorState.Stable ||
-                Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion)
+                Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
+                IsMaxPollIntervalExpired())
                 return default;
 
             result = ProcessConsumerGroupHeartbeatResponse(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -178,12 +178,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private void ThrowIfMaxPollIntervalExpired()
     {
-        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
-            return;
-
-        var pollDeadlineElapsed = _state == CoordinatorState.Stable
-            && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
-        if (!pollDeadlineElapsed && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0)
+        if (!IsMaxPollIntervalExpired())
             return;
 
         throw new GroupException(
@@ -192,6 +187,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             GroupId = _options.GroupId
         };
+    }
+
+    private bool IsMaxPollIntervalExpired()
+    {
+        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+            return false;
+
+        var pollDeadlineElapsed = _state == CoordinatorState.Stable
+            && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
+        return pollDeadlineElapsed || Volatile.Read(ref _maxPollExpiredAtPollVersion) >= 0;
     }
 
     internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)
@@ -968,6 +973,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
+
+        if (discardIfMembershipChanged &&
+            (_state != CoordinatorState.Stable ||
+             Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
+             IsMaxPollIntervalExpired()))
+            return default;
 
         var version = _metadataManager.GetNegotiatedApiVersion(
             ApiKey.ConsumerGroupHeartbeat,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -70,6 +70,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private long _pollVersion;
     private long _maxPollExpiredAtPollVersion = -1;
     private long _maxPollExpirationVersion;
+    private int _maxPollLossNotificationPending;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
@@ -110,6 +111,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal ValueTask RecordPollAsync(CancellationToken cancellationToken)
     {
+        // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
+        // unchanged so EnsureActiveGroup cannot rejoin until notification completes.
+        if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
+            return ValueTask.CompletedTask;
+
         var now = Stopwatch.GetTimestamp();
         if (_state == CoordinatorState.Stable
             && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
@@ -125,7 +131,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         var expiration = await TryExpireMaxPollIntervalAsync(cancellationToken).ConfigureAwait(false);
         if (expiration.Expired)
-            await InvokePartitionsLostAsync(expiration.Lost).ConfigureAwait(false);
+            await CompleteMaxPollExpirationAsync(expiration.Lost).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
         // Advance only after loss callbacks so prefetch cannot rejoin during notification.
@@ -1318,7 +1324,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 var expiration = await TryExpireMaxPollIntervalAsync(cancellationToken).ConfigureAwait(false);
                 if (expiration.Expired)
                 {
-                    await InvokePartitionsLostAsync(expiration.Lost).ConfigureAwait(false);
+                    await CompleteMaxPollExpirationAsync(expiration.Lost).ConfigureAwait(false);
 
                     break;
                 }
@@ -1420,9 +1426,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             // EnsureActiveGroup, but only a new foreground poll increments this generation.
             Interlocked.Increment(ref _maxPollExpirationVersion);
             Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
-            _state = CoordinatorState.Unjoined;
-
             var lost = ClearAssignment();
+            Volatile.Write(ref _maxPollLossNotificationPending, 1);
+            _state = CoordinatorState.Unjoined;
 
             LogMaxPollIntervalExceeded(_options.MaxPollIntervalMs);
             await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
@@ -1431,6 +1437,18 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         finally
         {
             _lock.Release();
+        }
+    }
+
+    private async ValueTask CompleteMaxPollExpirationAsync(IReadOnlyList<TopicPartition>? lost)
+    {
+        try
+        {
+            await InvokePartitionsLostAsync(lost).ConfigureAwait(false);
+        }
+        finally
+        {
+            Volatile.Write(ref _maxPollLossNotificationPending, 0);
         }
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1070,34 +1070,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 assignmentVersion,
                 subscribedTopicRegex);
 
-        ConsumerHeartbeatResult result;
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // A foreground poll can expire the member while this request is in flight.
-            // Validate and publish under the same lock used by expiry so it cannot clear
-            // membership between this guard and the epoch/assignment writes below.
+            // Validate, publish, and notify under the same lock used by expiry so it cannot
+            // report a newly committed assignment as lost before listeners see it assigned.
             if (_state != CoordinatorState.Stable ||
                 Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
                 IsCurrentPollGenerationExpired())
                 return default;
 
-            result = ProcessConsumerGroupHeartbeatResponse(
+            var result = ProcessConsumerGroupHeartbeatResponse(
                 response,
                 isInitial,
                 ownedTopicPartitions,
                 assignmentVersion,
                 subscribedTopicRegex);
+
+            await FireConsumerProtocolRebalanceListenersAsync(
+                result,
+                cancellationToken,
+                maxPollExpirationVersion).ConfigureAwait(false);
         }
         finally
         {
             _lock.Release();
         }
-
-        await FireConsumerProtocolRebalanceListenersAsync(
-            result,
-            cancellationToken,
-            maxPollExpirationVersion).ConfigureAwait(false);
 
         // Steady-heartbeat callbacks are fired above while publication is fenced against
         // max-poll expiry. The heartbeat loop must not fire the result a second time.

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -614,6 +614,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     OffsetCommitRequest.LowestSupportedVersion,
                     OffsetCommitRequest.HighestSupportedVersion);
 
+                ThrowIfMaxPollIntervalExpired();
                 var response = await connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
                     request,
                     offsetCommitVersion,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -232,6 +232,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
     }
 
+    internal void AcknowledgeAssignmentSync(int assignmentVersion)
+    {
+        lock (_assignmentStateLock)
+        {
+            if (Volatile.Read(ref _assignmentVersion) != assignmentVersion
+                || !_revokedPartitionsSinceLastSync.IsEmpty)
+            {
+                return;
+            }
+
+            Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
+        }
+    }
+
     private void EnqueueRevokedPartitions(IEnumerable<TopicPartition> revoked)
     {
         foreach (var partition in revoked)
@@ -1371,7 +1385,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                     _state = CoordinatorState.Stable;
                     RefreshPollDeadline();
-                    Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
 
                     Diagnostics.DekafMetrics.RebalanceDuration.Record(
                         Stopwatch.GetElapsedTime(startedAt).TotalSeconds,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -110,7 +110,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     internal void RecordPoll()
     {
         var now = Stopwatch.GetTimestamp();
-        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
+        if (_state == CoordinatorState.Stable
+            && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
             && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
         {
             // Preserve the overdue poll generation until the heartbeat records its expiry.
@@ -124,7 +125,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private void ThrowIfMaxPollIntervalExpired()
     {
-        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0)
+        var pollDeadlineElapsed = _state == CoordinatorState.Stable
+            && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
+        if (!pollDeadlineElapsed && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0)
             return;
 
         throw new GroupException(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -74,6 +74,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private long _maxPollExpiredAtPollVersion = -1;
     private long _maxPollExpirationVersion;
     private int _maxPollLossNotificationPending;
+    // A pending MoveNext/ConsumeOne fetch is application poll activity. Track concurrent callers
+    // without allocating a scope object on each fetch cycle.
+    private int _foregroundFetchWaitCount;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
@@ -119,6 +122,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
             return ValueTask.CompletedTask;
 
+        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+        {
+            RefreshPollDeadline();
+            return ValueTask.CompletedTask;
+        }
+
         var now = Stopwatch.GetTimestamp();
         if (_state == CoordinatorState.Stable
             && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
@@ -153,8 +162,25 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         Interlocked.Increment(ref _pollVersion);
     }
 
+    internal void BeginForegroundFetchWait()
+    {
+        Interlocked.Increment(ref _foregroundFetchWaitCount);
+        RefreshPollDeadline();
+    }
+
+    internal void EndForegroundFetchWait()
+    {
+        RefreshPollDeadline();
+        Interlocked.Decrement(ref _foregroundFetchWaitCount);
+    }
+
+    private void RefreshPollDeadline() => Volatile.Write(ref _lastPollTimestamp, Stopwatch.GetTimestamp());
+
     private void ThrowIfMaxPollIntervalExpired()
     {
+        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+            return;
+
         var pollDeadlineElapsed = _state == CoordinatorState.Stable
             && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
         if (!pollDeadlineElapsed && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0)
@@ -1322,6 +1348,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         cancellationToken).ConfigureAwait(false);
 
                     _state = CoordinatorState.Stable;
+                    RefreshPollDeadline();
                     Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
 
                     Diagnostics.DekafMetrics.RebalanceDuration.Record(
@@ -1493,6 +1520,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             if (_state != CoordinatorState.Stable)
                 return default;
+
+            if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+            {
+                RefreshPollDeadline();
+                return default;
+            }
 
             var pollVersion = Volatile.Read(ref _pollVersion);
             var lastPollTimestamp = Volatile.Read(ref _lastPollTimestamp);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -48,9 +48,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // every assignment site: ProcessConsumerGroupAssignment() and DisposeAsync().
     private volatile HashSet<TopicPartition> _assignedPartitions = [];
     private readonly SemaphoreSlim _lock = new(1, 1);
-    // Serializes max-poll expiry with the synchronous start of steady-heartbeat
-    // rebalance callbacks. User callbacks are awaited only after this gate is released.
-    private readonly object _heartbeatResponsePublicationGate = new();
+    // Serializes user rebalance callbacks without holding the coordinator state lock. This
+    // permits callbacks to re-enter consumer APIs while preserving assigned-before-lost order.
+    private readonly SemaphoreSlim _rebalanceListenerLock = new(1, 1);
     private readonly object _heartbeatGuard = new();
     private CancellationTokenSource? _heartbeatCts;
     private Task? _heartbeatTask;
@@ -555,29 +555,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         IReadOnlyList<TopicPartition> partitions,
         IRebalanceListener listener,
         Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
-        CancellationToken cancellationToken,
-        long? maxPollExpirationVersion = null)
+        CancellationToken cancellationToken)
     {
         try
         {
-            ValueTask callbackTask;
-            if (maxPollExpirationVersion is { } expectedVersion)
-            {
-                lock (_heartbeatResponsePublicationGate)
-                {
-                    if (_state != CoordinatorState.Stable ||
-                        Volatile.Read(ref _maxPollExpirationVersion) != expectedVersion)
-                        return;
-
-                    LogRebalanceListenerCall(callbackName, partitions.Count);
-                    callbackTask = callback(listener, partitions, cancellationToken);
-                }
-            }
-            else
-            {
-                LogRebalanceListenerCall(callbackName, partitions.Count);
-                callbackTask = callback(listener, partitions, cancellationToken);
-            }
+            LogRebalanceListenerCall(callbackName, partitions.Count);
+            var callbackTask = callback(listener, partitions, cancellationToken);
 
             await callbackTask.ConfigureAwait(false);
         }
@@ -591,8 +574,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         string callbackName,
         IReadOnlyList<TopicPartition> partitions,
         Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
-        CancellationToken cancellationToken,
-        long? maxPollExpirationVersion = null)
+        CancellationToken cancellationToken)
     {
         var configuredListener = _rebalanceListener;
         if (configuredListener is not null)
@@ -602,8 +584,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 partitions,
                 configuredListener,
                 callback,
-                cancellationToken,
-                maxPollExpirationVersion).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
         }
 
         var runtimeListener = Volatile.Read(ref _runtimeRebalanceListener);
@@ -614,8 +595,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 partitions,
                 runtimeListener,
                 callback,
-                cancellationToken,
-                maxPollExpirationVersion).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -961,8 +941,24 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private async ValueTask FireConsumerProtocolRebalanceListenersAsync(
         ConsumerHeartbeatResult result,
-        CancellationToken cancellationToken,
-        long? maxPollExpirationVersion = null)
+        CancellationToken cancellationToken)
+    {
+        await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await FireConsumerProtocolRebalanceListenersCoreAsync(
+                result,
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _rebalanceListenerLock.Release();
+        }
+    }
+
+    private async ValueTask FireConsumerProtocolRebalanceListenersCoreAsync(
+        ConsumerHeartbeatResult result,
+        CancellationToken cancellationToken)
     {
         if (!result.AssignmentChanged)
             return;
@@ -972,16 +968,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "OnPartitionsRevoked",
                 result.Revoked,
                 static (listener, partitions, token) => listener.OnPartitionsRevokedAsync(partitions, token),
-                cancellationToken,
-                maxPollExpirationVersion).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
         if (result.Assigned is { Count: > 0 })
             await InvokeRebalanceListenersAsync(
                 "OnPartitionsAssigned",
                 result.Assigned,
                 static (listener, partitions, token) => listener.OnPartitionsAssignedAsync(partitions, token),
-                cancellationToken,
-                maxPollExpirationVersion).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1070,32 +1064,39 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 assignmentVersion,
                 subscribedTopicRegex);
 
-        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // A foreground poll can expire the member while this request is in flight.
-            // Validate, publish, and notify under the same lock used by expiry so it cannot
-            // report a newly committed assignment as lost before listeners see it assigned.
-            if (_state != CoordinatorState.Stable ||
-                Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
-                IsCurrentPollGenerationExpired())
-                return default;
+            ConsumerHeartbeatResult result;
+            await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // A foreground poll can expire the member while this request is in flight.
+                // Validate and publish under the state lock. The listener lock preserves
+                // callback ordering after this lock is released without blocking re-entrant APIs.
+                if (_state != CoordinatorState.Stable ||
+                    Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
+                    IsCurrentPollGenerationExpired())
+                    return default;
 
-            var result = ProcessConsumerGroupHeartbeatResponse(
-                response,
-                isInitial,
-                ownedTopicPartitions,
-                assignmentVersion,
-                subscribedTopicRegex);
+                result = ProcessConsumerGroupHeartbeatResponse(
+                    response,
+                    isInitial,
+                    ownedTopicPartitions,
+                    assignmentVersion,
+                    subscribedTopicRegex);
+            }
+            finally
+            {
+                _lock.Release();
+            }
 
-            await FireConsumerProtocolRebalanceListenersAsync(
-                result,
-                cancellationToken,
-                maxPollExpirationVersion).ConfigureAwait(false);
+            await FireConsumerProtocolRebalanceListenersCoreAsync(result, cancellationToken)
+                .ConfigureAwait(false);
         }
         finally
         {
-            _lock.Release();
+            _rebalanceListenerLock.Release();
         }
 
         // Steady-heartbeat callbacks are fired above while publication is fenced against
@@ -1503,11 +1504,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             var lost = _assignedPartitions.ToList();
                             if (lost.Count > 0)
                             {
-                                await InvokeRebalanceListenersAsync(
-                                    "OnPartitionsLost",
-                                    lost,
-                                    static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
-                                    CancellationToken.None).ConfigureAwait(false);
+                                await InvokePartitionsLostAsync(lost).ConfigureAwait(false);
                             }
 
                             ResetMemberState();
@@ -1570,15 +1567,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             // Record the poll generation that expired. A prefetch loop may continue calling
             // EnsureActiveGroup, but only a new foreground poll increments this generation.
-            IReadOnlyList<TopicPartition>? lost;
-            lock (_heartbeatResponsePublicationGate)
-            {
-                Interlocked.Increment(ref _maxPollExpirationVersion);
-                Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
-                lost = ClearAssignment();
-                Volatile.Write(ref _maxPollLossNotificationPending, 1);
-                _state = CoordinatorState.Unjoined;
-            }
+            Interlocked.Increment(ref _maxPollExpirationVersion);
+            Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
+            var lost = ClearAssignment();
+            Volatile.Write(ref _maxPollLossNotificationPending, 1);
+            _state = CoordinatorState.Unjoined;
 
             LogMaxPollIntervalExceeded(_options.MaxPollIntervalMs);
             await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
@@ -1602,14 +1595,25 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
     }
 
-    private ValueTask InvokePartitionsLostAsync(IReadOnlyList<TopicPartition>? lost)
-        => lost is { Count: > 0 }
-            ? InvokeRebalanceListenersAsync(
+    private async ValueTask InvokePartitionsLostAsync(IReadOnlyList<TopicPartition>? lost)
+    {
+        if (lost is not { Count: > 0 })
+            return;
+
+        await _rebalanceListenerLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            await InvokeRebalanceListenersAsync(
                 "OnPartitionsLost",
                 lost,
                 static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
-                CancellationToken.None)
-            : ValueTask.CompletedTask;
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        finally
+        {
+            _rebalanceListenerLock.Release();
+        }
+    }
 
     /// <summary>
     /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic members,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -48,6 +48,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // every assignment site: ProcessConsumerGroupAssignment() and DisposeAsync().
     private volatile HashSet<TopicPartition> _assignedPartitions = [];
     private readonly SemaphoreSlim _lock = new(1, 1);
+    // Serializes max-poll expiry with the synchronous start of steady-heartbeat
+    // rebalance callbacks. User callbacks are awaited only after this gate is released.
+    private readonly object _heartbeatResponsePublicationGate = new();
     private readonly object _heartbeatGuard = new();
     private CancellationTokenSource? _heartbeatCts;
     private Task? _heartbeatTask;
@@ -493,13 +496,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private async ValueTask InvokeRebalanceListenerAsync(
         string callbackName,
         IReadOnlyList<TopicPartition> partitions,
-        Func<IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
-        CancellationToken cancellationToken)
+        IRebalanceListener listener,
+        Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
+        CancellationToken cancellationToken,
+        long? maxPollExpirationVersion = null)
     {
-        LogRebalanceListenerCall(callbackName, partitions.Count);
         try
         {
-            await callback(partitions, cancellationToken).ConfigureAwait(false);
+            ValueTask callbackTask;
+            if (maxPollExpirationVersion is { } expectedVersion)
+            {
+                lock (_heartbeatResponsePublicationGate)
+                {
+                    if (_state != CoordinatorState.Stable ||
+                        Volatile.Read(ref _maxPollExpirationVersion) != expectedVersion)
+                        return;
+
+                    LogRebalanceListenerCall(callbackName, partitions.Count);
+                    callbackTask = callback(listener, partitions, cancellationToken);
+                }
+            }
+            else
+            {
+                LogRebalanceListenerCall(callbackName, partitions.Count);
+                callbackTask = callback(listener, partitions, cancellationToken);
+            }
+
+            await callbackTask.ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -511,7 +534,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         string callbackName,
         IReadOnlyList<TopicPartition> partitions,
         Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long? maxPollExpirationVersion = null)
     {
         var configuredListener = _rebalanceListener;
         if (configuredListener is not null)
@@ -519,8 +543,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             await InvokeRebalanceListenerAsync(
                 callbackName,
                 partitions,
-                (items, token) => callback(configuredListener, items, token),
-                cancellationToken).ConfigureAwait(false);
+                configuredListener,
+                callback,
+                cancellationToken,
+                maxPollExpirationVersion).ConfigureAwait(false);
         }
 
         var runtimeListener = Volatile.Read(ref _runtimeRebalanceListener);
@@ -529,8 +555,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             await InvokeRebalanceListenerAsync(
                 callbackName,
                 partitions,
-                (items, token) => callback(runtimeListener, items, token),
-                cancellationToken).ConfigureAwait(false);
+                runtimeListener,
+                callback,
+                cancellationToken,
+                maxPollExpirationVersion).ConfigureAwait(false);
         }
     }
 
@@ -876,7 +904,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private async ValueTask FireConsumerProtocolRebalanceListenersAsync(
         ConsumerHeartbeatResult result,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long? maxPollExpirationVersion = null)
     {
         if (!result.AssignmentChanged)
             return;
@@ -886,14 +915,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "OnPartitionsRevoked",
                 result.Revoked,
                 static (listener, partitions, token) => listener.OnPartitionsRevokedAsync(partitions, token),
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                maxPollExpirationVersion).ConfigureAwait(false);
 
         if (result.Assigned is { Count: > 0 })
             await InvokeRebalanceListenersAsync(
                 "OnPartitionsAssigned",
                 result.Assigned,
                 static (listener, partitions, token) => listener.OnPartitionsAssignedAsync(partitions, token),
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                maxPollExpirationVersion).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -968,12 +999,54 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
             request, version, cancellationToken).ConfigureAwait(false);
 
-        // A foreground poll can expire the member while this request is in flight.
-        // Ignore the stale response before it can update the epoch or assignment.
-        if (discardIfMembershipChanged &&
-            (_state != CoordinatorState.Stable ||
-             Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion))
-            return default;
+        if (!discardIfMembershipChanged)
+            return ProcessConsumerGroupHeartbeatResponse(
+                response,
+                isInitial,
+                ownedTopicPartitions,
+                assignmentVersion,
+                subscribedTopicRegex);
+
+        ConsumerHeartbeatResult result;
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // A foreground poll can expire the member while this request is in flight.
+            // Validate and publish under the same lock used by expiry so it cannot clear
+            // membership between this guard and the epoch/assignment writes below.
+            if (_state != CoordinatorState.Stable ||
+                Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion)
+                return default;
+
+            result = ProcessConsumerGroupHeartbeatResponse(
+                response,
+                isInitial,
+                ownedTopicPartitions,
+                assignmentVersion,
+                subscribedTopicRegex);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        await FireConsumerProtocolRebalanceListenersAsync(
+            result,
+            cancellationToken,
+            maxPollExpirationVersion).ConfigureAwait(false);
+
+        // Steady-heartbeat callbacks are fired above while publication is fenced against
+        // max-poll expiry. The heartbeat loop must not fire the result a second time.
+        return default;
+    }
+
+    private ConsumerHeartbeatResult ProcessConsumerGroupHeartbeatResponse(
+        ConsumerGroupHeartbeatResponse response,
+        bool isInitial,
+        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions,
+        int assignmentVersion,
+        string? subscribedTopicRegex)
+    {
 
         if (response.ErrorCode != ErrorCode.None)
         {
@@ -1340,13 +1413,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 if (_state != CoordinatorState.Stable)
                     break;
 
-                var result = await SendConsumerGroupHeartbeatAsync(
+                await SendConsumerGroupHeartbeatAsync(
                     isInitial: false,
                     discardIfMembershipChanged: true,
                     cancellationToken).ConfigureAwait(false);
-
-                await FireConsumerProtocolRebalanceListenersAsync(result, cancellationToken)
-                    .ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1431,11 +1501,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             // Record the poll generation that expired. A prefetch loop may continue calling
             // EnsureActiveGroup, but only a new foreground poll increments this generation.
-            Interlocked.Increment(ref _maxPollExpirationVersion);
-            Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
-            var lost = ClearAssignment();
-            Volatile.Write(ref _maxPollLossNotificationPending, 1);
-            _state = CoordinatorState.Unjoined;
+            IReadOnlyList<TopicPartition>? lost;
+            lock (_heartbeatResponsePublicationGate)
+            {
+                Interlocked.Increment(ref _maxPollExpirationVersion);
+                Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
+                lost = ClearAssignment();
+                Volatile.Write(ref _maxPollLossNotificationPending, 1);
+                _state = CoordinatorState.Unjoined;
+            }
 
             LogMaxPollIntervalExceeded(_options.MaxPollIntervalMs);
             await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -887,6 +887,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private async ValueTask<ConsumerHeartbeatResult> SendConsumerGroupHeartbeatAsync(
         bool isInitial,
+        bool discardIfNotStable,
         CancellationToken cancellationToken)
     {
         using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
@@ -949,6 +950,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         var response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
             request, version, cancellationToken).ConfigureAwait(false);
+
+        // A foreground poll can expire the member while this request is in flight.
+        // Ignore the stale response before it can update the epoch or assignment.
+        if (discardIfNotStable && _state != CoordinatorState.Stable)
+            return default;
 
         if (response.ErrorCode != ErrorCode.None)
         {
@@ -1220,6 +1226,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                     heartbeatResult = await SendConsumerGroupHeartbeatAsync(
                         isInitial: _memberId is null || _generationId <= 0,
+                        discardIfNotStable: false,
                         cancellationToken).ConfigureAwait(false);
 
                     _state = CoordinatorState.Stable;
@@ -1315,7 +1322,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     break;
 
                 var result = await SendConsumerGroupHeartbeatAsync(
-                    isInitial: false, cancellationToken).ConfigureAwait(false);
+                    isInitial: false,
+                    discardIfNotStable: true,
+                    cancellationToken).ConfigureAwait(false);
 
                 await FireConsumerProtocolRebalanceListenersAsync(result, cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -111,6 +111,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         Interlocked.Increment(ref _pollVersion);
     }
 
+    private void ThrowIfMaxPollIntervalExpired()
+    {
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0)
+            return;
+
+        throw new GroupException(
+            ErrorCode.FencedMemberEpoch,
+            $"Offset commit rejected because maximum poll interval of {_options.MaxPollIntervalMs}ms was exceeded")
+        {
+            GroupId = _options.GroupId
+        };
+    }
+
     internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)
         GetAssignmentSnapshotAndDrainRevocations()
     {
@@ -490,6 +503,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return;
 
+        ThrowIfMaxPollIntervalExpired();
+
         LogCommitOffsetsStarted(_options.GroupId!);
         // Lock is intentionally held across retries to protect the shared _commitTopicGroups dictionary,
         // which is reused across calls to avoid allocations. With up to 3 retries x ~600ms each,
@@ -499,6 +514,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             await RetryHelper.WithRetryAsync(async () =>
             {
+                // Expiration can happen while this call waits for the commit lock.
+                ThrowIfMaxPollIntervalExpired();
+
                 using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
                     _coordinatorId,
                     _getCoordinationConnectionIndex(),
@@ -1139,9 +1157,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 if (Volatile.Read(ref _pollVersion) == expiredPollVersion)
                     return;
 
+                // Keep the marker until this join succeeds so commits stay locally fenced.
                 _memberId = null;
                 _generationId = -1;
-                Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
             }
 
             if (_state == CoordinatorState.Stable)
@@ -1178,6 +1196,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         cancellationToken).ConfigureAwait(false);
 
                     _state = CoordinatorState.Stable;
+                    Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
 
                     Diagnostics.DekafMetrics.RebalanceDuration.Record(
                         Stopwatch.GetElapsedTime(startedAt).TotalSeconds,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -69,6 +69,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private long _lastPollTimestamp;
     private long _pollVersion;
     private long _maxPollExpiredAtPollVersion = -1;
+    private long _maxPollExpirationVersion;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
@@ -887,9 +888,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private async ValueTask<ConsumerHeartbeatResult> SendConsumerGroupHeartbeatAsync(
         bool isInitial,
-        bool discardIfNotStable,
+        bool discardIfMembershipChanged,
         CancellationToken cancellationToken)
     {
+        var maxPollExpirationVersion = discardIfMembershipChanged
+            ? Volatile.Read(ref _maxPollExpirationVersion)
+            : 0;
         using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
             _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
             .ConfigureAwait(false);
@@ -953,7 +957,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         // A foreground poll can expire the member while this request is in flight.
         // Ignore the stale response before it can update the epoch or assignment.
-        if (discardIfNotStable && _state != CoordinatorState.Stable)
+        if (discardIfMembershipChanged &&
+            (_state != CoordinatorState.Stable ||
+             Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion))
             return default;
 
         if (response.ErrorCode != ErrorCode.None)
@@ -1226,7 +1232,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                     heartbeatResult = await SendConsumerGroupHeartbeatAsync(
                         isInitial: _memberId is null || _generationId <= 0,
-                        discardIfNotStable: false,
+                        discardIfMembershipChanged: false,
                         cancellationToken).ConfigureAwait(false);
 
                     _state = CoordinatorState.Stable;
@@ -1323,7 +1329,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 var result = await SendConsumerGroupHeartbeatAsync(
                     isInitial: false,
-                    discardIfNotStable: true,
+                    discardIfMembershipChanged: true,
                     cancellationToken).ConfigureAwait(false);
 
                 await FireConsumerProtocolRebalanceListenersAsync(result, cancellationToken)
@@ -1412,6 +1418,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             // Record the poll generation that expired. A prefetch loop may continue calling
             // EnsureActiveGroup, but only a new foreground poll increments this generation.
+            Interlocked.Increment(ref _maxPollExpirationVersion);
             Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
             _state = CoordinatorState.Unjoined;
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -135,8 +135,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return ExpireAndRecordPollAsync(cancellationToken);
         }
 
-        RecordPoll(now);
+        RecordPollIfLossNotificationComplete(now);
         return ValueTask.CompletedTask;
+    }
+
+    private void RecordPollIfLossNotificationComplete(long timestamp)
+    {
+        if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
+            return;
+
+        RecordPoll(timestamp);
     }
 
     private async ValueTask ExpireAndRecordPollAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1158,8 +1158,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     return;
 
                 // Keep the marker until this join succeeds so commits stay locally fenced.
-                _memberId = null;
-                _generationId = -1;
+                // Reuse the member identity for this process. Static members must rejoin with
+                // epoch -2; dynamic members rejoin with the initial epoch 0.
+                _generationId = _options.GroupInstanceId is null ? 0 : -2;
             }
 
             if (_state == CoordinatorState.Stable)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1336,6 +1336,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             ThrowIfFatalHeartbeatException();
 
+            if (_state == CoordinatorState.Stable)
+                return;
+
             var expiredPollVersion = Volatile.Read(ref _maxPollExpiredAtPollVersion);
             if (expiredPollVersion >= 0)
             {
@@ -1349,9 +1352,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 // epoch -2; dynamic members rejoin with the initial epoch 0.
                 _generationId = _options.GroupInstanceId is null ? 0 : -2;
             }
-
-            if (_state == CoordinatorState.Stable)
-                return;
 
             LogEnsureActiveGroupStarted(_options.GroupId!, _state);
             var startedAt = Stopwatch.GetTimestamp();

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1310,6 +1310,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     break;
                 }
 
+                // A foreground poll may have expired the member while this loop waited for _lock.
+                if (_state != CoordinatorState.Stable)
+                    break;
+
                 var result = await SendConsumerGroupHeartbeatAsync(
                     isInitial: false, cancellationToken).ConfigureAwait(false);
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -107,19 +107,33 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
-    internal void RecordPoll()
+    internal ValueTask RecordPollAsync(CancellationToken cancellationToken)
     {
         var now = Stopwatch.GetTimestamp();
         if (_state == CoordinatorState.Stable
-            && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
             && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
         {
-            // Preserve the overdue poll generation until the heartbeat records its expiry.
-            // A later foreground poll can advance it once the expiry marker is visible.
-            return;
+            return ExpireAndRecordPollAsync(cancellationToken);
         }
 
-        Volatile.Write(ref _lastPollTimestamp, now);
+        RecordPoll(now);
+        return ValueTask.CompletedTask;
+    }
+
+    private async ValueTask ExpireAndRecordPollAsync(CancellationToken cancellationToken)
+    {
+        var expiration = await TryExpireMaxPollIntervalAsync(cancellationToken).ConfigureAwait(false);
+        if (expiration.Expired)
+            await InvokePartitionsLostAsync(expiration.Lost).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        // Advance only after loss callbacks so prefetch cannot rejoin during notification.
+        RecordPoll(Stopwatch.GetTimestamp());
+    }
+
+    private void RecordPoll(long timestamp)
+    {
+        Volatile.Write(ref _lastPollTimestamp, timestamp);
         Interlocked.Increment(ref _pollVersion);
     }
 
@@ -1291,14 +1305,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 var expiration = await TryExpireMaxPollIntervalAsync(cancellationToken).ConfigureAwait(false);
                 if (expiration.Expired)
                 {
-                    if (expiration.Lost is { Count: > 0 })
-                    {
-                        await InvokeRebalanceListenersAsync(
-                            "OnPartitionsLost",
-                            expiration.Lost,
-                            static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
-                            CancellationToken.None).ConfigureAwait(false);
-                    }
+                    await InvokePartitionsLostAsync(expiration.Lost).ConfigureAwait(false);
 
                     break;
                 }
@@ -1387,7 +1394,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             var pollVersion = Volatile.Read(ref _pollVersion);
             var lastPollTimestamp = Volatile.Read(ref _lastPollTimestamp);
-            if (Stopwatch.GetElapsedTime(lastPollTimestamp) < TimeSpan.FromMilliseconds(_options.MaxPollIntervalMs))
+            if (Stopwatch.GetTimestamp() - lastPollTimestamp < _maxPollIntervalStopwatchTicks)
                 return default;
 
             // Record the poll generation that expired. A prefetch loop may continue calling
@@ -1406,6 +1413,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _lock.Release();
         }
     }
+
+    private ValueTask InvokePartitionsLostAsync(IReadOnlyList<TopicPartition>? lost)
+        => lost is { Count: > 0 }
+            ? InvokeRebalanceListenersAsync(
+                "OnPartitionsLost",
+                lost,
+                static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
+                CancellationToken.None)
+            : ValueTask.CompletedTask;
 
     /// <summary>
     /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic members,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -186,7 +186,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private void ThrowIfMaxPollIntervalExpired()
     {
-        if (!IsMaxPollIntervalExpired())
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
+            && !IsCurrentPollGenerationExpired())
             return;
 
         throw new GroupException(
@@ -197,9 +198,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         };
     }
 
-    private bool IsMaxPollIntervalExpired()
+    private bool IsCurrentPollGenerationExpired()
     {
-        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) >= 0)
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) == Volatile.Read(ref _pollVersion))
             return true;
 
         if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
@@ -999,9 +1000,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var connection = connectionLease.Connection;
 
         if (discardIfMembershipChanged &&
-            (_state != CoordinatorState.Stable ||
+             (_state != CoordinatorState.Stable ||
              Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
-             IsMaxPollIntervalExpired()))
+             IsCurrentPollGenerationExpired()))
             return default;
 
         var version = _metadataManager.GetNegotiatedApiVersion(
@@ -1077,7 +1078,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             // membership between this guard and the epoch/assignment writes below.
             if (_state != CoordinatorState.Stable ||
                 Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
-                IsMaxPollIntervalExpired())
+                IsCurrentPollGenerationExpired())
                 return default;
 
             result = ProcessConsumerGroupHeartbeatResponse(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -65,6 +65,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     // KIP-848 consumer protocol state
     private volatile int _heartbeatIntervalMs;
+    private long _lastPollTimestamp;
+    private long _pollVersion;
+    private long _maxPollExpiredAtPollVersion = -1;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
@@ -93,6 +96,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
             : () => GetCoordinationConnectionIndex(options.ConnectionsPerBroker);
         _heartbeatIntervalMs = options.HeartbeatIntervalMs;
+        _lastPollTimestamp = Stopwatch.GetTimestamp();
     }
 
     public string? MemberId => _memberId;
@@ -100,6 +104,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
+
+    internal void RecordPoll()
+    {
+        Volatile.Write(ref _lastPollTimestamp, Stopwatch.GetTimestamp());
+        Interlocked.Increment(ref _pollVersion);
+    }
 
     internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)
         GetAssignmentSnapshotAndDrainRevocations()
@@ -775,11 +785,18 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// </summary>
     private void ResetMemberState()
     {
-        var revoked = _assignedPartitions.Count != 0 ? _assignedPartitions.ToList() : null;
-
         _memberId = null;
         _generationId = -1;
         _state = CoordinatorState.Unjoined;
+        Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
+
+        ClearAssignment();
+    }
+
+    private IReadOnlyList<TopicPartition>? ClearAssignment()
+    {
+        var revoked = _assignedPartitions.Count != 0 ? _assignedPartitions.ToList() : null;
+
         lock (_assignmentStateLock)
         {
             _assignedPartitions = [];
@@ -792,6 +809,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         if (revoked is not null)
             _onPartitionsRevoked?.Invoke(revoked);
+
+        return revoked;
     }
 
     /// <summary>
@@ -876,7 +895,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             MemberId = memberId,
             MemberEpoch = memberEpoch,
             InstanceId = _options.GroupInstanceId,
-            RebalanceTimeoutMs = isInitial ? _options.RebalanceTimeoutMs : -1,
+            RebalanceTimeoutMs = isInitial ? _options.MaxPollIntervalMs : -1,
             RackId = isInitial ? _options.ClientRack : null,
             SubscribedTopicNames = subscribedTopics,
             SubscribedTopicRegex = subscribedTopicRegex,
@@ -1112,6 +1131,19 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             ThrowIfFatalHeartbeatException();
 
+            var expiredPollVersion = Volatile.Read(ref _maxPollExpiredAtPollVersion);
+            if (expiredPollVersion >= 0)
+            {
+                // Background prefetch also calls EnsureActiveGroup. Do not let it rejoin a
+                // member evicted for max.poll.interval until the application polls again.
+                if (Volatile.Read(ref _pollVersion) == expiredPollVersion)
+                    return;
+
+                _memberId = null;
+                _generationId = -1;
+                Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
+            }
+
             if (_state == CoordinatorState.Stable)
                 return;
 
@@ -1220,9 +1252,24 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             try
             {
                 // Task.Delay (not PeriodicTimer): the broker controls the interval via each response,
-                // and PeriodicTimer cannot change its period after construction. At ~5s intervals,
-                // the per-tick TimerQueueTimer allocation is negligible.
-                await Task.Delay(_heartbeatIntervalMs, cancellationToken).ConfigureAwait(false);
+                // and PeriodicTimer cannot change its period after construction. Wake at the
+                // max.poll deadline when it is sooner so eviction is not heartbeat-interval late.
+                await Task.Delay(GetConsumerProtocolHeartbeatDelay(), cancellationToken).ConfigureAwait(false);
+
+                var expiration = await TryExpireMaxPollIntervalAsync(cancellationToken).ConfigureAwait(false);
+                if (expiration.Expired)
+                {
+                    if (expiration.Lost is { Count: > 0 })
+                    {
+                        await InvokeRebalanceListenersAsync(
+                            "OnPartitionsLost",
+                            expiration.Lost,
+                            static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
+                            CancellationToken.None).ConfigureAwait(false);
+                    }
+
+                    break;
+                }
 
                 var result = await SendConsumerGroupHeartbeatAsync(
                     isInitial: false, cancellationToken).ConfigureAwait(false);
@@ -1285,11 +1332,71 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
     }
 
+    private TimeSpan GetConsumerProtocolHeartbeatDelay()
+    {
+        var heartbeatDelay = TimeSpan.FromMilliseconds(Math.Max(_heartbeatIntervalMs, 1));
+        var remaining = TimeSpan.FromMilliseconds(_options.MaxPollIntervalMs)
+            - Stopwatch.GetElapsedTime(Volatile.Read(ref _lastPollTimestamp));
+
+        if (remaining <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return remaining < heartbeatDelay ? remaining : heartbeatDelay;
+    }
+
+    private async ValueTask<(bool Expired, IReadOnlyList<TopicPartition>? Lost)> TryExpireMaxPollIntervalAsync(
+        CancellationToken cancellationToken)
+    {
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_state != CoordinatorState.Stable)
+                return default;
+
+            var pollVersion = Volatile.Read(ref _pollVersion);
+            var lastPollTimestamp = Volatile.Read(ref _lastPollTimestamp);
+            if (Stopwatch.GetElapsedTime(lastPollTimestamp) < TimeSpan.FromMilliseconds(_options.MaxPollIntervalMs))
+                return default;
+
+            // Record the poll generation that expired. A prefetch loop may continue calling
+            // EnsureActiveGroup, but only a new foreground poll increments this generation.
+            Volatile.Write(ref _maxPollExpiredAtPollVersion, pollVersion);
+            _state = CoordinatorState.Unjoined;
+
+            var lost = ClearAssignment();
+
+            LogMaxPollIntervalExceeded(_options.MaxPollIntervalMs);
+            await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
+            return (true, lost);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
     /// <summary>
     /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic members,
     /// or -2 for static members so the broker keeps the assignment warm.
     /// </summary>
     private async ValueTask LeaveGroupConsumerProtocolAsync(CancellationToken cancellationToken)
+    {
+        await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
+
+        await StopHeartbeatAsync().ConfigureAwait(false);
+
+        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            ResetMemberState();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    private async ValueTask SendConsumerProtocolLeaveRequestAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -1326,18 +1433,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         catch (Exception ex)
         {
             LogLeaveGroupRequestFailed(ex);
-        }
-
-        await StopHeartbeatAsync().ConfigureAwait(false);
-
-        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
-        try
-        {
-            ResetMemberState();
-        }
-        finally
-        {
-            _lock.Release();
         }
     }
 
@@ -1429,6 +1524,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Heartbeat failed")]
     private partial void LogHeartbeatFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Maximum poll interval of {MaxPollIntervalMs}ms exceeded; leaving consumer group")]
+    private partial void LogMaxPollIntervalExceeded(int maxPollIntervalMs);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "LeaveGroup failed with error: {ErrorCode}")]
     private partial void LogLeaveGroupFailed(ErrorCode errorCode);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -989,16 +989,21 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var maxPollExpirationVersion = discardIfMembershipChanged
             ? Volatile.Read(ref _maxPollExpirationVersion)
             : 0;
-        using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-            _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
-            .ConfigureAwait(false);
-        var connection = connectionLease.Connection;
+        ConsumerGroupHeartbeatResponse response;
+        int assignmentVersion;
+        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions;
+        string? subscribedTopicRegex;
+        using (var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                   _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken)
+                   .ConfigureAwait(false))
+        {
+            var connection = connectionLease.Connection;
 
-        if (discardIfMembershipChanged &&
-             (_state != CoordinatorState.Stable ||
-             Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
-             IsCurrentPollGenerationExpired()))
-            return default;
+            if (discardIfMembershipChanged &&
+                 (_state != CoordinatorState.Stable ||
+                 Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
+                 IsCurrentPollGenerationExpired()))
+                return default;
 
         var version = _metadataManager.GetNegotiatedApiVersion(
             ApiKey.ConsumerGroupHeartbeat,
@@ -1022,8 +1027,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         // On initial join, send empty array (owns nothing). null means "unchanged" in KIP-848
         // which is invalid when there's no previous state.
-        var assignmentVersion = Volatile.Read(ref _assignmentVersion);
-        IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? ownedTopicPartitions =
+        assignmentVersion = Volatile.Read(ref _assignmentVersion);
+        ownedTopicPartitions =
             isInitial ? [] : GetOwnedTopicPartitionsForHeartbeat(assignmentVersion);
 
         // Atomically snapshot and clear the subscription-changed flag to prevent a race where
@@ -1035,7 +1040,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var subscriptionShouldBeSent = isInitial || subscriptionChanged;
         var currentSubscribedTopicRegex = _subscribedTopicRegex;
         var subscribedTopics = subscriptionShouldBeSent ? _subscribedTopics?.ToList() : null;
-        var subscribedTopicRegex = subscriptionShouldBeSent && version >= 1
+        subscribedTopicRegex = subscriptionShouldBeSent && version >= 1
             ? currentSubscribedTopicRegex ?? (isInitial ? null : string.Empty)
             : null;
 
@@ -1053,8 +1058,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             TopicPartitions = ownedTopicPartitions
         };
 
-        var response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
-            request, version, cancellationToken).ConfigureAwait(false);
+            response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                request, version, cancellationToken).ConfigureAwait(false);
+        }
 
         if (!discardIfMembershipChanged)
             return ProcessConsumerGroupHeartbeatResponse(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -74,9 +74,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private long _maxPollExpiredAtPollVersion = -1;
     private long _maxPollExpirationVersion;
     private int _maxPollLossNotificationPending;
-    // A pending MoveNext/ConsumeOne fetch is application poll activity. Track concurrent callers
-    // without allocating a scope object on each fetch cycle.
-    private int _foregroundFetchWaitCount;
+    // Foreground assignment initialization and fetch waits are application poll activity. Track
+    // concurrent callers without allocating a scope object on each poll cycle.
+    private int _foregroundPollActivityCount;
     private int _subscriptionChanged; // 0 = false, 1 = true; use Interlocked.Exchange for atomic snapshot
     private volatile StringSet? _subscribedTopics;
     private volatile string? _subscribedTopicRegex;
@@ -122,7 +122,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
             return ValueTask.CompletedTask;
 
-        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+        if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
         {
             RefreshPollDeadline();
             return ValueTask.CompletedTask;
@@ -170,16 +170,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         Interlocked.Increment(ref _pollVersion);
     }
 
-    internal void BeginForegroundFetchWait()
+    internal void BeginForegroundPollActivity()
     {
-        Interlocked.Increment(ref _foregroundFetchWaitCount);
+        Interlocked.Increment(ref _foregroundPollActivityCount);
         RefreshPollDeadline();
     }
 
-    internal void EndForegroundFetchWait()
+    internal void EndForegroundPollActivity()
     {
         RefreshPollDeadline();
-        Interlocked.Decrement(ref _foregroundFetchWaitCount);
+        Interlocked.Decrement(ref _foregroundPollActivityCount);
     }
 
     private void RefreshPollDeadline() => Volatile.Write(ref _lastPollTimestamp, Stopwatch.GetTimestamp());
@@ -203,7 +203,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (Volatile.Read(ref _maxPollExpiredAtPollVersion) == Volatile.Read(ref _pollVersion))
             return true;
 
-        if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+        if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
             return false;
 
         return _state == CoordinatorState.Stable
@@ -1557,7 +1557,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             if (_state != CoordinatorState.Stable)
                 return default;
 
-            if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
+            if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
             {
                 RefreshPollDeadline();
                 return default;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -238,7 +238,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         lock (_assignmentStateLock)
         {
             if (Volatile.Read(ref _assignmentVersion) != assignmentVersion
-                || !_revokedPartitionsSinceLastSync.IsEmpty)
+                || !_revokedPartitionsSinceLastSync.IsEmpty
+                || Volatile.Read(ref _maxPollExpiredAtPollVersion) == Volatile.Read(ref _pollVersion))
             {
                 return;
             }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -191,12 +191,14 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private bool IsMaxPollIntervalExpired()
     {
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) >= 0)
+            return true;
+
         if (Volatile.Read(ref _foregroundFetchWaitCount) != 0)
             return false;
 
-        var pollDeadlineElapsed = _state == CoordinatorState.Stable
+        return _state == CoordinatorState.Stable
             && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
-        return pollDeadlineElapsed || Volatile.Read(ref _maxPollExpiredAtPollVersion) >= 0;
     }
 
     internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1396,7 +1396,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            _coordinator?.RecordPoll();
+            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
@@ -1604,7 +1604,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         yield return nextResult;
-                        _coordinator?.RecordPoll();
+                        await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
                         // User code at the yield point may have called Seek/Assign, which
                         // clears _pendingFetches and disposes `pending` while it is still
@@ -1671,7 +1671,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     eofEvent.Partition.Topic,
                     eofEvent.Partition.Partition,
                     eofEvent.Offset);
-                _coordinator?.RecordPoll();
+                await RecordPollAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -1702,7 +1702,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            _coordinator?.RecordPoll();
+            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
@@ -1793,7 +1793,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
-                    _coordinator?.RecordPoll();
+                    await RecordPollAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -1841,7 +1841,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            _coordinator?.RecordPoll();
+            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
@@ -1927,7 +1927,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     ConsumeRawBatch batch = new(pending, CanContinueBatchIteration, _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
-                    _coordinator?.RecordPoll();
+                    await RecordPollAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -3054,7 +3054,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            _coordinator?.RecordPoll();
+            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
@@ -4143,6 +4143,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         return changed;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ValueTask RecordPollAsync(CancellationToken cancellationToken)
+        => _coordinator is { } coordinator
+            ? coordinator.RecordPollAsync(cancellationToken)
+            : ValueTask.CompletedTask;
 
     internal async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -952,6 +952,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollIntervalMs, 1);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
@@ -1378,6 +1379,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
 
         ThrowIfNotInitialized();
+        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1601,6 +1603,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         yield return nextResult;
+                        _coordinator?.RecordPoll();
 
                         // User code at the yield point may have called Seek/Assign, which
                         // clears _pendingFetches and disposes `pending` while it is still
@@ -1667,6 +1670,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     eofEvent.Partition.Topic,
                     eofEvent.Partition.Partition,
                     eofEvent.Offset);
+                _coordinator?.RecordPoll();
             }
         }
     }
@@ -1680,6 +1684,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         ThrowIfNotInitialized();
+        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1786,6 +1791,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
+                    _coordinator?.RecordPoll();
                 }
                 finally
                 {
@@ -1816,6 +1822,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         ThrowIfNotInitialized();
+        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1917,6 +1924,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     ConsumeRawBatch batch = new(pending, CanContinueBatchIteration, _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
+                    _coordinator?.RecordPoll();
                 }
                 finally
                 {
@@ -3028,6 +3036,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
 
         ThrowIfNotInitialized();
+        _coordinator?.RecordPoll();
 
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1379,7 +1379,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
 
         ThrowIfNotInitialized();
-        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1397,6 +1396,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            _coordinator?.RecordPoll();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -1684,7 +1685,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         ThrowIfNotInitialized();
-        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1702,6 +1702,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            _coordinator?.RecordPoll();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -1822,7 +1824,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         ThrowIfNotInitialized();
-        _coordinator?.RecordPoll();
 
         // Start auto-commit if enabled (only in Auto mode)
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
@@ -1840,6 +1841,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            _coordinator?.RecordPoll();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
@@ -3036,7 +3039,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
 
         ThrowIfNotInitialized();
-        _coordinator?.RecordPoll();
 
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto && _coordinator is not null)
         {
@@ -3052,6 +3054,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
+            _coordinator?.RecordPoll();
+
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4180,7 +4180,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
             if (Volatile.Read(ref _lastCoordinatorAssignmentVersion) == coordinatorAssignmentVersion)
+            {
+                coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
                 return;
+            }
         }
         else if (IsManualAssignmentEnsureCurrent())
         {
@@ -4211,6 +4214,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (_assignment.SetEquals(coordinatorAssignment) && coordinatorRevocations is null)
                 {
                     Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+                    coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
                     return;
                 }
 
@@ -4288,6 +4292,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
 
                 Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+                coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
                 unacknowledgedCoordinatorRevocations = null;
             }
             else

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4520,13 +4520,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask FetchRecordsAsync(CancellationToken cancellationToken)
     {
-        _coordinator?.BeginForegroundFetchWait();
         // Rent a CTS from the pool to avoid allocating a LinkedCTS
         var consumeCts = _ctsPool.Rent();
         _activeConsumeCancellationSources.TryAdd(consumeCts, 0);
 
         try
         {
+            _coordinator?.BeginForegroundFetchWait();
+
             // Forward outer cancellation into the pooled CTS via registration
             // instead of allocating a LinkedCTS (matches the prefetch path pattern)
             using var reg = cancellationToken.CanBeCanceled

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1403,7 +1403,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (_assignmentSnapshot.Count == 0)
             {
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                await DelayForForegroundPollAsync(100, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
@@ -1709,7 +1709,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (_assignmentSnapshot.Count == 0)
             {
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                await DelayForForegroundPollAsync(100, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
@@ -1848,7 +1848,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (_assignmentSnapshot.Count == 0)
             {
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                await DelayForForegroundPollAsync(100, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
@@ -3069,7 +3069,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             if (_assignmentSnapshot.Count == 0)
             {
-                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                await DelayForForegroundPollAsync(100, cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
@@ -4165,6 +4165,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         try
         {
             await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            coordinator?.EndForegroundPollActivity();
+        }
+    }
+
+    internal async ValueTask DelayForForegroundPollAsync(int milliseconds, CancellationToken cancellationToken)
+    {
+        var coordinator = _coordinator;
+        coordinator?.BeginForegroundPollActivity();
+        try
+        {
+            await Task.Delay(milliseconds, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2932,13 +2932,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask<bool> WaitForPrefetchDataAsync(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        _coordinator?.BeginForegroundFetchWait();
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-        if (_prefetchBuffer.HasDataAvailable())
-            return true;
+            if (_prefetchBuffer.HasDataAvailable())
+                return true;
 
-        return await _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken)
-            .ConfigureAwait(false);
+            return await _prefetchBuffer.WaitToReadAsync(_options.FetchMaxWaitMs, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _coordinator?.EndForegroundFetchWait();
+        }
     }
 
     private void TrackPrefetchedBytes(PendingFetchData pending, bool release)
@@ -4507,6 +4515,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask FetchRecordsAsync(CancellationToken cancellationToken)
     {
+        _coordinator?.BeginForegroundFetchWait();
         // Rent a CTS from the pool to avoid allocating a LinkedCTS
         var consumeCts = _ctsPool.Rent();
         _activeConsumeCancellationSources.TryAdd(consumeCts, 0);
@@ -4629,6 +4638,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
             consumeCts.Dispose();
+            _coordinator?.EndForegroundFetchWait();
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1398,7 +1398,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
-            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
@@ -1704,7 +1704,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
-            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
@@ -1843,7 +1843,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
-            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
@@ -2932,7 +2932,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask<bool> WaitForPrefetchDataAsync(CancellationToken cancellationToken)
     {
-        _coordinator?.BeginForegroundFetchWait();
+        _coordinator?.BeginForegroundPollActivity();
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -2945,7 +2945,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
-            _coordinator?.EndForegroundFetchWait();
+            _coordinator?.EndForegroundPollActivity();
         }
     }
 
@@ -3064,7 +3064,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
-            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+            await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             ClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
@@ -4158,6 +4158,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ? coordinator.RecordPollAsync(cancellationToken)
             : ValueTask.CompletedTask;
 
+    internal async ValueTask EnsureAssignmentForPollAsync(CancellationToken cancellationToken)
+    {
+        var coordinator = _coordinator;
+        coordinator?.BeginForegroundPollActivity();
+        try
+        {
+            await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            coordinator?.EndForegroundPollActivity();
+        }
+    }
+
     internal async ValueTask EnsureAssignmentAsync(CancellationToken cancellationToken)
     {
         // Refresh pattern subscription BEFORE acquiring the lock — RefreshFilteredTopicsAsync
@@ -4526,7 +4540,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
-            _coordinator?.BeginForegroundFetchWait();
+            _coordinator?.BeginForegroundPollActivity();
 
             // Forward outer cancellation into the pooled CTS via registration
             // instead of allocating a LinkedCTS (matches the prefetch path pattern)
@@ -4644,7 +4658,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
             consumeCts.Dispose();
-            _coordinator?.EndForegroundFetchWait();
+            _coordinator?.EndForegroundPollActivity();
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -345,7 +345,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                     new TopicPartitionOffset(topic, 0, MessagesPerPartition),
                     cancellationToken))
             .Throws<GroupException>();
-        await Assert.That(IsExpectedCommitFailure(staleCommit!.ErrorCode)).IsTrue();
+        await Assert.That(
+                staleCommit!.ErrorCode is { } errorCode && IsExpectedCommitFailure(errorCode))
+            .IsTrue();
 
         healthy.Allow(PartitionCount * MessagesPerPartition * 2);
         await oracle.WaitForAllSequencesAsync(cancellationToken);

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -32,6 +32,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
     private static readonly TimeSpan GroupConfigVerificationDelay = TimeSpan.FromMilliseconds(500);
     private const int CrashPhaseMessages = 12;
     private static readonly TimeSpan CrashClientReadyTimeout = TimeSpan.FromSeconds(90);
+    private static readonly TimeSpan MaxPollEvictionInterval = TimeSpan.FromSeconds(2);
     private static readonly HashSet<string> ExpectedCommitFailureNames = new(StringComparer.Ordinal)
     {
         nameof(ErrorCode.IllegalGeneration),
@@ -295,6 +296,69 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         {
             await RunAbruptMemberLossScenarioAsync(assignor, cancellationToken);
         }
+    }
+
+    [Test]
+    [Timeout(600_000)]
+    public async Task MaxPollIntervalEvictsStalledMemberWithoutAdvancingItsCommits(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: PartitionCount);
+        var groupId = $"rebalance-max-poll-{Guid.NewGuid():N}";
+        var oracle = new SequenceOracle(topic, PartitionCount, MessagesPerPartition, CommitInterval);
+
+        await ProduceSequencedBacklogAsync(topic, cancellationToken);
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var stalled = await CreateDekafMemberAsync(
+            topic,
+            groupId,
+            "max-poll-stalled",
+            "uniform",
+            oracle,
+            cancellationToken,
+            maxPollInterval: MaxPollEvictionInterval);
+
+        stalled.Allow(1);
+        await stalled.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+        await stalled.WaitForObservedCountAsync(1, cancellationToken);
+
+        await using var healthy = await CreateDekafMemberAsync(
+            topic,
+            groupId,
+            "max-poll-healthy",
+            "uniform",
+            oracle,
+            cancellationToken);
+
+        healthy.Allow(1);
+        await healthy.WaitForAnyAssignmentAsync(cancellationToken);
+        await healthy.WaitForObservedCountAsync(1, cancellationToken);
+        await healthy.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+
+        var descriptions = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken);
+        var description = descriptions[groupId];
+        await Assert.That(description.Members).Count().IsEqualTo(1);
+        await Assert.That(description.Members[0].ClientId).IsEqualTo("max-poll-healthy");
+
+        var staleCommit = await Assert.That(async () =>
+                await stalled.CommitAsync(
+                    new TopicPartitionOffset(topic, 0, MessagesPerPartition),
+                    cancellationToken))
+            .Throws<GroupException>();
+        await Assert.That(IsExpectedCommitFailure(staleCommit!.ErrorCode)).IsTrue();
+
+        healthy.Allow(PartitionCount * MessagesPerPartition * 2);
+        await oracle.WaitForAllSequencesAsync(cancellationToken);
+        await oracle.WaitForFinalCommitsAsync(cancellationToken);
+        await healthy.StopAsync();
+        await stalled.StopAsync();
+
+        await Assert.That(oracle.UniqueCount).IsEqualTo(PartitionCount * MessagesPerPartition);
+        await Assert.That(oracle.DuplicateCount).IsLessThanOrEqualTo(CommitInterval);
+        var violations = oracle.Violations;
+        await Assert.That(violations).IsEmpty()
+            .Because(string.Join(Environment.NewLine, violations));
+        await AssertCommittedOffsetsAsync(groupId, oracle, cancellationToken);
     }
 
     private async Task RunChurnScenarioAsync(string assignor, CancellationToken cancellationToken)
@@ -665,14 +729,15 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             cancellationToken);
     }
 
-    private async Task<IConsumerMember> CreateDekafMemberAsync(
+    private async Task<DekafConsumerMember> CreateDekafMemberAsync(
         string topic,
         string groupId,
         string clientId,
         string assignor,
         SequenceOracle oracle,
         CancellationToken cancellationToken,
-        string? groupInstanceId = null)
+        string? groupInstanceId = null,
+        TimeSpan? maxPollInterval = null)
     {
         var assignments = new AssignmentTracker();
         var builder = Kafka.CreateConsumer<string, string>()
@@ -689,6 +754,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
 
         if (groupInstanceId is not null)
             builder.WithGroupInstanceId(groupInstanceId);
+
+        if (maxPollInterval is { } interval)
+            builder.WithMaxPollInterval(interval);
 
         var consumer = await builder.BuildAsync(cancellationToken);
 
@@ -1115,6 +1183,11 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
 
         protected override ValueTask DisposeConsumerAsync() => _consumer.DisposeAsync();
+
+        public ValueTask CommitAsync(
+            TopicPartitionOffset offset,
+            CancellationToken cancellationToken) =>
+            _consumer.CommitAsync([offset], cancellationToken);
 
         private async ValueTask<bool> TryCommitAsync(
             TopicPartitionOffset offset,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -224,6 +224,32 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task DelayForForegroundPollAsync_EmptyAssignment_DoesNotExpireMember()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment());
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager, maxPollIntervalMs: 10);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var coordinator = GetCoordinator(consumer);
+        var delay = consumer.DelayForForegroundPollAsync(100, CancellationToken.None).AsTask();
+        LastPollTimestampField.SetValue(
+            coordinator,
+            Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        await coordinator.RecordPollAsync(CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await delay;
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_CoordinatorRevocation_ClearsPendingAndPrefetchedRecordsForRemovedPartitions()
     {
         var connectionPool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
@@ -20,6 +21,10 @@ public sealed class ConsumerAssignmentFastPathTests
         "_pollVersion",
         BindingFlags.NonPublic | BindingFlags.Instance)
         ?? throw new InvalidOperationException("_pollVersion field not found.");
+    private static readonly FieldInfo LastPollTimestampField = typeof(ConsumerCoordinator).GetField(
+        "_lastPollTimestamp",
+        BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("_lastPollTimestamp field not found.");
 
     [Test]
     public async Task ConsumeAsync_IdleLoop_RecordsForegroundPollProgress()
@@ -172,6 +177,49 @@ public sealed class ConsumerAssignmentFastPathTests
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 0));
+        await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 1));
+    }
+
+    [Test]
+    public async Task EnsureAssignmentForPollAsync_SlowPositionInitialization_DoesNotExpireMember()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupChangingConsumerGroupHeartbeat(connection);
+        var offsetFetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOffsetFetch = new TaskCompletionSource<OffsetFetchResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        SetupBlockingSecondOffsetFetch(connection, offsetFetchStarted, releaseOffsetFetch);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager, maxPollIntervalMs: 100);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var coordinator = GetCoordinator(consumer);
+        coordinator.RequestRejoin();
+        var assignment = consumer.EnsureAssignmentForPollAsync(CancellationToken.None).AsTask();
+        CoordinatorState stateDuringInitialization;
+        try
+        {
+            await offsetFetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            LastPollTimestampField.SetValue(
+                coordinator,
+                Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+            await coordinator.RecordPollAsync(CancellationToken.None);
+            stateDuringInitialization = coordinator.State;
+        }
+        finally
+        {
+            releaseOffsetFetch.TrySetResult(CreateSuccessfulOffsetFetchResponse());
+            await assignment;
+        }
+
+        await Assert.That(stateDuringInitialization).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
         await Assert.That(consumer.Assignment).Contains(new TopicPartition("test-topic", 1));
     }
 
@@ -558,7 +606,8 @@ public sealed class ConsumerAssignmentFastPathTests
     private static KafkaConsumer<string, string> CreateGroupConsumer(
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
-        int queuedMinMessages = 1)
+        int queuedMinMessages = 1,
+        int maxPollIntervalMs = 300_000)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -566,7 +615,8 @@ public sealed class ConsumerAssignmentFastPathTests
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "group-a",
                 OffsetCommitMode = OffsetCommitMode.Manual,
-                QueuedMinMessages = queuedMinMessages
+                QueuedMinMessages = queuedMinMessages,
+                MaxPollIntervalMs = maxPollIntervalMs
             },
             Serializers.String,
             Serializers.String,
@@ -737,6 +787,26 @@ public sealed class ConsumerAssignmentFastPathTests
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
+    }
+
+    private static void SetupBlockingSecondOffsetFetch(
+        IKafkaConnection connection,
+        TaskCompletionSource offsetFetchStarted,
+        TaskCompletionSource<OffsetFetchResponse> releaseOffsetFetch)
+    {
+        var callCount = 0;
+        connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref callCount) == 1)
+                    return ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse());
+
+                offsetFetchStarted.TrySetResult();
+                return new ValueTask<OffsetFetchResponse>(releaseOffsetFetch.Task);
+            });
     }
 
     private static void SetupOffsetFetchFailureAfterInitialAssignment(IKafkaConnection connection)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -234,11 +234,12 @@ public sealed class ConsumerAssignmentFastPathTests
         SetupFindCoordinator(connection);
         SetupConsumerGroupHeartbeat(connection, CreateAssignment());
 
-        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager, maxPollIntervalMs: 10);
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
         consumer.Subscribe("test-topic");
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         var coordinator = GetCoordinator(consumer);
+        await coordinator.StopHeartbeatAsync();
         using var delayCancellation = new CancellationTokenSource();
         var delay = consumer.DelayForForegroundPollAsync(
             Timeout.Infinite,
@@ -247,7 +248,7 @@ public sealed class ConsumerAssignmentFastPathTests
         {
             LastPollTimestampField.SetValue(
                 coordinator,
-                Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+                Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
             await coordinator.RecordPollAsync(CancellationToken.None);
 
             await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -16,6 +16,51 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class ConsumerAssignmentFastPathTests
 {
     private static readonly Guid TestTopicId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+    private static readonly FieldInfo PollVersionField = typeof(ConsumerCoordinator).GetField(
+        "_pollVersion",
+        BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("_pollVersion field not found.");
+
+    [Test]
+    public async Task ConsumeAsync_IdleLoop_RecordsForegroundPollProgress()
+    {
+        await AssertIdleLoopRecordsPollProgressAsync(
+            static (consumer, token) => consumer.ConsumeAsync(token));
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_IdleLoop_RecordsForegroundPollProgress()
+    {
+        await AssertIdleLoopRecordsPollProgressAsync(
+            static (consumer, token) => consumer.ConsumeBatchAsync(token));
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_IdleLoop_RecordsForegroundPollProgress()
+    {
+        await AssertIdleLoopRecordsPollProgressAsync(
+            static (consumer, token) => consumer.ConsumeRawBatchAsync(token));
+    }
+
+    private static async Task AssertIdleLoopRecordsPollProgressAsync<T>(
+        Func<KafkaConsumer<string, string>, CancellationToken, IAsyncEnumerable<T>> consume)
+    {
+        await using var consumer = CreatePausedGroupConsumer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await using var enumerator = consume(consumer, cts.Token).GetAsyncEnumerator();
+        var moveNext = enumerator.MoveNextAsync().AsTask();
+
+        try
+        {
+            await Assert.That(() => GetPollVersion(consumer))
+                .Eventually(version => version.IsGreaterThanOrEqualTo(3), TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            cts.Cancel();
+            await IgnoreCancellationAsync(moveNext);
+        }
+    }
 
     [Test]
     public async Task EnsureAssignmentAsync_UnchangedManualAssignment_SkipsAssignmentLock()
@@ -484,6 +529,30 @@ public sealed class ConsumerAssignmentFastPathTests
             },
             Serializers.String,
             Serializers.String);
+    }
+
+    private static KafkaConsumer<string, string> CreatePausedGroupConsumer()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var metadataManager = CreateMetadataManager(connectionPool);
+        var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        SetInitialized(consumer);
+
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+        consumer.Pause(partition);
+        return consumer;
+    }
+
+    private static async Task IgnoreCancellationAsync(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     private static KafkaConsumer<string, string> CreateGroupConsumer(
@@ -967,6 +1036,11 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinator field not found.");
 
         return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static long GetPollVersion(KafkaConsumer<string, string> consumer)
+    {
+        return (long)PollVersionField.GetValue(GetCoordinator(consumer))!;
     }
 
     private static void InvalidateCoordinatorAssignmentSnapshot(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -239,14 +239,24 @@ public sealed class ConsumerAssignmentFastPathTests
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         var coordinator = GetCoordinator(consumer);
-        var delay = consumer.DelayForForegroundPollAsync(100, CancellationToken.None).AsTask();
-        LastPollTimestampField.SetValue(
-            coordinator,
-            Stopwatch.GetTimestamp() - Stopwatch.Frequency);
-        await coordinator.RecordPollAsync(CancellationToken.None);
+        using var delayCancellation = new CancellationTokenSource();
+        var delay = consumer.DelayForForegroundPollAsync(
+            Timeout.Infinite,
+            delayCancellation.Token).AsTask();
+        try
+        {
+            LastPollTimestampField.SetValue(
+                coordinator,
+                Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+            await coordinator.RecordPollAsync(CancellationToken.None);
 
-        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
-        await delay;
+            await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        }
+        finally
+        {
+            delayCancellation.Cancel();
+            await IgnoreCancellationAsync(delay);
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -162,7 +162,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             "SendConsumerGroupHeartbeatAsync",
             BindingFlags.NonPublic | BindingFlags.Instance);
 
-        var result = method!.Invoke(coordinator, [false, CancellationToken.None])!;
+        var result = method!.Invoke(coordinator, [false, true, CancellationToken.None])!;
         var task = (Task)result.GetType().GetMethod("AsTask")!.Invoke(result, null)!;
         await task;
     }
@@ -601,6 +601,80 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await competingHeartbeat.WaitAsync(cancellationToken);
 
         await Assert.That(steadyHeartbeatCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_ForegroundExpiry_DropsInFlightHeartbeatResponse(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var steadyHeartbeatStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var steadyHeartbeatResponse = new TaskCompletionSource<ConsumerGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == 0)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 1,
+                        HeartbeatIntervalMs = 60_000,
+                        Assignment = CreateAssignment(TestTopicId, 0)
+                    });
+                }
+
+                if (request.MemberEpoch == -1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = -1,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                steadyHeartbeatStarted.TrySetResult();
+                return new ValueTask<ConsumerGroupHeartbeatResponse>(steadyHeartbeatResponse.Task);
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+
+        var inFlightHeartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
+        await steadyHeartbeatStarted.Task.WaitAsync(cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        await coordinator.RecordPollAsync(cancellationToken);
+        steadyHeartbeatResponse.TrySetResult(new ConsumerGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = 2,
+            HeartbeatIntervalMs = 60_000,
+            Assignment = CreateAssignment(TestTopicId, 1)
+        });
+        await inFlightHeartbeat;
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(1);
+        await Assert.That(coordinator.Assignment).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -207,6 +207,18 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         field.SetValue(coordinator, value);
     }
 
+    private static void SetCoordinatorState(
+        ConsumerCoordinator coordinator,
+        CoordinatorState state)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            "_state",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_state field not found.");
+
+        field.SetValue(coordinator, state);
+    }
+
     private static async Task AssertOwnedTopicPartitionsAsync(
         IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? topicPartitions,
         Guid topicId,
@@ -307,11 +319,12 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task RecordPoll_OverdueBeforeExpiry_PreservesDeadlineUntilEviction()
+    public async Task RecordPoll_OverdueStableMember_PreservesDeadlineUntilEviction()
     {
         var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         var overdueTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+        SetCoordinatorState(coordinator, CoordinatorState.Stable);
         SetCoordinatorLongField(coordinator, "_lastPollTimestamp", overdueTimestamp);
         var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
 
@@ -323,6 +336,23 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             .IsEqualTo(pollVersion);
 
         SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", pollVersion);
+        coordinator.RecordPoll();
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
+            .IsGreaterThan(overdueTimestamp);
+        await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+            .IsEqualTo(pollVersion + 1);
+    }
+
+    [Test]
+    public async Task RecordPoll_OverdueUnjoinedMember_RefreshesDeadline()
+    {
+        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var overdueTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+        SetCoordinatorLongField(coordinator, "_lastPollTimestamp", overdueTimestamp);
+        var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
+
         coordinator.RecordPoll();
 
         await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
@@ -502,6 +532,45 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                 await coordinator.CommitOffsetsAsync(
                     [new TopicPartitionOffset("test-topic", 0, 1)],
                     cancellationToken))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(heartbeatIntervalMs: 60_000);
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        var exception = await Assert.That(async () =>
+                await coordinator.CommitOffsetsAsync(
+                    [new TopicPartitionOffset("test-topic", 0, 1)],
+                    CancellationToken.None))
             .Throws<GroupException>();
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -605,7 +605,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Timeout(5_000)]
-    public async Task ConsumerProtocol_ForegroundExpiry_DropsInFlightHeartbeatResponse(
+    public async Task ConsumerProtocol_ForegroundExpiry_DropsInFlightHeartbeatResponseAfterRejoin(
         CancellationToken cancellationToken)
     {
         SetupFindCoordinator();
@@ -613,6 +613,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         var steadyHeartbeatResponse = new TaskCompletionSource<ConsumerGroupHeartbeatResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var joinCount = 0;
 
         _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
                 Arg.Any<ConsumerGroupHeartbeatRequest>(),
@@ -623,11 +624,12 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                 var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
                 if (request.MemberEpoch == 0)
                 {
+                    var memberEpoch = Interlocked.Increment(ref joinCount) == 1 ? 1 : 3;
                     return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
                     {
                         ErrorCode = ErrorCode.None,
                         MemberId = "member-1",
-                        MemberEpoch = 1,
+                        MemberEpoch = memberEpoch,
                         HeartbeatIntervalMs = 60_000,
                         Assignment = CreateAssignment(TestTopicId, 0)
                     });
@@ -652,7 +654,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             heartbeatIntervalMs: 60_000,
             maxPollIntervalMs: 300_000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
-        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+        var topics = new HashSet<string> { "test-topic" };
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
 
         var inFlightHeartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
         await steadyHeartbeatStarted.Task.WaitAsync(cancellationToken);
@@ -662,6 +665,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
 
         await coordinator.RecordPollAsync(cancellationToken);
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
         steadyHeartbeatResponse.TrySetResult(new ConsumerGroupHeartbeatResponse
         {
             ErrorCode = ErrorCode.None,
@@ -672,9 +676,11 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         });
         await inFlightHeartbeat;
 
-        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
-        await Assert.That(coordinator.GenerationId).IsEqualTo(1);
-        await Assert.That(coordinator.Assignment).IsEmpty();
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(3);
+        await Assert.That(coordinator.Assignment).Count().IsEqualTo(1);
+        await Assert.That(coordinator.Assignment).Contains(new TopicPartition("test-topic", 0));
+        await Assert.That(coordinator.Assignment).DoesNotContain(new TopicPartition("test-topic", 1));
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -167,6 +167,17 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await task;
     }
 
+    private static Task InvokeConsumerProtocolHeartbeatLoopAsync(
+        ConsumerCoordinator coordinator,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "ConsumerProtocolHeartbeatLoopAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return (Task)method!.Invoke(coordinator, [cancellationToken])!;
+    }
+
     private static ConsumerGroupHeartbeatAssignment CreateAssignment(
         Guid topicId, params int[] partitions)
     {
@@ -529,6 +540,67 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
         await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_ForegroundExpiry_StopsConcurrentStaleHeartbeat(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var leaveStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var leaveResponse = new TaskCompletionSource<ConsumerGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var steadyHeartbeatCount = 0;
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == 0)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 1,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                if (request.MemberEpoch == -1)
+                {
+                    leaveStarted.TrySetResult();
+                    return new ValueTask<ConsumerGroupHeartbeatResponse>(leaveResponse.Task);
+                }
+
+                Interlocked.Increment(ref steadyHeartbeatCount);
+                return ValueTask.FromException<ConsumerGroupHeartbeatResponse>(
+                    new GroupException(ErrorCode.FencedMemberEpoch, "stale heartbeat"));
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        var foregroundPoll = coordinator.RecordPollAsync(cancellationToken).AsTask();
+        await leaveStarted.Task.WaitAsync(cancellationToken);
+        var competingHeartbeat = InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, cancellationToken);
+
+        leaveResponse.TrySetException(new InvalidOperationException("leave failed"));
+        await foregroundPoll;
+        await competingHeartbeat.WaitAsync(cancellationToken);
+
+        await Assert.That(steadyHeartbeatCount).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -954,6 +954,55 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Timeout(5_000)]
+    public async Task ConsumerProtocol_SteadyHeartbeatListener_ReentersCoordinatorWithoutDeadlock(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var heartbeatCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref heartbeatCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, count - 1)
+                });
+            });
+
+        var topics = new HashSet<string> { "test-topic" };
+        ConsumerCoordinator? coordinator = null;
+        var assignmentCallbackCount = 0;
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Interlocked.Increment(ref assignmentCallbackCount) == 1
+                ? ValueTask.CompletedTask
+                : coordinator!.EnsureActiveGroupAsync(topics, cancellationToken));
+
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000);
+        await using var ownedCoordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        coordinator = ownedCoordinator;
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        await coordinator.StopHeartbeatAsync();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask().WaitAsync(cancellationToken);
+
+        await Assert.That(assignmentCallbackCount).IsEqualTo(2);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+    }
+
+    [Test]
+    [Timeout(5_000)]
     public async Task ConsumerProtocol_HeartbeatExpiry_BlocksRejoinUntilPartitionsLostCompletes(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -869,7 +869,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Timeout(5_000)]
-    public async Task ConsumerProtocol_ExpirySkipsRemainingCallbacksFromPublishedHeartbeat(
+    public async Task ConsumerProtocol_ExpiryWaitsForPublishedHeartbeatCallbacks(
         CancellationToken cancellationToken)
     {
         SetupFindCoordinator();
@@ -940,13 +940,16 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             "_lastPollTimestamp",
             Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
 
-        await coordinator.RecordPollAsync(cancellationToken);
+        var expiration = coordinator.RecordPollAsync(cancellationToken).AsTask();
+        await Assert.That(expiration.IsCompleted).IsFalse();
+
         releaseRevocation.TrySetResult();
         await steadyHeartbeat.WaitAsync(cancellationToken);
+        await expiration.WaitAsync(cancellationToken);
 
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
         await Assert.That(coordinator.Assignment).IsEmpty();
-        await Assert.That(assignedCallbackCount).IsEqualTo(1);
+        await Assert.That(assignedCallbackCount).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1039,6 +1039,73 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_SteadyHeartbeat_ReleasesConnectionLeaseBeforeCallbacks()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        var retirableConnection = new RetirableTestConnection(connection);
+        _connectionPool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(retirableConnection));
+        _connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(retirableConnection));
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "test-group",
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+        var heartbeatCount = 0;
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref heartbeatCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, count - 1)
+                });
+            });
+
+        var leaseStatesDuringCallbacks = new List<int>();
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                leaseStatesDuringCallbacks.Add(retirableConnection.LeaseCount);
+                return ValueTask.CompletedTask;
+            });
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(leaseStatesDuringCallbacks).IsEquivalentTo([0, 0]);
+    }
+
+    [Test]
     [Timeout(5_000)]
     public async Task ConsumerProtocol_HeartbeatExpiry_BlocksRejoinUntilPartitionsLostCompletes(
         CancellationToken cancellationToken)
@@ -3063,4 +3130,81 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     #endregion
+
+    private sealed class RetirableTestConnection(IKafkaConnection inner) :
+        IKafkaConnection,
+        IRetirableKafkaConnection
+    {
+        private int _leaseCount;
+
+        public int BrokerId => inner.BrokerId;
+        public string Host => inner.Host;
+        public int Port => inner.Port;
+        public bool IsConnected => inner.IsConnected;
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        public int ActiveOperationCount => 0;
+
+        public bool TryAcquireLease() => Interlocked.CompareExchange(ref _leaseCount, 1, 0) == 0;
+
+        public void ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+        public void BeginRetirement()
+        {
+        }
+
+        public void CompleteRetirement()
+        {
+        }
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendFireAndForgetAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendPipelinedAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+            => inner.ConnectAsync(cancellationToken);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -324,6 +324,72 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Timeout(5_000)]
+    public async Task ConsumerProtocol_StaticMaxPollExpiry_RejoinsWithNegativeTwoAndSameMemberId(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var leaveRequest = new TaskCompletionSource<ConsumerGroupHeartbeatRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var rejoinRequest = new TaskCompletionSource<ConsumerGroupHeartbeatRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var rejoining = 0;
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (Volatile.Read(ref rejoining) == 1)
+                {
+                    rejoinRequest.TrySetResult(request);
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = 2,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                if (request.MemberEpoch == -2)
+                    leaveRequest.TrySetResult(request);
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = request.MemberEpoch == -2 ? -2 : 1,
+                    HeartbeatIntervalMs = 10
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            groupInstanceId: "static-1",
+            heartbeatIntervalMs: 10,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        var leave = await leaveRequest.Task.WaitAsync(cancellationToken);
+
+        await Assert.That(leave.MemberId).IsEqualTo("member-1");
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+
+        Volatile.Write(ref rejoining, 1);
+        coordinator.RecordPoll();
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+
+        var rejoin = await rejoinRequest.Task.WaitAsync(cancellationToken);
+        await Assert.That(rejoin.MemberId).IsEqualTo("member-1");
+        await Assert.That(rejoin.MemberEpoch).IsEqualTo(-2);
+        await Assert.That(rejoin.InstanceId).IsEqualTo("static-1");
+    }
+
+    [Test]
+    [Timeout(5_000)]
     public async Task ConsumerProtocol_MaxPollIntervalExceeded_RejectsCommitWhenLeaveFails(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -395,7 +395,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task RecordPollAsync_ActiveForegroundFetchWait_DoesNotExpireMember()
+    public async Task RecordPollAsync_ActiveForegroundPollActivity_DoesNotExpireMember()
     {
         SetupSuccessfulConsumerProtocolJoin();
         var options = CreateConsumerProtocolOptions(
@@ -405,7 +405,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
         await coordinator.StopHeartbeatAsync();
 
-        coordinator.BeginForegroundFetchWait();
+        coordinator.BeginForegroundPollActivity();
         try
         {
             SetCoordinatorLongField(
@@ -423,7 +423,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         }
         finally
         {
-            coordinator.EndForegroundFetchWait();
+            coordinator.EndForegroundPollActivity();
         }
     }
 
@@ -1257,7 +1257,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task CommitOffsetsAsync_EstablishedMaxPollFence_RejectsDuringForegroundFetchWait()
+    public async Task CommitOffsetsAsync_EstablishedMaxPollFence_RejectsDuringForegroundPollActivity()
     {
         _metadataManager.SetApiVersion(
             ApiKey.OffsetCommit,
@@ -1283,7 +1283,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             "_maxPollExpiredAtPollVersion",
             GetCoordinatorLongField(coordinator, "_pollVersion"));
 
-        coordinator.BeginForegroundFetchWait();
+        coordinator.BeginForegroundPollActivity();
         GroupException? exception;
         try
         {
@@ -1295,7 +1295,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         }
         finally
         {
-            coordinator.EndForegroundFetchWait();
+            coordinator.EndForegroundPollActivity();
         }
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -323,6 +323,71 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_MaxPollIntervalExceeded_RejectsCommitWhenLeaveFails(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var leaveAttempted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == -1)
+                {
+                    leaveAttempted.TrySetResult();
+                    return ValueTask.FromException<ConsumerGroupHeartbeatResponse>(
+                        new InvalidOperationException("leave failed"));
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = 1,
+                    HeartbeatIntervalMs = 10
+                });
+            });
+
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 10,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+        await leaveAttempted.Task.WaitAsync(cancellationToken);
+
+        var exception = await Assert.That(async () =>
+                await coordinator.CommitOffsetsAsync(
+                    [new TopicPartitionOffset("test-topic", 0, 1)],
+                    cancellationToken))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
     {
         var assignment = CreateAssignment(TestTopicId, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1196,6 +1196,52 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task CommitOffsetsAsync_EstablishedMaxPollFence_RejectsDuringForegroundFetchWait()
+    {
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+        SetupSuccessfulConsumerProtocolJoin();
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetCoordinatorLongField(
+            coordinator,
+            "_maxPollExpiredAtPollVersion",
+            GetCoordinatorLongField(coordinator, "_pollVersion"));
+
+        coordinator.BeginForegroundFetchWait();
+        GroupException? exception;
+        try
+        {
+            exception = await Assert.That(async () =>
+                    await coordinator.CommitOffsetsAsync(
+                        [new TopicPartitionOffset("test-topic", 0, 1)],
+                        CancellationToken.None))
+                .Throws<GroupException>();
+        }
+        finally
+        {
+            coordinator.EndForegroundFetchWait();
+        }
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
     {
         var assignment = CreateAssignment(TestTopicId, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -913,6 +913,62 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task CommitOffsetsAsync_PollExpiresDuringConnectionWait_RejectsCommit(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(heartbeatIntervalMs: 60_000);
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+
+        var connectionRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseConnection = new TaskCompletionSource<IKafkaConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _connectionPool.GetConnectionByIndexAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                connectionRequested.TrySetResult();
+                return new ValueTask<IKafkaConnection>(releaseConnection.Task);
+            });
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var commit = coordinator.CommitOffsetsAsync(
+            [new TopicPartitionOffset("test-topic", 0, 1)],
+            cancellationToken).AsTask();
+        await connectionRequested.Task.WaitAsync(cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+        releaseConnection.TrySetResult(_connection);
+
+        var exception = await Assert.That(async () => await commit).Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
     {
         var assignment = CreateAssignment(TestTopicId, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -89,7 +89,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         string? groupRemoteAssignor = null,
         string? clientRack = null,
         int heartbeatIntervalMs = 3000,
-        int rebalanceTimeoutMs = 30000) => new()
+        int rebalanceTimeoutMs = 30000,
+        int maxPollIntervalMs = 300000) => new()
         {
             BootstrapServers = ["localhost:9092"],
             GroupId = groupId,
@@ -98,7 +99,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             ClientRack = clientRack,
             RebalanceListener = rebalanceListener,
             HeartbeatIntervalMs = heartbeatIntervalMs,
-            RebalanceTimeoutMs = rebalanceTimeoutMs
+            RebalanceTimeoutMs = rebalanceTimeoutMs,
+            MaxPollIntervalMs = maxPollIntervalMs
         };
 
     private void SetupFindCoordinator()
@@ -261,6 +263,63 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
         // MemberEpoch is stored in GenerationId for offset commit compatibility
         await Assert.That(coordinator.GenerationId).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_InitialJoin_SendsMaxPollIntervalAsRebalanceTimeout()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(
+            rebalanceTimeoutMs: 30_000,
+            maxPollIntervalMs: 12_345);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(request => request.RebalanceTimeoutMs == 12_345),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_MaxPollIntervalExceeded_LeavesDynamicMember(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var leaveRequest = new TaskCompletionSource<ConsumerGroupHeartbeatRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == -1)
+                    leaveRequest.TrySetResult(request);
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = request.MemberEpoch == -1 ? -1 : 1,
+                    HeartbeatIntervalMs = 10
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 10,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+
+        var request = await leaveRequest.Task.WaitAsync(cancellationToken);
+        await Assert.That(request.MemberEpoch).IsEqualTo(-1);
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -511,6 +511,45 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_RejoinCommitFence_DoesNotSuppressSteadyHeartbeat()
+    {
+        SetupFindCoordinator();
+        var steadyHeartbeatCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch > 0)
+                    Interlocked.Increment(ref steadyHeartbeatCount);
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = request.MemberEpoch > 0 ? request.MemberEpoch : 1,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, 0)
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.RecordPollAsync(CancellationToken.None);
+        SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", 0);
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(steadyHeartbeatCount).IsEqualTo(1);
+    }
+
+    [Test]
     [Timeout(5_000)]
     public async Task ConsumerProtocol_MaxPollIntervalExceeded_LeavesDynamicMember(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -428,6 +428,12 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
 
         Volatile.Write(ref rejoining, 1);
+        // Prefetch calls EnsureActiveGroupAsync without recording foreground poll progress.
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+
+        await Assert.That(rejoinRequest.Task.IsCompleted).IsFalse();
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+
         coordinator.RecordPoll();
         await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
 
@@ -1047,6 +1053,68 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(capturedRequest.Groups!).Count().IsEqualTo(1);
         await Assert.That(capturedRequest.Groups![0].MemberId).IsEqualTo("member-42");
         await Assert.That(capturedRequest.Groups[0].MemberEpoch).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task FetchOffsetsAsync_UnknownMemberAfterMaxPollExpiry_PreservesCommitFence()
+    {
+        _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+        SetupSuccessfulConsumerProtocolJoin();
+
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new OffsetFetchResponse
+            {
+                Groups =
+                [
+                    new OffsetFetchResponseGroup
+                    {
+                        GroupId = "test-group",
+                        Topics = [],
+                        ErrorCode = ErrorCode.UnknownMemberId
+                    }
+                ]
+            }));
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetCoordinatorLongField(
+            coordinator,
+            "_maxPollExpiredAtPollVersion",
+            GetCoordinatorLongField(coordinator, "_pollVersion"));
+
+        await Assert.That(async () =>
+                await coordinator.FetchOffsetsAsync(
+                    [new TopicPartition("test-topic", 0)],
+                    CancellationToken.None))
+            .Throws<GroupException>();
+
+        var exception = await Assert.That(async () =>
+                await coordinator.CommitOffsetsAsync(
+                    [new TopicPartitionOffset("test-topic", 0, 1)],
+                    CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -468,6 +468,49 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_SteadyHeartbeat_CrossesMaxPollWhileAwaitingResponse_DiscardsResponse()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        var heartbeatSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var heartbeatResponse = new TaskCompletionSource<ConsumerGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                heartbeatSent.TrySetResult();
+                return new ValueTask<ConsumerGroupHeartbeatResponse>(heartbeatResponse.Task);
+            });
+
+        var heartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
+        await heartbeatSent.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        heartbeatResponse.SetResult(new ConsumerGroupHeartbeatResponse
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = 99,
+            HeartbeatIntervalMs = 60_000
+        });
+
+        await heartbeat.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(coordinator.GenerationId).IsEqualTo(1);
+    }
+
+    [Test]
     [Timeout(5_000)]
     public async Task ConsumerProtocol_MaxPollIntervalExceeded_LeavesDynamicMember(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -323,10 +323,47 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                 });
             });
 
-        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        coordinator.BeginForegroundPollActivity();
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        }
+        finally
+        {
+            coordinator.EndForegroundPollActivity();
+        }
 
         await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
             .IsGreaterThan(staleTimestamp);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_BackgroundRejoin_DoesNotRefreshPollDeadline()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+        coordinator.BeginForegroundPollActivity();
+        try
+        {
+            await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        }
+        finally
+        {
+            coordinator.EndForegroundPollActivity();
+        }
+        await coordinator.StopHeartbeatAsync();
+
+        coordinator.RequestRejoin();
+        var staleTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+        SetCoordinatorLongField(coordinator, "_lastPollTimestamp", staleTimestamp);
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
+            .IsEqualTo(staleTimestamp);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1101,6 +1101,25 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task RecordPollIfLossNotificationComplete_PendingLoss_DoesNotAdvancePollVersion()
+    {
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
+        typeof(ConsumerCoordinator).GetField(
+            "_maxPollLossNotificationPending",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(coordinator, 1);
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "RecordPollIfLossNotificationComplete",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        method.Invoke(coordinator, [Stopwatch.GetTimestamp()]);
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+            .IsEqualTo(pollVersion);
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1348,6 +1348,23 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task EnsureActiveGroupAsync_StableWithRetainedFence_PreservesMemberEpoch()
+    {
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(memberEpoch: 7, heartbeatIntervalMs: 60_000);
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.RecordPollAsync(CancellationToken.None);
+        SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", 0);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(7);
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_BackgroundAssignmentSyncPreservesFenceUntilForegroundPoll()
     {
         SetupSuccessfulConsumerProtocolJoin(assignment: CreateAssignment(TestTopicId, 0));

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1345,6 +1345,47 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task CommitOffsetsAsync_BackgroundAssignmentSyncPreservesFenceUntilForegroundPoll()
+    {
+        SetupSuccessfulConsumerProtocolJoin(assignment: CreateAssignment(TestTopicId, 0));
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetCoordinatorLongField(
+            coordinator,
+            "_maxPollExpiredAtPollVersion",
+            GetCoordinatorLongField(coordinator, "_pollVersion"));
+
+        var (_, assignmentVersion, _) = coordinator.GetAssignmentSnapshotAndDrainRevocations();
+        coordinator.AcknowledgeAssignmentSync(assignmentVersion);
+
+        var exception = await Assert.That(async () =>
+                await coordinator.CommitOffsetsAsync(
+                    [new TopicPartitionOffset("test-topic", 0, 1)],
+                    CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
     {
         var assignment = CreateAssignment(TestTopicId, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -207,18 +207,6 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         field.SetValue(coordinator, value);
     }
 
-    private static void SetCoordinatorState(
-        ConsumerCoordinator coordinator,
-        CoordinatorState state)
-    {
-        var field = typeof(ConsumerCoordinator).GetField(
-            "_state",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("_state field not found.");
-
-        field.SetValue(coordinator, state);
-    }
-
     private static async Task AssertOwnedTopicPartitionsAsync(
         IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? topicPartitions,
         Guid topicId,
@@ -319,33 +307,38 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task RecordPoll_OverdueStableMember_PreservesDeadlineUntilEviction()
+    public async Task RecordPollAsync_OverdueStableMember_ExpiresAssignmentBeforeReturning()
     {
-        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(
+            heartbeatIntervalMs: 60_000,
+            assignment: CreateAssignment(TestTopicId, 0, 1));
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
-        var overdueTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
-        SetCoordinatorState(coordinator, CoordinatorState.Stable);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        var overdueTimestamp = Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L);
         SetCoordinatorLongField(coordinator, "_lastPollTimestamp", overdueTimestamp);
         var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
 
-        coordinator.RecordPoll();
+        await coordinator.RecordPollAsync(CancellationToken.None);
 
-        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
-            .IsEqualTo(overdueTimestamp);
-        await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
-            .IsEqualTo(pollVersion);
-
-        SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", pollVersion);
-        coordinator.RecordPoll();
-
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.Assignment).IsEmpty();
         await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
             .IsGreaterThan(overdueTimestamp);
         await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
             .IsEqualTo(pollVersion + 1);
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(request => request.MemberEpoch == -1),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task RecordPoll_OverdueUnjoinedMember_RefreshesDeadline()
+    public async Task RecordPollAsync_OverdueUnjoinedMember_RefreshesDeadline()
     {
         var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
@@ -353,7 +346,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         SetCoordinatorLongField(coordinator, "_lastPollTimestamp", overdueTimestamp);
         var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
 
-        coordinator.RecordPoll();
+        await coordinator.RecordPollAsync(CancellationToken.None);
 
         await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
             .IsGreaterThan(overdueTimestamp);
@@ -464,7 +457,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(rejoinRequest.Task.IsCompleted).IsFalse();
         await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
 
-        coordinator.RecordPoll();
+        await coordinator.RecordPollAsync(cancellationToken);
         await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
 
         var rejoin = await rejoinRequest.Task.WaitAsync(cancellationToken);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -301,6 +301,35 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_SuccessfulSlowJoin_RefreshesPollDeadline()
+    {
+        SetupFindCoordinator();
+        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var staleTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                SetCoordinatorLongField(coordinator, "_lastPollTimestamp", staleTimestamp);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = 1,
+                    HeartbeatIntervalMs = 60_000
+                });
+            });
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
+            .IsGreaterThan(staleTimestamp);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_InitialJoin_SendsMaxPollIntervalAsRebalanceTimeout()
     {
         SetupSuccessfulConsumerProtocolJoin();
@@ -363,6 +392,39 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             .IsGreaterThan(overdueTimestamp);
         await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
             .IsEqualTo(pollVersion + 1);
+    }
+
+    [Test]
+    public async Task RecordPollAsync_ActiveForegroundFetchWait_DoesNotExpireMember()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        coordinator.BeginForegroundFetchWait();
+        try
+        {
+            SetCoordinatorLongField(
+                coordinator,
+                "_lastPollTimestamp",
+                Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+
+            await coordinator.RecordPollAsync(CancellationToken.None);
+
+            await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+            await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Is<ConsumerGroupHeartbeatRequest>(request => request.MemberEpoch == -1),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            coordinator.EndForegroundFetchWait();
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -684,6 +684,94 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_HeartbeatExpiry_BlocksRejoinUntilPartitionsLostCompletes(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var lossStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLoss = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var assignmentCount = 0;
+        var joinRequestCount = 0;
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref assignmentCount);
+                return ValueTask.CompletedTask;
+            });
+        listener.OnPartitionsLostAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                lossStarted.TrySetResult();
+                return new ValueTask(releaseLoss.Task);
+            });
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == -1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = -1,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                var join = Interlocked.Increment(ref joinRequestCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = join,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, join - 1)
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        var heartbeatExpiry = InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, cancellationToken);
+        await lossStarted.Task.WaitAsync(cancellationToken);
+
+        await coordinator.RecordPollAsync(cancellationToken);
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        var joinsWhileLossPending = Volatile.Read(ref joinRequestCount);
+        var assignmentsWhileLossPending = Volatile.Read(ref assignmentCount);
+
+        releaseLoss.TrySetResult();
+        await heartbeatExpiry.WaitAsync(cancellationToken);
+        await coordinator.RecordPollAsync(cancellationToken);
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+
+        await Assert.That(joinsWhileLossPending).IsEqualTo(1);
+        await Assert.That(assignmentsWhileLossPending).IsEqualTo(1);
+        await Assert.That(joinRequestCount).IsEqualTo(2);
+        await Assert.That(assignmentCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -428,6 +428,46 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_SteadyHeartbeat_CrossesMaxPollWhileAcquiringConnection_DoesNotSend()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+
+        var connectionRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _connectionPool.GetConnectionByIndexAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                connectionRequested.TrySetResult();
+                return new ValueTask<IKafkaConnection>(connectionAvailable.Task);
+            });
+
+        var heartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
+        await connectionRequested.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        connectionAvailable.SetResult(_connection);
+
+        await heartbeat.WaitAsync(TimeSpan.FromSeconds(1));
+
+        await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(request => request.MemberEpoch > 0),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     [Timeout(5_000)]
     public async Task ConsumerProtocol_MaxPollIntervalExceeded_LeavesDynamicMember(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -772,6 +772,108 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_ConcurrentForegroundExpiry_DoesNotRecordPollDuringPartitionsLost(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var lossStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLoss = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsLostAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                lossStarted.TrySetResult();
+                return new ValueTask(releaseLoss.Task);
+            });
+
+        var joinRequestCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == -1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = -1,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                var join = Interlocked.Increment(ref joinRequestCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = join,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, join - 1)
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+        var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
+        var coordinatorLock = (SemaphoreSlim)typeof(ConsumerCoordinator).GetField(
+            "_lock",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(coordinator)!;
+
+        await coordinatorLock.WaitAsync(cancellationToken);
+        Task firstPoll;
+        Task secondPoll;
+        try
+        {
+            firstPoll = coordinator.RecordPollAsync(cancellationToken).AsTask();
+            secondPoll = coordinator.RecordPollAsync(cancellationToken).AsTask();
+        }
+        finally
+        {
+            coordinatorLock.Release();
+        }
+
+        try
+        {
+            await lossStarted.Task.WaitAsync(cancellationToken);
+            var nonExpiringPoll = await Task.WhenAny(firstPoll, secondPoll).WaitAsync(cancellationToken);
+            await nonExpiringPoll;
+            await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+
+            await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+                .IsEqualTo(pollVersion);
+            await Assert.That(joinRequestCount).IsEqualTo(1);
+
+            releaseLoss.TrySetResult();
+            await Task.WhenAll(firstPoll, secondPoll).WaitAsync(cancellationToken);
+            await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+
+            await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+                .IsEqualTo(pollVersion + 1);
+            await Assert.That(joinRequestCount).IsEqualTo(2);
+        }
+        finally
+        {
+            releaseLoss.TrySetResult();
+        }
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -183,6 +184,29 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         };
     }
 
+    private static long GetCoordinatorLongField(ConsumerCoordinator coordinator, string fieldName)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+
+        return (long)field.GetValue(coordinator)!;
+    }
+
+    private static void SetCoordinatorLongField(
+        ConsumerCoordinator coordinator,
+        string fieldName,
+        long value)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+
+        field.SetValue(coordinator, value);
+    }
+
     private static async Task AssertOwnedTopicPartitionsAsync(
         IReadOnlyList<ConsumerGroupHeartbeatTopicPartitions>? topicPartitions,
         Guid topicId,
@@ -280,6 +304,31 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             Arg.Is<ConsumerGroupHeartbeatRequest>(request => request.RebalanceTimeoutMs == 12_345),
             Arg.Any<short>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RecordPoll_OverdueBeforeExpiry_PreservesDeadlineUntilEviction()
+    {
+        var options = CreateConsumerProtocolOptions(maxPollIntervalMs: 50);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var overdueTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+        SetCoordinatorLongField(coordinator, "_lastPollTimestamp", overdueTimestamp);
+        var pollVersion = GetCoordinatorLongField(coordinator, "_pollVersion");
+
+        coordinator.RecordPoll();
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
+            .IsEqualTo(overdueTimestamp);
+        await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+            .IsEqualTo(pollVersion);
+
+        SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", pollVersion);
+        coordinator.RecordPoll();
+
+        await Assert.That(GetCoordinatorLongField(coordinator, "_lastPollTimestamp"))
+            .IsGreaterThan(overdueTimestamp);
+        await Assert.That(GetCoordinatorLongField(coordinator, "_pollVersion"))
+            .IsEqualTo(pollVersion + 1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1261,6 +1261,51 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task CommitOffsetsAsync_RejoinPreservesFenceUntilAssignmentSync()
+    {
+        SetupSuccessfulConsumerProtocolJoin(assignment: CreateAssignment(TestTopicId, 0));
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.RecordPollAsync(CancellationToken.None);
+        SetCoordinatorLongField(coordinator, "_maxPollExpiredAtPollVersion", 0);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        var exception = await Assert.That(async () =>
+                await coordinator.CommitOffsetsAsync(
+                    [new TopicPartitionOffset("test-topic", 0, 1)],
+                    CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
+        await Assert.That(commitRequestCount).IsEqualTo(0);
+
+        var (_, assignmentVersion, _) = coordinator.GetAssignmentSnapshotAndDrainRevocations();
+        coordinator.AcknowledgeAssignmentSync(assignmentVersion);
+        await coordinator.CommitOffsetsAsync(
+            [new TopicPartitionOffset("test-topic", 0, 1)],
+            CancellationToken.None);
+
+        await Assert.That(commitRequestCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_SuccessfulJoin_WithAssignment_SetsPartitions()
     {
         var assignment = CreateAssignment(TestTopicId, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -685,6 +685,88 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 
     [Test]
     [Timeout(5_000)]
+    public async Task ConsumerProtocol_ExpirySkipsRemainingCallbacksFromPublishedHeartbeat(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+        var revocationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRevocation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var assignedCallbackCount = 0;
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsRevokedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                revocationStarted.TrySetResult();
+                return new ValueTask(releaseRevocation.Task);
+            });
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref assignedCallbackCount);
+                return ValueTask.CompletedTask;
+            });
+
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<ConsumerGroupHeartbeatRequest>();
+                if (request.MemberEpoch == -1)
+                {
+                    return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        MemberId = "member-1",
+                        MemberEpoch = -1,
+                        HeartbeatIntervalMs = 60_000
+                    });
+                }
+
+                var isInitial = request.MemberEpoch == 0;
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = isInitial ? 1 : 2,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = CreateAssignment(TestTopicId, isInitial ? 0 : 1)
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000,
+            maxPollIntervalMs: 300_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, cancellationToken);
+        await coordinator.StopHeartbeatAsync();
+
+        var steadyHeartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
+        await revocationStarted.Task.WaitAsync(cancellationToken);
+        SetCoordinatorLongField(
+            coordinator,
+            "_lastPollTimestamp",
+            Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 600L));
+
+        await coordinator.RecordPollAsync(cancellationToken);
+        releaseRevocation.TrySetResult();
+        await steadyHeartbeat.WaitAsync(cancellationToken);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(coordinator.Assignment).IsEmpty();
+        await Assert.That(assignedCallbackCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(5_000)]
     public async Task ConsumerProtocol_HeartbeatExpiry_BlocksRejoinUntilPartitionsLostCompletes(
         CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary
- send `max.poll.interval.ms` as the KIP-848 rebalance timeout and track foreground polls
- leave stalled members, fence late commits, and cover deterministic reassignment with a sequence oracle

## Test plan
- [x] `ConsumerCoordinatorKip848Tests` (net8.0, net10.0)
- [x] `ConsumerGroupRebalanceChaosTests` (Kafka 4.0, net8.0)
- [x] `dotnet format Dekaf.sln --verify-no-changes`

Closes #1617