### PR TITLE
Recover inconsistent fetch-clear markers

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -752,6 +752,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _coordinatorRevokedPartitionsPendingFetchClearLock = new();
     private readonly ConcurrentDictionary<TopicPartition, byte> _coordinatorRevokedPartitionsPendingFetchClear = new();
     private readonly ConcurrentDictionary<TopicPartition, (long EndOffset, int Epoch)> _pendingDivergingEpochResets = new();
+    private int _stagedDivergingEpochResetBatches;
     private int _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent;
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
 
@@ -2703,10 +2704,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (partitionResponse.DivergingEpoch is not null)
                         {
                             _stuckFetchPositionTracker.Reset(tp);
-                            queuedDivergingEpochReset |= ResetToDivergingEpoch(
+                            if (ResetToDivergingEpoch(
                                 topic,
                                 partitionResponse,
-                                fetchBufferEpoch);
+                                fetchBufferEpoch,
+                                startsBatch: !queuedDivergingEpochReset))
+                            {
+                                queuedDivergingEpochReset = true;
+                            }
                             continue;
                         }
 
@@ -3920,20 +3925,28 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int fetchBufferEpoch)
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-            return TryQueueDivergingEpochResetLocked(partition, endOffset, epoch, fetchBufferEpoch);
+            return TryQueueDivergingEpochResetLocked(
+                partition,
+                endOffset,
+                epoch,
+                fetchBufferEpoch,
+                startsBatch: true);
     }
 
     private bool TryQueueDivergingEpochResetLocked(
         TopicPartition partition,
         long endOffset,
         int epoch,
-        int fetchBufferEpoch)
+        int fetchBufferEpoch,
+        bool startsBatch)
     {
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
             return false;
 
         _pendingDivergingEpochResets[partition] = (endOffset, epoch);
         _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+        if (startsBatch)
+            _stagedDivergingEpochResetBatches++;
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
         return true;
     }
@@ -3941,7 +3954,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void CompleteDivergingEpochResets()
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        {
+            if (_stagedDivergingEpochResetBatches > 0)
+                _stagedDivergingEpochResetBatches--;
+
+            if (_stagedDivergingEpochResetBatches == 0)
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        }
     }
 
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
@@ -4048,19 +4067,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
                 return false;
 
-            // A diverging-epoch reset is staged before response processing completes.
-            // Restore visibility immediately, but let CompleteDivergingEpochResets publish
-            // the drain only after the in-flight response has finished.
-            var hasStagedDivergingEpochReset = false;
-            foreach (var entry in _coordinatorRevokedPartitionsPendingFetchClear)
-            {
-                if (_pendingDivergingEpochResets.ContainsKey(entry.Key))
-                {
-                    hasStagedDivergingEpochReset = true;
-                    break;
-                }
-            }
-
             var recovered = false;
             if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
             {
@@ -4068,7 +4074,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 recovered = true;
             }
 
