### PR TITLE
Verify consumed record batch CRC-32C

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1334,7 +1334,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int? _heartbeatIntervalMs;
     private int _rebalanceTimeoutMs = 60000;
     private int _requestTimeoutMs = 30000;
-    private bool _checkCrcs;
+    private bool _checkCrcs = true;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private List<IConsumerInterceptor<TKey, TValue>>? _interceptors;
@@ -2383,7 +2383,11 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
-    internal ConsumerBuilder<TKey, TValue> WithCheckCrcs(bool checkCrcs)
+    /// <summary>
+    /// Enables or disables CRC-32C verification for consumed record batches.
+    /// Enabled by default; disable only when throughput is preferred over corruption detection.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithCheckCrcs(bool checkCrcs)
     {
         _checkCrcs = checkCrcs;
         return this;

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -200,9 +200,9 @@ public sealed class ConsumerOptions
     public int TcpKeepAliveRetryCount { get; init; } = ConnectionOptions.DefaultTcpKeepAliveRetryCount;
 
     /// <summary>
-    /// Check CRCs.
+    /// Whether to verify CRC-32C for consumed record batches. Enabled by default.
     /// </summary>
-    public bool CheckCrcs { get; init; }
+    public bool CheckCrcs { get; init; } = true;
 
     /// <summary>
     /// Use TLS.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2472,6 +2472,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             request.MaxWaitMs = _options.FetchMaxWaitMs;
             request.MinBytes = _options.FetchMinBytes;
             request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
+            request.CheckCrcs = _options.CheckCrcs;
             request.IsolationLevel = _options.IsolationLevel;
             request.RackId = _options.ClientRack;
             request.Topics = fetchSessionBuild?.Topics ?? topicData;
@@ -5183,6 +5184,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         request.MaxWaitMs = _options.FetchMaxWaitMs;
         request.MinBytes = _options.FetchMinBytes;
         request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
+        request.CheckCrcs = _options.CheckCrcs;
         request.IsolationLevel = _options.IsolationLevel;
         request.RackId = _options.ClientRack;
         request.Topics = fetchSessionBuild?.Topics ?? topicData;

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -599,7 +599,11 @@ public sealed partial class KafkaConnection :
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
-        pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
+        pending.Initialize(
+            responseHeaderVersion,
+            cancellationToken,
+            registerCancellation: false,
+            checkCrcs: request is FetchRequest { CheckCrcs: true });
         try
         {
             AddPendingRequest(correlationId, pending);
@@ -800,7 +804,11 @@ public sealed partial class KafkaConnection :
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
-        pending.Initialize(responseHeaderVersion, cancellationToken, registerCancellation: false);
+        pending.Initialize(
+            responseHeaderVersion,
+            cancellationToken,
+            registerCancellation: false,
+            checkCrcs: request is FetchRequest { CheckCrcs: true });
         try
         {
             AddPendingRequest(correlationId, pending);
@@ -932,7 +940,10 @@ public sealed partial class KafkaConnection :
 
             if (isFetchResponse)
             {
-                return ParseFetchResponse<TRequest, TResponse>(pooledBuffer, apiVersion);
+                return ParseFetchResponse<TRequest, TResponse>(
+                    pooledBuffer,
+                    apiVersion,
+                    pending.CheckCrcs);
             }
             else
             {
@@ -967,12 +978,13 @@ public sealed partial class KafkaConnection :
 
     internal static TResponse ParseFetchResponse<TRequest, TResponse>(
         PooledResponseBuffer pooledBuffer,
-        short apiVersion)
+        short apiVersion,
+        bool checkCrcs = false)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
         var memoryOwner = pooledBuffer.TransferOwnership();
-        using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner);
+        using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner, checkCrcs);
 
         try
         {
@@ -3689,15 +3701,21 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     private short _responseHeaderVersion;
     private CancellationTokenRegistration _cancellationRegistration;
     private CancellationToken _cancellationToken;
+    private bool _checkCrcs;
     private int _state; // High 16 bits = core version; low 16 bits = State*
 
     /// <summary>
     /// Initializes the request for a new operation.
     /// </summary>
-    public void Initialize(short responseHeaderVersion, CancellationToken cancellationToken, bool registerCancellation = true)
+    public void Initialize(
+        short responseHeaderVersion,
+        CancellationToken cancellationToken,
+        bool registerCancellation = true,
+        bool checkCrcs = false)
     {
         _responseHeaderVersion = responseHeaderVersion;
         _cancellationToken = cancellationToken;
+        _checkCrcs = checkCrcs;
         _state = CreateState(_core.Version, StatePending);
 
         // Register for cancellation if the token can be cancelled
@@ -3751,6 +3769,8 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     /// Gets the current version token.
     /// </summary>
     public short Version => _core.Version;
+
+    public bool CheckCrcs => _checkCrcs;
 
     /// <summary>
     /// Attempts to complete the request with response data.
@@ -3966,6 +3986,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         _cancellationRegistration.Dispose();
         _cancellationRegistration = default;
         _cancellationToken = default;
+        _checkCrcs = false;
 
         // Reset the core for reuse
         _core.Reset();

--- a/src/Dekaf/Protocol/Messages/FetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/FetchRequest.cs
@@ -46,6 +46,8 @@ public sealed class FetchRequest : IKafkaRequest<FetchResponse>
     /// </summary>
     public int MaxBytes { get; internal set; } = 0x7FFFFFFF;
 
+    internal bool CheckCrcs { get; set; } = true;
+
     /// <summary>
     /// Isolation level (v4+).
     /// </summary>
@@ -99,6 +101,7 @@ public sealed class FetchRequest : IKafkaRequest<FetchResponse>
             item.MaxWaitMs = 0;
             item.MinBytes = 0;
             item.MaxBytes = 0x7FFFFFFF;
+            item.CheckCrcs = true;
             item.IsolationLevel = IsolationLevel.ReadUncommitted;
             item.SessionId = 0;
             item.SessionEpoch = -1;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -306,6 +306,7 @@ public sealed class RecordBatch : IDisposable
     internal const int BatchBodyOffset = BatchLengthOffset + sizeof(int);
     internal const int CrcOffset = BatchBodyOffset + sizeof(int) + sizeof(byte);
     internal const int CrcContentOffset = CrcOffset + sizeof(uint);
+    internal const int CrcContentFixedSize = 40;
     internal const int BatchHeaderSize = sizeof(int) + sizeof(byte) + sizeof(uint) + sizeof(short) +
                                          sizeof(int) + sizeof(long) + sizeof(long) + sizeof(long) +
                                          sizeof(short) + sizeof(int) + sizeof(int);
@@ -791,8 +792,7 @@ public sealed class RecordBatch : IDisposable
             // CRC content size: 2 (attributes) + 4 (lastOffsetDelta) + 8 (baseTimestamp) +
             // 8 (maxTimestamp) + 8 (producerId) + 2 (producerEpoch) + 4 (baseSequence) +
             // 4 (recordsCount) + compressedRecords = 40 + records
-            const int crcContentFixedSize = 40;
-            var crcContentSize = crcContentFixedSize + compressedRecords.Length;
+            var crcContentSize = CrcContentFixedSize + compressedRecords.Length;
 
             // Get one contiguous span for CRC (4 bytes) + content, write content directly,
             // calculate CRC, and backpatch. This avoids a crcBuffer intermediate copy, but
@@ -823,7 +823,7 @@ public sealed class RecordBatch : IDisposable
             offset += 4;
             BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], records.Count);
             offset += 4;
-            var headerCrc = Crc32C.Compute(contentSpan[..crcContentFixedSize]);
+            var headerCrc = Crc32C.Compute(contentSpan[..CrcContentFixedSize]);
             compressedRecords.CopyTo(contentSpan[offset..]);
 
             var crc = Crc32C.Combine(headerCrc, compressedRecordsCrc, compressedRecords.Length);
@@ -986,7 +986,11 @@ public sealed class RecordBatch : IDisposable
     /// of the pooled memory, and subsequent batches will share it.
     /// Call Dispose() on the batch to release the pooled memory when done.
     /// </remarks>
-    public static RecordBatch Read(ref KafkaProtocolReader reader, CompressionCodecRegistry? codecs = null, int availableBytes = int.MaxValue)
+    public static RecordBatch Read(
+        ref KafkaProtocolReader reader,
+        CompressionCodecRegistry? codecs = null,
+        int availableBytes = int.MaxValue,
+        bool checkCrcs = false)
     {
         var baseOffset = reader.ReadInt64();
         var batchLength = reader.ReadInt32();
@@ -1023,6 +1027,21 @@ public sealed class RecordBatch : IDisposable
 
         // Capture the raw record data
         var rawRecordData = reader.ReadMemorySlice(recordsLength);
+
+        if (checkCrcs || ResponseParsingContext.CheckCrcs)
+        {
+            ValidateCrc(
+                crc,
+                attributes,
+                lastOffsetDelta,
+                baseTimestamp,
+                maxTimestamp,
+                producerId,
+                producerEpoch,
+                baseSequence,
+                recordCount,
+                rawRecordData.Span);
+        }
 
         // Determine how to handle the record data based on compression and pooled memory availability
         LazyRecordList lazyRecords;
@@ -1077,6 +1096,37 @@ public sealed class RecordBatch : IDisposable
         batch.BaseSequence = baseSequence;
         batch.Records = lazyRecords;
         return batch;
+    }
+
+    private static void ValidateCrc(
+        uint expectedCrc,
+        RecordBatchAttributes attributes,
+        int lastOffsetDelta,
+        long baseTimestamp,
+        long maxTimestamp,
+        long producerId,
+        short producerEpoch,
+        int baseSequence,
+        int recordCount,
+        ReadOnlySpan<byte> recordData)
+    {
+        Span<byte> header = stackalloc byte[CrcContentFixedSize];
+        BinaryPrimitives.WriteInt16BigEndian(header, (short)attributes);
+        BinaryPrimitives.WriteInt32BigEndian(header[2..], lastOffsetDelta);
+        BinaryPrimitives.WriteInt64BigEndian(header[6..], baseTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(header[14..], maxTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(header[22..], producerId);
+        BinaryPrimitives.WriteInt16BigEndian(header[30..], producerEpoch);
+        BinaryPrimitives.WriteInt32BigEndian(header[32..], baseSequence);
+        BinaryPrimitives.WriteInt32BigEndian(header[36..], recordCount);
+
+        var headerCrc = Crc32C.Compute(header);
+        var actualCrc = Crc32C.Combine(headerCrc, Crc32C.Compute(recordData), recordData.Length);
+        if (actualCrc != expectedCrc)
+        {
+            throw new InvalidDataException(
+                $"Record batch CRC mismatch: expected 0x{expectedCrc:X8}, computed 0x{actualCrc:X8}.");
+        }
     }
 }
 

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -989,8 +989,17 @@ public sealed class RecordBatch : IDisposable
     public static RecordBatch Read(
         ref KafkaProtocolReader reader,
         CompressionCodecRegistry? codecs = null,
-        int availableBytes = int.MaxValue,
-        bool checkCrcs = false)
+        int availableBytes = int.MaxValue) =>
+        Read(ref reader, codecs, availableBytes, checkCrcs: false);
+
+    /// <summary>
+    /// Reads a RecordBatch and optionally verifies its CRC-32C before decompression.
+    /// </summary>
+    public static RecordBatch Read(
+        ref KafkaProtocolReader reader,
+        CompressionCodecRegistry? codecs,
+        int availableBytes,
+        bool checkCrcs)
     {
         var baseOffset = reader.ReadInt64();
         var batchLength = reader.ReadInt32();

--- a/src/Dekaf/Protocol/ResponseParsingContext.cs
+++ b/src/Dekaf/Protocol/ResponseParsingContext.cs
@@ -25,6 +25,7 @@ internal static class ResponseParsingContext
     {
         public IPooledMemory? PooledMemory;
         public bool MemoryUsed;
+        public bool CheckCrcs;
     }
 
     /// <summary>
@@ -33,7 +34,7 @@ internal static class ResponseParsingContext
     /// Must be called before parsing a FetchResponse. Use with <c>using</c>:
     /// <code>using var scope = ResponseParsingContext.SetPooledMemory(memory);</code>
     /// </summary>
-    public static ParsingScope SetPooledMemory(IPooledMemory memory)
+    public static ParsingScope SetPooledMemory(IPooledMemory memory, bool checkCrcs = false)
     {
         var state = t_state ??= new ParsingContextState();
 
@@ -42,6 +43,7 @@ internal static class ResponseParsingContext
         // path that bypassed the scope disposal).
         state.PooledMemory = memory;
         state.MemoryUsed = false;
+        state.CheckCrcs = checkCrcs;
         return new ParsingScope();
     }
 
@@ -49,6 +51,8 @@ internal static class ResponseParsingContext
     /// Returns true if pooled memory is available for zero-copy parsing.
     /// </summary>
     public static bool HasPooledMemory => t_state?.PooledMemory is not null;
+
+    public static bool CheckCrcs => t_state?.CheckCrcs ?? false;
 
     /// <summary>
     /// Marks the pooled memory as being used by at least one batch.
@@ -97,6 +101,7 @@ internal static class ResponseParsingContext
         {
             state.PooledMemory = null;
             state.MemoryUsed = false;
+            state.CheckCrcs = false;
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
@@ -13,6 +13,44 @@ namespace Dekaf.Tests.Integration;
 public sealed class FetchBufferEdgeCaseTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    public async Task CheckCrcs_DefaultAndOptOut_ConsumeValidBatch()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "crc-key",
+            Value = "crc-value"
+        }, CancellationToken.None);
+
+        await using var checkedConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        checkedConsumer.Assign(new TopicPartition(topic, 0));
+
+        await using var uncheckedConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithCheckCrcs(false)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        uncheckedConsumer.Assign(new TopicPartition(topic, 0));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var checkedResult = await checkedConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cts.Token);
+        var uncheckedResult = await uncheckedConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cts.Token);
+
+        await Assert.That(checkedResult!.Value.Value).IsEqualTo("crc-value");
+        await Assert.That(uncheckedResult!.Value.Value).IsEqualTo("crc-value");
+    }
+
+    [Test]
     public async Task FetchMinBytes_SetHigh_ConsumerWaitsForEnoughData()
     {
         // Arrange - produce a small message that won't meet the min bytes threshold

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -167,10 +167,10 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
-    public async Task CheckCrcs_DefaultsTo_False()
+    public async Task CheckCrcs_DefaultsTo_True()
     {
         var options = CreateOptions();
-        await Assert.That(options.CheckCrcs).IsFalse();
+        await Assert.That(options.CheckCrcs).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -7,6 +7,24 @@ namespace Dekaf.Tests.Unit.Networking;
 public class PooledPendingRequestTests
 {
     [Test]
+    public async Task PoolReturn_ResetsCheckCrcs()
+    {
+        var pool = new PendingRequestPool(maxPoolSize: 1);
+        var request = pool.Rent();
+        request.Initialize(
+            responseHeaderVersion: 0,
+            CancellationToken.None,
+            checkCrcs: true);
+        await Assert.That(request.CheckCrcs).IsTrue();
+
+        pool.Return(request);
+        var reused = pool.Rent();
+
+        await Assert.That(reused.CheckCrcs).IsFalse();
+        pool.Return(reused);
+    }
+
+    [Test]
     public async Task TryComplete_WithValidBuffer_CompletesWithSlicedResult()
     {
         var pool = new PendingRequestPool();

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Diagnostics.Metrics;
 using Dekaf.Diagnostics;
+using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
@@ -10,6 +11,21 @@ namespace Dekaf.Tests.Unit.Protocol;
 [NotInParallel("MeterListener")]
 public sealed class FetchResponseParseErrorTests
 {
+    [Test]
+    public async Task Read_CrcMismatch_SurfacesPartitionParseError()
+    {
+        var buffer = CreateResponseWithCrcMismatch();
+
+        var response = ReadResponse(buffer, checkCrcs: true);
+        var partition = response.Responses[0].Partitions[0];
+
+        await Assert.That(partition.RecordParseError).IsNotNull();
+        await Assert.That(partition.RecordParseError!.InnerException).IsTypeOf<InvalidDataException>();
+        await Assert.That(partition.Records).IsNull();
+
+        response.ReturnToPool();
+    }
+
     [Test]
     public async Task Read_MalformedRecordBatch_ThrowsTypedErrorAndRecordsMetric()
     {
@@ -44,10 +60,57 @@ public sealed class FetchResponseParseErrorTests
         response.ReturnToPool();
     }
 
-    private static FetchResponse ReadResponse(ReadOnlyMemory<byte> buffer)
+    private static FetchResponse ReadResponse(ReadOnlyMemory<byte> buffer, bool checkCrcs = false)
     {
-        var reader = new KafkaProtocolReader(buffer);
+        using var memory = PooledResponseMemory.Create(
+            buffer.ToArray(),
+            buffer.Length,
+            isPooled: false,
+            offset: 0);
+        using var scope = ResponseParsingContext.SetPooledMemory(memory, checkCrcs);
+        var reader = new KafkaProtocolReader(memory.Memory);
         return (FetchResponse)FetchResponse.Read(ref reader, version: 16);
+    }
+
+    private static ReadOnlyMemory<byte> CreateResponseWithCrcMismatch()
+    {
+        var batchBuffer = new ArrayBufferWriter<byte>();
+        using (var batch = new RecordBatch
+        {
+            BaseOffset = 0,
+            PartitionLeaderEpoch = -1,
+            BaseTimestamp = 1_000,
+            MaxTimestamp = 1_000,
+            Records = [new Record { OffsetDelta = 0, TimestampDelta = 0, Value = "value"u8.ToArray() }]
+        })
+        {
+            batch.Write(batchBuffer);
+        }
+
+        var batchBytes = batchBuffer.WrittenSpan.ToArray();
+        batchBytes[^1] ^= 0x01;
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteUuid(Guid.NewGuid());
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt32(7);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt64(10);
+        writer.WriteInt64(10);
+        writer.WriteInt64(0);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteInt32(-1);
+        writer.WriteCompactNullableBytes(batchBytes, isNull: false);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(0);
+
+        return buffer.WrittenMemory;
     }
 
     private static ReadOnlyMemory<byte> CreateResponseWithMalformedBatch()

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -709,6 +709,52 @@ public class RecordBatchTests
         await Assert.That(readBatch.Records[1].Value.ToArray()).IsEquivalentTo("value-1"u8.ToArray());
     }
 
+    [Test]
+    public async Task Read_CheckCrcs_ValidBatchSucceeds()
+    {
+        using var batch = CreateTwoRecordBatch();
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+
+        using var parsed = ReadBatch(buffer.WrittenSpan.ToArray(), checkCrcs: true);
+
+        await Assert.That(parsed.Records.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Read_CheckCrcs_CorruptHeaderThrows()
+    {
+        using var batch = CreateTwoRecordBatch();
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes[RecordBatch.CrcContentOffset + 6] ^= 0x01;
+
+        await Assert.That(() => ReadBatch(bytes, checkCrcs: true))
+            .Throws<InvalidDataException>()
+            .WithMessageContaining("CRC mismatch");
+    }
+
+    [Test]
+    public async Task Read_CheckCrcsDisabled_CorruptHeaderSucceeds()
+    {
+        using var batch = CreateTwoRecordBatch();
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes[RecordBatch.CrcContentOffset + 6] ^= 0x01;
+
+        using var parsed = ReadBatch(bytes, checkCrcs: false);
+
+        await Assert.That(parsed.Records.Count).IsEqualTo(2);
+    }
+
+    private static RecordBatch ReadBatch(byte[] bytes, bool checkCrcs)
+    {
+        var reader = new KafkaProtocolReader(bytes);
+        return RecordBatch.Read(ref reader, checkCrcs: checkCrcs);
+    }
+
     private static RecordBatch CreateTwoRecordBatch() => new()
     {
         BaseOffset = 0,

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -749,10 +749,28 @@ public class RecordBatchTests
         await Assert.That(parsed.Records.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Read_ThreeParameterOverload_RemainsAvailable()
+    {
+        var method = typeof(RecordBatch).GetMethod(
+            nameof(RecordBatch.Read),
+            [
+                typeof(KafkaProtocolReader).MakeByRefType(),
+                typeof(CompressionCodecRegistry),
+                typeof(int)
+            ]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
     private static RecordBatch ReadBatch(byte[] bytes, bool checkCrcs)
     {
         var reader = new KafkaProtocolReader(bytes);
-        return RecordBatch.Read(ref reader, checkCrcs: checkCrcs);
+        return RecordBatch.Read(
+            ref reader,
+            codecs: null,
+            availableBytes: int.MaxValue,
+            checkCrcs);
     }
 
     private static RecordBatch CreateTwoRecordBatch() => new()


### PR DESCRIPTION
## Summary
- verify Kafka record-batch CRC-32C before decompression/deserialization
- enable checks by default and expose public WithCheckCrcs(false) opt-out
- carry the per-request flag through pooled pending requests so shared connections remain consumer-specific
- keep validation zero-allocation with stack header encoding and hardware-accelerated CRC32C
- cover valid, corrupt, opt-out, pooled reset, defaults, DI, and real-broker paths

## Verification
- Dekaf net10.0 + netstandard2.0 build: 0 warnings
- integration project build: 0 warnings
- focused unit tests: 159 passed
- CheckCrcs_DefaultAndOptOut_ConsumeValidBatch: passed against Testcontainers Kafka

## Dependency
- Typed partition-local surfacing of a CRC mismatch depends on #1730; this PR supplies the corruption signal consumed by that path.

Closes #1727