### PR TITLE
fix(producer): preserve non-idempotent ordering

### DIFF
--- a/docs/docs/producer/basics.md
+++ b/docs/docs/producer/basics.md
@@ -159,7 +159,7 @@ With idempotence enabled:
 
 `MaxInFlightRequestsPerConnection` controls how many produce requests can be outstanding on one broker connection. Idempotent and transactional producers are capped at 5, which is the Kafka protocol limit for sequence tracking.
 
-When idempotence is disabled, Dekaf defaults to 100 in-flight requests per connection so fire-and-forget and `Acks.Leader` workloads can keep the broker pipeline full. With retries enabled, non-idempotent producers using more than 1 in-flight request can reorder messages if an earlier request is retried after a later request succeeds. Set `MaxInFlightRequestsPerConnection` to 1, or keep idempotence enabled, when strict per-partition ordering matters.
+When idempotence is disabled, Dekaf defaults to 100 in-flight requests per connection so fire-and-forget and `Acks.Leader` workloads can keep the broker pipeline full across partitions. Because non-idempotent batches have no sequence numbers, Dekaf keeps at most one batch per partition in flight while still sending different partitions concurrently. This preserves per-partition order, though retries may still produce duplicates.
 
 ## Error Handling
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -424,15 +424,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Func<bool> _isTransactional;
     private readonly Func<TopicPartition, CancellationToken, ValueTask>? _ensurePartitionInTransaction;
 
-    // Send-time muting: when true, partitions are muted at send time (limiting to 1
-    // in-flight batch per partition). When false, multiple in-flight batches per partition
-    // are allowed, relying on sequence numbers for ordering instead of muting.
-    // Only enabled when MaxInFlight <= 1; idempotent producers with MaxInFlight > 1
-    // use sequence numbers to guarantee ordering without send-time muting.
+    // Send-time muting limits each partition to 1 in-flight batch when producer sequence
+    // numbers are unavailable, or when the configured request limit is already 1.
+    // Idempotent producers with MaxInFlight > 1 rely on sequence numbers instead.
     private readonly bool _muteOnSend;
 
     // Muted partitions: partitions with a retry in progress or limited to 1 in-flight
-    // batch (when _muteOnSend). Prevents newer batches from being sent, maintaining
+    // batch by _muteOnSend. Prevents newer batches from being sent, maintaining
     // per-partition ordering. Aligned with Java Kafka producer's mute mechanism.
     // Uses ConcurrentDictionary as a concurrent set (byte value unused): with multi-connection
     // sends, concurrent Z handlers (catch blocks in SendCoalescedAsync) can write from
@@ -612,15 +610,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         });
 
         _maxInFlight = options.MaxInFlightRequestsPerConnection;
+        _isIdempotent = options.EnableIdempotence;
 
-        // Only mute at send time when limited to 1 in-flight request.
-        // Idempotent producers with maxInFlight > 1 rely on sequence numbers for ordering.
-        _muteOnSend = _maxInFlight <= 1;
+        // Non-idempotent batches have no sequence numbers, so concurrent requests for the
+        // same partition can be appended out of order even when no retry occurs.
+        _muteOnSend = !_isIdempotent || _maxInFlight <= 1;
 
         // All producers use partition affinity (partition % connectionCount) for CPU cache
         // locality. Idempotent producers additionally need affinity for sequence ordering.
         _connectionCount = options.ConnectionsPerBroker;
-        _isIdempotent = options.EnableIdempotence;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
 
         // Adaptive scaling: available for all non-transactional producers.
@@ -1522,9 +1520,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     //
                     // Can pipeline: progress was made, no muted carry-over that could
                     // generate stale channel events, and in-flight capacity remains.
-                    // Note: when _muteOnSend is true (MaxInFlightRequestsPerConnection == 1),
-                    // waitPendingCount == _totalMaxInFlight after every send, so canPipeline
-                    // is always false — single-in-flight producers always take the response-wait path.
+                    // A request limit of 1 always fills capacity and takes the response-wait path.
+                    // Non-idempotent producers can still pipeline batches for other partitions;
+                    // their same-partition batches remain in carry-over while muted.
                     var canPipeline = sentThisIteration
                         && carryOver.Count == 0
                         && waitPendingCount < _totalMaxInFlight;
@@ -2355,8 +2353,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     continue;
                 }
 
