### PR TITLE
Shrink adaptive fetches only under memory pressure

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2242,7 +2242,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <item><description>FetchMaxBytes: 100MB (allow larger total fetch responses; note that the response buffer pool
     /// may retain up to 8 arrays of this size per consumer instance)</description></item>
     /// <item><description>PrefetchPipelineDepth: 5 (aggressive prefetching to hide network latency)</description></item>
-    /// <item><description>AdaptiveFetchSizing: enabled (auto-grows fetch sizes when consumer keeps up, shrinks when falling behind)</description></item>
+    /// <item><description>AdaptiveFetchSizing: enabled (auto-grows fetch sizes when consumer keeps up, shrinks under prefetch memory pressure)</description></item>
     /// <item><description>CheckCrcs: disabled (skips client-side CRC32C re-validation of fetched batches; TCP checksums and
     /// broker-side validation already cover corruption in transit — matches librdkafka's default. Re-enable with
     /// <see cref="WithCheckCrcs"/> after this preset if end-to-end validation is required)</description></item>
@@ -2265,8 +2265,10 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _enableAdaptiveFetchSizing = true; // Intentional: ForHighThroughput always enables adaptive sizing
         _adaptiveFetchSizingOptions ??= new AdaptiveFetchSizingOptions
         {
+            MinPartitionFetchBytes = 4 * 1024 * 1024,
             InitialPartitionFetchBytes = 4 * 1024 * 1024,
             MaxPartitionFetchBytes = 16 * 1024 * 1024,
+            MinFetchMaxBytes = 100 * 1024 * 1024,
             InitialFetchMaxBytes = 100 * 1024 * 1024,
             MaxFetchMaxBytes = 200 * 1024 * 1024
         };

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2279,14 +2279,21 @@ public sealed class ConsumerBuilder<TKey, TValue>
 
     private void ApplyHighThroughputAdaptiveDefaults()
     {
+        var maxPartitionFetchBytes =
+            (int)Math.Min((long)_maxPartitionFetchBytes * 4, int.MaxValue);
+        var initialFetchMaxBytes = Math.Max(_fetchMaxBytes, _maxPartitionFetchBytes);
+        var maxFetchMaxBytes = Math.Max(
+            (int)Math.Min((long)_fetchMaxBytes * 2, int.MaxValue),
+            maxPartitionFetchBytes);
+
         _adaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
         {
             MinPartitionFetchBytes = _maxPartitionFetchBytes,
             InitialPartitionFetchBytes = _maxPartitionFetchBytes,
-            MaxPartitionFetchBytes = (int)Math.Min((long)_maxPartitionFetchBytes * 4, int.MaxValue),
-            MinFetchMaxBytes = _fetchMaxBytes,
-            InitialFetchMaxBytes = _fetchMaxBytes,
-            MaxFetchMaxBytes = (int)Math.Min((long)_fetchMaxBytes * 2, int.MaxValue)
+            MaxPartitionFetchBytes = maxPartitionFetchBytes,
+            MinFetchMaxBytes = initialFetchMaxBytes,
+            InitialFetchMaxBytes = initialFetchMaxBytes,
+            MaxFetchMaxBytes = maxFetchMaxBytes
         };
     }
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1381,6 +1381,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private bool _enableAdaptiveFetchSizing;
     private AdaptiveFetchSizingOptions? _adaptiveFetchSizingOptions;
+    private bool _usesHighThroughputAdaptiveDefaults;
     private bool _enableFetchSessions = true;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
@@ -1610,6 +1611,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (maxBytes < 1)
             throw new ArgumentOutOfRangeException(nameof(maxBytes), "Fetch max bytes must be at least 1");
         _fetchMaxBytes = maxBytes;
+        if (_usesHighThroughputAdaptiveDefaults)
+            ApplyHighThroughputAdaptiveDefaults();
         return this;
     }
 
@@ -1625,6 +1628,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (maxBytes < 1)
             throw new ArgumentOutOfRangeException(nameof(maxBytes), "Max partition fetch bytes must be at least 1");
         _maxPartitionFetchBytes = maxBytes;
