### PR TITLE
Surface malformed fetch record batches

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Dekaf.Errors;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using Dekaf.Compression;
@@ -82,6 +83,7 @@ internal sealed class PendingFetchData : IDisposable
     private int _headerGeneration;
     private bool _eagerParsed;
     private bool _hasBufferedCurrent;
+    private ConsumeException? _error;
 
     public string Topic { get; private set; } = null!;
     public int PartitionIndex { get; private set; }
@@ -167,6 +169,17 @@ internal sealed class PendingFetchData : IDisposable
             }
         }
 
+        return instance;
+    }
+
+    public static PendingFetchData CreateError(string topic, int partitionIndex, ConsumeException error)
+    {
+        var instance = Rent();
+        instance.Topic = topic;
+        instance.PartitionIndex = partitionIndex;
+        instance.TopicPartition = new TopicPartition(topic, partitionIndex);
+        instance._batches = Array.Empty<RecordBatch>();
+        instance._error = error;
         return instance;
     }
 
@@ -279,6 +292,9 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public void EagerParseAll()
     {
+        if (Interlocked.Exchange(ref _error, null) is { } error)
+            throw error;
+
         if (_eagerParsed)
             return;
 
@@ -489,6 +505,7 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsCount = 0;
         _eagerParsed = false;
         _hasBufferedCurrent = false;
+        _error = null;
         unchecked
         {
             _headerGeneration++;
@@ -2503,6 +2520,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                         UpdateWatermarksFromFetchResponse(topic, partitionResponse);
                         UpdatePreferredReadReplica(topic, partitionResponse);
+
+                        if (partitionResponse.RecordParseError is { } parseError)
+                        {
+                            pendingItems.Add(PendingFetchData.CreateError(
+                                topic,
+                                partitionResponse.PartitionIndex,
+                                new ConsumeException(
+                                    $"Failed to parse record batch for {topic}-{partitionResponse.PartitionIndex}",
+                                    parseError)));
+                            continue;
+                        }
 
                         if (partitionResponse.DivergingEpoch is not null)
                         {
@@ -5180,6 +5208,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Update watermark cache from fetch response (even on errors, watermarks may be valid)
                     UpdateWatermarksFromFetchResponse(topic, partitionResponse);
                     UpdatePreferredReadReplica(topic, partitionResponse);
+
+                    if (partitionResponse.RecordParseError is { } parseError)
+                    {
+                        pendingItems ??= ConsumerFetchPools.RentPendingFetchDataList();
+                        pendingItems.Add(PendingFetchData.CreateError(
+                            topic,
+                            partitionResponse.PartitionIndex,
+                            new ConsumeException(
+                                $"Failed to parse record batch for {topic}-{partitionResponse.PartitionIndex}",
+                                parseError)));
+                        continue;
+                    }
 
                     if (partitionResponse.DivergingEpoch is not null)
                     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1505,7 +1505,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // This converts per-record lazy parse overhead (disposed check +
                     // bounds check + EnsureParsedUpTo per indexer call) into a single
                     // batch-level cost. Parsing is cache-friendly in a tight loop.
-                    pending.EagerParseAll();
+                    EagerParsePendingOrRemove(pending);
 
                     // Compiler requires definite assignment; always assigned inside try before yield.
                     ConsumeResult<TKey, TValue> nextResult = default!;
@@ -3171,6 +3171,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return true;
     }
 
+    private void EagerParsePendingOrRemove(PendingFetchData pending)
+    {
+        try
+        {
+            pending.EagerParseAll();
+        }
+        catch
+        {
+            if (_pendingFetches.Count > 0
+                && ReferenceEquals(_pendingFetches.Peek(), pending))
+            {
+                DisposeQueuedFetch(_pendingFetches.Dequeue());
+            }
+
+            throw;
+        }
+    }
+
     private bool TryConsumeOneFromPendingFetches(out ConsumeResult<TKey, TValue> result)
     {
         result = default!;
@@ -3190,7 +3208,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             long? batchProcessingStarted = _adaptiveFetchSizer is not null
                 ? Stopwatch.GetTimestamp() : null;
 
-            pending.EagerParseAll();
+            EagerParsePendingOrRemove(pending);
 
             System.Diagnostics.Activity? activity = null;
             try

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -65,6 +65,12 @@ internal static class DekafMetrics
             unit: "s",
             description: "Round-trip time of fetch requests to Kafka brokers.");
 
+    internal static readonly Counter<long> BatchParseErrors =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "messaging.consumer.batch.parse.errors",
+            unit: "{error}",
+            description: "Number of record batches that failed protocol parsing.");
+
     // Consumer lag — single static gauge with shared callback registry.
     // Each KafkaConsumer instance registers/unregisters its callback, avoiding
     // duplicate instrument registration and ensuring disposed consumers stop reporting.

--- a/src/Dekaf/Protocol/MalformedProtocolDataException.cs
+++ b/src/Dekaf/Protocol/MalformedProtocolDataException.cs
@@ -6,4 +6,10 @@ namespace Dekaf.Protocol;
 /// <see cref="InsufficientDataException"/> which indicates truncated but
 /// structurally valid data.
 /// </summary>
-internal sealed class MalformedProtocolDataException(string message) : Exception(message);
+internal sealed class MalformedProtocolDataException : Exception
+{
+    public MalformedProtocolDataException(string message) : base(message) { }
+
+    public MalformedProtocolDataException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -415,6 +415,8 @@ public sealed class FetchResponsePartition
     /// </summary>
     public int PreferredReadReplica { get; internal set; } = -1;
 
+    internal MalformedProtocolDataException? RecordParseError { get; private set; }
+
     /// <summary>
     /// Record batches.
     /// </summary>
@@ -493,6 +495,7 @@ public sealed class FetchResponsePartition
         var abortedList = s_abortedTxListPool.Rent();
         var abortedListReturned = false;
         List<RecordBatch>? records = null;
+        MalformedProtocolDataException? recordParseError = null;
 
         try
         {
@@ -539,8 +542,13 @@ public sealed class FetchResponsePartition
                     catch (Exception ex)
                     {
                         DekafMetrics.BatchParseErrors.Add(1);
-                        throw new MalformedProtocolDataException(
+                        recordParseError = new MalformedProtocolDataException(
                             $"Failed to parse record batch for partition {partitionIndex}", ex);
+                        foreach (var record in records)
+                            record.Dispose();
+                        ReturnRecordBatchList(records);
+                        records = null;
+                        break;
                     }
                 }
 
@@ -566,6 +574,7 @@ public sealed class FetchResponsePartition
             result.AbortedTransactions = abortedTransactions;
             result.PreferredReadReplica = preferredReadReplica;
             result.Records = records;
+            result.RecordParseError = recordParseError;
             return result;
         }
         catch
@@ -642,6 +651,7 @@ public sealed class FetchResponsePartition
             item._abortedTransactions = null;
             item.PreferredReadReplica = -1;
             item._records = null;
+            item.RecordParseError = null;
         }
     }
 

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using Dekaf.Diagnostics;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
 