-                // Only unmute on success when mute-on-send is active (maxInFlight <= 1).
-                // With maxInFlight > 1, partitions are muted only on error (HandleRetriableBatch).
+                // Only unmute on success when mute-on-send is active (non-idempotent or maxInFlight <= 1).
+                // Idempotent producers with maxInFlight > 1 mute partitions only on error.
                 // Unconditionally unmuting on success would prematurely clear the mute set by a
                 // DIFFERENT failed batch for the same partition still pending retry. This allows
                 // newer carry-over batches to skip ahead of the older retry batch, violating
@@ -3001,10 +2999,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         .UnsafeOnCompleted(_responseCompletionCallback);
                 }
 
-                // Mute partitions at send time when limited to 1 in-flight request.
+                // Mute partitions when producer sequence numbers cannot preserve order, or when
+                // the configured request limit already permits only 1 in-flight request.
                 // This ensures at most one batch per partition in-flight across all requests.
-                // When maxInFlight > 1, sequence numbers guarantee ordering instead,
-                // and retry-time muting handles error recovery.
+                // Idempotent producers with maxInFlight > 1 use sequence numbers instead.
                 if (_muteOnSend)
                 {
                     for (var i = 0; i < count; i++)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -621,11 +621,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _connectionCount = options.ConnectionsPerBroker;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
 
-        // Adaptive scaling: available for all non-transactional producers.
-        // All producers use partition affinity (partition % N) for cache locality.
-        // Idempotent producers additionally need affinity for sequence ordering.
         // Transactions are excluded because coordinator requests require a single connection.
-        _adaptiveScalingEnabled = options.EnableAdaptiveConnections && options.TransactionalId is null;
+        // Acks.None is excluded because no broker acknowledgement establishes a safe boundary
+        // for remapping a partition to another connection without risking reordered appends.
+        _adaptiveScalingEnabled = options.EnableAdaptiveConnections
+            && options.TransactionalId is null
+            && options.Acks != Acks.None;
         _canPhysicallyShrinkConnections = canPhysicallyShrinkConnections;
         _minConnectionCount = options.ConnectionsPerBroker;
         _maxConnectionsPerBroker = options.MaxConnectionsPerBroker;
@@ -1028,7 +1029,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                 }
 
-                // ── 4b. Adaptive connection scaling (all non-transactional producers) ──
+                // ── 4b. Adaptive connection scaling ──
                 if (_adaptiveScalingEnabled)
                 {
                     var scaledToCount = MaybeScaleConnections();

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1318,6 +1318,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                 var slot = nextSingleConnectionFireAndForgetSlot;
                                 nextSingleConnectionFireAndForgetSlot = 1 - nextSingleConnectionFireAndForgetSlot;
 
+                                // The single-connection fire-and-forget path starts the next write
+                                // before awaiting the previous flush. Fence these partitions before
+                                // starting the write so a newer same-partition batch stays in
+                                // carry-over while other partitions can still use the open slot.
+                                MutePartitionsForSend(batchesToSend, countToSend);
+
                                 ResetBucketTimeout(ref singleConnectionFireAndForgetTimeoutCts[slot],
                                     cancellationToken);
 
@@ -1546,6 +1552,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 else if (carryOver.Count > 0)
                 {
+                    if (hasPendingSingleConnectionFireAndForgetSend)
+                    {
+                        await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false);
+                        continue;
+                    }
+
                     // Carry-over exists but no pending responses (e.g. retry backoff waiting).
                     // Timed wait — loop back after earliest retry backoff or delivery deadline.
                     var wakeupMs = ComputeNextWakeupMs(carryOver);
@@ -2884,6 +2896,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     await connection.SendFireAndForgetWithCallerTimeoutAsync<ProduceRequest, ProduceResponse>(
                         request, (short)apiVersion, cancellationToken).ConfigureAwait(false);
 
+                    // The write is now ordered on the connection. Release the send-time fence
+                    // before resource pins so each batch still owns its original partition.
+                    if (_muteOnSend)
+                    {
+                        for (var i = 0; i < count; i++)
+                            UnmutePartition(batches[i].TopicPartition);
+                    }
+
                     // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
                     scratch.ClearReferences();
                     ReleaseResourcePins(batches, resourcePinCount);
@@ -3003,14 +3023,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // the configured request limit already permits only 1 in-flight request.
                 // This ensures at most one batch per partition in-flight across all requests.
                 // Idempotent producers with maxInFlight > 1 use sequence numbers instead.
-                if (_muteOnSend)
-                {
-                    for (var i = 0; i < count; i++)
-                    {
-                        if (!batches[i].IsLoopExitRedelivery)
-                            MutePartition(batches[i].TopicPartition);
-                    }
-                }
+                MutePartitionsForSend(batches, count);
 
                 LogPipelinedSend(_brokerId, count, _totalPendingResponseCount);
             }