+        if (_usesHighThroughputAdaptiveDefaults)
+            ApplyHighThroughputAdaptiveDefaults();
         return this;
     }
 
@@ -1642,6 +1647,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         _enableAdaptiveFetchSizing = true;
         _adaptiveFetchSizingOptions = options;
+        _usesHighThroughputAdaptiveDefaults = false;
         return this;
     }
 
@@ -2263,16 +2269,25 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _prefetchPipelineDepth = 5;
         _checkCrcs = false;
         _enableAdaptiveFetchSizing = true; // Intentional: ForHighThroughput always enables adaptive sizing
-        _adaptiveFetchSizingOptions ??= new AdaptiveFetchSizingOptions
+        if (_adaptiveFetchSizingOptions is null || _usesHighThroughputAdaptiveDefaults)
         {
-            MinPartitionFetchBytes = 4 * 1024 * 1024,
-            InitialPartitionFetchBytes = 4 * 1024 * 1024,
-            MaxPartitionFetchBytes = 16 * 1024 * 1024,
-            MinFetchMaxBytes = 100 * 1024 * 1024,
-            InitialFetchMaxBytes = 100 * 1024 * 1024,
-            MaxFetchMaxBytes = 200 * 1024 * 1024
-        };
+            _usesHighThroughputAdaptiveDefaults = true;
+            ApplyHighThroughputAdaptiveDefaults();
+        }
         return this;
