### PR TITLE
Fast-path buffered ConsumeOneAsync polls

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -28,10 +28,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IRebalanceListener? _rebalanceListener;
-    // Heartbeats can revoke and reassign a partition between poll-loop snapshots.
-    // Preserve both the immediate stale-fetch signal and the revocation history needed
-    // to defeat assignment ABA (A -> B -> A with the same final set).
+    // Retained for the public six-parameter constructor and direct coordinator callers.
+    // KafkaConsumer uses the pre-publication hook below to invalidate buffered fetches.
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
+    // Heartbeats can revoke and reassign a partition between poll-loop snapshots.
+    // Signal before publication to defeat assignment ABA (A -> B -> A with the same final set).
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoking;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
     // Assignment publication and revocation history form one snapshot. Rebalance callbacks
@@ -270,7 +271,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     internal bool TryRecordPollFast()
     {
         // The fatal can be published after the assignment-currency gate. Recheck here,
-        // immediately before the caller dequeues a buffered record, so the slow path throws it.
+        // immediately before the caller dequeues a buffered record, so a group-managed
+        // slow path surfaces it. Manual assignment does not run the heartbeat loop.
         if (Volatile.Read(ref _fatalHeartbeatException) is not null)
             return false;
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -44,6 +44,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private volatile string? _memberId;
     private volatile int _generationId = -1;
     private int _assignmentVersion;
+    private int _assignmentProcessingCount;
     // Volatile ensures cross-thread visibility of the reference. Thread-safety relies on
     // all writes replacing the reference entirely (never in-place mutation) — verified at
     // every assignment site: ProcessConsumerGroupAssignment() and DisposeAsync().
@@ -243,6 +244,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     internal bool IsAssignmentSyncCurrent(int assignmentVersion) =>
         _state == CoordinatorState.Stable
         && Volatile.Read(ref _assignmentVersion) == assignmentVersion
+        && Volatile.Read(ref _assignmentProcessingCount) == 0
         && _revokedPartitionsSinceLastSync.IsEmpty
         && Volatile.Read(ref _fatalHeartbeatException) is null
         && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0;
@@ -1084,6 +1086,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 request, version, cancellationToken).ConfigureAwait(false);
         }
 