-            if (!hasStagedDivergingEpochReset
+            if (_stagedDivergingEpochResetBatches == 0
                 && Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
             {
                 Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
@@ -5603,10 +5609,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     if (partitionResponse.DivergingEpoch is not null)
                     {
                         _stuckFetchPositionTracker.Reset(tp);
-                        queuedDivergingEpochReset |= ResetToDivergingEpoch(
+                        if (ResetToDivergingEpoch(
                             topic,
                             partitionResponse,
-                            fetchBufferEpoch);
+                            fetchBufferEpoch,
+                            startsBatch: !queuedDivergingEpochReset))
+                        {
+                            queuedDivergingEpochReset = true;
+                        }
                         continue;
                     }
 
@@ -5857,7 +5867,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private bool ResetToDivergingEpoch(
         string topic,
         FetchResponsePartition partitionResponse,
-        int fetchBufferEpoch)
+        int fetchBufferEpoch,
+        bool startsBatch)
     {
         if (partitionResponse.DivergingEpoch is not { } divergingEpoch)
             return false;
@@ -5866,11 +5877,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
             return false;
 
-        return StageDivergingEpochReset(
-            partition,
-            divergingEpoch.EndOffset,
-            divergingEpoch.Epoch,
-            fetchBufferEpoch);
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            return TryQueueDivergingEpochResetLocked(
+                partition,
+                divergingEpoch.EndOffset,
+                divergingEpoch.Epoch,
+                fetchBufferEpoch,
+                startsBatch);
+        }
     }
 
     private async ValueTask ResetOffsetOutOfRangeAsync(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3976,8 +3976,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool RecoverAndClearFetchBufferForPendingCoordinatorRevocations()
     {
-        TryRecoverMissingPendingFetchClearMarkers();
-        return ClearFetchBufferForPendingCoordinatorRevocations();
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            TryRecoverMissingPendingFetchClearMarkers();
+            return ClearFetchBufferForPendingCoordinatorRevocations();
+        }
     }
 
     private void ApplyPendingDivergingEpochResets(IReadOnlyCollection<TopicPartition> partitions)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4061,7 +4061,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool ShouldDropStaleFetchPartition(TopicPartition partition, int fetchBufferEpoch) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
-        || HasPendingFetchClear(partition)
+        || _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
         || !IsCurrentlyAssigned(partition);
 
     private void InvalidateAllFetchesLocked()

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2341,7 +2341,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
         Dictionary<int, List<TopicPartition>> partitionsByBroker)
     {
-        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
+        if (!HasAnyPendingFetchClear())
             return partitionsByBroker;
 
         var filtered = new Dictionary<int, List<TopicPartition>>(partitionsByBroker.Count);
@@ -4013,7 +4013,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private bool HasPendingCoordinatorRevocations() =>
-        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0;
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0
+        || TryRecoverMissingPendingFetchClearMarkers();
 
     private bool IsCurrentlyAssigned(TopicPartition partition)
     {
@@ -4022,8 +4023,41 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool HasPendingFetchClear(TopicPartition partition) =>
-        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
+        HasAnyPendingFetchClear()
         && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition);
+
+    private bool HasAnyPendingFetchClear()
+    {
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+            return true;
+
+        TryRecoverMissingPendingFetchClearMarkers();
+        return Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0;
+    }
+
+    private bool TryRecoverMissingPendingFetchClearMarkers()
+    {
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+            return false;
+
+        if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            return false;
+
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+                return false;
+
+            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+                return false;
+
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+        }
+
+        LogRecoveredPendingFetchClearInvariant();
+        return true;
+    }
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
         !HasPendingFetchClear(partition)
@@ -4036,7 +4070,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool ShouldDropStaleFetchPartition(TopicPartition partition, int fetchBufferEpoch) =>
         IsFetchBufferEpochStale(partition, fetchBufferEpoch)
-        || _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition)
+        || HasPendingFetchClear(partition)
         || !IsCurrentlyAssigned(partition);
 
     private void InvalidateAllFetchesLocked()
@@ -6909,6 +6943,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         long resumeOffset,
         long endOffset,
         int leaderEpoch);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recovered pending fetch-clear state with missing coordination markers")]