+    }
+
+    private void ApplyHighThroughputAdaptiveDefaults()
+    {
+        _adaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+        {
+            MinPartitionFetchBytes = _maxPartitionFetchBytes,
+            InitialPartitionFetchBytes = _maxPartitionFetchBytes,
+            MaxPartitionFetchBytes = (int)Math.Min((long)_maxPartitionFetchBytes * 4, int.MaxValue),
+            MinFetchMaxBytes = _fetchMaxBytes,
+            InitialFetchMaxBytes = _fetchMaxBytes,
+            MaxFetchMaxBytes = (int)Math.Min((long)_fetchMaxBytes * 2, int.MaxValue)
+        };
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -10,7 +10,8 @@ namespace Dekaf.Consumer;
 /// fetch sizes grow to reduce round-trip overhead. Memory pressure shrinks fetch sizes.
 /// </summary>
 /// <remarks>
-/// <para>This class is not thread-safe and should be called from a single loop (the prefetch loop).</para>
+/// <para>Size adjustments are not thread-safe and must be called from the consumer processing thread.
+/// Fetch timing may be recorded by the prefetch loop.</para>
 /// <para>The feedback signal is the ratio of processing time to fetch latency:</para>
 /// <list type="bullet">
 /// <item><description>Ratio &lt; 1.0: consumer processes faster than it fetches (keeping up) — grow fetch size</description></item>

--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -4,20 +4,20 @@ using System.Runtime.CompilerServices;
 namespace Dekaf.Consumer;
 
 /// <summary>
-/// Dynamically adjusts fetch sizes based on the ratio of processing time to fetch wait time.
+/// Dynamically grows fetch sizes based on the ratio of processing time to fetch wait time
+/// and shrinks them only when the prefetch pipeline reports memory pressure.
 /// When the consumer is keeping up (processing finishes before the next fetch returns),
-/// fetch sizes grow to reduce round-trip overhead. When falling behind, fetch sizes shrink
-/// to reduce memory pressure and allow the consumer to catch up.
+/// fetch sizes grow to reduce round-trip overhead. Memory pressure shrinks fetch sizes.
 /// </summary>
 /// <remarks>
 /// <para>This class is not thread-safe and should be called from a single loop (the prefetch loop).</para>
 /// <para>The feedback signal is the ratio of processing time to fetch latency:</para>
 /// <list type="bullet">
 /// <item><description>Ratio &lt; 1.0: consumer processes faster than it fetches (keeping up) — grow fetch size</description></item>
-/// <item><description>Ratio &gt; 1.0: consumer processes slower than it fetches (falling behind) — shrink fetch size</description></item>
+/// <item><description>Ratio &gt; 1.0: consumer is CPU-bound or backlogged — arm shrinkage, applied only if memory pressure also occurs</description></item>
 /// </list>
-/// <para>Growth is multiplicative (×1.5) and shrinkage is also multiplicative (×0.75),
-/// providing asymmetric scaling: growing is cautious, shrinking is responsive.</para>
+/// <para>Growth is multiplicative (×1.5) and memory-pressure shrinkage is
+/// multiplicative (×0.75).</para>
 /// </remarks>
 internal sealed class AdaptiveFetchSizer
 {
@@ -139,6 +139,22 @@ internal sealed class AdaptiveFetchSizer
     }
 
     /// <summary>
+    /// Reports that prefetched bytes reached the configured memory limit.
+    /// Sustained pressure shrinks fetch sizes after the stable window.
+    /// </summary>
+    internal void ReportMemoryPressure()
+    {
+        _consecutiveShrinkSignals++;
+        _consecutiveGrowSignals = 0;
+
+        if (_consecutiveShrinkSignals < _stableWindowCount)
+            return;
+
+        Shrink();
+        _consecutiveShrinkSignals = 0;
+    }
+
+    /// <summary>
     /// Evaluates the processing-to-fetch ratio and adjusts fetch sizes if thresholds
     /// have been sustained for the required window count.
     /// </summary>
@@ -163,14 +179,10 @@ internal sealed class AdaptiveFetchSizer
                 break;
 
             case var r when r > _shrinkThreshold:
-                _consecutiveShrinkSignals++;
                 _consecutiveGrowSignals = 0;
-
-                if (_consecutiveShrinkSignals >= _stableWindowCount)
-                {
-                    Shrink();
-                    _consecutiveShrinkSignals = 0;
-                }
+                _consecutiveShrinkSignals = Math.Min(
+                    _consecutiveShrinkSignals + 1,
+                    _stableWindowCount);
                 break;
 
             default:
@@ -252,7 +264,7 @@ public sealed class AdaptiveFetchSizingOptions
     public double GrowthFactor { get; init; } = 1.5;
 
     /// <summary>
-    /// Multiplicative factor for shrinking fetch sizes. Applied when the consumer is falling behind.
+    /// Multiplicative factor for shrinking fetch sizes. Applied under sustained prefetch memory pressure.
     /// Default is 0.75 (25% reduction per step).
     /// </summary>
     public double ShrinkFactor { get; init; } = 0.75;
@@ -264,8 +276,8 @@ public sealed class AdaptiveFetchSizingOptions
     public double GrowThreshold { get; init; } = 0.5;
 
     /// <summary>
-    /// Processing-to-fetch ratio above which the consumer is considered "falling behind"
-    /// and fetch sizes should shrink. Default is 2.0 (processing takes more than twice the fetch time).
+    /// Processing-to-fetch ratio above which shrinkage is armed. Fetch sizes remain unchanged
+    /// until prefetch memory pressure is also reported. Default is 2.0.
     /// </summary>
     public double ShrinkThreshold { get; init; } = 2.0;
 

--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -170,7 +170,6 @@ internal sealed class AdaptiveFetchSizer
         {
             case var r when r < _growThreshold:
                 _consecutiveGrowSignals++;
-                _consecutiveShrinkSignals = 0;
 
                 if (_consecutiveGrowSignals >= _stableWindowCount)
                 {
@@ -181,15 +180,12 @@ internal sealed class AdaptiveFetchSizer
 
             case var r when r > _shrinkThreshold:
                 _consecutiveGrowSignals = 0;
-                _consecutiveShrinkSignals = Math.Min(
-                    _consecutiveShrinkSignals + 1,
-                    _stableWindowCount);
                 break;
 
             default:
-                // In the stable zone — reset both counters
+                // In the stable zone — reset ratio-driven growth only. Memory-pressure
+                // signals accumulate independently until they trigger a shrink.
                 _consecutiveGrowSignals = 0;
-                _consecutiveShrinkSignals = 0;
                 break;
         }
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2182,6 +2182,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     var currentPrefetchedBytes = Interlocked.Read(ref _prefetchedBytes);
                     if (PrefetchLoopControl.ShouldWaitForMemory(currentPrefetchedBytes, maxBytes))
                     {
+                        _adaptiveFetchSizer?.ReportMemoryPressure();
                         LogPrefetchMemoryLimitPaused(currentPrefetchedBytes, maxBytes);
                         await _prefetchMemoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
                         continue;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -809,6 +809,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private int _fetchApiVersion = -1;
     private readonly ConsumerConnectionScaler? _connectionScaler;
     private readonly AdaptiveFetchSizer? _adaptiveFetchSizer;
+    private int _adaptiveFetchMemoryPressureSignals;
 
     // Dead letter queue raw byte tracking (zero overhead when not enabled)
     private bool _rawRecordTrackingEnabled;
@@ -2182,7 +2183,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     var currentPrefetchedBytes = Interlocked.Read(ref _prefetchedBytes);
                     if (PrefetchLoopControl.ShouldWaitForMemory(currentPrefetchedBytes, maxBytes))
                     {
-                        _adaptiveFetchSizer?.ReportMemoryPressure();
+                        Interlocked.Increment(ref _adaptiveFetchMemoryPressureSignals);
                         LogPrefetchMemoryLimitPaused(currentPrefetchedBytes, maxBytes);
                         await _prefetchMemoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
                         continue;
@@ -6488,6 +6489,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var previousPartitionFetchBytes = sizer.CurrentPartitionFetchBytes;
         var previousFetchMaxBytes = sizer.CurrentFetchMaxBytes;
         sizer.ReportProcessingComplete(processingDuration);
+
+        var pressureSignals = Interlocked.Exchange(ref _adaptiveFetchMemoryPressureSignals, 0);
+        for (var i = 0; i < pressureSignals; i++)
+            sizer.ReportMemoryPressure();
 
         if (sizer.CurrentPartitionFetchBytes > previousPartitionFetchBytes
             || sizer.CurrentFetchMaxBytes > previousFetchMaxBytes)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -6488,11 +6488,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         var previousPartitionFetchBytes = sizer.CurrentPartitionFetchBytes;
         var previousFetchMaxBytes = sizer.CurrentFetchMaxBytes;
-        sizer.ReportProcessingComplete(processingDuration);
 
         var pressureSignals = Interlocked.Exchange(ref _adaptiveFetchMemoryPressureSignals, 0);
-        for (var i = 0; i < pressureSignals; i++)
-            sizer.ReportMemoryPressure();
+        if (pressureSignals == 0)
+        {
+            sizer.ReportProcessingComplete(processingDuration);
+        }
+        else
+        {
+            for (var i = 0; i < pressureSignals; i++)
+                sizer.ReportMemoryPressure();
+        }
 
         if (sizer.CurrentPartitionFetchBytes > previousPartitionFetchBytes
             || sizer.CurrentFetchMaxBytes > previousFetchMaxBytes)

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -397,6 +397,26 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_FetchOverridesUpdateAdaptiveBounds()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .WithMaxPartitionFetchBytes(1024 * 1024)
+            .WithFetchMaxBytes(8 * 1024 * 1024)
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options.AdaptiveFetchSizingOptions!;
+
+        await Assert.That(options.MinPartitionFetchBytes).IsEqualTo(1024 * 1024);
+        await Assert.That(options.InitialPartitionFetchBytes).IsEqualTo(1024 * 1024);
+        await Assert.That(options.MaxPartitionFetchBytes).IsEqualTo(4 * 1024 * 1024);
+        await Assert.That(options.MinFetchMaxBytes).IsEqualTo(8 * 1024 * 1024);
+        await Assert.That(options.InitialFetchMaxBytes).IsEqualTo(8 * 1024 * 1024);
+        await Assert.That(options.MaxFetchMaxBytes).IsEqualTo(16 * 1024 * 1024);
+    }
+
+    [Test]
     public async Task ForHighThroughput_ThenWithCheckCrcs_OverridesPreset()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -417,6 +417,23 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_TotalAdaptiveBoundsCoverOnePartition()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .WithFetchMaxBytes(8 * 1024 * 1024)
+            .WithMaxPartitionFetchBytes(64 * 1024 * 1024)
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options.AdaptiveFetchSizingOptions!;
+
+        await Assert.That(options.MinFetchMaxBytes).IsEqualTo(64 * 1024 * 1024);
+        await Assert.That(options.InitialFetchMaxBytes).IsEqualTo(64 * 1024 * 1024);
+        await Assert.That(options.MaxFetchMaxBytes).IsEqualTo(256 * 1024 * 1024);
+    }
+
+    [Test]
     public async Task ForHighThroughput_ThenWithCheckCrcs_OverridesPreset()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -383,6 +383,20 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_AdaptiveFloorsMatchPresetFetchSizes()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options.AdaptiveFetchSizingOptions!;
+
+        await Assert.That(options.MinPartitionFetchBytes).IsEqualTo(4 * 1024 * 1024);
+        await Assert.That(options.MinFetchMaxBytes).IsEqualTo(100 * 1024 * 1024);
+    }
+
+    [Test]
     public async Task ForHighThroughput_ThenWithCheckCrcs_OverridesPreset()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
@@ -89,7 +89,7 @@ public class AdaptiveFetchSizerTests
     #region Shrinkage — consumer falling behind
 
     [Test]
-    public async Task EvaluateAndAdjust_ShrinksWhenFallingBehind_AfterStableWindow()
+    public async Task ReportMemoryPressure_ShrinksAfterStableWindow()
     {
         var options = new AdaptiveFetchSizingOptions
         {
@@ -99,16 +99,16 @@ public class AdaptiveFetchSizerTests
         };
         var sizer = new AdaptiveFetchSizer(options);
 
-        // Send enough shrink signals to hit the stable window
+        // Send enough memory-pressure signals to hit the stable window
         for (var i = 0; i < 3; i++)
-            sizer.EvaluateAndAdjust(3.0); // Above shrink threshold of 2.0
+            sizer.ReportMemoryPressure();
 
         await Assert.That(sizer.CurrentPartitionFetchBytes).IsLessThan(4_000_000);
         await Assert.That(sizer.CurrentFetchMaxBytes).IsLessThan(100_000_000);
     }
 
     [Test]
-    public async Task EvaluateAndAdjust_DoesNotShrinkBeforeStableWindow()
+    public async Task ReportMemoryPressure_DoesNotShrinkBeforeStableWindow()
     {
         var options = new AdaptiveFetchSizingOptions
         {
@@ -117,15 +117,15 @@ public class AdaptiveFetchSizerTests
         };
         var sizer = new AdaptiveFetchSizer(options);
 
-        sizer.EvaluateAndAdjust(3.0);
-        sizer.EvaluateAndAdjust(3.0);
+        sizer.ReportMemoryPressure();
+        sizer.ReportMemoryPressure();
 
         await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(4_000_000);
         await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(2);
     }
 
     [Test]
-    public async Task EvaluateAndAdjust_ShrinksByExpectedFactor()
+    public async Task ReportMemoryPressure_ShrinksByExpectedFactor()
     {
         var options = new AdaptiveFetchSizingOptions
         {
@@ -136,13 +136,31 @@ public class AdaptiveFetchSizerTests
         };
         var sizer = new AdaptiveFetchSizer(options);
 
-        sizer.EvaluateAndAdjust(3.0);
+        sizer.ReportMemoryPressure();
 
         await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2_000_000);
         await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(50_000_000);
     }
 
     #endregion
