### PR TITLE
Replace batch assignment hashes with epochs

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -12,13 +12,54 @@ namespace Dekaf.Consumer
     internal readonly struct BatchIterationGuard(
         BatchIterationEpoch? epoch,
         int capturedVersion,
-        Func<TopicPartition, bool>? isInitiallyAssigned = null)
+        Func<TopicPartition, bool>? canContinue = null)
     {
-        public bool CanStart(TopicPartition partition) =>
-            (isInitiallyAssigned is null || isInitiallyAssigned(partition))
-            && IsCurrent;
+        public int CapturedVersion => capturedVersion;
 
-        public bool IsCurrent => epoch is null || Volatile.Read(ref epoch.Version) == capturedVersion;
+        public bool CanStart(TopicPartition partition, ref int observedVersion)
+        {
+            if (epoch is null)
+                return canContinue is null || canContinue(partition);
+
+            if (canContinue is null)
+                return Volatile.Read(ref epoch.Version) == observedVersion;
+
+            while (true)
+            {
+                var currentVersion = Volatile.Read(ref epoch.Version);
+                if (!canContinue(partition))
+                    return false;
+
+                if (Volatile.Read(ref epoch.Version) == currentVersion)
+                {
+                    observedVersion = currentVersion;
+                    return true;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsCurrent(TopicPartition partition, ref int observedVersion)
+        {
+            if (epoch is null)
+                return canContinue is null || canContinue(partition);
+
+            while (true)
+            {
+                var currentVersion = Volatile.Read(ref epoch.Version);
+                if (currentVersion == observedVersion)
+                    return true;
+
+                if (canContinue is null || !canContinue(partition))
+                    return false;
+
+                if (Volatile.Read(ref epoch.Version) == currentVersion)
+                {
+                    observedVersion = currentVersion;
+                    return true;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -99,12 +140,16 @@ namespace Dekaf.Consumer
         {
             private readonly ConsumeBatch<TKey, TValue> _batch;
             private readonly bool _canContinue;
+            private int _observedVersion;
             private int _recordsYielded;
 
             internal Enumerator(ConsumeBatch<TKey, TValue> batch)
             {
                 _batch = batch;
-                _canContinue = batch._iterationGuard.CanStart(batch._pendingFetchData.TopicPartition);
+                _observedVersion = batch._iterationGuard.CapturedVersion;
+                _canContinue = batch._iterationGuard.CanStart(
+                    batch._pendingFetchData.TopicPartition,
+                    ref _observedVersion);
                 _recordsYielded = 0;
                 Current = default!;
             }
@@ -126,7 +171,7 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (!_canContinue || !_batch._iterationGuard.IsCurrent)
+                if (!_canContinue || !_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                     return false;
 
                 if (_recordsYielded >= _batch._maxRecords)
@@ -167,7 +212,7 @@ namespace Dekaf.Consumer
                     keyDeserializer: _batch._keyDeserializer,
                     valueDeserializer: _batch._valueDeserializer);
 
-                if (!_batch._iterationGuard.IsCurrent)
+                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                     return false;
 
                 pending.TrackConsumed(offset, messageBytes);

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -6,7 +6,31 @@ namespace Dekaf.Consumer
 {
     internal sealed class BatchIterationEpoch
     {
+        // Seqlock: even versions are stable; odd versions mean assignment/revocation state
+        // is being published and must not be adopted by a batch iterator.
+        private readonly object _publicationLock = new();
         public int Version;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Invalidate()
+        {
+            lock (_publicationLock)
+                Interlocked.Add(ref Version, 2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void BeginPublication()
+        {
+            Monitor.Enter(_publicationLock);
+            Interlocked.Increment(ref Version);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void EndPublication()
+        {
+            Interlocked.Increment(ref Version);
+            Monitor.Exit(_publicationLock);
+        }
     }
 
     internal readonly struct BatchIterationGuard(
@@ -22,11 +46,21 @@ namespace Dekaf.Consumer
                 return canContinue is null || canContinue(partition);
 
             if (canContinue is null)
-                return Volatile.Read(ref epoch.Version) == observedVersion;
+            {
+                var currentVersion = Volatile.Read(ref epoch.Version);
+                return (currentVersion & 1) == 0 && currentVersion == observedVersion;
+            }
 
+            var spin = new SpinWait();
             while (true)
             {
                 var currentVersion = Volatile.Read(ref epoch.Version);
+                if ((currentVersion & 1) != 0)
+                {
+                    spin.SpinOnce();
+                    continue;
+                }
+
                 if (!canContinue(partition))
                     return false;
 
@@ -44,9 +78,16 @@ namespace Dekaf.Consumer
             if (epoch is null)
                 return canContinue is null || canContinue(partition);
 
+            var spin = new SpinWait();
             while (true)
             {
                 var currentVersion = Volatile.Read(ref epoch.Version);
+                if ((currentVersion & 1) != 0)
+                {
+                    spin.SpinOnce();
+                    continue;
+                }
+
                 if (currentVersion == observedVersion)
                     return true;
 

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -4,6 +4,23 @@ using Dekaf.Serialization;
 
 namespace Dekaf.Consumer
 {
+    internal sealed class BatchIterationEpoch
+    {
+        public int Version;
+    }
+
+    internal readonly struct BatchIterationGuard(
+        BatchIterationEpoch? epoch,
+        int capturedVersion,
+        Func<TopicPartition, bool>? isInitiallyAssigned = null)
+    {
+        public bool CanStart(TopicPartition partition) =>
+            (isInitiallyAssigned is null || isInitiallyAssigned(partition))
+            && IsCurrent;
+
+        public bool IsCurrent => epoch is null || Volatile.Read(ref epoch.Version) == capturedVersion;
+    }
+
     /// <summary>
     /// Represents a batch of consume results from a single partition fetch response.
     /// Records within the batch are iterated synchronously, eliminating async state machine
@@ -16,21 +33,21 @@ namespace Dekaf.Consumer
         private readonly PendingFetchData _pendingFetchData;
         private readonly IDeserializer<TKey>? _keyDeserializer;
         private readonly IDeserializer<TValue>? _valueDeserializer;
-        private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
+        private readonly BatchIterationGuard _iterationGuard;
         private readonly int _maxRecords;
         private long _count;
 
         internal ConsumeBatch(PendingFetchData pendingFetchData,
             IDeserializer<TKey>? keyDeserializer,
             IDeserializer<TValue>? valueDeserializer,
-            Func<TopicPartition, bool>? isPartitionStillAssigned = null,
+            BatchIterationGuard iterationGuard = default,
             int maxRecords = int.MaxValue)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
             _keyDeserializer = keyDeserializer;
             _valueDeserializer = valueDeserializer;
-            _isPartitionStillAssigned = isPartitionStillAssigned;
+            _iterationGuard = iterationGuard;
             _maxRecords = maxRecords;
         }
 
@@ -81,11 +98,13 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeResult<TKey, TValue>>
         {
             private readonly ConsumeBatch<TKey, TValue> _batch;
+            private readonly bool _canContinue;
             private int _recordsYielded;
 
             internal Enumerator(ConsumeBatch<TKey, TValue> batch)
             {
                 _batch = batch;
+                _canContinue = batch._iterationGuard.CanStart(batch._pendingFetchData.TopicPartition);
                 _recordsYielded = 0;
                 Current = default!;
             }
@@ -107,11 +126,8 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (_batch._isPartitionStillAssigned is not null
-                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
-                {
+                if (!_canContinue || !_batch._iterationGuard.IsCurrent)
                     return false;
-                }
 
                 if (_recordsYielded >= _batch._maxRecords)
                 {
@@ -151,11 +167,8 @@ namespace Dekaf.Consumer
                     keyDeserializer: _batch._keyDeserializer,
                     valueDeserializer: _batch._valueDeserializer);
 
-                if (_batch._isPartitionStillAssigned is not null
-                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
-                {
+                if (!_batch._iterationGuard.IsCurrent)
                     return false;
-                }
 
                 pending.TrackConsumed(offset, messageBytes);
                 _recordsYielded++;

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -104,12 +104,16 @@ namespace Dekaf.Consumer
         {
             private readonly ConsumeRawBatch _batch;
             private readonly bool _canContinue;
+            private int _observedVersion;
             private int _recordsYielded;
 
             internal Enumerator(ConsumeRawBatch batch)
             {
                 _batch = batch;
-                _canContinue = batch._iterationGuard.CanStart(batch._pendingFetchData.TopicPartition);
+                _observedVersion = batch._iterationGuard.CapturedVersion;
+                _canContinue = batch._iterationGuard.CanStart(
+                    batch._pendingFetchData.TopicPartition,
+                    ref _observedVersion);
                 _recordsYielded = 0;
                 Current = default;
             }
@@ -130,7 +134,7 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (!_canContinue || !_batch._iterationGuard.IsCurrent)
+                if (!_canContinue || !_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                     return false;
 
                 if (_recordsYielded >= _batch._maxRecords)
@@ -161,7 +165,7 @@ namespace Dekaf.Consumer
                     isKeyNull: record.IsKeyNull,
                     isValueNull: record.IsValueNull);
 
-                if (!_batch._iterationGuard.IsCurrent)
+                if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                     return false;
 
                 pending.TrackConsumed(offset, messageBytes);

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -41,18 +41,18 @@ namespace Dekaf.Consumer
     public sealed class ConsumeRawBatch : IEnumerable<ConsumeRawRecord>
     {
         private readonly PendingFetchData _pendingFetchData;
-        private readonly Func<TopicPartition, bool>? _isPartitionStillAssigned;
+        private readonly BatchIterationGuard _iterationGuard;
         private readonly int _maxRecords;
         private long _count;
 
         internal ConsumeRawBatch(
             PendingFetchData pendingFetchData,
-            Func<TopicPartition, bool>? isPartitionStillAssigned = null,
+            BatchIterationGuard iterationGuard = default,
             int maxRecords = int.MaxValue)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
-            _isPartitionStillAssigned = isPartitionStillAssigned;
+            _iterationGuard = iterationGuard;
             _maxRecords = maxRecords;
         }
 
@@ -103,11 +103,13 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeRawRecord>
         {
             private readonly ConsumeRawBatch _batch;
+            private readonly bool _canContinue;
             private int _recordsYielded;
 
             internal Enumerator(ConsumeRawBatch batch)
             {
                 _batch = batch;
+                _canContinue = batch._iterationGuard.CanStart(batch._pendingFetchData.TopicPartition);
                 _recordsYielded = 0;
                 Current = default;
             }
@@ -128,11 +130,8 @@ namespace Dekaf.Consumer
             {
                 PendingFetchData pending = _batch._pendingFetchData;
 
-                if (_batch._isPartitionStillAssigned is not null
-                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
-                {
+                if (!_canContinue || !_batch._iterationGuard.IsCurrent)
                     return false;
-                }
 
                 if (_recordsYielded >= _batch._maxRecords)
                 {
@@ -162,11 +161,8 @@ namespace Dekaf.Consumer
                     isKeyNull: record.IsKeyNull,
                     isValueNull: record.IsValueNull);
 
-                if (_batch._isPartitionStillAssigned is not null
-                    && !_batch._isPartitionStillAssigned(pending.TopicPartition))
-                {
+                if (!_batch._iterationGuard.IsCurrent)
                     return false;
-                }
 
                 pending.TrackConsumed(offset, messageBytes);
                 _recordsYielded++;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -761,6 +761,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _stagedDivergingEpochResetBatches;
     private int _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent;
     private int _coordinatorRevokedPartitionsPendingFetchClearPending;
+    private readonly BatchIterationEpoch _batchIterationEpoch = new();
 
     // Background prefetch support
     private readonly MpscFetchBuffer _prefetchBuffer;
@@ -1914,11 +1915,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the batch to the caller for synchronous iteration
+                    var batchIterationVersion = Volatile.Read(ref _batchIterationEpoch.Version);
                     ConsumeBatch<TKey, TValue> batch = new(
                         pending,
                         _keyDeserializer,
                         _valueDeserializer,
-                        CanContinueBatchIteration,
+                        new BatchIterationGuard(
+                            _batchIterationEpoch,
+                            batchIterationVersion,
+                            CanContinueBatchIteration),
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
@@ -2053,7 +2058,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     pending.EagerParseAll();
 
                     // Yield the raw batch to the caller for synchronous iteration
-                    ConsumeRawBatch batch = new(pending, CanContinueBatchIteration, _options.MaxPollRecords);
+                    var batchIterationVersion = Volatile.Read(ref _batchIterationEpoch.Version);
+                    ConsumeRawBatch batch = new(
+                        pending,
+                        new BatchIterationGuard(
+                            _batchIterationEpoch,
+                            batchIterationVersion,
+                            CanContinueBatchIteration),
+                        _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
                     await RecordPollAsync(cancellationToken).ConfigureAwait(false);
@@ -3921,6 +3933,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Waiting for the consume loop to drain the queued clear lets an ABA reassignment
             // make a stale response look current and advance the reinitialized fetch position.
             InvalidateFetchesForPartitionsLocked(partitions);
+            Interlocked.Increment(ref _batchIterationEpoch.Version);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
         }
@@ -3956,6 +3969,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
         if (startsBatch)
             _stagedDivergingEpochResetBatches++;
+        Interlocked.Increment(ref _batchIterationEpoch.Version);
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
         return true;
     }
@@ -5167,6 +5181,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void PublishAssignmentSnapshot()
     {
         _assignmentSnapshot = new HashSet<TopicPartition>(_assignment);
+        Interlocked.Increment(ref _batchIterationEpoch.Version);
         Interlocked.Increment(ref _assignmentEnsureVersion);
         Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4122,6 +4122,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
         {
             Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+            Interlocked.Increment(ref _batchIterationEpoch.Version);
             recovered = true;
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3933,9 +3933,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Waiting for the consume loop to drain the queued clear lets an ABA reassignment
             // make a stale response look current and advance the reinitialized fetch position.
             InvalidateFetchesForPartitionsLocked(partitions);
-            Interlocked.Increment(ref _batchIterationEpoch.Version);
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+            _batchIterationEpoch.BeginPublication();
+            try
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+            }
+            finally
+            {
+                _batchIterationEpoch.EndPublication();
+            }
         }
     }
 
@@ -3969,8 +3976,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
         if (startsBatch)
             _stagedDivergingEpochResetBatches++;
-        Interlocked.Increment(ref _batchIterationEpoch.Version);
-        Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+        _batchIterationEpoch.BeginPublication();
+        try
+        {
+            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+        }
+        finally
+        {
+            _batchIterationEpoch.EndPublication();
+        }
         return true;
     }
 
@@ -4121,8 +4135,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var recovered = false;
         if (Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) == 0)
         {
-            Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
-            Interlocked.Increment(ref _batchIterationEpoch.Version);
+            _batchIterationEpoch.BeginPublication();
+            try
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+            }
+            finally
+            {
+                _batchIterationEpoch.EndPublication();
+            }
             recovered = true;
         }
 
@@ -5181,8 +5202,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void PublishAssignmentSnapshot()
     {
-        _assignmentSnapshot = new HashSet<TopicPartition>(_assignment);
-        Interlocked.Increment(ref _batchIterationEpoch.Version);
+        var assignmentSnapshot = new HashSet<TopicPartition>(_assignment);
+        _batchIterationEpoch.BeginPublication();
+        try
+        {
+            _assignmentSnapshot = assignmentSnapshot;
+        }
+        finally
+        {
+            _batchIterationEpoch.EndPublication();
+        }
         Interlocked.Increment(ref _assignmentEnsureVersion);
         Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -134,6 +134,35 @@ public class ConsumeBatchTests
         await Assert.That(batch.Count).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ConsumeBatch_UnrelatedEpochChange_DoesNotDropRecord()
+    {
+        using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 2);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var membershipChecks = 0;
+        var batch = new ConsumeBatch<string, string>(
+            pending,
+            Serializers.String,
+            Serializers.String,
+            new BatchIterationGuard(
+                assignmentEpoch,
+                assignmentEpoch.Version,
+                _ =>
+                {
+                    membershipChecks++;
+                    return true;
+                }));
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        assignmentEpoch.Version++;
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        await Assert.That(enumerator.Current.Offset).IsEqualTo(1);
+        await Assert.That(batch.Count).IsEqualTo(2);
+        await Assert.That(membershipChecks).IsEqualTo(2);
+    }
+
     /// <summary>
     /// Creates a PendingFetchData with a single RecordBatch containing the specified number of records.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -128,7 +128,7 @@ public class ConsumeBatchTests
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assignmentEpoch.Version++;
+        assignmentEpoch.Invalidate();
 
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);
@@ -155,12 +155,31 @@ public class ConsumeBatchTests
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assignmentEpoch.Version++;
+        assignmentEpoch.Invalidate();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
         await Assert.That(enumerator.Current.Offset).IsEqualTo(1);
         await Assert.That(batch.Count).IsEqualTo(2);
         await Assert.That(membershipChecks).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task BatchIterationGuard_DoesNotAdoptInProgressPublication()
+    {
+        var assignmentEpoch = new BatchIterationEpoch();
+        assignmentEpoch.BeginPublication();
+        var observedVersion = assignmentEpoch.Version;
+        var guard = new BatchIterationGuard(assignmentEpoch, observedVersion);
+
+        try
+        {
+            await Assert.That(guard.CanStart(new TopicPartition("test-topic", 0), ref observedVersion))
+                .IsFalse();
+        }
+        finally
+        {
+            assignmentEpoch.EndPublication();
+        }
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeBatchTests.cs
@@ -118,17 +118,17 @@ public class ConsumeBatchTests
     public async Task ConsumeBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
     {
         using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
-        var assigned = true;
+        var assignmentEpoch = new BatchIterationEpoch();
         var batch = new ConsumeBatch<string, string>(
             pending,
             Serializers.String,
             Serializers.String,
-            _ => assigned);
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version));
 
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assigned = false;
+        assignmentEpoch.Version++;
 
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -150,16 +150,47 @@ public class ConsumeRawBatchTests
     public async Task ConsumeRawBatch_StopsEnumerationWhenPartitionIsNoLongerAssigned()
     {
         using var pending = CreatePendingFetchData("test-topic", partitionIndex: 0, baseOffset: 0, messageCount: 3);
-        var assigned = true;
-        var batch = new ConsumeRawBatch(pending, _ => assigned);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var batch = new ConsumeRawBatch(
+            pending,
+            new BatchIterationGuard(assignmentEpoch, assignmentEpoch.Version));
 
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assigned = false;
+        assignmentEpoch.Version++;
 
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatch_ChecksPartitionMembershipOncePerEnumeration()
+    {
+        using var pending = CreatePendingFetchData(
+            "test-topic",
+            partitionIndex: 0,
+            baseOffset: 0,
+            messageCount: 3);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var membershipChecks = 0;
+        var batch = new ConsumeRawBatch(
+            pending,
+            new BatchIterationGuard(
+                assignmentEpoch,
+                assignmentEpoch.Version,
+                _ =>
+                {
+                    membershipChecks++;
+                    return true;
+                }));
+
+        foreach (var _ in batch)
+        {
+        }
+
+        await Assert.That(batch.Count).IsEqualTo(3);
+        await Assert.That(membershipChecks).IsEqualTo(1);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -193,6 +193,37 @@ public class ConsumeRawBatchTests
         await Assert.That(membershipChecks).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ConsumeRawBatch_UnrelatedEpochChange_DoesNotDropRecord()
+    {
+        using var pending = CreatePendingFetchData(
+            "test-topic",
+            partitionIndex: 0,
+            baseOffset: 0,
+            messageCount: 2);
+        var assignmentEpoch = new BatchIterationEpoch();
+        var membershipChecks = 0;
+        var batch = new ConsumeRawBatch(
+            pending,
+            new BatchIterationGuard(
+                assignmentEpoch,
+                assignmentEpoch.Version,
+                _ =>
+                {
+                    membershipChecks++;
+                    return true;
+                }));
+        using var enumerator = batch.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        assignmentEpoch.Version++;
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        await Assert.That(enumerator.Current.Offset).IsEqualTo(1);
+        await Assert.That(batch.Count).IsEqualTo(2);
+        await Assert.That(membershipChecks).IsEqualTo(2);
+    }
+
     /// <summary>
     /// Creates a PendingFetchData with a single RecordBatch containing the specified number of records.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeRawBatchTests.cs
@@ -158,7 +158,7 @@ public class ConsumeRawBatchTests
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assignmentEpoch.Version++;
+        assignmentEpoch.Invalidate();
 
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(batch.Count).IsEqualTo(1);
@@ -216,7 +216,7 @@ public class ConsumeRawBatchTests
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
-        assignmentEpoch.Version++;
+        assignmentEpoch.Invalidate();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
         await Assert.That(enumerator.Current.Offset).IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -580,10 +580,12 @@ public sealed class ConsumerAssignmentFastPathTests
         // before the fetch response is complete.
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        var batchIterationVersion = GetBatchIterationVersion(consumer);
         SetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer, 0);
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
+        await Assert.That(GetBatchIterationVersion(consumer)).IsEqualTo(batchIterationVersion + 1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).ContainsKey(partition);
 
         CompleteDivergingEpochResets(consumer);
@@ -1197,6 +1199,16 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_fetchBufferEpoch field not found.");
 
         return (int)field.GetValue(consumer)!;
+    }
+
+    private static int GetBatchIterationVersion(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_batchIterationEpoch",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_batchIterationEpoch field not found.");
+
+        return ((BatchIterationEpoch)field.GetValue(consumer)!).Version;
     }
 
     private static int GetMinimumFetchBufferEpoch(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -585,7 +585,7 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsFalse();
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearMarkerPresent(consumer)).IsEqualTo(1);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClearPending(consumer)).IsEqualTo(0);
-        await Assert.That(GetBatchIterationVersion(consumer)).IsEqualTo(batchIterationVersion + 1);
+        await Assert.That(GetBatchIterationVersion(consumer)).IsEqualTo(batchIterationVersion + 2);
         await Assert.That(GetCoordinatorRevokedPartitionsPendingFetchClear(consumer)).ContainsKey(partition);
 
         CompleteDivergingEpochResets(consumer);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -383,7 +383,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             pending,
             Serializers.String,
             Serializers.String,
-            GetCanContinueBatchIteration(consumer));
+            GetBatchIterationGuard(consumer));
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
@@ -418,7 +418,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             pending,
             keyDeserializer,
             Serializers.String,
-            GetCanContinueBatchIteration(consumer));
+            GetBatchIterationGuard(consumer));
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsFalse();
@@ -570,7 +570,7 @@ public sealed class ConsumerLeaderDiscoveryTests
 
         var pending = CreatePendingFetchData();
         GetPendingFetches(consumer).Enqueue(pending);
-        var batch = new ConsumeRawBatch(pending, GetCanContinueBatchIteration(consumer));
+        var batch = new ConsumeRawBatch(pending, GetBatchIterationGuard(consumer));
         using var enumerator = batch.GetEnumerator();
 
         await Assert.That(enumerator.MoveNext()).IsTrue();
@@ -579,24 +579,6 @@ public sealed class ConsumerLeaderDiscoveryTests
         await Assert.That(enumerator.MoveNext()).IsFalse();
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
         await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task RawBatch_RechecksAssignmentBeforeTrackingRecord()
-    {
-        var pool = Substitute.For<IConnectionPool>();
-        await using var metadataManager = CreateMetadataManager(pool);
-        await using var consumer = CreateConsumer(pool, metadataManager);
-        var pending = CreatePendingFetchData();
-        GetPendingFetches(consumer).Enqueue(pending);
-        var assignmentChecks = 0;
-        var batch = new ConsumeRawBatch(
-            pending,
-            _ => Interlocked.Increment(ref assignmentChecks) == 1);
-        using var enumerator = batch.GetEnumerator();
-
-        await Assert.That(enumerator.MoveNext()).IsFalse();
-        await Assert.That(assignmentChecks).IsEqualTo(2);
     }
 
     [Test]
@@ -865,15 +847,22 @@ public sealed class ConsumerLeaderDiscoveryTests
         return pending;
     }
 
-    private static Func<TopicPartition, bool> GetCanContinueBatchIteration(
+    private static BatchIterationGuard GetBatchIterationGuard(
         KafkaConsumer<string, string> consumer)
     {
-        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var assignmentMethod = consumerType.GetMethod(
             "CanContinueBatchIteration",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("CanContinueBatchIteration method not found");
+        var epochField = consumerType.GetField(
+            "_batchIterationEpoch",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_batchIterationEpoch field not found");
 
-        return method.CreateDelegate<Func<TopicPartition, bool>>(consumer);
+        var isAssigned = assignmentMethod.CreateDelegate<Func<TopicPartition, bool>>(consumer);
+        var epoch = (BatchIterationEpoch)epochField.GetValue(consumer)!;
+        return new BatchIterationGuard(epoch, Volatile.Read(ref epoch.Version), isAssigned);
     }
 
     private static async ValueTask InvokeHandleLeaderEpochRefreshAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1261,7 +1261,7 @@ public sealed class PartitionedConsumerRuntimeTests
                     pending,
                     Serializers.String,
                     Serializers.String,
-                    IsAssigned);
+                    new BatchIterationGuard(null, 0, IsAssigned));
             }
         }
 

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
@@ -141,6 +141,7 @@ public sealed class FetchResponseBatchBoundaryTests
                 }
 
                 FetchResponsePartition.ReturnRecordBatchList(batches);
+                partition.Records = null;
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -179,6 +179,7 @@ public class ResponseWireFormatSnapshotTests
                 if (batches is List<RecordBatch> pooledBatches)
                 {
                     FetchResponsePartition.ReturnRecordBatchList(pooledBatches);
+                    partition.Records = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- cache partition membership once when each decoded/raw batch enumeration starts
- replace two per-record `TopicPartition` hash lookups with direct volatile assignment-epoch comparisons
- bump batch epoch on assignment publication, coordinator revocation, and divergence-reset staging
- preserve checks both before record construction and before tracking delivery

## Test plan
- [x] Release unit-project build (net10.0 + netstandard2.0 library)
- [x] consumer namespace: 658 passed
- [x] `ConsumeBatchTests`: 8 passed
- [x] `ConsumeRawBatchTests`: 9 passed
- [x] `ConsumerLeaderDiscoveryTests`: 22 passed
- [x] `ConsumerAssignmentFastPathTests`: 28 passed

Closes #1760
