### PR TITLE
Back off and break deterministic prefetch failures

### DIFF
--- a/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
+++ b/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
@@ -54,13 +54,14 @@ internal sealed class BrokerPrefetchScheduler
         await Task.WhenAny(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask DrainAllSafelyAsync(Action<Exception> logError)
+    public async ValueTask<Exception?> DrainAllSafelyAsync(Action<Exception> logError)
     {
         if (_inFlight.Count == 0)
-            return;
+            return null;
 
         var tasks = _inFlight.Values.ToArray();
         _inFlight.Clear();
+        Exception? firstFailure = null;
 
         for (var i = 0; i < tasks.Length; i++)
         {
@@ -74,7 +75,10 @@ internal sealed class BrokerPrefetchScheduler
             catch (Exception ex)
             {
                 logError(ex);
+                firstFailure ??= ex;
             }
         }
+
+        return firstFailure;
     }
 }

--- a/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
+++ b/src/Dekaf/Consumer/BrokerPrefetchScheduler.cs
@@ -54,7 +54,9 @@ internal sealed class BrokerPrefetchScheduler
         await Task.WhenAny(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<Exception?> DrainAllSafelyAsync(Action<Exception> logError)
+    public async ValueTask<Exception?> DrainAllSafelyAsync(
+        Action<Exception> logError,
+        Func<Exception, bool> shouldReturn)
     {
         if (_inFlight.Count == 0)
             return null;
@@ -75,7 +77,8 @@ internal sealed class BrokerPrefetchScheduler
             catch (Exception ex)
             {
                 logError(ex);
-                firstFailure ??= ex;
+                if (firstFailure is null && shouldReturn(ex))
+                    firstFailure = ex;
             }
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2142,7 +2142,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                     if (_assignmentSnapshot.Count == 0)
                     {
-                        await _brokerPrefetchScheduler.DrainAllSafelyAsync(LogPrefetchLoopError).ConfigureAwait(false);
+                        var drainError = await _brokerPrefetchScheduler
+                            .DrainAllSafelyAsync(LogPrefetchLoopError)
+                            .ConfigureAwait(false);
+                        if (drainError is not null)
+                            ExceptionDispatchInfo.Capture(drainError).Throw();
+
                         await Task.Delay(AllPartitionsPausedDelayMs, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
@@ -2220,7 +2225,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
-            await _brokerPrefetchScheduler.DrainAllSafelyAsync(LogPrefetchLoopError).ConfigureAwait(false);
+            var drainError = await _brokerPrefetchScheduler
+                .DrainAllSafelyAsync(LogPrefetchLoopError)
+                .ConfigureAwait(false);
+            if (completionError is null && drainError is not null && IsFatalPrefetchError(drainError))
+                completionError = drainError;
+
             _prefetchBuffer.Complete(completionError);
         }
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -641,6 +641,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private const int AllPartitionsPausedDelayMs = 100;
     private const int MaxConsecutivePrefetchErrors = 50;
     private const int MaxConsecutiveEmptyParsedFetches = 3;
+    private const int MaxRepeatedDeterministicPrefetchFailures = 3;
+    private const int InitialPrefetchFailureBackoffMs = 100;
+    private const int MaxPrefetchFailureBackoffMs = 5_000;
     private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
 
     private readonly ConsumerOptions _options;
@@ -771,6 +774,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly BrokerPrefetchScheduler _brokerPrefetchScheduler = new();
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler> _fetchSessions = new();
     private readonly StuckFetchPositionTracker _stuckFetchPositionTracker = new(MaxConsecutiveEmptyParsedFetches);
+    private readonly PrefetchFailureTracker _prefetchFailureTracker = new(
+        MaxRepeatedDeterministicPrefetchFailures,
+        InitialPrefetchFailureBackoffMs,
+        MaxPrefetchFailureBackoffMs);
 
     // Lock ordering (always acquire in this order to prevent deadlocks):
     //   1. _initLock          — guards one-time initialization; never held while acquiring other locks
@@ -1700,7 +1707,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         {
                             throw;
                         }
-                        catch (Exception ex) when (ex is InsufficientDataException or ArgumentOutOfRangeException or MalformedProtocolDataException)
+                        catch (Exception ex) when (ProtocolDataErrorClassifier.IsProtocolDataError(ex))
                         {
                             // Protocol-layer data errors from corrupted/truncated wire data should not
                             // kill the consumer. User-facing exceptions (deserializer errors, etc.)
@@ -2416,6 +2423,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         CancellationToken linkedToken,
         CancellationToken consumeCancellationToken)
     {
+        var failureKey = new PrefetchFailureKey(brokerId, connectionIndex);
+
         try
         {
             await PrefetchFromBrokerAsync(
@@ -2426,13 +2435,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 connectionIndex,
                 fetchBufferEpoch,
                 linkedToken).ConfigureAwait(false);
+            _prefetchFailureTracker.Reset(failureKey);
         }
         catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
         {
+            _prefetchFailureTracker.Reset(failureKey);
             // Consume cancellation requested, exit silently
         }
         catch (Exception ex) when (IsFatalPrefetchError(ex))
         {
+            _prefetchFailureTracker.Reset(failureKey);
             // Non-recoverable errors that should propagate to the broker prefetch loop's
             // consecutive error counter. See IsFatalPrefetchError for classification logic.
             LogFatalPrefetchError(ex, brokerId);
@@ -2440,12 +2452,51 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         catch (Exception ex)
         {
-            // Transient errors (connection timeouts, broker unavailable, etc.) — log and
-            // suppress. The pipeline retries on the next cycle, and in multi-broker setups
-            // other brokers may still succeed in this cycle.
+            var positions = CapturePrefetchPositions(
+                partitions,
+                partitionStartIndex,
+                partitionCount);
+            var deterministic = ProtocolDataErrorClassifier.IsProtocolDataError(ex);
+            var decision = _prefetchFailureTracker.Observe(
+                failureKey,
+                ex.GetType(),
+                positions,
+                deterministic);
+
             ClearPreferredReadReplicasForBroker(brokerId, partitions, partitionStartIndex, partitionCount);
             LogPrefetchFromBrokerError(ex, brokerId);
+
+            if (decision.IsTerminal)
+            {
+                var terminalError = new Errors.ConsumeException(
+                    ErrorCode.CorruptMessage,
+                    $"Broker {brokerId} connection {connectionIndex} failed to parse the same fetch positions " +
+                    $"{decision.Count} consecutive times: {ex.Message}",
+                    isRetriable: false,
+                    ex);
+                LogFatalPrefetchError(terminalError, brokerId);
+                throw terminalError;
+            }
+
+            await Task.Delay(decision.DelayMs, linkedToken).ConfigureAwait(false);
         }
+    }
+
+    private PrefetchPosition[] CapturePrefetchPositions(
+        List<TopicPartition> partitions,
+        int partitionStartIndex,
+        int partitionCount)
+    {
+        var positions = new PrefetchPosition[partitionCount];
+        var endIndex = partitionStartIndex + partitionCount;
+        for (var i = partitionStartIndex; i < endIndex; i++)
+        {
+            var partition = partitions[i];
+            var offset = _fetchPositions.GetValueOrDefault(partition, long.MinValue);
+            positions[i - partitionStartIndex] = new PrefetchPosition(partition, offset);
+        }
+
+        return positions;
     }
 
     /// <summary>
@@ -3410,7 +3461,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         throw;
                     }
-                    catch (Exception ex) when (ex is InsufficientDataException or ArgumentOutOfRangeException or MalformedProtocolDataException)
+                    catch (Exception ex) when (ProtocolDataErrorClassifier.IsProtocolDataError(ex))
                     {
                         LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                         break;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2143,7 +2143,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     if (_assignmentSnapshot.Count == 0)
                     {
                         var drainError = await _brokerPrefetchScheduler
-                            .DrainAllSafelyAsync(LogPrefetchLoopError)
+                            .DrainAllSafelyAsync(LogPrefetchLoopError, IsFatalPrefetchError)
                             .ConfigureAwait(false);
                         if (drainError is not null)
                             ExceptionDispatchInfo.Capture(drainError).Throw();
@@ -2226,7 +2226,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         finally
         {
             var drainError = await _brokerPrefetchScheduler
-                .DrainAllSafelyAsync(LogPrefetchLoopError)
+                .DrainAllSafelyAsync(LogPrefetchLoopError, IsFatalPrefetchError)
                 .ConfigureAwait(false);
             if (completionError is null && drainError is not null && IsFatalPrefetchError(drainError))
                 completionError = drainError;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2225,6 +2225,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         finally
         {
+            if (completionError is not null)
+                _prefetchCts?.Cancel();
+
             var drainError = await _brokerPrefetchScheduler
                 .DrainAllSafelyAsync(LogPrefetchLoopError, IsFatalPrefetchError)
                 .ConfigureAwait(false);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1619,6 +1619,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // Wrap MoveNext + record parsing in try-catch so a corrupted fetch
                         // does not kill the consumer permanently. The yield must be outside
                         // the try block (CS1626), so we build the result first then yield below.
+                        var readingProtocolData = true;
                         try
                         {
                             if (!pending.MoveNext())
@@ -1659,7 +1660,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     previousActivity = activity;
                             }
 
-                            // Create result - deserialization happens eagerly in the constructor
+                            // Create result - deserialization happens eagerly in the constructor.
+                            // Exceptions from user deserializers must never be classified as wire corruption.
+                            readingProtocolData = false;
                             nextResult = new ConsumeResult<TKey, TValue>(
                                 topic: pending.Topic,
                                 partition: pending.PartitionIndex,
@@ -1707,7 +1710,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         {
                             throw;
                         }
-                        catch (Exception ex) when (ProtocolDataErrorClassifier.IsProtocolDataError(ex))
+                        catch (Exception ex) when (
+                            readingProtocolData && ProtocolDataErrorClassifier.IsProtocolDataError(ex))
                         {
                             // Protocol-layer data errors from corrupted/truncated wire data should not
                             // kill the consumer. User-facing exceptions (deserializer errors, etc.)
@@ -3397,6 +3401,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 while (true)
                 {
+                    var readingProtocolData = true;
                     try
                     {
                         if (!pending.MoveNext())
@@ -3419,6 +3424,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             activity = StartConsumeActivity(pending, headers, offset, messageBytes);
                         }
 
+                        // User deserialization begins in this constructor. Its exceptions
+                        // must propagate even when their type also occurs in protocol codecs.
+                        readingProtocolData = false;
                         result = new ConsumeResult<TKey, TValue>(
                             topic: pending.Topic,
                             partition: pending.PartitionIndex,
@@ -3461,7 +3469,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         throw;
                     }
-                    catch (Exception ex) when (ProtocolDataErrorClassifier.IsProtocolDataError(ex))
+                    catch (Exception ex) when (
+                        readingProtocolData && ProtocolDataErrorClassifier.IsProtocolDataError(ex))
                     {
                         LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                         break;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4059,36 +4059,47 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             var pending = pendingItems[i];
             var tracked = false;
-            while (true)
+            try
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+                while (true)
                 {
-                    // Seek uses this same lock, so a fetch is either published before its
-                    // invalidation and drained, or observes the new epoch and is dropped.
-                    if (ShouldDropStaleFetchPartition(pending.TopicPartition, fetchBufferEpoch))
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
                     {
-                        if (tracked)
-                            TrackPrefetchedBytes(pending, release: true);
-                        pending.Dispose();
-                        break;
+                        // Seek uses this same lock, so a fetch is either published before its
+                        // invalidation and drained, or observes the new epoch and is dropped.
+                        if (ShouldDropStaleFetchPartition(pending.TopicPartition, fetchBufferEpoch))
+                        {
+                            if (tracked)
+                                TrackPrefetchedBytes(pending, release: true);
+                            pending.Dispose();
+                            break;
+                        }
+
+                        if (!tracked)
+                        {
+                            TrackPrefetchedBytes(pending, release: false);
+                            UpdateFetchPositionsFromPrefetch(pending, fetchBufferEpoch);
+                            tracked = true;
+                        }
+
+                        if (_prefetchBuffer.TryWrite(pending))
+                            break;
                     }
 
-                    if (!tracked)
-                    {
-                        TrackPrefetchedBytes(pending, release: false);
-                        UpdateFetchPositionsFromPrefetch(pending, fetchBufferEpoch);
-                        tracked = true;
-                    }
-
-                    if (_prefetchBuffer.TryWrite(pending))
-                    {
-                        break;
-                    }
+                    await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
                 }
+            }
+            catch
+            {
+                if (tracked)
+                    TrackPrefetchedBytes(pending, release: true);
 
-                await _prefetchBuffer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+                for (var j = i; j < pendingItems.Count; j++)
+                    pendingItems[j].Dispose();
+
+                throw;
             }
         }
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2473,7 +2473,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var deterministic = ProtocolDataErrorClassifier.IsProtocolDataError(ex);
             var decision = _prefetchFailureTracker.Observe(
                 failureKey,
-                ex.GetType(),
                 positions,
                 deterministic);
 

--- a/src/Dekaf/Consumer/PrefetchFailureTracker.cs
+++ b/src/Dekaf/Consumer/PrefetchFailureTracker.cs
@@ -27,7 +27,6 @@ internal sealed class PrefetchFailureTracker
 
     public PrefetchFailureDecision Observe(
         PrefetchFailureKey key,
-        Type exceptionType,
         PrefetchPosition[] positions,
         bool deterministic)
     {
@@ -36,7 +35,7 @@ internal sealed class PrefetchFailureTracker
             int count;
             PrefetchPosition[] storedPositions;
             if (_failures.TryGetValue(key, out var current)
-                && current.ExceptionType == exceptionType
+                && current.Deterministic == deterministic
                 && PositionsEqual(current.Positions, positions))
             {
                 count = current.Count + 1;
@@ -48,7 +47,7 @@ internal sealed class PrefetchFailureTracker
                 storedPositions = (PrefetchPosition[])positions.Clone();
             }
 
-            _failures[key] = new FailureState(exceptionType, storedPositions, count);
+            _failures[key] = new FailureState(deterministic, storedPositions, count);
 
             var shift = Math.Min(count - 1, 30);
             var delayMs = (int)Math.Min(_maxDelayMs, (long)_initialDelayMs << shift);
@@ -81,5 +80,5 @@ internal sealed class PrefetchFailureTracker
         return true;
     }
 
-    private readonly record struct FailureState(Type ExceptionType, PrefetchPosition[] Positions, int Count);
+    private readonly record struct FailureState(bool Deterministic, PrefetchPosition[] Positions, int Count);
 }

--- a/src/Dekaf/Consumer/PrefetchFailureTracker.cs
+++ b/src/Dekaf/Consumer/PrefetchFailureTracker.cs
@@ -1,0 +1,85 @@
+namespace Dekaf.Consumer;
+
+internal readonly record struct PrefetchFailureKey(int BrokerId, int ConnectionIndex);
+
+internal readonly record struct PrefetchPosition(TopicPartition Partition, long Offset);
+
+internal readonly record struct PrefetchFailureDecision(int DelayMs, bool IsTerminal, int Count);
+
+internal sealed class PrefetchFailureTracker
+{
+    private readonly Dictionary<PrefetchFailureKey, FailureState> _failures = [];
+    private readonly object _lock = new();
+    private readonly int _terminalThreshold;
+    private readonly int _initialDelayMs;
+    private readonly int _maxDelayMs;
+
+    public PrefetchFailureTracker(int terminalThreshold, int initialDelayMs, int maxDelayMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(terminalThreshold, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(initialDelayMs, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDelayMs, initialDelayMs);
+
+        _terminalThreshold = terminalThreshold;
+        _initialDelayMs = initialDelayMs;
+        _maxDelayMs = maxDelayMs;
+    }
+
+    public PrefetchFailureDecision Observe(
+        PrefetchFailureKey key,
+        Type exceptionType,
+        PrefetchPosition[] positions,
+        bool deterministic)
+    {
+        lock (_lock)
+        {
+            int count;
+            PrefetchPosition[] storedPositions;
+            if (_failures.TryGetValue(key, out var current)
+                && current.ExceptionType == exceptionType
+                && PositionsEqual(current.Positions, positions))
+            {
+                count = current.Count + 1;
+                storedPositions = current.Positions;
+            }
+            else
+            {
+                count = 1;
+                storedPositions = (PrefetchPosition[])positions.Clone();
+            }
+
+            _failures[key] = new FailureState(exceptionType, storedPositions, count);
+
+            var shift = Math.Min(count - 1, 30);
+            var delayMs = (int)Math.Min(_maxDelayMs, (long)_initialDelayMs << shift);
+            return new PrefetchFailureDecision(
+                delayMs,
+                IsTerminal: deterministic && count >= _terminalThreshold,
+                count);
+        }
+    }
+
+    public void Reset(PrefetchFailureKey key)
+    {
+        lock (_lock)
+        {
+            _failures.Remove(key);
+        }
+    }
+
+    private static bool PositionsEqual(PrefetchPosition[] left, PrefetchPosition[] right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (left[i] != right[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private readonly record struct FailureState(Type ExceptionType, PrefetchPosition[] Positions, int Count);
+}

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -38,6 +38,13 @@ public class KafkaException : Exception
         _isRetriableOverride = isRetriable;
     }
 
+    internal KafkaException(ErrorCode errorCode, string message, bool isRetriable, Exception innerException)
+        : base(message, innerException)
+    {
+        ErrorCode = errorCode;
+        _isRetriableOverride = isRetriable;
+    }
+
     /// <summary>
     /// Creates a new KafkaException with an inner exception.
     /// </summary>
@@ -297,6 +304,11 @@ public sealed class ConsumeException : KafkaException
     }
 
     internal ConsumeException(ErrorCode errorCode, string message, bool isRetriable) : base(errorCode, message, isRetriable)
+    {
+    }
+
+    internal ConsumeException(ErrorCode errorCode, string message, bool isRetriable, Exception innerException)
+        : base(errorCode, message, isRetriable, innerException)
     {
     }
 

--- a/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
+++ b/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
@@ -5,7 +5,5 @@ internal static class ProtocolDataErrorClassifier
     public static bool IsProtocolDataError(Exception exception) => exception is
         InsufficientDataException or
         MalformedProtocolDataException or
-        InvalidDataException or
-        ArgumentOutOfRangeException or
-        NotSupportedException;
+        ArgumentOutOfRangeException;
 }

--- a/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
+++ b/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
@@ -5,5 +5,7 @@ internal static class ProtocolDataErrorClassifier
     public static bool IsProtocolDataError(Exception exception) => exception is
         InsufficientDataException or
         MalformedProtocolDataException or
-        ArgumentOutOfRangeException;
+        InvalidDataException or
+        ArgumentOutOfRangeException or
+        NotSupportedException;
 }

--- a/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
+++ b/src/Dekaf/Protocol/ProtocolDataErrorClassifier.cs
@@ -1,0 +1,11 @@
+namespace Dekaf.Protocol;
+
+internal static class ProtocolDataErrorClassifier
+{
+    public static bool IsProtocolDataError(Exception exception) => exception is
+        InsufficientDataException or
+        MalformedProtocolDataException or
+        InvalidDataException or
+        ArgumentOutOfRangeException or
+        NotSupportedException;
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
@@ -47,4 +47,28 @@ public sealed class BrokerPrefetchSchedulerTests
         await Assert.That(async () => await scheduler.DrainCompletedAsync().ConfigureAwait(false))
             .Throws<InvalidOperationException>();
     }
+
+    [Test]
+    public async Task DrainAllSafely_ReturnsFirstFailureAndObservesRemainingFailures()
+    {
+        var scheduler = new BrokerPrefetchScheduler();
+        var firstFailure = new InvalidOperationException("first");
+        var secondFailure = new InvalidOperationException("second");
+        var loggedFailures = new List<Exception>();
+
+        scheduler.TryStart(
+            (BrokerId: 1, ConnectionIndex: 0),
+            () => Task.FromException(firstFailure));
+        scheduler.TryStart(
+            (BrokerId: 2, ConnectionIndex: 0),
+            () => Task.FromException(secondFailure));
+
+        var drainedFailure = await scheduler.DrainAllSafelyAsync(loggedFailures.Add).ConfigureAwait(false);
+
+        await Assert.That(drainedFailure).IsSameReferenceAs(firstFailure);
+        await Assert.That(loggedFailures).Count().IsEqualTo(2);
+        await Assert.That(loggedFailures[0]).IsSameReferenceAs(firstFailure);
+        await Assert.That(loggedFailures[1]).IsSameReferenceAs(secondFailure);
+        await Assert.That(scheduler.HasInFlight).IsFalse();
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BrokerPrefetchSchedulerTests.cs
@@ -30,7 +30,7 @@ public sealed class BrokerPrefetchSchedulerTests
         await Assert.That(scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), static () => Task.CompletedTask)).IsFalse();
 
         slowBrokerCanComplete.SetResult();
-        await scheduler.DrainAllSafelyAsync(static _ => { }).ConfigureAwait(false);
+        await scheduler.DrainAllSafelyAsync(static _ => { }, static _ => false).ConfigureAwait(false);
     }
 
     [Test]
@@ -49,7 +49,7 @@ public sealed class BrokerPrefetchSchedulerTests
     }
 
     [Test]
-    public async Task DrainAllSafely_ReturnsFirstFailureAndObservesRemainingFailures()
+    public async Task DrainAllSafely_ReturnsFirstMatchingFailureAndObservesAll()
     {
         var scheduler = new BrokerPrefetchScheduler();
         var firstFailure = new InvalidOperationException("first");
@@ -63,9 +63,11 @@ public sealed class BrokerPrefetchSchedulerTests
             (BrokerId: 2, ConnectionIndex: 0),
             () => Task.FromException(secondFailure));
 
-        var drainedFailure = await scheduler.DrainAllSafelyAsync(loggedFailures.Add).ConfigureAwait(false);
+        var drainedFailure = await scheduler.DrainAllSafelyAsync(
+            loggedFailures.Add,
+            exception => ReferenceEquals(exception, secondFailure)).ConfigureAwait(false);
 
-        await Assert.That(drainedFailure).IsSameReferenceAs(firstFailure);
+        await Assert.That(drainedFailure).IsSameReferenceAs(secondFailure);
         await Assert.That(loggedFailures).Count().IsEqualTo(2);
         await Assert.That(loggedFailures[0]).IsSameReferenceAs(firstFailure);
         await Assert.That(loggedFailures[1]).IsSameReferenceAs(secondFailure);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -317,6 +317,23 @@ public sealed class ConsumeOneFastPathTests
         await Assert.That(parsingErrorLog.Exception).IsNotNull();
     }
 
+    [Test]
+    public async Task ConsumeOneAsync_DeserializerInvalidDataException_Propagates()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(0, CreateRecord(0, "key", "value"))
+        ]);
+        await using var consumer = CreateInitializedConsumerWithValueDeserializer(
+            new InvalidDataThrowingDeserializer(),
+            fetch);
+
+        await Assert.That(async () =>
+            await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
+            .Throws<InvalidDataException>()
+            .WithMessageContaining("user deserializer");
+    }
+
     private static KafkaConsumer<string, string> CreateInitializedConsumer(params PendingFetchData[] fetches)
     {
         return CreateInitializedConsumer(queuedMinMessages: 1, fetchMaxWaitMs: 200, fetches);
@@ -390,6 +407,33 @@ public sealed class ConsumeOneFastPathTests
             pendingFetches.Enqueue(fetch);
 
         return consumer;
+    }
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumerWithValueDeserializer(
+        IDeserializer<string> valueDeserializer,
+        PendingFetchData fetch)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200
+            },
+            Serializers.String,
+            valueDeserializer);
+
+        SetInitialized(consumer);
+        AssignTestPartition(consumer);
+        GetPendingFetches(consumer).Enqueue(fetch);
+        return consumer;
+    }
+
+    private sealed class InvalidDataThrowingDeserializer : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            throw new InvalidDataException("user deserializer failed");
     }
 
     private static void AssignTestPartition(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -635,6 +635,46 @@ public sealed class ConsumerAssignmentFastPathTests
         SetPrefetchedBytes(consumer, 0);
     }
 