+
+    [Test]
+    public async Task EvaluateAndAdjust_HighProcessingRatioAlone_DoesNotShrink()
+    {
+        var options = new AdaptiveFetchSizingOptions
+        {
+            InitialPartitionFetchBytes = 4_000_000,
+            InitialFetchMaxBytes = 100_000_000,
+            StableWindowCount = 3
+        };
+        var sizer = new AdaptiveFetchSizer(options);
+
+        for (var i = 0; i < 10; i++)
+            sizer.EvaluateAndAdjust(10.0);
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(4_000_000);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(100_000_000);
+    }
 
     #region Bounds enforcement
 
@@ -176,7 +194,7 @@ public class AdaptiveFetchSizerTests
         var sizer = new AdaptiveFetchSizer(options);
 
         // Shrink to 750K — should clamp to min of 1048576
-        sizer.EvaluateAndAdjust(3.0);
+        sizer.ReportMemoryPressure();
 
         await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(1_048_576);
     }
@@ -211,7 +229,7 @@ public class AdaptiveFetchSizerTests
         var sizer = new AdaptiveFetchSizer(options);
 
         // Shrink to 500K — should clamp to min of 1048576
-        sizer.EvaluateAndAdjust(3.0);
+        sizer.ReportMemoryPressure();
 
         await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(1_048_576);
     }