+        using var assignmentProcessing = BeginAssignmentProcessing(response.Assignment);
+
         if (!discardIfMembershipChanged)
             return ProcessConsumerGroupHeartbeatResponse(
                 response,
@@ -1130,6 +1134,29 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         // Steady-heartbeat callbacks are fired above while publication is fenced against
         // max-poll expiry. The heartbeat loop must not fire the result a second time.
         return default;
+    }
+
+    private AssignmentProcessingScope BeginAssignmentProcessing(
+        ConsumerGroupHeartbeatAssignment? assignment)
+    {
+        if (assignment is null)
+            return default;
+
+        Interlocked.Increment(ref _assignmentProcessingCount);
+        return new AssignmentProcessingScope(this);
+    }
+
+    private readonly struct AssignmentProcessingScope : IDisposable
+    {
+        private readonly ConsumerCoordinator? _coordinator;
+
+        public AssignmentProcessingScope(ConsumerCoordinator coordinator) => _coordinator = coordinator;
+
+        public void Dispose()
+        {
+            if (_coordinator is { } coordinator)
+                Interlocked.Decrement(ref coordinator._assignmentProcessingCount);
+        }
     }
 
     private ConsumerHeartbeatResult ProcessConsumerGroupHeartbeatResponse(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -117,26 +117,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal ValueTask RecordPollAsync(CancellationToken cancellationToken)
     {
-        // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
-        // unchanged so EnsureActiveGroup cannot rejoin until notification completes.
-        if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
-            return ValueTask.CompletedTask;
-
-        if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
-        {
-            RefreshPollDeadline();
-            return ValueTask.CompletedTask;
-        }
-
-        var now = Stopwatch.GetTimestamp();
-        if (_state == CoordinatorState.Stable
-            && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
-        {
-            return ExpireAndRecordPollAsync(cancellationToken);
-        }
-
-        RecordPollIfLossNotificationComplete(now);
-        return ValueTask.CompletedTask;
+        return TryRecordPollFast()
+            ? ValueTask.CompletedTask
+            : ExpireAndRecordPollAsync(cancellationToken);
     }
 
     private void RecordPollIfLossNotificationComplete(long timestamp)
@@ -235,6 +218,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal void AcknowledgeAssignmentSync(int assignmentVersion)
     {
+        if (Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0
+            && _revokedPartitionsSinceLastSync.IsEmpty)
+        {
+            return;
+        }
+
         lock (_assignmentStateLock)
         {
             if (Volatile.Read(ref _assignmentVersion) != assignmentVersion
@@ -246,6 +235,36 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             Volatile.Write(ref _maxPollExpiredAtPollVersion, -1);
         }
+    }
+
+    internal bool IsAssignmentSyncCurrent(int assignmentVersion) =>
+        _state == CoordinatorState.Stable
+        && Volatile.Read(ref _assignmentVersion) == assignmentVersion
+        && _revokedPartitionsSinceLastSync.IsEmpty
+        && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0;
+
+    internal bool TryRecordPollFast()
+    {
+        // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
+        // unchanged so EnsureActiveGroup cannot rejoin until notification completes.
+        if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
+            return true;
+
+        if (Volatile.Read(ref _foregroundPollActivityCount) != 0)
+        {
+            RefreshPollDeadline();
+            return true;
+        }
+
+        var now = Stopwatch.GetTimestamp();
+        if (_state == CoordinatorState.Stable
+            && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
+        {
+            return false;
+        }
+
+        RecordPollIfLossNotificationComplete(now);
+        return true;
     }
 
     private void EnqueueRevokedPartitions(IEnumerable<TopicPartition> revoked)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -32,6 +32,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // Preserve both the immediate stale-fetch signal and the revocation history needed
     // to defeat assignment ABA (A -> B -> A with the same final set).
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
+    private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoking;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
     // Assignment publication and revocation history form one snapshot. Rebalance callbacks
     // run only after this lock is released so user code cannot extend its critical section.
@@ -93,13 +94,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         MetadataManager metadataManager,
         ILogger<ConsumerCoordinator>? logger = null,
         Func<int>? getConnectionCount = null,
-        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked = null)
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked = null,
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking = null)
     {
         _options = options;
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
         _rebalanceListener = options.RebalanceListener;
         _onPartitionsRevoked = onPartitionsRevoked;
+        _onPartitionsRevoking = onPartitionsRevoking;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConsumerCoordinator>.Instance;
         _getCoordinationConnectionIndex = getConnectionCount is not null
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
@@ -940,6 +943,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         var revoked = _assignedPartitions.Count != 0 ? _assignedPartitions.ToList() : null;
 
+        if (revoked is not null)
+            _onPartitionsRevoking?.Invoke(revoked);
+
         lock (_assignmentStateLock)
         {
             _assignedPartitions = [];
@@ -1313,6 +1319,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
+            if (revoked is not null)
+                _onPartitionsRevoking?.Invoke(revoked);
+
             lock (_assignmentStateLock)
             {
                 _assignedPartitions = newAssignment;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -269,6 +269,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal bool TryRecordPollFast()
     {
+        // The fatal can be published after the assignment-currency gate. Recheck here,
+        // immediately before the caller dequeues a buffered record, so the slow path throws it.
+        if (Volatile.Read(ref _fatalHeartbeatException) is not null)
+            return false;
+
         // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
         // unchanged so EnsureActiveGroup cannot rejoin until notification completes.
         if (Volatile.Read(ref _maxPollLossNotificationPending) != 0)
@@ -1046,58 +1051,58 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                  IsCurrentPollGenerationExpired()))
                 return default;
 
-        var version = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ConsumerGroupHeartbeat,
-            ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
-            ConsumerGroupHeartbeatRequest.HighestSupportedVersion);
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                ApiKey.ConsumerGroupHeartbeat,
+                ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
+                ConsumerGroupHeartbeatRequest.HighestSupportedVersion);
 
-        // KIP-1082: v1+ uses client-generated UUID v4 instead of empty string for new members.
-        // Generate once when _memberId is null; subsequent heartbeats reuse the stored ID.
-        // Thread-safety: _memberId is only null on the initial join path (protected by _lock)
-        // or after ResetMemberState() which also transitions to Unjoined before any heartbeat loop restart.
-        if (_memberId is null && version >= 1)
-            _memberId = Guid.NewGuid().ToString();
+            // KIP-1082: v1+ uses client-generated UUID v4 instead of empty string for new members.
+            // Generate once when _memberId is null; subsequent heartbeats reuse the stored ID.
+            // Thread-safety: _memberId is only null on the initial join path (protected by _lock)
+            // or after ResetMemberState() which also transitions to Unjoined before any heartbeat loop restart.
+            if (_memberId is null && version >= 1)
+                _memberId = Guid.NewGuid().ToString();
 
-        var memberId = _memberId ?? string.Empty;
+            var memberId = _memberId ?? string.Empty;
 
-        // MemberEpoch: 0 for initial join, -2 for static rejoin (set by fencing handler),
-        // or the current epoch for steady-state heartbeats
-        var memberEpoch = isInitial
-            ? (_generationId == -2 && _options.GroupInstanceId is not null ? -2 : 0)
-            : _generationId;
+            // MemberEpoch: 0 for initial join, -2 for static rejoin (set by fencing handler),
+            // or the current epoch for steady-state heartbeats
+            var memberEpoch = isInitial
+                ? (_generationId == -2 && _options.GroupInstanceId is not null ? -2 : 0)
+                : _generationId;
 
-        // On initial join, send empty array (owns nothing). null means "unchanged" in KIP-848
-        // which is invalid when there's no previous state.
-        assignmentVersion = Volatile.Read(ref _assignmentVersion);
-        ownedTopicPartitions =
-            isInitial ? [] : GetOwnedTopicPartitionsForHeartbeat(assignmentVersion);
+            // On initial join, send empty array (owns nothing). null means "unchanged" in KIP-848
+            // which is invalid when there's no previous state.
+            assignmentVersion = Volatile.Read(ref _assignmentVersion);
+            ownedTopicPartitions =
+                isInitial ? [] : GetOwnedTopicPartitionsForHeartbeat(assignmentVersion);
 
-        // Atomically snapshot and clear the subscription-changed flag to prevent a race where
-        // a concurrent EnsureActiveGroupConsumerProtocolAsync sets new topics + flag=true,
-        // but this heartbeat clears the flag after sending the old topics.
-        // Always send topics on initial/re-join — KIP-848 requires SubscribedTopicNames to be
-        // non-null when joining. The flag must still be cleared to avoid a stale re-send later.
-        var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
-        var subscriptionShouldBeSent = isInitial || subscriptionChanged;
-        var currentSubscribedTopicRegex = _subscribedTopicRegex;
-        var subscribedTopics = subscriptionShouldBeSent ? _subscribedTopics?.ToList() : null;
-        subscribedTopicRegex = subscriptionShouldBeSent && version >= 1
-            ? currentSubscribedTopicRegex ?? (isInitial ? null : string.Empty)
-            : null;
+            // Atomically snapshot and clear the subscription-changed flag to prevent a race where
+            // a concurrent EnsureActiveGroupConsumerProtocolAsync sets new topics + flag=true,
+            // but this heartbeat clears the flag after sending the old topics.
+            // Always send topics on initial/re-join — KIP-848 requires SubscribedTopicNames to be
+            // non-null when joining. The flag must still be cleared to avoid a stale re-send later.
+            var subscriptionChanged = Interlocked.Exchange(ref _subscriptionChanged, 0) == 1;
+            var subscriptionShouldBeSent = isInitial || subscriptionChanged;
+            var currentSubscribedTopicRegex = _subscribedTopicRegex;
+            var subscribedTopics = subscriptionShouldBeSent ? _subscribedTopics?.ToList() : null;
+            subscribedTopicRegex = subscriptionShouldBeSent && version >= 1
+                ? currentSubscribedTopicRegex ?? (isInitial ? null : string.Empty)
+                : null;
 
-        var request = new ConsumerGroupHeartbeatRequest
-        {
-            GroupId = _options.GroupId!,
-            MemberId = memberId,
-            MemberEpoch = memberEpoch,
-            InstanceId = _options.GroupInstanceId,
-            RebalanceTimeoutMs = isInitial ? _options.MaxPollIntervalMs : -1,
-            RackId = isInitial ? _options.ClientRack : null,
-            SubscribedTopicNames = subscribedTopics,
-            SubscribedTopicRegex = subscribedTopicRegex,
-            ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
-            TopicPartitions = ownedTopicPartitions
-        };
+            var request = new ConsumerGroupHeartbeatRequest
+            {
+                GroupId = _options.GroupId!,
+                MemberId = memberId,
+                MemberEpoch = memberEpoch,
+                InstanceId = _options.GroupInstanceId,
+                RebalanceTimeoutMs = isInitial ? _options.MaxPollIntervalMs : -1,
+                RackId = isInitial ? _options.ClientRack : null,
+                SubscribedTopicNames = subscribedTopics,
+                SubscribedTopicRegex = subscribedTopicRegex,
+                ServerAssignor = isInitial ? _options.GroupRemoteAssignor : null,
+                TopicPartitions = ownedTopicPartitions
+            };
 
             response = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -95,8 +95,26 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         MetadataManager metadataManager,
         ILogger<ConsumerCoordinator>? logger = null,
         Func<int>? getConnectionCount = null,
-        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked = null,
-        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking = null)
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked = null)
+        : this(
+            options,
+            connectionPool,
+            metadataManager,
+            logger,
+            getConnectionCount,
+            onPartitionsRevoked,
+            onPartitionsRevoking: null)
+    {
+    }
+
+    internal ConsumerCoordinator(
+        ConsumerOptions options,
+        IConnectionPool connectionPool,
+        MetadataManager metadataManager,
+        ILogger<ConsumerCoordinator>? logger,
+        Func<int>? getConnectionCount,
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked,
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking)
     {
         _options = options;
         _connectionPool = connectionPool;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -241,6 +241,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         _state == CoordinatorState.Stable
         && Volatile.Read(ref _assignmentVersion) == assignmentVersion
         && _revokedPartitionsSinceLastSync.IsEmpty
+        && Volatile.Read(ref _fatalHeartbeatException) is null
         && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0;
 
     internal bool TryRecordPollFast()

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -270,11 +270,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     internal bool TryRecordPollFast()
     {
-        // The fatal can be published after the assignment-currency gate. Recheck here,
-        // immediately before the caller dequeues a buffered record, so a group-managed
-        // slow path surfaces it. Manual assignment does not run the heartbeat loop.
-        if (Volatile.Read(ref _fatalHeartbeatException) is not null)
-            return false;
+        // The fatal can be published after the assignment-currency gate. Surface it here,
+        // before either a buffered dequeue or the timeout-bound coordinator lock path.
+        ThrowIfFatalHeartbeatException();
 
         // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
         // unchanged so EnsureActiveGroup cannot rejoin until notification completes.

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -260,14 +260,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return true;
         }
 
-        var now = Stopwatch.GetTimestamp();
-        if (_state == CoordinatorState.Stable
-            && now - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks)
-        {
+        if (IsCurrentPollGenerationExpired())
             return false;
-        }
 
-        RecordPollIfLossNotificationComplete(now);
+        RecordPollIfLossNotificationComplete(Stopwatch.GetTimestamp());
         return true;
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -959,8 +959,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         var revoked = _assignedPartitions.Count != 0 ? _assignedPartitions.ToList() : null;
 
-        if (revoked is not null)
-            _onPartitionsRevoking?.Invoke(revoked);
+        NotifyRevoking(revoked);
 
         lock (_assignmentStateLock)
         {
@@ -1104,49 +1103,62 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 request, version, cancellationToken).ConfigureAwait(false);
         }
 
