### PR TITLE
Return pooled objects after failed fetch parsing

### DIFF
--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -103,17 +103,30 @@ public sealed class FetchResponse : IKafkaResponse
 
         // Use pooled list to avoid per-fetch array allocation
         var responses = s_topicListPool.Rent();
-        reader.ReadCompactArrayInto(responses, static (ref KafkaProtocolReader r, short v) => FetchResponseTopic.Read(ref r, v), version);
+        try
+        {
+            reader.ReadCompactArrayInto(responses, static (ref KafkaProtocolReader r, short v) => FetchResponseTopic.Read(ref r, v), version);
 
-        var nodeEndpoints = ReadResponseTaggedFields(ref reader, version);
+            var nodeEndpoints = ReadResponseTaggedFields(ref reader, version);
 
-        var response = Rent();
-        response.ThrottleTimeMs = throttleTimeMs;
-        response.ErrorCode = errorCode;
-        response.SessionId = sessionId;
-        response.Responses = responses;
-        response.NodeEndpoints = nodeEndpoints;
-        return response;
+            var response = Rent();
+            response.ThrottleTimeMs = throttleTimeMs;
+            response.ErrorCode = errorCode;
+            response.SessionId = sessionId;
+            response.Responses = responses;
+            response.NodeEndpoints = nodeEndpoints;
+            return response;
+        }
+        catch
+        {
+            for (var i = 0; i < responses.Count; i++)
+            {
+                responses[i].ReturnToPoolAfterFailedParse();
+            }
+
+            s_topicListPool.Return(responses);
+            throw;
+        }
     }
 
     private static NodeEndpoint[] ReadResponseTaggedFields(ref KafkaProtocolReader reader, short version)
@@ -230,6 +243,22 @@ public sealed class FetchResponseTopic
         return item;
     }
 
+    internal void ReturnToPoolAfterFailedParse()
+    {
+        for (var i = 0; i < _partitions.Count; i++)
+        {
+            _partitions[i].ReturnToPoolAfterFailedParse();
+        }
+
+        if (_partitions is List<FetchResponsePartition> partitionList)
+        {
+            s_partitionListPool.Return(partitionList);
+            _partitions = Array.Empty<FetchResponsePartition>();
+        }
+
+        ReturnToPool();
+    }
+
     public static FetchResponseTopic Read(ref KafkaProtocolReader reader, short version)
     {
         Guid topicId = Guid.Empty;
@@ -249,15 +278,28 @@ public sealed class FetchResponseTopic
 
         // Use pooled list to avoid per-topic array allocation
         var partitions = s_partitionListPool.Rent();
-        reader.ReadCompactArrayInto(partitions, static (ref KafkaProtocolReader r, short v) => FetchResponsePartition.Read(ref r, v), version);
+        try
+        {
+            reader.ReadCompactArrayInto(partitions, static (ref KafkaProtocolReader r, short v) => FetchResponsePartition.Read(ref r, v), version);
 
-        reader.SkipTaggedFields();
+            reader.SkipTaggedFields();
 
-        var result = Rent();
-        result.Topic = topic;
-        result.TopicId = topicId;
-        result.Partitions = partitions;
-        return result;
+            var result = Rent();
+            result.Topic = topic;
+            result.TopicId = topicId;
+            result.Partitions = partitions;
+            return result;
+        }
+        catch
+        {
+            for (var i = 0; i < partitions.Count; i++)
+            {
+                partitions[i].ReturnToPoolAfterFailedParse();
+            }
+
+            s_partitionListPool.Return(partitions);
+            throw;
+        }
     }
 
     private sealed class FetchResponseTopicPool() : ObjectPool<FetchResponseTopic>(maxPoolSize: 32)
@@ -301,6 +343,19 @@ public sealed class FetchResponsePartition
     internal static List<RecordBatch> RentRecordBatchList() => s_recordBatchListPool.Rent();
 
     internal static void ReturnRecordBatchList(List<RecordBatch> list) => s_recordBatchListPool.Return(list);
+
+    internal static void ReturnRecordBatchListAfterFailedParse(List<RecordBatch>? list)
+    {
+        if (list is null)
+            return;
+
+        for (var i = 0; i < list.Count; i++)
+        {
+            list[i].Dispose();
+        }
+
+        s_recordBatchListPool.Return(list);
+    }
 
     /// <summary>
     /// Partition index.
