### PR TITLE
Reduce streaming consumer per-record overhead

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1601,6 +1601,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
                 var hasInterceptors = _interceptors is not null;
                 var rawTrackingEnabled = _rawRecordTrackingEnabled;
+                const int pollRefreshRecordInterval = 32;
+                var recordsUntilPollRefresh = pollRefreshRecordInterval;
 
                 while (_pendingFetches.Count > 0)
                 {
@@ -1740,6 +1742,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // pooled buffers.
                         if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
                             break;
+
+                        if (--recordsUntilPollRefresh == 0)
+                        {
+                            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
+                            recordsUntilPollRefresh = pollRefreshRecordInterval;
+                        }
                     }
 
                     // Dispose last activity from this pending fetch

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1733,7 +1733,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
 
                         yield return nextResult;
-                        await RecordPollAsync(cancellationToken).ConfigureAwait(false);
 
                         // User code at the yield point may have called Seek/Assign, which
                         // clears _pendingFetches and disposes `pending` while it is still
@@ -2899,6 +2898,21 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void PublishActiveConsumedPosition(TopicPartition partition, long position, int leaderEpoch)
     {
+        var observedVersion = Volatile.Read(ref _activeConsumedPositionVersion);
+        if ((observedVersion & 1) == 0
+            && Volatile.Read(ref _activeConsumedPartition) == partition.Partition
+            && Volatile.Read(ref _activeConsumedLeaderEpoch) == leaderEpoch
+            && string.Equals(
+                Volatile.Read(ref _activeConsumedTopic),
+                partition.Topic,
+                StringComparison.Ordinal))
+        {
+            Volatile.Write(ref _activeConsumedPosition, position);
+
+            if (Volatile.Read(ref _activeConsumedPositionVersion) == observedVersion)
+                return;
+        }
+
         var version = BeginActiveConsumedPositionWrite();
         Volatile.Write(ref _activeConsumedTopic, partition.Topic);
         Volatile.Write(ref _activeConsumedPartition, partition.Partition);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -107,16 +107,17 @@ public sealed class ConsumeAsyncRecoveryTests
     /// via reflection so ConsumeAsync can iterate pre-loaded pending fetches
     /// without hitting the network.
     /// </summary>
-    private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
+    private static KafkaConsumer<string, string> CreateConsumerWithPendingFetchesCore(
         ILoggerFactory? loggerFactory,
         string topic,
         int partition,
+        OffsetCommitMode offsetCommitMode,
         params PendingFetchData[] fetches)
     {
         var options = new ConsumerOptions
         {
             BootstrapServers = ["localhost:9092"],
-            OffsetCommitMode = OffsetCommitMode.Manual,
+            OffsetCommitMode = offsetCommitMode,
             QueuedMinMessages = 1 // Disable prefetching
         };
 
@@ -156,8 +157,30 @@ public sealed class ConsumeAsyncRecoveryTests
 
     private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
         ILoggerFactory? loggerFactory,
+        string topic,
+        int partition,
+        params PendingFetchData[] fetches)
+        => CreateConsumerWithPendingFetchesCore(
+            loggerFactory,
+            topic,
+            partition,
+            OffsetCommitMode.Manual,
+            fetches);
+
+    private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
+        ILoggerFactory? loggerFactory,
         params PendingFetchData[] fetches)
         => CreateConsumerWithPendingFetches(loggerFactory, Topic, Partition, fetches);
+
+    private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
+        OffsetCommitMode offsetCommitMode,
+        params PendingFetchData[] fetches)
+        => CreateConsumerWithPendingFetchesCore(
+            null,
+            Topic,
+            Partition,
+            offsetCommitMode,
+            fetches);
 
     private static ConcurrentDictionary<TopicPartition, long> GetPositions(
         KafkaConsumer<string, string> consumer)
@@ -480,6 +503,40 @@ public sealed class ConsumeAsyncRecoveryTests
         await Assert.That(results[0].Offset).IsEqualTo(20L);
         await Assert.That(results[1].Offset).IsEqualTo(21L);
         await Assert.That(results[2].Offset).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_AutoCommit_ReusesActivePositionPublicationWithinFetch()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "1"),
