### PR TITLE
perf(consumer): slab-allocate parsed fetch records

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -77,6 +77,7 @@ internal sealed class PendingFetchData : IDisposable
     private IReadOnlyList<RecordBatch> _batches = null!;
     private Dictionary<long, Queue<long>>? _abortedProducers;
     private IPooledMemory? _memoryOwner;
+    private Record[]? _parsedRecordSlab;
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
@@ -153,6 +154,7 @@ internal sealed class PendingFetchData : IDisposable
         instance.TopicPartition = new TopicPartition(topic, partitionIndex);
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
+        instance.AttachParsedRecordSlab(batches);
 
         if (abortedTransactions is { Count: > 0 })
         {
@@ -170,6 +172,35 @@ internal sealed class PendingFetchData : IDisposable
         }
 
         return instance;
+    }
+
+    private void AttachParsedRecordSlab(IReadOnlyList<RecordBatch> batches)
+    {
+        const int maxSlabRecordCount = 1_000_000;
+        var totalRecordCount = 0;
+
+        for (var i = 0; i < batches.Count; i++)
+        {
+            var recordCount = batches[i].UnparsedLazyRecordCount;
+            if (recordCount < 0 || recordCount > maxSlabRecordCount - totalRecordCount)
+                return;
+            totalRecordCount += recordCount;
+        }
+
+        if (totalRecordCount == 0)
+            return;
+
+        var slab = ArrayPool<Record>.Shared.Rent(totalRecordCount);
+        var offset = 0;
+        for (var i = 0; i < batches.Count; i++)
+        {
+            var batch = batches[i];
+            var recordCount = batch.UnparsedLazyRecordCount;
+            batch.UseParsedRecordSlab(slab, offset);
+            offset += recordCount;
+        }
+
+        _parsedRecordSlab = slab;
     }
 
     public static PendingFetchData CreateError(string topic, int partitionIndex, ConsumeException error)
@@ -227,7 +258,7 @@ internal sealed class PendingFetchData : IDisposable
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => _currentRecordsArray is not null
-            ? _currentRecordsArray[_recordIndex]
+            ? _currentRecordsArray[_currentRecordsArrayOffset + _recordIndex]
             : _currentRecords![_recordIndex];
     }
 
@@ -235,6 +266,7 @@ internal sealed class PendingFetchData : IDisposable
     // _currentRecordsArray bypasses IReadOnlyList<Record> virtual dispatch + lazy parsing
     // indexer overhead by caching the underlying Record[] directly.
     private Record[]? _currentRecordsArray;
+    private int _currentRecordsArrayOffset;
     private IReadOnlyList<Record>? _currentRecords;
     private int _currentRecordsCount;
 
@@ -323,6 +355,7 @@ internal sealed class PendingFetchData : IDisposable
         // Cache raw array for direct indexing (bypasses lazy-list indexer overhead).
         _currentRecordsArray = batch.GetParsedRecordsArray()
             ?? (records is Protocol.Records.LazyRecordList lazyList ? lazyList.GetParsedArray() : null);
+        _currentRecordsArrayOffset = batch.GetParsedRecordsOffset();
 
         CurrentBaseOffset = batch.BaseOffset;
         CurrentPartitionLeaderEpoch = batch.PartitionLeaderEpoch;
@@ -485,6 +518,11 @@ internal sealed class PendingFetchData : IDisposable
             batches[i].Dispose();
         }
 
