### PR TITLE
test(consumer): cover abrupt member loss

### DIFF
--- a/tests/Dekaf.Tests.Integration/BoundedProcessDiagnostics.cs
+++ b/tests/Dekaf.Tests.Integration/BoundedProcessDiagnostics.cs
@@ -1,0 +1,27 @@
+using System.Text;
+
+namespace Dekaf.Tests.Integration;
+
+internal sealed class BoundedProcessDiagnostics(int maximumCharacters)
+{
+    private readonly StringBuilder _buffer = new();
+
+    public void Append(string stream, string? message)
+    {
+        if (message is null)
+            return;
+
+        lock (_buffer)
+        {
+            _buffer.Append('[').Append(stream).Append("] ").AppendLine(message);
+            if (_buffer.Length > maximumCharacters)
+                _buffer.Remove(0, _buffer.Length - maximumCharacters);
+        }
+    }
+
+    public override string ToString()
+    {
+        lock (_buffer)
+            return _buffer.ToString();
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
@@ -111,6 +111,15 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
 
             if (ReferenceEquals(completedTask, exitTask))
             {
+                linkedSource.Cancel();
+                try
+                {
+                    await connectionTask;
+                }
+                catch (OperationCanceledException) when (linkedSource.IsCancellationRequested)
+                {
+                }
+
                 await exitTask;
                 throw new InvalidOperationException(
                     $"Consumer group crash client exited before signaling readiness with code {_process.ExitCode}." +
@@ -143,6 +152,10 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
         try
         {
             await ForceTerminateAsync(requireRunning: false, CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            _diagnostics.Append("cleanup", exception.ToString());
         }
         finally
         {
@@ -260,29 +273,6 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
         return startInfo;
     }
 
-    private sealed class BoundedProcessDiagnostics(int maximumCharacters)
-    {
-        private readonly StringBuilder _buffer = new();
-
-        public void Append(string stream, string? message)
-        {
-            if (message is null)
-                return;
-
-            lock (_buffer)
-            {
-                _buffer.Append('[').Append(stream).Append("] ").AppendLine(message);
-                if (_buffer.Length > maximumCharacters)
-                    _buffer.Remove(0, _buffer.Length - maximumCharacters);
-            }
-        }
-
-        public override string ToString()
-        {
-            lock (_buffer)
-                return _buffer.ToString();
-        }
-    }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
@@ -213,14 +213,9 @@ internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
                 process.WaitForExit(milliseconds: 10_000);
             }
         }
-        catch (InvalidOperationException)
+        catch (Exception)
         {
-        }
-        catch (System.ComponentModel.Win32Exception)
-        {
-        }
-        catch (NotSupportedException)
-        {
+            // Startup cleanup is best-effort; preserve the original start failure.
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupCrashClientProcess.cs
@@ -1,0 +1,395 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Pipes;
+using System.Text;
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Integration;
+
+internal readonly record struct ConsumerGroupCrashObservation(
+    int Partition,
+    long CommittedOffset,
+    string CommittedValue,
+    long Offset,
+    string Value);
+
+/// <summary>
+/// Runs a consumer group member in a child process so termination cannot execute
+/// consumer disposal, LeaveGroup, or a terminal ConsumerGroupHeartbeat.
+/// </summary>
+internal sealed class ConsumerGroupCrashClientProcess : IAsyncDisposable
+{
+    internal const string EnabledVariable = "DEKAF_CONSUMER_GROUP_CRASH_CLIENT";
+    internal const string BootstrapServersVariable = "DEKAF_CONSUMER_GROUP_CRASH_BOOTSTRAP_SERVERS";
+    internal const string TopicVariable = "DEKAF_CONSUMER_GROUP_CRASH_TOPIC";
+    internal const string GroupIdVariable = "DEKAF_CONSUMER_GROUP_CRASH_GROUP_ID";
+    internal const string ClientIdVariable = "DEKAF_CONSUMER_GROUP_CRASH_CLIENT_ID";
+    internal const string AssignorVariable = "DEKAF_CONSUMER_GROUP_CRASH_ASSIGNOR";
+    internal const string ReadyPipeVariable = "DEKAF_CONSUMER_GROUP_CRASH_READY_PIPE";
+    private const int MaximumDiagnosticCharacters = 16_384;
+
+    private readonly Process _process;
+    private readonly NamedPipeServerStream _readyPipe;
+    private readonly BoundedProcessDiagnostics _diagnostics;
+
+    private ConsumerGroupCrashClientProcess(
+        Process process,
+        NamedPipeServerStream readyPipe,
+        BoundedProcessDiagnostics diagnostics)
+    {
+        _process = process;
+        _readyPipe = readyPipe;
+        _diagnostics = diagnostics;
+    }
+
+    public static ConsumerGroupCrashClientProcess Start(
+        string bootstrapServers,
+        string topic,
+        string groupId,
+        string clientId,
+        string assignor)
+    {
+        var pipeName = $"dekaf-consumer-group-crash-{Guid.NewGuid():N}";
+        var readyPipe = new NamedPipeServerStream(
+            pipeName,
+            PipeDirection.In,
+            maxNumberOfServerInstances: 1,
+            PipeTransmissionMode.Byte,
+            PipeOptions.Asynchronous);
+        var process = new Process
+        {
+            StartInfo = CreateStartInfo(
+                bootstrapServers,
+                topic,
+                groupId,
+                clientId,
+                assignor,
+                pipeName)
+        };
+        var diagnostics = new BoundedProcessDiagnostics(MaximumDiagnosticCharacters);
+
+        process.OutputDataReceived += (_, eventArgs) => diagnostics.Append("stdout", eventArgs.Data);
+        process.ErrorDataReceived += (_, eventArgs) => diagnostics.Append("stderr", eventArgs.Data);
+
+        var started = false;
+        try
+        {
+            started = process.Start();
+            if (!started)
+                throw new InvalidOperationException("Consumer group crash client did not start.");
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            return new ConsumerGroupCrashClientProcess(process, readyPipe, diagnostics);
+        }
+        catch
+        {
+            if (started)
+                TryTerminateStartedProcess(process);
+
+            process.Dispose();
+            readyPipe.Dispose();
+            throw;
+        }
+    }
+
+    public async Task<ConsumerGroupCrashObservation> WaitUntilReadyAsync(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutSource = new CancellationTokenSource(timeout);
+        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutSource.Token,
+            cancellationToken);
+
+        try
+        {
+            var connectionTask = _readyPipe.WaitForConnectionAsync(linkedSource.Token);
+            var exitTask = _process.WaitForExitAsync(CancellationToken.None);
+            var completedTask = await Task.WhenAny(connectionTask, exitTask)
+                .WaitAsync(linkedSource.Token);
+
+            if (ReferenceEquals(completedTask, exitTask))
+            {
+                await exitTask;
+                throw new InvalidOperationException(
+                    $"Consumer group crash client exited before signaling readiness with code {_process.ExitCode}." +
+                    Environment.NewLine + _diagnostics);
+            }
+
+            await connectionTask;
+            using var reader = new StreamReader(
+                _readyPipe,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                detectEncodingFromByteOrderMarks: false,
+                bufferSize: 1024,
+                leaveOpen: true);
+            var signal = await reader.ReadLineAsync(linkedSource.Token);
+            return ParseObservation(signal);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Consumer group crash client did not signal readiness within {timeout}." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    public Task TerminateAsync(CancellationToken cancellationToken) =>
+        ForceTerminateAsync(requireRunning: true, cancellationToken);
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await ForceTerminateAsync(requireRunning: false, CancellationToken.None);
+        }
+        finally
+        {
+            _process.Dispose();
+            await _readyPipe.DisposeAsync();
+        }
+    }
+
+    private async Task ForceTerminateAsync(bool requireRunning, CancellationToken cancellationToken)
+    {
+        if (_process.HasExited)
+        {
+            if (requireRunning)
+            {
+                throw new InvalidOperationException(
+                    $"Consumer group crash client exited before force termination with code {_process.ExitCode}." +
+                    Environment.NewLine + _diagnostics);
+            }
+
+            return;
+        }
+
+        _process.Kill(entireProcessTree: true);
+
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutSource.Token,
+            cancellationToken);
+        try
+        {
+            await _process.WaitForExitAsync(linkedSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                "Consumer group crash client did not exit after force termination." +
+                Environment.NewLine + _diagnostics);
+        }
+    }
+
+    private static ConsumerGroupCrashObservation ParseObservation(string? signal)
+    {
+        var fields = signal?.Split('|', count: 5);
+        if (fields is not { Length: 5 } ||
+            !int.TryParse(fields[0], NumberStyles.None, CultureInfo.InvariantCulture, out var partition) ||
+            !long.TryParse(fields[1], NumberStyles.None, CultureInfo.InvariantCulture, out var committedOffset) ||
+            !long.TryParse(fields[3], NumberStyles.None, CultureInfo.InvariantCulture, out var offset))
+        {
+            throw new InvalidOperationException(
+                $"Consumer group crash client wrote invalid readiness signal '{signal}'.");
+        }
+
+        return new ConsumerGroupCrashObservation(
+            partition,
+            committedOffset,
+            fields[2],
+            offset,
+            fields[4]);
+    }
+
+    private static void TryTerminateStartedProcess(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.WaitForExit(milliseconds: 10_000);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+        }
+        catch (NotSupportedException)
+        {
+        }
+    }
+
+    private static ProcessStartInfo CreateStartInfo(
+        string bootstrapServers,
+        string topic,
+        string groupId,
+        string clientId,
+        string assignor,
+        string pipeName)
+    {
+        var processPath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Cannot locate the integration test executable.");
+        var startInfo = new ProcessStartInfo(processPath)
+        {
+            WorkingDirectory = AppContext.BaseDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (string.Equals(
+                Path.GetFileNameWithoutExtension(processPath),
+                "dotnet",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.ArgumentList.Add(Environment.GetCommandLineArgs()[0]);
+        }
+
+        startInfo.ArgumentList.Add("--treenode-filter");
+        startInfo.ArgumentList.Add("/*/*/ConsumerGroupCrashClient/*");
+        startInfo.ArgumentList.Add("--maximum-parallel-tests");
+        startInfo.ArgumentList.Add("1");
+        startInfo.Environment[EnabledVariable] = "1";
+        startInfo.Environment[BootstrapServersVariable] = bootstrapServers;
+        startInfo.Environment[TopicVariable] = topic;
+        startInfo.Environment[GroupIdVariable] = groupId;
+        startInfo.Environment[ClientIdVariable] = clientId;
+        startInfo.Environment[AssignorVariable] = assignor;
+        startInfo.Environment[ReadyPipeVariable] = pipeName;
+        return startInfo;
+    }
+
+    private sealed class BoundedProcessDiagnostics(int maximumCharacters)
+    {
+        private readonly StringBuilder _buffer = new();
+
+        public void Append(string stream, string? message)
+        {
+            if (message is null)
+                return;
+
+            lock (_buffer)
+            {
+                _buffer.Append('[').Append(stream).Append("] ").AppendLine(message);
+                if (_buffer.Length > maximumCharacters)
+                    _buffer.Remove(0, _buffer.Length - maximumCharacters);
+            }
+        }
+
+        public override string ToString()
+        {
+            lock (_buffer)
+                return _buffer.ToString();
+        }
+    }
+}
+
+/// <summary>
+/// Child-process entry point. The parent kills this process while its consumer is
+/// live, so no graceful group-leave path can run.
+/// </summary>
+public sealed class ConsumerGroupCrashClient
+{
+    [Test]
+    public async Task ConsumeOneRecordAndHoldMembership()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable(ConsumerGroupCrashClientProcess.EnabledVariable),
+                "1",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var bootstrapServers = GetRequiredEnvironmentVariable(
+            ConsumerGroupCrashClientProcess.BootstrapServersVariable);
+        var topic = GetRequiredEnvironmentVariable(ConsumerGroupCrashClientProcess.TopicVariable);
+        var groupId = GetRequiredEnvironmentVariable(ConsumerGroupCrashClientProcess.GroupIdVariable);
+        var clientId = GetRequiredEnvironmentVariable(ConsumerGroupCrashClientProcess.ClientIdVariable);
+        var assignor = GetRequiredEnvironmentVariable(ConsumerGroupCrashClientProcess.AssignorVariable);
+        var pipeName = GetRequiredEnvironmentVariable(ConsumerGroupCrashClientProcess.ReadyPipeVariable);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(bootstrapServers)
+            .WithClientId(clientId)
+            .WithGroupId(groupId)
+            .WithGroupRemoteAssignor(assignor)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithMaxPollRecords(1)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+        using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        await using var enumerator = consumer
+            .ConsumeAsync(timeoutSource.Token)
+            .GetAsyncEnumerator(timeoutSource.Token);
+        if (!await enumerator.MoveNextAsync())
+            throw new InvalidOperationException("Consumer group crash client completed before receiving a record.");
+
+        var committedResult = enumerator.Current;
+        var committedPartition = new TopicPartition(topic, committedResult.Partition);
+        var otherPartitions = consumer.Assignment
+            .Where(partition => partition != committedPartition)
+            .ToArray();
+        if (otherPartitions.Length > 0)
+            consumer.Pause(otherPartitions);
+
+        await consumer.CommitAsync(
+            [new TopicPartitionOffset(topic, committedResult.Partition, committedResult.Offset + 1)],
+            timeoutSource.Token);
+
+        ConsumeResult<string, string> crashResult;
+        do
+        {
+            if (!await enumerator.MoveNextAsync())
+            {
+                throw new InvalidOperationException(
+                    "Consumer group crash client completed before receiving its uncommitted crash record.");
+            }
+
+            crashResult = enumerator.Current;
+        }
+        while (crashResult.Partition != committedResult.Partition);
+
+        if (crashResult.Offset != committedResult.Offset + 1)
+        {
+            throw new InvalidOperationException(
+                $"Consumer group crash client expected offset {committedResult.Offset + 1} after its commit, " +
+                $"but received {crashResult.Offset}.");
+        }
+
+        await using var readyPipe = new NamedPipeClientStream(
+            ".",
+            pipeName,
+            PipeDirection.Out,
+            PipeOptions.Asynchronous);
+        await readyPipe.ConnectAsync(timeoutSource.Token);
+        await using var writer = new StreamWriter(
+            readyPipe,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            bufferSize: 1024,
+            leaveOpen: true)
+        {
+            AutoFlush = true
+        };
+        await writer.WriteLineAsync(
+            $"{committedResult.Partition.ToString(CultureInfo.InvariantCulture)}|" +
+            $"{committedResult.Offset.ToString(CultureInfo.InvariantCulture)}|{committedResult.Value}|" +
+            $"{crashResult.Offset.ToString(CultureInfo.InvariantCulture)}|{crashResult.Value}");
+
+        await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken.None);
+    }
+
+    private static string GetRequiredEnvironmentVariable(string name) =>
+        Environment.GetEnvironmentVariable(name)
+        ?? throw new InvalidOperationException($"Required environment variable '{name}' is not set.");
+}

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -472,18 +472,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         // masquerade as recovery.
         await survivor.WaitForPartitionAssignedAsync(crashedPartition, cancellationToken);
         await survivor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
-        await AssertGroupMemberPresenceAsync(
-            admin,
-            groupId,
-            crashedClientId,
-            expected: false,
-            cancellationToken);
-        var committedAfterExpiry = await CaptureAndAssertCommittedOffsetsAsync(
-            admin,
-            groupId,
-            oracle,
-            cancellationToken,
-            committedAtCrash);
+
+        // A two-member uniform/range assignment cannot return the crashed partition
+        // and all four partitions to the survivor until the broker expires the killed member.
 
         var remainingPermits = PartitionCount * MessagesPerPartition * 2;
         survivor.Allow(remainingPermits);
@@ -509,12 +500,15 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 .IsEquivalentTo(Enumerable.Range(0, MessagesPerPartition).Select(static value => (long)value));
         }
 