@@ -374,7 +392,7 @@ public class AdaptiveFetchSizerTests
         };
         var sizer = new AdaptiveFetchSizer(options);
 
-        sizer.EvaluateAndAdjust(3.0); // Triggers shrink, resets counter
+        sizer.ReportMemoryPressure(); // Triggers shrink, resets counter
         await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(0);
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
@@ -274,7 +274,7 @@ public class AdaptiveFetchSizerTests
     #region Signal interruption — opposing signals reset counters
 
     [Test]
-    public async Task EvaluateAndAdjust_ShrinkSignalResetsGrowCounter()
+    public async Task EvaluateAndAdjust_HighRatioResetsGrowCounter()
     {
         var sizer = CreateSizer();
 
@@ -283,25 +283,25 @@ public class AdaptiveFetchSizerTests
         sizer.EvaluateAndAdjust(0.3);
         await Assert.That(sizer.ConsecutiveGrowSignals).IsEqualTo(2);
 
-        // A shrink signal should reset the grow counter
+        // A high ratio should stop growth without pretending memory pressure occurred.
         sizer.EvaluateAndAdjust(3.0);
         await Assert.That(sizer.ConsecutiveGrowSignals).IsEqualTo(0);
-        await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(1);
+        await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(0);
     }
 
     [Test]