@@ -538,10 +538,9 @@ public sealed class FetchResponsePartition
                     }
                     catch (Exception ex)
                     {
-                        // Unexpected error parsing a record batch — log for visibility and skip remaining batches.
-                        // This should not happen under normal conditions and may indicate data corruption or a parsing bug.
-                        Trace.WriteLine($"Dekaf: Unexpected exception parsing RecordBatch: {ex}");
-                        break;
+                        DekafMetrics.BatchParseErrors.Add(1);
+                        throw new MalformedProtocolDataException(
+                            $"Failed to parse record batch for partition {partitionIndex}", ex);
                     }
                 }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -24,6 +25,22 @@ public sealed class ConsumeAsyncRecoveryTests
 {
     private const string Topic = "test-topic";
     private const int Partition = 0;
+
+    [Test]
+    public async Task ConsumeAsync_PendingProtocolError_ThrowsTypedConsumeExceptionOnce()
+    {
+        var parseError = new MalformedProtocolDataException("malformed record batch");
+        var pending = PendingFetchData.CreateError(
+            Topic,
+            Partition,
+            new ConsumeException($"Failed to parse record batch for {Topic}-{Partition}", parseError));
+        await using var consumer = CreateConsumerWithPendingFetches(null, pending);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var _ in consumer.ConsumeAsync()) { }
+        }).Throws<ConsumeException>().WithMessageContaining($"{Topic}-{Partition}");
+    }
 
     /// <summary>
     /// Creates a KafkaConsumer with minimal configuration, sets internal state

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -34,12 +34,72 @@ public sealed class ConsumeAsyncRecoveryTests
             Topic,
             Partition,
             new ConsumeException($"Failed to parse record batch for {Topic}-{Partition}", parseError));