+        // Reconnect after the broker-side session transition; the pre-crash
+        // admin connection can time out while rediscovering the coordinator.
+        await using var finalAdmin = KafkaContainer.CreateAdminClient();
         await CaptureAndAssertCommittedOffsetsAsync(
-            admin,
+            finalAdmin,
             groupId,
             oracle,
             cancellationToken,
-            committedAfterExpiry);
+            committedAtCrash);
     }
 
     private async Task ProduceSequencedBacklogAsync(string topic, CancellationToken cancellationToken)
@@ -611,8 +605,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
 
         for (var partition = 0; partition < PartitionCount; partition++)
         {
-            var explicitCommit = oracle.GetCommittedOffset(partition);
-            var processedExclusive = oracle.GetProcessedExclusive(partition);
+            var (explicitCommit, processedExclusive) = oracle.GetProgressBounds(partition);
             var actual = committedOffsets.GetValueOrDefault(
                 new TopicPartition(oracle.Topic, partition),
                 0);
@@ -1089,13 +1082,6 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
 
             if (finalCommit)
                 _finalCommits.Increment();
-        }
-
-        public long GetProcessedExclusive(int partition)
-        {
-            var state = _partitions[partition];
-            lock (state.Gate)
-                return state.NextExpected;
         }
 
         public void BeginCrashWindow(IReadOnlyList<long> brokerCommittedOffsets)

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -473,8 +473,21 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         await survivor.WaitForPartitionAssignedAsync(crashedPartition, cancellationToken);
         await survivor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
 
