### PR TITLE
perf: share warm pipe pools across clients

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -26,9 +26,9 @@ public sealed partial class ConnectionPool : IConnectionPool
     private Task? _idleReaperTask;
 
     /// <summary>
-    /// Shared memory pool for all connections. Bounds total retained memory to one set of
-    /// array buckets regardless of connection count, preventing multi-GB WorkingSet growth
-    /// in multi-broker scenarios with adaptive scaling. See <see cref="PipeMemoryPool"/>.
+    /// Process-shared memory pool for all clients with this size configuration. Bounds total
+    /// retained memory to one set of array buckets, preventing per-client cold starts and
+    /// multi-GB WorkingSet growth in multi-broker scenarios. See <see cref="PipeMemoryPool"/>.
     /// Bucket capacity is either provided by broker-aware producer sizing or falls back to
     /// scaling by <c>_connectionsPerBroker</c> for direct ConnectionPool use.
     /// </summary>
@@ -112,7 +112,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _responseBufferPool = responseBufferPool;
         _telemetryMetricCollector = telemetryMetricCollector;
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
-        _sharedPipeMemoryPool = new PipeMemoryPool(maxArraysPerBucket: bucketCapacity);
+        _sharedPipeMemoryPool = PipeMemoryPool.Create(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
         StartIdleConnectionReaper();
     }
@@ -220,9 +220,8 @@ public sealed partial class ConnectionPool : IConnectionPool
     /// exceeds the current value. New connections will use the larger pool; existing connections
     /// continue using the previous pool until they are recycled.
     /// <para/>
-    /// The previous pool is not disposed during the swap because active pipes may still return
-    /// segments to it. Its lifetime is bounded by the connections that captured it: once those
-    /// connections and their in-flight pipe segments are gone, the old pool becomes GC-eligible.
+    /// Pools remain process-wide so active pipes and later client sessions can reuse returned
+    /// segments without disposal races or cold-start allocations.
     /// </summary>
     internal void RatchetPipeMemoryBucketCapacity(int bucketCapacity)
     {
@@ -234,7 +233,9 @@ public sealed partial class ConnectionPool : IConnectionPool
             if (bucketCapacity <= _currentPipeMemoryBucketCapacity)
                 return;
 
-            Volatile.Write(ref _sharedPipeMemoryPool, new PipeMemoryPool(maxArraysPerBucket: bucketCapacity));
+            Volatile.Write(
+                ref _sharedPipeMemoryPool,
+                PipeMemoryPool.Create(maxArraysPerBucket: bucketCapacity));
             Volatile.Write(ref _currentPipeMemoryBucketCapacity, bucketCapacity);
         }
     }
@@ -1366,11 +1367,6 @@ public sealed partial class ConnectionPool : IConnectionPool
         _idleReaperCts?.Dispose();
 
         await CloseAllAsync().ConfigureAwait(false);
-
-        // Dispose the shared memory pool only when the pool itself is disposed.
-        // Public CloseAllAsync is a reset/reconnect operation; keeping the pool alive
-        // lets subsequent connections reuse it without tripping ObjectDisposedException.
-        _sharedPipeMemoryPool?.Dispose();
 
         _sharedOAuthBearerTokenProvider?.Dispose();
         _disposeLock.Dispose();

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -18,22 +18,28 @@ namespace Dekaf.Networking;
 /// WorkingSet growth proportional to the number of brokers — even though individual
 /// connections properly return their buffers.
 /// <para/>
-/// <b>Shared pool design:</b> <see cref="Create"/> shares one <see cref="PipeMemoryPool"/>
-/// process-wide for each size configuration. This bounds total retained memory to one set of
-/// array buckets (maxArraysPerBucket × bucketCount) regardless of how many clients or connections
-/// exist. Without sharing, each connection independently retained up to
+/// <b>Shared pool design:</b> <see cref="Create"/> shares a bounded set of
+/// <see cref="PipeMemoryPool"/> instances process-wide by size configuration. This bounds retained
+/// memory for common configurations to one set of array buckets (maxArraysPerBucket × bucketCount)
+/// regardless of how many clients or connections exist. Without sharing, each connection
+/// independently retained up to
 /// <c>maxArraysPerBucket</c> arrays per size class — with 3 brokers × 10 connections/broker
 /// = 30 independent pools, each retaining arrays in large buckets, causing multi-GB
 /// WorkingSet growth. With a shared pool, one configured bucket depth is recycled across
 /// all connections instead of multiplying retention by connection count.
