### PR TITLE
Avoid timer cancellation allocation on disposal

### DIFF
--- a/src/Dekaf/NetStandardPolyfillGaps.cs
+++ b/src/Dekaf/NetStandardPolyfillGaps.cs
@@ -172,6 +172,7 @@ internal sealed class PeriodicTimer : IDisposable
 {
     private readonly TimeSpan _period;
     private readonly CancellationTokenSource _disposed = new();
+    private int _disposeState;
 
     public PeriodicTimer(TimeSpan period)
     {
@@ -194,8 +195,10 @@ internal sealed class PeriodicTimer : IDisposable
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+            return;
+
         _disposed.Cancel();
-        _disposed.Dispose();
     }
 }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1217,7 +1217,11 @@ public sealed partial class ConnectionPool : IConnectionPool
         try
         {
             using var timer = new PeriodicTimer(GetIdleReaperInterval(_connectionOptions.ConnectionsMaxIdleMs));
-            while (await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            using var cancellationRegistration = cancellationToken.UnsafeRegister(
+                static state => ((PeriodicTimer)state!).Dispose(),
+                timer);
+
+            while (await timer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
             {
                 await ReapIdleConnectionsAsync().ConfigureAwait(false);
             }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1226,9 +1226,6 @@ public sealed partial class ConnectionPool : IConnectionPool
                 await ReapIdleConnectionsAsync().ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-        }
         catch (Exception ex)
         {
             LogIdleConnectionReaperFailed(ex);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2975,39 +2975,32 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var orphanSweepIntervalTicks = (long)(5.0 * Stopwatch.Frequency);
         var lastOrphanSweepTicks = Stopwatch.GetTimestamp();
 
-        try
+        using var cancellationRegistration = cancellationToken.UnsafeRegister(
+            static state => ((PeriodicTimer)state!).Dispose(),
+            _lingerTimer);
+
+        while (await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
         {
-            using var cancellationRegistration = cancellationToken.UnsafeRegister(
-                static state => ((PeriodicTimer)state!).Dispose(),
-                _lingerTimer);
-
-            while (await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
+            try
             {
-                try
-                {
-                    await _accumulator.ExpireLingerAsync(cancellationToken).ConfigureAwait(false);
+                await _accumulator.ExpireLingerAsync(cancellationToken).ConfigureAwait(false);
 
-                    // Periodic orphan sweep: fail in-flight batches that exceeded delivery timeout.
-                    var now = Stopwatch.GetTimestamp();
-                    if (now - lastOrphanSweepTicks >= orphanSweepIntervalTicks)
-                    {
-                        lastOrphanSweepTicks = now;
-                        _accumulator.SweepExpiredInFlightBatches();
-                    }
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                // Periodic orphan sweep: fail in-flight batches that exceeded delivery timeout.
+                var now = Stopwatch.GetTimestamp();
+                if (now - lastOrphanSweepTicks >= orphanSweepIntervalTicks)
                 {
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    LogLingerLoopError(ex);
+                    lastOrphanSweepTicks = now;
+                    _accumulator.SweepExpiredInFlightBatches();
                 }
             }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // Expected during shutdown
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                LogLingerLoopError(ex);
+            }
         }
     }
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2977,7 +2977,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         try
         {
-            while (await _lingerTimer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false))
+            using var cancellationRegistration = cancellationToken.UnsafeRegister(
+                static state => ((PeriodicTimer)state!).Dispose(),
+                _lingerTimer);
+
+            while (await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
             {
                 try
                 {

--- a/tests/Dekaf.Tests.Unit/Compatibility/PeriodicTimerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compatibility/PeriodicTimerTests.cs
@@ -1,0 +1,28 @@
+#if NET8_0
+namespace Dekaf.Tests.Unit.Compatibility;
+
+public sealed class NetStandardPeriodicTimerTests
+{
+    [Test]
+    public async Task Dispose_IsIdempotentAndCompletesPendingWaitWithFalse()
+    {
+        var timerType = typeof(Kafka).Assembly.GetType(
+            "System.Threading.PeriodicTimer",
+            throwOnError: true)!;
+        using var timer = (IDisposable)Activator.CreateInstance(
+            timerType,
+            TimeSpan.FromMinutes(1))!;
+        var waitForNextTick = timerType.GetMethod(
+            "WaitForNextTickAsync",
+            [typeof(CancellationToken)])!;
+        var pendingTick = ((ValueTask<bool>)waitForNextTick.Invoke(
+            timer,
+            [CancellationToken.None])!).AsTask();
+
+        timer.Dispose();
+        timer.Dispose();
+
+        await Assert.That(await pendingTick).IsFalse();
+    }
+}
+#endif

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -29,6 +29,17 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task DisposeAsync_StopsPendingIdleReaperPromptly()
+    {
+        var pool = new ConnectionPool("test-client");
+
+        var disposal = pool.DisposeAsync().AsTask();
+
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(disposal.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
     public async Task GetConnectionAsync_UnknownBrokerId_ThrowsInvalidOperationException()
     {
         await using var pool = new ConnectionPool("test-client");

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -10,6 +10,20 @@ namespace Dekaf.Tests.Unit.Producer;
 public class ProducerCancellationTests
 {
     [Test]
+    public async Task DisposeAsync_StopsPendingLingerTimerPromptly()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithLinger(TimeSpan.FromMinutes(1))
+            .Build();
+
+        var disposal = producer.DisposeAsync().AsTask();
+
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(disposal.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
     public async Task RecordAccumulator_FlushAsync_PreCancelledToken_ThrowsImmediately()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
@@ -141,6 +141,7 @@ public sealed class FetchResponseBatchBoundaryTests
                 }
 
                 FetchResponsePartition.ReturnRecordBatchList(batches);
+                partition.Records = null;
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -179,6 +179,7 @@ public class ResponseWireFormatSnapshotTests
                 if (batches is List<RecordBatch> pooledBatches)
                 {
                     FetchResponsePartition.ReturnRecordBatchList(pooledBatches);
+                    partition.Records = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stop connection idle-reaper and producer linger waits by disposing their `PeriodicTimer`
- avoid cancellation-driven `OperationCanceledException` stack-trace formatting during client disposal
- make netstandard `PeriodicTimer` disposal idempotent for callback plus lexical cleanup

## Test plan
- [x] `dotnet build src/Dekaf/Dekaf.csproj --configuration Release --framework netstandard2.0`
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] `ConnectionPoolTests` (38 passed)
- [x] `ProducerCancellationTests` (7 passed)
- [x] full unit suite: 5,087 passed; unrelated `LockFreeStackTests.TryPush_TryPop_DoNotAllocateInSteadyState` allocation assertion failed under parallel run, then passed in isolation

Closes #1766
