### PR TITLE
test(stress): isolate delivery error metrics

### DIFF
--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
@@ -308,9 +309,17 @@ public class RoundTripMessageCodecTests
     public async Task DekafDeliveryMetricFailure_CountsAsRoundTripDeliveryError()
     {
         var throughput = new ThroughputTracker();
-        using var listener = ProducerRoundTripStressTest.CreateDeliveryErrorListener(throughput);
+        var topic = $"delivery-errors-{Guid.NewGuid():N}";
+        using var listener = ProducerRoundTripStressTest.CreateDeliveryErrorListener(throughput, topic);
 
-        DekafMetrics.ProduceErrors.Add(2);
+        DekafMetrics.ProduceErrors.Add(1, new TagList
+        {
+            { DekafDiagnostics.MessagingDestinationName, "unrelated-topic" }
+        });
+        DekafMetrics.ProduceErrors.Add(2, new TagList
+        {
+            { DekafDiagnostics.MessagingDestinationName, topic }
+        });
 
         await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(2);
         await Assert.That(throughput.ErrorCount).IsEqualTo(0);

--- a/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
+++ b/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
@@ -17,7 +17,7 @@ internal sealed class DekafDeliveryErrorListener : IDisposable
 {
     private readonly MeterListener _listener;
 
-    public DekafDeliveryErrorListener(ThroughputTracker throughput)
+    public DekafDeliveryErrorListener(ThroughputTracker throughput, string? topic = null)
     {
         // Resolved before the listener starts: touching DekafMetrics inside the
         // InstrumentPublished callback can re-enter its static initializer (the callback
@@ -36,9 +36,29 @@ internal sealed class DekafDeliveryErrorListener : IDisposable
             }
         };
 
-        _listener.SetMeasurementEventCallback<long>(
-            (_, measurement, _, _) => throughput.RecordDeliveryErrors(measurement));
+        _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            if (topic is null || HasTopic(tags, topic))
+                throughput.RecordDeliveryErrors(measurement);
+        });
         _listener.Start();
+    }
+
+    private static bool HasTopic(
+        ReadOnlySpan<KeyValuePair<string, object?>> tags,
+        string expectedTopic)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == DekafDiagnostics.MessagingDestinationName
+                && tag.Value is string topic
+                && topic == expectedTopic)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void Dispose() => _listener.Dispose();

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -172,8 +172,10 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             producerDiagnostics);
     }
 
-    internal static DekafDeliveryErrorListener CreateDeliveryErrorListener(ThroughputTracker throughput) =>
-        new(throughput);
+    internal static DekafDeliveryErrorListener CreateDeliveryErrorListener(
+        ThroughputTracker throughput,
+        string? topic = null) =>
+        new(throughput, topic);
 
     internal static async Task<bool> ConsumeAndValidateAsync(
         IKafkaConsumer<string, byte[]> consumer,


### PR DESCRIPTION
## Summary
- add an optional topic filter to the stress delivery-error listener
- keep production stress runs aggregating all producer delivery failures
- isolate the unit regression with a unique topic and prove unrelated tagged errors are ignored

## Validation
- Release build: 0 warnings/errors
- regression repeated: 20/20 pass
- full parallel net10 unit suite: 5102/5102 pass

Closes #1787