+                CreateRecord(1, "b", "2"),
+                CreateRecord(2, "c", "3"))
+        ]);
+
+        await using var consumer = CreateConsumerWithPendingFetches(OffsetCommitMode.Auto, fetch);
+
+        using var cts = new CancellationTokenSource();
+        var versionField = typeof(KafkaConsumer<string, string>).GetField(
+            "_activeConsumedPositionVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_activeConsumedPositionVersion field not found.");
+        var consumed = 0;
+        var activeVersion = 0;
+        await foreach (var _ in consumer.ConsumeAsync(cts.Token))
+        {
+            if (++consumed == 3)
+            {
+                activeVersion = (int)versionField.GetValue(consumer)!;
+                cts.Cancel();
+                break;
+            }
+        }
+
+        await Assert.That(activeVersion).IsEqualTo(2);
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, Partition))).IsEqualTo(23L);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -47,6 +47,27 @@ public sealed class ConsumerAssignmentFastPathTests
             static (consumer, token) => consumer.ConsumeRawBatchAsync(token));
     }
 
+    [Test]
+    public async Task ConsumeAsync_LargePendingBatch_RefreshesPollProgress()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        SetInitialized(consumer);
+        consumer.IncrementalAssign([new TopicPartitionOffset("test-topic", 0, 0)]);
+        GetPendingFetches(consumer).Enqueue(CreateFetchWithRecords(recordCount: 33));
+        var initialPollVersion = GetPollVersion(consumer);
+        var consumed = 0;
+
+        await foreach (var _ in consumer.ConsumeAsync())
+        {
+            if (++consumed == 33)
+                break;
+        }
+
+        await Assert.That(GetPollVersion(consumer)).IsGreaterThanOrEqualTo(initialPollVersion + 2);
+    }
+
     private static async Task AssertIdleLoopRecordsPollProgressAsync<T>(
         Func<KafkaConsumer<string, string>, CancellationToken, IAsyncEnumerable<T>> consume)
     {
@@ -1508,6 +1529,36 @@ public sealed class ConsumerAssignmentFastPathTests
                         HeaderCount = 0
                     }
                 ]
+            }
+        ]);
+    }
+
+    private static PendingFetchData CreateFetchWithRecords(int recordCount)
+    {
+        var records = new List<Record>(recordCount);
+        for (var i = 0; i < recordCount; i++)
+        {
+            records.Add(new Record
+            {
+                OffsetDelta = i,
+                TimestampDelta = i,
+                Key = Encoding.UTF8.GetBytes($"key-{i}"),
+                IsKeyNull = false,
+                Value = Encoding.UTF8.GetBytes($"value-{i}"),
+                IsValueNull = false,
+                Headers = null,
+                HeaderCount = 0
+            });
+        }
+
+        return PendingFetchData.Create("test-topic", 0,
+        [
+            new RecordBatch
+            {
+                BaseOffset = 0,
+                BaseTimestamp = 1700000000000L,
+                Attributes = 0,
+                Records = records
             }
         ]);
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
@@ -141,6 +141,7 @@ public sealed class FetchResponseBatchBoundaryTests
                 }
 
                 FetchResponsePartition.ReturnRecordBatchList(batches);
+                partition.Records = null;
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -179,6 +179,7 @@ public class ResponseWireFormatSnapshotTests
                 if (batches is List<RecordBatch> pooledBatches)
                 {
                     FetchResponsePartition.ReturnRecordBatchList(pooledBatches);
+                    partition.Records = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove redundant `RecordPollAsync` from every streaming record yield; outer fetch loop still records foreground poll progress
- reuse active consumed-position seqlock generation while topic, partition, and leader epoch remain stable
- keep `GetPosition` and auto-commit position current through a single ordered volatile position write

## Test plan
- [x] unit project Release build (net10.0 + netstandard2.0 library)
- [x] consumer unit namespace: 660 passed
- [x] new auto-commit active-position generation regression
- [x] isolated protocol boundary test passed
- [ ] full suite: 5,087 passed; two parallel-only failures (`FetchResponseBatchBoundaryTests` shared-state mismatch and `ConsumerAssignmentFastPathTests` 10s timing timeout), both relevant scoped tests pass

Closes #1759
