### PR TITLE
Capture consumer state in stress watchdog artifacts

### DIFF
--- a/src/Dekaf/Consumer/ConsumerDiagnosticSnapshot.cs
+++ b/src/Dekaf/Consumer/ConsumerDiagnosticSnapshot.cs
@@ -1,0 +1,33 @@
+namespace Dekaf.Consumer;
+
+internal sealed class ConsumerDiagnosticSnapshot
+{
+    public required DateTimeOffset CapturedAtUtc { get; init; }
+    public required ConsumerPartitionOffsetDiagnostic[] FetchPositions { get; init; }
+    public required ConsumerTopicPartitionDiagnostic[] Assignment { get; init; }
+    public required long PrefetchedBytes { get; init; }
+    public required int PendingFetchDepth { get; init; }
+    public required int PrefetchBufferDepth { get; init; }
+    public required int PrefetchDepth { get; init; }
+    public required ConsumerTopicPartitionDiagnostic[] PendingRevocations { get; init; }
+    public required bool PendingRevocationMarkerPresent { get; init; }
+    public required bool PendingRevocationClearPending { get; init; }
+    public required ConsumerDivergingEpochResetDiagnostic[] PendingDivergingEpochResets { get; init; }
+    public required int FetchBufferEpoch { get; init; }
+    public required int MinimumFetchBufferEpoch { get; init; }
+    public required ConsumerPartitionEpochDiagnostic[] MinimumFetchBufferEpochsByPartition { get; init; }
+    public required int? AdaptivePartitionFetchBytes { get; init; }
+    public required int? AdaptiveFetchMaxBytes { get; init; }
+}
+
+internal sealed record ConsumerTopicPartitionDiagnostic(string Topic, int Partition);
+
+internal sealed record ConsumerPartitionOffsetDiagnostic(string Topic, int Partition, long Offset);
+
+internal sealed record ConsumerPartitionEpochDiagnostic(string Topic, int Partition, int Epoch);
+
+internal sealed record ConsumerDivergingEpochResetDiagnostic(
+    string Topic,
+    int Partition,
+    long EndOffset,
+    int Epoch);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -701,6 +701,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
+    private int _pendingFetchDepth;
     // Auto-commit reads this snapshot from its background task instead of touching _pendingFetches.
     private string? _activeConsumedTopic;
     private int _activeConsumedPartition;
@@ -1121,7 +1122,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 entry.Value.EndOffset,
                 entry.Value.Epoch))
             .ToArray();
-        var pendingFetchDepth = _pendingFetches.Count;
+        var pendingFetchDepth = Volatile.Read(ref _pendingFetchDepth);
         var prefetchBufferDepth = _prefetchBuffer.Count;
 
         return new ConsumerDiagnosticSnapshot
@@ -1146,6 +1147,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             AdaptiveFetchMaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes
         };
     }
+
     public string? MemberId => _coordinator?.MemberId;
     public TopicPartitionSet Paused => _pausedSnapshot;
     public IConsumerPositions Positions => this;
@@ -1478,7 +1480,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Try to read from prefetch buffer, draining available items up to a bound
                     if (_prefetchBuffer.TryRead(out var prefetched))
                     {
-                        _pendingFetches.Enqueue(prefetched);
+                        EnqueuePendingFetch(prefetched);
                         TrackPrefetchedBytes(prefetched, release: true);
                         DrainPrefetchBuffer();
                     }
@@ -1495,7 +1497,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             {
                                 if (_prefetchBuffer.TryRead(out var fetched))
                                 {
-                                    _pendingFetches.Enqueue(fetched);
+                                    EnqueuePendingFetch(fetched);
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
                                 }
@@ -1706,7 +1708,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     }
 
                     // Dequeue and dispose the pending fetch (releases pooled network buffer memory)
-                    _pendingFetches.Dequeue().Dispose();
+                    DequeuePendingFetch().Dispose();
                 }
             }
             finally
@@ -1784,7 +1786,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Try to read from prefetch buffer, draining available items up to a bound
                     if (_prefetchBuffer.TryRead(out PendingFetchData? prefetched))
                     {
-                        _pendingFetches.Enqueue(prefetched);
+                        EnqueuePendingFetch(prefetched);
                         TrackPrefetchedBytes(prefetched, release: true);
                         DrainPrefetchBuffer();
                     }
