### PR TITLE
Expose Dekaf client logs in stress runs

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/StressClientLoggingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StressClientLoggingTests.cs
@@ -33,4 +33,11 @@ public sealed class StressClientLoggingTests
         await Assert.That(StressClientLogging.ParseLevel("verbose"))
             .IsEqualTo(LogLevel.Warning);
     }
+
+    [Test]
+    public async Task ParseLevel_UndefinedNumericValueFallsBackToWarning()
+    {
+        await Assert.That(StressClientLogging.ParseLevel("10"))
+            .IsEqualTo(LogLevel.Warning);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/StressClientLoggingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StressClientLoggingTests.cs
@@ -1,0 +1,36 @@
+using Dekaf.StressTests;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class StressClientLoggingTests
+{
+    [Test]
+    public async Task Create_DefaultsToWarning()
+    {
+        using var factory = StressClientLogging.Create(null);
+        var logger = factory.CreateLogger("test");
+
+        await Assert.That(logger.IsEnabled(LogLevel.Debug)).IsFalse();
+        await Assert.That(logger.IsEnabled(LogLevel.Information)).IsFalse();
+        await Assert.That(logger.IsEnabled(LogLevel.Warning)).IsTrue();
+        await Assert.That(logger.IsEnabled(LogLevel.Error)).IsTrue();
+    }
+
+    [Test]
+    public async Task Create_DebugOverrideEnablesDebug()
+    {
+        using var factory = StressClientLogging.Create("Debug");
+        var logger = factory.CreateLogger("test");
+
+        await Assert.That(logger.IsEnabled(LogLevel.Debug)).IsTrue();
+        await Assert.That(logger.IsEnabled(LogLevel.Trace)).IsFalse();
+    }
+
+    [Test]
+    public async Task ParseLevel_InvalidValueFallsBackToWarning()
+    {
+        await Assert.That(StressClientLogging.ParseLevel("verbose"))
+            .IsEqualTo(LogLevel.Warning);
+    }
+}

--- a/tools/Dekaf.StressTests/Diagnostics/StressClientLogging.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/StressClientLogging.cs
@@ -16,6 +16,7 @@ internal static class StressClientLogging
 
     internal static LogLevel ParseLevel(string? configuredLevel) =>
         Enum.TryParse<LogLevel>(configuredLevel, ignoreCase: true, out var level)
+            && Enum.IsDefined(level)
             ? level
             : LogLevel.Warning;
 

--- a/tools/Dekaf.StressTests/Diagnostics/StressClientLogging.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/StressClientLogging.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.StressTests;
+
+internal static class StressClientLogging
+{
+    internal const string LogLevelEnvironmentVariable = "DEKAF_STRESS_LOG_LEVEL";
+
+    internal static LogLevel MinimumLevel { get; } =
+        ParseLevel(Environment.GetEnvironmentVariable(LogLevelEnvironmentVariable));
+
+    internal static ILoggerFactory LoggerFactory { get; } = new ConsoleLoggerFactory(MinimumLevel);
+
+    internal static ILoggerFactory Create(string? configuredLevel) =>
+        new ConsoleLoggerFactory(ParseLevel(configuredLevel));
+
+    internal static LogLevel ParseLevel(string? configuredLevel) =>
+        Enum.TryParse<LogLevel>(configuredLevel, ignoreCase: true, out var level)
+            ? level
+            : LogLevel.Warning;
+
+    private sealed class ConsoleLoggerFactory(LogLevel minimumLevel) : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => new ConsoleLogger(categoryName, minimumLevel);
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+    }
+
+    private sealed class ConsoleLogger(string categoryName, LogLevel minimumLevel) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel != LogLevel.None && logLevel >= minimumLevel;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            Console.Error.WriteLine(
+                $"[{DateTimeOffset.UtcNow:O}] {logLevel,-11} {categoryName}[{eventId.Id}] {formatter(state, exception)}");
+            if (exception is not null)
+                Console.Error.WriteLine(exception);
+        }
+    }
+}

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -192,6 +192,7 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
     {
         var replicationFactor = (short)Math.Min(3, BrokerCount);
         await using var admin = Kafka.CreateAdminClient()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(BootstrapServers)
             .WithClientId("fault-injection-admin")
             .Build();

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionRunner.cs
@@ -168,6 +168,7 @@ internal static class FaultInjectionRunner
         try
         {
             producer = await Kafka.CreateProducer<string, string>()
+                .WithLoggerFactory(StressClientLogging.LoggerFactory)
                 .WithBootstrapServers(environment.BootstrapServers)
                 .WithClientId($"fault-producer-{definition.Name}")
                 .WithIdempotence(true)
@@ -551,6 +552,7 @@ internal static class FaultInjectionRunner
         try
         {
             await using var consumer = await Kafka.CreateConsumer<string, string>()
+                .WithLoggerFactory(StressClientLogging.LoggerFactory)
                 .WithBootstrapServers(bootstrapServers)
                 .WithClientId($"fault-live-consumer-{Guid.NewGuid():N}")
                 .WithGroupId($"fault-live-{Guid.NewGuid():N}")

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -272,6 +272,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             try
             {
                 await using var producer = await Kafka.CreateProducer<string, string>()
+                    .WithLoggerFactory(StressClientLogging.LoggerFactory)
                     .WithBootstrapServers(bootstrapServers)
                     .WithClientId("kafka-ready-check")
                     .WithAcks(Producer.Acks.Leader)
@@ -326,6 +327,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         IReadOnlyDictionary<string, string>? configs)
     {
         await using var adminClient = Kafka.CreateAdminClient()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("stress-test-admin")
             .Build();

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -126,6 +126,8 @@ public static class Program
             Console.WriteLine($"Resource sample interval: {options.ResourceSampleIntervalSeconds:N0} seconds");
         }
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
+        Console.WriteLine($"Dekaf client logs: {StressClientLogging.MinimumLevel}+ " +
+            $"(set {StressClientLogging.LogLevelEnvironmentVariable}=Debug for verbose diagnostics)");
         Console.WriteLine($"Progress watchdog: stacks at {ProgressWatchdog.DefaultCaptureAfter.TotalSeconds:F0}s; " +
             $"fail at {ProgressWatchdog.DefaultExitAfter.TotalMinutes:F0} minutes");
         if (options.ConnectionsPerBroker > 1)
@@ -650,6 +652,7 @@ public static class Program
         var totalMessages = options.SeedMessages;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("stress-seeder")
             .WithAcks(Acks.Leader)

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -24,6 +24,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         // A live feeder would compete with the consumer for CPU and cap throughput at the
         // feeder's rate, measuring the feeder instead of the consumer.
         await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-batch-dekaf")
             .WithGroupId($"stress-group-batch-dekaf-{Guid.NewGuid():N}")

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -25,6 +25,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         // feeder's rate, measuring the feeder instead of the consumer.
         // Consumer uses string types but ConsumeRawBatchAsync skips deserialization
         await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-raw-batch-dekaf")
             .WithGroupId($"stress-group-raw-batch-dekaf-{Guid.NewGuid():N}")

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -27,6 +27,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         // feeder's rate, measuring the feeder instead of the consumer.
         // Consumer uses Ignore for key (don't care) and ReadOnlyMemory<byte> for zero-copy value access
         await using var consumer = await Kafka.CreateConsumer<Ignore, ReadOnlyMemory<byte>>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-raw-dekaf")
             .WithGroupId($"stress-group-raw-dekaf-{Guid.NewGuid():N}")

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -19,6 +19,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         // A live feeder would compete with the consumer for CPU and cap throughput at the
         // feeder's rate, measuring the feeder instead of the consumer.
         await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-consumer-dekaf")
             .WithGroupId($"stress-group-dekaf-{Guid.NewGuid():N}")

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -23,6 +23,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-acks-all-dekaf")
             .WithIdempotence(false)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -21,6 +21,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-async-idempotent-dekaf")
             .WithIdempotence(true)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -21,6 +21,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-async-dekaf")
             .WithIdempotence(false)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -23,6 +23,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-idempotent-dekaf")
             .WithIdempotence(true)

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -23,6 +23,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         await using var consumer = await Kafka.CreateConsumer<string, byte[]>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-roundtrip-consumer-dekaf")
             .WithGroupId($"stress-roundtrip-dekaf-{Guid.NewGuid():N}")
@@ -36,6 +37,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             cancellationToken);
 
         var builder = Kafka.CreateProducer<string, byte[]>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-roundtrip-producer-dekaf")
             // Deliberately exercise retry duplicate detection; idempotent producers

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -23,6 +23,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-dekaf")
             .WithIdempotence(false)

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -31,6 +31,7 @@ internal sealed class SoakStressTest : IStressTestScenario
         var consumedMessages = 0L;
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("soak-consumer-dekaf")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
@@ -51,6 +52,7 @@ internal sealed class SoakStressTest : IStressTestScenario
             consumerCts.Token);
 
         var producerBuilder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("soak-producer-dekaf")
             .WithIdempotence(true)

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -104,6 +104,7 @@ internal static class StressTestHelpers
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await using var adminClient = Kafka.CreateAdminClient()
+                .WithLoggerFactory(StressClientLogging.LoggerFactory)
                 .WithBootstrapServers(bootstrapServers)
                 .WithClientId("stress-watermark-query")
                 .Build();

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -25,6 +25,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         var startedAt = DateTime.UtcNow;
 
         var builder = Kafka.CreateProducer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-producer-transactional-dekaf")
             .WithTransactionalId($"stress-{runId}")
@@ -272,6 +273,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
             return oracle.CreateSnapshot(acceptedMessages);
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
             .WithClientId("stress-transaction-verifier")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)


### PR DESCRIPTION
## Summary
- add shared stderr logger factory for stress-harness Dekaf clients
- default to Warning+ and support `DEKAF_STRESS_LOG_LEVEL=Debug`
- wire all 22 Dekaf producer, consumer, admin, seeder, verifier, readiness, and fault-injection builders
- print active level and override hint at run startup

## Test plan
- [x] all Dekaf builder/logger count audit: `creates=22 loggers=22`
- [x] `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj --configuration Release`
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] `StressClientLoggingTests` (3 passed)

Closes #1734
