### PR TITLE
perf(protocol): merge lazy records into RecordBatch

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -219,7 +219,7 @@ internal sealed class PendingFetchData : IDisposable
         Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _headerGeneration) == generation;
 
     /// <summary>
-    /// Gets the current record via direct array access, bypassing the LazyRecordList
+    /// Gets the current record via direct array access, bypassing lazy record-list
     /// indexer overhead (Volatile.Read + disposed check + EnsureParsedUpTo per access).
     /// Safe because EagerParseAll() is called before iteration begins.
     /// </summary>
@@ -232,7 +232,7 @@ internal sealed class PendingFetchData : IDisposable
     }
 
     // Cached batch state updated only on batch transitions, amortizing per-record cost.
-    // _currentRecordsArray bypasses IReadOnlyList<Record> virtual dispatch + LazyRecordList
+    // _currentRecordsArray bypasses IReadOnlyList<Record> virtual dispatch + lazy parsing
     // indexer overhead by caching the underlying Record[] directly.
     private Record[]? _currentRecordsArray;
     private IReadOnlyList<Record>? _currentRecords;
@@ -300,10 +300,10 @@ internal sealed class PendingFetchData : IDisposable
 
         for (var i = 0; i < _batches.Count; i++)
         {
-            if (_batches[i].Records is Protocol.Records.LazyRecordList lazyList)
-            {
+            var batch = _batches[i];
+            batch.EnsureAllRecordsParsed();
+            if (batch.Records is Protocol.Records.LazyRecordList lazyList)
                 lazyList.EnsureAllParsed();
-            }
         }
         _eagerParsed = true;
     }
@@ -320,10 +320,9 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecords = records;
         _currentRecordsCount = records.Count;
 
-        // Cache raw array for direct indexing (bypasses LazyRecordList indexer overhead).
-        _currentRecordsArray = records is Protocol.Records.LazyRecordList lazyList
-            ? lazyList.GetParsedArray()
-            : null;
+        // Cache raw array for direct indexing (bypasses lazy-list indexer overhead).
+        _currentRecordsArray = batch.GetParsedRecordsArray()
+            ?? (records is Protocol.Records.LazyRecordList lazyList ? lazyList.GetParsedArray() : null);
 
         CurrentBaseOffset = batch.BaseOffset;
         CurrentPartitionLeaderEpoch = batch.PartitionLeaderEpoch;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -277,10 +277,10 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
 /// </summary>
 /// <remarks>
 /// When created via Read() during FetchResponse parsing with pooled memory context,
-/// the Records property returns a LazyRecordList that references the pooled network buffer.
+/// the batch itself lazily parses records that reference the pooled network buffer.
 /// Call DisposeRecords() to release the pooled memory when done consuming records.
 /// </remarks>
-public sealed class RecordBatch : IDisposable
+public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 {
     /// <summary>
     /// Size of the batch header fields after batchLength: partitionLeaderEpoch(4) + magic(1) +
@@ -435,6 +435,147 @@ public sealed class RecordBatch : IDisposable
     }
 
     private IReadOnlyList<Record> _records = null!;