@@ -1800,7 +1802,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             {
                                 if (_prefetchBuffer.TryRead(out PendingFetchData? fetched))
                                 {
-                                    _pendingFetches.Enqueue(fetched);
+                                    EnqueuePendingFetch(fetched);
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
                                 }
@@ -1923,7 +1925,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     // Try to read from prefetch buffer, draining available items up to a bound
                     if (_prefetchBuffer.TryRead(out PendingFetchData? prefetched))
                     {
-                        _pendingFetches.Enqueue(prefetched);
+                        EnqueuePendingFetch(prefetched);
                         TrackPrefetchedBytes(prefetched, release: true);
                         DrainPrefetchBuffer();
                     }
@@ -1939,7 +1941,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             {
                                 if (_prefetchBuffer.TryRead(out PendingFetchData? fetched))
                                 {
-                                    _pendingFetches.Enqueue(fetched);
+                                    EnqueuePendingFetch(fetched);
                                     TrackPrefetchedBytes(fetched, release: true);
                                     DrainPrefetchBuffer();
                                 }
@@ -2038,7 +2040,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         if (disposePending || pending.IsExhausted || !IsCurrentlyAssigned(pending.TopicPartition))
         {
-            _pendingFetches.Dequeue().Dispose();
+            DequeuePendingFetch().Dispose();
         }
     }
 
@@ -2988,7 +2990,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         for (var i = 0; i < maxDrain && _prefetchBuffer.TryRead(out var additional); i++)
         {
-            _pendingFetches.Enqueue(additional);
+            EnqueuePendingFetch(additional);
             TrackPrefetchedBytes(additional, release: true);
         }
     }
@@ -3170,7 +3172,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         if (_prefetchBuffer.TryRead(out var prefetched))
         {
-            _pendingFetches.Enqueue(prefetched);
+            EnqueuePendingFetch(prefetched);
             TrackPrefetchedBytes(prefetched, release: true);
             DrainPrefetchBuffer();
             return true;
@@ -3184,7 +3186,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 if (_prefetchBuffer.TryRead(out var fetched))
                 {
-                    _pendingFetches.Enqueue(fetched);
+                    EnqueuePendingFetch(fetched);
                     TrackPrefetchedBytes(fetched, release: true);
                     DrainPrefetchBuffer();
                 }
@@ -3319,7 +3321,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
             }
 
-            _pendingFetches.Dequeue().Dispose();
+            DequeuePendingFetch().Dispose();
         }
 
         return false;
@@ -3588,6 +3590,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         pending.Dispose();
     }
 
+    private void EnqueuePendingFetch(PendingFetchData pending)
+    {
+        _pendingFetches.Enqueue(pending);
+        Interlocked.Increment(ref _pendingFetchDepth);
+    }
+
+    private PendingFetchData DequeuePendingFetch()
+    {
+        var pending = _pendingFetches.Dequeue();
+        Interlocked.Decrement(ref _pendingFetchDepth);
+        return pending;
+    }
+
     private void ClearFetchBuffer()
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -3599,6 +3614,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Dispose and clear pending fetches to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
+            Interlocked.Decrement(ref _pendingFetchDepth);
             DisposeQueuedFetch(pending);
         }
         // Also drain prefetched items that haven't been moved to _pendingFetches yet.
@@ -3641,14 +3657,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         for (var i = 0; i < count; i++)
         {
-            var pending = _pendingFetches.Dequeue();
+            var pending = DequeuePendingFetch();
 
             // Check if this partition should be kept
             // Build TopicPartition inline for the Contains check
             if (!removeSet.Contains(pending.TopicPartition))
             {
                 // Keep this item by re-enqueueing it
-                _pendingFetches.Enqueue(pending);
+                EnqueuePendingFetch(pending);
             }
             else
             {
@@ -4730,7 +4746,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     continue;
                                 }
 
-                                _pendingFetches.Enqueue(pending);
+                                EnqueuePendingFetch(pending);
                             }
                         }
                         finally
@@ -6214,6 +6230,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Step 10: Clear pending fetch data and dispose to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
+            Interlocked.Decrement(ref _pendingFetchDepth);
             pending.Dispose();
         }
         while (_prefetchBuffer.TryRead(out var prefetched))