-        using var assignmentProcessing = BeginAssignmentProcessing(response.Assignment);
+        var assignmentProcessing = BeginAssignmentProcessing(response.Assignment);
 
         if (!discardIfMembershipChanged)
-            return ProcessConsumerGroupHeartbeatResponse(
-                response,
-                isInitial,
-                ownedTopicPartitions,
-                assignmentVersion,
-                subscribedTopicRegex);
-
-        await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
         {
-            ConsumerHeartbeatResult result;
-            await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
+            using (assignmentProcessing)
             {
-                // A foreground poll can expire the member while this request is in flight.
-                // Validate and publish under the state lock. The listener lock preserves
-                // callback ordering after this lock is released without blocking re-entrant APIs.
-                if (_state != CoordinatorState.Stable ||
-                    Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
-                    IsCurrentPollGenerationExpired())
-                    return default;
-
-                result = ProcessConsumerGroupHeartbeatResponse(
+                return ProcessConsumerGroupHeartbeatResponse(
                     response,
                     isInitial,
                     ownedTopicPartitions,
                     assignmentVersion,
                     subscribedTopicRegex);
             }
-            finally
+        }
+
+        var rebalanceListenerLockHeld = false;
+        try
+        {
+            ConsumerHeartbeatResult result;
+            using (assignmentProcessing)
             {
-                _lock.Release();
+                await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                rebalanceListenerLockHeld = true;
+                await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    // A foreground poll can expire the member while this request is in flight.
+                    // Validate and publish under the state lock. The listener lock preserves
+                    // callback ordering after this lock is released without blocking re-entrant APIs.
+                    if (_state != CoordinatorState.Stable ||
+                        Volatile.Read(ref _maxPollExpirationVersion) != maxPollExpirationVersion ||
+                        IsCurrentPollGenerationExpired())
+                        return default;
+
+                    result = ProcessConsumerGroupHeartbeatResponse(
+                        response,
+                        isInitial,
+                        ownedTopicPartitions,
+                        assignmentVersion,
+                        subscribedTopicRegex);
+                }
+                finally
+                {
+                    _lock.Release();
+                }
             }
 
+            // Assignment state and the immediate stale-fetch marker are published. User
+            // callbacks remain serialized, but no longer suppress buffered polls while awaiting.
             await FireConsumerProtocolRebalanceListenersCoreAsync(result, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
         {
-            _rebalanceListenerLock.Release();
+            if (rebalanceListenerLockHeld)
+                _rebalanceListenerLock.Release();
         }
 
         // Steady-heartbeat callbacks are fired above while publication is fenced against
@@ -1360,8 +1372,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
         if (changed)
         {
-            if (revoked is not null)
-                _onPartitionsRevoking?.Invoke(revoked);
+            NotifyRevoking(revoked);
 
             lock (_assignmentStateLock)
             {
@@ -1379,6 +1390,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
 
         return new ConsumerHeartbeatResult(changed, revoked, assigned);
+    }
+
+    private void NotifyRevoking(IReadOnlyList<TopicPartition>? revoked)
+    {
+        if (revoked is not null)
+            _onPartitionsRevoking?.Invoke(revoked);
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3262,6 +3262,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             pollRecorded = _coordinator?.TryRecordPollFast() ?? true;
             if (pollRecorded && TryConsumeOneFromPendingFetches(out var bufferedResult))
                 return bufferedResult;
+
+            if (pollRecorded && _pendingEofEvents.TryDequeue(out var eofEvent))
+            {
+                return ConsumeResult<TKey, TValue>.CreatePartitionEof(
+                    eofEvent.Partition.Topic,
+                    eofEvent.Partition.Partition,
+                    eofEvent.Offset);
+            }
         }
 
         using var timeoutCts = _ctsPool.Rent();
@@ -3300,9 +3308,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ValidateConsumeOneTimeout(TimeSpan timeout)
     {
-        const long MaxSupportedTimeoutMilliseconds = 0xfffffffe;
-        var timeoutMilliseconds = (long)timeout.TotalMilliseconds;
-        if (timeoutMilliseconds < -1 || timeoutMilliseconds > MaxSupportedTimeoutMilliseconds)
+        const long MaxSupportedTimeoutTicks = 0xfffffffeL * TimeSpan.TicksPerMillisecond;
+        if (timeout.Ticks < -TimeSpan.TicksPerMillisecond || timeout.Ticks > MaxSupportedTimeoutTicks)
             throw new ArgumentOutOfRangeException(nameof(timeout));
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1099,6 +1099,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 getConnectionCount: _connectionScaler is not null
                     ? () => _connectionScaler.CurrentConnectionCount
                     : null,
+                onPartitionsRevoked: null,
                 onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear);
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3260,19 +3260,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var timeoutMilliseconds = ValidateConsumeOneTimeout(timeout);
 
         var pollRecorded = false;
+        long? bufferedDrainStarted = null;
         if (!RequiresRuntimeTimeoutValidation(timeoutMilliseconds)
             && CanUseBufferedConsumeOneFastPath(cancellationToken))
         {
             pollRecorded = _coordinator?.TryRecordPollFast() ?? true;
-            if (pollRecorded && TryConsumeOneFromPendingFetches(out var bufferedResult))
-                return bufferedResult;
+            if (pollRecorded)
+            {
+                bufferedDrainStarted = Stopwatch.GetTimestamp();
+                if (TryConsumeOneFromPendingFetches(out var bufferedResult))
+                    return bufferedResult;
 
-            if (pollRecorded && TryDequeuePendingEofResult(out var eofResult))
-                return eofResult;
+                if (TryDequeuePendingEofResult(out var eofResult))
+                    return eofResult;
+            }
         }
 
         using var timeoutCts = _ctsPool.Rent();
-        timeoutCts.CancelAfter(timeout);
+        timeoutCts.CancelAfter(CalculateRemainingConsumeOneTimeout(timeout, bufferedDrainStarted));
 
         // Fast path: if no external cancellation, use timeout CTS directly (avoids allocation)
         if (!cancellationToken.CanBeCanceled)
@@ -3325,6 +3330,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 #else
         return false;
 #endif
+    }
+
+    internal static TimeSpan CalculateRemainingConsumeOneTimeout(TimeSpan timeout, long? bufferedDrainStarted)
+    {
+        if (bufferedDrainStarted is not { } startedAt || timeout < TimeSpan.Zero)
+            return timeout;
+
+        var remaining = timeout - Stopwatch.GetElapsedTime(startedAt);
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
     }
 
     private bool CanUseBufferedConsumeOneFastPath(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3308,8 +3308,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void ValidateConsumeOneTimeout(TimeSpan timeout)
     {
-        const long MaxSupportedTimeoutTicks = 0xfffffffeL * TimeSpan.TicksPerMillisecond;
-        if (timeout.Ticks < -TimeSpan.TicksPerMillisecond || timeout.Ticks > MaxSupportedTimeoutTicks)
+        const long MaxSupportedTimeoutMilliseconds = 0xfffffffe;
+        var timeoutMilliseconds = (long)timeout.TotalMilliseconds;
+        if (timeoutMilliseconds < -1 || timeoutMilliseconds > MaxSupportedTimeoutMilliseconds)
             throw new ArgumentOutOfRangeException(nameof(timeout));
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2113,6 +2113,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
+        if (Volatile.Read(ref _prefetchTask) is not null)
+            return;
+
         lock (_prefetchStartLock)
         {
             if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
@@ -3250,6 +3253,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
     {
+        if (CanUseBufferedConsumeOneFastPath(cancellationToken)
+            && TryConsumeOneFromPendingFetches(out var bufferedResult))
+        {
+            return bufferedResult;
+        }
+
         using var timeoutCts = _ctsPool.Rent();
         timeoutCts.CancelAfter(timeout);
 
@@ -3281,6 +3290,43 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return null;
+    }
+
+    private bool CanUseBufferedConsumeOneFastPath(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested
+            || Volatile.Read(ref _consumerDisposed) != 0
+            || !_initialized
+            || _pendingFetches.Count == 0
+            || Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent) != 0)
+        {
+            return false;
+        }
+
+        if (_options.OffsetCommitMode == OffsetCommitMode.Auto
+            && _coordinator is not null
+            && Volatile.Read(ref _autoCommitTask) is not { IsCompleted: false })
+        {
+            return false;
+        }
+
+        if (_options.QueuedMinMessages > 1 && Volatile.Read(ref _prefetchTask) is null)
+            return false;
+
+        var pending = _pendingFetches.Peek();
+        if (!IsCurrentlyAssigned(pending.TopicPartition))
+            return false;
+
+        var coordinator = _coordinator;
+        if ((_subscriptionSnapshot.Count != 0 || _topicPattern is not null) && coordinator is not null)
+        {
+            var assignmentVersion = coordinator.AssignmentVersion;
+            return Volatile.Read(ref _lastCoordinatorAssignmentVersion) == assignmentVersion
+                   && coordinator.IsAssignmentSyncCurrent(assignmentVersion)
+                   && coordinator.TryRecordPollFast();
+        }
+
+        return IsManualAssignmentEnsureCurrent();
     }
 
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(CancellationToken cancellationToken)
@@ -6442,6 +6488,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private async Task StartAutoCommitAsync(CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
+            return;
+
+        if (Volatile.Read(ref _autoCommitTask) is { IsCompleted: false })
             return;
 
         Task? oldTask;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1098,7 +1098,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 getConnectionCount: _connectionScaler is not null
                     ? () => _connectionScaler.CurrentConnectionCount
                     : null,
-                onPartitionsRevoked: QueueCoordinatorRevokedPartitionsForFetchClear);
+                onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear);
         }
 
         _prefetchBuffer = new MpscFetchBuffer(CalculatePrefetchBufferCapacity(options));
@@ -3314,6 +3314,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
         }
 