+/// The cache retains at most 16 configurations. Eviction removes only the cache reference;
+/// active connections keep using their pool, which becomes GC-eligible after they release it.
 /// <para/>
 /// Connections created outside a <see cref="ConnectionPool"/> (e.g., in tests) fall back
 /// to creating their own per-connection pool for backward compatibility.
 /// </summary>
 internal sealed class PipeMemoryPool : MemoryPool<byte>
 {
-    private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), PipeMemoryPool>
-        s_sharedPools = new();
+    private const int MaxSharedPoolConfigurations = 16;
+    private static readonly object s_sharedPoolsLock = new();
+    private static readonly Dictionary<(int MaxArrayLength, int MaxArraysPerBucket), PipeMemoryPool>
+        s_sharedPools = [];
+    private static readonly Queue<(int MaxArrayLength, int MaxArraysPerBucket)> s_sharedPoolOrder = [];
 
     private readonly ArrayPool<byte> _pool;
     private readonly ConcurrentStack<PooledMemoryOwner> _ownerPool = new();
@@ -80,11 +86,33 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     internal static PipeMemoryPool Create(
         int maxArrayLength = 4 * 1024 * 1024,
         int maxArraysPerBucket = 32)
-        => s_sharedPools.GetOrAdd(
-            (maxArrayLength, maxArraysPerBucket),
-            static configuration => new PipeMemoryPool(
-                configuration.MaxArrayLength,
-                configuration.MaxArraysPerBucket));
+    {
+        var configuration = (maxArrayLength, maxArraysPerBucket);
+
+        lock (s_sharedPoolsLock)
+        {
+            if (s_sharedPools.TryGetValue(configuration, out var sharedPool))
+                return sharedPool;
+
+            sharedPool = new PipeMemoryPool(maxArrayLength, maxArraysPerBucket);
+
+            if (s_sharedPools.Count == MaxSharedPoolConfigurations)
+                s_sharedPools.Remove(s_sharedPoolOrder.Dequeue());
+
+            s_sharedPools.Add(configuration, sharedPool);
+            s_sharedPoolOrder.Enqueue(configuration);
+            return sharedPool;
+        }
+    }
+
+    internal static int SharedPoolCount
+    {
+        get
+        {
+            lock (s_sharedPoolsLock)
+                return s_sharedPools.Count;
+        }
+    }
 
     // Returns int.MaxValue to match MemoryPool<byte>.Shared behavior.
     // System.IO.Pipelines does not rely on MaxBufferSize for sizing decisions;

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -18,10 +18,10 @@ namespace Dekaf.Networking;
 /// WorkingSet growth proportional to the number of brokers — even though individual
 /// connections properly return their buffers.
 /// <para/>
-/// <b>Shared pool design:</b> A single <see cref="PipeMemoryPool"/> is shared across all
-/// connections managed by a <see cref="ConnectionPool"/>. This bounds total retained memory
-/// to one set of array buckets (maxArraysPerBucket × bucketCount) regardless of how many
-/// connections exist. Without sharing, each connection independently retained up to
+/// <b>Shared pool design:</b> <see cref="Create"/> shares one <see cref="PipeMemoryPool"/>
+/// process-wide for each size configuration. This bounds total retained memory to one set of
+/// array buckets (maxArraysPerBucket × bucketCount) regardless of how many clients or connections
+/// exist. Without sharing, each connection independently retained up to
 /// <c>maxArraysPerBucket</c> arrays per size class — with 3 brokers × 10 connections/broker
 /// = 30 independent pools, each retaining arrays in large buckets, causing multi-GB
 /// WorkingSet growth. With a shared pool, one configured bucket depth is recycled across
@@ -32,6 +32,9 @@ namespace Dekaf.Networking;
 /// </summary>
 internal sealed class PipeMemoryPool : MemoryPool<byte>
 {
+    private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), PipeMemoryPool>
+        s_sharedPools = new();
+
     private readonly ArrayPool<byte> _pool;
     private readonly ConcurrentStack<PooledMemoryOwner> _ownerPool = new();
     private int _ownerPoolCount;
@@ -73,6 +76,15 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     {
         _pool = ArrayPool<byte>.Create(maxArrayLength, maxArraysPerBucket);
     }