@@ -6502,6 +6519,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Clear and dispose any pending fetch data to release pooled memory
         while (_pendingFetches.TryDequeue(out var pending))
         {
+            Interlocked.Decrement(ref _pendingFetchDepth);
             pending.Dispose();
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1083,6 +1083,69 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public StringSet Subscription => _subscriptionSnapshot;
     public string? SubscriptionPattern => _topicPattern;
     public TopicPartitionSet Assignment => _assignmentSnapshot;
+
+    internal ConsumerDiagnosticSnapshot CaptureDiagnosticSnapshot()
+    {
+        var assignment = _assignmentSnapshot
+            .OrderBy(partition => partition.Topic, StringComparer.Ordinal)
+            .ThenBy(partition => partition.Partition)
+            .Select(partition => new ConsumerTopicPartitionDiagnostic(partition.Topic, partition.Partition))
+            .ToArray();
+        var fetchPositions = _fetchPositions
+            .OrderBy(entry => entry.Key.Topic, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Key.Partition)
+            .Select(entry => new ConsumerPartitionOffsetDiagnostic(
+                entry.Key.Topic,
+                entry.Key.Partition,
+                entry.Value))
+            .ToArray();
+        var pendingRevocations = _coordinatorRevokedPartitionsPendingFetchClear.Keys
+            .OrderBy(partition => partition.Topic, StringComparer.Ordinal)
+            .ThenBy(partition => partition.Partition)
+            .Select(partition => new ConsumerTopicPartitionDiagnostic(partition.Topic, partition.Partition))
+            .ToArray();
+        var minimumEpochs = _minimumFetchBufferEpochsByPartition
+            .OrderBy(entry => entry.Key.Topic, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Key.Partition)
+            .Select(entry => new ConsumerPartitionEpochDiagnostic(
+                entry.Key.Topic,
+                entry.Key.Partition,
+                entry.Value))
+            .ToArray();
+        var divergingEpochResets = _pendingDivergingEpochResets
+            .OrderBy(entry => entry.Key.Topic, StringComparer.Ordinal)
+            .ThenBy(entry => entry.Key.Partition)
+            .Select(entry => new ConsumerDivergingEpochResetDiagnostic(
+                entry.Key.Topic,
+                entry.Key.Partition,
+                entry.Value.EndOffset,
+                entry.Value.Epoch))
+            .ToArray();
+        var pendingFetchDepth = _pendingFetches.Count;
+        var prefetchBufferDepth = _prefetchBuffer.Count;
+
+        return new ConsumerDiagnosticSnapshot
+        {
+            CapturedAtUtc = DateTimeOffset.UtcNow,
+            FetchPositions = fetchPositions,
+            Assignment = assignment,
+            PrefetchedBytes = Interlocked.Read(ref _prefetchedBytes),
+            PendingFetchDepth = pendingFetchDepth,
+            PrefetchBufferDepth = prefetchBufferDepth,
+            PrefetchDepth = pendingFetchDepth + prefetchBufferDepth,
+            PendingRevocations = pendingRevocations,
+            PendingRevocationMarkerPresent =
+                Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0,
+            PendingRevocationClearPending =
+                Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0,
+            PendingDivergingEpochResets = divergingEpochResets,
+            FetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch),
+            MinimumFetchBufferEpoch = Volatile.Read(ref _minimumFetchBufferEpoch),
+            MinimumFetchBufferEpochsByPartition = minimumEpochs,
+            AdaptivePartitionFetchBytes = _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+            AdaptiveFetchMaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes
+        };
+    }
     public string? MemberId => _coordinator?.MemberId;
     public TopicPartitionSet Paused => _pausedSnapshot;
     public IConsumerPositions Positions => this;

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -56,6 +56,11 @@ internal sealed class MpscFetchBuffer
 
     internal int Capacity => _buffer.Length;
 
+    internal int Count => (int)Math.Clamp(
+        Volatile.Read(ref _headCommitted.Value) - Volatile.Read(ref _tail.Value),
+        0,
+        _buffer.Length);
+
     internal int ProducerWaiterCount => Volatile.Read(ref _producerWaiterCount);
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -205,7 +205,7 @@ public sealed class ConsumerAssignmentFastPathTests
         CoordinatorState stateDuringInitialization;
         try
         {
-            await offsetFetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            await offsetFetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
             LastPollTimestampField.SetValue(
                 coordinator,
                 Stopwatch.GetTimestamp() - Stopwatch.Frequency);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -35,11 +36,22 @@ public sealed class ConsumerDiagnosticSnapshotTests
         GetField<ConcurrentDictionary<TopicPartition, int>>(
             consumer,
             "_minimumFetchBufferEpochsByPartition")[partition] = 6;
+        GetField<ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)>>(
+            consumer,
+            "_pendingDivergingEpochResets")[partition] = (EndOffset: 123, Epoch: 8);
         SetField(consumer, "_prefetchedBytes", 1_024L);
         SetField(consumer, "_fetchBufferEpoch", 7);
         SetField(consumer, "_minimumFetchBufferEpoch", 5);
         SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent", 1);
         SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearPending", 1);
+        EnqueuePendingFetch(consumer, PendingFetchData.Create(
+            partition.Topic,
+            partition.Partition,
+            Array.Empty<RecordBatch>()));
+        GetField<MpscFetchBuffer>(consumer, "_prefetchBuffer").TryWrite(PendingFetchData.Create(
+            partition.Topic,
+            partition.Partition,
+            Array.Empty<RecordBatch>()));
 
         var snapshot = consumer.CaptureDiagnosticSnapshot();
 
@@ -47,12 +59,18 @@ public sealed class ConsumerDiagnosticSnapshotTests
         await Assert.That(snapshot.FetchPositions).Contains(item =>
             item.Topic == partition.Topic && item.Partition == partition.Partition && item.Offset == 42);
         await Assert.That(snapshot.PrefetchedBytes).IsEqualTo(1_024);
+        await Assert.That(snapshot.PendingFetchDepth).IsEqualTo(1);
+        await Assert.That(snapshot.PrefetchBufferDepth).IsEqualTo(1);
+        await Assert.That(snapshot.PrefetchDepth).IsEqualTo(2);
         await Assert.That(snapshot.PendingRevocations).HasSingleItem();
         await Assert.That(snapshot.PendingRevocationMarkerPresent).IsTrue();
         await Assert.That(snapshot.PendingRevocationClearPending).IsTrue();
         await Assert.That(snapshot.FetchBufferEpoch).IsEqualTo(7);
         await Assert.That(snapshot.MinimumFetchBufferEpoch).IsEqualTo(5);
         await Assert.That(snapshot.MinimumFetchBufferEpochsByPartition).HasSingleItem();