-        // A two-member uniform/range assignment cannot return the crashed partition
-        // and all four partitions to the survivor until the broker expires the killed member.
+        // Start the post-expiry admin probe only after full reassignment shows the
+        // coordinator transition has settled, then reuse it for both checkpoints.
+        await using var postExpiryAdmin = KafkaContainer.CreateAdminClient();
+        await AssertGroupMemberPresenceAsync(
+            postExpiryAdmin,
+            groupId,
+            crashedClientId,
+            expected: false,
+            cancellationToken);
+        var committedAfterExpiry = await CaptureAndAssertCommittedOffsetsAsync(
+            postExpiryAdmin,
+            groupId,
+            oracle,
+            cancellationToken,
+            committedAtCrash);
 
         var remainingPermits = PartitionCount * MessagesPerPartition * 2;
         survivor.Allow(remainingPermits);
@@ -500,15 +513,12 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 .IsEquivalentTo(Enumerable.Range(0, MessagesPerPartition).Select(static value => (long)value));
         }
 
-        // Reconnect after the broker-side session transition; the pre-crash
-        // admin connection can time out while rediscovering the coordinator.
-        await using var finalAdmin = KafkaContainer.CreateAdminClient();
         await CaptureAndAssertCommittedOffsetsAsync(
-            finalAdmin,
+            postExpiryAdmin,
             groupId,
             oracle,
             cancellationToken,
-            committedAtCrash);
+            committedAfterExpiry);
     }
 
     private async Task ProduceSequencedBacklogAsync(string topic, CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -31,6 +31,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
     private static readonly TimeSpan StaticMemberSessionTimeout = TimeSpan.FromSeconds(6);
     private static readonly TimeSpan StaticMemberHeartbeatInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan GroupConfigVerificationDelay = TimeSpan.FromMilliseconds(500);
+    private const int CrashPhaseMessages = 12;
+    private static readonly TimeSpan CrashClientReadyTimeout = TimeSpan.FromSeconds(90);
 
     [Test]
     [Timeout(600_000)]
@@ -241,6 +243,17 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             keyDeserializer: null,
             valueDeserializer: Serializers.String);
 
