### PR TITLE
Prevent adaptive scale-down under producer load

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4302,12 +4302,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         foreach (var (topicPartition, _) in _mutedPartitions)
         {
-            if (_accumulator.GetPartitionQueueBytes(
-                    topicPartition.Topic,
-                    topicPartition.Partition) > 0)
-            {
+            if (_accumulator.HasQueuedBatches(topicPartition))
                 return true;
-            }
         }
 
         return false;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1035,7 +1035,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // ── 4b. Adaptive connection scaling ──
                 if (_adaptiveScalingEnabled)
                 {
-                    var scaledToCount = MaybeScaleConnections();
+                    var scaledToCount = MaybeScaleConnections(carryOver);
 
                     if (scaledToCount > 0)
                     {
@@ -4088,7 +4088,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// (polled each iteration).
     /// Returns the new connection count if scaling completed this iteration, or 0 otherwise.
     /// </summary>
-    private int MaybeScaleConnections()
+    private int MaybeScaleConnections(PartitionCarryOver carryOver)
     {
         // Phase 0: Poll draining connection for disposal
         MaybeDrainAndDisposeConnection();
@@ -4234,7 +4234,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ? (double)pendingResponseCount / _totalMaxInFlight
             : 0;
         if (inFlightUtilization >= ScaleDownInFlightUtilizationThreshold
-            || HasMutedPartitionLoad())
+            || HasMutedPartitionLoad(carryOver))
         {
             _lowUtilizationStartTicks = 0;
             return 0;
@@ -4295,14 +4295,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return 0;
     }
 
-    private bool HasMutedPartitionLoad()
+    private bool HasMutedPartitionLoad(PartitionCarryOver carryOver)
     {
         if (!_muteOnSend || _mutedPartitions.IsEmpty)
             return false;
 
         foreach (var (topicPartition, _) in _mutedPartitions)
         {
-            if (_accumulator.HasQueuedBatches(topicPartition))
+            if ((carryOver.Partitions.TryGetValue(topicPartition, out var carryOverQueue)
+                 && carryOverQueue.Count > 0)
+                || _accumulator.HasQueuedBatches(topicPartition))
                 return true;
         }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -509,6 +509,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     // Scale-down thresholds
     private const double ScaleDownUtilizationThreshold = 0.3; // Buffer utilization below which scale-down is considered
+    private const double ScaleDownInFlightUtilizationThreshold = 0.3;
     private const long ScaleDownSustainedMs = 120_000; // 2 minutes of sustained low utilization required
 
     // Effective scaling timings: the constants above unless overridden via the internal
@@ -4223,6 +4224,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (now - _lowUtilizationStartTicks < _scaleDownSustainedMs)
             return 0; // Not sustained long enough
 
+        // Low buffer occupancy can mean the expanded connection group is keeping up, not
+        // that it is idle. In particular, acks=all non-idempotent producers mute each
+        // partition while its request is in flight; shrinking that load-bearing width
+        // reintroduces head-of-line blocking. Require both low aggregate in-flight use and
+        // no queued work behind a muted partition before retiring a connection.
+        var pendingResponseCount = Volatile.Read(ref _totalPendingResponseCount);
+        var inFlightUtilization = _totalMaxInFlight > 0
+            ? (double)pendingResponseCount / _totalMaxInFlight
+            : 0;
+        if (inFlightUtilization >= ScaleDownInFlightUtilizationThreshold
+            || HasMutedPartitionLoad())
+        {
+            _lowUtilizationStartTicks = 0;
+            return 0;
+        }
+
         // Idempotent producers require ALL connections to be drained before shrinking
         // because partitions remap (P % N -> P % (N-1)) and in-flight batches on any
         // connection could conflict with new batches post-remap, causing sequence errors.
@@ -4276,6 +4293,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _brokerId, targetShrinkCount, _cts.Token).AsTask();
 
         return 0;
+    }
+
+    private bool HasMutedPartitionLoad()
+    {
+        if (!_muteOnSend || _mutedPartitions.IsEmpty)
+            return false;
+
+        foreach (var (topicPartition, _) in _mutedPartitions)
+        {
+            if (_accumulator.GetPartitionQueueBytes(
+                    topicPartition.Topic,
+                    topicPartition.Partition) > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1035,7 +1035,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // ── 4b. Adaptive connection scaling ──
                 if (_adaptiveScalingEnabled)
                 {
-                    var scaledToCount = MaybeScaleConnections(carryOver);
+                    var hasUnreadEvent = !_isIdempotent && eventReader.TryPeek(out _);
+                    var scaledToCount = MaybeScaleConnections(carryOver, hasUnreadEvent);
 
                     if (scaledToCount > 0)
                     {
@@ -4088,7 +4089,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// (polled each iteration).
     /// Returns the new connection count if scaling completed this iteration, or 0 otherwise.
     /// </summary>
-    private int MaybeScaleConnections(PartitionCarryOver carryOver)
+    private int MaybeScaleConnections(PartitionCarryOver carryOver, bool hasUnreadEvent)
     {
         // Phase 0: Poll draining connection for disposal
         MaybeDrainAndDisposeConnection();
@@ -4234,7 +4235,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ? (double)pendingResponseCount / _totalMaxInFlight
             : 0;
         if (inFlightUtilization >= ScaleDownInFlightUtilizationThreshold
-            || HasMutedPartitionLoad(carryOver))
+            || HasMutedPartitionLoad(carryOver, hasUnreadEvent))
         {
             _lowUtilizationStartTicks = 0;
             return 0;
@@ -4295,10 +4296,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return 0;
     }
 
-    private bool HasMutedPartitionLoad(PartitionCarryOver carryOver)
+    private bool HasMutedPartitionLoad(PartitionCarryOver carryOver, bool hasUnreadEvent)
     {
         if (!_muteOnSend || _mutedPartitions.IsEmpty)
             return false;
+
+        // The channel is unified, so its unread tail can include wake-up signals as
+        // well as batches. For the non-idempotent acks=all workload this guard targets,
+        // conservatively defer until the single reader can classify the tail. Idempotent
+        // producers retain their existing ability to shrink under continuous traffic.
+        if (hasUnreadEvent)
+            return true;
 
         foreach (var (topicPartition, _) in _mutedPartitions)
         {

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1686,20 +1686,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         // Re-notify so Ready() picks up any sealed batches that were skipped while muted.
-        if (_partitionDeques.TryGetValue(tp, out var pd))
-        {
-            bool hasBatches;
-            {
-                using var guard = new SpinLockGuard(ref pd.Lock);
-                hasBatches = pd.PeekFirst() is not null;
-            }
-            if (hasBatches)
-                _readyPartitions.Enqueue(tp);
-        }
+        if (HasQueuedBatches(tp))
+            _readyPartitions.Enqueue(tp);
 
         SignalWakeup(); // Wake sender loop so it can drain the newly-unmuted partition
     }
     internal bool IsMuted(TopicPartition tp) => _mutedPartitions.ContainsKey(tp);
+
+    internal bool HasQueuedBatches(TopicPartition tp)
+    {
+        if (!_partitionDeques.TryGetValue(tp, out var pd))
+            return false;
+
+        using var guard = new SpinLockGuard(ref pd.Lock);
+        return pd.PeekFirst() is not null;
+    }
 
     internal void SignalWakeup()
     {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -433,6 +433,53 @@ public sealed class AdaptiveScaleDownTests
         var pool = Substitute.For<IConnectionPool>();
         var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
         var topicPartition = new TopicPartition(Topic, 0);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            SetField(sender, "_connectionCount", 4);
+            SetField(sender, "_totalMaxInFlight", 4);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            var partitionQueueBytes = GetField<ConcurrentDictionary<TopicPartition, long>>(
+                accumulator,
+                "_partitionQueueBytes");
+            partitionQueueBytes[topicPartition] = 100;
+            accumulator.Reenqueue(CreateTestBatch(valueTaskSourcePool, partition: 0), 0);
+
+            typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ScaleDown_MutedPartitionWithOnlyInFlightBatch_Shrinks()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var topicPartition = new TopicPartition(Topic, 0);
 
         try
         {
@@ -453,11 +500,11 @@ public sealed class AdaptiveScaleDownTests
             InvokeMaybeScaleConnections(sender);
             InvokeMaybeScaleConnections(sender);
 
-            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+            await pool.Received(1).ShrinkConnectionGroupAsync(
                 Arg.Any<int>(),
-                Arg.Any<int>(),
+                3,
                 Arg.Any<CancellationToken>());
-            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(3);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -362,14 +362,10 @@ public sealed class AdaptiveScaleDownTests
                 BindingFlags.Instance | BindingFlags.NonPublic)!
                 .SetValue(sender, 2);
 
-            var maybeScaleConnections = typeof(BrokerSender).GetMethod(
-                "MaybeScaleConnections",
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
-
             // First pass starts low-utilization tracking; zero sustained window makes
             // the second pass eligible to shrink if shared-pool protection is absent.
-            maybeScaleConnections.Invoke(sender, null);
-            maybeScaleConnections.Invoke(sender, null);
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
 
             var connectionCount = (int)typeof(BrokerSender).GetField(
                 "_connectionCount",
@@ -513,11 +509,72 @@ public sealed class AdaptiveScaleDownTests
         }
     }
 
-    private static void InvokeMaybeScaleConnections(BrokerSender sender) =>
+    [Test]
+    public async Task ScaleDown_MutedPartitionWithCarryOverBatch_DoesNotShrink()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var topicPartition = new TopicPartition(Topic, 0);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var carryOver = CreateCarryOver(CreateTestBatch(valueTaskSourcePool, partition: 0));
+
+        try
+        {
+            SetField(sender, "_connectionCount", 4);
+            SetField(sender, "_totalMaxInFlight", 4);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+
+            InvokeMaybeScaleConnections(sender, carryOver);
+            InvokeMaybeScaleConnections(sender, carryOver);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    private static object CreateCarryOver(ReadyBatch? batch = null)
+    {
+        var carryOverType = typeof(BrokerSender).GetNestedType(
+            "PartitionCarryOver",
+            BindingFlags.NonPublic)!;
+        var carryOver = Activator.CreateInstance(carryOverType)!;
+        if (batch is null)
+            return carryOver;
+
+        var batchReferenceType = typeof(BrokerSender).GetNestedType(
+            "BatchReference",
+            BindingFlags.NonPublic)!;
+        var batchReference = Activator.CreateInstance(
+            batchReferenceType,
+            [batch, batch.Generation])!;
+        carryOverType.GetMethod("Add")!.Invoke(carryOver, [batchReference]);
+        return carryOver;
+    }
+
+    private static void InvokeMaybeScaleConnections(BrokerSender sender, object? carryOver = null) =>
         typeof(BrokerSender).GetMethod(
             "MaybeScaleConnections",
             BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(sender, null);
+            .Invoke(sender, [carryOver ?? CreateCarryOver()]);
 
     private static T GetField<T>(object instance, string fieldName) =>
         (T)instance.GetType().GetField(

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Errors;
@@ -387,6 +388,99 @@ public sealed class AdaptiveScaleDownTests
             await accumulator.DisposeAsync();
         }
     }
+
+    [Test]
+    public async Task ScaleDown_SaturatedInFlightCapacity_DoesNotShrink()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 2);
+            SetField(sender, "_totalMaxInFlight", 2);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(2);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ScaleDown_MutedPartitionWithQueuedBatch_DoesNotShrink()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var topicPartition = new TopicPartition(Topic, 0);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 4);
+            SetField(sender, "_totalMaxInFlight", 4);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            var partitionQueueBytes = GetField<ConcurrentDictionary<TopicPartition, long>>(
+                accumulator,
+                "_partitionQueueBytes");
+            partitionQueueBytes[topicPartition] = 100;
+
+            typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    private static void InvokeMaybeScaleConnections(BrokerSender sender) =>
+        typeof(BrokerSender).GetMethod(
+            "MaybeScaleConnections",
+            BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(sender, null);
+
+    private static T GetField<T>(object instance, string fieldName) =>
+        (T)instance.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(instance)!;
+
+    private static void SetField<T>(object instance, string fieldName, T value) =>
+        instance.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
 
     [Test]
     [Arguments(false, false, true)]

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -551,6 +551,45 @@ public sealed class AdaptiveScaleDownTests
         }
     }
 
+    [Test]
+    public async Task ScaleDown_MutedPartitionWithUnreadChannelTail_DoesNotShrink()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var topicPartition = new TopicPartition(Topic, 0);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 4);
+            SetField(sender, "_totalMaxInFlight", 4);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+
+            InvokeMaybeScaleConnections(sender, hasUnreadEvent: true);
+            InvokeMaybeScaleConnections(sender, hasUnreadEvent: true);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
     private static object CreateCarryOver(ReadyBatch? batch = null)
     {
         var carryOverType = typeof(BrokerSender).GetNestedType(
@@ -570,11 +609,14 @@ public sealed class AdaptiveScaleDownTests
         return carryOver;
     }
 
-    private static void InvokeMaybeScaleConnections(BrokerSender sender, object? carryOver = null) =>
+    private static void InvokeMaybeScaleConnections(
+        BrokerSender sender,
+        object? carryOver = null,
+        bool hasUnreadEvent = false) =>
         typeof(BrokerSender).GetMethod(
             "MaybeScaleConnections",
             BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(sender, [carryOver ?? CreateCarryOver()]);
+            .Invoke(sender, [carryOver ?? CreateCarryOver(), hasUnreadEvent]);
 
     private static T GetField<T>(object instance, string fieldName) =>
         (T)instance.GetType().GetField(


### PR DESCRIPTION
## Summary
- block adaptive scale-down while aggregate in-flight capacity remains saturated
- preserve connection width when mute-on-send partitions still carry queued work
- cover both load-bearing signals with scale-down regression tests

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] full unit suite: 5,135 passed
- [x] `MultiConnectionProducerTests`: 8 passed with Docker/Kafka

Closes #1796