-        await using var consumer = CreateConsumerWithPendingFetches(null, pending);
+        var goodFetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(100, CreateRecord(0, "next", "value"))]);
+        await using var consumer = CreateConsumerWithPendingFetches(null, pending, goodFetch);
 
         await Assert.That(async () =>
         {
             await foreach (var _ in consumer.ConsumeAsync()) { }
         }).Throws<ConsumeException>().WithMessageContaining($"{Topic}-{Partition}");
+        await Assert.That(GetPendingFetchCount(consumer)).IsEqualTo(1);
+
+        ConsumeResult<string, string>? recovered = null;
+        await foreach (var result in consumer.ConsumeAsync())
+        {
+            recovered = result;
+            break;
+        }
+
+        await Assert.That(recovered).IsNotNull();
+        await Assert.That(recovered!.Value.Key).IsEqualTo("next");
+    }
+
+    [Test]
+    public async Task ConsumeOne_PendingProtocolError_RemovesErrorBeforeNextPoll()
+    {
+        var pending = PendingFetchData.CreateError(
+            Topic,
+            Partition,
+            new ConsumeException($"Failed to parse record batch for {Topic}-{Partition}"));
+        var goodFetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(100, CreateRecord(0, "next", "value"))]);
+        await using var consumer = CreateConsumerWithPendingFetches(null, pending, goodFetch);
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("TryConsumeOneFromPendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("TryConsumeOneFromPendingFetches method not found.");
+
+        Exception? error = null;
+        try
+        {
+            method.Invoke(consumer, [null]);
+        }
+        catch (TargetInvocationException exception)
+        {
+            error = exception.InnerException;
+        }
+
+        await Assert.That(GetPendingFetchCount(consumer)).IsEqualTo(1);
+
+        var arguments = new object?[] { null };
+        var consumed = (bool)method.Invoke(consumer, arguments)!;
+        var result = (ConsumeResult<string, string>)arguments[0]!;
+
+        await Assert.That(error).IsTypeOf<ConsumeException>();
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(result.Key).IsEqualTo("next");
+    }
+
+    private static int GetPendingFetchCount(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_pendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pendingFetches field not found.");
+        return ((Queue<PendingFetchData>)field.GetValue(consumer)!).Count;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
@@ -30,10 +30,18 @@ public sealed class FetchResponseParseErrorTests
 
         var buffer = CreateResponseWithMalformedBatch();
 
-        await Assert.That(() => ReadResponse(buffer))
-            .Throws<MalformedProtocolDataException>()
-            .WithMessageContaining("partition 7");
+        var response = ReadResponse(buffer);
+        var partition = response.Responses[0].Partitions[0];
+
+        await Assert.That(partition.RecordParseError).IsNotNull();
+        await Assert.That(partition.RecordParseError!.Message).Contains("partition 7");
+        await Assert.That(partition.Records).IsNull();
+        await Assert.That(response.Responses[0].Partitions).Count().IsEqualTo(2);
+        await Assert.That(response.Responses[0].Partitions[1].PartitionIndex).IsEqualTo(8);
+        await Assert.That(response.Responses[0].Partitions[1].RecordParseError).IsNull();
         await Assert.That(parseErrors).IsEqualTo(1);
+
+        response.ReturnToPool();
     }
 
     private static FetchResponse ReadResponse(ReadOnlyMemory<byte> buffer)