+    [Test]
+    [Timeout(600_000)]
+    public async Task AbruptMemberLoss_AfterSessionExpiry_PreservesSequencesAndCommittedProgress(
+        CancellationToken cancellationToken)
+    {
+        foreach (var assignor in new[] { "uniform", "range" })
+        {
+            await RunAbruptMemberLossScenarioAsync(assignor, cancellationToken);
+        }
+    }
+
     private async Task RunChurnScenarioAsync(string assignor, CancellationToken cancellationToken)
     {
         var (topic, groupId, oracle) = await CreateScenarioAsync(
@@ -347,6 +360,163 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             cancellationToken: cancellationToken);
     }
 
+    private async Task RunAbruptMemberLossScenarioAsync(
+        string assignor,
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: PartitionCount);
+        var groupId = $"rebalance-crash-{assignor}-{Guid.NewGuid():N}";
+        var oracle = new SequenceOracle(topic, PartitionCount, MessagesPerPartition, CommitInterval);
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await admin.IncrementalAlterConfigsAsync(
+            new Dictionary<ConfigResource, IReadOnlyList<ConfigAlter>>
+            {
+                [ConfigResource.Topic(topic)] = [ConfigAlter.Set("retention.ms", "600000")]
+            },
+            cancellationToken: cancellationToken);
+        await ProduceSequencedBacklogAsync(topic, cancellationToken);
+
+        await using var survivor = await CreateMemberAsync(
+            topic,
+            groupId,
+            $"{assignor}-survivor",
+            assignor,
+            oracle,
+            cancellationToken);
+
+        survivor.Allow(1);
+        await survivor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+        await survivor.WaitForObservedCountAsync(1, cancellationToken);
+
+        var crashedClientId = $"{assignor}-crashed";
+        await using var crashedMember = ConsumerGroupCrashClientProcess.Start(
+            KafkaContainer.BootstrapServers,
+            topic,
+            groupId,
+            crashedClientId,
+            assignor);
+        var crashedObservation = await crashedMember.WaitUntilReadyAsync(
+            CrashClientReadyTimeout,
+            cancellationToken);
+
+        await survivor.WaitForAssignmentCountBelowAsync(PartitionCount, cancellationToken);
+        var crashedPartition = new TopicPartition(topic, crashedObservation.Partition);
+        await survivor.WaitForPartitionUnassignedAsync(crashedPartition, cancellationToken);
+        oracle.Record(
+            crashedClientId,
+            crashedObservation.Partition,
+            crashedObservation.CommittedOffset,
+            crashedObservation.CommittedValue);
+        oracle.Record(
+            crashedClientId,
+            crashedObservation.Partition,
+            crashedObservation.Offset,
+            crashedObservation.Value);
+        await AssertGroupMemberPresenceAsync(
+            admin,
+            groupId,
+            crashedClientId,
+            expected: true,
+            cancellationToken);
+        await AssertObservationIsUncommittedAsync(
+            admin,
+            groupId,
+            topic,
+            crashedObservation,
+            cancellationToken);
+
+        var survivorJointTarget = survivor.ObservedCount + JointPhaseMessagesPerMember;
+        survivor.Allow(JointPhaseMessagesPerMember);
+        await survivor.WaitForObservedCountAsync(survivorJointTarget, cancellationToken);
+
+        var processingAcrossCrash = survivor.PauseNextRecord();
+        var crashPhaseProgressTarget = survivor.ObservedCount + CrashPhaseMessages;
+        survivor.Allow(CrashPhaseMessages);
+        await processingAcrossCrash.WaitUntilPausedAsync(cancellationToken);
+
+        var committedAtCrash = await CaptureAndAssertCommittedOffsetsAsync(
+            admin,
+            groupId,
+            oracle,
+            cancellationToken);
+        oracle.BeginCrashWindow(committedAtCrash);
+        await Assert.That(oracle.IsInCrashWindow(
+                crashedObservation.Partition,
+                crashedObservation.Offset))
+            .IsTrue()
+            .Because("the child record must be inside the committed/processed window captured at kill");
+
+        await crashedMember.TerminateAsync(cancellationToken);
+
+        // A force-killed KIP-848 member remains registered until its broker-side
+        // session expires; no LeaveGroup or terminal heartbeat removed it.
+        await AssertGroupMemberPresenceAsync(
+            admin,
+            groupId,
+            crashedClientId,
+            expected: true,
+            cancellationToken);
+
+        processingAcrossCrash.Release();
+        await survivor.WaitForObservedCountAsync(crashPhaseProgressTarget, cancellationToken);
+        await AssertGroupMemberPresenceAsync(
+            admin,
+            groupId,
+            crashedClientId,
+            expected: true,
+            cancellationToken);
+
+        // This waiter is created only after the child took the partition and the
+        // survivor reported it revoked, so an old full-assignment signal cannot
+        // masquerade as recovery.
+        await survivor.WaitForPartitionAssignedAsync(crashedPartition, cancellationToken);
+        await survivor.WaitForAssignmentCountAsync(PartitionCount, cancellationToken);
+        await AssertGroupMemberPresenceAsync(
+            admin,
+            groupId,
+            crashedClientId,
+            expected: false,
+            cancellationToken);
+        var committedAfterExpiry = await CaptureAndAssertCommittedOffsetsAsync(
+            admin,
+            groupId,
+            oracle,
+            cancellationToken,
+            committedAtCrash);
+
+        var remainingPermits = PartitionCount * MessagesPerPartition * 2;
+        survivor.Allow(remainingPermits);
+        await oracle.WaitForAllSequencesAsync(cancellationToken);
+        await oracle.WaitForFinalCommitsAsync(cancellationToken);
+
+        await Assert.That(oracle.WasDuplicatedAfterCrash(
+                crashedObservation.Partition,
+                crashedObservation.Offset))
+            .IsTrue()
+            .Because("the crashed member's last uncommitted record must be replayed after session expiry");
+
+        await survivor.StopAsync();
+
+        await Assert.That(oracle.UniqueCount).IsEqualTo(PartitionCount * MessagesPerPartition);
+        var violations = oracle.Violations;
+        await Assert.That(violations).IsEmpty()
+            .Because(string.Join(Environment.NewLine, violations));
+
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            await Assert.That(oracle.GetSeenOffsets(partition))
+                .IsEquivalentTo(Enumerable.Range(0, MessagesPerPartition).Select(static value => (long)value));
+        }
+
+        await CaptureAndAssertCommittedOffsetsAsync(
+            admin,
+            groupId,
+            oracle,
+            cancellationToken,
+            committedAfterExpiry);
+    }
+
     private async Task ProduceSequencedBacklogAsync(string topic, CancellationToken cancellationToken)
     {
         await using var producer = await Kafka.CreateProducer<string, string>()
@@ -429,6 +599,79 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
     }
 
