### PR TITLE
test(kafka): refresh broker version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
       fail-fast: true
       matrix:
         framework: [net8.0, net10.0]
-        kafka: ['4.0.2', '4.1.2', '4.2.1']
+        kafka: ['4.0.2', '4.1.2', '4.2.1', '4.3.1']
     uses: ./.github/workflows/integration-groups.yml
     with:
       framework: ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
       fail-fast: true
       matrix:
         framework: [net8.0, net10.0]
-        kafka: ['4.0.1', '4.1.1', '4.2.0']
+        kafka: ['4.0.2', '4.1.2', '4.2.1']
     uses: ./.github/workflows/integration-groups.yml
     with:
       framework: ${{ matrix.framework }}
@@ -284,7 +284,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        kafka: ['4.0.1', '4.2.0']
+        kafka: ['4.0.2', '4.3.1']
     uses: ./.github/workflows/integration-groups.yml
     with:
       framework: aot

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -17,7 +17,7 @@ on:
         description: 'apache/kafka image tag for KafkaIntegrationTest-derived tests'
         required: false
         type: string
-        default: '4.2.0'
+        default: '4.3.1'
 
 jobs:
   groups:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Dekaf is a high-performance, pure C# Apache Kafka client library for .NET 10+. T
 ## Important Warnings
 
 - **Test Projects Require Docker**: Integration tests use Testcontainers.Kafka. Ensure Docker is running before executing integration tests.
-- **Broker Version Is Env-Driven**: `KafkaIntegrationTest`-derived tests run against a single Kafka broker whose image tag comes from `KAFKA_TEST_IMAGE_TAG` (default `4.2.0`). PR CI tests only the current release; the full 4.0.1/4.1.1/4.2.0 sweep runs as the NuGet release gate (`workflow_dispatch` with `publish_nuget=true`), which must pass before packages are pushed. To test an older broker locally, set the env var before running the integration exe.
+- **Broker Version Is Env-Driven**: `KafkaIntegrationTest`-derived tests run against a single Kafka broker whose image tag comes from `KAFKA_TEST_IMAGE_TAG` (default `4.3.1`). PR CI tests only the current release; the full 4.0.2/4.1.2/4.2.1/4.3.1 sweep runs as the NuGet release gate (`workflow_dispatch` with `publish_nuget=true`), which must pass before packages are pushed. To test an older broker locally, set the env var before running the integration exe.
 - **Benchmarks Compare Against Confluent.Kafka**: Producer/Consumer benchmarks spin up real Kafka instances. Memory/Serialization benchmarks run without Docker.
 - **Protocol Code Uses Unsafe**: The `Dekaf.Protocol` namespace uses unsafe code for performance. Changes here require extra scrutiny.
 - **BufferMemory Enforces Strict Limits**: Producer `BufferMemory` setting enforces limits across all append paths (both slow path and arena fast path) to prevent unbounded growth. Exceeding this limit blocks `ProduceAsync` until space is available via backpressure.

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Integration;
 /// The broker image tag is driven by the <c>KAFKA_TEST_IMAGE_TAG</c> environment variable
 /// (default 4.3.1), so a single test binary covers the whole supported broker range:
 /// PR CI runs the current release, and the NuGet release gate sweeps the supported
