### PR TITLE
Stop fabricating offset zero for unknown positions

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2078,7 +2078,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
                 catch (Exception ex)
                 {
-                    consecutiveErrors++;
+                    consecutiveErrors = PrefetchLoopControl.RecordConsecutiveError(consecutiveErrors, ex);
                     LogPrefetchLoopError(ex);
 
                     if (PrefetchLoopControl.ShouldBreakOnConsecutiveError(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4256,7 +4256,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                 // Set equality alone is insufficient: the assignment can change away and back
                 // between polls. Unseen revocations require stale-fetch cleanup and position reset.
-                if (_assignment.SetEquals(coordinatorAssignment) && coordinatorRevocations is null)
+                if (_assignment.SetEquals(coordinatorAssignment)
+                    && coordinatorRevocations is null
+                    && HasInitializedFetchPositions(coordinatorAssignment))
                 {
                     Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
                     coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
@@ -4267,7 +4269,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 List<TopicPartition>? newPartitions = null;
                 foreach (var partition in coordinatorAssignment)
                 {
-                    if (!_assignment.Contains(partition))
+                    if (!_assignment.Contains(partition) || !_fetchPositions.ContainsKey(partition))
                     {
                         newPartitions ??= new List<TopicPartition>();
                         newPartitions.Add(partition);
@@ -4385,6 +4387,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         var assignmentEnsureVersion = Volatile.Read(ref _assignmentEnsureVersion);
         return Volatile.Read(ref _lastManualAssignmentEnsureVersion) == assignmentEnsureVersion;
+    }
+
+    private bool HasInitializedFetchPositions(TopicPartitionSet partitions)
+    {
+        foreach (var partition in partitions)
+        {
+            if (!_fetchPositions.ContainsKey(partition))
+                return false;
+        }
+
+        return true;
     }
 
     private async ValueTask InitializeManualAssignmentPositionsAsync(List<TopicPartition> partitions, CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4528,10 +4528,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 ]
             };
 
-            var response = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-                request,
-                listOffsetsVersion,
-                cancellationToken).ConfigureAwait(false);
+            ListOffsetsResponse response;
+            try
+            {
+                response = await connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                    request,
+                    listOffsetsVersion,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (TimeoutException ex)
+            {
+                throw new KafkaException(
+                    ErrorCode.RequestTimedOut,
+                    $"ListOffsets request timed out for {partition}.",
+                    ex);
+            }
 
             ListOffsetsResponsePartition? partitionResponse = null;
             foreach (var topic in response.Topics)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -545,6 +545,9 @@ internal static class ConsumerFetchPools
         return list;
     }
 
+    internal static void ReturnFetchRequestPartitionList(List<FetchRequestPartition> list)
+        => s_fetchRequestPartitionLists.Return(list);
+
     internal static void ReturnFetchRequestTopics(List<FetchRequestTopic> topics)
     {
         for (var i = 0; i < topics.Count; i++)
@@ -4460,7 +4463,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         for (var i = startIndex; i < endIndex; i++)
         {
             var partition = partitions[i];
-            var fetchPosition = _fetchPositions.GetValueOrDefault(partition, 0);
+            if (!_fetchPositions.TryGetValue(partition, out var fetchPosition))
+                continue;
+
             if (fetchPosition == -1 || fetchPosition == -2)
             {
                 // -1 = latest, -2 = earliest
@@ -4479,7 +4484,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var connectionLease = await GetPartitionLeaderControlConnectionAsync(partition, cancellationToken)
                 .ConfigureAwait(false);
             if (connectionLease is null)
-                return 0;
+                throw CreateOffsetResolutionUnavailableException(partition);
             using var lease = connectionLease.Value;
             var connection = lease.Connection;
 
@@ -4538,9 +4543,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     $"ListOffsets failed for {partition}: {partitionResponse.ErrorCode}");
             }
 
-            return partitionResponse?.Offset ?? 0;
+            if (partitionResponse is null)
+            {
+                throw new KafkaException(
+                    ErrorCode.UnknownTopicOrPartition,
+                    $"ListOffsets response did not contain {partition}.");
+            }
+
+            return partitionResponse.Offset;
         }, _metadataManager, cancellationToken);
     }
+
+    internal static KafkaException CreateOffsetResolutionUnavailableException(TopicPartition partition) =>
+        new(
+            ErrorCode.LeaderNotAvailable,
+            $"No partition leader connection is available to resolve the offset for {partition}.");
 
     private async ValueTask<KafkaConnectionLease?> GetPartitionLeaderControlConnectionAsync(
         TopicPartition partition,
@@ -5804,16 +5821,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
             foreach (var (template, tp) in cachedPartitions)
             {
+                if (!fetchPositions.TryGetValue(tp, out var fetchOffset))
+                    continue;
+
                 var currentLeaderEpoch = clusterMetadata?.GetPartitionInfo(tp.Topic, tp.Partition)?.LeaderEpoch ?? -1;
                 partitionList.Add(new FetchRequestPartition
                 {
                     Partition = template.Partition,
-                    FetchOffset = fetchPositions.GetValueOrDefault(tp, 0),
+                    FetchOffset = fetchOffset,
                     CurrentLeaderEpoch = currentLeaderEpoch,
                     LastFetchedEpoch = lastConsumedLeaderEpochs?.GetValueOrDefault(tp, -1) ?? -1,
                     LogStartOffset = template.LogStartOffset,
                     PartitionMaxBytes = adaptivePartitionMaxBytes ?? template.PartitionMaxBytes
                 });
+            }
+
+            if (partitionList.Count == 0)
+            {
+                ConsumerFetchPools.ReturnFetchRequestPartitionList(partitionList);
+                continue;
             }
 
             result.Add(new FetchRequestTopic

--- a/src/Dekaf/Consumer/PrefetchLoopControl.cs
+++ b/src/Dekaf/Consumer/PrefetchLoopControl.cs
@@ -1,3 +1,5 @@
+using Dekaf.Errors;
+
 namespace Dekaf.Consumer;
 
 internal enum PrefetchLoopAction
@@ -19,6 +21,11 @@ internal static class PrefetchLoopControl
 
     public static bool ShouldBreakOnConsecutiveError(int consecutiveErrors, int threshold)
         => consecutiveErrors >= threshold;
+
+    public static int RecordConsecutiveError(int consecutiveErrors, Exception exception)
+        => exception is KafkaException { IsRetriable: true }
+            ? 0
+            : consecutiveErrors + 1;
 
     public static bool ShouldResetConsecutiveErrors(int drained)
         => drained > 0;

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using Dekaf.Internal;
+using Dekaf.Protocol;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -425,11 +426,13 @@ public sealed partial class ConnectionPool : IConnectionPool
         catch (TimeoutException)
         {
             throw new KafkaException(
+                ErrorCode.RequestTimedOut,
                 $"Connection group creation timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId}");
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             throw new KafkaException(
+                ErrorCode.RequestTimedOut,
                 $"Connection group creation timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId}");
         }
         finally
@@ -665,6 +668,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             throw new KafkaException(
+                ErrorCode.RequestTimedOut,
                 $"Connection replacement timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId} index {index}");
         }
         finally
@@ -826,6 +830,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             throw new KafkaException(
+                ErrorCode.RequestTimedOut,
                 $"Connection timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
         }
         finally

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1179,6 +1179,7 @@ public sealed partial class KafkaConnection :
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
+                    ErrorCode.RequestTimedOut,
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
         }
@@ -1199,6 +1200,7 @@ public sealed partial class KafkaConnection :
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
+                    ErrorCode.RequestTimedOut,
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
         }