@@ -3609,6 +3622,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         if (_mutedPartitions.TryAdd(tp, 0))
             _accumulator.MutePartition(tp);
+    }
+
+    private void MutePartitionsForSend(ReadyBatch[] batches, int count)
+    {
+        if (!_muteOnSend)
+            return;
+
+        for (var i = 0; i < count; i++)
+        {
+            if (!batches[i].IsLoopExitRedelivery)
+                MutePartition(batches[i].TopicPartition);
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -164,9 +164,9 @@ public sealed class ProducerOptions
     /// producers at 5. When idempotence is disabled and this value is not explicitly set,
     /// Dekaf uses 100 to keep the non-idempotent pipeline full.
     /// <para>
-    /// Non-idempotent producers with retries enabled and more than 1 in-flight request may
-    /// reorder messages if an earlier request is retried after a later one succeeds. Set this
-    /// to 1, or keep idempotence enabled, when strict per-partition ordering matters.
+    /// Non-idempotent producers use this capacity across partitions, while Dekaf keeps at most
+    /// one batch per partition in flight because those batches have no sequence numbers.
+    /// Per-partition order is preserved, but retries may still produce duplicates.
     /// </para>
     /// </summary>
     public int MaxInFlightRequestsPerConnection

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -529,13 +529,14 @@ public sealed class ProducerOptions
     /// When enabled, the producer will automatically increase connections per broker
     /// when sustained buffer backpressure is detected, improving drain throughput.
     /// <para>
-    /// Applies to both idempotent and non-idempotent producers. Idempotent producers
+    /// Applies to idempotent and acknowledged non-idempotent producers. Idempotent producers
     /// use partition affinity (partition % connectionCount) to preserve per-partition
     /// sequence ordering across multiple connections, so adaptive scaling is safe.
     /// </para>
     /// <para>
-    /// Only automatically disabled for transactional producers (<see cref="TransactionalId"/> is set),
-    /// because transaction coordinator requests require a single connection per broker.
+    /// Automatically disabled for transactional producers (<see cref="TransactionalId"/> is set),
+    /// because transaction coordinator requests require a single connection per broker, and for
+    /// <c>Acks.None</c>, because no broker acknowledgement establishes a safe remapping boundary.
     /// </para>
     /// Default: true.
     /// </summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -873,6 +873,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         (long)(DisposeAppendInProgressWaitMs * (Stopwatch.Frequency / 1000.0));
 
     private readonly ProducerOptions _options;
+    private readonly bool _serializeBatchesPerPartition;
     private readonly CompressionCodecRegistry? _compressionCodecs;
     private readonly ConcurrentDictionary<string, int> _singleBatchRequestFixedSizes =
         new(StringComparer.Ordinal);
@@ -1871,6 +1872,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         _options = options;
+        _serializeBatchesPerPartition = !options.EnableIdempotence
+            || options.MaxInFlightRequestsPerConnection <= 1;
         _compressionCodecs = compressionCodecs;
         _onBatchComplete = onBatchComplete;
         _onRecordAppended = onRecordAppended;
@@ -3393,7 +3396,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSealAppendedBatch(PartitionBatch batch)
         => batch.IsExactlyAtSizeLimit
-            || (_options.LingerMs == 0 && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs));
+            || (_options.LingerMs == 0
+                && !ShouldDeferPartialBatchSeal(batch.TopicPartition)
+                && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool ShouldDeferPartialBatchSeal(TopicPartition topicPartition)
+    {
+        if (_mutedPartitions.ContainsKey(topicPartition))
+            return true;
+
+        return _serializeBatchesPerPartition
+            && _partitionQueueBytes.TryGetValue(topicPartition, out var queuedBytes)
+            && queuedBytes > 0;
+    }
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
@@ -4088,7 +4104,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     break;
                 }
-                else if (sealAll || pd.CurrentBatch.ShouldFlush(now, _options.LingerMs))
+                // A muted or serialized busy partition already has an earlier batch to send.
+                // Keep its partial arena open so zero-linger appends coalesce instead of
+                // allocating one BatchSize arena per record while they wait. Size-full batches
+                // still seal in the append path, and FlushAsync must always seal.
+                else if (sealAll
+                    || (!ShouldDeferPartialBatchSeal(topicPartition)
+                        && pd.CurrentBatch.ShouldFlush(now, _options.LingerMs)))
                 {
                     ProducerDebugCounters.RecordBatchFlushedFromDictionary();
                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, pd.CurrentBatch);

--- a/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
@@ -4,39 +4,40 @@ using Dekaf.Producer;
 namespace Dekaf.Tests.Integration;
 
 /// <summary>
-/// Integration tests for multiple in-flight batches per partition.
-/// Verifies that producers with multiple in-flight batches preserve
-/// per-partition ordering and deliver all messages.
+/// Integration tests for multiple in-flight produce requests.
+/// Verifies per-partition ordering and complete delivery across producer modes.
 /// </summary>
 [Category("MultiInFlightProducer")]
 public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
-    public async Task MultiInflight_SinglePartition_OrderingPreserved()
+    public async Task NonIdempotentMultiInflight_SinglePartition_OrderingPreserved()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
-        const int messageCount = 1000;
+        const int messageCount = 10_000;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
-            .WithClientId("test-multi-inflight-single-partition")
+            .WithClientId("test-non-idempotent-multi-inflight-single-partition")
+            .WithIdempotence(false)
             .WithAcks(Acks.All)
-
-            .WithBatchSize(512) // Small batch size to force many batches
+            .WithBatchSize(256) // Force many concurrently submitted batches
             .WithLinger(TimeSpan.FromMilliseconds(1))
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
+        var deliveries = new Task<RecordMetadata>[messageCount];
         for (var i = 0; i < messageCount; i++)
         {
-            await producer.ProduceAsync(new ProducerMessage<string, string>
+            deliveries[i] = producer.ProduceAsync(new ProducerMessage<string, string>
             {
                 Topic = topic,
                 Key = "ordering-key",
                 Value = $"msg-{i:D4}"
-            }, CancellationToken.None);
+            }, CancellationToken.None).AsTask();
         }
 