+    private partial void LogRecoveredPendingFetchClearInvariant();
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Preferred read replica {ReplicaId} selected for {Topic}-{Partition}")]
     private partial void LogPreferredReadReplicaSelected(string topic, int partition, int replicaId);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2341,7 +2341,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
         Dictionary<int, List<TopicPartition>> partitionsByBroker)
     {
-        if (!HasAnyPendingFetchClear())
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
             return partitionsByBroker;
 
         var filtered = new Dictionary<int, List<TopicPartition>>(partitionsByBroker.Count);
@@ -3946,7 +3946,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
-        if (!HasPendingCoordinatorRevocations())
+        if (!HasPendingCoordinatorRevocations()
+            && !TryRecoverMissingPendingFetchClearMarkers())
             return false;
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -4013,8 +4014,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private bool HasPendingCoordinatorRevocations() =>
-        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0
-        || TryRecoverMissingPendingFetchClearMarkers();
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0;
 
     private bool IsCurrentlyAssigned(TopicPartition partition)
     {
@@ -4023,17 +4023,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool HasPendingFetchClear(TopicPartition partition) =>
-        HasAnyPendingFetchClear()
+        Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
         && _coordinatorRevokedPartitionsPendingFetchClear.ContainsKey(partition);
-
-    private bool HasAnyPendingFetchClear()
-    {
-        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
-            return true;
-
-        TryRecoverMissingPendingFetchClearMarkers();
-        return Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0;
-    }
 
     private bool TryRecoverMissingPendingFetchClearMarkers()
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1517,7 +1517,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-            ClearFetchBufferForPendingCoordinatorRevocations();
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -1827,7 +1827,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-            ClearFetchBufferForPendingCoordinatorRevocations();
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -1966,7 +1966,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-            ClearFetchBufferForPendingCoordinatorRevocations();
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -3294,7 +3294,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
-            ClearFetchBufferForPendingCoordinatorRevocations();
+            RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
 
             if (_assignmentSnapshot.Count == 0)
             {
@@ -3946,8 +3946,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool ClearFetchBufferForPendingCoordinatorRevocations()
     {
-        if (!HasPendingCoordinatorRevocations()
-            && !TryRecoverMissingPendingFetchClearMarkers())
+        if (!HasPendingCoordinatorRevocations())
             return false;
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -3973,6 +3972,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
             return true;
         }
+    }
+
+    private bool RecoverAndClearFetchBufferForPendingCoordinatorRevocations()
+    {
+        TryRecoverMissingPendingFetchClearMarkers();
+        return ClearFetchBufferForPendingCoordinatorRevocations();
     }
 
     private void ApplyPendingDivergingEpochResets(IReadOnlyCollection<TopicPartition> partitions)
@@ -4043,7 +4048,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return false;
 
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+
+            // A diverging-epoch reset is staged before response processing completes.
+            // Restore visibility immediately, but let CompleteDivergingEpochResets publish
+            // the drain only after the in-flight response has finished.
+            var hasStagedDivergingEpochReset = false;
+            foreach (var entry in _coordinatorRevokedPartitionsPendingFetchClear)
+            {
+                if (_pendingDivergingEpochResets.ContainsKey(entry.Key))
+                {
+                    hasStagedDivergingEpochReset = true;
+                    break;
+                }
+            }
+
+            if (!hasStagedDivergingEpochReset)
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
         }
 
         LogRecoveredPendingFetchClearInvariant();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4033,7 +4033,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool TryRecoverMissingPendingFetchClearMarkers()
     {
-        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0
+            && Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0)
             return false;
 
         if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
@@ -4041,13 +4042,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
-                return false;
-
             if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
                 return false;
-
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
 
             // A diverging-epoch reset is staged before response processing completes.
             // Restore visibility immediately, but let CompleteDivergingEpochResets publish
@@ -4062,8 +4058,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
-            if (!hasStagedDivergingEpochReset)
+            var recovered = false;
+            if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+                recovered = true;
+            }
+
+            if (!hasStagedDivergingEpochReset
+                && Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+            {
                 Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+                recovered = true;
+            }
+
+            if (!recovered)
+                return false;
         }
 
         LogRecoveredPendingFetchClearInvariant();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -523,6 +523,59 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task PendingFetchClear_MissingMarkers_RepairsAndDrains()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)[partition] = 0;
+
+        var filtered = ExcludePartitionsPendingFetchClear(
+            consumer,
+            new Dictionary<int, List<TopicPartition>> { [0] = [partition] });
+
+        await Assert.That(filtered).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
+
+        SetCoordinatorRevokedPartitionsPendingFetchClearMarkers(consumer, markerPresent: 0, pending: 0);
+
+        await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PendingFetchClear_StagedDivergence_WaitsForCompletion()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        StageDivergingEpochReset(
+            consumer,
+            partition,
+            endOffset: 42,
+            epoch: 7,
+            GetFetchBufferEpoch(consumer));
+
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).ContainsKey(partition);
+
+        CompleteDivergingEpochResets(consumer);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+    }
+
+    [Test]
     public async Task IncrementalUnassign_InvalidatesOnlyRemovedPartitionFetches()
     {
         await using var consumer = CreateConsumer();
@@ -1127,6 +1180,61 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearPending field not found.");
 
         return (int)field.GetValue(consumer)!;
+    }
+
+    private static int GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
+
+        return (int)field.GetValue(consumer)!;
+    }
+
+    private static void SetCoordinatorRevokedPartitionsPendingFetchClearMarkers(
+        KafkaConsumer<string, string> consumer,
+        int markerPresent,
+        int pending)
+    {
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var markerField = consumerType.GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
+        var pendingField = consumerType.GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearPending",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearPending field not found.");
+
+        markerField.SetValue(consumer, markerPresent);
+        pendingField.SetValue(consumer, pending);
+    }
+
+    private static Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
+        KafkaConsumer<string, string> consumer,
+        Dictionary<int, List<TopicPartition>> partitionsByBroker)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "ExcludePartitionsPendingFetchClear",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ExcludePartitionsPendingFetchClear method not found.");
+
+        return (Dictionary<int, List<TopicPartition>>)method.Invoke(consumer, [partitionsByBroker])!;
+    }
+
+    private static bool ShouldDropStaleFetchPartition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        int fetchBufferEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "ShouldDropStaleFetchPartition",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ShouldDropStaleFetchPartition method not found.");
+
+        return (bool)method.Invoke(consumer, [partition, fetchBufferEpoch])!;
     }
 
     private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -546,6 +546,23 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task PendingFetchClear_MissingPendingFlag_RepairsAndDrains()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)[partition] = 0;
