### PR TITLE
Ratchet record wrapper pools from prefetch memory

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1088,6 +1088,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (options.EnableAdaptiveFetchSizing)
         {
             _adaptiveFetchSizer = new AdaptiveFetchSizer(ResolveAdaptiveFetchSizingOptions(options));
+            RatchetRecordWrapperPools(partitionCount: 64);
         }
 
         if (!string.IsNullOrEmpty(options.GroupId))
@@ -1770,7 +1771,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     if (batchProcessingStarted.HasValue)
                     {
                         var processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
-                        _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
+                        ReportAdaptiveProcessingComplete(processingDuration);
                     }
 
                     // Dequeue and dispose the pending fetch (releases pooled network buffer memory)
@@ -2101,7 +2102,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (batchProcessingStarted.HasValue)
         {
             TimeSpan processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
-            _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
+            ReportAdaptiveProcessingComplete(processingDuration);
         }
 
         if (disposePending || pending.IsExhausted || !IsCurrentlyAssigned(pending.TopicPartition))
@@ -3520,7 +3521,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (batchProcessingStarted.HasValue)
             {
                 var processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
-                _adaptiveFetchSizer!.ReportProcessingComplete(processingDuration);
+                ReportAdaptiveProcessingComplete(processingDuration);
             }
 
             DequeuePendingFetch().Dispose();
@@ -6447,12 +6448,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var prefetchMaxBytes = CalculatePrefetchMaxBytes(
             (int)Math.Min(CurrentQueuedMaxBytes / 1024, int.MaxValue),
             Math.Max(1, partitionCount),
-            _options.MaxPartitionFetchBytes,
-            _options.FetchMaxBytes,
+            _adaptiveFetchSizer?.CurrentPartitionFetchBytes ?? _options.MaxPartitionFetchBytes,
+            _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes,
             _options.PrefetchPipelineDepth);
         var wrapperPoolSize = PoolSizing.ForConsumerRecordWrappers(prefetchMaxBytes);
         RecordBatch.RatchetPoolSize(wrapperPoolSize);
         LazyRecordList.RatchetPoolSize(wrapperPoolSize);
+    }
+
+    private void ReportAdaptiveProcessingComplete(TimeSpan processingDuration)
+    {
+        var sizer = _adaptiveFetchSizer;
+        if (sizer is null)
+            return;
+
+        var previousPartitionFetchBytes = sizer.CurrentPartitionFetchBytes;
+        var previousFetchMaxBytes = sizer.CurrentFetchMaxBytes;
+        sizer.ReportProcessingComplete(processingDuration);
+
+        if (sizer.CurrentPartitionFetchBytes > previousPartitionFetchBytes
+            || sizer.CurrentFetchMaxBytes > previousFetchMaxBytes)
+        {
+            RatchetRecordWrapperPools(_assignmentSnapshot.Count);
+        }
     }
 
     private async Task StartAutoCommitAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -678,6 +678,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     void IBudgetedInstance.OnBudgetChanged(ulong newLimit)
     {
         Interlocked.Exchange(ref _currentQueuedMaxBytes, (long)newLimit);
+        RatchetRecordWrapperPools(_assignmentSnapshot.Count);
     }
 
     private readonly IDeserializer<TKey> _keyDeserializer;
@@ -1031,6 +1032,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // PendingFetchData uses a ratchet, so this only increases over time.
         var consumerSizes = PoolSizing.ForConsumer(maxPartitionCount: 64);
         PendingFetchData.RatchetPoolSize(consumerSizes.FetchDataPool);
+        RatchetRecordWrapperPools(partitionCount: 64);
         _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
         _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
 
@@ -6430,13 +6432,27 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     /// <summary>
     /// Ratchets process-global consumer pool sizes based on actual partition count.