+    private static async Task<long[]> CaptureAndAssertCommittedOffsetsAsync(
+        IAdminClient admin,
+        string groupId,
+        SequenceOracle oracle,
+        CancellationToken cancellationToken,
+        IReadOnlyList<long>? previousBrokerOffsets = null)
+    {
+        var committedOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken);
+        var actualOffsets = new long[PartitionCount];
+
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            var explicitCommit = oracle.GetCommittedOffset(partition);
+            var processedExclusive = oracle.GetProcessedExclusive(partition);
+            var actual = committedOffsets.GetValueOrDefault(
+                new TopicPartition(oracle.Topic, partition),
+                0);
+            actualOffsets[partition] = actual;
+            await Assert.That(actual)
+                .IsLessThanOrEqualTo(processedExclusive)
+                .Because($"partition {partition} broker commit cannot jump ahead of processed records");
+            await Assert.That(actual)
+                .IsGreaterThanOrEqualTo(explicitCommit)
+                .Because($"partition {partition} broker commit cannot trail a successful explicit commit");
+
+            if (previousBrokerOffsets is not null)
+            {
+                await Assert.That(actual)
+                    .IsGreaterThanOrEqualTo(previousBrokerOffsets[partition])
+                    .Because($"partition {partition} broker commit cannot rewind between checkpoints");
+            }
+        }
+
+        return actualOffsets;
+    }
+
+    private static async Task AssertObservationIsUncommittedAsync(
+        IAdminClient admin,
+        string groupId,
+        string topic,
+        ConsumerGroupCrashObservation observation,
+        CancellationToken cancellationToken)
+    {
+        var committedOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken);
+        var committedExclusive = committedOffsets.GetValueOrDefault(
+            new TopicPartition(topic, observation.Partition),
+            0);
+
+        await Assert.That(observation.Offset)
+            .IsEqualTo(observation.CommittedOffset + 1)
+            .Because("the child must commit one record immediately before its crash record");
+        await Assert.That(committedExclusive)
+            .IsEqualTo(observation.Offset)
+            .Because("the crash record must be the first offset after the child's durable commit");
+    }
+
+    private static async Task AssertGroupMemberPresenceAsync(
+        IAdminClient admin,
+        string groupId,
+        string clientId,
+        bool expected,
+        CancellationToken cancellationToken)
+    {
+        var descriptions = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken);
+        var description = descriptions[groupId];
+        var containsMember = description.Members.Any(member =>
+            string.Equals(member.ClientId, clientId, StringComparison.Ordinal));
+
+        await Assert.That(containsMember)
+            .IsEqualTo(expected)
+            .Because($"group members: {string.Join(", ", description.Members.Select(member => member.ClientId))}");
+    }
+
     private sealed class ConsumerMember : IAsyncDisposable
     {
         private readonly IKafkaConsumer<string, string> _consumer;
@@ -439,6 +682,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         private readonly SemaphoreSlim _permits = new(0, int.MaxValue);
         private readonly AsyncCounter _observed = new();
         private readonly Task _runTask;
+        private RecordProcessingBarrier? _nextRecordBarrier;
         private int _stopped;
 
         public ConsumerMember(
@@ -464,6 +708,15 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
 
         public void ResetMaxAssignmentCount() => _assignments.ResetMaxAssignmentCount();
 
+        public RecordProcessingBarrier PauseNextRecord()
+        {
+            var barrier = new RecordProcessingBarrier();
+            if (Interlocked.CompareExchange(ref _nextRecordBarrier, barrier, null) is not null)
+                throw new InvalidOperationException("A record-processing barrier is already pending.");
+
+            return barrier;
+        }
+
         public Task WaitForAnyAssignmentAsync(CancellationToken cancellationToken) =>
             WaitForSignalOrCompletionAsync(
                 _assignments.WaitForAnyAsync(cancellationToken),
@@ -474,6 +727,28 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             WaitForSignalOrCompletionAsync(
                 _assignments.WaitForCountAsync(count, cancellationToken),
                 $"Consumer completed before receiving {count} partitions",
+                cancellationToken);
+
+        public Task WaitForAssignmentCountBelowAsync(int count, CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _assignments.WaitForCountBelowAsync(count, cancellationToken),
+                $"Consumer completed before its assignment dropped below {count} partitions",
+                cancellationToken);
+
+        public Task WaitForPartitionAssignedAsync(
+            TopicPartition partition,
+            CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _assignments.WaitForPartitionAssignedAsync(partition, cancellationToken),
+                $"Consumer completed before {partition} was assigned",
+                cancellationToken);
+
+        public Task WaitForPartitionUnassignedAsync(
+            TopicPartition partition,
+            CancellationToken cancellationToken) =>
+            WaitForSignalOrCompletionAsync(
+                _assignments.WaitForPartitionUnassignedAsync(partition, cancellationToken),
+                $"Consumer completed before {partition} was revoked",
                 cancellationToken);
 
         public Task WaitForObservedCountAsync(int count, CancellationToken cancellationToken) =>
@@ -526,9 +801,13 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                     }
 
                     var result = enumerator.Current;
+                    var barrier = Interlocked.Exchange(ref _nextRecordBarrier, null);
+                    if (barrier is not null)
+                        await barrier.PauseAsync(_stopping.Token);
+
                     _oracle.Record(_clientId, result);
-                    _observed.Increment();
                     await _oracle.CommitIfNeededAsync(_consumer, result, _stopping.Token);
+                    _observed.Increment();
                 }
             }
             catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