+        await Assert.That(snapshot.PendingDivergingEpochResets).Contains(item =>
+            item.Topic == partition.Topic && item.Partition == partition.Partition &&
+            item.EndOffset == 123 && item.Epoch == 8);
         await Assert.That(snapshot.AdaptivePartitionFetchBytes).IsEqualTo(2_000_000);
         await Assert.That(snapshot.AdaptiveFetchMaxBytes).IsEqualTo(20_000_000);
     }
@@ -68,4 +86,12 @@ public sealed class ConsumerDiagnosticSnapshotTests
             .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException($"Could not find {name}."))
         .SetValue(consumer, value);
+
+    private static void EnqueuePendingFetch(
+        KafkaConsumer<string, string> consumer,
+        PendingFetchData pending) =>
+        (typeof(KafkaConsumer<string, string>)
+            .GetMethod("EnqueuePendingFetch", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Could not find EnqueuePendingFetch."))
+        .Invoke(consumer, [pending]);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerDiagnosticSnapshotTests
+{
+    [Test]
+    public async Task CaptureDiagnosticSnapshot_IncludesConsumerStallState()
+    {
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                EnableAdaptiveFetchSizing = true,
+                AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+                {
+                    InitialPartitionFetchBytes = 2_000_000,
+                    InitialFetchMaxBytes = 20_000_000,
+                    MaxPartitionFetchBytes = 4_000_000,
+                    MaxFetchMaxBytes = 40_000_000
+                }
+            },
+            Serializers.String,
+            Serializers.String);
+        var partition = new TopicPartition("diagnostics-topic", 2);
+        consumer.IncrementalAssign(
+            [new TopicPartitionOffset(partition.Topic, partition.Partition, 42)]);
+
+        GetField<ConcurrentDictionary<TopicPartition, byte>>(
+            consumer,
+            "_coordinatorRevokedPartitionsPendingFetchClear")[partition] = 0;
+        GetField<ConcurrentDictionary<TopicPartition, int>>(
+            consumer,
+            "_minimumFetchBufferEpochsByPartition")[partition] = 6;
+        SetField(consumer, "_prefetchedBytes", 1_024L);
+        SetField(consumer, "_fetchBufferEpoch", 7);
+        SetField(consumer, "_minimumFetchBufferEpoch", 5);
+        SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent", 1);
+        SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearPending", 1);
+
+        var snapshot = consumer.CaptureDiagnosticSnapshot();
+
+        await Assert.That(snapshot.Assignment).HasSingleItem();
+        await Assert.That(snapshot.FetchPositions).Contains(item =>
+            item.Topic == partition.Topic && item.Partition == partition.Partition && item.Offset == 42);
+        await Assert.That(snapshot.PrefetchedBytes).IsEqualTo(1_024);
+        await Assert.That(snapshot.PendingRevocations).HasSingleItem();
+        await Assert.That(snapshot.PendingRevocationMarkerPresent).IsTrue();
+        await Assert.That(snapshot.PendingRevocationClearPending).IsTrue();
+        await Assert.That(snapshot.FetchBufferEpoch).IsEqualTo(7);
+        await Assert.That(snapshot.MinimumFetchBufferEpoch).IsEqualTo(5);
+        await Assert.That(snapshot.MinimumFetchBufferEpochsByPartition).HasSingleItem();
+        await Assert.That(snapshot.AdaptivePartitionFetchBytes).IsEqualTo(2_000_000);
+        await Assert.That(snapshot.AdaptiveFetchMaxBytes).IsEqualTo(20_000_000);
+    }
+
+    private static TField GetField<TField>(KafkaConsumer<string, string> consumer, string name) =>
+        (TField)(typeof(KafkaConsumer<string, string>)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(consumer)
+            ?? throw new InvalidOperationException($"Could not read {name}."));
+
+    private static void SetField<TField>(KafkaConsumer<string, string> consumer, string name, TField value) =>
+        (typeof(KafkaConsumer<string, string>)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Could not find {name}."))
+        .SetValue(consumer, value);
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -1,3 +1,4 @@
+using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.Metrics;
@@ -31,7 +32,8 @@ public sealed class ProgressWatchdogTests
                 {
                     DiagnosticsEnabled = true,
                     CapturedAtUtc = DateTimeOffset.UtcNow
-                });
+                },
+                CreateConsumerSnapshot);
 
             var exitCode = await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -39,11 +41,17 @@ public sealed class ProgressWatchdogTests
             var diagnosticsDirectory = GetDiagnosticsDirectory(outputDirectory);
             var stackArtifacts = Directory.GetFiles(diagnosticsDirectory, "*-stacks.txt");
             var producerArtifacts = Directory.GetFiles(diagnosticsDirectory, "*-producer.json");
+            var consumerArtifacts = Directory.GetFiles(diagnosticsDirectory, "*-consumer.json");
             await Assert.That(stackArtifacts.Length).IsEqualTo(2);
             await Assert.That(producerArtifacts.Length).IsEqualTo(2);
