### PR TITLE
Spin before parking empty consumer fetch waits

### DIFF
--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -26,6 +26,7 @@ internal sealed class MpscFetchBuffer
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
     private readonly object _dataAvailableWaiterLock = new();
     private readonly Action? _afterProducerWaiterCountIncrementedForTesting;
+    private readonly Action? _beforeConsumerWaitSpinForTesting;
     private TaskCompletionSource<bool>? _dataAvailableWaiter;
     private int _producerWaiterCount;
     private int _consumerWaiting;
@@ -33,11 +34,17 @@ internal sealed class MpscFetchBuffer
     private volatile Exception? _completionError;
 
     public MpscFetchBuffer(int capacity)
-        : this(capacity, afterProducerWaiterCountIncrementedForTesting: null)
+        : this(
+            capacity,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerWaitSpinForTesting: null)
     {
     }
 
-    internal MpscFetchBuffer(int capacity, Action? afterProducerWaiterCountIncrementedForTesting)
+    internal MpscFetchBuffer(
+        int capacity,
+        Action? afterProducerWaiterCountIncrementedForTesting,
+        Action? beforeConsumerWaitSpinForTesting = null)
     {
         if (capacity < 1)
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
@@ -52,6 +59,7 @@ internal sealed class MpscFetchBuffer
         _buffer = new PendingFetchData?[size];
         _mask = size - 1;
         _afterProducerWaiterCountIncrementedForTesting = afterProducerWaiterCountIncrementedForTesting;
+        _beforeConsumerWaitSpinForTesting = beforeConsumerWaitSpinForTesting;
     }
 
     internal int Capacity => _buffer.Length;
@@ -237,6 +245,19 @@ internal sealed class MpscFetchBuffer
             if (_completionError is not null)
                 throw _completionError;
             return HasDataAvailable();
+        }
+
+        // Catch near-simultaneous producer arrivals without publishing a TCS and forcing its
+        // continuation through the ThreadPool. Stop before SpinWait would yield or sleep so the
+        // optimization remains bounded and does not delay unrelated work on a busy host.
+        _beforeConsumerWaitSpinForTesting?.Invoke();
+        var spin = new SpinWait();
+        while (!spin.NextSpinWillYield)
+        {
+            if (HasDataAvailable())
+                return true;
+
+            spin.SpinOnce();
         }
 
         TaskCompletionSource<bool>? waiter = null;

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -268,6 +268,32 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_DataArrivesBeforePark_SkipsWaiter()
+    {
+        var item = CreateDummy();
+        MpscFetchBuffer? buffer = null;
+        buffer = new MpscFetchBuffer(
+            4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerWaitSpinForTesting: () => buffer!.TryWrite(item));
+
+        try
+        {
+            var result = await buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+
+            await Assert.That(result).IsTrue();
+            await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+            await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+            await Assert.That(buffer.TryRead(out var read)).IsTrue();
+            await Assert.That(read).IsSameReferenceAs(item);
+        }
+        finally
+        {
+            item.Dispose();
+        }
+    }
+
+    [Test]
     public async Task WaitToReadAsync_Timeout_ReturnsFalseAndClearsWaiterState()
     {
         var buffer = new MpscFetchBuffer(4);


### PR DESCRIPTION
Closes #1764

## Summary
- spin only while `SpinWait` can remain on-core before publishing the async data waiter
- retain existing locked rechecks and TCS park path after the bounded spin budget
- add deterministic coverage proving a near-simultaneous write skips waiter publication

## Validation
- Release build: 0 warnings, 0 errors
- `MpscFetchBufferTests`: 24/24 passed
- full net8 suite: changed tests passed; 8 unrelated load-sensitive failures, including the known #1773 fixture not yet merged into this branch base