+    [Test]
+    public async Task WritePrefetchedItemsAsync_CancellationDisposesUnpublishedSharedMemory()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        var prefetchBuffer = GetPrefetchBuffer(consumer);
+        while (true)
+        {
+            var filler = CreateFetch(partition: 0, baseOffset: 0, value: "filler");
+            if (prefetchBuffer.TryWrite(filler))
+                continue;
+
+            filler.Dispose();
+            break;
+        }
+
+        var memory = new TrackingPooledMemory();
+        var shared = RefCountedMemoryOwner.Create(memory, initialRefCount: 2);
+        var first = CreateFetch(partition: 0, baseOffset: 10, value: "first");
+        var second = CreateFetch(partition: 0, baseOffset: 11, value: "second");
+        first.SetMemoryOwner(shared);
+        second.SetMemoryOwner(shared);
+        using var cts = new CancellationTokenSource();
+
+        var writeTask = StartWritePrefetchedItemsAsync(
+            consumer,
+            [first, second],
+            GetFetchBufferEpoch(consumer),
+            cts.Token).AsTask();
+        await Assert.That(writeTask.IsCompleted).IsFalse();
+
+        cts.Cancel();
+        await Assert.That(async () => await writeTask).Throws<OperationCanceledException>();
+
+        await Assert.That(memory.DisposeCount).IsEqualTo(1);
+        await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -1135,7 +1175,8 @@ public sealed class ConsumerAssignmentFastPathTests
     private static ValueTask StartWritePrefetchedItemsAsync(
         KafkaConsumer<string, string> consumer,
         IReadOnlyList<PendingFetchData> pendingItems,
-        int fetchBufferEpoch)
+        int fetchBufferEpoch,
+        CancellationToken cancellationToken = default)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
             "WritePrefetchedItemsAsync",