+        SetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer, 1);
+
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task PendingFetchClear_StagedDivergence_WaitsForCompletion()
     {
         await using var consumer = CreateConsumer();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -559,10 +559,14 @@ public sealed class ConsumerAssignmentFastPathTests
             epoch: 7,
             GetFetchBufferEpoch(consumer));
 
-        // A staged reset has a marker but is not drainable until the fetch response is complete.
+        // Recovery must restore a missing marker without making a staged reset drainable
+        // before the fetch response is complete.
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        SetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer, 0);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).ContainsKey(partition);
 
         CompleteDivergingEpochResets(consumer);
@@ -1189,6 +1193,18 @@ public sealed class ConsumerAssignmentFastPathTests
         return (int)field.GetValue(consumer)!;
     }
 
+    private static void SetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(
+        KafkaConsumer<string, string> consumer,
+        int value)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
+
+        field.SetValue(consumer, value);
+    }
+
     private static Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
         KafkaConsumer<string, string> consumer,
         Dictionary<int, List<TopicPartition>> partitionsByBroker)
@@ -1289,9 +1305,9 @@ public sealed class ConsumerAssignmentFastPathTests
     private static bool ClearFetchBufferForPendingCoordinatorRevocations(KafkaConsumer<string, string> consumer)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
-            "ClearFetchBufferForPendingCoordinatorRevocations",
+            "RecoverAndClearFetchBufferForPendingCoordinatorRevocations",
             BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("ClearFetchBufferForPendingCoordinatorRevocations method not found.");
+            ?? throw new InvalidOperationException("RecoverAndClearFetchBufferForPendingCoordinatorRevocations method not found.");
 
         return (bool)method.Invoke(consumer, [])!;
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -593,6 +593,49 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task PendingFetchClear_CompletedDivergence_RepairsLostPendingFlag()
+    {
+        await using var consumer = CreateConsumer();
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+
+        StageDivergingEpochReset(
+            consumer,
+            partition,
+            endOffset: 42,
+            epoch: 7,
+            GetFetchBufferEpoch(consumer));
+        CompleteDivergingEpochResets(consumer);
+        SetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer, 0);
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+    }
+
+    [Test]
+    public async Task PendingFetchClear_MultipleStagedBatches_WaitsForAllCompletions()
+    {
+        await using var consumer = CreateConsumer();
+        var first = new TopicPartition("test-topic", 0);
+        var second = new TopicPartition("test-topic", 1);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(first.Topic, first.Partition, 0),
+            new TopicPartitionOffset(second.Topic, second.Partition, 0)
+        ]);
+
+        StageDivergingEpochReset(consumer, first, 42, 7, GetFetchBufferEpoch(consumer));
+        StageDivergingEpochReset(consumer, second, 84, 8, GetFetchBufferEpoch(consumer));
+
+        CompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
+
+        CompleteDivergingEpochResets(consumer);
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
+    }
+
+    [Test]
     public async Task IncrementalUnassign_InvalidatesOnlyRemovedPartitionFetches()
     {
         await using var consumer = CreateConsumer();
@@ -1218,6 +1261,18 @@ public sealed class ConsumerAssignmentFastPathTests
             "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
+
+        field.SetValue(consumer, value);
+    }
+
+    private static void SetCoordinatorRevokedPartitionsPendingFetchClearPending(
+        KafkaConsumer<string, string> consumer,
+        int value)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinatorRevokedPartitionsPendingFetchClearPending",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearPending field not found.");
 
         field.SetValue(consumer, value);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -535,15 +535,10 @@ public sealed class ConsumerAssignmentFastPathTests
             consumer,
             new Dictionary<int, List<TopicPartition>> { [0] = [partition] });
 
