### PR TITLE
Fail consumers stuck at an unchanged fetch offset

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -623,6 +623,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private const int AllPartitionsPausedDelayMs = 100;
     private const int MaxConsecutivePrefetchErrors = 50;
+    private const int MaxConsecutiveEmptyParsedFetches = 3;
     private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
 
     private readonly ConsumerOptions _options;
@@ -751,6 +752,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), List<PendingFetchData>> _prefetchPendingItemsByBroker = new();
     private readonly BrokerPrefetchScheduler _brokerPrefetchScheduler = new();
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler> _fetchSessions = new();
+    private readonly StuckFetchPositionTracker _stuckFetchPositionTracker = new(MaxConsecutiveEmptyParsedFetches);
 
     // Lock ordering (always acquire in this order to prevent deadlocks):
     //   1. _initLock          — guards one-time initialization; never held while acquiring other locks
@@ -2073,6 +2075,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     break;
                 }
+                catch (Exception ex) when (IsFatalPrefetchError(ex))
+                {
+                    LogPrefetchLoopError(ex);
+                    completionError = ex;
+                    break;
+                }
                 catch (Exception ex)
                 {
                     consecutiveErrors++;
@@ -2506,6 +2514,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.DivergingEpoch is not null)
                         {
+                            _stuckFetchPositionTracker.Reset(tp);
                             queuedDivergingEpochReset |= ResetToDivergingEpoch(
                                 topic,
                                 partitionResponse,
@@ -2515,6 +2524,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (partitionResponse.ErrorCode != ErrorCode.None)
                         {
+                            _stuckFetchPositionTracker.Reset(tp);
                             if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                             {
                                 await ResetOffsetOutOfRangeAsync(tp, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
@@ -2541,6 +2551,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (records is { Count: > 0 })
                         {
+                            _stuckFetchPositionTracker.Reset(tp);
                             // We have new records - reset EOF state for this partition
                             _eofEmitted.TryRemove(tp, out _);
 
@@ -2554,16 +2565,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             // Collect for later - we'll assign memory owner to the last one
                             pendingItems.Add(pending);
                         }
-                        else if (_options.EnablePartitionEof)
+                        else
                         {
-                            // No records returned - check if we're at EOF
-                            var fetchPosition = _fetchPositions.GetValueOrDefault(tp, 0);
-
-                            // EOF condition: position >= high watermark and we haven't emitted EOF yet
-                            if (fetchPosition >= partitionResponse.HighWatermark && _eofEmitted.TryAdd(tp, 0))
+                            var stuckError = HandleEmptyFetchResponse(tp, records, partitionResponse.HighWatermark);
+                            if (stuckError is not null)
                             {
-                                // Queue EOF event and mark as emitted
-                                _pendingEofEvents.Enqueue((tp, fetchPosition));
+                                DisposePendingFetches(pendingItems);
+                                memoryOwner?.Dispose();
+                                memoryOwner = null;
+                                throw stuckError;
                             }
                         }
                     }
@@ -2907,6 +2917,37 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     ? currentPos
                     : Math.Max(currentPos, update.NextOffset),
             update);
+    }
+
+    private Errors.ConsumeException? HandleEmptyFetchResponse(
+        TopicPartition partition,
+        IReadOnlyList<RecordBatch>? records,
+        long highWatermark)
+    {
+        // FetchResponsePartition creates Records only when record bytes were present.
+        // A non-null empty list therefore means parsing produced no complete batches.
+        if (records is not { Count: 0 }
+            || !_fetchPositions.TryGetValue(partition, out var fetchPosition))
+        {
+            _stuckFetchPositionTracker.Reset(partition);
+            if (!_options.EnablePartitionEof)
+                return null;
+
+            fetchPosition = _fetchPositions.GetValueOrDefault(partition, 0);
+        }
+        else if (_stuckFetchPositionTracker.ObserveEmptyParsedFetch(partition, fetchPosition) is { } stuckError)
+        {
+            return stuckError;
+        }
+
+        if (_options.EnablePartitionEof
+            && fetchPosition >= highWatermark
+            && _eofEmitted.TryAdd(partition, 0))
+        {
+            _pendingEofEvents.Enqueue((partition, fetchPosition));
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -3529,6 +3570,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void ClearFetchBuffer()
     {
+        _stuckFetchPositionTracker.Clear();
+
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
             InvalidateAllFetchesLocked();
@@ -3562,6 +3605,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         if (removeSet.Count == 0)
             return;
+
+        foreach (var partition in removeSet)
+            _stuckFetchPositionTracker.Reset(partition);
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
@@ -5169,6 +5215,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (partitionResponse.DivergingEpoch is not null)
                     {
+                        _stuckFetchPositionTracker.Reset(tp);
                         queuedDivergingEpochReset |= ResetToDivergingEpoch(
                             topic,
                             partitionResponse,
@@ -5178,6 +5225,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (partitionResponse.ErrorCode != ErrorCode.None)
                     {
+                        _stuckFetchPositionTracker.Reset(tp);
                         if (partitionResponse.ErrorCode == ErrorCode.OffsetOutOfRange)
                         {
                             await ResetOffsetOutOfRangeAsync(tp, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
@@ -5204,6 +5252,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (records is { Count: > 0 })
                     {
+                        _stuckFetchPositionTracker.Reset(tp);
                         // We have new records - reset EOF state for this partition
                         _eofEmitted.TryRemove(tp, out _);
 
@@ -5216,16 +5265,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             partitionResponse.AbortedTransactions,
                             activityName: activityName));
                     }
-                    else if (_options.EnablePartitionEof)
+                    else
                     {
-                        // No records returned - check if we're at EOF
-                        var fetchPosition = _fetchPositions.GetValueOrDefault(tp, 0);
-
-                        // EOF condition: position >= high watermark and we haven't emitted EOF yet
-                        if (fetchPosition >= partitionResponse.HighWatermark && _eofEmitted.TryAdd(tp, 0))
+                        var stuckError = HandleEmptyFetchResponse(tp, records, partitionResponse.HighWatermark);
+                        if (stuckError is not null)
                         {
-                            // Queue EOF event and mark as emitted
-                            _pendingEofEvents.Enqueue((tp, fetchPosition));
+                            if (pendingItems is not null)
+                            {
+                                DisposePendingFetches(pendingItems);
+                                ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
+                                pendingItems = null;
+                            }
+
+                            memoryOwner?.Dispose();
+                            memoryOwner = null;
+                            throw stuckError;
                         }
                     }
                 }
@@ -5264,6 +5318,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             pendingItems[i].SetMemoryOwner(shared);
         }
+    }
+
+    private static void DisposePendingFetches(List<PendingFetchData> pendingItems)
+    {
+        for (var i = 0; i < pendingItems.Count; i++)
+        {
+            pendingItems[i].Dispose();
+        }
+
+        pendingItems.Clear();
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4738,6 +4738,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Consume cancellation requested, exit silently
             return null;
         }
+        catch (Exception ex) when (IsFatalPrefetchError(ex))
+        {
+            LogFatalPrefetchError(ex, brokerId);
+            throw;
+        }
         catch (Exception ex)
         {
             ClearPreferredReadReplicasForBroker(brokerId, partitions);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4674,12 +4674,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 // the bottleneck (slowest broker) which is the right signal for adaptive sizing.
                 _adaptiveFetchSizer?.RecordFetchStart();
 
+                try
+                {
 #if NETSTANDARD2_0
-                await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
+                    await Task.WhenAll(fetchTasks.Take(taskCount)).ConfigureAwait(false);
 #else
-                // ReadOnlySpan overload: same zero-copy benefit as above
-                await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
+                    // ReadOnlySpan overload: same zero-copy benefit as above
+                    await Task.WhenAll(new ReadOnlySpan<Task<List<PendingFetchData>?>>(fetchTasks, 0, taskCount)).ConfigureAwait(false);
 #endif
+                }
+                catch
+                {
+                    DisposeCompletedFetchResults(fetchTasks, taskCount);
+                    throw;
+                }
 
                 _adaptiveFetchSizer?.RecordFetchEnd();
 
@@ -4719,6 +4727,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _activeConsumeCancellationSources.TryRemove(consumeCts, out _);
             consumeCts.Dispose();
             _coordinator?.EndForegroundPollActivity();
+        }
+    }
+
+    internal static void DisposeCompletedFetchResults(
+        Task<List<PendingFetchData>?>[] fetchTasks,
+        int taskCount)
+    {
+        for (var i = 0; i < taskCount; i++)
+        {
+            var task = fetchTasks[i];
+            if (task.Status != TaskStatus.RanToCompletion || task.Result is not { } pendingItems)
+                continue;
+
+            DisposePendingFetches(pendingItems);
+            ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
         }
     }
 

--- a/src/Dekaf/Consumer/StuckFetchPositionTracker.cs
+++ b/src/Dekaf/Consumer/StuckFetchPositionTracker.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+
+namespace Dekaf.Consumer;
+
+internal sealed class StuckFetchPositionTracker
+{
+    private readonly ConcurrentDictionary<TopicPartition, Observation> _observations = new();
+    private readonly int _threshold;
+
+    public StuckFetchPositionTracker(int threshold)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(threshold, 1);
+        _threshold = threshold;
+    }
+
+    public Errors.ConsumeException? ObserveEmptyParsedFetch(TopicPartition partition, long position)
+    {
+        var observation = _observations.AddOrUpdate(
+            partition,
+            static (_, position) => new Observation(position, Count: 1),
+            static (_, current, position) => current.Position == position
+                ? current with { Count = current.Count + 1 }
+                : new Observation(position, Count: 1),
+            position);
+
+        if (observation.Count < _threshold)
+            return null;
+
+        return new Errors.ConsumeException(
+            Protocol.ErrorCode.CorruptMessage,
+            $"Partition {partition.Topic}[{partition.Partition}] returned record bytes but no parseable batches " +
+            $"at fetch offset {position} for {_threshold} consecutive responses.",
+            isRetriable: false);
+    }
+
+    public void Reset(TopicPartition partition) => _observations.TryRemove(partition, out _);
+
+    public void Clear() => _observations.Clear();
+
+    private readonly record struct Observation(long Position, int Count);
+}

--- a/tests/Dekaf.Tests.Integration/StuckFetchPositionIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/StuckFetchPositionIntegrationTests.cs
@@ -1,0 +1,191 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+public sealed class StuckFetchPositionIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task EmptyParsedFetchesAtSameOffset_SurfaceFatalConsumeError()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync())
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "key",
+                Value = "value"
+            }, CancellationToken.None);
+        }
+
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = [KafkaContainer.BootstrapServers],
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            OffsetCommitMode = OffsetCommitMode.Manual,
+            QueuedMinMessages = 1,
+            EnableFetchSessions = false,
+            RequestTimeoutMs = 10_000
+        };
+        var connectionOptions = new ConnectionOptions
+        {
+            RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs)
+        };
+        var injector = new EmptyFetchInjector();
+        var connectionPool = new ConnectionPool(
+            options.ClientId,
+            connectionOptions,
+            options.ConnectionsPerBroker,
+            async (brokerId, host, port, _, cancellationToken) =>
+            {
+                var connection = new KafkaConnection(
+                    brokerId,
+                    host,
+                    port,
+                    options.ClientId,
+                    connectionOptions);
+                await connection.ConnectAsync(cancellationToken);
+                return new EmptyFetchConnection(connection, injector);
+            });
+        var metadataManager = new MetadataManager(connectionPool, options.BootstrapServers);
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager,
+            GlobalTestSetup.GetLoggerFactory());
+        await consumer.InitializeAsync();
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var exception = await Assert.ThrowsAsync<ConsumeException>(async () =>
+            await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(20), timeout.Token));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.CorruptMessage);
+        await Assert.That(exception.IsRetriable).IsFalse();
+        await Assert.That(injector.MutatedFetchCount).IsGreaterThanOrEqualTo(3);
+    }
+
+    private sealed class EmptyFetchInjector
+    {
+        private int _mutatedFetchCount;
+
+        public int MutatedFetchCount => Volatile.Read(ref _mutatedFetchCount);
+
+        public void Mutate(FetchResponse response)
+        {
+            var mutated = false;
+            foreach (var topic in response.Responses)
+            {
+                foreach (var partition in topic.Partitions)
+                {
+                    if (partition.Records is not List<RecordBatch> records || records.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    records.Clear();
+                    mutated = true;
+                }
+            }
+
+            if (mutated)
+            {
+                Interlocked.Increment(ref _mutatedFetchCount);
+            }
+        }
+    }
+
+    private sealed class EmptyFetchConnection(
+        IKafkaConnection inner,
+        EmptyFetchInjector injector) : IKafkaConnection
+    {
+        public int BrokerId => inner.BrokerId;
+        public string Host => inner.Host;
+        public int Port => inner.Port;
+        public bool IsConnected => inner.IsConnected;
+
+        public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            var response = await inner.SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            MutateFetchResponse(response);
+            return response;
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendFireAndForgetAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public async Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            var response = await inner.SendPipelinedAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+            MutateFetchResponse(response);
+            return response;
+        }
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => inner.SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
+
+        public async Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            var response = await inner.SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+            MutateFetchResponse(response);
+            return response;
+        }
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+            => inner.ConnectAsync(cancellationToken);
+
+        public ValueTask DisposeAsync() => inner.DisposeAsync();
+
+        private void MutateFetchResponse<TResponse>(TResponse response)
+            where TResponse : IKafkaResponse
+        {
+            if (response is FetchResponse fetchResponse)
+            {
+                injector.Mutate(fetchResponse);
+            }
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/DirectFetchCleanupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DirectFetchCleanupTests.cs
@@ -1,0 +1,32 @@
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class DirectFetchCleanupTests
+{
+    [Test]
+    public async Task DisposeCompletedFetchResults_FaultedPeer_DisposesSuccessfulResult()
+    {
+        var memory = new TrackingPooledMemory();
+        var pending = PendingFetchData.Create(
+            "topic",
+            0,
+            Array.Empty<RecordBatch>(),
+            memoryOwner: memory);
+        var completed = Task.FromResult<List<PendingFetchData>?>([pending]);
+        var faulted = Task.FromException<List<PendingFetchData>?>(new InvalidOperationException("fatal"));
+
+        KafkaConsumer<string, string>.DisposeCompletedFetchResults([completed, faulted], 2);
+
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+    }
+
+    private sealed class TrackingPooledMemory : IPooledMemory
+    {
+        public ReadOnlyMemory<byte> Memory => ReadOnlyMemory<byte>.Empty;
+        public int DisposeCount { get; private set; }
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/FatalPrefetchErrorClassificationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FatalPrefetchErrorClassificationTests.cs
@@ -61,6 +61,15 @@ public class FatalPrefetchErrorClassificationTests
         await Assert.That(KafkaConsumer<string, string>.IsFatalPrefetchError(ex)).IsTrue();
     }
 
+    [Test]
+    public async Task ConsumeException_NonRetriableCorruptMessage_IsFatal()
+    {
+        var ex = new ConsumeException(ErrorCode.CorruptMessage, "stuck fetch position", isRetriable: false);
+
+        await Assert.That(ex.IsRetriable).IsFalse();
+        await Assert.That(KafkaConsumer<string, string>.IsFatalPrefetchError(ex)).IsTrue();
+    }
+
     #endregion
 
     #region Transient errors — should return false

--- a/tests/Dekaf.Tests.Unit/Consumer/StuckFetchPositionTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/StuckFetchPositionTrackerTests.cs
@@ -1,0 +1,71 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class StuckFetchPositionTrackerTests
+{
+    private static readonly TopicPartition Partition = new("topic", 0);
+
+    [Test]
+    public async Task ObserveEmptyParsedFetch_TripsAtThresholdForUnchangedPosition()
+    {
+        var tracker = new StuckFetchPositionTracker(threshold: 3);
+
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 42)).IsNull();
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 42)).IsNull();
+
+        var error = tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+
+        await Assert.That(error).IsNotNull();
+        await Assert.That(error!.ErrorCode).IsEqualTo(Dekaf.Protocol.ErrorCode.CorruptMessage);
+        await Assert.That(error.IsRetriable).IsFalse();
+        await Assert.That(error.Message).Contains("topic[0]");
+        await Assert.That(error.Message).Contains("offset 42");
+    }
+
+    [Test]
+    public async Task ObserveEmptyParsedFetch_PositionChangeRestartsCount()
+    {
+        var tracker = new StuckFetchPositionTracker(threshold: 3);
+
+        tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+        tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 43)).IsNull();
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 43)).IsNull();
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 43)).IsNotNull();
+    }
+
+    [Test]
+    public async Task Reset_RemovesPreviousObservations()
+    {
+        var tracker = new StuckFetchPositionTracker(threshold: 3);
+        tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+        tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+
+        tracker.Reset(Partition);
+
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 42)).IsNull();
+    }
+
+    [Test]
+    public async Task Clear_RemovesAllPartitionObservations()
+    {
+        var tracker = new StuckFetchPositionTracker(threshold: 2);
+        var otherPartition = new TopicPartition("topic", 1);
+        tracker.ObserveEmptyParsedFetch(Partition, position: 42);
+        tracker.ObserveEmptyParsedFetch(otherPartition, position: 84);
+
+        tracker.Clear();
+
+        await Assert.That(tracker.ObserveEmptyParsedFetch(Partition, position: 42)).IsNull();
+        await Assert.That(tracker.ObserveEmptyParsedFetch(otherPartition, position: 84)).IsNull();
+    }
+
+    [Test]
+    public async Task Constructor_RejectsNonPositiveThreshold()
+    {
+        await Assert.That(() => new StuckFetchPositionTracker(threshold: 0))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Summary
- detect byte-bearing fetch responses that repeatedly parse zero batches at an unchanged partition offset
- surface a typed non-retriable `ConsumeException` after three observations and terminate prefetch immediately
- reset detector state on progress, protocol errors, assignment changes, and buffer clears
- clean pending batches and pooled response memory before fatal propagation

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] focused detector/prefetch tests (24 passed)
- [x] complete unit suite (5,037 passed)
- [ ] integration tests (Docker daemon unavailable; `docker info` timed out)

Closes #1718