@@ -1144,7 +1185,14 @@ public sealed class ConsumerAssignmentFastPathTests
 
         return (ValueTask)method.Invoke(
             consumer,
-            [pendingItems, fetchBufferEpoch, CancellationToken.None])!;
+            [pendingItems, fetchBufferEpoch, cancellationToken])!;
+    }
+
+    private sealed class TrackingPooledMemory : IPooledMemory
+    {
+        public ReadOnlyMemory<byte> Memory => ReadOnlyMemory<byte>.Empty;
+        public int DisposeCount { get; private set; }
+        public void Dispose() => DisposeCount++;
     }
 
     private static void SetPrefetchedBytes(KafkaConsumer<string, string> consumer, long bytes)

--- a/tests/Dekaf.Tests.Unit/Consumer/FatalPrefetchErrorClassificationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FatalPrefetchErrorClassificationTests.cs
@@ -70,6 +70,20 @@ public class FatalPrefetchErrorClassificationTests
         await Assert.That(KafkaConsumer<string, string>.IsFatalPrefetchError(ex)).IsTrue();
     }
 
+    [Test]
+    public async Task ConsumeException_NonRetriableCorruption_IsFatalAndPreservesCause()
+    {
+        var cause = new InvalidDataException("invalid compressed payload");
+        var ex = new ConsumeException(
+            ErrorCode.CorruptMessage,
+            "repeated deterministic fetch failure",
+            isRetriable: false,
+            cause);
+
+        await Assert.That(KafkaConsumer<string, string>.IsFatalPrefetchError(ex)).IsTrue();
+        await Assert.That(ex.InnerException).IsSameReferenceAs(cause);
+    }
+
     #endregion
 
     #region Transient errors — should return false

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
@@ -16,9 +16,9 @@ public sealed class PrefetchFailureTrackerTests
     {
         var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
 
-        var first = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
-        var second = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
-        var third = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        var first = tracker.Observe(Key, Positions, deterministic: true);
+        var second = tracker.Observe(Key, Positions, deterministic: true);
+        var third = tracker.Observe(Key, Positions, deterministic: true);
 
         await Assert.That(first).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
         await Assert.That(second).IsEqualTo(new PrefetchFailureDecision(200, IsTerminal: false, Count: 2));
@@ -29,27 +29,27 @@ public sealed class PrefetchFailureTrackerTests
     public async Task Observe_ChangedPositionRestartsFailureCount()
     {
         var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, Positions, deterministic: true);
+        tracker.Observe(Key, Positions, deterministic: true);
         PrefetchPosition[] advanced =
         [
             new(new TopicPartition("topic", 0), Offset: 43),
             new(new TopicPartition("topic", 1), Offset: 84)
         ];
 
-        var decision = tracker.Observe(Key, typeof(InvalidDataException), advanced, deterministic: true);
+        var decision = tracker.Observe(Key, advanced, deterministic: true);
 
         await Assert.That(decision).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
     }
 
     [Test]