-    /// Only <see cref="PendingFetchData"/> is ratcheted — the per-instance CTS pool
-    /// is fixed at construction and cannot be resized after creation.
+    /// Pending fetch and record wrapper pools grow process-wide; the per-instance
+    /// CTS pool is fixed at construction and cannot be resized after creation.
     /// </summary>
-    private static void RatchetConsumerPoolSizes(int partitionCount)
+    private void RatchetConsumerPoolSizes(int partitionCount)
     {
         var sizes = PoolSizing.ForConsumer(partitionCount);
         PendingFetchData.RatchetPoolSize(sizes.FetchDataPool);
+        RatchetRecordWrapperPools(partitionCount);
+    }
+
+    private void RatchetRecordWrapperPools(int partitionCount)
+    {
+        var prefetchMaxBytes = CalculatePrefetchMaxBytes(
+            (int)Math.Min(CurrentQueuedMaxBytes / 1024, int.MaxValue),
+            Math.Max(1, partitionCount),
+            _options.MaxPartitionFetchBytes,
+            _options.FetchMaxBytes,
+            _options.PrefetchPipelineDepth);
+        var wrapperPoolSize = PoolSizing.ForConsumerRecordWrappers(prefetchMaxBytes);
+        RecordBatch.RatchetPoolSize(wrapperPoolSize);
+        LazyRecordList.RatchetPoolSize(wrapperPoolSize);
     }
 
     private async Task StartAutoCommitAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -114,6 +114,16 @@ internal static class PoolSizing
         };
     }
 
+    internal static int ForConsumerRecordWrappers(long prefetchMaxBytes)
+    {
+        const int estimatedWireBatchBytes = 16 * 1024;
+        const int minWrappers = 2048;
+        const int maxWrappers = 65536;
+
+        var estimatedLiveBatches = Math.Max(1L, prefetchMaxBytes) / estimatedWireBatchBytes;
+        return (int)Math.Clamp(estimatedLiveBatches, minWrappers, maxWrappers);
+    }
+
     internal static int ForConsumerPrefetchBuffer(
         int queuedMaxMessagesKbytes,
         int maxPartitionFetchBytes,

--- a/src/Dekaf/Producer/ObjectPool.cs
+++ b/src/Dekaf/Producer/ObjectPool.cs
@@ -16,18 +16,20 @@ namespace Dekaf.Producer;
 /// <typeparam name="T">The pooled item type. Must be a reference type.</typeparam>
 internal abstract class ObjectPool<T> where T : class
 {
-    private readonly LockFreeStack<T> _stack;
+    private LockFreeStack<T> _stack;
+    private readonly Lock _resizeLock = new();
+    private int _maxPoolSize;
     private long _misses;
 
     /// <summary>
     /// Maximum number of items the pool will retain. Excess items are discarded for GC.
     /// </summary>
-    public int MaxPoolSize { get; }
+    public int MaxPoolSize => Volatile.Read(ref _maxPoolSize);
 
     /// <summary>
     /// Approximate number of items currently in the pool.
     /// </summary>
-    public int ApproximateCount => _stack.Count;
+    public int ApproximateCount => Volatile.Read(ref _stack).Count;
 
     /// <summary>
     /// Number of times <see cref="Rent"/> found the pool empty and had to allocate.
@@ -38,7 +40,7 @@ internal abstract class ObjectPool<T> where T : class
     protected ObjectPool(int maxPoolSize)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
-        MaxPoolSize = maxPoolSize;
+        _maxPoolSize = maxPoolSize;
         _stack = new LockFreeStack<T>(maxPoolSize);
     }
 
@@ -61,7 +63,7 @@ internal abstract class ObjectPool<T> where T : class
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T Rent()
     {
-        if (_stack.TryPop(out var item))
+        if (Volatile.Read(ref _stack).TryPop(out var item))
             return item;
 
         Interlocked.Increment(ref _misses);
@@ -80,7 +82,34 @@ internal abstract class ObjectPool<T> where T : class
     public void Return(T item)
     {
         Reset(item);
-        _stack.TryPush(item);
+        Volatile.Read(ref _stack).TryPush(item);
+    }
+
+    /// <summary>
+    /// Increases retained capacity while preserving items already in the pool.
+    /// A concurrent return through a stale stack reference may be lost during the
+    /// one-time migration; later returns use the newly published pool.
+    /// </summary>
+    public void RatchetMaxPoolSize(int newSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(newSize);
+        InterlockedHelper.RatchetUp(ref _maxPoolSize, newSize);
+
+        var currentPool = Volatile.Read(ref _stack);
+        if (currentPool.Capacity >= newSize)
+            return;
+
+        lock (_resizeLock)
+        {
+            currentPool = Volatile.Read(ref _stack);
+            if (currentPool.Capacity >= newSize)
+                return;
+
+            var newPool = new LockFreeStack<T>(newSize);
+            while (currentPool.TryPop(out var item))
+                newPool.TryPush(item);
+            Volatile.Write(ref _stack, newPool);
+        }
     }
 
     /// <summary>
@@ -95,7 +124,7 @@ internal abstract class ObjectPool<T> where T : class
         for (var i = 0; i < count; i++)
         {
             var item = Create();
-            if (!_stack.TryPush(item))
+            if (!Volatile.Read(ref _stack).TryPush(item))
                 break;
         }
     }
@@ -106,6 +135,6 @@ internal abstract class ObjectPool<T> where T : class
     /// </summary>
     public void Clear()
     {
-        _stack.Clear();
+        Volatile.Read(ref _stack).Clear();
     }
 }

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -593,6 +593,10 @@ public sealed class RecordBatch : IDisposable
     // Reuses ObjectPool<T> for zero-alloc CAS-based pooling with miss tracking and exception safety.
     private static readonly RecordBatchPool s_pool = new();
 