+        if (IsTopicFilterRefreshDue())
+            return false;
+
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto
             && _coordinator is not null
             && Volatile.Read(ref _autoCommitTask) is not { IsCompleted: false })
@@ -3338,6 +3341,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return IsManualAssignmentEnsureCurrent();
+    }
+
+    private bool IsTopicFilterRefreshDue()
+    {
+        const long filterRefreshIntervalMilliseconds = 30_000;
+        var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
+        return _topicFilter is not null
+               && (lastRefresh == 0
+                   || Dekaf.MonotonicClock.GetMilliseconds() - lastRefresh >= filterRefreshIntervalMilliseconds);
     }
 
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -647,6 +647,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private const int MaxRepeatedDeterministicPrefetchFailures = 3;
     private const int InitialPrefetchFailureBackoffMs = 100;
     private const int MaxPrefetchFailureBackoffMs = 5_000;
+    private const long FilterRefreshIntervalMilliseconds = 30_000;
     private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
 
     private readonly ConsumerOptions _options;
@@ -3255,10 +3256,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         ValidateConsumeOneTimeout(timeout);
 
-        if (CanUseBufferedConsumeOneFastPath(cancellationToken)
-            && TryConsumeOneFromPendingFetches(out var bufferedResult))
+        var pollRecorded = false;
+        if (CanUseBufferedConsumeOneFastPath(cancellationToken))
         {
-            return bufferedResult;
+            pollRecorded = _coordinator?.TryRecordPollFast() ?? true;
+            if (pollRecorded && TryConsumeOneFromPendingFetches(out var bufferedResult))
+                return bufferedResult;
         }
 
         using var timeoutCts = _ctsPool.Rent();
@@ -3269,7 +3272,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             try
             {
-                return await ConsumeOneCoreAsync(timeoutCts.Token).ConfigureAwait(false);
+                return await ConsumeOneCoreAsync(timeoutCts.Token, pollRecorded).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
             {
@@ -3283,7 +3286,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
-            return await ConsumeOneCoreAsync(linkedCts.Token).ConfigureAwait(false);
+            return await ConsumeOneCoreAsync(linkedCts.Token, pollRecorded).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -3336,8 +3339,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             var assignmentVersion = coordinator.AssignmentVersion;
             return Volatile.Read(ref _lastCoordinatorAssignmentVersion) == assignmentVersion
-                   && coordinator.IsAssignmentSyncCurrent(assignmentVersion)
-                   && coordinator.TryRecordPollFast();
+                   && coordinator.IsAssignmentSyncCurrent(assignmentVersion);
         }
 
         return IsManualAssignmentEnsureCurrent();
@@ -3345,14 +3347,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool IsTopicFilterRefreshDue()
     {
-        const long filterRefreshIntervalMilliseconds = 30_000;
         var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
         return _topicFilter is not null
                && (lastRefresh == 0
-                   || Dekaf.MonotonicClock.GetMilliseconds() - lastRefresh >= filterRefreshIntervalMilliseconds);
+                   || Dekaf.MonotonicClock.GetMilliseconds() - lastRefresh >= FilterRefreshIntervalMilliseconds);
     }
 