@@ -550,6 +829,25 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             }
 
             await signal.WaitAsync(cancellationToken);
+        }
+
+        public sealed class RecordProcessingBarrier
+        {
+            private readonly TaskCompletionSource _paused = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _released = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task WaitUntilPausedAsync(CancellationToken cancellationToken) =>
+                _paused.Task.WaitAsync(cancellationToken);
+
+            public void Release() => _released.TrySetResult();
+
+            internal async Task PauseAsync(CancellationToken cancellationToken)
+            {
+                _paused.TrySetResult();
+                await _released.Task.WaitAsync(cancellationToken);
+            }
         }
     }
 
@@ -608,38 +906,47 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 return;
             }
 
-            if (result.Partition < 0 || result.Partition >= _partitions.Length)
+            Record(clientId, result.Partition, result.Offset, result.Value);
+        }
+
+        public void Record(
+            string clientId,
+            int partition,
+            long offset,
+            string? value)
+        {
+            if (partition < 0 || partition >= _partitions.Length)
             {
-                AddViolation($"Unexpected partition {result.Partition}");
+                AddViolation($"Unexpected partition {partition}");
                 return;
             }
 
-            if (!long.TryParse(result.Value, NumberStyles.None, CultureInfo.InvariantCulture, out var sequence))
+            if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var sequence))
             {
-                AddViolation($"Partition {result.Partition}: invalid sequence payload '{result.Value}'");
+                AddViolation($"Partition {partition}: invalid sequence payload '{value}'");
                 return;
             }
 