+    private ReadOnlyMemory<byte> _rawRecordData;
+    private byte[]? _pooledRecordData;
+    private Record[]? _parsedRecords;
+    private int _recordCount;
+    private int _parsedRecordCount;
+    private int _nextRecordParseOffset;
+
+    int IReadOnlyCollection<Record>.Count => GetLazyRecordCount();
+
+    Record IReadOnlyList<Record>.this[int index] => GetLazyRecord(index);
+
+    IEnumerator<Record> IEnumerable<Record>.GetEnumerator() => EnumerateLazyRecords().GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+        EnumerateLazyRecords().GetEnumerator();
+
+    private int GetLazyRecordCount()
+    {
+        ThrowIfNotLazyRecordList();
+        return _recordCount;
+    }
+
+    private Record GetLazyRecord(int index)
+    {
+        ThrowIfNotLazyRecordList();
+        if (index < 0 || index >= _recordCount)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        EnsureLazyRecordsParsedUpTo(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _recordCount);
+        return _parsedRecords![index];
+    }
+
+    private IEnumerable<Record> EnumerateLazyRecords()
+    {
+        ThrowIfNotLazyRecordList();
+        for (var i = 0; i < _recordCount; i++)
+        {
+            EnsureLazyRecordsParsedUpTo(i);
+            if (i >= _recordCount)
+                yield break;
+
+            yield return _parsedRecords![i];
+        }
+    }
+
+    private void ThrowIfNotLazyRecordList()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            throw new ObjectDisposedException(nameof(RecordBatch));
+        if (!ReferenceEquals(_records, this))
+            throw new InvalidOperationException("This batch does not own a lazy record list.");
+    }
+
+    private void InitializeLazyRecords(ReadOnlyMemory<byte> rawData, byte[]? pooledArray, int count)
+    {
+        _rawRecordData = rawData;
+        _pooledRecordData = pooledArray;
+        _recordCount = count;
+        _records = this;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void EnsureAllRecordsParsed()
+    {
+        if (ReferenceEquals(_records, this)
+            && _recordCount > 0
+            && (_parsedRecords is null || _parsedRecordCount < _recordCount))
+        {
+            EnsureLazyRecordsParsedUpTo(_recordCount - 1);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal Record[]? GetParsedRecordsArray() =>
+        ReferenceEquals(_records, this) ? _parsedRecords : null;
+
+    private const int MaxReasonableLazyRecordCount = 1_000_000;
+
+    private void EnsureLazyRecordsParsedUpTo(int index)
+    {
+        if (_parsedRecords is null)
+        {
+            var capacity = _recordCount > MaxReasonableLazyRecordCount ? 16 : _recordCount;
+            _parsedRecords = ArrayPool<Record>.Shared.Rent(capacity);
+        }
+
+        if (_parsedRecordCount > index || _parsedRecordCount >= _recordCount)
+            return;
+
+        var reader = new KafkaProtocolReader(_rawRecordData.Slice(_nextRecordParseOffset));
+        var readerStartOffset = _nextRecordParseOffset;
+        while (_parsedRecordCount <= index && _parsedRecordCount < _recordCount)
+        {
+            if (_parsedRecordCount >= _parsedRecords.Length)
+            {
+                var newArray = ArrayPool<Record>.Shared.Rent(_parsedRecords.Length * 2);
+                _parsedRecords.AsSpan(0, _parsedRecordCount).CopyTo(newArray);
+                ArrayPool<Record>.Shared.Return(_parsedRecords, clearArray: true);
+                _parsedRecords = newArray;
+            }
+
+            try
+            {
+                _parsedRecords[_parsedRecordCount++] = Record.Read(ref reader);
+                _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
+            }
+            catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
+            {
+                Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedRecordCount} of {_recordCount} records parsed successfully.");
+                _recordCount = _parsedRecordCount;
+                break;
+            }
+        }
+    }
+
+    private void DisposeLazyRecords()
+    {
+        var pooledArray = _pooledRecordData;
+        _pooledRecordData = null;
+        if (pooledArray is not null)
+            ArrayPool<byte>.Shared.Return(pooledArray, clearArray: false);
+
+        var parsedRecords = _parsedRecords;
+        _parsedRecords = null;
+        if (parsedRecords is not null)
+        {
+            for (var i = 0; i < _parsedRecordCount; i++)
+            {
+                if (parsedRecords[i].Headers is { } headers)
+                    ArrayPool<Header>.Shared.Return(headers, clearArray: true);
+            }
+
+            ArrayPool<Record>.Shared.Return(parsedRecords, clearArray: true);
+        }
+
+        _rawRecordData = default;
+        _recordCount = 0;
+        _parsedRecordCount = 0;
+        _nextRecordParseOffset = 0;
+    }
 
     /// <summary>
     /// Pre-compressed records data. When set, <see cref="Write"/> skips compression
@@ -562,7 +703,11 @@ public sealed class RecordBatch : IDisposable
 
     internal void DisposeRecordList()
     {
-        if (_records is IDisposable disposable)
+        if (ReferenceEquals(_records, this))
+        {
+            DisposeLazyRecords();
+        }
+        else if (_records is IDisposable disposable)
         {
             disposable.Dispose();
         }
@@ -605,6 +750,12 @@ public sealed class RecordBatch : IDisposable
         {
             // Clear references to avoid holding onto GC-tracked objects
             item._records = null!;
+            item._rawRecordData = default;
+            item._pooledRecordData = null;
+            item._parsedRecords = null;
+            item._recordCount = 0;
+            item._parsedRecordCount = 0;
+            item._nextRecordParseOffset = 0;
             item.PreCompressedRecords = null;
             item.PreCompressedLength = 0;
             item.PreCompressedType = CompressionType.None;
@@ -1067,12 +1218,13 @@ public sealed class RecordBatch : IDisposable
         }
 
         // Determine how to handle the record data based on compression and pooled memory availability
-        LazyRecordList lazyRecords;
+        ReadOnlyMemory<byte> lazyRecordData;
+        byte[]? pooledRecordData;
 
         if (compression != CompressionType.None)
         {
             // Decompress directly into an ArrayPool<byte>.Shared-backed writer, then
-            // detach the array for zero-copy handoff to LazyRecordList.
+            // detach the array for zero-copy handoff to the pooled RecordBatch.
             // This eliminates the previous decompress-to-scratch-then-copy pattern.
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
@@ -1082,8 +1234,8 @@ public sealed class RecordBatch : IDisposable
 
             // Transfer ownership of the pooled array — Dispose is a no-op after DetachBuffer.
             var pooledArray = decompressWriter.DetachBuffer(out var writtenLength);
-            var pooledData = new PooledRecordData(pooledArray, writtenLength);
-            lazyRecords = LazyRecordList.Create(pooledData, recordCount);
+            lazyRecordData = pooledArray.AsMemory(0, writtenLength);
+            pooledRecordData = pooledArray;
         }
         else if (ResponseParsingContext.HasPooledMemory)
         {
@@ -1091,7 +1243,8 @@ public sealed class RecordBatch : IDisposable
             // Mark that at least one batch used the pooled memory, so ownership
             // will be transferred to PendingFetchData after parsing completes
             ResponseParsingContext.MarkMemoryUsed();
-            lazyRecords = LazyRecordList.Create(rawRecordData, recordCount);
+            lazyRecordData = rawRecordData;
+            pooledRecordData = null;
         }
         else
         {
@@ -1100,8 +1253,8 @@ public sealed class RecordBatch : IDisposable
             var length = rawRecordData.Length;
             var pooledArray = ArrayPool<byte>.Shared.Rent(length);
             rawRecordData.Span.CopyTo(pooledArray);
-            var pooledData = new PooledRecordData(pooledArray, length);
-            lazyRecords = LazyRecordList.Create(pooledData, recordCount);
+            lazyRecordData = pooledArray.AsMemory(0, length);
+            pooledRecordData = pooledArray;
         }
 
         var batch = RentFromPool();
@@ -1117,7 +1270,7 @@ public sealed class RecordBatch : IDisposable
         batch.ProducerId = producerId;
         batch.ProducerEpoch = producerEpoch;
         batch.BaseSequence = baseSequence;
-        batch.Records = lazyRecords;
+        batch.InitializeLazyRecords(lazyRecordData, pooledRecordData, recordCount);
         return batch;
     }
 

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -442,14 +442,17 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     private int _parsedRecordCount;
     private int _nextRecordParseOffset;
 
-    int IReadOnlyCollection<Record>.Count => GetLazyRecordCount();
+    int IReadOnlyCollection<Record>.Count =>
+        ReferenceEquals(_records, this) ? GetLazyRecordCount() : Records.Count;
 
-    Record IReadOnlyList<Record>.this[int index] => GetLazyRecord(index);
+    Record IReadOnlyList<Record>.this[int index] =>
+        ReferenceEquals(_records, this) ? GetLazyRecord(index) : Records[index];
 
-    IEnumerator<Record> IEnumerable<Record>.GetEnumerator() => EnumerateLazyRecords().GetEnumerator();
+    IEnumerator<Record> IEnumerable<Record>.GetEnumerator() =>
+        ReferenceEquals(_records, this) ? EnumerateLazyRecords().GetEnumerator() : Records.GetEnumerator();
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
-        EnumerateLazyRecords().GetEnumerator();
+        ((IEnumerable<Record>)this).GetEnumerator();
 
     private int GetLazyRecordCount()
     {
@@ -540,7 +543,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
             try
             {
-                _parsedRecords[_parsedRecordCount++] = Record.Read(ref reader);
+                _parsedRecords[_parsedRecordCount] = Record.Read(ref reader);
+                _parsedRecordCount++;
                 _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
             }
             catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -470,9 +470,10 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     private IEnumerable<Record> EnumerateLazyRecords()
     {
-        ThrowIfNotLazyRecordList();
-        for (var i = 0; i < _recordCount; i++)
+        var initialRecordCount = _recordCount;
+        for (var i = 0; i < initialRecordCount; i++)
         {
+            ThrowIfNotLazyRecordList();
             EnsureLazyRecordsParsedUpTo(i);
             if (i >= _recordCount)
                 yield break;

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -417,6 +417,23 @@ public class RecordBatchTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task RecordBatch_DisposedDuringEnumeration_ThrowsOnNextRecord()
+    {
+        using var originalBatch = CreateTwoRecordBatch();
+        var buffer = new ArrayBufferWriter<byte>();
+        originalBatch.Write(buffer);
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        using var parsedBatch = RecordBatch.Read(ref reader);
+        using var enumerator = parsedBatch.Records.GetEnumerator();
+
+        await Assert.That(enumerator.MoveNext()).IsTrue();
+        parsedBatch.Dispose();
+
+        await Assert.That(() => enumerator.MoveNext()).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
     public async Task RecordBatch_Dispose_IsIdempotent()
     {
         var buffer = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -768,6 +768,35 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task IReadOnlyList_ProducerBatch_ForwardsToAssignedRecords()
+    {
+        using var batch = CreateTwoRecordBatch();
+        var records = (IReadOnlyList<Record>)batch;
+
+        await Assert.That(records.Count).IsEqualTo(2);
+        await Assert.That(records[1].OffsetDelta).IsEqualTo(1);
+        await Assert.That(records.Select(record => record.OffsetDelta)).IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
+    public async Task LazyRecords_TruncatedAfterValidRecords_DoesNotExposeDefaultRecord()
+    {
+        using var originalBatch = CreateTwoRecordBatch();
+        var buffer = new ArrayBufferWriter<byte>();
+        originalBatch.Write(buffer);
+        var bytes = buffer.WrittenSpan.ToArray();
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(RecordBatch.TotalBatchHeaderSize - sizeof(int)),
+            3);
+
+        using var parsed = ReadBatch(bytes, checkCrcs: false);
+        var records = parsed.Records.ToArray();
+
+        await Assert.That(records.Length).IsEqualTo(2);
+        await Assert.That(records.Select(record => record.OffsetDelta)).IsEquivalentTo([0, 1]);
+    }
+
+    [Test]
     public async Task Read_ThreeParameterOverload_RemainsAvailable()
     {
         var method = typeof(RecordBatch).GetMethod(

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -145,6 +145,7 @@ public class RecordBatchTests
         await Assert.That(parsedBatch.ProducerId).IsEqualTo(123L);
         await Assert.That(parsedBatch.ProducerEpoch).IsEqualTo((short)0);
         await Assert.That(parsedBatch.BaseSequence).IsEqualTo(0);
+        await Assert.That(ReferenceEquals(parsedBatch.Records, parsedBatch)).IsTrue();
         await Assert.That(parsedBatch.Records.Count).IsEqualTo(1);
 
         var record = parsedBatch.Records[0];

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseWireFormatSnapshotTests.cs
@@ -304,6 +304,26 @@ public class ResponseWireFormatSnapshotTests
                 };
             }
 
+            if (value is RecordBatch batch)
+            {
+                return new SortedDictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    [nameof(RecordBatch.Attributes)] = batch.Attributes,
+                    [nameof(RecordBatch.BaseOffset)] = batch.BaseOffset,
+                    [nameof(RecordBatch.BaseSequence)] = batch.BaseSequence,
+                    [nameof(RecordBatch.BaseTimestamp)] = batch.BaseTimestamp,
+                    [nameof(RecordBatch.BatchLength)] = batch.BatchLength,
+                    [nameof(RecordBatch.Crc)] = batch.Crc,
+                    [nameof(RecordBatch.LastOffsetDelta)] = batch.LastOffsetDelta,
+                    [nameof(RecordBatch.Magic)] = batch.Magic,
+                    [nameof(RecordBatch.MaxTimestamp)] = batch.MaxTimestamp,
+                    [nameof(RecordBatch.PartitionLeaderEpoch)] = batch.PartitionLeaderEpoch,
+                    [nameof(RecordBatch.ProducerEpoch)] = batch.ProducerEpoch,
+                    [nameof(RecordBatch.ProducerId)] = batch.ProducerId,
+                    [nameof(RecordBatch.Records)] = NormalizeValue(batch.Records.ToArray(), ancestors)
+                };
+            }
+
             var trackReference = !type.IsValueType;
             if (trackReference && !ancestors.Add(value))
             {


### PR DESCRIPTION
## Summary
- make pooled fetch `RecordBatch` own its lazy parser state and implement `IReadOnlyList<Record>`
- remove the separate `LazyRecordList` wrapper from consumer response parsing while retaining it for producer pre-encoded arena ownership
- preserve eager parsing/direct-array consumption, truncation handling, pooled decompression buffers, header cleanup, pool reuse, and post-dispose guards
- preserve response snapshot object shape for the new list-like batch type

## Validation
- Release build: 0 warnings/errors across both library TFMs
- focused RecordBatch/ConsumeBatch/ConsumeRawBatch: 62/62 pass after latest-main rebase
- pre-rebase full net10 suite: 5091/5091 pass
- post-rebase full net10 suite: 5101/5102 pass; sole unrelated global meter-listener contamination filed as #1787

Closes #1778
Part of #1761