-    public async Task Observe_ChangedExceptionTypeRestartsFailureCount()
+    public async Task Observe_ChangedFailureClassificationRestartsFailureCount()
     {
         var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, Positions, deterministic: false);
+        tracker.Observe(Key, Positions, deterministic: false);
 
-        var decision = tracker.Observe(Key, typeof(FormatException), Positions, deterministic: true);
+        var decision = tracker.Observe(Key, Positions, deterministic: true);
 
         await Assert.That(decision).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
     }
@@ -62,7 +62,7 @@ public sealed class PrefetchFailureTrackerTests
 
         for (var i = 0; i < 10; i++)
         {
-            decision = tracker.Observe(Key, typeof(IOException), Positions, deterministic: false);
+            decision = tracker.Observe(Key, Positions, deterministic: false);
         }
 
         await Assert.That(decision.DelayMs).IsEqualTo(500);
@@ -74,11 +74,11 @@ public sealed class PrefetchFailureTrackerTests
     public async Task Reset_RestartsFailureCount()
     {
         var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
-        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, Positions, deterministic: true);
+        tracker.Observe(Key, Positions, deterministic: true);
 
         tracker.Reset(Key);
-        var decision = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        var decision = tracker.Observe(Key, Positions, deterministic: true);
 
         await Assert.That(decision.Count).IsEqualTo(1);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