-    private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(CancellationToken cancellationToken)
+    private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(
+        CancellationToken cancellationToken,
+        bool pollRecorded)
     {
         if (Volatile.Read(ref _consumerDisposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
@@ -3373,7 +3376,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            await RecordPollAsync(cancellationToken).ConfigureAwait(false);
+            if (pollRecorded)
+            {
+                pollRecorded = false;
+            }
+            else
+            {
+                await RecordPollAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             await EnsureAssignmentForPollAsync(cancellationToken).ConfigureAwait(false);
             RecoverAndClearFetchBufferForPendingCoordinatorRevocations();
@@ -4556,13 +4566,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <returns>True if the subscription changed.</returns>
     private async ValueTask<bool> RefreshFilteredTopicsAsync(Func<string, bool> filter, CancellationToken cancellationToken)
     {
-        const long refreshIntervalTicks = 30 * TimeSpan.TicksPerSecond;
-
         var now = Dekaf.MonotonicClock.GetMilliseconds();
         var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
 
         // Rate-limit: skip if we refreshed recently (unless this is the first call)
-        if (lastRefresh != 0 && (now - lastRefresh) < (refreshIntervalTicks / TimeSpan.TicksPerMillisecond))
+        if (lastRefresh != 0 && now - lastRefresh < FilterRefreshIntervalMilliseconds)
         {
             return false;
         }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2115,7 +2115,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        if (Volatile.Read(ref _prefetchTask) is not null)
+        // Prefetch is a lifetime loop. A non-null terminal task represents a stopped
+        // consumer path and must not be silently restarted, unlike the auto-commit loop.
+        if (HasPrefetchStarted())
             return;
 
         lock (_prefetchStartLock)
@@ -2123,7 +2125,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
                 return;
 
-            if (_prefetchTask is not null)
+            if (HasPrefetchStarted())
                 return;
 
             _prefetchCts = new CancellationTokenSource();
@@ -3336,7 +3338,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return false;
         }
 
-        if (_options.QueuedMinMessages > 1 && Volatile.Read(ref _prefetchTask) is null)
+        if (_options.QueuedMinMessages > 1 && !HasPrefetchStarted())
             return false;
 
         var pending = _pendingFetches.Peek();
@@ -3346,20 +3348,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var coordinator = _coordinator;
         if ((_subscriptionSnapshot.Count != 0 || _topicPattern is not null) && coordinator is not null)
         {
-            var assignmentVersion = coordinator.AssignmentVersion;
-            return Volatile.Read(ref _lastCoordinatorAssignmentVersion) == assignmentVersion
-                   && coordinator.IsAssignmentSyncCurrent(assignmentVersion);
+            return IsCoordinatorAssignmentSyncCurrent(coordinator, out _);
         }
 
         return IsManualAssignmentEnsureCurrent();
     }
 
     private bool IsTopicFilterRefreshDue()
+        => _topicFilter is not null && IsFilterRefreshDue();
+
+    private bool IsFilterRefreshDue()
     {
         var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
-        return _topicFilter is not null
-               && (lastRefresh == 0
-                   || Dekaf.MonotonicClock.GetMilliseconds() - lastRefresh >= FilterRefreshIntervalMilliseconds);
+        return lastRefresh == 0
+               || Dekaf.MonotonicClock.GetMilliseconds() - lastRefresh >= FilterRefreshIntervalMilliseconds;
+    }
+
+    private bool HasPrefetchStarted() => Volatile.Read(ref _prefetchTask) is not null;
+
+    private bool IsCoordinatorAssignmentSyncCurrent(
+        ConsumerCoordinator coordinator,
+        out int assignmentVersion)
+    {
+        assignmentVersion = coordinator.AssignmentVersion;
+        return Volatile.Read(ref _lastCoordinatorAssignmentVersion) == assignmentVersion
+               && coordinator.IsAssignmentSyncCurrent(assignmentVersion);
     }
 
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(
@@ -4575,14 +4588,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <returns>True if the subscription changed.</returns>
     private async ValueTask<bool> RefreshFilteredTopicsAsync(Func<string, bool> filter, CancellationToken cancellationToken)
     {
-        var now = Dekaf.MonotonicClock.GetMilliseconds();
-        var lastRefresh = Volatile.Read(ref _lastFilterRefreshTicks);
-
-        // Rate-limit: skip if we refreshed recently (unless this is the first call)
-        if (lastRefresh != 0 && now - lastRefresh < FilterRefreshIntervalMilliseconds)
-        {
+        if (!IsFilterRefreshDue())
             return false;
-        }
+
+        var now = Dekaf.MonotonicClock.GetMilliseconds();
 
         Volatile.Write(ref _lastFilterRefreshTicks, now);
 
@@ -4684,8 +4693,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             await coordinator.EnsureActiveGroupAsync(subscriptionSnapshot, topicPattern, cancellationToken).ConfigureAwait(false);
 
-            var coordinatorAssignmentVersion = coordinator.AssignmentVersion;
-            if (Volatile.Read(ref _lastCoordinatorAssignmentVersion) == coordinatorAssignmentVersion)
+            if (IsCoordinatorAssignmentSyncCurrent(coordinator, out var coordinatorAssignmentVersion))
             {
                 coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
                 return;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3267,13 +3267,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (pollRecorded && TryConsumeOneFromPendingFetches(out var bufferedResult))
                 return bufferedResult;
 
-            if (pollRecorded && _pendingEofEvents.TryDequeue(out var eofEvent))
-            {
-                return ConsumeResult<TKey, TValue>.CreatePartitionEof(
-                    eofEvent.Partition.Topic,
-                    eofEvent.Partition.Partition,
-                    eofEvent.Offset);
-            }
+            if (pollRecorded && TryDequeuePendingEofResult(out var eofResult))
+                return eofResult;
         }
 
         using var timeoutCts = _ctsPool.Rent();
@@ -3348,7 +3343,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto
             && _coordinator is not null
-            && Volatile.Read(ref _autoCommitTask) is not { IsCompleted: false })
+            && !IsAutoCommitRunning())
         {
             return false;
         }
@@ -3380,6 +3375,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private bool HasPrefetchStarted() => Volatile.Read(ref _prefetchTask) is not null;
+
+    private bool IsAutoCommitRunning() => Volatile.Read(ref _autoCommitTask) is { IsCompleted: false };
 
     private bool IsCoordinatorAssignmentSyncCurrent(
         ConsumerCoordinator coordinator,
@@ -3443,16 +3440,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (TryConsumeOneFromPendingFetches(out var result))
                 return result;
 
-            if (_pendingEofEvents.TryDequeue(out var eofEvent))
-            {
-                return ConsumeResult<TKey, TValue>.CreatePartitionEof(
-                    eofEvent.Partition.Topic,
-                    eofEvent.Partition.Partition,
-                    eofEvent.Offset);
-            }
+            if (TryDequeuePendingEofResult(out var eofResult))
+                return eofResult;
         }
 
         return null;
+    }
+
+    private bool TryDequeuePendingEofResult(out ConsumeResult<TKey, TValue> result)
+    {
+        if (_pendingEofEvents.TryDequeue(out var eofEvent))
+        {
+            result = ConsumeResult<TKey, TValue>.CreatePartitionEof(
+                eofEvent.Partition.Topic,
+                eofEvent.Partition.Partition,
+                eofEvent.Offset);
+            return true;
+        }
+
+        result = default;
+        return false;
     }
 
     private async ValueTask<bool> FillPendingFetchesForSingleConsumeAsync(bool prefetchEnabled, CancellationToken cancellationToken)
@@ -6553,7 +6560,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _consumerDisposed) != 0 || Volatile.Read(ref _closed) != 0)
             return;
 
-        if (Volatile.Read(ref _autoCommitTask) is { IsCompleted: false })
+        if (IsAutoCommitRunning())
             return;
 
         Task? oldTask;
@@ -6564,7 +6571,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return;
 
             var currentTask = _autoCommitTask;