@@ -374,8 +429,8 @@ public sealed class FetchResponsePartition
     }
 
     /// <summary>
-    /// Returns this FetchResponsePartition to the pool. Does NOT return Records or AbortedTransactions
-    /// since those are transferred to PendingFetchData and have separate lifecycles.
+    /// Returns this FetchResponsePartition to the pool. Non-empty Records lists are transferred
+    /// to PendingFetchData; empty Records and AbortedTransactions lists remain wrapper-owned.
     /// </summary>
     internal void ReturnToPool()
     {
@@ -391,7 +446,26 @@ public sealed class FetchResponsePartition
             _abortedTransactions = null;
         }
 
+        // Non-empty Records lists transfer to PendingFetchData. An empty list carries no
+        // transferable data, so this response wrapper retains and returns its ownership.
+        if (_records is List<RecordBatch> { Count: 0 } emptyRecords)
+        {
+            s_recordBatchListPool.Return(emptyRecords);
+            _records = null;
+        }
+
         s_pool.Return(this);
+    }
+
+    internal void ReturnToPoolAfterFailedParse()
+    {
+        if (_records is List<RecordBatch> records)
+        {
+            ReturnRecordBatchListAfterFailedParse(records);
+            _records = null;
+        }
+
+        ReturnToPool();
     }
 
     internal static FetchResponsePartition Rent()
@@ -417,75 +491,94 @@ public sealed class FetchResponsePartition
         // Use pooled list to avoid per-partition array allocation for aborted transactions
         IReadOnlyList<AbortedTransaction>? abortedTransactions = null;
         var abortedList = s_abortedTxListPool.Rent();
-        var abortedCount = reader.ReadCompactArrayInto(abortedList, static (ref KafkaProtocolReader r, short v) => AbortedTransaction.Read(ref r, v), version);
-
-        if (abortedCount > 0)
-        {
-            abortedTransactions = abortedList;
-        }
-        else
-        {
-            // No aborted transactions — return the empty list to the pool immediately
-            s_abortedTxListPool.Return(abortedList);
-        }
-
-        var preferredReadReplica = reader.ReadInt32();
-
-        // Read record batches
-        // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null)
-        var recordsLength = reader.ReadUnsignedVarInt() - 1;
-
+        var abortedListReturned = false;
         List<RecordBatch>? records = null;
-        if (recordsLength > 0)
+
+        try
         {
-            records = RentRecordBatchList();
-            var recordsEndPosition = reader.Consumed + recordsLength;
+            var abortedCount = reader.ReadCompactArrayInto(
+                abortedList,
+                static (ref KafkaProtocolReader r, short v) => AbortedTransaction.Read(ref r, v),
+                version);
 
-            while (reader.Consumed < recordsEndPosition && !reader.End)
+            if (abortedCount > 0)
             {
-                try
+                abortedTransactions = abortedList;
+            }
+            else
+            {
+                // No aborted transactions — return the empty list to the pool immediately
+                s_abortedTxListPool.Return(abortedList);
+                abortedListReturned = true;
+            }
+
+            var preferredReadReplica = reader.ReadInt32();
+
+            // Read record batches
+            // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null)
+            var recordsLength = reader.ReadUnsignedVarInt() - 1;
+
+            if (recordsLength > 0)
+            {
+                records = RentRecordBatchList();
+                var recordsEndPosition = reader.Consumed + recordsLength;
+
+                while (reader.Consumed < recordsEndPosition && !reader.End)
                 {
-                    var availableBytes = (int)(recordsEndPosition - reader.Consumed);
-                    records.Add(RecordBatch.Read(ref reader, availableBytes: availableBytes));
+                    try
+                    {
+                        var availableBytes = (int)(recordsEndPosition - reader.Consumed);
+                        records.Add(RecordBatch.Read(ref reader, availableBytes: availableBytes));
+                    }
+                    catch (InsufficientDataException)
+                    {
+                        // Partial batch at end of records section — not enough data to read a complete batch.
+                        // This is a normal Kafka scenario when the fetch response is truncated.
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Unexpected error parsing a record batch — log for visibility and skip remaining batches.
+                        // This should not happen under normal conditions and may indicate data corruption or a parsing bug.
+                        Trace.WriteLine($"Dekaf: Unexpected exception parsing RecordBatch: {ex}");
+                        break;
+                    }
                 }
-                catch (InsufficientDataException)
+
+                // Skip any remaining bytes
+                var remaining = (int)(recordsEndPosition - reader.Consumed);
+                if (remaining > 0)
                 {
-                    // Partial batch at end of records section — not enough data to read a complete batch.
-                    // This is a normal Kafka scenario when the fetch response is truncated.
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    // Unexpected error parsing a record batch — log for visibility and skip remaining batches.
-                    // This should not happen under normal conditions and may indicate data corruption or a parsing bug.
-                    Trace.WriteLine($"Dekaf: Unexpected exception parsing RecordBatch: {ex}");
-                    break;
+                    reader.Skip(remaining);
                 }
             }
 
-            // Skip any remaining bytes
-            var remaining = (int)(recordsEndPosition - reader.Consumed);
-            if (remaining > 0)
-            {
-                reader.Skip(remaining);
-            }
+            ReadPartitionTaggedFields(ref reader, version, out divergingEpoch, out currentLeader, out snapshotId);
+
+            var result = Rent();
+            result.PartitionIndex = partitionIndex;
+            result.ErrorCode = errorCode;
+            result.HighWatermark = highWatermark;
+            result.LastStableOffset = lastStableOffset;
+            result.LogStartOffset = logStartOffset;
+            result.DivergingEpoch = divergingEpoch;
+            result.CurrentLeader = currentLeader;
+            result.SnapshotId = snapshotId;
+            result.AbortedTransactions = abortedTransactions;
+            result.PreferredReadReplica = preferredReadReplica;
+            result.Records = records;
+            return result;
         }