+        await Task.WhenAll(deliveries);
         await producer.FlushWithTimeoutAsync();
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
@@ -384,10 +385,8 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        // Warm up all partitions to ensure the broker has fully initialized partition
-        // state tracking. Without this, the first produce to a newly-created partition
-        // may get NotLeaderOrFollower, and with MaxInFlight > 1 later in-flight batches
-        // for the same partition can succeed out of order at the broker.
+        // Warm up all partitions so this test covers coalescing rather than initial
+        // partition metadata recovery.
         for (var p = 0; p < partitionCount; p++)
             await producer.ProduceAsync(new ProducerMessage<int, string>
             {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -39,10 +39,11 @@ public sealed class BrokerSenderMuteOrderingTests
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
-        int maxRequestSize = 1_048_576) => new()
+        int maxRequestSize = 1_048_576, bool enableIdempotence = true) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
+            EnableIdempotence = enableIdempotence,
             Acks = acks,
             DeliveryTimeoutMs = deliveryTimeoutMs,
             RetryBackoffMs = retryBackoffMs,
@@ -298,6 +299,74 @@ public sealed class BrokerSenderMuteOrderingTests
             completionSourcesCount: 0,
             dataSize: 100);
         return batch;
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task NonIdempotentProducer_MultipleInFlight_SerializesSamePartitionBatches(
+        CancellationToken ct)
+    {
+        var responses = Enumerable.Range(0, 2)
+            .Select(_ => new TaskCompletionSource<ProduceResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sendLogger = new PipelinedSendLogger(expectedSends: 2);
+        var acknowledgedOffsets = new List<long>();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, offset, _, _, ex) =>
+            {
+                if (ex is not null)
+                    return;
+
+                lock (acknowledgedOffsets)
+                {
+                    acknowledgedOffsets.Add(offset);
+                    if (acknowledgedOffsets.Count == 2)
+                        allAcknowledged.TrySetResult();
+                }
+            },
+            logger: sendLogger);
+
+        try
+        {
+            var firstBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
+            sender.Enqueue(firstBatch);
+            await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+
+            await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsTrue();
+
+            var secondBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
+            sender.Enqueue(secondBatch);
+
+            await WaitForDiagAsync(secondBatch, 'O', TimeSpan.FromSeconds(5), ct);
+            await Assert.That(sendLogger.SendCount).IsEqualTo(1);
+
+            responses[0].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 100));
+            await sendLogger.SendSignals[1].Task.WaitAsync(ct);
+            responses[1].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 101));
+
+            await allAcknowledged.Task.WaitAsync(ct);
+            await Assert.That(acknowledgedOffsets[0]).IsEqualTo(100);
+            await Assert.That(acknowledgedOffsets[1]).IsEqualTo(101);
+        }
+        finally
+        {
+            responses[0].TrySetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 100));
+            responses[1].TrySetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 101));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
     }
 
     [Test]