-        await Assert.That(filtered).IsEmpty();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
-
-        SetCoordinatorRevokedPartitionsPendingFetchClearMarkers(consumer, markerPresent: 0, pending: 0);
-
-        await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsTrue();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
+        await Assert.That(filtered[0]).Contains(partition);
+        await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsFalse();
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
@@ -564,6 +559,7 @@ public sealed class ConsumerAssignmentFastPathTests
             epoch: 7,
             GetFetchBufferEpoch(consumer));
 
+        // A staged reset has a marker but is not drainable until the fetch response is complete.
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
@@ -1191,25 +1187,6 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
 
         return (int)field.GetValue(consumer)!;
-    }
-
-    private static void SetCoordinatorRevokedPartitionsPendingFetchClearMarkers(
-        KafkaConsumer<string, string> consumer,
-        int markerPresent,
-        int pending)
-    {
-        var consumerType = typeof(KafkaConsumer<string, string>);
-        var markerField = consumerType.GetField(
-            "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent field not found.");
-        var pendingField = consumerType.GetField(
-            "_coordinatorRevokedPartitionsPendingFetchClearPending",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("_coordinatorRevokedPartitionsPendingFetchClearPending field not found.");
-
-        markerField.SetValue(consumer, markerPresent);
-        pendingField.SetValue(consumer, pending);
     }
 
     private static Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -536,7 +536,7 @@ public sealed class ConsumerAssignmentFastPathTests
             new Dictionary<int, List<TopicPartition>> { [0] = [partition] });
 
         await Assert.That(filtered[0]).Contains(partition);
-        await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsFalse();
+        await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsTrue();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -205,7 +205,8 @@ public sealed class ConsumerLeaderDiscoveryTests
         InvokeResetToDivergingEpoch(
             consumer,
             CreateDivergingEpochResponse(partition: 1, epoch: 8, endOffset: 18),
-            fetchBufferEpoch);
+            fetchBufferEpoch,
+            startsBatch: false);
 
         await Assert.That(GetFetchBufferEpoch(consumer)).IsEqualTo(fetchBufferEpoch);
         InvokeCompleteDivergingEpochResets(consumer);
@@ -894,14 +895,15 @@ public sealed class ConsumerLeaderDiscoveryTests
     private static bool InvokeResetToDivergingEpoch(
         KafkaConsumer<string, string> consumer,
         FetchResponsePartition partitionResponse,
-        int? fetchBufferEpoch = null)
+        int? fetchBufferEpoch = null,
+        bool startsBatch = true)
     {
         var method = typeof(KafkaConsumer<string, string>)
             .GetMethod("ResetToDivergingEpoch", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("ResetToDivergingEpoch method not found");
 
         var epoch = fetchBufferEpoch ?? GetFetchBufferEpoch(consumer);
-        var staged = (bool)method.Invoke(consumer, [Topic, partitionResponse, epoch])!;
+        var staged = (bool)method.Invoke(consumer, [Topic, partitionResponse, epoch, startsBatch])!;
 
         if (fetchBufferEpoch is null && staged)
             InvokeCompleteDivergingEpochResets(consumer);


### PR DESCRIPTION
## Summary
- centralize pending fetch-clear marker reads
- recover impossible dictionary-without-marker state under the existing coordination lock
- arm the foreground drain and emit a warning instead of silently excluding/dropping forever
- preserve the valid staged diverging-epoch window where marker is set before pending

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release --no-restore`
- `ConsumerAssignmentFastPathTests`: 23/23 passed on net10.0

No Testcontainers case is added because the inconsistent state is explicitly not reachable through current public behavior; the regression injects the synthetic internal state described by the issue.

Closes #1725