### PR TITLE
Complete fetch-clear marker recovery

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2132,6 +2132,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 try
                 {
                     await EnsureAssignmentAsync(cancellationToken).ConfigureAwait(false);
+                    TryRecoverMissingPendingFetchClearMarkers();
                     if (HasPendingCoordinatorRevocations())
                     {
                         // Only the user consume loop owns _pendingFetches. Let it discard
@@ -2342,6 +2343,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private Dictionary<int, List<TopicPartition>> ExcludePartitionsPendingFetchClear(
         Dictionary<int, List<TopicPartition>> partitionsByBroker)
     {
+        TryRecoverMissingPendingFetchClearMarkers();
         if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
             return partitionsByBroker;
 
@@ -3922,7 +3924,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TopicPartition partition,
         long endOffset,
         int epoch,
-        int fetchBufferEpoch)
+        int fetchBufferEpoch,
+        bool startsBatch)
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
             return TryQueueDivergingEpochResetLocked(
@@ -3930,7 +3933,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 endOffset,
                 epoch,
                 fetchBufferEpoch,
-                startsBatch: true);
+                startsBatch);
     }
 
     private bool TryQueueDivergingEpochResetLocked(
@@ -3969,37 +3972,54 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+            return ClearFetchBufferForPendingCoordinatorRevocationsLocked();
+    }
+
+    private bool ClearFetchBufferForPendingCoordinatorRevocationsLocked()
+    {
+        if (!HasPendingCoordinatorRevocations())
+            return false;
+
+        if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
         {
-            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
-            {
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
-                return false;
-            }
-
-            var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
-
-            // Keep partitions marked while clearing. Background prefetches use this
-            // marker to avoid advancing positions for data that will be discarded.
-            ApplyPendingDivergingEpochResets(partitionsToRemove);
-            ClearFetchBufferForPartitions(partitionsToRemove);
-
-            foreach (var partition in partitionsToRemove)
-                _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
-
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
-            return true;
+            return false;
         }
+
+        var partitionsToRemove = _coordinatorRevokedPartitionsPendingFetchClear.Keys.ToHashSet();
+
+        // Keep partitions marked while clearing. Background prefetches use this
+        // marker to avoid advancing positions for data that will be discarded.
+        ApplyPendingDivergingEpochResets(partitionsToRemove);
+        ClearFetchBufferForPartitions(partitionsToRemove);
+
+        foreach (var partition in partitionsToRemove)
+            _coordinatorRevokedPartitionsPendingFetchClear.TryRemove(partition, out _);
+
+        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
+        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+        return true;
     }
 
     private bool RecoverAndClearFetchBufferForPendingCoordinatorRevocations()
     {
+        if (!HasPendingCoordinatorRevocations()
+            && _coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            return false;
+
+        bool recovered;
+        bool cleared;
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            TryRecoverMissingPendingFetchClearMarkers();
-            return ClearFetchBufferForPendingCoordinatorRevocations();
+            recovered = TryRecoverMissingPendingFetchClearMarkersLocked();
+            cleared = ClearFetchBufferForPendingCoordinatorRevocationsLocked();
         }
+
+        if (recovered)
+            LogRecoveredPendingFetchClearInvariant();
+
+        return cleared;
     }
 
     private void ApplyPendingDivergingEpochResets(IReadOnlyCollection<TopicPartition> partitions)
@@ -4062,31 +4082,37 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
             return false;
 
+        bool recovered;
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
-                return false;
+            recovered = TryRecoverMissingPendingFetchClearMarkersLocked();
 
-            var recovered = false;
-            if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
-            {
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
-                recovered = true;
-            }
-
-            if (_stagedDivergingEpochResetBatches == 0
-                && Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
-            {
-                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
-                recovered = true;
-            }
-
-            if (!recovered)
-                return false;
-        }
+        if (!recovered)
+            return false;
 
         LogRecoveredPendingFetchClearInvariant();
         return true;
+    }
+
+    private bool TryRecoverMissingPendingFetchClearMarkersLocked()
+    {
+        if (_coordinatorRevokedPartitionsPendingFetchClear.IsEmpty)
+            return false;
+
+        var recovered = false;
+        if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
+        {
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+            recovered = true;
+        }
+
+        if (_stagedDivergingEpochResetBatches == 0
+            && Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) == 0)
+        {
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+            recovered = true;
+        }
+
+        return recovered;
     }
 
     private bool CanContinueBatchIteration(TopicPartition partition) =>
@@ -5877,15 +5903,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (ShouldDropStaleFetchPartition(partition, fetchBufferEpoch))
             return false;
 
-        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
-        {
-            return TryQueueDivergingEpochResetLocked(
-                partition,
-                divergingEpoch.EndOffset,
-                divergingEpoch.Epoch,
-                fetchBufferEpoch,
-                startsBatch);
-        }
+        return StageDivergingEpochReset(
+            partition,
+            divergingEpoch.EndOffset,
+            divergingEpoch.Epoch,
+            fetchBufferEpoch,
+            startsBatch);
     }
 
     private async ValueTask ResetOffsetOutOfRangeAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -535,10 +535,10 @@ public sealed class ConsumerAssignmentFastPathTests
             consumer,
             new Dictionary<int, List<TopicPartition>> { [0] = [partition] });
 
-        await Assert.That(filtered[0]).Contains(partition);
+        await Assert.That(filtered).IsEmpty();
         await Assert.That(ShouldDropStaleFetchPartition(consumer, partition, GetFetchBufferEpoch(consumer))).IsTrue();
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
-        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
+        await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(1);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).IsEmpty();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(0);
@@ -1361,7 +1361,7 @@ public sealed class ConsumerAssignmentFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("StageDivergingEpochReset method not found.");
 
-        method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch]);
+        method.Invoke(consumer, [partition, endOffset, epoch, fetchBufferEpoch, true]);
     }
 
     private static void CompleteDivergingEpochResets(KafkaConsumer<string, string> consumer)


### PR DESCRIPTION
## Summary
- self-heal missing fetch-clear flags from both foreground and background prefetch paths
- preserve the lock-free no-work poll path while keeping recovery and drain atomic
- centralize locked recovery/drain helpers and reuse diverging-reset staging code
- update the missing-marker regression for background partition exclusion

## Validation
- full unit project builds cleanly (0 warnings/errors)
- ConsumerAssignmentFastPathTests + ConsumerLeaderDiscoveryTests: 51/51 passed

Follow-up to the blocking review that landed after #1744 was merged.

Closes #1746