-            if (sequence != result.Offset)
-                AddViolation($"Partition {result.Partition}: payload {sequence} does not match offset {result.Offset}");
+            if (sequence != offset)
+                AddViolation($"Partition {partition}: payload {sequence} does not match offset {offset}");
 
-            if (result.Offset < 0 || result.Offset >= _messagesPerPartition)
+            if (offset < 0 || offset >= _messagesPerPartition)
             {
-                AddViolation($"Partition {result.Partition}: offset {result.Offset} is outside seeded range");
+                AddViolation($"Partition {partition}: offset {offset} is outside seeded range");
                 return;
             }
 
-            var state = _partitions[result.Partition];
+            var state = _partitions[partition];
             var unique = false;
             lock (state.Gate)
             {
-                if (state.Seen.Add(result.Offset))
+                if (state.Seen.Add(offset))
                 {
                     unique = true;
-                    if (result.Offset != state.NextExpected)
+                    if (offset != state.NextExpected)
                     {
                         AddViolation(
-                            $"Partition {result.Partition}: observed new offset {result.Offset} before {state.NextExpected}");
+                            $"Partition {partition}: observed new offset {offset} before {state.NextExpected}");
                     }
 
                     while (state.Seen.Contains(state.NextExpected))
@@ -648,10 +955,23 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 else
                 {
                     Interlocked.Increment(ref _duplicateCount);
-                    if (result.Offset < state.CommittedExclusive)
+                    if (state.CrashWindowActive)
+                    {
+                        state.PostCrashDuplicates.Add(offset);
+                        if (offset < state.CrashCommittedExclusive ||
+                            offset >= state.CrashProcessedExclusive)
+                        {
+                            AddViolation(
+                                $"{clientId}, partition {partition}: post-crash replay {offset} outside " +
+                                $"uncommitted window [{state.CrashCommittedExclusive}, " +
+                                $"{state.CrashProcessedExclusive})");
+                        }
+                    }
+
+                    if (offset < state.CommittedExclusive)
                     {
                         AddViolation(
-                            $"{clientId}, partition {result.Partition}: replayed offset {result.Offset} below committed offset {state.CommittedExclusive}");
+                            $"{clientId}, partition {partition}: replayed offset {offset} below committed offset {state.CommittedExclusive}");
                     }
                 }
             }
@@ -771,6 +1091,48 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 _finalCommits.Increment();
         }
 
+        public long GetProcessedExclusive(int partition)
+        {
+            var state = _partitions[partition];
+            lock (state.Gate)
+                return state.NextExpected;
+        }
+
+        public void BeginCrashWindow(IReadOnlyList<long> brokerCommittedOffsets)
+        {
+            if (brokerCommittedOffsets.Count != _partitions.Length)
+                throw new ArgumentException("A committed offset is required for every partition.", nameof(brokerCommittedOffsets));
+
+            for (var partition = 0; partition < _partitions.Length; partition++)
+            {
+                var state = _partitions[partition];
+                lock (state.Gate)
+                {
+                    state.CrashCommittedExclusive = brokerCommittedOffsets[partition];
+                    state.CrashProcessedExclusive = state.NextExpected;
+                    state.CrashWindowActive = true;
+                }
+            }
+        }
+
+        public bool IsInCrashWindow(int partition, long offset)
+        {
+            var state = _partitions[partition];
+            lock (state.Gate)
+            {
+                return state.CrashWindowActive &&
+                       offset >= state.CrashCommittedExclusive &&
+                       offset < state.CrashProcessedExclusive;
+            }
+        }
+
+        public bool WasDuplicatedAfterCrash(int partition, long offset)
+        {
+            var state = _partitions[partition];
+            lock (state.Gate)
+                return state.PostCrashDuplicates.Contains(offset);
+        }
+
         private static bool IsExpectedRebalanceCommitFailure(ErrorCode? errorCode) => errorCode is
             ErrorCode.IllegalGeneration or
             ErrorCode.UnknownMemberId or