+            await Assert.That(consumerArtifacts.Length).IsEqualTo(2);
             await Assert.That(Directory.GetFiles(outputDirectory, "*.json")).IsEmpty();
             await Assert.That(await File.ReadAllTextAsync(stackArtifacts[0])).Contains("fake managed stack");
             await Assert.That(await File.ReadAllTextAsync(producerArtifacts[0])).Contains("\"diagnosticsEnabled\": true");
+            var consumerJson = await File.ReadAllTextAsync(consumerArtifacts[0]);
+            await Assert.That(consumerJson).Contains("\"fetchPositions\"");
+            await Assert.That(consumerJson).Contains("\"prefetchedBytes\": 1024");
+            await Assert.That(consumerJson).Contains("\"fetchBufferEpoch\": 7");
         }
         finally
         {
@@ -141,4 +149,24 @@ public sealed class ProgressWatchdogTests
 
     private static string GetDiagnosticsDirectory(string outputDirectory) =>
         Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName);
+
+    private static ConsumerDiagnosticSnapshot CreateConsumerSnapshot() => new()
+    {
+        CapturedAtUtc = DateTimeOffset.UtcNow,
+        FetchPositions = [new ConsumerPartitionOffsetDiagnostic("topic", 0, 42)],
+        Assignment = [new ConsumerTopicPartitionDiagnostic("topic", 0)],
+        PrefetchedBytes = 1_024,
+        PendingFetchDepth = 1,
+        PrefetchBufferDepth = 2,
+        PrefetchDepth = 3,
+        PendingRevocations = [new ConsumerTopicPartitionDiagnostic("topic", 1)],
+        PendingRevocationMarkerPresent = true,
+        PendingRevocationClearPending = true,
+        PendingDivergingEpochResets = [],
+        FetchBufferEpoch = 7,
+        MinimumFetchBufferEpoch = 6,
+        MinimumFetchBufferEpochsByPartition = [new ConsumerPartitionEpochDiagnostic("topic", 0, 6)],
+        AdaptivePartitionFetchBytes = 1_048_576,
+        AdaptiveFetchMaxBytes = 50_000_000
+    };
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
@@ -1,4 +1,5 @@
 #if NET10_0
+using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Diagnostics;
 using Dekaf.StressTests.Metrics;
@@ -45,6 +46,62 @@ public sealed class SoakStressTestTests
             var contents = await File.ReadAllTextAsync(producerArtifact);
             await Assert.That(contents).Contains("\"scenario\": \"soak\"");
             await Assert.That(contents).Contains("\"diagnosticsEnabled\": true");
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TrackConsumerMeasurementProgress_StallCapturesConsumerDiagnostics()
+    {
+        var outputDirectory = Path.Combine(Path.GetTempPath(), $"dekaf-soak-consumer-watchdog-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outputDirectory);
+
+        try
+        {
+            var exited = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var consumerThroughput = new ThroughputTracker();
+            consumerThroughput.Start();
+
+            using var watchdog = new ProgressWatchdog(
+                outputDirectory,
+                captureAfter: TimeSpan.FromMilliseconds(20),
+                exitAfter: TimeSpan.FromMilliseconds(60),
+                pollInterval: TimeSpan.FromMilliseconds(10),
+                exitProcess: code => exited.TrySetResult(code),
+                captureManagedStackReport: () => "fake managed stack");
+            using var registration = new SoakStressTest().TrackConsumerMeasurementProgress(
+                watchdog,
+                consumerThroughput,
+                () => new ConsumerDiagnosticSnapshot
+                {
+                    CapturedAtUtc = DateTimeOffset.UtcNow,
+                    Assignment = [],
+                    FetchPositions = [],
+                    PrefetchedBytes = 0,
+                    PendingFetchDepth = 0,
+                    PrefetchBufferDepth = 0,
+                    PrefetchDepth = 0,
+                    PendingRevocations = [],
+                    PendingRevocationMarkerPresent = false,
+                    PendingRevocationClearPending = false,
+                    PendingDivergingEpochResets = [],
+                    FetchBufferEpoch = 0,
+                    MinimumFetchBufferEpoch = 0,
+                    MinimumFetchBufferEpochsByPartition = [],
+                    AdaptivePartitionFetchBytes = null,
+                    AdaptiveFetchMaxBytes = null
+                });
+
+            await exited.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var consumerArtifact = Directory.GetFiles(
+                Path.Combine(outputDirectory, ProgressWatchdog.ArtifactsDirectoryName),
+                "*-fatal-consumer.json").Single();
+            var contents = await File.ReadAllTextAsync(consumerArtifact);
+            await Assert.That(contents).Contains("\"scenario\": \"soak-consumer\"");
         }
         finally
         {

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 
@@ -141,7 +142,8 @@ internal sealed class ProgressWatchdog : IDisposable
         ThroughputTracker throughput,
         string client,
         string scenario,
-        Func<ProducerDeliveryDiagnosticsSnapshot?>? captureProducerDiagnostics = null)
+        Func<ProducerDeliveryDiagnosticsSnapshot?>? captureProducerDiagnostics = null,
+        Func<ConsumerDiagnosticSnapshot?>? captureConsumerDiagnostics = null)
     {
         ArgumentNullException.ThrowIfNull(throughput);
         ArgumentException.ThrowIfNullOrWhiteSpace(client);
@@ -162,6 +164,7 @@ internal sealed class ProgressWatchdog : IDisposable
                 client,
                 scenario,
                 captureProducerDiagnostics,
+                captureConsumerDiagnostics,
                 detector);
             _wakeUp.Set();
             return new Registration(this, registrationId);
@@ -180,7 +183,7 @@ internal sealed class ProgressWatchdog : IDisposable
             _wakeUp.Set();
         }
 
