### PR TITLE
test(producer): exercise multi-partition pipeline

### DIFF
--- a/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
@@ -370,7 +370,9 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
         }
     }
 
-    [Test]
+    // This validates cross-partition coalescing, not shared-broker saturation.
+    // Run alone so the test's 30-second broker retention does not trim early partitions.
+    [Test, NotInParallel]
     public async Task MultiInflight_WithCoalescing_OrderingPreserved()
     {
         const int partitionCount = 8;
@@ -404,13 +406,13 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
         {
             for (var p = 0; p < partitionCount; p++)
             {
-                await producer.ProduceAsync(new ProducerMessage<int, string>
+                await producer.FireAsync(new ProducerMessage<int, string>
                 {
                     Topic = topic,
                     Partition = p,
                     Key = p,
                     Value = $"coal-p{p}-{i:D4}"
-                }, CancellationToken.None);
+                });
             }
         }
 

--- a/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
@@ -89,13 +89,13 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
 
         // Warm up all partitions to ensure the broker has fully initialized partition state.
         for (var p = 0; p < partitionCount; p++)
-            await producer.FireAsync(new ProducerMessage<int, string>
+            await producer.ProduceAsync(new ProducerMessage<int, string>
             {
                 Topic = topic,
                 Key = -1,
                 Value = "warmup",
                 Partition = p
-            });
+            }, CancellationToken.None);
 
         // Produce messages keyed by partition index
         for (var p = 0; p < partitionCount; p++)

--- a/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/MultiInflightProducerTests.cs
@@ -69,7 +69,9 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
         }
     }
 
-    [Test]
+    // This validates client-side multi-partition pipelining, not shared-broker saturation.
+    // Run alone so the test's 30-second broker retention does not trim early partitions.
+    [Test, NotInParallel]
     public async Task MultiInflight_MultiPartition_PerPartitionOrderingPreserved()
     {
         const int partitionCount = 8;
@@ -87,26 +89,26 @@ public sealed class MultiInflightProducerTests(KafkaTestContainer kafka) : Kafka
 
         // Warm up all partitions to ensure the broker has fully initialized partition state.
         for (var p = 0; p < partitionCount; p++)
-            await producer.ProduceAsync(new ProducerMessage<int, string>
+            await producer.FireAsync(new ProducerMessage<int, string>
             {
                 Topic = topic,
                 Key = -1,
                 Value = "warmup",
                 Partition = p
-            }, CancellationToken.None);
+            });
 
         // Produce messages keyed by partition index
         for (var p = 0; p < partitionCount; p++)
         {
             for (var i = 0; i < messagesPerPartition; i++)
             {
-                await producer.ProduceAsync(new ProducerMessage<int, string>
+                await producer.FireAsync(new ProducerMessage<int, string>
                 {
                     Topic = topic,
                     Partition = p,
                     Key = p,
                     Value = $"p{p}-msg-{i:D4}"
-                }, CancellationToken.None);
+                });
             }
         }
 


### PR DESCRIPTION
## Summary

- replace serialized delivery waits with `FireAsync` so the multi-inflight test actually pipelines records
- isolate the shared Kafka fixture so unrelated integration load cannot consume the broker's 30-second retention window
- preserve all per-partition count and ordering assertions

## Root cause

The deterministic integration failure was not a consumer fetch stall. Producing 4,008 records with an awaited broker acknowledgement per record took over 60 seconds while the test broker retains logs for 30 seconds. Before consumption began, broker low watermarks had advanced to the end on the earliest partitions (for example, `501-501` on partitions 0-2), so those records no longer existed to fetch.

The exact retention-free 500,000-message, three-partition round-trip was also rerun against current main plus #1696 and consumed 500,000/500,000 with zero missing, duplicate, corrupt, out-of-order, or mispartitioned records.

## Validation

- red baseline: net10.0 failed 3/3 after about two minutes
- net8.0 focused integration: 3/3 passed
- net10.0 focused integration: 3/3 passed
- net10.0 `MultiInflightProducerTests`: 21/21 passed
- exact 500,000-message round-trip: 500,000/500,000 passed
- scoped `dotnet format --verify-no-changes`

Closes #1697