@@ -1428,6 +1430,7 @@ public sealed partial class KafkaConnection :
         MarkDisposed();
 
         return new KafkaException(
+            ErrorCode.RequestTimedOut,
             $"Receive timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms - connection to broker {BrokerId} failed");
     }
 

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -36,7 +36,7 @@ internal static class RetryHelper
             }
             catch (KafkaException ex) when (ex.IsRetriable && attempt < maxRetries)
             {
-                await metadataManager.RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
+                await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
 
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
@@ -69,7 +69,7 @@ internal static class RetryHelper
             }
             catch (KafkaException ex) when (ex.IsRetriable && attempt < maxRetries)
             {
-                await metadataManager.RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
+                await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
 
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
@@ -77,6 +77,23 @@ internal static class RetryHelper
                 var jitter = Random.Shared.Next(0, 100);
                 await Task.Delay(RetryDelayMs + jitter, cancellationToken).ConfigureAwait(false);
             }
+        }
+    }
+
+    private static async ValueTask RefreshMetadataForRetryAsync(
+        MetadataManager metadataManager,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await metadataManager.RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (
+            ex is not ObjectDisposedException
+            && !cancellationToken.IsCancellationRequested)
+        {
+            // Refresh is best-effort. Keep retrying the original operation so its typed
+            // Kafka failure remains the final error when every broker is unavailable.
         }
     }
 }

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
@@ -52,11 +52,18 @@ public class ConsumerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
             using var unavailableCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             unavailableCts.CancelAfter(TimeSpan.FromSeconds(15));
 