@@ -788,8 +1150,12 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         {
             public object Gate { get; } = new();
             public HashSet<long> Seen { get; } = [];
+            public HashSet<long> PostCrashDuplicates { get; } = [];
             public long NextExpected { get; set; }
             public long CommittedExclusive { get; set; }
+            public long CrashCommittedExclusive { get; set; }
+            public long CrashProcessedExclusive { get; set; }
+            public bool CrashWindowActive { get; set; }
         }
     }
 
@@ -840,17 +1206,32 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
 
         public Task WaitForAnyAsync(CancellationToken cancellationToken) =>
-            WaitForAsync(static count => count > 0, cancellationToken);
+            WaitForAsync(static assigned => assigned.Count > 0, cancellationToken);
 
         public Task WaitForCountAsync(int count, CancellationToken cancellationToken) =>
-            WaitForAsync(current => current == count, cancellationToken);
+            WaitForAsync(assigned => assigned.Count == count, cancellationToken);
 
-        private Task WaitForAsync(Func<int, bool> predicate, CancellationToken cancellationToken)
+        public Task WaitForCountBelowAsync(int count, CancellationToken cancellationToken) =>
+            WaitForAsync(assigned => assigned.Count < count, cancellationToken);
+
+        public Task WaitForPartitionAssignedAsync(
+            TopicPartition partition,
+            CancellationToken cancellationToken) =>
+            WaitForAsync(assigned => assigned.Contains(partition), cancellationToken);
+
+        public Task WaitForPartitionUnassignedAsync(
+            TopicPartition partition,
+            CancellationToken cancellationToken) =>
+            WaitForAsync(assigned => !assigned.Contains(partition), cancellationToken);
+
+        private Task WaitForAsync(
+            Func<HashSet<TopicPartition>, bool> predicate,
+            CancellationToken cancellationToken)
         {
             Task signal;
             lock (_gate)
             {
-                if (predicate(_assigned.Count))
+                if (predicate(_assigned))
                     return Task.CompletedTask;
 
                 var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -879,7 +1260,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                 for (var index = _waiters.Count - 1; index >= 0; index--)
                 {
                     var waiter = _waiters[index];
-                    if (!waiter.Predicate(_assigned.Count))
+                    if (!waiter.Predicate(_assigned))
                         continue;
 
                     completed ??= [];
@@ -896,7 +1277,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
 
         private sealed record AssignmentWaiter(
-            Func<int, bool> Predicate,
+            Func<HashSet<TopicPartition>, bool> Predicate,
             TaskCompletionSource Completion);
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -790,6 +790,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                     .IsGreaterThanOrEqualTo(previousBrokerOffsets[partition])
                     .Because($"partition {partition} broker commit cannot rewind between checkpoints");
             }
+
+            oracle.ObserveCommittedOffset(partition, actual);
         }
 
         return actualOffsets;
@@ -823,6 +825,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         CancellationToken cancellationToken)
     {
         var descriptions = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken);
+        await Assert.That(descriptions).ContainsKey(groupId);
+
         var description = descriptions[groupId];
         var containsMember = description.Members.Any(member =>
             string.Equals(member.ClientId, clientId, StringComparison.Ordinal));

--- a/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionalCrashClientProcess.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
@@ -300,35 +299,6 @@ internal sealed class TransactionalCrashClientProcess : IAsyncDisposable
         }
     }
 
-    private sealed class BoundedProcessDiagnostics(int maximumCharacters)
-    {
-        private readonly StringBuilder _buffer = new();
-
-        public void Append(string stream, string? message)
-        {
-            if (message is null)
-            {
-                return;
-            }
-
-            lock (_buffer)
-            {
-                _buffer.Append('[').Append(stream).Append("] ").AppendLine(message);
-                if (_buffer.Length > maximumCharacters)
-                {
-                    _buffer.Remove(0, _buffer.Length - maximumCharacters);
-                }
-            }
-        }
-
-        public override string ToString()
-        {
-            lock (_buffer)
-            {
-                return _buffer.ToString();
-            }
-        }
-    }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- force-kill a dedicated KIP-848 consumer child process without disposal, LeaveGroup, or a terminal heartbeat
- prove the survivor keeps processing while the dead member remains registered, then reacquires its partition after session expiry
- validate gap-free recovery, replay only inside a nonzero uncommitted window, and broker commits never ahead of processed records

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --framework net10.0 --no-restore`
- [x] `Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConsumerGroupRebalanceChaosTests/AbruptMemberLoss_AfterSessionExpiry_PreservesSequencesAndCommittedProgress" --maximum-parallel-tests 1` (3/3 Kafka-version cases)
- [x] `Dekaf.Tests.Integration.exe --treenode-filter "/*/*/ConsumerGroupRebalanceChaosTests/*" --maximum-parallel-tests 1` (6/6 cases)

Closes #1615