-        if (_thread.Join(StackCaptureTimeout + _producerDiagnosticsTimeout + TimeSpan.FromSeconds(5)))
+        if (_thread.Join(StackCaptureTimeout + (_producerDiagnosticsTimeout * 2) + TimeSpan.FromSeconds(5)))
             _wakeUp.Dispose();
     }
 
@@ -262,6 +265,7 @@ internal sealed class ProgressWatchdog : IDisposable
             stalledFor,
             _captureManagedStackReport);
         CaptureProducerDiagnostics($"{prefix}-producer.json", activeRun, capturedAt, stalledFor);
+        CaptureConsumerDiagnostics($"{prefix}-consumer.json", activeRun, capturedAt, stalledFor);
 
         if (action == StallAction.CaptureAndExit)
         {
@@ -405,6 +409,75 @@ internal sealed class ProgressWatchdog : IDisposable
             Error = error
         }, JsonOptions));
 
+    private void CaptureConsumerDiagnostics(
+        string path,
+        ActiveRun activeRun,
+        DateTimeOffset capturedAt,
+        TimeSpan stalledFor)
+    {
+        if (activeRun.CaptureConsumerDiagnostics is null)
+            return;
+
+        ConsumerDiagnosticSnapshot? snapshot = null;
+        Exception? captureException = null;
+        var captureThread = new Thread(() =>
+        {
+            try
+            {
+                snapshot = activeRun.CaptureConsumerDiagnostics();
+            }
+            catch (Exception exception)
+            {
+                captureException = exception;
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "Dekaf consumer diagnostics capture"
+        };
+        captureThread.Start();
+
+        if (!captureThread.Join(_producerDiagnosticsTimeout))
+        {
+            var error = $"Consumer diagnostics capture timed out after {_producerDiagnosticsTimeout}.";
+            WriteConsumerDiagnosticsError(path, activeRun, capturedAt, error);
+            Console.Error.WriteLine($"PROGRESS WATCHDOG: {error}");
+            return;
+        }
+
+        if (captureException is not null)
+        {
+            WriteConsumerDiagnosticsError(path, activeRun, capturedAt, captureException.ToString());
+            Console.Error.WriteLine(
+                $"PROGRESS WATCHDOG: consumer diagnostics capture failed: {captureException.Message}");
+            return;
+        }
+
+        var artifact = new
+        {
+            CapturedAtUtc = capturedAt,
+            activeRun.Client,
+            activeRun.Scenario,
+            MessageCount = activeRun.Throughput.MessageCount,
+            StalledFor = stalledFor,
+            ConsumerDiagnostics = snapshot
+        };
+        WriteArtifact(path, JsonSerializer.Serialize(artifact, JsonOptions));
+    }
+
+    private static void WriteConsumerDiagnosticsError(
+        string path,
+        ActiveRun activeRun,
+        DateTimeOffset capturedAt,
+        string error) =>
+        WriteArtifact(path, JsonSerializer.Serialize(new
+        {
+            CapturedAtUtc = capturedAt,
+            activeRun.Client,
+            activeRun.Scenario,
+            Error = error
+        }, JsonOptions));
+
     private static void WriteArtifact(string path, string contents)
     {
         try
@@ -432,6 +505,7 @@ internal sealed class ProgressWatchdog : IDisposable
         string Client,
         string Scenario,
         Func<ProducerDeliveryDiagnosticsSnapshot?>? CaptureProducerDiagnostics,
+        Func<ConsumerDiagnosticSnapshot?>? CaptureConsumerDiagnostics,
         StallDetector Detector);
 
     private sealed class Registration(ProgressWatchdog owner, long registrationId) : IDisposable

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -171,6 +171,16 @@ internal sealed class ProgressWatchdog : IDisposable
         }
     }
 