-            if (currentTask is { IsCompleted: false })
+            if (IsAutoCommitRunning())
                 return;
 
             oldTask = currentTask;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3272,7 +3272,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             try
             {
-                return await ConsumeOneCoreAsync(timeoutCts.Token, pollRecorded).ConfigureAwait(false);
+                return await ConsumeOneCoreAsync(pollRecorded, timeoutCts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
             {
@@ -3286,7 +3286,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
-            return await ConsumeOneCoreAsync(linkedCts.Token, pollRecorded).ConfigureAwait(false);
+            return await ConsumeOneCoreAsync(pollRecorded, linkedCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
@@ -3354,8 +3354,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneCoreAsync(
-        CancellationToken cancellationToken,
-        bool pollRecorded)
+        bool pollRecorded,
+        CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _consumerDisposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3257,10 +3257,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
     {
-        ValidateConsumeOneTimeout(timeout);
+        var timeoutMilliseconds = ValidateConsumeOneTimeout(timeout);
 
         var pollRecorded = false;
-        if (CanUseBufferedConsumeOneFastPath(cancellationToken))
+        if (!RequiresRuntimeTimeoutValidation(timeoutMilliseconds)
+            && CanUseBufferedConsumeOneFastPath(cancellationToken))
         {
             pollRecorded = _coordinator?.TryRecordPollFast() ?? true;
             if (pollRecorded && TryConsumeOneFromPendingFetches(out var bufferedResult))
@@ -3309,12 +3310,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ValidateConsumeOneTimeout(TimeSpan timeout)
+    private static long ValidateConsumeOneTimeout(TimeSpan timeout)
     {
         const long MaxSupportedTimeoutMilliseconds = 0xfffffffe;
         var timeoutMilliseconds = (long)timeout.TotalMilliseconds;
         if (timeoutMilliseconds < -1 || timeoutMilliseconds > MaxSupportedTimeoutMilliseconds)
             throw new ArgumentOutOfRangeException(nameof(timeout));
+
+        return timeoutMilliseconds;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool RequiresRuntimeTimeoutValidation(long timeoutMilliseconds)
+    {
+#if NETSTANDARD2_0
+        // Legacy runtimes consuming this asset may cap CancelAfter at Int32.MaxValue.
+        // Route ambiguous values through the CTS path so the actual runtime decides.
+        return timeoutMilliseconds > int.MaxValue;
+#else
+        return false;
+#endif
     }
 
     private bool CanUseBufferedConsumeOneFastPath(CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3253,6 +3253,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
     {
+        ValidateConsumeOneTimeout(timeout);
+
         if (CanUseBufferedConsumeOneFastPath(cancellationToken)
             && TryConsumeOneFromPendingFetches(out var bufferedResult))
         {
@@ -3290,6 +3292,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return null;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ValidateConsumeOneTimeout(TimeSpan timeout)
+    {
+        const long MaxSupportedTimeoutMilliseconds = 0xfffffffe;
+        var timeoutMilliseconds = (long)timeout.TotalMilliseconds;
+        if (timeoutMilliseconds < -1 || timeoutMilliseconds > MaxSupportedTimeoutMilliseconds)
+            throw new ArgumentOutOfRangeException(nameof(timeout));
     }
 
     private bool CanUseBufferedConsumeOneFastPath(CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -186,6 +187,70 @@ public sealed class ConsumerConfigurationTests(KafkaTestContainer kafka) : Kafka
         await Assert.That(result.Value.Value).IsEqualTo("partition-2-message");
         // Assignment should reflect what we manually assigned
         await Assert.That(consumer.Assignment).Contains(new TopicPartition(topic, 2));
+    }
+
+    [Test]
+    public async Task Consumer_SubscribeThenAssign_BufferedConsumeRecordsGroupPoll()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-subscribe-assign")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 20; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-consumer-subscribe-assign")
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithQueuedMinMessages(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30))).IsNotNull();
+
+        consumer.Assign(new TopicPartition(topic, 0));
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30))).IsNotNull();
+
+        var coordinator = GetCoordinator((KafkaConsumer<string, string>)consumer);
+        var pollVersion = GetPollVersion(coordinator);
+        var bufferedConsume = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(bufferedConsume.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await bufferedConsume).IsNotNull();
+        await Assert.That(GetPollVersion(coordinator)).IsEqualTo(pollVersion + 1);
+    }
+
+    private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinator",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinator field not found.");
+        return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static long GetPollVersion(ConsumerCoordinator coordinator)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            "_pollVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pollVersion field not found.");
+        return (long)field.GetValue(coordinator)!;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerConfigurationTests.cs
@@ -227,12 +227,23 @@ public sealed class ConsumerConfigurationTests(KafkaTestContainer kafka) : Kafka
         await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30))).IsNotNull();
 
         var coordinator = GetCoordinator((KafkaConsumer<string, string>)consumer);
-        var pollVersion = GetPollVersion(coordinator);
-        var bufferedConsume = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30));
+        var observedBufferedConsume = false;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var pollVersion = GetPollVersion(coordinator);
+            var consume = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30));
+            var completedSynchronously = consume.IsCompletedSuccessfully;
 
-        await Assert.That(bufferedConsume.IsCompletedSuccessfully).IsTrue();
-        await Assert.That(await bufferedConsume).IsNotNull();
-        await Assert.That(GetPollVersion(coordinator)).IsEqualTo(pollVersion + 1);
+            await Assert.That(await consume).IsNotNull();
+            if (!completedSynchronously)
+                continue;
+
+            observedBufferedConsume = true;
+            await Assert.That(GetPollVersion(coordinator)).IsEqualTo(pollVersion + 1);
+            break;
+        }
+
+        await Assert.That(observedBufferedConsume).IsTrue();
     }
 
     private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -64,6 +64,22 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task TopicFilterRefreshDue_TracksRefreshInterval()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(fetch);
+        SetPrivateField<Func<string, bool>>(consumer, "_topicFilter", static _ => true);
+
+        await Assert.That(IsTopicFilterRefreshDue(consumer)).IsTrue();
+
+        SetPrivateField(consumer, "_lastFilterRefreshTicks", Math.Max(1, Dekaf.MonotonicClock.GetMilliseconds()));
+        await Assert.That(IsTopicFilterRefreshDue(consumer)).IsFalse();
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_InvalidTimeoutsWithPendingFetch_ThrowBeforeConsuming()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
@@ -501,6 +517,27 @@ public sealed class ConsumeOneFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("_lastManualAssignmentEnsureVersion field not found.");
         acknowledgedVersion.SetValue(consumer, assignmentVersion.GetValue(consumer));
