### PR TITLE
Watch EOS verification and expose sentinel failures

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
@@ -103,6 +103,7 @@ public sealed class TransactionalReportingTests
         LeakedAbortedMessages = 0,
         UnexpectedMessages = 0,
         MissingSentinelPartitions = 0,
+        SentinelCommitFailed = false,
         FailureSamples = duplicateMessages == 0 ? [] : ["Duplicate committed index 1."]
     };
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
@@ -100,4 +100,23 @@ public sealed class TransactionalSequenceOracleTests
         await Assert.That(snapshot.IsSuccessful).IsFalse();
         await Assert.That(snapshot.FailureSamples).Contains(sample => sample.Contains("partition 1"));
     }
+
+    [Test]
+    public async Task CreateSnapshot_SentinelCommitFailed_IsDistinctFailure()
+    {
+        var oracle = new TransactionalSequenceOracle(
+            runId: "run-sentinel-failure",
+            committedMessages: 0,
+            abortedMessages: 0,
+            partitionCount: 2);
+
+        var snapshot = oracle.CreateSnapshot(
+            acceptedMessages: 0,
+            sentinelCommitFailed: true);
+
+        await Assert.That(snapshot.SentinelCommitFailed).IsTrue();
+        await Assert.That(snapshot.IsSuccessful).IsFalse();
+        await Assert.That(snapshot.FailureSamples)
+            .Contains(sample => sample.Contains("sentinel transaction failed to commit"));
+    }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalSequenceOracleTests.cs
@@ -106,16 +106,17 @@ public sealed class TransactionalSequenceOracleTests
     {
         var oracle = new TransactionalSequenceOracle(
             runId: "run-sentinel-failure",
-            committedMessages: 0,
+            committedMessages: 3,
             abortedMessages: 0,
             partitionCount: 2);
 
         var snapshot = oracle.CreateSnapshot(
-            acceptedMessages: 0,
+            acceptedMessages: 3,
             sentinelCommitFailed: true);
 
         await Assert.That(snapshot.SentinelCommitFailed).IsTrue();
         await Assert.That(snapshot.IsSuccessful).IsFalse();
+        await Assert.That(snapshot.FailureSamples).Count().IsEqualTo(1);
         await Assert.That(snapshot.FailureSamples)
             .Contains(sample => sample.Contains("sentinel transaction failed to commit"));
     }

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -546,7 +546,8 @@ public static class Program
             $"shortfall={verification.ShortfallMessages:N0}, " +
             $"leakedAborted={verification.LeakedAbortedMessages:N0}, " +
             $"unexpected={verification.UnexpectedMessages:N0}, " +
-            $"missingSentinels={verification.MissingSentinelPartitions:N0}");
+            $"missingSentinels={verification.MissingSentinelPartitions:N0}, " +
+            $"sentinelCommitFailed={verification.SentinelCommitFailed}");
 
         foreach (var sample in verification.FailureSamples)
         {

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -203,8 +203,8 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## {title}");
         sb.AppendLine();
-        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Accepted | Committed | Aborted | Delivered | Duplicates | Shortfall | Aborted leaks | Unexpected | Missing sentinels | Status |");
-        sb.AppendLine($"|{new string('-', clientWidth + 2)}|----------|-----------|---------|-----------|------------|-----------|---------------|------------|-------------------|--------|");
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Accepted | Committed | Aborted | Delivered | Duplicates | Shortfall | Aborted leaks | Unexpected | Missing sentinels | Sentinel commit | Status |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|----------|-----------|---------|-----------|------------|-----------|---------------|------------|-------------------|-----------------|--------|");
 
         foreach (var result in results.OrderBy(r => r.Client))
         {
@@ -215,7 +215,8 @@ internal static class MarkdownReporter
                 $"{verification.CommittedMessages,9:N0} | {verification.AbortedMessages,7:N0} | " +
                 $"{verification.DeliveredMessages,9:N0} | {verification.DuplicateMessages,10:N0} | " +
                 $"{verification.ShortfallMessages,9:N0} | {verification.LeakedAbortedMessages,13:N0} | " +
-                $"{verification.UnexpectedMessages,10:N0} | {verification.MissingSentinelPartitions,17:N0} | {status} |");
+                $"{verification.UnexpectedMessages,10:N0} | {verification.MissingSentinelPartitions,17:N0} | " +
+                $"{(verification.SentinelCommitFailed ? "FAILED" : "OK"),15} | {status} |");
         }
 
         sb.AppendLine();

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -156,6 +156,7 @@ internal sealed class TransactionVerificationSnapshot
     public required long LeakedAbortedMessages { get; init; }
     public required long UnexpectedMessages { get; init; }
     public required int MissingSentinelPartitions { get; init; }
+    public bool SentinelCommitFailed { get; init; }
     public required List<string> FailureSamples { get; init; }
 
     public bool IsSuccessful =>
@@ -163,7 +164,8 @@ internal sealed class TransactionVerificationSnapshot
         ShortfallMessages == 0 &&
         LeakedAbortedMessages == 0 &&
         UnexpectedMessages == 0 &&