+    internal static int MaxPoolSizeValue => s_pool.MaxPoolSize;
+
+    internal static void RatchetPoolSize(int newSize) => s_pool.RatchetMaxPoolSize(newSize);
+
     private sealed class RecordBatchPool : ObjectPool<RecordBatch>
     {
         public RecordBatchPool() : base(maxPoolSize: 2048) { }
@@ -1184,8 +1188,18 @@ internal readonly struct PooledRecordData
 internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
 {
     // Pool for reusing LazyRecordList instances to eliminate per-batch class allocation.
-    private const int MaxPooledInstances = 256;
-    private static readonly LockFreeStack<LazyRecordList> s_instancePool = new(MaxPooledInstances);
+    private const int DefaultMaxPooledInstances = 256;
+    private static readonly LazyRecordListPool s_instancePool = new();
+
+    private sealed class LazyRecordListPool() : ObjectPool<LazyRecordList>(DefaultMaxPooledInstances)
+    {
+        protected override LazyRecordList Create() => new();
+        protected override void Reset(LazyRecordList item) { }
+    }
+
+    internal static int MaxPoolSizeValue => s_instancePool.MaxPoolSize;
+
+    internal static void RatchetPoolSize(int newSize) => s_instancePool.RatchetMaxPoolSize(newSize);
 
     private ReadOnlyMemory<byte> _rawData;
     private byte[]? _pooledArray; // Track pooled array for cleanup (mutable for idempotent dispose)
@@ -1224,13 +1238,9 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static LazyRecordList Rent()
     {
-        if (s_instancePool.TryPop(out var instance))
-        {
-            Volatile.Write(ref instance._disposed, 0);
-            return instance;
-        }
-
-        return new LazyRecordList();
+        var instance = s_instancePool.Rent();
+        Volatile.Write(ref instance._disposed, 0);
+        return instance;
     }
 
     public int Count => _count;
@@ -1403,7 +1413,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
         _nextParseOffset = 0;
 
         // Return to pool. If full, let GC handle this instance.
-        s_instancePool.TryPush(this);
+        s_instancePool.Return(this);
     }
 }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Internal;