+    }
+
+    private static bool IsTopicFilterRefreshDue(KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "IsTopicFilterRefreshDue",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("IsTopicFilterRefreshDue method not found.");
+        return (bool)method.Invoke(consumer, null)!;
+    }
+
+    private static void SetPrivateField<T>(
+        KafkaConsumer<string, string> consumer,
+        string fieldName,
+        T value)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        field.SetValue(consumer, value);
     }
 
     private static int GetTimeoutCtsPoolCount(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -112,6 +112,9 @@ public sealed class ConsumeOneFastPathTests
                 await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(-2), CancellationToken.None))
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromTicks(-TimeSpan.TicksPerMillisecond - 1), CancellationToken.None))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(async () =>
                 await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(0xffffffff), CancellationToken.None))
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(1);
@@ -499,6 +502,23 @@ public sealed class ConsumeOneFastPathTests
         AssignTestPartition(consumer);
         GetPendingFetches(consumer).Enqueue(fetch);
         return consumer;
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_EmptyPendingFetchWithQueuedEof_ReturnsEofSynchronously()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition, [CreateBatch(20)]);
+        await using var consumer = CreateInitializedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+        GetPendingEofEvents(consumer).Enqueue((new TopicPartition(Topic, Partition), 20L));
+
+        var resultTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(resultTask.IsCompletedSuccessfully).IsTrue();
+        var result = await resultTask;
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.IsPartitionEof).IsTrue();
+        await Assert.That(result.Value.Offset).IsEqualTo(20L);
     }
 
     private static KafkaConsumer<string, string> CreateInitializedGroupedConsumer(PendingFetchData fetch)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -47,6 +47,23 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_CurrentBufferedAssignment_DoesNotRentTimeoutCts()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromMinutes(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(GetTimeoutCtsPoolCount(consumer)).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_WithPendingFetch_FlushesPositionWhenFetchExhausted()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
@@ -450,6 +467,32 @@ public sealed class ConsumeOneFastPathTests
             ?? throw new InvalidOperationException("_initialized field not found.");
 
         initializedField.SetValue(consumer, true);
+    }
+
+    private static void MarkManualAssignmentCurrent(KafkaConsumer<string, string> consumer)
+    {
+        var consumerType = typeof(KafkaConsumer<string, string>);
+        var assignmentVersion = consumerType.GetField(
+            "_assignmentEnsureVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_assignmentEnsureVersion field not found.");
+        var acknowledgedVersion = consumerType.GetField(
+            "_lastManualAssignmentEnsureVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_lastManualAssignmentEnsureVersion field not found.");
+        acknowledgedVersion.SetValue(consumer, assignmentVersion.GetValue(consumer));
+    }
+
+    private static int GetTimeoutCtsPoolCount(KafkaConsumer<string, string> consumer)
+    {
+        var ctsPoolField = typeof(KafkaConsumer<string, string>).GetField(
+            "_ctsPool",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_ctsPool field not found.");
+        var ctsPool = ctsPoolField.GetValue(consumer)!;
+        var countField = ctsPool.GetType().GetField("_count", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CancellationTokenSourcePool._count field not found.");
+        return (int)countField.GetValue(ctsPool)!;
     }
 
     private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -64,6 +64,26 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_InvalidTimeoutsWithPendingFetch_ThrowBeforeConsuming()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+
+        await using var consumer = CreateInitializedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+
+        await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(-2), CancellationToken.None))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(0xffffffff), CancellationToken.None))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_WithPendingFetch_FlushesPositionWhenFetchExhausted()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -82,6 +82,38 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_PrefetchNotStarted_UsesSlowPath()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetch);
+        MarkManualAssignmentCurrent(consumer);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(GetTimeoutCtsPoolCount(consumer)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_GroupedAutoCommitNotStarted_UsesSlowPath()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedGroupedConsumer(fetch, OffsetCommitMode.Auto);
+        MarkManualAssignmentCurrent(consumer);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(GetTimeoutCtsPoolCount(consumer)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task TopicFilterRefreshDue_TracksRefreshInterval()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
@@ -553,14 +585,16 @@ public sealed class ConsumeOneFastPathTests
         await Assert.That(result.Value.Offset).IsEqualTo(20L);
     }
 
-    private static KafkaConsumer<string, string> CreateInitializedGroupedConsumer(PendingFetchData fetch)
+    private static KafkaConsumer<string, string> CreateInitializedGroupedConsumer(
+        PendingFetchData fetch,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual)
     {
         var consumer = new KafkaConsumer<string, string>(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "consume-one-fast-path-tests",
-                OffsetCommitMode = OffsetCommitMode.Manual,
+                OffsetCommitMode = offsetCommitMode,
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200
             },

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -112,12 +112,26 @@ public sealed class ConsumeOneFastPathTests
                 await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(-2), CancellationToken.None))
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(async () =>
-                await consumer.ConsumeOneAsync(TimeSpan.FromTicks(-TimeSpan.TicksPerMillisecond - 1), CancellationToken.None))
-            .Throws<ArgumentOutOfRangeException>();
-        await Assert.That(async () =>
                 await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(0xffffffff), CancellationToken.None))
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_FractionalNegativeTimeout_MatchesCancelAfterTruncation()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+
+        var result = await consumer.ConsumeOneAsync(
+            TimeSpan.FromTicks(-TimeSpan.TicksPerMillisecond - 1),
+            CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
@@ -164,6 +165,31 @@ public sealed class ConsumeOneFastPathTests
             CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
+    public async Task CalculateRemainingConsumeOneTimeout_IncludesBufferedDrainTime()
+    {
+        var drainStarted = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+
+        var remaining = KafkaConsumer<string, string>.CalculateRemainingConsumeOneTimeout(
+            TimeSpan.FromMilliseconds(100),
+            drainStarted);
+
+        await Assert.That(remaining).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task CalculateRemainingConsumeOneTimeout_PreservesInfiniteSentinel()
+    {
+        var timeout = TimeSpan.FromTicks(-TimeSpan.TicksPerMillisecond - 1);
+        var drainStarted = Stopwatch.GetTimestamp() - Stopwatch.Frequency;
+
+        var remaining = KafkaConsumer<string, string>.CalculateRemainingConsumeOneTimeout(
+            timeout,
+            drainStarted);
+
+        await Assert.That(remaining).IsEqualTo(timeout);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -135,6 +135,24 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_RuntimeSupportedLargeTimeout_UsesBufferedFastPath()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+
+        var resultTask = consumer.ConsumeOneAsync(
+            TimeSpan.FromMilliseconds((long)int.MaxValue + 1),
+            CancellationToken.None);
+
+        await Assert.That(resultTask.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(await resultTask).IsNotNull();
+    }
+
+    [Test]
     public async Task ConsumeOneAsync_WithPendingFetch_FlushesPositionWhenFetchExhausted()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -64,6 +64,24 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    public async Task ConsumeOneAsync_ManualAssignmentWithCoordinator_RecordsPollOnce()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedGroupedConsumer(fetch);
+        MarkManualAssignmentCurrent(consumer);
+        var coordinator = GetCoordinator(consumer);
+        var initialPollVersion = GetCoordinatorPollVersion(coordinator);
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(GetCoordinatorPollVersion(coordinator)).IsEqualTo(initialPollVersion + 1);
+    }
+
+    [Test]
     public async Task TopicFilterRefreshDue_TracksRefreshInterval()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
@@ -483,6 +501,26 @@ public sealed class ConsumeOneFastPathTests
         return consumer;
     }
 
+    private static KafkaConsumer<string, string> CreateInitializedGroupedConsumer(PendingFetchData fetch)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "consume-one-fast-path-tests",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200
+            },
+            Serializers.String,
+            Serializers.String);
+
+        SetInitialized(consumer);
+        AssignTestPartition(consumer);
+        GetPendingFetches(consumer).Enqueue(fetch);
+        return consumer;
+    }
+
     private sealed class InvalidDataThrowingDeserializer : IDeserializer<string>
     {
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
@@ -538,6 +576,24 @@ public sealed class ConsumeOneFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException($"{fieldName} field not found.");
         field.SetValue(consumer, value);
+    }
+
+    private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_coordinator",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_coordinator field not found.");
+        return (ConsumerCoordinator)field.GetValue(consumer)!;
+    }
+
+    private static long GetCoordinatorPollVersion(ConsumerCoordinator coordinator)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            "_pollVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_pollVersion field not found.");
+        return (long)field.GetValue(coordinator)!;
     }
 
     private static int GetTimeoutCtsPoolCount(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -17,6 +17,25 @@ namespace Dekaf.Tests.Unit.Consumer;
 /// </summary>
 public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
 {
+    [Test]
+    public async Task PublicConstructor_PreservesSixParameterBinarySignature()
+    {
+        var constructor = typeof(ConsumerCoordinator).GetConstructor(
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            [
+                typeof(ConsumerOptions),
+                typeof(IConnectionPool),
+                typeof(MetadataManager),
+                typeof(Microsoft.Extensions.Logging.ILogger<ConsumerCoordinator>),
+                typeof(Func<int>),
+                typeof(Action<IReadOnlyList<TopicPartition>>)
+            ],
+            modifiers: null);
+
+        await Assert.That(constructor).IsNotNull();
+    }
+
     private static readonly Guid TestTopicId = Guid.Parse("00000000-0000-0000-0000-000000000001");
 
     private readonly IConnectionPool _connectionPool;
@@ -1674,6 +1693,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             options,
             _connectionPool,
             _metadataManager,
+            logger: null,
+            getConnectionCount: null,
             onPartitionsRevoked: OnPartitionsRevoked,
             onPartitionsRevoking: OnPartitionsRevoking);
         await using var coordinatorLifetime = coordinator;

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3187,6 +3187,22 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task TryRecordPollFast_PendingFatalHeartbeat_ReturnsFalse()
+    {
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await Assert.That(coordinator.TryRecordPollFast()).IsTrue();
+
+        SetPrivateField(
+            coordinator,
+            "_fatalHeartbeatException",
+            new GroupException(ErrorCode.GroupAuthorizationFailed, "fatal heartbeat"));
+
+        await Assert.That(coordinator.TryRecordPollFast()).IsFalse();
+    }
+
+    [Test]
     public async Task IsAssignmentSyncCurrent_HeartbeatAssignmentProcessing_ReturnsFalse()
     {
         var options = CreateConsumerProtocolOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3187,7 +3187,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task TryRecordPollFast_PendingFatalHeartbeat_ReturnsFalse()
+    public async Task TryRecordPollFast_PendingFatalHeartbeat_ThrowsBeforeLockPath()
     {
         var options = CreateConsumerProtocolOptions();
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
@@ -3199,7 +3199,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             "_fatalHeartbeatException",
             new GroupException(ErrorCode.GroupAuthorizationFailed, "fatal heartbeat"));
 
-        await Assert.That(coordinator.TryRecordPollFast()).IsFalse();
+        await Assert.That(() => coordinator.TryRecordPollFast())
+            .Throws<GroupException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1649,8 +1649,16 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             });
 
         ConsumerCoordinator? coordinator = null;