@@ -52,7 +60,7 @@ public sealed class FetchResponseParseErrorTests
         writer.WriteInt32(0);
         writer.WriteUnsignedVarInt(2);
         writer.WriteUuid(Guid.NewGuid());
-        writer.WriteUnsignedVarInt(2);
+        writer.WriteUnsignedVarInt(3);
         writer.WriteInt32(7);
         writer.WriteInt16((short)ErrorCode.None);
         writer.WriteInt64(10);
@@ -61,6 +69,15 @@ public sealed class FetchResponseParseErrorTests
         writer.WriteUnsignedVarInt(1);
         writer.WriteInt32(-1);
         writer.WriteCompactNullableBytes(new byte[RecordBatch.TotalBatchHeaderSize], isNull: false);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteInt32(8);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt64(10);
+        writer.WriteInt64(10);
+        writer.WriteInt64(0);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteInt32(-1);
+        writer.WriteUnsignedVarInt(0);
         writer.WriteUnsignedVarInt(0);
         writer.WriteUnsignedVarInt(0);
         writer.WriteUnsignedVarInt(0);

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
@@ -1,0 +1,70 @@
+using System.Buffers;
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+[NotInParallel("MeterListener")]
+public sealed class FetchResponseParseErrorTests
+{
+    [Test]
+    public async Task Read_MalformedRecordBatch_ThrowsTypedErrorAndRecordsMetric()
+    {
+        long parseErrors = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                    instrument.Name == "messaging.consumer.batch.parse.errors")
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => parseErrors += value);
+        listener.Start();
+
+        var buffer = CreateResponseWithMalformedBatch();
+
+        await Assert.That(() => ReadResponse(buffer))
+            .Throws<MalformedProtocolDataException>()
+            .WithMessageContaining("partition 7");
+        await Assert.That(parseErrors).IsEqualTo(1);
+    }
+
+    private static FetchResponse ReadResponse(ReadOnlyMemory<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer);
+        return (FetchResponse)FetchResponse.Read(ref reader, version: 16);
+    }
+
+    private static ReadOnlyMemory<byte> CreateResponseWithMalformedBatch()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteUuid(Guid.NewGuid());
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt32(7);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt64(10);
+        writer.WriteInt64(10);
+        writer.WriteInt64(0);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteInt32(-1);
+        writer.WriteCompactNullableBytes(new byte[RecordBatch.TotalBatchHeaderSize], isNull: false);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);
+
+        return buffer.WrittenMemory;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponsePoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponsePoolingTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Unit.Protocol;
 /// Verifies that objects are reused from pools, properly cleared on return, and that
 /// use-after-return is detected.
 /// </summary>
-[NotInParallel("FetchResponsePool")]
+[NotInParallel]
 public class FetchResponsePoolingTests
 {
     // ── FetchResponse pooling ──


### PR DESCRIPTION
## Summary
- propagate unexpected record-batch parsing failures as typed `MalformedProtocolDataException`
- include partition context while preserving original exception as inner cause
- count failures with `messaging.consumer.batch.parse.errors`
- retain `InsufficientDataException` handling for legitimate truncated trailing batches

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] malformed fetch response regression (typed error + metric)
- [x] `RecordBatchTests` (41 passed)
- [x] `ResponseWireFormatSnapshotTests` (127 passed)
- [x] `LeaderDiscoveryResponseTests` (2 passed)

Closes #1717