+    internal ProgressWatchdog CreateSibling() =>
+        new(
+            Path.GetDirectoryName(_diagnosticsDirectory)!,
+            _captureAfter,
+            _exitAfter,
+            _pollInterval,
+            _exitProcess,
+            _captureManagedStackReport,
+            _diagnosticsCaptureTimeout);
+
     public void Dispose()
     {
         lock (_sync)

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -95,7 +95,7 @@ internal sealed class ProgressWatchdog : IDisposable
     private readonly TimeSpan _pollInterval;
     private readonly Action<int> _exitProcess;
     private readonly Func<string> _captureManagedStackReport;
-    private readonly TimeSpan _producerDiagnosticsTimeout;
+    private readonly TimeSpan _diagnosticsCaptureTimeout;
     private readonly Stopwatch _clock = Stopwatch.StartNew();
     private readonly AutoResetEvent _wakeUp = new(initialState: false);
     private readonly object _sync = new();
@@ -122,12 +122,12 @@ internal sealed class ProgressWatchdog : IDisposable
         _pollInterval = pollInterval ?? DefaultPollInterval;
         _exitProcess = exitProcess ?? Environment.Exit;
         _captureManagedStackReport = captureManagedStackReport ?? CaptureManagedStackReport;
-        _producerDiagnosticsTimeout = producerDiagnosticsTimeout ?? DefaultProducerDiagnosticsTimeout;
+        _diagnosticsCaptureTimeout = producerDiagnosticsTimeout ?? DefaultProducerDiagnosticsTimeout;
 
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_captureAfter, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_exitAfter, _captureAfter);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_pollInterval, TimeSpan.Zero);
-        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_producerDiagnosticsTimeout, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(_diagnosticsCaptureTimeout, TimeSpan.Zero);
 
         Directory.CreateDirectory(_diagnosticsDirectory);
         _thread = new Thread(Run)
@@ -183,7 +183,7 @@ internal sealed class ProgressWatchdog : IDisposable
             _wakeUp.Set();
         }
 
-        if (_thread.Join(StackCaptureTimeout + (_producerDiagnosticsTimeout * 2) + TimeSpan.FromSeconds(5)))
+        if (_thread.Join(StackCaptureTimeout + (_diagnosticsCaptureTimeout * 2) + TimeSpan.FromSeconds(5)))
             _wakeUp.Dispose();
     }
 
@@ -368,9 +368,9 @@ internal sealed class ProgressWatchdog : IDisposable
         };
         captureThread.Start();
 
-        if (!captureThread.Join(_producerDiagnosticsTimeout))
+        if (!captureThread.Join(_diagnosticsCaptureTimeout))
         {
-            var error = $"Producer diagnostics capture timed out after {_producerDiagnosticsTimeout}.";
+            var error = $"Producer diagnostics capture timed out after {_diagnosticsCaptureTimeout}.";
             WriteProducerDiagnosticsError(path, activeRun, capturedAt, error);
             Console.Error.WriteLine($"PROGRESS WATCHDOG: {error}");
             return;
@@ -437,9 +437,9 @@ internal sealed class ProgressWatchdog : IDisposable
         };
         captureThread.Start();
 
-        if (!captureThread.Join(_producerDiagnosticsTimeout))
+        if (!captureThread.Join(_diagnosticsCaptureTimeout))
         {
-            var error = $"Consumer diagnostics capture timed out after {_producerDiagnosticsTimeout}.";
+            var error = $"Consumer diagnostics capture timed out after {_diagnosticsCaptureTimeout}.";
             WriteConsumerDiagnosticsError(path, activeRun, capturedAt, error);
             Console.Error.WriteLine($"PROGRESS WATCHDOG: {error}");
             return;

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -57,7 +57,11 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -57,7 +57,11 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -59,7 +59,11 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -52,7 +52,11 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         StressTestHelpers.LogResourceUsage("Initial");
 
         throughput.Start();
-        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
         var progress = new PeriodicProgressReporter(throughput);
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -126,15 +126,31 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var endOffsets = queriedEndOffsets ?? startOffsets;
         var delivered = RoundTripScenarioHelpers.CountRecords(startOffsets, endOffsets);
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
-        var timedOut = queriedEndOffsets is null || await ConsumeAndValidateAsync(
-                consumer,
-                options,
-                startOffsets,
-                endOffsets,
-                validator,
-                throughput,
-                cancellationToken)
-            .ConfigureAwait(false);
+        var consumeProgress = new ThroughputTracker();
+        consumeProgress.Start();
+        using var consumeWatchdog = options.ProgressWatchdog.Track(
+            consumeProgress,
+            Client,
+            $"{Name}-consume",
+            captureConsumerDiagnostics: () => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
+        bool timedOut;
+        try
+        {
+            timedOut = queriedEndOffsets is null || await ConsumeAndValidateAsync(
+                    consumer,
+                    options,
+                    startOffsets,
+                    endOffsets,
+                    validator,
+                    throughput,
+                    cancellationToken,
+                    () => consumeProgress.RecordMessage(0))
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            consumeProgress.Stop();
+        }
 
         throughput.Stop();
 
@@ -164,7 +180,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         long[] endOffsets,
         RoundTripValidator validator,
         ThroughputTracker throughput,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action? recordProgress = null)
     {
         var completion = new RoundTripCompletionTracker(startOffsets, endOffsets);
         if (completion.IsComplete)
@@ -182,6 +199,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         {
             await foreach (var record in consumer.ConsumeAsync(timeout.Token).ConfigureAwait(false))
             {
+                recordProgress?.Invoke();
                 var partition = record.Partition;
                 if (completion.Record(partition, record.Offset))
                 {

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -111,7 +111,8 @@ internal sealed class SoakStressTest : IStressTestScenario
             using (var measurementWatchdog = TrackMeasurementProgress(
                        options.ProgressWatchdog,
                        throughput,
-                       () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options)))
+                       () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options),
+                       () => StressTestHelpers.CaptureConsumerDiagnostics(consumer)))
             {
                 await RunPacedProducerAsync(
                     producer,
@@ -230,8 +231,14 @@ internal sealed class SoakStressTest : IStressTestScenario
     internal IDisposable TrackMeasurementProgress(
         ProgressWatchdog watchdog,
         ThroughputTracker throughput,
-        Func<ProducerDeliveryDiagnosticsSnapshot?> captureProducerDiagnostics) =>
-        watchdog.Track(throughput, Client, Name, captureProducerDiagnostics);
+        Func<ProducerDeliveryDiagnosticsSnapshot?> captureProducerDiagnostics,
+        Func<ConsumerDiagnosticSnapshot?>? captureConsumerDiagnostics = null) =>
+        watchdog.Track(
+            throughput,
+            Client,
+            Name,
+            captureProducerDiagnostics,
+            captureConsumerDiagnostics);
 
     internal static bool IsBrokerDeliveryExact(long acceptedMessages, long deliveredMessages) =>
         acceptedMessages == deliveredMessages;

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -26,6 +26,7 @@ internal sealed class SoakStressTest : IStressTestScenario
     {
         var messageValue = new string('x', options.MessageSizeBytes);
         var throughput = new ThroughputTracker();
+        var consumerThroughput = new ThroughputTracker();
         var warmupSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var measurementActive = 0;
         var consumedMessages = 0L;
@@ -47,7 +48,11 @@ internal sealed class SoakStressTest : IStressTestScenario
             throughput,
             warmupSeen,
             () => Volatile.Read(ref measurementActive) != 0,
-            () => Interlocked.Increment(ref consumedMessages),
+            () =>
+            {
+                Interlocked.Increment(ref consumedMessages);
+                consumerThroughput.RecordMessage(options.MessageSizeBytes);
+            },
             consumerCts.Token);
 
         var producerBuilder = Kafka.CreateProducer<string, string>()
@@ -104,14 +109,20 @@ internal sealed class SoakStressTest : IStressTestScenario
                 $"trend warmup {options.ResourceTrendThresholds.WarmupMinutes:N0}m");
 
             throughput.Start();
+            consumerThroughput.Start();
             Volatile.Write(ref measurementActive, 1);
             var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, measurementCts.Token);
             var monitorTask = monitor.RunAsync(measurementCts.Token);
 
