### PR TITLE
bench: measure consumer steady state, not harness artifacts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -240,101 +240,57 @@ jobs:
           # Add the BenchmarkDotNet markdown reports directly
           # They have proper tables with Ratio columns
 
-          # Producer benchmarks
-          producer_md = glob.glob("benchmark-results/Client/results/*ProducerBenchmarks*-github.md")
-          if producer_md:
-              output.append("## Producer Benchmarks (Dekaf vs Confluent.Kafka)\n")
-              output.append("> **Ratio < 1.0 means Dekaf is faster than Confluent**\n")
-              with open(producer_md[0]) as f:
-                  content = f.read()
-                  # Remove the ``` code block wrapper
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
-
-          # Consumer benchmarks
-          consumer_md = glob.glob("benchmark-results/Client/results/*ConsumerBenchmarks*-github.md")
-          if consumer_md:
-              output.append("## Consumer Benchmarks (Dekaf vs Confluent.Kafka)\n")
-              with open(consumer_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
-
-          # Native memory benchmarks (Windows, ETW-based NativeMemoryProfiler)
-          native_md = glob.glob("benchmark-results/ClientNative/results/*ConsumerBenchmarks*-github.md")
-          native_md += glob.glob("benchmark-results/ClientNative/results/*ProducerBenchmarks*-github.md")
-          if native_md:
-              output.append("## Native Memory Comparison (Windows, ETW)\n")
-              output.append("> **'Allocated native memory' captures librdkafka's unmanaged allocations, invisible to the managed Allocated column.** Compare Dekaf's Allocated against Confluent's Allocated + Allocated native memory for a fair total.\n")
-              for md in native_md:
+          def append_tables(paths):
+              # Extract the markdown tables (all '|' lines onward) from each report file.
+              for md in paths:
                   with open(md) as f:
-                      content = f.read()
-                      lines = content.split('\n')
                       in_table = False
-                      for line in lines:
+                      for line in f.read().split('\n'):
                           if line.startswith('|'):
                               in_table = True
                           if in_table:
                               output.append(line)
                   output.append("")
 
+          # Producer benchmarks
+          producer_md = sorted(glob.glob("benchmark-results/Client/results/*ProducerBenchmarks*-github.md"))
+          if producer_md:
+              output.append("## Producer Benchmarks (Dekaf vs Confluent.Kafka)\n")
+              output.append("> **Ratio < 1.0 means Dekaf is faster than Confluent**\n")
+              append_tables(producer_md)
+
+          # Consumer benchmarks (ConsumerBenchmarks + ConsumerPollBenchmarks)
+          consumer_md = sorted(glob.glob("benchmark-results/Client/results/*Consumer*Benchmarks*-github.md"))
+          if consumer_md:
+              output.append("## Consumer Benchmarks (Dekaf vs Confluent.Kafka)\n")
+              append_tables(consumer_md)
+
+          # Native memory benchmarks (Windows, ETW-based NativeMemoryProfiler)
+          native_md = sorted(glob.glob("benchmark-results/ClientNative/results/*Consumer*Benchmarks*-github.md"))
+          native_md += sorted(glob.glob("benchmark-results/ClientNative/results/*ProducerBenchmarks*-github.md"))
+          if native_md:
+              output.append("## Native Memory Comparison (Windows, ETW)\n")
+              output.append("> **'Allocated native memory' captures librdkafka's unmanaged allocations, invisible to the managed Allocated column.** Compare Dekaf's Allocated against Confluent's Allocated + Allocated native memory for a fair total.\n")
+              append_tables(native_md)
+
           # Protocol benchmarks (zero-allocation)
-          protocol_md = glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md")
+          protocol_md = sorted(glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md"))
           if protocol_md:
               output.append("## Protocol Benchmarks (Zero-Allocation Wire Protocol)\n")
               output.append("> **Allocated = `-` means zero heap allocations** ✓\n")
-              with open(protocol_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(protocol_md)
 
           # Serializer benchmarks
-          serializer_md = glob.glob("benchmark-results/Unit/results/*SerializerBenchmarks*-github.md")
+          serializer_md = sorted(glob.glob("benchmark-results/Unit/results/*SerializerBenchmarks*-github.md"))
           if serializer_md:
               output.append("## Serializer Benchmarks\n")
-              with open(serializer_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(serializer_md)
 
           # Compression benchmarks
-          compression_md = glob.glob("benchmark-results/Unit/results/*CompressionBenchmarks*-github.md")
+          compression_md = sorted(glob.glob("benchmark-results/Unit/results/*CompressionBenchmarks*-github.md"))
           if compression_md:
               output.append("## Compression Benchmarks (Snappy)\n")
-              with open(compression_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(compression_md)
 
           output.append("---\n")
           output.append("*Benchmarks run on GitHub Actions (ubuntu-latest) with BenchmarkDotNet*")
@@ -451,48 +407,42 @@ jobs:
           output.append("")
           output.append(":::info")
           output.append("These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. ")
-          output.append("**Ratio < 1.0 means Dekaf is faster than Confluent.Kafka**")
+          output.append("Ratio semantics differ per table — see 'How to Read These Results' below.")
           output.append(":::")
           output.append("")
 
+          def append_tables(paths):
+              # Extract the markdown tables (all '|' lines onward) from each report file.
+              for md in paths:
+                  with open(md) as f:
+                      in_table = False
+                      for line in f.read().split('\n'):
+                          if line.startswith('|'):
+                              in_table = True
+                          if in_table:
+                              output.append(line)
+                  output.append("")
+
           # Producer benchmarks
-          producer_md = glob.glob("benchmark-results/Client/results/*ProducerBenchmarks*-github.md")
+          producer_md = sorted(glob.glob("benchmark-results/Client/results/*ProducerBenchmarks*-github.md"))
           if producer_md:
               output.append("## Producer Benchmarks")
               output.append("")
               output.append("Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.")
               output.append("")
-              with open(producer_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(producer_md)
 
-          # Consumer benchmarks
-          consumer_md = glob.glob("benchmark-results/Client/results/*ConsumerBenchmarks*-github.md")
+          # Consumer benchmarks (ConsumerBenchmarks + ConsumerPollBenchmarks)
+          consumer_md = sorted(glob.glob("benchmark-results/Client/results/*Consumer*Benchmarks*-github.md"))
           if consumer_md:
               output.append("## Consumer Benchmarks")
               output.append("")
               output.append("Comparing Dekaf vs Confluent.Kafka for message consumption.")
               output.append("")
-              with open(consumer_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(consumer_md)
 
           # Protocol benchmarks (zero-allocation)
-          protocol_md = glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md")
+          protocol_md = sorted(glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md"))
           if protocol_md:
               output.append("## Protocol Benchmarks")
               output.append("")
@@ -502,48 +452,21 @@ jobs:
               output.append("**Allocated = `-` means zero heap allocations** - the goal of Dekaf's design!")
               output.append(":::")
               output.append("")
-              with open(protocol_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(protocol_md)
 
           # Serializer benchmarks
-          serializer_md = glob.glob("benchmark-results/Unit/results/*SerializerBenchmarks*-github.md")
+          serializer_md = sorted(glob.glob("benchmark-results/Unit/results/*SerializerBenchmarks*-github.md"))
           if serializer_md:
               output.append("## Serializer Benchmarks")
               output.append("")
-              with open(serializer_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(serializer_md)
 
           # Compression benchmarks
-          compression_md = glob.glob("benchmark-results/Unit/results/*CompressionBenchmarks*-github.md")
+          compression_md = sorted(glob.glob("benchmark-results/Unit/results/*CompressionBenchmarks*-github.md"))
           if compression_md:
               output.append("## Compression Benchmarks")
               output.append("")
-              with open(compression_md[0]) as f:
-                  content = f.read()
-                  lines = content.split('\n')
-                  in_table = False
-                  for line in lines:
-                      if line.startswith('|'):
-                          in_table = True
-                      if in_table:
-                          output.append(line)
-              output.append("")
+              append_tables(compression_md)
 
           output.append("---")
           output.append("")
@@ -552,10 +475,9 @@ jobs:
           output.append("- **Mean**: Average execution time")
           output.append("- **Error**: Half of 99.9% confidence interval")
           output.append("- **StdDev**: Standard deviation of all measurements")
-          output.append("- **Ratio**: Performance relative to baseline (Confluent.Kafka)")
-          output.append("  - `< 1.0` = Dekaf is faster")
-          output.append("  - `> 1.0` = Confluent is faster")
-          output.append("  - `1.0` = Same performance")
+          output.append("- **Ratio**: Performance relative to that table's baseline row")
+          output.append("  - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster")
+          output.append("  - Unit tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent")
           output.append("- **Allocated**: Heap memory allocated per operation")
           output.append("  - `-` = Zero allocations (ideal!)")
           output.append("")

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2243,6 +2243,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// may retain up to 8 arrays of this size per consumer instance)</description></item>
     /// <item><description>PrefetchPipelineDepth: 5 (aggressive prefetching to hide network latency)</description></item>
     /// <item><description>AdaptiveFetchSizing: enabled (auto-grows fetch sizes when consumer keeps up, shrinks when falling behind)</description></item>
+    /// <item><description>CheckCrcs: disabled (skips client-side CRC32C re-validation of fetched batches; TCP checksums and
+    /// broker-side validation already cover corruption in transit — matches librdkafka's default. Re-enable with
+    /// <see cref="WithCheckCrcs"/> after this preset if end-to-end validation is required)</description></item>
     /// </list>
     /// <para><b>Memory note:</b> The combined in-flight memory ceiling is
     /// <c>PrefetchPipelineDepth × FetchMaxBytes</c> — with these defaults that is
@@ -2258,6 +2261,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _maxPartitionFetchBytes = 4 * 1024 * 1024;
         _fetchMaxBytes = 100 * 1024 * 1024;
         _prefetchPipelineDepth = 5;
+        _checkCrcs = false;
         _enableAdaptiveFetchSizing = true; // Intentional: ForHighThroughput always enables adaptive sizing
         _adaptiveFetchSizingOptions ??= new AdaptiveFetchSizingOptions
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -651,6 +651,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private readonly ConsumerOptions _options;
 
+    /// <summary>
+    /// The effective options this consumer was built with. Exposed for tests that
+    /// verify builder/preset-to-options mapping.
+    /// </summary>
+    internal ConsumerOptions Options => _options;
+
     // Current budget limit in bytes (mutated live by DekafMemoryBudget rebalancing).
     private long _currentQueuedMaxBytes;
 

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -370,6 +370,33 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_DisablesCheckCrcs()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.CheckCrcs).IsFalse();
+    }
+
+    [Test]
+    public async Task ForHighThroughput_ThenWithCheckCrcs_OverridesPreset()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .WithCheckCrcs(true)
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.CheckCrcs).IsTrue();
+    }
+
+    [Test]
     public async Task ForLowLatency_ThenBuild_Succeeds()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
@@ -10,6 +10,16 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 /// Consumer benchmarks comparing Dekaf vs Confluent.Kafka.
 /// Confluent is marked as baseline for ratio comparison.
 /// </summary>
+/// <remarks>
+/// The topic is seeded once per process in <c>[GlobalSetup]</c>; each iteration creates,
+/// subscribes, and primes a fresh consumer (fresh group id, earliest reset) in
+/// <c>[IterationSetup]</c> so it re-reads the same data and the timed region measures
+/// steady-state consumption only. Including the lifecycle in the op would make both the
+/// time and Allocated columns incomparable: Confluent's group join dominates its time
+/// (~3s of waiting), and its session setup is native librdkafka memory that
+/// MemoryDiagnoser cannot see, while Dekaf's is managed and fully visible.
+/// Single-message poll benchmarks live in <see cref="ConsumerPollBenchmarks"/>.
+/// </remarks>
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
@@ -20,15 +30,14 @@ public class ConsumerBenchmarks
     private Confluent.Kafka.IProducer<string, string> _confluentProducer = null!;
 
     private const string TopicPrefix = "benchmark-consumer-";
-    private const int PollSingleWarmupMessages = 1;
-    private static readonly TimeSpan PollSingleTimeout = TimeSpan.FromSeconds(10);
+    private const int PrimeMessages = 1;
+    private static readonly TimeSpan ConsumeTimeout = TimeSpan.FromSeconds(30);
 
     private string _topic = null!;
-    private int _topicCounter;
 
-    // Pre-created and primed consumers for warm PollSingle benchmarks.
-    private Confluent.Kafka.IConsumer<string, string>? _confluentPollConsumer;
-    private DekafConsumer.IKafkaConsumer<string, string>? _dekafPollConsumer;
+    private Confluent.Kafka.IConsumer<string, string>? _confluentConsumer;
+    private DekafConsumer.IKafkaConsumer<string, string>? _dekafConsumer;
+    private CancellationTokenSource? _dekafConsumeCts;
 
     [Params(100, 1000)]
     public int MessageCount { get; set; }
@@ -47,15 +56,18 @@ public class ConsumerBenchmarks
             ClientId = "benchmark-seeder"
         };
         _confluentProducer = new Confluent.Kafka.ProducerBuilder<string, string>(confluentConfig).Build();
+
+        SeedTopic();
     }
 
-    private void SeedTopic(int extraMessages = 0)
+    // Mirrors ConsumerPollBenchmarks.SeedTopic; keep the two in sync.
+    private void SeedTopic()
     {
-        _topic = $"{TopicPrefix}{++_topicCounter}-{MessageCount}-{MessageSize}";
+        _topic = $"{TopicPrefix}{MessageCount}-{MessageSize}-{Guid.NewGuid():N}";
         _kafka.CreateTopicAsync(_topic, 1).GetAwaiter().GetResult();
 
         var value = new string('x', MessageSize);
-        var totalMessages = MessageCount + extraMessages;
+        var totalMessages = MessageCount + PrimeMessages;
         for (var i = 0; i < totalMessages; i++)
         {
             _confluentProducer.Produce(_topic, new Confluent.Kafka.Message<string, string>
@@ -67,47 +79,65 @@ public class ConsumerBenchmarks
         _confluentProducer.Flush(TimeSpan.FromSeconds(30));
     }
 
-    [IterationSetup(Targets = [nameof(Confluent_ConsumeAll), nameof(Dekaf_ConsumeAll)])]
-    public void ConsumeAllIterationSetup() => SeedTopic();
-
-    [IterationSetup(Targets = [nameof(Confluent_PollSingle), nameof(Dekaf_PollSingle)])]
-    public void PollSingleIterationSetup()
+    [IterationSetup(Targets = [nameof(Confluent_ConsumeAll)])]
+    public void ConfluentIterationSetup()
     {
-        SeedTopic(PollSingleWarmupMessages);
-
-        _confluentPollConsumer = new Confluent.Kafka.ConsumerBuilder<string, string>(
+        _confluentConsumer = new Confluent.Kafka.ConsumerBuilder<string, string>(
             new Confluent.Kafka.ConsumerConfig
             {
                 BootstrapServers = _kafka.BootstrapServers,
-                ClientId = "confluent-poll-benchmark",
-                GroupId = $"confluent-poll-{Guid.NewGuid():N}",
-                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest
+                ClientId = "confluent-consumer-benchmark",
+                GroupId = $"confluent-benchmark-{Guid.NewGuid():N}",
+                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest,
+                EnableAutoCommit = false
             }).Build();
-        _confluentPollConsumer.Subscribe(_topic);
+        _confluentConsumer.Subscribe(_topic);
 
-        _dekafPollConsumer = Kafka.CreateConsumer<string, string>()
+        // Prime through group join and the first fetch so the timed region starts warm.
+        if (_confluentConsumer.Consume(ConsumeTimeout) is null)
+        {
+            throw new InvalidOperationException("Confluent consumer did not receive a prime message.");
+        }
+    }
+
+    [IterationSetup(Targets = [nameof(Dekaf_ConsumeAll)])]
+    public void DekafIterationSetup()
+    {
+        _dekafConsumer = Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
-            .WithClientId("dekaf-poll-benchmark")
-            .WithGroupId($"dekaf-poll-{Guid.NewGuid():N}")
+            .WithClientId("dekaf-consumer-benchmark")
+            .WithGroupId($"dekaf-benchmark-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(DekafConsumer.AutoOffsetReset.Earliest)
             .BuildAsync()
             .GetAwaiter()
             .GetResult();
-        _dekafPollConsumer.Subscribe(_topic);
+        _dekafConsumer.Subscribe(_topic);
 
-        PrimeConfluentPollConsumer();
-        PrimeDekafPollConsumer().GetAwaiter().GetResult();
+        if (_dekafConsumer.ConsumeOneAsync(ConsumeTimeout).AsTask().GetAwaiter().GetResult() is null)
+        {
+            throw new InvalidOperationException("Dekaf consumer did not receive a prime message.");
+        }
+
+        // Created outside the timed op so its timer allocation doesn't skew the Allocated
+        // column (the Confluent baseline's timeout budget is an allocation-free deadline).
+        _dekafConsumeCts = new CancellationTokenSource(ConsumeTimeout);
     }
 
-    [IterationCleanup(Targets = [nameof(Confluent_PollSingle), nameof(Dekaf_PollSingle)])]
-    public void PollSingleIterationCleanup()
+    [IterationCleanup(Targets = [nameof(Confluent_ConsumeAll)])]
+    public void ConfluentIterationCleanup()
     {
-        _confluentPollConsumer?.Close();
-        _confluentPollConsumer?.Dispose();
-        _confluentPollConsumer = null;
+        _confluentConsumer?.Close();
+        _confluentConsumer?.Dispose();
+        _confluentConsumer = null;
+    }
 
-        _dekafPollConsumer?.DisposeAsync().GetAwaiter().GetResult();
-        _dekafPollConsumer = null;
+    [IterationCleanup(Targets = [nameof(Dekaf_ConsumeAll)])]
+    public void DekafIterationCleanup()
+    {
+        _dekafConsumer?.DisposeAsync().GetAwaiter().GetResult();
+        _dekafConsumer = null;
+        _dekafConsumeCts?.Dispose();
+        _dekafConsumeCts = null;
     }
 
     [GlobalCleanup]
@@ -125,29 +155,16 @@ public class ConsumerBenchmarks
     {
         var count = 0;
 
-        var config = new Confluent.Kafka.ConsumerConfig
-        {
-            BootstrapServers = _kafka.BootstrapServers,
-            ClientId = "confluent-consumer-benchmark",
-            GroupId = $"confluent-benchmark-{Guid.NewGuid():N}",
-            AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest,
-            EnableAutoCommit = false
-        };
-
-        using var consumer = new Confluent.Kafka.ConsumerBuilder<string, string>(config).Build();
-        consumer.Subscribe(_topic);
-
-        var deadline = DateTime.UtcNow.AddSeconds(30);
+        var deadline = DateTime.UtcNow + ConsumeTimeout;
         while (count < MessageCount && DateTime.UtcNow < deadline)
         {
-            var result = consumer.Consume(TimeSpan.FromSeconds(5));
+            var result = _confluentConsumer!.Consume(TimeSpan.FromSeconds(5));
             if (result is not null)
             {
                 count++;
             }
         }
 
-        consumer.Close();
         return count;
     }
 
@@ -157,19 +174,7 @@ public class ConsumerBenchmarks
     {
         var count = 0;
 
-        await using var consumer = await Kafka.CreateConsumer<string, string>()
-            .WithBootstrapServers(_kafka.BootstrapServers)
-            .WithClientId("dekaf-consumer-benchmark")
-            .WithGroupId($"dekaf-benchmark-{Guid.NewGuid():N}")
-            .WithAutoOffsetReset(DekafConsumer.AutoOffsetReset.Earliest)
-            .BuildAsync()
-            .ConfigureAwait(false);
-
-        consumer.Subscribe(_topic);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
-        await foreach (var result in consumer.ConsumeAsync(cts.Token).ConfigureAwait(false))
+        await foreach (var result in _dekafConsumer!.ConsumeAsync(_dekafConsumeCts!.Token).ConfigureAwait(false))
         {
             count++;
             if (count >= MessageCount)
@@ -177,39 +182,5 @@ public class ConsumerBenchmarks
         }
 
         return count;
-    }
-
-    // ===== Poll Single Message =====
-
-    [BenchmarkCategory("PollSingle")]
-    [Benchmark(Baseline = true)]
-    public Confluent.Kafka.ConsumeResult<string, string>? Confluent_PollSingle()
-    {
-        return _confluentPollConsumer!.Consume(PollSingleTimeout);
-    }
-
-    [BenchmarkCategory("PollSingle")]
-    [Benchmark]
-    public async Task<DekafConsumer.ConsumeResult<string, string>?> Dekaf_PollSingle()
-    {
-        return await _dekafPollConsumer!.ConsumeOneAsync(PollSingleTimeout).ConfigureAwait(false);
-    }
-
-    private void PrimeConfluentPollConsumer()
-    {
-        var result = _confluentPollConsumer!.Consume(PollSingleTimeout);
-        if (result is null)
-        {
-            throw new InvalidOperationException("Confluent poll consumer did not receive a warmup message.");
-        }
-    }
-
-    private async Task PrimeDekafPollConsumer()
-    {
-        var result = await _dekafPollConsumer!.ConsumeOneAsync(PollSingleTimeout).ConfigureAwait(false);
-        if (result is null)
-        {
-            throw new InvalidOperationException("Dekaf poll consumer did not receive a warmup message.");
-        }
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -1,0 +1,171 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Dekaf.Benchmarks.Infrastructure;
+using DekafConsumer = Dekaf.Consumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Client;
+
+/// <summary>
+/// Steady-state single-message poll benchmarks comparing Dekaf vs Confluent.Kafka.
+/// Confluent is marked as baseline for ratio comparison.
+/// </summary>
+/// <remarks>
+/// The topic is seeded once per process in <c>[GlobalSetup]</c>; each iteration creates
+/// and primes a fresh consumer (fresh group id, earliest reset) that re-reads it, then
+/// measures <see cref="PollsPerIteration"/> consecutive polls. The explicit invocation count in
+/// <see cref="PollJobConfig"/> is essential: with an <c>[IterationSetup]</c> present,
+/// BenchmarkDotNet otherwise forces a single invocation per iteration, which measures
+/// three cold single-shot samples per case — the call graph never reaches the tiered
+/// compilation promotion threshold, so the managed poll path runs unoptimized Tier-0
+/// code while Confluent's native librdkafka path is unaffected, and one scheduler
+/// preemption distorts the whole statistic. Thousands of warm polls per iteration give
+/// both clients Tier-1 code and real statistics.
+/// </remarks>
+[MemoryDiagnoser]
+[Config(typeof(PollJobConfig))]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class ConsumerPollBenchmarks
+{
+    private const int PollsPerIteration = 10_000;
+    private const int PrimeMessages = 1;
+    private const string TopicPrefix = "benchmark-poll-";
+    private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
+
+    private sealed class PollJobConfig : ManualConfig
+    {
+        public PollJobConfig()
+        {
+            AddJob(Job.Default
+                .WithStrategy(RunStrategy.Throughput)
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(3)
+                .WithInvocationCount(PollsPerIteration)
+                .WithUnrollFactor(1));
+        }
+    }
+
+    private KafkaTestEnvironment _kafka = null!;
+    private Confluent.Kafka.IProducer<string, string> _confluentProducer = null!;
+
+    private string _topic = null!;
+
+    private Confluent.Kafka.IConsumer<string, string>? _confluentPollConsumer;
+    private DekafConsumer.IKafkaConsumer<string, string>? _dekafPollConsumer;
+
+    [Params(100, 1000)]
+    public int MessageSize { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _kafka = await KafkaTestEnvironment.CreateAsync().ConfigureAwait(false);
+
+        var confluentConfig = new Confluent.Kafka.ProducerConfig
+        {
+            BootstrapServers = _kafka.BootstrapServers,
+            ClientId = "benchmark-seeder"
+        };
+        _confluentProducer = new Confluent.Kafka.ProducerBuilder<string, string>(confluentConfig).Build();
+
+        SeedTopic();
+    }
+
+    // Mirrors ConsumerBenchmarks.SeedTopic; keep the two in sync.
+    private void SeedTopic()
+    {
+        _topic = $"{TopicPrefix}{MessageSize}-{Guid.NewGuid():N}";
+        _kafka.CreateTopicAsync(_topic, 1).GetAwaiter().GetResult();
+
+        var value = new string('x', MessageSize);
+        var totalMessages = PollsPerIteration + PrimeMessages;
+        for (var i = 0; i < totalMessages; i++)
+        {
+            _confluentProducer.Produce(_topic, new Confluent.Kafka.Message<string, string>
+            {
+                Key = $"key-{i}",
+                Value = value
+            });
+        }
+        _confluentProducer.Flush(TimeSpan.FromSeconds(30));
+    }
+
+    [IterationSetup(Targets = [nameof(Confluent_PollSingle)])]
+    public void ConfluentIterationSetup()
+    {
+        _confluentPollConsumer = new Confluent.Kafka.ConsumerBuilder<string, string>(
+            new Confluent.Kafka.ConsumerConfig
+            {
+                BootstrapServers = _kafka.BootstrapServers,
+                ClientId = "confluent-poll-benchmark",
+                GroupId = $"confluent-poll-{Guid.NewGuid():N}",
+                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest
+            }).Build();
+        _confluentPollConsumer.Subscribe(_topic);
+
+        if (_confluentPollConsumer.Consume(PollTimeout) is null)
+        {
+            throw new InvalidOperationException("Confluent poll consumer did not receive a prime message.");
+        }
+    }
+
+    [IterationSetup(Targets = [nameof(Dekaf_PollSingle)])]
+    public void DekafIterationSetup()
+    {
+        _dekafPollConsumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(_kafka.BootstrapServers)
+            .WithClientId("dekaf-poll-benchmark")
+            .WithGroupId($"dekaf-poll-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(DekafConsumer.AutoOffsetReset.Earliest)
+            .BuildAsync()
+            .GetAwaiter()
+            .GetResult();
+        _dekafPollConsumer.Subscribe(_topic);
+
+        if (_dekafPollConsumer.ConsumeOneAsync(PollTimeout).AsTask().GetAwaiter().GetResult() is null)
+        {
+            throw new InvalidOperationException("Dekaf poll consumer did not receive a prime message.");
+        }
+    }
+
+    [IterationCleanup(Targets = [nameof(Confluent_PollSingle)])]
+    public void ConfluentIterationCleanup()
+    {
+        _confluentPollConsumer?.Close();
+        _confluentPollConsumer?.Dispose();
+        _confluentPollConsumer = null;
+    }
+
+    [IterationCleanup(Targets = [nameof(Dekaf_PollSingle)])]
+    public void DekafIterationCleanup()
+    {
+        _dekafPollConsumer?.DisposeAsync().GetAwaiter().GetResult();
+        _dekafPollConsumer = null;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        _confluentProducer.Dispose();
+        await _kafka.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // ===== Poll Single Message =====
+
+    [BenchmarkCategory("PollSingle")]
+    [Benchmark(Baseline = true)]
+    public Confluent.Kafka.ConsumeResult<string, string>? Confluent_PollSingle()
+    {
+        return _confluentPollConsumer!.Consume(PollTimeout);
+    }
+
+    [BenchmarkCategory("PollSingle")]
+    [Benchmark]
+    public ValueTask<DekafConsumer.ConsumeResult<string, string>?> Dekaf_PollSingle()
+    {
+        return _dekafPollConsumer!.ConsumeOneAsync(PollTimeout);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SerializerBenchmarks.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 
@@ -9,14 +10,24 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// Serializer performance benchmarks.
 /// Tests the ISerializer/IDeserializer implementations.
 /// </summary>
+/// <remarks>
+/// Benchmarks are grouped by category so the Ratio column only compares like with like;
+/// the single baseline lives in the Writer category. There is deliberately no
+/// <c>[IterationSetup]</c>: its presence would force single-invocation iterations, which
+/// cannot produce meaningful statistics for nanosecond-scale operations — buffers are
+/// reset inside each benchmark instead.
+/// </remarks>
 [MemoryDiagnoser]
 [ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
 public class SerializerBenchmarks
 {
     private ArrayBufferWriter<byte> _buffer = null!;
     private string _smallString = null!;
     private string _mediumString = null!;
     private string _largeString = null!;
+    private string[] _batchKeys = null!;
     private byte[] _stringBytes = null!;
     private SerializationContext _context;
 
@@ -28,6 +39,10 @@ public class SerializerBenchmarks
         _mediumString = new string('a', 100);
         _largeString = new string('a', 1000);
 
+        // Pre-created so the batch benchmark's Allocated column reflects the library,
+        // not the benchmark's own key-string interpolation.
+        _batchKeys = [.. Enumerable.Range(0, 100).Select(i => $"key-{i}")];
+
         _context = new SerializationContext
         {
             Topic = "test-topic",
@@ -38,32 +53,33 @@ public class SerializerBenchmarks
         _stringBytes = System.Text.Encoding.UTF8.GetBytes(_mediumString);
     }
 
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _buffer.Clear();
-    }
-
     // ===== String Serialization =====
 
+    [BenchmarkCategory("Scalar")]
     [Benchmark(Description = "Serialize String (10 chars)")]
     public void SerializeString_Small()
     {
+        _buffer.ResetWrittenCount();
         Serializers.String.Serialize(_smallString, ref _buffer, _context);
     }
 
+    [BenchmarkCategory("Scalar")]
     [Benchmark(Description = "Serialize String (100 chars)")]
     public void SerializeString_Medium()
     {
+        _buffer.ResetWrittenCount();
         Serializers.String.Serialize(_mediumString, ref _buffer, _context);
     }
 
+    [BenchmarkCategory("Scalar")]
     [Benchmark(Description = "Serialize String (1000 chars)")]
     public void SerializeString_Large()
     {
+        _buffer.ResetWrittenCount();
         Serializers.String.Serialize(_largeString, ref _buffer, _context);
     }
 
+    [BenchmarkCategory("Scalar")]
     [Benchmark(Description = "Deserialize String")]
     public string DeserializeString()
     {
@@ -72,14 +88,17 @@ public class SerializerBenchmarks
 
     // ===== Int32 Serialization =====
 
+    [BenchmarkCategory("Scalar")]
     [Benchmark(Description = "Serialize Int32")]
     public void SerializeInt32()
     {
+        _buffer.ResetWrittenCount();
         Serializers.Int32.Serialize(12345678, ref _buffer, _context);
     }
 
     // ===== Batch Serialization (100 messages) =====
 
+    [BenchmarkCategory("Batch")]
     [Benchmark(Description = "Serialize 100 Messages (key+value)")]
     public void SerializeBatch()
     {
@@ -89,7 +108,7 @@ public class SerializerBenchmarks
         for (var i = 0; i < 100; i++)
         {
             var keyWriter = new PooledBufferWriter(initialCapacity: 64);
-            Serializers.String.Serialize($"key-{i}", ref keyWriter, keyContext);
+            Serializers.String.Serialize(_batchKeys[i], ref keyWriter, keyContext);
             var keyMemory = keyWriter.ToPooledMemory();
 
             var valueWriter = new PooledBufferWriter(initialCapacity: 256);
@@ -103,22 +122,24 @@ public class SerializerBenchmarks
 
     // ===== PooledBufferWriter vs ArrayBufferWriter =====
 
+    [BenchmarkCategory("Writer")]
     [Benchmark(Baseline = true, Description = "ArrayBufferWriter + Copy")]
-    public PooledMemory Serialize_ArrayBufferWriter()
+    public void Serialize_ArrayBufferWriter()
     {
         var arrayWriter = new ArrayBufferWriter<byte>(256);
         Serializers.String.Serialize(_mediumString, ref arrayWriter, _context);
 
-        var buffer = ArrayPool<byte>.Shared.Rent(arrayWriter.WrittenCount);
+        var buffer = ProducerDataPool.BytePool.Rent(arrayWriter.WrittenCount);
         arrayWriter.WrittenSpan.CopyTo(buffer);
-        return new PooledMemory(buffer, arrayWriter.WrittenCount);
+        new PooledMemory(buffer, arrayWriter.WrittenCount).Return();
     }
 
+    [BenchmarkCategory("Writer")]
     [Benchmark(Description = "PooledBufferWriter Direct")]
-    public PooledMemory Serialize_PooledBufferWriter()
+    public void Serialize_PooledBufferWriter()
     {
         var pooledWriter = new PooledBufferWriter(initialCapacity: 256);
         Serializers.String.Serialize(_mediumString, ref pooledWriter, _context);
-        return pooledWriter.ToPooledMemory();
+        pooledWriter.ToPooledMemory().Return();
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -31,7 +31,9 @@ internal static class ConfluentStressTestHelpers
     // the preset's fields are private, so there is no compile-time link (same constraint as
     // QueueBufferingMaxMessages above). librdkafka has no adaptive-fetch-sizing or explicit
     // max-poll-records equivalent, so these pin the preset's base fetch sizes; the consume loop
-    // is single-message (consumer.Consume) either way.
+    // is single-message (consumer.Consume) either way. CRC validation is aligned implicitly:
+    // ForHighThroughput() sets CheckCrcs=false, matching librdkafka's check.crcs default (false),
+    // so neither client re-validates CRC32C on fetch.
 
     /// <summary>Dekaf <c>_fetchMinBytes</c> — fetch.min.bytes.</summary>
     internal const int FetchMinBytes = 1024;


### PR DESCRIPTION
## Summary

The 2026-07-11 Confluent-gap audit found that most published "Dekaf worse than Confluent" consumer numbers were benchmark-harness artifacts. This PR fixes the harness so the tables measure the clients, plus one preset alignment. Closes #1752, #1753, #1754, #1755.

### PollSingle (#1752)
`[IterationSetup]` forces BDN to `InvocationCount=1`, so each published stat was 3 single-shot samples running Tier-0 JIT (~14 total calls, below the ~30-call promotion threshold) — Confluent's native path is immune, Dekaf's managed path is not. PollSingle now lives in `ConsumerPollBenchmarks` with an explicit `InvocationCount(10_000)`/`UnrollFactor(1)` job measuring warm Tier-1 polls.

**Local validation:** Dekaf poll 29–39μs ±18μs → **2.1–2.9μs ±0.3μs**.

### ConsumeAll (#1753)
The op timed the full create/join/consume/dispose lifecycle. Confluent's session setup is native (invisible to MemoryDiagnoser); Dekaf's is managed — the entire 8.34x alloc ratio was fixed session cost, while per-message Dekaf already allocates less (~575B vs ~650B). Consumers are now created and primed in `IterationSetup`; the op times steady-state consumption. Topics seed once per process; each iteration re-reads with a fresh group id.

**Local validation:** 100×100B op allocation 637KB → **56KB (~573B/msg)**.

### SerializerBenchmarks (#1754)
Per-category baselines (the class-wide baseline made 'Serialize 100 Messages' print a bogus 14.43x ratio against a single-string micro-op), IterationSetup removed so nanosecond ops get real multi-invocation statistics, key strings precomputed (Allocated now reflects the library: **0B**), and rented memory returned to `ProducerDataPool.BytePool` — the pool `PooledMemory.Return()` actually targets.

### Workflow scripts
Both embedded python blocks now use one `append_tables()` helper instead of 11 copies of the extraction loop, removing the remaining `glob(...)[0]` reads that would silently drop reports the next time a benchmark class splits. Consumer sections pick up both consumer classes; the generated docs now state which tables compare vs Confluent and which use internal baselines.

### CheckCrcs preset alignment (#1755)
`ForHighThroughput()` now sets `CheckCrcs = false`, matching librdkafka's `check.crcs` default — the stress consumer comparison previously included CRC32C validation of every fetched byte that only Dekaf performed. Library default stays `true`; re-enable after the preset with `.WithCheckCrcs(true)`. Covered by two new builder tests via a new internal `KafkaConsumer.Options` accessor.

## Validation

- Full solution builds clean; 77 builder/options unit tests pass.
- All changed client benchmarks executed locally against a real Kafka 4.3.1 broker (results above); serializer benchmarks executed locally (SerializeBatch 0B allocated, writer comparison now shows PooledBufferWriter at 0.44x with zero alloc).
- Embedded workflow python compile-checked.

Follow-ups tracked separately: consumer CPU gap #1757–#1762, #1767; poll/session overhead #1763–#1766; seeder batch size #1756.