### PR TITLE
Return pooled fetch buffers after parse failures

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -932,30 +932,7 @@ public sealed partial class KafkaConnection :
 
             if (isFetchResponse)
             {
-                var memoryOwner = pooledBuffer.TransferOwnership();
-                using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner);
-
-                var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                var response = KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
-
-                if (ResponseParsingContext.WasMemoryUsed)
-                {
-                    var takenMemory = ResponseParsingContext.TakePooledMemory();
-                    if (response is FetchResponse fetchResponse && takenMemory is not null)
-                    {
-                        fetchResponse.PooledMemoryOwner = takenMemory;
-                    }
-                    else
-                    {
-                        takenMemory?.Dispose();
-                    }
-                }
-                else
-                {
-                    memoryOwner.Dispose();
-                }
-
-                return response;
+                return ParseFetchResponse<TRequest, TResponse>(pooledBuffer, apiVersion);
             }
             else
             {
@@ -985,6 +962,46 @@ public sealed partial class KafkaConnection :
                     _cancelledCorrelationIds.TryAdd(correlationId);
                 }
             }
+        }
+    }
+
+    internal static TResponse ParseFetchResponse<TRequest, TResponse>(
+        PooledResponseBuffer pooledBuffer,
+        short apiVersion)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        var memoryOwner = pooledBuffer.TransferOwnership();
+        using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner);
+
+        try
+        {
+            var reader = new KafkaProtocolReader(pooledBuffer.Data);
+            var response = KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
+
+            if (ResponseParsingContext.WasMemoryUsed)
+            {
+                var takenMemory = ResponseParsingContext.TakePooledMemory();
+                if (response is FetchResponse fetchResponse && takenMemory is not null)
+                {
+                    fetchResponse.PooledMemoryOwner = takenMemory;
+                }
+                else
+                {
+                    takenMemory?.Dispose();
+                }
+            }
+            else
+            {
+                memoryOwner.Dispose();
+            }
+
+            return response;
+        }
+        catch
+        {
+            memoryOwner.Dispose();
+            throw;
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -105,6 +105,22 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task ParseFetchResponse_WhenParsingThrows_ReturnsPooledBuffer()
+    {
+        var pool = new ResponseBufferPool(1024);
+        var array = pool.Pool.Rent(16);
+        Array.Clear(array);
+        var buffer = new PooledResponseBuffer(array, 1, isPooled: true, pool: pool);
+
+        await Assert.That(() => KafkaConnection.ParseFetchResponse<FetchRequest, FetchResponse>(buffer, 16))
+            .ThrowsException();
+
+        var returned = pool.Pool.Rent(16);
+        await Assert.That(returned).IsSameReferenceAs(array);
+        pool.Pool.Return(returned);
+    }
+
+    [Test]
     public async Task Host_ReturnsConstructorValue()
     {
         var connection = new KafkaConnection("my-broker.example.com", 9092);


### PR DESCRIPTION
## Summary
- make fetch response parsing exception-safe after pooled-buffer ownership transfer
- return transferred response memory when parsing throws
- add regression coverage proving malformed fetch responses return rented arrays

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/KafkaConnectionTests/*'` (33 passed)
- [ ] Full unit suite: 5,031 passed; unrelated `EnsureAssignmentForPollAsync_SlowPositionInitialization_DoesNotExpireMember` timed out

Closes #1720