+
+    internal static PipeMemoryPool Create(
+        int maxArrayLength = 4 * 1024 * 1024,
+        int maxArraysPerBucket = 32)
+        => s_sharedPools.GetOrAdd(
+            (maxArrayLength, maxArraysPerBucket),
+            static configuration => new PipeMemoryPool(
+                configuration.MaxArrayLength,
+                configuration.MaxArraysPerBucket));
 
     // Returns int.MaxValue to match MemoryPool<byte>.Shared behavior.
     // System.IO.Pipelines does not rely on MaxBufferSize for sizing decisions;

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -132,14 +132,20 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task DisposeAsync_DisposesSharedPipeMemoryPool()
+    public async Task ConnectionPools_WithSameConfiguration_SharePipeMemoryPool()
     {
-        var pool = new ConnectionPool("test-client");
-        var sharedPool = GetSharedPipeMemoryPool(pool);
+        var first = new ConnectionPool("first-client");
+        var second = new ConnectionPool("second-client");
+        var firstSharedPool = GetSharedPipeMemoryPool(first);
+        var secondSharedPool = GetSharedPipeMemoryPool(second);
 
-        await pool.DisposeAsync();
+        await first.DisposeAsync();
 
-        await Assert.That(() => sharedPool.Rent(1)).Throws<ObjectDisposedException>();
+        await Assert.That(firstSharedPool).IsSameReferenceAs(secondSharedPool);
+        using var owner = secondSharedPool.Rent(1);
+        await Assert.That(owner.Memory.Length).IsGreaterThanOrEqualTo(1);
+
+        await second.DisposeAsync();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/PipeMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PipeMemoryPoolTests.cs
@@ -5,6 +5,17 @@ namespace Dekaf.Tests.Unit.Networking;
 public class PipeMemoryPoolTests
 {
     [Test]
+    public async Task Create_SharesPoolsByConfiguration()
+    {
+        var first = PipeMemoryPool.Create(maxArrayLength: 1024 * 1024, maxArraysPerBucket: 17);
+        var same = PipeMemoryPool.Create(maxArrayLength: 1024 * 1024, maxArraysPerBucket: 17);
+        var different = PipeMemoryPool.Create(maxArrayLength: 1024 * 1024, maxArraysPerBucket: 18);
+
+        await Assert.That(first).IsSameReferenceAs(same);
+        await Assert.That(first).IsNotSameReferenceAs(different);
+    }
+
+    [Test]
     public async Task Rent_ReturnsMemoryOwner_WithRequestedSize()
     {
         using var pool = new PipeMemoryPool();

--- a/tests/Dekaf.Tests.Unit/Networking/PipeMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PipeMemoryPoolTests.cs
@@ -2,6 +2,7 @@ using Dekaf.Networking;
 
 namespace Dekaf.Tests.Unit.Networking;
 
+[NotInParallel]
 public class PipeMemoryPoolTests
 {
     [Test]
@@ -13,6 +14,15 @@ public class PipeMemoryPoolTests
 
         await Assert.That(first).IsSameReferenceAs(same);
         await Assert.That(first).IsNotSameReferenceAs(different);
+    }
+
+    [Test]
+    public async Task Create_BoundsSharedConfigurationCache()
+    {
+        for (var i = 1; i <= 32; i++)
+            _ = PipeMemoryPool.Create(maxArrayLength: 1024 * 1024, maxArraysPerBucket: i);
+
+        await Assert.That(PipeMemoryPool.SharedPoolCount).IsEqualTo(16);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
@@ -141,6 +141,7 @@ public sealed class FetchResponseBatchBoundaryTests
                 }
 
                 FetchResponsePartition.ReturnRecordBatchList(batches);
+                partition.Records = null;
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -179,6 +179,7 @@ public class ResponseWireFormatSnapshotTests
                 if (batches is List<RecordBatch> pooledBatches)
                 {
                     FetchResponsePartition.ReturnRecordBatchList(pooledBatches);
+                    partition.Records = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- share `PipeMemoryPool` process-wide by bounded size configuration
- reuse warm 64KB pipe segments across short-lived client sessions
- keep distinct bucket capacities isolated and stop client disposal from killing global pools
- include pending pooled-list test cleanup needed for stable full-suite CI

## Test plan
- [x] Release build (`netstandard2.0`, `net8.0`, `net10.0` graph)
- [x] `ConnectionPoolTests` (38/38)
- [x] `PipeMemoryPoolTests` (12/12)
- [x] full net10 unit suite (5,090/5,090)

Closes #1765