@@ -1386,6 +1455,42 @@ public sealed class BrokerSenderMuteOrderingTests
             _crashGate.Task.GetAwaiter().GetResult();
             if (Volatile.Read(ref _armed) != 0 && Interlocked.Exchange(ref _thrown, 1) == 0)
                 throw new InvalidOperationException("Injected send-loop crash");
+        }
+    }
+
+    private sealed class PipelinedSendLogger : ILogger
+    {
+        private int _sendCount;
+
+        public PipelinedSendLogger(int expectedSends)
+        {
+            SendSignals = Enumerable.Range(0, expectedSends)
+                .Select(_ => new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously))
+                .ToArray();
+        }
+
+        public TaskCompletionSource[] SendSignals { get; }
+
+        public int SendCount => Volatile.Read(ref _sendCount);
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel == LogLevel.Debug;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (eventId.Name != "LogPipelinedSend")
+                return;
+
+            var index = Interlocked.Increment(ref _sendCount) - 1;
+            if ((uint)index < (uint)SendSignals.Length)
+                SendSignals[index].TrySetResult();
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -370,6 +370,33 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
+    public async Task NonIdempotentFireAndForget_DisablesAdaptiveConnectionRemapping()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var options = CreateOptions(
+            acks: Acks.None,
+            maxInFlight: 2,
+            enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var adaptiveScalingEnabled = (bool)typeof(BrokerSender).GetField(
+                "_adaptiveScalingEnabled",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+
+            await Assert.That(adaptiveScalingEnabled).IsFalse()
+                .Because("Acks.None has no broker acknowledgement that makes cross-connection remapping safe");
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(30_000)]
     public async Task NonIdempotentFireAndForget_SerializesSamePartitionWrites(
         CancellationToken ct)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -370,6 +370,78 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task NonIdempotentFireAndForget_SerializesSamePartitionWrites(
+        CancellationToken ct)
+    {
+        var firstWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWrite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWriteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var connection = new TestKafkaConnection();
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var options = CreateOptions(
+            acks: Acks.None,
+            maxInFlight: 2,
+            enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledgedCount = 0;
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        BrokerSender? sender = null;
+        var secondBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
+        var sendCount = 0;
+
+        connection.SendProduceFireAndForgetWithCallerTimeout = () =>
+        {
+            var current = Interlocked.Increment(ref sendCount);
+            if (current == 1)
+            {
+                sender!.Enqueue(secondBatch);
+                return new ValueTask(firstWrite.Task);
+            }
+
+            secondWriteStarted.TrySetResult();
+            return new ValueTask(secondWrite.Task);
+        };
+
+        sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, ex) =>
+            {
+                if (ex is null && Interlocked.Increment(ref acknowledgedCount) == 2)
+                    allAcknowledged.TrySetResult();
+            });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", partition: 0));
+
+            await WaitForDiagAsync(secondBatch, 'O', TimeSpan.FromSeconds(5), ct);
+            await Assert.That(secondWriteStarted.Task.IsCompleted).IsFalse();
+
+            firstWrite.SetResult();
+            await secondWriteStarted.Task.WaitAsync(ct);
+            secondWrite.SetResult();
+            await allAcknowledged.Task.WaitAsync(ct);
+        }
+        finally
+        {
+            firstWrite.TrySetResult();
+            secondWrite.TrySetResult();
+            if (sender is not null)
+                await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task CoalesceBatch_WhenFull_CarriesOverNormalBatch()
     {
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -28,12 +28,14 @@ public sealed class BrokerSenderSendLoopTests
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
-        int connectionsPerBroker = 1, bool enableAdaptiveConnections = true) => new()
+        int connectionsPerBroker = 1, bool enableAdaptiveConnections = true,
+        bool enableIdempotence = true) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
             ConnectionsPerBroker = connectionsPerBroker,
             EnableAdaptiveConnections = enableAdaptiveConnections,