+        HashSet<TopicPartition>? assignmentObservedByRevokingCallback = null;
+        var versionObservedByRevokingCallback = -1;
         HashSet<TopicPartition>? assignmentObservedByCallback = null;
         var versionObservedByCallback = -1;
+
+        void OnPartitionsRevoking(IReadOnlyList<TopicPartition> _)
+        {
+            assignmentObservedByRevokingCallback = coordinator!.Assignment.ToHashSet();
+            versionObservedByRevokingCallback = coordinator.AssignmentVersion;
+        }
 
         void OnPartitionsRevoked(IReadOnlyList<TopicPartition> _)
         {
@@ -1663,7 +1671,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             options,
             _connectionPool,
             _metadataManager,
-            onPartitionsRevoked: OnPartitionsRevoked);
+            onPartitionsRevoked: OnPartitionsRevoked,
+            onPartitionsRevoking: OnPartitionsRevoking);
         await using var coordinatorLifetime = coordinator;
         var topics = new HashSet<string> { "test-topic" };
 
@@ -1675,6 +1684,10 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
         await coordinator.StopHeartbeatAsync();
 
+        await Assert.That(assignmentObservedByRevokingCallback).IsNotNull();
+        await Assert.That(assignmentObservedByRevokingCallback!).Contains(new TopicPartition("test-topic", 0));
+        await Assert.That(assignmentObservedByRevokingCallback).Contains(new TopicPartition("test-topic", 1));
+        await Assert.That(versionObservedByRevokingCallback).IsEqualTo(versionAfterInitialAssignment);
         await Assert.That(assignmentObservedByCallback).IsNotNull();
         await Assert.That(assignmentObservedByCallback!).Contains(new TopicPartition("test-topic", 1));
         await Assert.That(assignmentObservedByCallback).DoesNotContain(new TopicPartition("test-topic", 0));

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1651,6 +1651,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         ConsumerCoordinator? coordinator = null;
         HashSet<TopicPartition>? assignmentObservedByRevokingCallback = null;
         var versionObservedByRevokingCallback = -1;
+        var assignmentSyncObservedByRevokingCallback = true;
         HashSet<TopicPartition>? assignmentObservedByCallback = null;
         var versionObservedByCallback = -1;
 
@@ -1658,6 +1659,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         {
             assignmentObservedByRevokingCallback = coordinator!.Assignment.ToHashSet();
             versionObservedByRevokingCallback = coordinator.AssignmentVersion;
+            assignmentSyncObservedByRevokingCallback =
+                coordinator.IsAssignmentSyncCurrent(versionObservedByRevokingCallback);
         }
 
         void OnPartitionsRevoked(IReadOnlyList<TopicPartition> _)
@@ -1688,6 +1691,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(assignmentObservedByRevokingCallback!).Contains(new TopicPartition("test-topic", 0));
         await Assert.That(assignmentObservedByRevokingCallback).Contains(new TopicPartition("test-topic", 1));
         await Assert.That(versionObservedByRevokingCallback).IsEqualTo(versionAfterInitialAssignment);
+        await Assert.That(assignmentSyncObservedByRevokingCallback).IsFalse();
         await Assert.That(assignmentObservedByCallback).IsNotNull();
         await Assert.That(assignmentObservedByCallback!).Contains(new TopicPartition("test-topic", 1));
         await Assert.That(assignmentObservedByCallback).DoesNotContain(new TopicPartition("test-topic", 0));
@@ -3157,6 +3161,22 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             coordinator,
             "_fatalHeartbeatException",
             new GroupException(ErrorCode.GroupAuthorizationFailed, "fatal heartbeat"));
+
+        await Assert.That(coordinator.IsAssignmentSyncCurrent(assignmentVersion)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsAssignmentSyncCurrent_HeartbeatAssignmentProcessing_ReturnsFalse()
+    {
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        const int assignmentVersion = 7;
+        SetPrivateField(coordinator, "_state", CoordinatorState.Stable);
+        SetPrivateField(coordinator, "_assignmentVersion", assignmentVersion);
+
+        await Assert.That(coordinator.IsAssignmentSyncCurrent(assignmentVersion)).IsTrue();
+
+        SetPrivateField(coordinator, "_assignmentProcessingCount", 1);
 
         await Assert.That(coordinator.IsAssignmentSyncCurrent(assignmentVersion)).IsFalse();
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3129,7 +3129,35 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(Guid.TryParse(coordinator.MemberId, out _)).IsTrue();
     }
 
+    [Test]
+    public async Task IsAssignmentSyncCurrent_PendingFatalHeartbeat_ReturnsFalse()
+    {
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        const int assignmentVersion = 7;
+        SetPrivateField(coordinator, "_state", CoordinatorState.Stable);
+        SetPrivateField(coordinator, "_assignmentVersion", assignmentVersion);
+
+        await Assert.That(coordinator.IsAssignmentSyncCurrent(assignmentVersion)).IsTrue();
+
+        SetPrivateField(
+            coordinator,
+            "_fatalHeartbeatException",
+            new GroupException(ErrorCode.GroupAuthorizationFailed, "fatal heartbeat"));
+
+        await Assert.That(coordinator.IsAssignmentSyncCurrent(assignmentVersion)).IsFalse();
+    }
+
     #endregion
+
+    private static void SetPrivateField<T>(ConsumerCoordinator coordinator, string fieldName, T value)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        field.SetValue(coordinator, value);
+    }
 
     private sealed class RetirableTestConnection(IKafkaConnection inner) :
         IKafkaConnection,

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseBatchBoundaryTests.cs
@@ -141,6 +141,7 @@ public sealed class FetchResponseBatchBoundaryTests
                 }
 
                 FetchResponsePartition.ReturnRecordBatchList(batches);
+                partition.Records = null;
             }
         }
     }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -179,6 +179,7 @@ public class ResponseWireFormatSnapshotTests
                 if (batches is List<RecordBatch> pooledBatches)
                 {
                     FetchResponsePartition.ReturnRecordBatchList(pooledBatches);
+                    partition.Records = null;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- consume current pending records before renting/arming timeout cancellation sources
- gate fast path on current assignment, stable coordinator state, no revocation marker, required background loops, and synchronous max-poll bookkeeping
- hoist already-running checks ahead of auto-commit/prefetch start locks
- early-exit assignment acknowledgement when no expiry or revocation state needs mutation
- share normal and fast max-poll logic to prevent drift

## Test plan
- [x] Release unit-project build (net10.0 + netstandard2.0 library)
- [x] buffered fast path proves timeout CTS pool remains untouched
- [x] `ConsumeOneFastPathTests`: 14 passed
- [x] `ConsumerAssignmentFastPathTests`: 28 passed
- [x] `ConsumerCoordinatorKip848Tests`: 74 passed
- [x] full unit suite: 5,090 passed

Closes #1763