+            using var consumerProgressWatchdog = options.ProgressWatchdog.CreateSibling();
             using (var measurementWatchdog = TrackMeasurementProgress(
                        options.ProgressWatchdog,
                        throughput,
                        () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options),
+                       () => StressTestHelpers.CaptureConsumerDiagnostics(consumer)))
+            using (var consumerMeasurementWatchdog = TrackConsumerMeasurementProgress(
+                       consumerProgressWatchdog,
+                       consumerThroughput,
                        () => StressTestHelpers.CaptureConsumerDiagnostics(consumer)))
             {
                 await RunPacedProducerAsync(
@@ -239,6 +250,16 @@ internal sealed class SoakStressTest : IStressTestScenario
             Name,
             captureProducerDiagnostics,
             captureConsumerDiagnostics);
+
+    internal IDisposable TrackConsumerMeasurementProgress(
+        ProgressWatchdog watchdog,
+        ThroughputTracker throughput,
+        Func<ConsumerDiagnosticSnapshot?> captureConsumerDiagnostics) =>
+        watchdog.Track(
+            throughput,
+            Client,
+            $"{Name}-consumer",
+            captureConsumerDiagnostics: captureConsumerDiagnostics);
 
     internal static bool IsBrokerDeliveryExact(long acceptedMessages, long deliveredMessages) =>
         acceptedMessages == deliveredMessages;

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -351,6 +351,10 @@ internal static class StressTestHelpers
         return snapshot;
     }
 
+    internal static ConsumerDiagnosticSnapshot? CaptureConsumerDiagnostics<TKey, TValue>(
+        IKafkaConsumer<TKey, TValue> consumer) =>
+        (consumer as KafkaConsumer<TKey, TValue>)?.CaptureDiagnosticSnapshot();
+
     /// <summary>
     /// Produces one message via ProduceAsync and records the full delivery round-trip
     /// into <paramref name="latency"/> when it completes. The append (including


### PR DESCRIPTION
## Summary
- add an internal cold-path consumer diagnostic snapshot
- capture fetch positions, assignment, prefetched bytes/depth, revocation state, fetch epochs, diverging resets, and adaptive fetch sizes
- write bounded consumer JSON artifacts on watchdog stall/fatal captures
- register Dekaf consumer, soak, and round-trip consume scenarios
- add snapshot and artifact regression coverage

## Verification
- Dekaf net10.0 + netstandard2.0 build: 0 warnings
- stress net10.0 build: 0 warnings
- focused tests: 57 passed

Closes #1736
Part of #1726