+        catch
+        {
+            if (!abortedListReturned)
+            {
+                s_abortedTxListPool.Return(abortedList);
+            }
 
-        ReadPartitionTaggedFields(ref reader, version, out divergingEpoch, out currentLeader, out snapshotId);
-
-        var result = Rent();
-        result.PartitionIndex = partitionIndex;
-        result.ErrorCode = errorCode;
-        result.HighWatermark = highWatermark;
-        result.LastStableOffset = lastStableOffset;
-        result.LogStartOffset = logStartOffset;
-        result.DivergingEpoch = divergingEpoch;
-        result.CurrentLeader = currentLeader;
-        result.SnapshotId = snapshotId;
-        result.AbortedTransactions = abortedTransactions;
-        result.PreferredReadReplica = preferredReadReplica;
-        result.Records = records;
-        return result;
+            ReturnRecordBatchListAfterFailedParse(records);
+            throw;
+        }
     }
 
     private static void ReadPartitionTaggedFields(

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponsePoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponsePoolingTests.cs
@@ -1,5 +1,7 @@
+using System.Buffers;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Protocol;
 
@@ -158,6 +160,133 @@ public class FetchResponsePoolingTests
         await Assert.That(reused.SnapshotId).IsNull();
 
         reused.ReturnToPool();
+    }
+
+    [Test]
+    public async Task FetchResponsePartition_ReturnToPool_ReturnsEmptyRecordsList()
+    {
+        var heldLists = Enumerable.Range(0, 65)
+            .Select(_ => FetchResponsePartition.RentRecordBatchList())
+            .ToArray();
+        var expected = heldLists[0];
+        var partition = FetchResponsePartition.Rent();
+        partition.Records = expected;
+
+        partition.ReturnToPool();
+        var actual = FetchResponsePartition.RentRecordBatchList();
+
+        await Assert.That(actual).IsSameReferenceAs(expected);
+
+        FetchResponsePartition.ReturnRecordBatchList(actual);
+        for (var i = 1; i < heldLists.Length; i++)
+        {
+            FetchResponsePartition.ReturnRecordBatchList(heldLists[i]);
+        }
+    }
+
+    [Test]
+    public async Task FetchResponse_ReadFailure_ReturnsParsedBatchesAndLists()
+    {
+        var responseBytes = CreateResponseWithMalformedSecondTopic();
+        var heldPartitions = Enumerable.Range(0, 65)
+            .Select(_ => FetchResponsePartition.Rent())
+            .ToArray();
+        var heldLists = Enumerable.Range(0, 65)
+            .Select(_ => FetchResponsePartition.RentRecordBatchList())
+            .ToArray();
+        var heldBatches = Enumerable.Range(0, 2_049)
+            .Select(_ => RecordBatch.RentFromPool())
+            .ToArray();
+        var expectedPartition = heldPartitions[0];
+        var expectedList = heldLists[0];
+        var expectedBatch = heldBatches[0];
+        expectedPartition.ReturnToPool();
+        FetchResponsePartition.ReturnRecordBatchList(expectedList);
+        expectedBatch.ReturnToPool();
+
+        var threw = ParseMalformedResponse(responseBytes);
+        var actualPartition = FetchResponsePartition.Rent();
+        var actualList = FetchResponsePartition.RentRecordBatchList();
+        var actualBatch = RecordBatch.RentFromPool();
+
+        try
+        {
+            await Assert.That(threw).IsTrue();
+            await Assert.That(actualPartition).IsSameReferenceAs(expectedPartition);
+            await Assert.That(actualList).IsSameReferenceAs(expectedList);
+            await Assert.That(actualBatch).IsSameReferenceAs(expectedBatch);
+        }
+        finally
+        {
+            actualPartition.ReturnToPool();
+            FetchResponsePartition.ReturnRecordBatchList(actualList);
+            actualBatch.ReturnToPool();
+
+            for (var i = 1; i < heldPartitions.Length; i++)
+            {
+                heldPartitions[i].ReturnToPool();
+                FetchResponsePartition.ReturnRecordBatchList(heldLists[i]);
+                heldBatches[i].ReturnToPool();
+            }
+
+            for (var i = heldPartitions.Length; i < heldBatches.Length; i++)
+            {
+                heldBatches[i].ReturnToPool();
+            }
+        }
+    }
+
+    private static bool ParseMalformedResponse(byte[] responseBytes)
+    {
+        var reader = new KafkaProtocolReader(responseBytes);
+        try
+        {
+            FetchResponse.Read(ref reader, version: 12);
+            return false;
+        }
+        catch (MalformedProtocolDataException)
+        {
+            return true;
+        }
+    }
+
+    private static byte[] CreateResponseWithMalformedSecondTopic()
+    {
+        var batchBuffer = new ArrayBufferWriter<byte>();
+        using (var batch = new RecordBatch
+        {
+            BaseOffset = 10,
+            PartitionLeaderEpoch = -1,
+            BaseTimestamp = 1_000,
+            MaxTimestamp = 1_000,
+            Records = [new Record { OffsetDelta = 0, TimestampDelta = 0, Value = "value"u8.ToArray() }]
+        })
+        {
+            batch.Write(batchBuffer);
+        }
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(3); // two topics
+        writer.WriteCompactString("valid-topic");
+        writer.WriteUnsignedVarInt(2); // one partition
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt64(100);
+        writer.WriteInt64(100);
+        writer.WriteInt64(0);
+        writer.WriteUnsignedVarInt(1); // empty aborted transactions
+        writer.WriteInt32(-1);
+        writer.WriteUnsignedVarInt(batchBuffer.WrittenCount + 1);
+        writer.WriteRawBytes(batchBuffer.WrittenSpan);
+        writer.WriteUnsignedVarInt(0); // partition tagged fields
+        writer.WriteUnsignedVarInt(0); // topic tagged fields
+        writer.WriteUnsignedVarInt(10); // malformed compact-string length for second topic
+        writer.WriteUInt8(0x41);
+        return buffer.WrittenSpan.ToArray();
     }
 
     // ── Thread-safety ──


### PR DESCRIPTION
## Summary
- return empty rented record-batch lists when response wrappers leave the parse path without transferable records
- unwind completed topics, partitions, record batches, aborted-transaction lists, and backing lists when nested fetch parsing fails
- preserve normal ownership transfer for non-empty record lists on successful responses
- prove cleanup under forced pool exhaustion by verifying exact pooled objects are reused

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] `FetchResponsePoolingTests` (21 passed)
- [x] complete unit suite (5,034 passed)
- [ ] integration tests (Docker daemon unavailable; `docker info` timed out)

Closes #1721
