### PR TITLE
stress: report consumer seed batch size

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -182,8 +182,12 @@ def format_throughput_table(results, title, include_ratio=False):
     lines = []
     duration = results[0].get('durationMinutes', 'N/A')
     message_size = results[0].get('messageSizeBytes', 'N/A')
+    seed_batch_size = results[0].get('consumerSeedBatchSizeBytes')
 
-    lines.append(f"## {title} ({duration} minutes, {message_size}B messages)")
+    workload = f"{duration} minutes, {message_size}B messages"
+    if seed_batch_size is not None:
+        workload += f", {seed_batch_size:,}B seed batches"
+    lines.append(f"## {title} ({workload})")
     lines.append("")
 
     if include_ratio:

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -21,6 +21,7 @@ _IDENTITY_FIELDS = (
     "brokerCount",
     "durationMinutes",
     "messageSizeBytes",
+    "consumerSeedBatchSizeBytes",
     "roundTripMessages",
 )
 
@@ -49,6 +50,14 @@ def _roundtrip_messages(result):
     return result.get("roundTripMessages")
 
 
+def _consumer_seed_batch_size(result):
+    value = result.get("consumerSeedBatchSizeBytes")
+    if value is not None:
+        return value
+    scenario = str(result.get("scenario", "")).casefold()
+    return 16_384 if scenario.startswith("consumer") else None
+
+
 def _identity(result):
     return (
         str(result.get("scenario", "unknown")).casefold(),
@@ -56,6 +65,7 @@ def _identity(result):
         result.get("brokerCount", 1),
         result.get("durationMinutes"),
         result.get("messageSizeBytes"),
+        _consumer_seed_batch_size(result),
         _roundtrip_messages(result),
     )
 
@@ -166,6 +176,7 @@ def evaluate_and_update(history, current_results, run_started_at):
     for result in current_results:
         prior = _matching_observations(baseline_runs, result)
         observation = {field: result.get(field) for field in _IDENTITY_FIELDS}
+        observation["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
         observation["brokerCount"] = result.get("brokerCount", 1)
         observation["roundTripMessages"] = _roundtrip_messages(result)
 

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -64,6 +64,14 @@ class StressReportTests(unittest.TestCase):
         self.assertTrue(rows[0].startswith("| Dekaf"))
         self.assertIn("| 2.00x |", rows[0])
 
+    def test_consumer_table_reports_seed_batch_size(self):
+        result = stress_result("Dekaf", effective_rate=2000)
+        result["consumerSeedBatchSizeBytes"] = 16_384
+
+        lines = format_throughput_table([result], "Consumer Throughput")
+
+        self.assertIn("16,384B seed batches", lines[0])
+
     def test_message_bounded_table_ignores_producer_only_median(self):
         lines = format_throughput_table(
             [

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -187,6 +187,32 @@ class StressTrendTests(unittest.TestCase):
         self.assertFalse(should_fail)
         self.assertEqual({"insufficient-history"}, {item["status"] for item in evaluations})
 
+    def test_consumer_seed_batch_size_preserves_legacy_baseline_and_separates_new_shapes(self):
+        history = {
+            "version": 1,
+            "runs": [history_run(i, scenario="consumer") for i in range(1, 4)],
+        }
+
+        legacy_evaluations, _, _ = evaluate_and_update(
+            history,
+            [result(scenario="consumer", consumerSeedBatchSizeBytes=16_384)],
+            "2026-07-01T02:00:00Z",
+        )
+        large_batch_evaluations, _, _ = evaluate_and_update(
+            history,
+            [result(scenario="consumer", consumerSeedBatchSizeBytes=1_048_576)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertNotEqual(
+            {"insufficient-history"},
+            {item["status"] for item in legacy_evaluations},
+        )
+        self.assertEqual(
+            {"insufficient-history"},
+            {item["status"] for item in large_batch_evaluations},
+        )
+
     def test_different_roundtrip_bound_does_not_supply_baseline(self):
         history = {
             "version": 1,

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -568,7 +568,7 @@ jobs:
           output.append("- **Median Interval Throughput**: table order and comparison ratios use median sampled client-side msg/s when available, which is less sensitive to short late-run stalls than the whole-run mean")
           output.append("- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM, with client order alternating by workflow run number to reduce order bias")
           output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
-          output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured")
+          output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured; table headings report the 16KB seed batch size because it amplifies per-batch costs relative to well-batched workloads")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
           output.append("- **Round-Trip Correctness**: Bounded sequenced payloads are consumed back and checked for corruption, wrong partitions, gaps, duplicates, and reordering")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -39,6 +39,7 @@ namespace Dekaf.StressTests;
 /// </summary>
 public static class Program
 {
+    private const int ConsumerSeedBatchSizeBytes = 16 * 1024;
     private static readonly ConcurrentQueue<Exception> UnobservedTaskExceptions = new();
 
     public static async Task<int> Main(string[] args)
@@ -210,6 +211,7 @@ public static class Program
             Partitions = options.Partitions,
             LingerMs = options.LingerMs,
             BatchSize = options.BatchSize,
+            ConsumerSeedBatchSizeBytes = UsesProducerTopic(scenarioName) ? null : ConsumerSeedBatchSizeBytes,
             Compression = options.Compression,
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
@@ -658,7 +660,7 @@ public static class Program
             .WithClientId("stress-seeder")
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(5))
-            .WithBatchSize(16384)
+            .WithBatchSize(ConsumerSeedBatchSizeBytes)
             .BuildAsync();
 
         var batchSize = 10_000;

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -12,6 +12,7 @@ internal sealed class StressTestResult
     public required string Client { get; set; }
     public required int DurationMinutes { get; init; }
     public required int MessageSizeBytes { get; init; }
+    public int? ConsumerSeedBatchSizeBytes { get; init; }
     public required DateTime StartedAtUtc { get; init; }
     public required DateTime CompletedAtUtc { get; init; }
     public required ThroughputSnapshot Throughput { get; init; }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -126,6 +126,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -114,6 +114,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -114,6 +114,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -110,6 +110,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -103,6 +103,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -20,6 +20,7 @@ internal sealed class StressTestOptions
     public int Partitions { get; init; } = 6;
     public int LingerMs { get; init; } = 5;
     public int BatchSize { get; init; } = 16384;
+    public int? ConsumerSeedBatchSizeBytes { get; init; }
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;


### PR DESCRIPTION
## Summary
- record 16KB consumer seed-batch shape in stress result JSON
- show seed batch size in published consumer table headings
- preserve legacy trend baselines while separating future batch shapes

## Test plan
- [x] `python .github/scripts/test_stress_report.py`
- [x] `python .github/scripts/test_stress_trend.py`
- [x] `dotnet build tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj --configuration Release`
- [x] `tools/Dekaf.StressTests.Tests/bin/Release/net10.0/Dekaf.StressTests.Tests.exe`

Closes #1756
