### PR TITLE
Size response frames for adaptive fetch maxima

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -928,7 +928,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(options.FetchMaxBytes),
+            ResponseBufferPool.Create(CalculateMaximumFetchResponsePayloadBytes(options)),
             telemetryMetricCollector: telemetryMetricCollector);
 
         var metadataManager = new MetadataManager(
@@ -939,6 +939,35 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         return (connectionPool, metadataManager, telemetryMetricCollector);
     }
+
+    internal static int CalculateMaximumFetchResponsePayloadBytes(ConsumerOptions options)
+    {
+        var maximumFetchBytes = options.FetchMaxBytes;
+        var maximumPartitionFetchBytes = options.MaxPartitionFetchBytes;
+
+        if (options.EnableAdaptiveFetchSizing)
+        {
+            var adaptiveOptions = ResolveAdaptiveFetchSizingOptions(options);
+            maximumFetchBytes = Math.Max(maximumFetchBytes, adaptiveOptions.MaxFetchMaxBytes);
+            maximumPartitionFetchBytes = Math.Max(
+                maximumPartitionFetchBytes,
+                adaptiveOptions.MaxPartitionFetchBytes);
+        }
+
+        // KIP-74 makes FetchRequest.MaxBytes a soft cap: the first record batch from the
+        // first non-empty partition is returned even when it crosses the total limit.
+        // Reserve one maximum partition batch beyond the total response maximum.
+        return (int)Math.Min(
+            (long)maximumFetchBytes + maximumPartitionFetchBytes,
+            int.MaxValue);
+    }
+
+    private static AdaptiveFetchSizingOptions ResolveAdaptiveFetchSizingOptions(ConsumerOptions options) =>
+        options.AdaptiveFetchSizingOptions ?? new AdaptiveFetchSizingOptions
+        {
+            InitialPartitionFetchBytes = options.MaxPartitionFetchBytes,
+            InitialFetchMaxBytes = options.FetchMaxBytes
+        };
 
     private KafkaConsumer(
         ConsumerOptions options,
@@ -1019,12 +1048,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Initialize adaptive fetch sizer if configured
         if (options.EnableAdaptiveFetchSizing)
         {
-            var sizingOptions = options.AdaptiveFetchSizingOptions ?? new AdaptiveFetchSizingOptions
-            {
-                InitialPartitionFetchBytes = options.MaxPartitionFetchBytes,
-                InitialFetchMaxBytes = options.FetchMaxBytes
-            };
-            _adaptiveFetchSizer = new AdaptiveFetchSizer(sizingOptions);
+            _adaptiveFetchSizer = new AdaptiveFetchSizer(ResolveAdaptiveFetchSizingOptions(options));
         }
 
         if (!string.IsNullOrEmpty(options.GroupId))

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
@@ -1,0 +1,66 @@
+using Dekaf.Consumer;
+using Dekaf.Networking;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerResponseBufferSizingTests
+{
+    [Test]
+    public async Task MaximumPayload_StaticSizing_IncludesOneOversizedPartitionBatch()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            FetchMaxBytes = 50 * 1024 * 1024,
+            MaxPartitionFetchBytes = 4 * 1024 * 1024
+        };
+
+        var maximumPayload = KafkaConsumer<string, string>
+            .CalculateMaximumFetchResponsePayloadBytes(options);
+
+        await Assert.That(maximumPayload).IsEqualTo(54 * 1024 * 1024);
+    }
+
+    [Test]
+    public async Task MaximumPayload_AdaptiveSizing_UsesConfiguredMaxima()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            FetchMaxBytes = 100 * 1024 * 1024,
+            MaxPartitionFetchBytes = 8 * 1024 * 1024,
+            EnableAdaptiveFetchSizing = true,
+            AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+            {
+                InitialFetchMaxBytes = 100 * 1024 * 1024,
+                MaxFetchMaxBytes = 200 * 1024 * 1024,
+                InitialPartitionFetchBytes = 8 * 1024 * 1024,
+                MaxPartitionFetchBytes = 16 * 1024 * 1024
+            }
+        };
+
+        var maximumPayload = KafkaConsumer<string, string>
+            .CalculateMaximumFetchResponsePayloadBytes(options);
+        var responsePool = ResponseBufferPool.Create(maximumPayload);
+
+        await Assert.That(maximumPayload).IsEqualTo(216 * 1024 * 1024);
+        await Assert.That(responsePool.MaxArrayLength)
+            .IsEqualTo(216 * 1024 * 1024 + ResponseBufferPool.ProtocolOverheadBytes);
+    }
+
+    [Test]
+    public async Task MaximumPayload_NearIntegerLimit_Saturates()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            FetchMaxBytes = int.MaxValue - 10,
+            MaxPartitionFetchBytes = 1_024
+        };
+
+        var maximumPayload = KafkaConsumer<string, string>
+            .CalculateMaximumFetchResponsePayloadBytes(options);
+
+        await Assert.That(maximumPayload).IsEqualTo(int.MaxValue);
+    }
+}


### PR DESCRIPTION
## Summary
- derive consumer response-buffer validation from maximum static/adaptive fetch sizing
- reserve one maximum partition batch beyond total fetch bytes per KIP-74 soft-cap semantics
- use saturating arithmetic near int.MaxValue
- share adaptive option fallback between pool sizing and runtime sizer
- add focused static, adaptive, and overflow coverage

## Verification
- Dekaf net10.0 + netstandard2.0 build: 0 warnings
- ConsumerResponseBufferSizingTests: 3 passed
- ResponseBufferPoolTests: 18 passed

Closes #1724