+        var parsedRecordSlab = _parsedRecordSlab;
+        _parsedRecordSlab = null;
+        if (parsedRecordSlab is not null)
+            ArrayPool<Record>.Shared.Return(parsedRecordSlab, clearArray: false);
+
         // Return the batch list to the pool for reuse
         if (_batches is List<RecordBatch> batchList)
         {
@@ -500,6 +538,7 @@ internal sealed class PendingFetchData : IDisposable
         _batchIndex = -1;
         _recordIndex = -1;
         _currentRecordsArray = null;
+        _currentRecordsArrayOffset = 0;
         _currentRecords = null;
         _currentRecordsCount = 0;
         _eagerParsed = false;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -154,7 +154,6 @@ internal sealed class PendingFetchData : IDisposable
         instance.TopicPartition = new TopicPartition(topic, partitionIndex);
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
-        instance.AttachParsedRecordSlab(batches);
 
         if (abortedTransactions is { Count: > 0 })
         {
@@ -176,13 +175,12 @@ internal sealed class PendingFetchData : IDisposable
 
     private void AttachParsedRecordSlab(IReadOnlyList<RecordBatch> batches)
     {
-        const int maxSlabRecordCount = 1_000_000;
         var totalRecordCount = 0;
 
         for (var i = 0; i < batches.Count; i++)
         {
             var recordCount = batches[i].UnparsedLazyRecordCount;
-            if (recordCount < 0 || recordCount > maxSlabRecordCount - totalRecordCount)
+            if (recordCount < 0 || recordCount > RecordBatch.MaxReasonableLazyRecordCount - totalRecordCount)
                 return;
             totalRecordCount += recordCount;
         }
@@ -329,6 +327,8 @@ internal sealed class PendingFetchData : IDisposable
 
         if (_eagerParsed)
             return;
+
+        AttachParsedRecordSlab(_batches);
 
         for (var i = 0; i < _batches.Count; i++)
         {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -189,6 +189,7 @@ internal sealed class PendingFetchData : IDisposable
             return;
 
         var slab = ArrayPool<Record>.Shared.Rent(totalRecordCount);
+        slab.AsSpan().Clear();
         var offset = 0;
         for (var i = 0; i < batches.Count; i++)
         {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -438,6 +438,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     private ReadOnlyMemory<byte> _rawRecordData;
     private byte[]? _pooledRecordData;
     private Record[]? _parsedRecords;
+    private int _parsedRecordsOffset;
+    private bool _ownsParsedRecords;
     private int _recordCount;
     private int _parsedRecordCount;
     private int _nextRecordParseOffset;
@@ -468,7 +470,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
         EnsureLazyRecordsParsedUpTo(index);
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _recordCount);
-        return _parsedRecords![index];
+        return _parsedRecords![_parsedRecordsOffset + index];
     }
 
     private IEnumerable<Record> EnumerateLazyRecords()
@@ -481,7 +483,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             if (i >= _recordCount)
                 yield break;
 
-            yield return _parsedRecords![i];
+            yield return _parsedRecords![_parsedRecordsOffset + i];
         }
     }
 
@@ -501,6 +503,21 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         _records = this;
     }
 
+    internal int UnparsedLazyRecordCount =>
+        ReferenceEquals(_records, this) && _parsedRecords is null ? _recordCount : -1;
+
+    internal void UseParsedRecordSlab(Record[] records, int offset)
+    {
+        if (!ReferenceEquals(_records, this) || _parsedRecords is not null)
+            throw new InvalidOperationException("A parsed-record slab can only be attached to an unparsed lazy batch.");
+        if ((uint)offset > (uint)records.Length || _recordCount > records.Length - offset)
+            throw new ArgumentOutOfRangeException(nameof(offset));
+
+        _parsedRecords = records;
+        _parsedRecordsOffset = offset;
+        _ownsParsedRecords = false;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void EnsureAllRecordsParsed()
     {
@@ -516,6 +533,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     internal Record[]? GetParsedRecordsArray() =>
         ReferenceEquals(_records, this) ? _parsedRecords : null;
 
+    internal int GetParsedRecordsOffset() =>
+        ReferenceEquals(_records, this) ? _parsedRecordsOffset : 0;
+
     private const int MaxReasonableLazyRecordCount = 1_000_000;
 
     private void EnsureLazyRecordsParsedUpTo(int index)
@@ -524,6 +544,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         {
             var capacity = _recordCount > MaxReasonableLazyRecordCount ? 16 : _recordCount;
             _parsedRecords = ArrayPool<Record>.Shared.Rent(capacity);
+            _ownsParsedRecords = true;
         }
 
         if (_parsedRecordCount > index || _parsedRecordCount >= _recordCount)
@@ -533,17 +554,21 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         var readerStartOffset = _nextRecordParseOffset;
         while (_parsedRecordCount <= index && _parsedRecordCount < _recordCount)
         {
-            if (_parsedRecordCount >= _parsedRecords.Length)
+            if (_parsedRecordCount >= _parsedRecords.Length - _parsedRecordsOffset)
             {
+                if (!_ownsParsedRecords)
+                    throw new InvalidOperationException("The shared parsed-record slab is smaller than the declared record count.");
+
                 var newArray = ArrayPool<Record>.Shared.Rent(_parsedRecords.Length * 2);
-                _parsedRecords.AsSpan(0, _parsedRecordCount).CopyTo(newArray);
+                _parsedRecords.AsSpan(_parsedRecordsOffset, _parsedRecordCount).CopyTo(newArray);
                 ArrayPool<Record>.Shared.Return(_parsedRecords, clearArray: true);
                 _parsedRecords = newArray;
+                _parsedRecordsOffset = 0;
             }
 
             try
             {
-                _parsedRecords[_parsedRecordCount] = Record.Read(ref reader);
+                _parsedRecords[_parsedRecordsOffset + _parsedRecordCount] = Record.Read(ref reader);
                 _parsedRecordCount++;
                 _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
             }
@@ -569,16 +594,21 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         {
             for (var i = 0; i < _parsedRecordCount; i++)
             {
-                if (parsedRecords[i].Headers is { } headers)
+                var recordIndex = _parsedRecordsOffset + i;
+                if (parsedRecords[recordIndex].Headers is { } headers)
                     ArrayPool<Header>.Shared.Return(headers, clearArray: true);
+                parsedRecords[recordIndex] = default;
             }
 
-            ArrayPool<Record>.Shared.Return(parsedRecords, clearArray: true);
+            if (_ownsParsedRecords)
+                ArrayPool<Record>.Shared.Return(parsedRecords, clearArray: false);
         }
 
         _rawRecordData = default;
         _recordCount = 0;
         _parsedRecordCount = 0;
+        _parsedRecordsOffset = 0;
+        _ownsParsedRecords = false;
         _nextRecordParseOffset = 0;
     }
 
@@ -758,6 +788,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             item._rawRecordData = default;
             item._pooledRecordData = null;
             item._parsedRecords = null;
+            item._parsedRecordsOffset = 0;
+            item._ownsParsedRecords = false;
             item._recordCount = 0;
             item._parsedRecordCount = 0;
             item._nextRecordParseOffset = 0;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -536,7 +536,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     internal int GetParsedRecordsOffset() =>
         ReferenceEquals(_records, this) ? _parsedRecordsOffset : 0;
 
-    private const int MaxReasonableLazyRecordCount = 1_000_000;
+    internal const int MaxReasonableLazyRecordCount = 1_000_000;
 
     private void EnsureLazyRecordsParsedUpTo(int index)
     {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -597,11 +597,12 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 var recordIndex = _parsedRecordsOffset + i;
                 if (parsedRecords[recordIndex].Headers is { } headers)
                     ArrayPool<Header>.Shared.Return(headers, clearArray: true);
-                parsedRecords[recordIndex] = default;
+                if (!_ownsParsedRecords)
+                    parsedRecords[recordIndex] = default;
             }
 
             if (_ownsParsedRecords)
-                ArrayPool<Record>.Shared.Return(parsedRecords, clearArray: false);
+                ArrayPool<Record>.Shared.Return(parsedRecords, clearArray: true);
         }
 
         _rawRecordData = default;

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -30,6 +30,9 @@ public class RecordBatchTests
         });
         using var pending = PendingFetchData.Create("topic", 0, [first, second]);
 
