### PR TITLE
Fence seek operations from stale prefetch writes

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3442,53 +3442,51 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         LogSeek(offset.Topic, offset.Partition, offset.Offset);
         var tp = new TopicPartition(offset.Topic, offset.Partition);
-        // Update positions (thread-safe with ConcurrentDictionary)
-        if (offset.LeaderEpoch >= 0)
-            SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
-        else
-            ClearLastConsumedLeaderEpoch(tp);
-        SetPosition(tp, offset.Offset, dirty: true);
-        _fetchPositions[tp] = offset.Offset;
+        // Keep invalidation, buffer drain, and position replacement atomic with prefetch publication.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            ClearFetchBufferForPartitions([tp]);
 
-        // Reset EOF state for this partition so it can fire again
-        _eofEmitted.TryRemove(tp, out _);
-        ClearFetchBufferForPartitions([tp]);
+            if (offset.LeaderEpoch >= 0)
+                SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
+            else
+                ClearLastConsumedLeaderEpoch(tp);
+            SetPosition(tp, offset.Offset, dirty: true);
+            _fetchPositions[tp] = offset.Offset;
+            _eofEmitted.TryRemove(tp, out _);
+        }
     }
 
     public void SeekToBeginning(params TopicPartition[] partitions)
     {
-        // Update positions (thread-safe with ConcurrentDictionary)
-        foreach (var partition in partitions)
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearLastConsumedLeaderEpoch(partition);
-            SetPosition(partition, 0, dirty: true);
-            _fetchPositions[partition] = 0;
-        }
+            ClearFetchBufferForPartitions(partitions);
 
-        // Reset EOF state
-        foreach (var partition in partitions)
-        {
-            _eofEmitted.TryRemove(partition, out _);
+            foreach (var partition in partitions)
+            {
+                ClearLastConsumedLeaderEpoch(partition);
+                SetPosition(partition, 0, dirty: true);
+                _fetchPositions[partition] = 0;
+                _eofEmitted.TryRemove(partition, out _);
+            }
         }
-        ClearFetchBufferForPartitions(partitions);
     }
 
     public void SeekToEnd(params TopicPartition[] partitions)
     {
-        // Update positions (thread-safe with ConcurrentDictionary)
-        foreach (var partition in partitions)
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearLastConsumedLeaderEpoch(partition);
-            SetPosition(partition, -1, dirty: true); // Special value meaning end
-            _fetchPositions[partition] = -1; // Special value meaning end
-        }
+            ClearFetchBufferForPartitions(partitions);
 
-        // Reset EOF state
-        foreach (var partition in partitions)
-        {
-            _eofEmitted.TryRemove(partition, out _);
+            foreach (var partition in partitions)
+            {
+                ClearLastConsumedLeaderEpoch(partition);
+                SetPosition(partition, -1, dirty: true); // Special value meaning end
+                _fetchPositions[partition] = -1; // Special value meaning end
+                _eofEmitted.TryRemove(partition, out _);
+            }
         }
-        ClearFetchBufferForPartitions(partitions);
     }
 
     /// <summary>
@@ -3792,20 +3790,36 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         for (var i = 0; i < pendingItems.Count; i++)
         {
             var pending = pendingItems[i];
-            if (ShouldDropStaleFetchPartition(pending.TopicPartition, fetchBufferEpoch))
-            {
-                pending.Dispose();
-                continue;
-            }
-
-            // Track memory and advance fetch positions only after confirming
-            // this pipelined response still belongs to the current assignment.
-            TrackPrefetchedBytes(pending, release: false);
-            UpdateFetchPositionsFromPrefetch(pending, fetchBufferEpoch);
-
-            while (!_prefetchBuffer.TryWrite(pending))
+            var tracked = false;
+            while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+                {
+                    // Seek uses this same lock, so a fetch is either published before its
+                    // invalidation and drained, or observes the new epoch and is dropped.
+                    if (ShouldDropStaleFetchPartition(pending.TopicPartition, fetchBufferEpoch))
+                    {
+                        if (tracked)
+                            TrackPrefetchedBytes(pending, release: true);
+                        pending.Dispose();
+                        break;
+                    }
+
+                    if (!tracked)
+                    {
+                        TrackPrefetchedBytes(pending, release: false);
+                        UpdateFetchPositionsFromPrefetch(pending, fetchBufferEpoch);
+                        tracked = true;
+                    }
+
+                    if (_prefetchBuffer.TryWrite(pending))
+                    {
+                        break;
+                    }
+                }
+
                 await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
             }
         }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -603,6 +603,38 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
     }
 
+    [Test]
+    public async Task WritePrefetchedItemsAsync_SeekWhileWaitingToWrite_DropsStaleFetch()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        var prefetchBuffer = GetPrefetchBuffer(consumer);
+        while (true)
+        {
+            var filler = CreateFetch(partition: 0, baseOffset: 0, value: "filler");
+            if (prefetchBuffer.TryWrite(filler))
+                continue;
+
+            filler.Dispose();
+            break;
+        }
+
+        var staleEpoch = GetFetchBufferEpoch(consumer);
+        var staleFetch = CreateFetch(partition: 0, baseOffset: 1_999_999, value: "stale-prefetch");
+        var writeTask = StartWritePrefetchedItemsAsync(consumer, [staleFetch], staleEpoch).AsTask();
+
+        await Assert.That(writeTask.IsCompleted).IsFalse();
+
+        consumer.SeekToBeginning(partition);
+        await writeTask.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(0L);
+        await Assert.That(prefetchBuffer.TryRead(out _)).IsFalse();
+        SetPrefetchedBytes(consumer, 0);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -1094,15 +1126,25 @@ public sealed class ConsumerAssignmentFastPathTests
         IReadOnlyList<PendingFetchData> pendingItems,
         int? fetchBufferEpoch = null)
     {
+        await StartWritePrefetchedItemsAsync(
+            consumer,
+            pendingItems,
+            fetchBufferEpoch ?? GetFetchBufferEpoch(consumer));
+    }
+
+    private static ValueTask StartWritePrefetchedItemsAsync(
+        KafkaConsumer<string, string> consumer,
+        IReadOnlyList<PendingFetchData> pendingItems,
+        int fetchBufferEpoch)
+    {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
             "WritePrefetchedItemsAsync",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("WritePrefetchedItemsAsync method not found.");
 
-        var valueTask = (ValueTask)method.Invoke(
+        return (ValueTask)method.Invoke(
             consumer,
-            [pendingItems, fetchBufferEpoch ?? GetFetchBufferEpoch(consumer), CancellationToken.None])!;
-        await valueTask;
+            [pendingItems, fetchBufferEpoch, CancellationToken.None])!;
     }
 
     private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)


### PR DESCRIPTION
## Summary
- serialize seek invalidation, stale-buffer drain, and position replacement with prefetch publication
- recheck fetch epochs after every full-buffer wait before publishing
- release tracked prefetch bytes when a waiting item becomes stale
- add deterministic regression for seek racing a blocked prefetch writer

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] `ConsumerAssignmentFastPathTests` (21 passed)
- [x] `ConsumerDirtyCommitTests` (12 passed)
- [x] `InMemoryKafkaClusterTests` (28 passed)

Closes #1722