@@ -25,6 +26,45 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
         ((IBudgetedInstance)consumer).OnBudgetChanged(512UL * 1024 * 1024);
         var expected = PoolSizing.ForConsumerRecordWrappers(512L * 1024 * 1024);
 
+        await Assert.That(RecordBatch.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
+        await Assert.That(LazyRecordList.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
+    }
+
+    [Test]
+    public async Task AdaptiveFetchGrowth_RatchetsRecordWrapperPools()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMinMessages = 2,
+            EnableAdaptiveFetchSizing = true,
+            AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+            {
+                MinPartitionFetchBytes = 1024 * 1024,
+                InitialPartitionFetchBytes = 1024 * 1024,
+                MaxPartitionFetchBytes = 256 * 1024 * 1024,
+                MinFetchMaxBytes = 1024 * 1024,
+                InitialFetchMaxBytes = 16 * 1024 * 1024,
+                MaxFetchMaxBytes = 512 * 1024 * 1024,
+                GrowthFactor = 2,
+                StableWindowCount = 1
+            }
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        var sizer = GetAdaptiveFetchSizer(consumer);
+        SetFetchTiming(sizer, TimeSpan.FromSeconds(1));
+
+        GetReportAdaptiveProcessingComplete().Invoke(consumer, [TimeSpan.FromMilliseconds(1)]);
+
+        var expectedBytes = Math.Min(
+            (long)sizer.CurrentFetchMaxBytes,
+            64L * sizer.CurrentPartitionFetchBytes);
+        var expected = PoolSizing.ForConsumerRecordWrappers(expectedBytes);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(32 * 1024 * 1024);
         await Assert.That(RecordBatch.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
         await Assert.That(LazyRecordList.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
     }
@@ -78,5 +118,33 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
         return typeof(KafkaConsumer<string, string>)
             .GetMethod("TrackPrefetchedBytes", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("TrackPrefetchedBytes method not found - was it renamed?");
+    }
+
+    private static AdaptiveFetchSizer GetAdaptiveFetchSizer(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField("_adaptiveFetchSizer", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_adaptiveFetchSizer field not found - was it renamed?");
+
+        return (AdaptiveFetchSizer)field.GetValue(consumer)!;
+    }
+
+    private static void SetFetchTiming(AdaptiveFetchSizer sizer, TimeSpan duration)
+    {
+        var startField = typeof(AdaptiveFetchSizer)
+            .GetField("_lastFetchStartTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var endField = typeof(AdaptiveFetchSizer)
+            .GetField("_lastFetchEndTimestamp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var end = Stopwatch.GetTimestamp();
+        var start = end - (long)(duration.TotalSeconds * Stopwatch.Frequency);
+        startField.SetValue(sizer, start);
+        endField.SetValue(sizer, end);
+    }
+
+    private static MethodInfo GetReportAdaptiveProcessingComplete()
+    {
+        return typeof(KafkaConsumer<string, string>)
+            .GetMethod("ReportAdaptiveProcessingComplete", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ReportAdaptiveProcessingComplete method not found - was it renamed?");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Internal;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 
@@ -7,6 +8,27 @@ namespace Dekaf.Tests.Unit.Consumer;
 
 public sealed class KafkaConsumerPrefetchMemorySignalTests
 {
+    [Test]
+    public async Task BudgetGrowth_RatchetsRecordWrapperPools()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            QueuedMinMessages = 2
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        ((IBudgetedInstance)consumer).OnBudgetChanged(512UL * 1024 * 1024);
+        var expected = PoolSizing.ForConsumerRecordWrappers(512L * 1024 * 1024);
+
+        await Assert.That(RecordBatch.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
+        await Assert.That(LazyRecordList.MaxPoolSizeValue).IsGreaterThanOrEqualTo(expected);
+    }
+
     [Test]
     public async Task TrackPrefetchedBytes_RepeatedRelease_DoesNotAccumulateMemorySignals()
     {

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -198,6 +198,15 @@ public class PoolSizingTests
     }
 
     [Test]
+    [Arguments(16L * 1024 * 1024, 2048)]
+    [Arguments(64L * 1024 * 1024, 4096)]
+    [Arguments(2L * 1024 * 1024 * 1024, 65536)]
+    public async Task ForConsumerRecordWrappers_ScalesWithPrefetchBytes(long bytes, int expected)
+    {
+        await Assert.That(PoolSizing.ForConsumerRecordWrappers(bytes)).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task ForConsumerPrefetchBuffer_PathologicalPipelineInputs_ClampsToMax()
     {
         var capacity = PoolSizing.ForConsumerPrefetchBuffer(

--- a/tests/Dekaf.Tests.Unit/Producer/ObjectPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ObjectPoolTests.cs
@@ -151,6 +151,29 @@ public class ObjectPoolTests
     }
 
     [Test]
+    public async Task RatchetMaxPoolSize_GrowsAndPreservesPooledItems()
+    {
+        var pool = new TestPool(1);
+        var item = pool.Rent();
+        pool.Return(item);
+
+        pool.RatchetMaxPoolSize(4);
+
+        await Assert.That(pool.MaxPoolSize).IsEqualTo(4);
+        await Assert.That(pool.Rent()).IsSameReferenceAs(item);
+    }
+
+    [Test]
+    public async Task RatchetMaxPoolSize_DoesNotShrink()
+    {
+        var pool = new TestPool(4);
+
+        pool.RatchetMaxPoolSize(2);
+
+        await Assert.That(pool.MaxPoolSize).IsEqualTo(4);
+    }
+
+    [Test]
     [Repeat(10)]
     public async Task ConcurrentRentReturn_MaintainsBounds()
     {

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -328,4 +328,15 @@ public class LazyRecordListTests
         list.Dispose();
         list.Dispose();
     }
+
+    [Test]
+    public async Task LazyRecordList_RatchetPoolSize_GrowsAndDoesNotShrink()
+    {
+        var target = LazyRecordList.MaxPoolSizeValue + 1;
+
+        LazyRecordList.RatchetPoolSize(target);
+        LazyRecordList.RatchetPoolSize(1);
+
+        await Assert.That(LazyRecordList.MaxPoolSizeValue).IsGreaterThanOrEqualTo(target);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1134,6 +1134,17 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task RecordBatch_RatchetPoolSize_GrowsAndDoesNotShrink()
+    {
+        var target = RecordBatch.MaxPoolSizeValue + 1;
+
+        RecordBatch.RatchetPoolSize(target);
+        RecordBatch.RatchetPoolSize(1);
+
+        await Assert.That(RecordBatch.MaxPoolSizeValue).IsGreaterThanOrEqualTo(target);
+    }
+
+    [Test]
     public async Task RecordBatch_PooledBatch_ClearsStaleRecordsOnReturn()
     {
         var buffer = new ArrayBufferWriter<byte>();


### PR DESCRIPTION
## Summary
- make shared `ObjectPool<T>` capacity monotonically resizable while preserving pooled items
- derive record-wrapper capacity from effective consumer prefetch bytes (16KB observed wire-batch estimate, bounded 2,048–65,536)
- ratchet `RecordBatch` and `LazyRecordList` pools at construction, assignment growth, and memory-budget growth
- retain existing concurrent stale-return safety during one-time pool migration

## Test plan
- [x] Release unit-project build (net10.0 + netstandard2.0 library)
- [x] focused pool/protocol/sizing/budget tests: 120 passed
- [x] full suite: 5,096 passed; known parallel-only `EnsureAssignmentForPollAsync_SlowPositionInitialization_DoesNotExpireMember` 10s timeout, passed isolated in 721ms

Closes #1777