-    public async Task EvaluateAndAdjust_GrowSignalResetsShrinkCounter()
+    public async Task EvaluateAndAdjust_GrowSignalPreservesMemoryPressureCounter()
     {
         var sizer = CreateSizer();
 
-        // Accumulate 2 shrink signals
-        sizer.EvaluateAndAdjust(3.0);
-        sizer.EvaluateAndAdjust(3.0);
+        // Accumulate 2 independent memory-pressure signals.
+        sizer.ReportMemoryPressure();
+        sizer.ReportMemoryPressure();
         await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(2);
 
-        // A grow signal should reset the shrink counter
+        // A grow-zone ratio must not erase sustained memory pressure.
         sizer.EvaluateAndAdjust(0.3);
-        await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(0);
+        await Assert.That(sizer.ConsecutiveShrinkSignals).IsEqualTo(2);
         await Assert.That(sizer.ConsecutiveGrowSignals).IsEqualTo(1);
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -90,6 +90,34 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
     }
 
     [Test]
+    public async Task FastProcessing_WithMemoryPressure_DoesNotGrowFetches()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            EnableAdaptiveFetchSizing = true,
+            AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+            {
+                InitialPartitionFetchBytes = 4_000_000,
+                InitialFetchMaxBytes = 100_000_000,
+                StableWindowCount = 1
+            }
+        };
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        var sizer = GetPrivateField<AdaptiveFetchSizer>(consumer, "_adaptiveFetchSizer");
+        SetFetchTiming(sizer, TimeSpan.FromSeconds(1));
+        SetPrivateField(consumer, "_adaptiveFetchMemoryPressureSignals", 1);
+
+        GetReportAdaptiveProcessingComplete().Invoke(consumer, [TimeSpan.FromMilliseconds(1)]);
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsLessThan(4_000_000);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsLessThan(100_000_000);
+    }
+
+    [Test]
     public async Task AdaptiveFetchGrowth_RatchetsRecordWrapperPools()
     {
         var options = new ConsumerOptions

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -31,6 +31,34 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
     }
 
     [Test]