-            await Assert.That(async () =>
+            Exception? offsetResolutionFailure = null;
+            try
             {
                 _ = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), unavailableCts.Token)
                     .ConfigureAwait(false);
-            }).Throws<KafkaException>();
+            }
+            catch (Exception ex) when (ex is KafkaException or TimeoutException)
+            {
+                offsetResolutionFailure = ex;
+            }
+
+            await Assert.That(offsetResolutionFailure).IsNotNull();
         }
         finally
         {

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
@@ -52,16 +52,11 @@ public class ConsumerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
             using var unavailableCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             unavailableCts.CancelAfter(TimeSpan.FromSeconds(15));
 
-            Exception? offsetResolutionFailure = null;
-            try
+            var offsetResolutionFailure = await Assert.That(async () =>
             {
                 _ = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), unavailableCts.Token)
                     .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is KafkaException or TimeoutException)
-            {
-                offsetResolutionFailure = ex;
-            }
+            }).Throws<KafkaException>();
 
             await Assert.That(offsetResolutionFailure).IsNotNull();
         }

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
@@ -14,6 +14,90 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 public class ConsumerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
 {
     [Test]
+    [Timeout(60_000)]
+    public async Task Consumer_LatestOffsetResolutionFailure_DoesNotReplayFromZero(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync();
+
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("offset-resolution-setup-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken))
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "before",
+                Value = "before"
+            }, cancellationToken);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("offset-resolution-consumer")
+            .WithAutoOffsetReset(AutoOffsetReset.Latest)
+            .WithQueuedMinMessages(1)
+            .WithRequestTimeout(TimeSpan.FromSeconds(1))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+        var partition = new TopicPartition(topic, 0);
+
+        await kafka.PauseAsync();
+        try
+        {
+            consumer.Assign(partition);
+            using var unavailableCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            unavailableCts.CancelAfter(TimeSpan.FromSeconds(15));
+
+            await Assert.That(async () =>
+            {
+                _ = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), unavailableCts.Token)
+                    .ConfigureAwait(false);
+            }).Throws<KafkaException>();
+        }
+        finally
+        {
+            await kafka.TryUnpauseAsync();
+        }
+
+        using var recoveryCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        recoveryCts.CancelAfter(TimeSpan.FromSeconds(20));
+        var consumeTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), recoveryCts.Token).AsTask();
+
+        while (consumer.GetPosition(partition) != 1)
+        {
+            if (consumeTask.IsCompleted)
+                _ = await consumeTask.ConfigureAwait(false);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), recoveryCts.Token).ConfigureAwait(false);
+        }
+
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("offset-resolution-recovery-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(recoveryCts.Token))
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "after",
+                Value = "after"
+            }, recoveryCts.Token).ConfigureAwait(false);
+        }
+
+        var result = await consumeTask.ConfigureAwait(false);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("after");
+        await Assert.That(result.Value.Offset).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Consumer_RejoinsGroup_AfterNetworkPartition()
     {
         // Arrange: short session timeout and heartbeat interval for fast detection

--- a/tests/Dekaf.Tests.Unit/Consumer/BuildFetchResultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/BuildFetchResultTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
@@ -139,14 +140,50 @@ public class BuildFetchResultTests
     }
 
     [Test]