@@ -1,0 +1,85 @@
+using Dekaf.Consumer;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class PrefetchFailureTrackerTests
+{
+    private static readonly PrefetchFailureKey Key = new(BrokerId: 1, ConnectionIndex: 0);
+    private static readonly PrefetchPosition[] Positions =
+    [
+        new(new TopicPartition("topic", 0), Offset: 42),
+        new(new TopicPartition("topic", 1), Offset: 84)
+    ];
+
+    [Test]
+    public async Task Observe_DeterministicFailureTripsAtThreshold()
+    {
+        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+
+        var first = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        var second = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        var third = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+
+        await Assert.That(first).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
+        await Assert.That(second).IsEqualTo(new PrefetchFailureDecision(200, IsTerminal: false, Count: 2));
+        await Assert.That(third).IsEqualTo(new PrefetchFailureDecision(400, IsTerminal: true, Count: 3));
+    }
+
+    [Test]
+    public async Task Observe_ChangedPositionRestartsFailureCount()
+    {
+        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        PrefetchPosition[] advanced =
+        [
+            new(new TopicPartition("topic", 0), Offset: 43),
+            new(new TopicPartition("topic", 1), Offset: 84)
+        ];
+
+        var decision = tracker.Observe(Key, typeof(InvalidDataException), advanced, deterministic: true);
+
+        await Assert.That(decision).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
+    }
+
+    [Test]
+    public async Task Observe_ChangedExceptionTypeRestartsFailureCount()
+    {
+        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+
+        var decision = tracker.Observe(Key, typeof(FormatException), Positions, deterministic: true);
+
+        await Assert.That(decision).IsEqualTo(new PrefetchFailureDecision(100, IsTerminal: false, Count: 1));
+    }
+
+    [Test]
+    public async Task Observe_TransientFailureBacksOffWithoutBecomingTerminal()
+    {
+        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 500);
+        PrefetchFailureDecision decision = default;
+
+        for (var i = 0; i < 10; i++)
+        {
+            decision = tracker.Observe(Key, typeof(IOException), Positions, deterministic: false);
+        }
+
+        await Assert.That(decision.DelayMs).IsEqualTo(500);
+        await Assert.That(decision.IsTerminal).IsFalse();
+        await Assert.That(decision.Count).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task Reset_RestartsFailureCount()
+    {
+        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+        tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+
+        tracker.Reset(Key);
+        var decision = tracker.Observe(Key, typeof(InvalidDataException), Positions, deterministic: true);
+
+        await Assert.That(decision.Count).IsEqualTo(1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
@@ -1,0 +1,40 @@
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ProtocolDataErrorClassifierTests
+{
+    [Test]
+    public async Task IsProtocolDataError_ClassifiesWireAndCodecFailures()
+    {
+        Exception[] protocolErrors =
+        [
+            new InsufficientDataException(),
+            new MalformedProtocolDataException("malformed"),
+            new InvalidDataException("invalid compressed payload"),
+            new ArgumentOutOfRangeException("length"),
+            new NotSupportedException("unsupported record format")
+        ];
+
+        foreach (var error in protocolErrors)
+        {
+            await Assert.That(ProtocolDataErrorClassifier.IsProtocolDataError(error)).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task IsProtocolDataError_DoesNotClassifyUserOrNetworkFailures()
+    {
+        Exception[] otherErrors =
+        [
+            new IOException("connection reset"),
+            new FormatException("user deserializer failed"),
+            new OperationCanceledException()
+        ];
+
+        foreach (var error in otherErrors)
+        {
+            await Assert.That(ProtocolDataErrorClassifier.IsProtocolDataError(error)).IsFalse();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
@@ -5,13 +5,15 @@ namespace Dekaf.Tests.Unit.Protocol;
 public sealed class ProtocolDataErrorClassifierTests
 {
     [Test]
-    public async Task IsProtocolDataError_ClassifiesWireFailures()
+    public async Task IsProtocolDataError_ClassifiesWireAndCodecFailures()
     {
         Exception[] protocolErrors =
         [
             new InsufficientDataException(),
             new MalformedProtocolDataException("malformed"),
-            new ArgumentOutOfRangeException("length")
+            new InvalidDataException("invalid compressed payload"),
+            new ArgumentOutOfRangeException("length"),
+            new NotSupportedException("unsupported record format")
         ];
 
         foreach (var error in protocolErrors)
@@ -26,8 +28,6 @@ public sealed class ProtocolDataErrorClassifierTests
         Exception[] otherErrors =
         [
             new IOException("connection reset"),
-            new InvalidDataException("user or unwrapped codec failure"),
-            new NotSupportedException("user or unwrapped codec failure"),
             new FormatException("user deserializer failed"),
             new OperationCanceledException()
         ];

--- a/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ProtocolDataErrorClassifierTests.cs
@@ -5,15 +5,13 @@ namespace Dekaf.Tests.Unit.Protocol;
 public sealed class ProtocolDataErrorClassifierTests
 {
     [Test]
-    public async Task IsProtocolDataError_ClassifiesWireAndCodecFailures()
+    public async Task IsProtocolDataError_ClassifiesWireFailures()
     {
         Exception[] protocolErrors =
         [
             new InsufficientDataException(),
             new MalformedProtocolDataException("malformed"),
-            new InvalidDataException("invalid compressed payload"),
-            new ArgumentOutOfRangeException("length"),
-            new NotSupportedException("unsupported record format")
+            new ArgumentOutOfRangeException("length")
         ];
 
         foreach (var error in protocolErrors)
@@ -28,6 +26,8 @@ public sealed class ProtocolDataErrorClassifierTests
         Exception[] otherErrors =
         [
             new IOException("connection reset"),
+            new InvalidDataException("user or unwrapped codec failure"),
+            new NotSupportedException("user or unwrapped codec failure"),
             new FormatException("user deserializer failed"),
             new OperationCanceledException()
         ];


### PR DESCRIPTION
## Summary
- apply exponential backoff per broker connection after prefetch failures, capped at 5 seconds
- compare exact partition/offset snapshots and fail after three classified deterministic protocol errors without progress
- propagate terminal failures immediately as typed non-retriable `ConsumeException` values while preserving the cause
- share protocol-data classification across prefetch and foreground lazy-record parsing while preserving user deserializer exceptions

Malformed compressed batches are handled earlier by the typed `FetchResponsePartition.RecordParseError` path merged in #1730: those errors surface directly to the consumer instead of entering this retry breaker. This breaker covers deterministic protocol failures that escape broker prefetch or lazy record parsing.

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] focused tracker/taxonomy/scheduler/fatal-error tests
- [x] complete unit suite (5,039 passed before dependency rebase)
- [x] full CI integration and NativeAOT sweep after rebasing onto #1730/#1732

Closes #1719