-/// versions (4.0.2, 4.1.2, 4.2.1) by setting the variable per job.
+/// versions (4.0.2, 4.1.2, 4.2.1, 4.3.1) by setting the variable per job.
 /// </summary>
 public class KafkaContainerDefault : KafkaTestContainer
 {

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -7,13 +7,13 @@ namespace Dekaf.Tests.Integration;
 /// <summary>
 /// The Kafka container used by all <see cref="KafkaIntegrationTest"/>-derived tests.
 /// The broker image tag is driven by the <c>KAFKA_TEST_IMAGE_TAG</c> environment variable
-/// (default 4.2.0), so a single test binary covers the whole supported broker range:
+/// (default 4.3.1), so a single test binary covers the whole supported broker range:
 /// PR CI runs the current release, and the NuGet release gate sweeps the supported
-/// versions (4.0.1, 4.1.1, 4.2.0) by setting the variable per job.
+/// versions (4.0.2, 4.1.2, 4.2.1) by setting the variable per job.
 /// </summary>
 public class KafkaContainerDefault : KafkaTestContainer
 {
-    public const string DefaultTag = "4.2.0";
+    public const string DefaultTag = "4.3.1";
 
     private static readonly string Tag =
         Environment.GetEnvironmentVariable("KAFKA_TEST_IMAGE_TAG") is { Length: > 0 } tag ? tag : DefaultTag;

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
@@ -14,7 +14,7 @@ public class NetworkPartitionKafkaContainer : KafkaTestContainer
     private DockerClient? _dockerClient;
 
     public override string ContainerName => "apache/kafka:4.0.2";
-    public override int Version => 401;
+    public override int Version => 402;
 
     /// <summary>
     /// Pauses the Kafka container, simulating a network partition.

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/NetworkPartitionKafkaContainer.cs
@@ -13,7 +13,7 @@ public class NetworkPartitionKafkaContainer : KafkaTestContainer
 {
     private DockerClient? _dockerClient;
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
     public override int Version => 401;
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 
 public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
-    private const string Image = "apache/kafka:4.2.0";
+    private const string Image = "apache/kafka:4.2.1";
     private const int InternalBrokerPort = 9092;
     private const int ControllerPort = 9093;
     private const int ExternalBrokerPort = 19092;

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -71,7 +71,7 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         Console.WriteLine("[KafkaWithSchemaRegistry] Starting Kafka container...");
 
         // Start Kafka with network alias
-        _kafkaContainer = new KafkaBuilder("apache/kafka:4.0.1")
+        _kafkaContainer = new KafkaBuilder("apache/kafka:4.0.2")
             .WithNetwork(_network)
             .WithNetworkAliases("kafka")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")

--- a/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
@@ -46,7 +46,7 @@ public class AclKafkaContainer : KafkaTestContainer
     /// </summary>
     public const string TestPrincipal = $"User:{TestUsername}";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
     public override int Version => 401;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>

--- a/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/AclKafkaContainer.cs
@@ -47,7 +47,7 @@ public class AclKafkaContainer : KafkaTestContainer
     public const string TestPrincipal = $"User:{TestUsername}";
 
     public override string ContainerName => "apache/kafka:4.0.2";
-    public override int Version => 401;
+    public override int Version => 402;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>
         builder

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
@@ -37,7 +37,7 @@ public class OAuthBearerKafkaContainer : KafkaTestContainer
         "org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler";
 
     public override string ContainerName => "apache/kafka:4.0.2";
-    public override int Version => 401;
+    public override int Version => 402;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => builder
         // External (PLAINTEXT-named) listener uses SASL_PLAINTEXT; inter-broker stays PLAINTEXT.

--- a/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/OAuthBearerKafkaContainer.cs
@@ -36,7 +36,7 @@ public class OAuthBearerKafkaContainer : KafkaTestContainer
     private const string UnsecuredValidatorCallbackHandler =
         "org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
     public override int Version => 401;
 
     protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) => builder

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -34,7 +34,7 @@ public class SaslKafkaContainer : KafkaTestContainer
         $"password=\"{SaslPassword}\" " +
         $"user_{SaslUsername}=\"{SaslPassword}\";";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
     public override int Version => 401;
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -35,7 +35,7 @@ public class SaslKafkaContainer : KafkaTestContainer
         $"user_{SaslUsername}=\"{SaslPassword}\";";
 
     public override string ContainerName => "apache/kafka:4.0.2";
-    public override int Version => 401;
+    public override int Version => 402;
 
     /// <summary>
     /// Adds SASL-specific environment variables to the Kafka container builder.

--- a/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
@@ -41,7 +41,7 @@ public class SaslSslKafkaContainer : KafkaTestContainer
     private const string TruststoreContainerPath = $"{ContainerSecretsDir}/truststore.p12";
 
     public override string ContainerName => "apache/kafka:4.0.2";
-    public override int Version => 401;
+    public override int Version => 402;
 
     /// <summary>
     /// TLS configuration that validates the broker certificate against the test CA.

--- a/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslSslKafkaContainer.cs
@@ -40,7 +40,7 @@ public class SaslSslKafkaContainer : KafkaTestContainer
     private const string KeystoreContainerPath = $"{ContainerSecretsDir}/server.p12";
     private const string TruststoreContainerPath = $"{ContainerSecretsDir}/truststore.p12";
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
     public override int Version => 401;
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -83,7 +83,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         TestCertificateGenerator.ExportCertificateToPemFile(_certGenerator.ServerCertificate, serverCertPemPath);
         TestCertificateGenerator.ExportPrivateKeyToPemFile(_certGenerator.ServerCertificate, serverKeyPemPath);
 
-        _container = new KafkaBuilder("apache/kafka:4.0.1")
+        _container = new KafkaBuilder("apache/kafka:4.0.2")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")
             // SSL listener configuration
             // The Testcontainers KafkaBuilder manages KAFKA_LISTENERS and KAFKA_LISTENER_SECURITY_PROTOCOL_MAP

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -28,7 +28,7 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
     private const ushort KafkaBrokerPort = 19_094;
     private const ushort KafkaControllerPort = 19_095;
 
-    public override string ContainerName => "apache/kafka:4.0.1";
+    public override string ContainerName => "apache/kafka:4.0.2";
 
     public override int Version => 401;
 
@@ -138,7 +138,7 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
         ushort producerPublicPort,
         ushort consumerPublicPort)
     {
-        return new ContainerBuilder("apache/kafka:4.0.1")
+        return new ContainerBuilder("apache/kafka:4.0.2")
             .WithNetwork(_network)
             .WithNetworkAliases(KafkaNetworkAlias)
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -30,7 +30,7 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
 
     public override string ContainerName => "apache/kafka:4.0.2";
 
-    public override int Version => 401;
+    public override int Version => 402;
 
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly ToxiproxyContainer _toxiproxy;

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -19,7 +19,7 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
     private const ushort InternalBrokerPort = 9092;
     private const ushort ControllerPort = 9093;
     private const ushort ExternalBrokerPort = 29092;
-    private const string KafkaImage = "apache/kafka:4.1.0";
+    private const string KafkaImage = "apache/kafka:4.1.2";
     private const string ToxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0";
     private const string ClusterId = "MkU3OEVBNTcwNTJENDM2Qg";
 

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -200,7 +200,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             var hostname = $"kafka-{nodeId}";
             var externalPort = 29091 + nodeId; // 29092, 29093, 29094
 
-            var containerBuilder = new ContainerBuilder("apache/kafka:4.1.0")
+            var containerBuilder = new ContainerBuilder("apache/kafka:4.1.2")
                 .WithName($"{hostname}-{Guid.NewGuid():N}")
                 .WithHostname(hostname)
                 .WithNetwork(network)


### PR DESCRIPTION
## Summary
- move default/PR integration broker to Kafka 4.3.1
- refresh release matrix to 4.0.2, 4.1.2, and 4.2.1; keep AOT on floor/current
- refresh specialized integration and stress fixture image pins

## Test plan
- [x] verify apache/kafka manifests for 4.0.2, 4.1.2, 4.2.1, and 4.3.1
- [x] parse updated GitHub Actions YAML
- [x] build integration and stress projects on net10.0
- [x] run Admin integration category against Kafka 4.3.1 (84/84)

Closes #1705