+            EnableIdempotence = enableIdempotence,
             Acks = acks,
             DeliveryTimeoutMs = deliveryTimeoutMs,
             RetryBackoffMs = retryBackoffMs,
@@ -1199,7 +1201,10 @@ public sealed class BrokerSenderSendLoopTests
         var sendCount = 0;
         BrokerSender? sender = null;
 
-        var options = CreateOptions(acks: Acks.None, maxInFlight: 5);
+        var options = CreateOptions(
+            acks: Acks.None,
+            maxInFlight: 5,
+            enableIdempotence: false);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
         var secondBatch = CreateTestBatch(vtPool, "test-topic", 1);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -22,7 +22,8 @@ public class RecordAccumulatorReadyTests
     private static ProducerOptions CreateTestOptions(
         int batchSize = 1000,
         int lingerMs = 10,
-        CompressionType compressionType = CompressionType.None)
+        CompressionType compressionType = CompressionType.None,
+        bool enableIdempotence = true)
     {
         return new ProducerOptions
         {
@@ -31,7 +32,8 @@ public class RecordAccumulatorReadyTests
             BufferMemory = ulong.MaxValue,
             BatchSize = batchSize,
             LingerMs = lingerMs,
-            CompressionType = compressionType
+            CompressionType = compressionType,
+            EnableIdempotence = enableIdempotence
         };
     }
 
@@ -886,6 +888,101 @@ public class RecordAccumulatorReadyTests
             await accumulator.DisposeAsync();
             await metadataManager.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task ExpireLingerAsync_MutedPartition_KeepsBatchOpenUntilUnmuted()
+    {
+        var options = CreateTestOptions(batchSize: 100_000, lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var metadataManager = CreateMetadataManager("test-topic", 1, nodeId: 1);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        accumulator.MutePartition(topicPartition);
+
+        try
+        {
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+            await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+            await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+
+            accumulator.UnmutePartition(topicPartition);
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
+            await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsFalse();
+
+            var readyNodes = new HashSet<int>();
+            accumulator.Ready(metadataManager, readyNodes);
+            await Assert.That(readyNodes).Contains(1);
+        }
+        finally
+        {
+            accumulator.UnmutePartition(topicPartition);
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ZeroLinger_SerializedPartition_KeepsNextBatchOpenWhilePreviousQueued()
+    {
+        var options = CreateTestOptions(
+            batchSize: 100_000,
+            lingerMs: 0,
+            enableIdempotence: false);
+        await using var accumulator = new RecordAccumulator(options);
+
+        var firstAppended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "first"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(firstAppended).IsTrue();
+        await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsFalse();
+        await Assert.That(accumulator.GetPartitionQueueBytes("test-topic", 0)).IsGreaterThan(0);
+
+        var secondAppended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "second"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(secondAppended).IsTrue();
+        await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+
+        await accumulator.ExpireLingerAsync(CancellationToken.None);
+        await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- serialize non-idempotent batches per partition because they have no Kafka sequence fencing
- retain concurrent requests across different partitions and idempotent same-partition pipelining
- add deterministic sender coverage plus a 10,000-record real-Kafka regression
- document the non-idempotent ordering guarantee

## Validation
- `dotnet build Dekaf.sln --configuration Release`
- BrokerSender unit tests: 44/44 on net8.0 and 44/44 on net10.0
- non-idempotent Kafka ordering regression: 3/3 on net8.0 and 3/3 on net10.0
- `npm run build --prefix docs`
- #1636 exact 500,000-message gate: accepted=500,000, broker delivered=500,000, errors=0, delivery errors=0, duplicates=0, corrupt=0, out-of-order=0, wrong-partition=0

The 500k run exposed an independent multi-partition Dekaf consumer stall after 426,837 records despite all 500,000 being present at broker end offsets. Existing idempotent integration coverage reproduces that unchanged path; tracked in #1697.

Closes #1696