+        await Assert.That(first.GetParsedRecordsArray()).IsNull();
+        await Assert.That(second.GetParsedRecordsArray()).IsNull();
+
         pending.EagerParseAll();
 
         var slab = first.GetParsedRecordsArray();
@@ -75,6 +78,24 @@ public class RecordBatchTests
         await Assert.That(next.GetParsedRecordsOffset()).IsEqualTo(3);
         await Assert.That(slab![0].Value.ToArray()).IsEquivalentTo("first"u8.ToArray());
         await Assert.That(slab[3].Value.ToArray()).IsEquivalentTo("next"u8.ToArray());
+    }
+
+    [Test]
+    public async Task PendingFetchData_MixedBatchKindsFallBackToOwnedParsedArray()
+    {
+        var lazy = ReadWrittenBatch(CreateTwoRecordBatch());
+        var assigned = new RecordBatch
+        {
+            Records = [new Record { Value = "assigned"u8.ToArray() }]
+        };
+        using var pending = PendingFetchData.Create("topic", 0, [lazy, assigned]);
+
+        pending.EagerParseAll();
+
+        await Assert.That(lazy.GetParsedRecordsArray()).IsNotNull();
+        await Assert.That(lazy.GetParsedRecordsOffset()).IsEqualTo(0);
+        await Assert.That(assigned.GetParsedRecordsArray()).IsNull();
+        await Assert.That(assigned.Records[0].Value.ToArray()).IsEquivalentTo("assigned"u8.ToArray());
     }
 
     private static RecordBatch ReadWrittenBatch(RecordBatch batch)

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using Dekaf.Compression;
+using Dekaf.Consumer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -15,6 +16,86 @@ namespace Dekaf.Tests.Unit.Protocol;
 public class RecordBatchTests
 {
     #region RecordBatch Structure Tests
+
+    [Test]
+    public async Task PendingFetchData_MultipleBatchesShareParsedRecordSlab()
+    {
+        var first = ReadWrittenBatch(CreateTwoRecordBatch());
+        var second = ReadWrittenBatch(new RecordBatch
+        {
+            BaseOffset = 2,
+            BaseTimestamp = 1002,
+            MaxTimestamp = 1002,
+            Records = [new Record { OffsetDelta = 0, Value = "value-2"u8.ToArray() }]
+        });
+        using var pending = PendingFetchData.Create("topic", 0, [first, second]);
+
+        pending.EagerParseAll();
+
+        var slab = first.GetParsedRecordsArray();
+        await Assert.That(slab).IsNotNull();
+        await Assert.That(second.GetParsedRecordsArray()).IsSameReferenceAs(slab);
+        await Assert.That(first.GetParsedRecordsOffset()).IsEqualTo(0);
+        await Assert.That(second.GetParsedRecordsOffset()).IsEqualTo(2);
+        await Assert.That(slab![0].Value.ToArray()).IsEquivalentTo("value-0"u8.ToArray());
+        await Assert.That(slab[2].Value.ToArray()).IsEquivalentTo("value-2"u8.ToArray());
+        await Assert.That(pending.MoveNext()).IsTrue();
+        await Assert.That(pending.CurrentRecord.Value.ToArray()).IsEquivalentTo("value-0"u8.ToArray());
+        await Assert.That(pending.MoveNext()).IsTrue();
+        await Assert.That(pending.CurrentRecord.Value.ToArray()).IsEquivalentTo("value-1"u8.ToArray());
+        await Assert.That(pending.MoveNext()).IsTrue();
+        await Assert.That(pending.CurrentRecord.Value.ToArray()).IsEquivalentTo("value-2"u8.ToArray());
+
+        first.Dispose();
+
+        await Assert.That(slab[0]).IsEqualTo(default(Record));
+        await Assert.That(slab[1]).IsEqualTo(default(Record));
+        await Assert.That(slab[2].Value.ToArray()).IsEquivalentTo("value-2"u8.ToArray());
+    }
+
+    [Test]
+    public async Task PendingFetchData_TruncatedBatchDoesNotOverwriteNextSlabSlice()
+    {
+        var truncated = ReadWrittenBatchWithDeclaredRecordCount(new RecordBatch
+        {
+            Records = [new Record { Value = "first"u8.ToArray() }]
+        }, declaredRecordCount: 3);
+        var next = ReadWrittenBatch(new RecordBatch
+        {
+            BaseOffset = 3,
+            Records = [new Record { Value = "next"u8.ToArray() }]
+        });
+        using var pending = PendingFetchData.Create("topic", 0, [truncated, next]);
+
+        pending.EagerParseAll();
+
+        var slab = truncated.GetParsedRecordsArray();
+        await Assert.That(truncated.Records.Count).IsEqualTo(1);
+        await Assert.That(next.GetParsedRecordsArray()).IsSameReferenceAs(slab);
+        await Assert.That(next.GetParsedRecordsOffset()).IsEqualTo(3);
+        await Assert.That(slab![0].Value.ToArray()).IsEquivalentTo("first"u8.ToArray());
+        await Assert.That(slab[3].Value.ToArray()).IsEquivalentTo("next"u8.ToArray());
+    }
+
+    private static RecordBatch ReadWrittenBatch(RecordBatch batch)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        return RecordBatch.Read(ref reader);
+    }
+
+    private static RecordBatch ReadWrittenBatchWithDeclaredRecordCount(RecordBatch batch, int declaredRecordCount)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        batch.Write(buffer);
+        var bytes = buffer.WrittenSpan.ToArray();
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(RecordBatch.TotalBatchHeaderSize - sizeof(int)),
+            declaredRecordCount);
+        var reader = new KafkaProtocolReader(bytes);
+        return RecordBatch.Read(ref reader);
+    }
 
     [Test]
     public async Task RecordBatch_MagicByte_IsTwo()

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -77,6 +77,8 @@ public class RecordBatchTests
         await Assert.That(next.GetParsedRecordsArray()).IsSameReferenceAs(slab);
         await Assert.That(next.GetParsedRecordsOffset()).IsEqualTo(3);
         await Assert.That(slab![0].Value.ToArray()).IsEquivalentTo("first"u8.ToArray());
+        await Assert.That(slab[1]).IsEqualTo(default(Record));
+        await Assert.That(slab[2]).IsEqualTo(default(Record));
         await Assert.That(slab[3].Value.ToArray()).IsEquivalentTo("next"u8.ToArray());
     }
 


### PR DESCRIPTION
Closes #1779
Part of #1761

## Summary
- rent one pooled `Record[]` slab per partition fetch and assign each lazy wire batch a slice
- preserve direct-array consumer access with batch-local offsets
- clear populated record slots and return header arrays per batch, then return the shared slab without redundant clearing
- bound slab sizing and fall back for mixed, already-parsed, or unreasonable batches

## Validation
- Release build: 0 warnings/errors
- focused `RecordBatchTests|ConsumeOneFastPathTests`: 64/64
- full net10 unit suite: 5110/5110