+    public async Task ProcessingComplete_DrainsMemoryPressureOnConsumerThread()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            EnableAdaptiveFetchSizing = true,
+            AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+            {
+                InitialPartitionFetchBytes = 4_000_000,
+                InitialFetchMaxBytes = 100_000_000,
+                StableWindowCount = 1
+            }
+        };
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        var sizer = GetPrivateField<AdaptiveFetchSizer>(consumer, "_adaptiveFetchSizer");
+        SetPrivateField(consumer, "_adaptiveFetchMemoryPressureSignals", 1);
+
+        GetReportAdaptiveProcessingComplete().Invoke(consumer, [TimeSpan.Zero]);
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsLessThan(4_000_000);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsLessThan(100_000_000);
+        await Assert.That(GetPrivateField<int>(consumer, "_adaptiveFetchMemoryPressureSignals")).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task AdaptiveFetchGrowth_RatchetsRecordWrapperPools()
     {
         var options = new ConsumerOptions
@@ -146,5 +174,22 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
         return typeof(KafkaConsumer<string, string>)
             .GetMethod("ReportAdaptiveProcessingComplete", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("ReportAdaptiveProcessingComplete method not found - was it renamed?");
+    }
+
+    private static T GetPrivateField<T>(KafkaConsumer<string, string> consumer, string fieldName) =>
+        (T)(typeof(KafkaConsumer<string, string>)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(consumer)
+        ?? throw new InvalidOperationException($"{fieldName} field not found - was it renamed?"));
+
+    private static void SetPrivateField<T>(
+        KafkaConsumer<string, string> consumer,
+        string fieldName,
+        T value)
+    {
+        var field = typeof(KafkaConsumer<string, string>)
+            .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found - was it renamed?");
+        field.SetValue(consumer, value);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerPrefetchMemorySignalTests.cs
@@ -59,6 +59,37 @@ public sealed class KafkaConsumerPrefetchMemorySignalTests
     }
 
     [Test]
+    public async Task FastProcessing_DoesNotEraseSustainedMemoryPressure()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            EnableAdaptiveFetchSizing = true,
+            AdaptiveFetchSizingOptions = new AdaptiveFetchSizingOptions
+            {
+                InitialPartitionFetchBytes = 4_000_000,
+                InitialFetchMaxBytes = 100_000_000,
+                StableWindowCount = 3
+            }
+        };
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        var sizer = GetPrivateField<AdaptiveFetchSizer>(consumer, "_adaptiveFetchSizer");
+
+        for (var i = 0; i < 3; i++)
+        {
+            SetFetchTiming(sizer, TimeSpan.FromSeconds(1));
+            SetPrivateField(consumer, "_adaptiveFetchMemoryPressureSignals", 1);
+            GetReportAdaptiveProcessingComplete().Invoke(consumer, [TimeSpan.FromMilliseconds(1)]);
+        }
+
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsLessThan(4_000_000);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsLessThan(100_000_000);
+    }
+
+    [Test]
     public async Task AdaptiveFetchGrowth_RatchetsRecordWrapperPools()
     {
         var options = new ConsumerOptions


### PR DESCRIPTION
## Summary
- stop shrinking adaptive fetch sizes from processing/fetch ratio alone
- arm shrinkage from high ratios but apply it only after actual prefetch memory-pressure signals
- report pressure when prefetched bytes reach the effective queue limit
- set high-throughput adaptive floors to its 4MB partition / 100MB response preset

## Test plan
- [x] Release unit-project build (net10.0 + netstandard2.0 library)
- [x] adaptive fetch sizer tests: 32 passed
- [x] consumer builder tests: 43 passed
- [x] full unit suite: 5,091 passed

Closes #1762