-        MissingSentinelPartitions == 0;
+        MissingSentinelPartitions == 0 &&
+        !SentinelCommitFailed;
 }
 
 internal sealed class StressTestResults

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -169,7 +169,8 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
             $"delivered={verification.DeliveredMessages:N0}, duplicates={verification.DuplicateMessages:N0}, " +
             $"shortfall={verification.ShortfallMessages:N0}, leakedAborted={verification.LeakedAbortedMessages:N0}, " +
             $"unexpected={verification.UnexpectedMessages:N0}, " +
-            $"missingSentinels={verification.MissingSentinelPartitions:N0}");
+            $"missingSentinels={verification.MissingSentinelPartitions:N0}, " +
+            $"sentinelCommitFailed={verification.SentinelCommitFailed}");
 
         return new StressTestResult
         {
@@ -269,7 +270,14 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
             options.Partitions,
             failedCommitMessages);
         if (!sentinelsCommitted)
-            return oracle.CreateSnapshot(acceptedMessages);
+            return oracle.CreateSnapshot(acceptedMessages, sentinelCommitFailed: true);
+
+        var verificationProgress = new ThroughputTracker();
+        verificationProgress.Start();
+        using var verificationWatchdog = options.ProgressWatchdog.Track(
+            verificationProgress,
+            client: "Dekaf",
+            scenario: "producer-transactional-read-committed-verification");
 
         await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(options.BootstrapServers)
@@ -291,6 +299,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         {
             await foreach (var record in consumer.ConsumeAsync(verificationCts.Token).ConfigureAwait(false))
             {
+                verificationProgress.RecordMessage(0);
                 oracle.Observe(record.Key);
                 if (oracle.AllSentinelsSeen)
                     break;
@@ -300,6 +309,10 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         {
             Console.WriteLine(
                 $"  Warning: read_committed verification timed out after {verificationMinutes:N0} minute(s).");
+        }
+        finally
+        {
+            verificationProgress.Stop();
         }
 
         return oracle.CreateSnapshot(acceptedMessages);

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
@@ -96,18 +96,22 @@ internal sealed class TransactionalSequenceOracle
 
         var samples = new List<string>(_failureSamples);
         if (sentinelCommitFailed)
+        {
             samples.Add("Partition sentinel transaction failed to commit; read_committed verification was not run.");
-
-        for (var index = 0; index < _seenCommitted.Length && samples.Count < MaxFailureSamples; index++)
-        {
-            if (!_seenCommitted[index])
-                samples.Add($"Missing committed index {index:N0}.");
         }
-
-        for (var partition = 0; partition < _seenSentinels.Length && samples.Count < MaxFailureSamples; partition++)
+        else
         {
-            if (!_seenSentinels[partition])
-                samples.Add($"Missing terminal sentinel for partition {partition}.");
+            for (var index = 0; index < _seenCommitted.Length && samples.Count < MaxFailureSamples; index++)
+            {
+                if (!_seenCommitted[index])
+                    samples.Add($"Missing committed index {index:N0}.");
+            }
+
+            for (var partition = 0; partition < _seenSentinels.Length && samples.Count < MaxFailureSamples; partition++)
+            {
+                if (!_seenSentinels[partition])
+                    samples.Add($"Missing terminal sentinel for partition {partition}.");
+            }
         }
 
         return new TransactionVerificationSnapshot

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalSequenceOracle.cs
@@ -88,11 +88,16 @@ internal sealed class TransactionalSequenceOracle
         }
     }
 
-    internal TransactionVerificationSnapshot CreateSnapshot(long acceptedMessages)
+    internal TransactionVerificationSnapshot CreateSnapshot(
+        long acceptedMessages,
+        bool sentinelCommitFailed = false)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(acceptedMessages);
 
         var samples = new List<string>(_failureSamples);
+        if (sentinelCommitFailed)
+            samples.Add("Partition sentinel transaction failed to commit; read_committed verification was not run.");
+
         for (var index = 0; index < _seenCommitted.Length && samples.Count < MaxFailureSamples; index++)
         {
             if (!_seenCommitted[index])
@@ -116,6 +121,7 @@ internal sealed class TransactionalSequenceOracle
             LeakedAbortedMessages = _leakedAbortedMessages,
             UnexpectedMessages = _unexpectedMessages,
             MissingSentinelPartitions = _seenSentinels.Length - _sentinelsSeen,
+            SentinelCommitFailed = sentinelCommitFailed,
             FailureSamples = samples
         };
     }


### PR DESCRIPTION
## Summary
- register transactional read_committed verification with the stress progress watchdog
- advance watchdog progress for every observed record
- record and report sentinel commit failure as a distinct verification result
- add focused oracle/reporting coverage

## Verification
- dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj --configuration Release --framework net10.0 --no-restore
- TransactionalSequenceOracleTests (5 passed)
- TransactionalReportingTests (4 passed)
- ProgressWatchdogTests (3 passed)

Closes #1735
Part of #1726