-    public async Task BuildFetchResult_MissingPosition_DefaultsToZero()
+    public async Task BuildFetchResult_MissingPosition_SkipsPartitionAndTopic()
     {
         var (templateDict, _) = CreateSinglePartitionTemplate();
         var fetchPositions = new ConcurrentDictionary<TopicPartition, long>();
 
         var result = KafkaConsumer<string, string>.BuildFetchResult(templateDict, fetchPositions);
 
-        await Assert.That(result[0].Partitions[0].FetchOffset).IsEqualTo(0);
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task BuildFetchResult_MixedPositions_SkipsOnlyMissingPartition()
+    {
+        var known = new TopicPartition("topic-a", 0);
+        var missing = new TopicPartition("topic-a", 1);
+        var templateDict = new Dictionary<string, List<(FetchRequestPartition, TopicPartition)>>
+        {
+            ["topic-a"] =
+            [
+                (new FetchRequestPartition { Partition = 0, FetchOffset = 0, PartitionMaxBytes = 1_048_576 }, known),
+                (new FetchRequestPartition { Partition = 1, FetchOffset = 0, PartitionMaxBytes = 1_048_576 }, missing)
+            ]
+        };
+        var fetchPositions = new ConcurrentDictionary<TopicPartition, long> { [known] = 42 };
+
+        var result = KafkaConsumer<string, string>.BuildFetchResult(templateDict, fetchPositions);
+
+        await Assert.That(result).Count().IsEqualTo(1);
+        await Assert.That(result[0].Partitions).Count().IsEqualTo(1);
+        await Assert.That(result[0].Partitions[0].Partition).IsEqualTo(0);
+        await Assert.That(result[0].Partitions[0].FetchOffset).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task OffsetResolutionUnavailableError_IsRetriableAndContextual()
+    {
+        var partition = new TopicPartition("topic-a", 7);
+
+        var error = KafkaConsumer<string, string>.CreateOffsetResolutionUnavailableException(partition);
+
+        await Assert.That(error).IsTypeOf<KafkaException>();
+        await Assert.That(error.IsRetriable).IsTrue();
+        await Assert.That(error.Message).Contains("topic-a");
+        await Assert.That(error.Message).Contains("7");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -431,6 +431,34 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task EnsureAssignmentAsync_InitialPositionFailure_RetriesUnchangedAssignment()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetchFailureThenSuccess(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+
+        _ = await Assert.That(async () =>
+                await consumer.EnsureAssignmentAsync(CancellationToken.None))
+            .Throws<GroupException>();
+
+        var partition = new TopicPartition("test-topic", 0);
+        await Assert.That(consumer.Assignment).Contains(partition);
+        await Assert.That(GetFetchPositions(consumer).ContainsKey(partition)).IsFalse();
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(10L);
+    }
+
+    [Test]
     public async Task EnsureAssignmentAsync_AssignmentChangesBeforeRevocationDrain_UsesMatchingSnapshot()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -886,6 +914,29 @@ public sealed class ConsumerAssignmentFastPathTests
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
             .Returns(_ => Interlocked.Increment(ref callCount) == 2
+                ? ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    Groups =
+                    [
+                        new OffsetFetchResponseGroup
+                        {
+                            GroupId = "group-a",
+                            Topics = [],
+                            ErrorCode = ErrorCode.StaleMemberEpoch
+                        }
+                    ]
+                })
+                : ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
+    }
+
+    private static void SetupOffsetFetchFailureThenSuccess(IKafkaConnection connection)
+    {
+        var callCount = 0;
+        connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Interlocked.Increment(ref callCount) == 1
                 ? ValueTask.FromResult(new OffsetFetchResponse
                 {
                     Groups =

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -189,15 +189,18 @@ public sealed class ConsumerAssignmentFastPathTests
 
         await using var metadataManager = CreateMetadataManager(connectionPool);
         SetupFindCoordinator(connection);
-        SetupChangingConsumerGroupHeartbeat(connection);
-        var offsetFetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseOffsetFetch = new TaskCompletionSource<OffsetFetchResponse>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        SetupBlockingSecondOffsetFetch(connection, offsetFetchStarted, releaseOffsetFetch);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetch(connection);
 
         await using var consumer = CreateGroupConsumer(connectionPool, metadataManager, maxPollIntervalMs: 100);
         consumer.Subscribe("test-topic");
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var offsetFetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOffsetFetch = new TaskCompletionSource<OffsetFetchResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0, 1));
+        SetupBlockingOffsetFetch(connection, offsetFetchStarted, releaseOffsetFetch);
 
         var coordinator = GetCoordinator(consumer);
         coordinator.RequestRejoin();
@@ -886,21 +889,17 @@ public sealed class ConsumerAssignmentFastPathTests
             .Returns(ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
     }
 
-    private static void SetupBlockingSecondOffsetFetch(
+    private static void SetupBlockingOffsetFetch(
         IKafkaConnection connection,
         TaskCompletionSource offsetFetchStarted,
         TaskCompletionSource<OffsetFetchResponse> releaseOffsetFetch)
     {
-        var callCount = 0;
         connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
                 Arg.Any<OffsetFetchRequest>(),
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
-                if (Interlocked.Increment(ref callCount) == 1)
-                    return ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse());
-
                 offsetFetchStarted.TrySetResult();
                 return new ValueTask<OffsetFetchResponse>(releaseOffsetFetch.Task);
             });

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Messages;
@@ -17,6 +18,11 @@ public sealed class ConsumerFetchPoolsTests
             "_fetchRequestTemplateCache",
             BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("Could not find _fetchRequestTemplateCache");
+    private static readonly FieldInfo FetchPositionsField =
+        typeof(KafkaConsumer<string, string>).GetField(
+            "_fetchPositions",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not find _fetchPositions");
 
     [Test]
     public async Task ReturnedPendingFetchDataLists_AreClearedBeforeRent()
@@ -184,9 +190,17 @@ public sealed class ConsumerFetchPoolsTests
         int startIndex,
         int count,
         int brokerId = 1)
-        => (List<FetchRequestTopic>)BuildFetchRequestTopicsMethod.Invoke(
+    {
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)FetchPositionsField.GetValue(consumer)!;
+        for (var i = startIndex; i < startIndex + count; i++)
+        {
+            fetchPositions.TryAdd(partitions[i], 0);
+        }
+
+        return (List<FetchRequestTopic>)BuildFetchRequestTopicsMethod.Invoke(
             consumer,
             [partitions, startIndex, count, brokerId])!;
+    }
 
     private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchLoopControlTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchLoopControlTests.cs
@@ -1,4 +1,6 @@
 using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
@@ -68,6 +70,26 @@ public sealed class PrefetchLoopControlTests
     {
         await Assert.That(PrefetchLoopControl.ShouldBreakOnConsecutiveError(49, 50)).IsFalse();
         await Assert.That(PrefetchLoopControl.ShouldBreakOnConsecutiveError(50, 50)).IsTrue();
+    }
+
+    [Test]
+    public async Task RecordConsecutiveError_RetriableKafkaFailureDoesNotPoisonLoop()
+    {
+        var error = new KafkaException(ErrorCode.RequestTimedOut, "offset resolution timed out");
+
+        var consecutiveErrors = PrefetchLoopControl.RecordConsecutiveError(49, error);
+
+        await Assert.That(consecutiveErrors).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordConsecutiveError_UnexpectedFailureIncrementsCount()
+    {
+        var consecutiveErrors = PrefetchLoopControl.RecordConsecutiveError(
+            49,
+            new InvalidOperationException("unexpected"));
+
+        await Assert.That(consecutiveErrors).IsEqualTo(50);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Internal;
 using Dekaf.Networking;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -215,9 +216,10 @@ public sealed class KafkaConnectionPipelinedTests
         SetPrivateField(connection, "_receiveTimeoutDeadlineTimestamp", 1L);
         InvokeReceiveTimeout(connection);
 
-        await Assert.That(async () => await requestTask.WaitAsync(TimeSpan.FromSeconds(1)))
-            .Throws<KafkaException>()
-            .WithMessageContaining("Receive timeout");
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await requestTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await Assert.That(exception.Message).Contains("Receive timeout");
         await receiveTask.WaitAsync(TimeSpan.FromSeconds(1));
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Networking;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Security;
 
@@ -517,10 +518,10 @@ public sealed class KafkaConnectionTests
 
         // The caller's timeout fires while the frame is in flight: the wait is abandoned,
         // but the socket write itself must never be cancelled mid-frame.
-        await Assert.That(async () =>
-                await InvokeAwaitFrameWriteAsync(connection, writeTask, callerOwnsTimeout: true, cts.Token))
-            .Throws<KafkaException>()
-            .WithMessageContaining("Flush timeout");
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await InvokeAwaitFrameWriteAsync(connection, writeTask, callerOwnsTimeout: true, cts.Token));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await Assert.That(exception.Message).Contains("Flush timeout");
 
         await Assert.That(writeTask.IsCompleted).IsFalse();
         await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsEqualTo(0);

--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -1,0 +1,72 @@
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Retry;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Retry;
+
+public sealed class RetryHelperTests
+{
+    [Test]
+    public async Task MetadataRefreshUnavailable_RetriesOriginalOperation()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        var attempts = 0;
+
+        var result = await RetryHelper.WithRetryAsync(
+            () => Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<int>(CreateRequestTimeout())
+                : ValueTask.FromResult(42),
+            metadataManager,
+            CancellationToken.None,
+            maxRetries: 1);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task MetadataRefreshUnavailable_PreservesFinalKafkaFailure()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        var attempts = 0;
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await RetryHelper.WithRetryAsync<int>(
+                () =>
+                {
+                    Interlocked.Increment(ref attempts);
+                    return ValueTask.FromException<int>(CreateRequestTimeout());
+                },
+                metadataManager,
+                CancellationToken.None,
+                maxRetries: 1));
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    private static MetadataManager CreateUnavailableMetadataManager()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        connectionPool.GetConnectionAsync(
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(new TimeoutException("broker unavailable")));
+
+        return new MetadataManager(
+            connectionPool,
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                MetadataRecoveryStrategy = MetadataRecoveryStrategy.None
+            });
+    }
+
+    private static KafkaException CreateRequestTimeout() =>
+        new(ErrorCode.RequestTimedOut, "request timed out");
+}


### PR DESCRIPTION
## Summary
- turn unavailable leader connections and missing `ListOffsets` partitions into retriable Kafka errors instead of successful offset `0`
- retry through existing metadata-refresh policy and propagate after exhaustion
- omit partitions with unknown fetch positions rather than dispatching broker fetches from offset `0`
- omit empty request topics and return their pooled partition lists immediately

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] build-result/pool tests (18 passed)
- [x] timing-sensitive unrelated failures verified isolated (2 passed)
- [x] complete unit suite (5,035 passed)
- [ ] integration tests (Docker daemon unavailable; `docker info` timed out)

Closes #1723
