### PR TITLE
Detect intra-run stress degradation

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -4,9 +4,6 @@ from collections import defaultdict
 from math import isfinite
 from statistics import median
 
-STEADY_STATE_PEAK_THRESHOLD = 0.85
-SLOPE_PERCENT_PER_MINUTE_THRESHOLD = -1.0
-
 SCENARIO_TITLES = {
     'producer': 'Producer (Fire-and-Forget)',
     'producer-idempotent': 'Producer (Fire-and-Forget, Idempotent)',
@@ -142,53 +139,38 @@ def median_interval_rate(result):
 
 
 def intra_run_throughput(result):
-    """Return intra-run degradation metrics, or None when samples are unsuitable."""
+    """Return C#-computed intra-run metrics, or None for older result files."""
     if result.get('isMessageBounded'):
         return None
 
-    throughput = result.get('throughput', {})
-    samples = throughput.get('messagesPerSecondSamples') or []
-    samples = [
-        float(sample) for sample in samples
-        if isinstance(sample, (int, float))
-        and not isinstance(sample, bool)
-        and isfinite(sample)
-        and sample >= 0
-    ]
-    elapsed_seconds = throughput.get('elapsedSeconds')
-    if len(samples) < 3 or not isinstance(elapsed_seconds, (int, float)) or elapsed_seconds <= 0:
-        return None
-
-    third_count = max(1, len(samples) // 3)
-    first_third = sum(samples[:third_count]) / third_count
-    last_third = sum(samples[-third_count:]) / third_count
-    peak = max(samples)
-    if first_third <= 0 or peak <= 0:
-        return None
-
-    mean = sum(samples) / len(samples)
-    centered_x = [(index - ((len(samples) - 1) / 2)) for index in range(len(samples))]
-    denominator = sum(value * value for value in centered_x)
-    slope_per_sample = (
-        sum(x * (sample - mean) for x, sample in zip(centered_x, samples)) / denominator
-    )
-    sample_minutes = elapsed_seconds / len(samples) / 60.0
-    slope_percent_per_minute = slope_per_sample / sample_minutes / first_third * 100.0
-    steady_state_peak_ratio = last_third / peak
-    drift_percent = (last_third - first_third) / first_third * 100.0
-
-    return {
-        'firstThirdAverage': first_third,
-        'lastThirdAverage': last_third,
-        'peak': peak,
-        'steadyStatePeakRatio': steady_state_peak_ratio,
-        'driftPercent': drift_percent,
-        'slopePercentPerMinute': slope_percent_per_minute,
-        'thresholdBreached': (
-            steady_state_peak_ratio < STEADY_STATE_PEAK_THRESHOLD
-            or slope_percent_per_minute < SLOPE_PERCENT_PER_MINUTE_THRESHOLD
+    numeric_fields = {
+        'steadyStatePeakRatio': result.get('steadyStatePeakRatio'),
+        'driftPercent': result.get('intraRunDriftPercent'),
+        'slopePercentPerMinute': result.get('throughputSlopePercentPerMinute'),
+        'steadyStatePeakRatioThreshold': result.get('steadyStatePeakRatioThreshold'),
+        'slopePercentPerMinuteThreshold': result.get(
+            'throughputSlopePercentPerMinuteThreshold'
         ),
     }
+    if any(
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not isfinite(value)
+        for value in numeric_fields.values()
+    ):
+        return None
+
+    boolean_fields = {
+        'steadyStatePeakThresholdBreached': result.get(
+            'steadyStatePeakThresholdBreached'
+        ),
+        'slopeThresholdBreached': result.get('throughputSlopeThresholdBreached'),
+        'thresholdBreached': result.get('intraRunThroughputThresholdBreached'),
+    }
+    if any(not isinstance(value, bool) for value in boolean_fields.values()):
+        return None
+
+    return numeric_fields | boolean_fields
 
 
 def comparison_rate(result):
@@ -282,8 +264,20 @@ def format_throughput_table(results, title, include_ratio=False):
         lines.append("*Rows and Comparison Ratio use Median msg/s when available; older result files without interval samples fall back to Messages/sec.*")
         lines.append("")
 
-    if any(intra_run_throughput(r) is not None for r in results):
-        lines.append("*Drift compares last-third with first-third average throughput. Slope is the normalized least-squares trend; steady-state below 85% of peak or slope below -1%/min fails the regression gate.*")
+    intra_run_metrics = None
+    for result in results:
+        intra_run_metrics = intra_run_throughput(result)
+        if intra_run_metrics is not None:
+            break
+    if intra_run_metrics is not None:
+        peak_threshold = intra_run_metrics['steadyStatePeakRatioThreshold']
+        slope_threshold = intra_run_metrics['slopePercentPerMinuteThreshold']
+        lines.append(
+            "*Drift compares last-third with first-third average throughput. "
+            "Slope is the normalized least-squares trend; steady-state below "
+            f"{peak_threshold:.0%} of peak or slope below {slope_threshold:g}%/min "
+            "fails the regression gate.*"
+        )
         lines.append("")
 
     if any(r.get('deliveredMessages') is not None for r in results):

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -4,6 +4,9 @@ from collections import defaultdict
 from math import isfinite
 from statistics import median
 
+STEADY_STATE_PEAK_THRESHOLD = 0.85
+SLOPE_PERCENT_PER_MINUTE_THRESHOLD = -1.0
+
 SCENARIO_TITLES = {
     'producer': 'Producer (Fire-and-Forget)',
     'producer-idempotent': 'Producer (Fire-and-Forget, Idempotent)',
@@ -138,6 +141,56 @@ def median_interval_rate(result):
     return median(finite_samples)
 
 
+def intra_run_throughput(result):
+    """Return intra-run degradation metrics, or None when samples are unsuitable."""
+    if result.get('isMessageBounded'):
+        return None
+
+    throughput = result.get('throughput', {})
+    samples = throughput.get('messagesPerSecondSamples') or []
+    samples = [
+        float(sample) for sample in samples
+        if isinstance(sample, (int, float))
+        and not isinstance(sample, bool)
+        and isfinite(sample)
+        and sample >= 0
+    ]
+    elapsed_seconds = throughput.get('elapsedSeconds')
+    if len(samples) < 3 or not isinstance(elapsed_seconds, (int, float)) or elapsed_seconds <= 0:
+        return None
+
+    third_count = max(1, len(samples) // 3)
+    first_third = sum(samples[:third_count]) / third_count
+    last_third = sum(samples[-third_count:]) / third_count
+    peak = max(samples)
+    if first_third <= 0 or peak <= 0:
+        return None
+
+    mean = sum(samples) / len(samples)
+    centered_x = [(index - ((len(samples) - 1) / 2)) for index in range(len(samples))]
+    denominator = sum(value * value for value in centered_x)
+    slope_per_sample = (
+        sum(x * (sample - mean) for x, sample in zip(centered_x, samples)) / denominator
+    )
+    sample_minutes = elapsed_seconds / len(samples) / 60.0
+    slope_percent_per_minute = slope_per_sample / sample_minutes / first_third * 100.0
+    steady_state_peak_ratio = last_third / peak
+    drift_percent = (last_third - first_third) / first_third * 100.0
+
+    return {
+        'firstThirdAverage': first_third,
+        'lastThirdAverage': last_third,
+        'peak': peak,
+        'steadyStatePeakRatio': steady_state_peak_ratio,
+        'driftPercent': drift_percent,
+        'slopePercentPerMinute': slope_percent_per_minute,
+        'thresholdBreached': (
+            steady_state_peak_ratio < STEADY_STATE_PEAK_THRESHOLD
+            or slope_percent_per_minute < SLOPE_PERCENT_PER_MINUTE_THRESHOLD
+        ),
+    }
+
+
 def comparison_rate(result):
     """Rate used for ranking and ratios: median interval rate when present, else headline rate."""
     rate = median_interval_rate(result)
@@ -191,11 +244,11 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |")
-        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|------------------|")
+        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |")
+        lines.append("|--------|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|------------------|")
     else:
-        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used |")
-        lines.append("|--------|------------|--------------|--------------|--------|----------------|--------|------------|")
+        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used |")
+        lines.append("|--------|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|")
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
     sorted_results = sorted(results, key=throughput_sort_key)
@@ -207,6 +260,9 @@ def format_throughput_table(results, title, include_ratio=False):
         mb_sec = effective_mb_rate(r)
         median_rate = median_interval_rate(r)
         median_msg_sec = f"{median_rate:,.0f}" if median_rate is not None else '-'
+        intra_run = intra_run_throughput(r)
+        drift = f"{intra_run['driftPercent']:+.1f}%" if intra_run is not None else '-'
+        slope = f"{intra_run['slopePercentPerMinute']:+.2f}%" if intra_run is not None else '-'
         accepted_rate = accepted_messages_per_second(r)
         accepted = f"{accepted_rate:,.0f}" if accepted_rate is not None else '-'
         errors = throughput.get('totalErrors', 0)
@@ -214,9 +270,9 @@ def format_throughput_table(results, title, include_ratio=False):
 
         if include_ratio:
             ratio = comparison_rate(r) / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
         else:
-            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
 
     lines.append("")
 
@@ -224,6 +280,10 @@ def format_throughput_table(results, title, include_ratio=False):
         lines.append("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*")
         lines.append("")
         lines.append("*Rows and Comparison Ratio use Median msg/s when available; older result files without interval samples fall back to Messages/sec.*")
+        lines.append("")
+
+    if any(intra_run_throughput(r) is not None for r in results):
+        lines.append("*Drift compares last-third with first-third average throughput. Slope is the normalized least-squares trend; steady-state below 85% of peak or slope below -1%/min fails the regression gate.*")
         lines.append("")
 
     if any(r.get('deliveredMessages') is not None for r in results):

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from statistics import median
 
 from stress_report import (
-    SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
-    STEADY_STATE_PEAK_THRESHOLD,
     cpu_micros_per_message,
     effective_rate,
     intra_run_throughput,
@@ -246,15 +244,15 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "steadyStatePeakRatio",
                     "Steady-state / peak",
                     intra_run["steadyStatePeakRatio"],
-                    STEADY_STATE_PEAK_THRESHOLD,
-                    intra_run["steadyStatePeakRatio"] < STEADY_STATE_PEAK_THRESHOLD,
+                    intra_run["steadyStatePeakRatioThreshold"],
+                    intra_run["steadyStatePeakThresholdBreached"],
                 ),
                 (
                     "slopePercentPerMinute",
                     "Slope %/min",
                     intra_run["slopePercentPerMinute"],
-                    SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
-                    intra_run["slopePercentPerMinute"] < SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
+                    intra_run["slopePercentPerMinuteThreshold"],
+                    intra_run["slopeThresholdBreached"],
                 ),
             )
             for metric, label, value, threshold, breached in threshold_metrics:

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -6,7 +6,13 @@ from math import isfinite
 from pathlib import Path
 from statistics import median
 
-from stress_report import cpu_micros_per_message, effective_rate
+from stress_report import (
+    SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
+    STEADY_STATE_PEAK_THRESHOLD,
+    cpu_micros_per_message,
+    effective_rate,
+    intra_run_throughput,
+)
 
 
 HISTORY_VERSION = 1
@@ -233,6 +239,42 @@ def evaluate_and_update(history, current_results, run_started_at):
             observation[f"{metric}Trend"] = evaluation["status"]
             evaluations.append(evaluation)
 
+        intra_run = intra_run_throughput(result)
+        if intra_run is not None:
+            threshold_metrics = (
+                (
+                    "steadyStatePeakRatio",
+                    "Steady-state / peak",
+                    intra_run["steadyStatePeakRatio"],
+                    STEADY_STATE_PEAK_THRESHOLD,
+                    intra_run["steadyStatePeakRatio"] < STEADY_STATE_PEAK_THRESHOLD,
+                ),
+                (
+                    "slopePercentPerMinute",
+                    "Slope %/min",
+                    intra_run["slopePercentPerMinute"],
+                    SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
+                    intra_run["slopePercentPerMinute"] < SLOPE_PERCENT_PER_MINUTE_THRESHOLD,
+                ),
+            )
+            for metric, label, value, threshold, breached in threshold_metrics:
+                evaluations.append({
+                    "scenario": _scenario_label(result),
+                    "metric": metric,
+                    "metricLabel": label,
+                    "current": value,
+                    "baselineCount": 0,
+                    "median": None,
+                    "mad": None,
+                    "lower": threshold,
+                    "upper": None,
+                    "status": "regression" if breached else "stable",
+                    "repeatedRegression": False,
+                    "thresholdBreach": breached,
+                })
+                observation[metric] = value
+                should_fail = should_fail or breached
+
         observations.append(observation)
 
     updated_runs = baseline_runs + [{
@@ -269,7 +311,10 @@ def format_markdown(evaluations):
     }
 
     for item in evaluations:
-        if item["median"] is None:
+        if "thresholdBreach" in item:
+            center = "-"
+            band = f">= {item['lower']:,.2f}"
+        elif item["median"] is None:
             center = "-"
             band = f"{item['baselineCount']}/{MIN_BASELINE_RUNS} runs"
         else:
@@ -277,7 +322,9 @@ def format_markdown(evaluations):
             band = f"{item['lower']:,.2f} – {item['upper']:,.2f}"
 
         status = labels[item["status"]]
-        if item["repeatedRegression"]:
+        if item.get("thresholdBreach"):
+            status = "Threshold breach (fail)"
+        elif item["repeatedRegression"]:
             status = "Repeated regression (fail)"
         elif item["status"] == "regression":
             status = "Regression (warning)"
@@ -300,7 +347,10 @@ def emit_annotations(evaluations):
         if item["status"] not in {"regression", "improvement"}:
             continue
 
-        if item["repeatedRegression"]:
+        if item.get("thresholdBreach"):
+            level = "error"
+            prefix = "Intra-run threshold breach"
+        elif item["repeatedRegression"]:
             level = "error"
             prefix = "Repeated regression"
         elif item["status"] == "regression":
@@ -310,10 +360,16 @@ def emit_annotations(evaluations):
             level = "notice"
             prefix = "Improvement"
 
-        message = (
-            f"{prefix}: {item['scenario']} {item['metricLabel']}={item['current']:.2f}; "
-            f"baseline {item['median']:.2f}, band {item['lower']:.2f}-{item['upper']:.2f}"
-        )
+        if "thresholdBreach" in item:
+            message = (
+                f"{prefix}: {item['scenario']} {item['metricLabel']}={item['current']:.2f}; "
+                f"required >= {item['lower']:.2f}"
+            )
+        else:
+            message = (
+                f"{prefix}: {item['scenario']} {item['metricLabel']}={item['current']:.2f}; "
+                f"baseline {item['median']:.2f}, band {item['lower']:.2f}-{item['upper']:.2f}"
+            )
         print(f"::{level} title=Stress performance trend::{_annotation_escape(message)}")
 
 

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -4,6 +4,7 @@ from stress_report import (
     format_roundtrip_validation_table,
     format_throughput_table,
     generate_scenario_tables,
+    intra_run_throughput,
 )
 
 
@@ -32,6 +33,49 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 
 
 class StressReportTests(unittest.TestCase):
+    def test_intra_run_throughput_detects_front_loaded_collapse(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"].update({
+            "elapsedSeconds": 900,
+            "messagesPerSecondSamples": [
+                1700, 1800, 1750, 2000, 2050, 1950,
+                1350, 1300, 1250, 1200, 1280, 1270,
+            ],
+        })
+
+        metrics = intra_run_throughput(value)
+
+        self.assertIsNotNone(metrics)
+        self.assertAlmostEqual(-31.03, metrics["driftPercent"], places=2)
+        self.assertLess(metrics["steadyStatePeakRatio"], 0.85)
+        self.assertLess(metrics["slopePercentPerMinute"], -1.0)
+        self.assertTrue(metrics["thresholdBreached"])
+
+    def test_throughput_table_surfaces_drift_and_slope(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"].update({
+            "elapsedSeconds": 360,
+            "messagesPerSecondSamples": [2000, 1900, 1800, 1400, 1300, 1200],
+        })
+
+        report = "\n".join(format_throughput_table([value], "Producer Throughput"))
+
+        self.assertIn("Drift", report)
+        self.assertIn("Slope %/min", report)
+        self.assertIn("-35.9%", report)
+
+    def test_intra_run_throughput_accepts_stable_samples(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"].update({
+            "elapsedSeconds": 360,
+            "messagesPerSecondSamples": [1400, 1410, 1390, 1405, 1395, 1400],
+        })
+
+        metrics = intra_run_throughput(value)
+
+        self.assertIsNotNone(metrics)
+        self.assertFalse(metrics["thresholdBreached"])
+
     def test_throughput_table_orders_and_ratios_by_median_when_available(self):
         lines = format_throughput_table(
             [

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -35,13 +35,17 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 class StressReportTests(unittest.TestCase):
     def test_intra_run_throughput_detects_front_loaded_collapse(self):
         value = stress_result("Dekaf", effective_rate=1400)
-        value["throughput"].update({
-            "elapsedSeconds": 900,
-            "messagesPerSecondSamples": [
-                1700, 1800, 1750, 2000, 2050, 1950,
-                1350, 1300, 1250, 1200, 1280, 1270,
-            ],
+        value.update({
+            "steadyStatePeakRatio": 0.62,
+            "intraRunDriftPercent": -31.03,
+            "throughputSlopePercentPerMinute": -4.2,
+            "steadyStatePeakRatioThreshold": 0.85,
+            "throughputSlopePercentPerMinuteThreshold": -1.0,
+            "steadyStatePeakThresholdBreached": True,
+            "throughputSlopeThresholdBreached": True,
+            "intraRunThroughputThresholdBreached": True,
         })
+        value["throughput"]["messagesPerSecondSamples"] = [1400, 1400, 1400]
 
         metrics = intra_run_throughput(value)
 
@@ -53,9 +57,15 @@ class StressReportTests(unittest.TestCase):
 
     def test_throughput_table_surfaces_drift_and_slope(self):
         value = stress_result("Dekaf", effective_rate=1400)
-        value["throughput"].update({
-            "elapsedSeconds": 360,
-            "messagesPerSecondSamples": [2000, 1900, 1800, 1400, 1300, 1200],
+        value.update({
+            "steadyStatePeakRatio": 0.6,
+            "intraRunDriftPercent": -35.9,
+            "throughputSlopePercentPerMinute": -8.0,
+            "steadyStatePeakRatioThreshold": 0.85,
+            "throughputSlopePercentPerMinuteThreshold": -1.0,
+            "steadyStatePeakThresholdBreached": True,
+            "throughputSlopeThresholdBreached": True,
+            "intraRunThroughputThresholdBreached": True,
         })
 
         report = "\n".join(format_throughput_table([value], "Producer Throughput"))
@@ -66,9 +76,15 @@ class StressReportTests(unittest.TestCase):
 
     def test_intra_run_throughput_accepts_stable_samples(self):
         value = stress_result("Dekaf", effective_rate=1400)
-        value["throughput"].update({
-            "elapsedSeconds": 360,
-            "messagesPerSecondSamples": [1400, 1410, 1390, 1405, 1395, 1400],
+        value.update({
+            "steadyStatePeakRatio": 0.99,
+            "intraRunDriftPercent": 0.0,
+            "throughputSlopePercentPerMinute": 0.0,
+            "steadyStatePeakRatioThreshold": 0.85,
+            "throughputSlopePercentPerMinuteThreshold": -1.0,
+            "steadyStatePeakThresholdBreached": False,
+            "throughputSlopeThresholdBreached": False,
+            "intraRunThroughputThresholdBreached": False,
         })
 
         metrics = intra_run_throughput(value)

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -41,6 +41,27 @@ def history_run(index, messages_per_second=1000.0, cpu_micros_per_message=2.0, *
 
 
 class StressTrendTests(unittest.TestCase):
+    def test_intra_run_threshold_breach_fails_without_history(self):
+        collapsing = result(
+            throughput={
+                "elapsedSeconds": 360,
+                "messagesPerSecondSamples": [2000, 1900, 1800, 1400, 1300, 1200],
+            },
+        )
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": []},
+            [collapsing],
+            "2026-07-01T02:00:00Z",
+        )
+
+        intra_run = [item for item in evaluations if item.get("thresholdBreach")]
+        self.assertTrue(should_fail)
+        self.assertEqual(
+            {"steadyStatePeakRatio", "slopePercentPerMinute"},
+            {item["metric"] for item in intra_run},
+        )
+
     def test_empty_history_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "Unsupported stress history version"):
             evaluate_and_update({}, [result()], "2026-07-01T02:00:00Z")
@@ -362,6 +383,20 @@ class StressTrendTests(unittest.TestCase):
         create_directory = step.index("mkdir -p merged-results")
         find_result = step.index("result_file=$(find merged-results")
         self.assertLess(create_directory, find_result)
+
+    def test_workflow_regression_gate_consumes_all_failure_kinds(self):
+        workflow = (
+            Path(__file__).parent.parent / "workflows" / "stress-tests.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "regression_failure: ${{ steps.stress-trends.outputs.should_fail }}",
+            workflow,
+        )
+        self.assertIn(
+            "needs.generate-summary.outputs.regression_failure == 'true'",
+            workflow,
+        )
 
     def test_history_merge_wait_retries_one_transient_state_query_failure(self):
         workflow = (

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -43,9 +43,17 @@ def history_run(index, messages_per_second=1000.0, cpu_micros_per_message=2.0, *
 class StressTrendTests(unittest.TestCase):
     def test_intra_run_threshold_breach_fails_without_history(self):
         collapsing = result(
+            steadyStatePeakRatio=0.6,
+            intraRunDriftPercent=-35.9,
+            throughputSlopePercentPerMinute=-8.0,
+            steadyStatePeakRatioThreshold=0.85,
+            throughputSlopePercentPerMinuteThreshold=-1.0,
+            steadyStatePeakThresholdBreached=True,
+            throughputSlopeThresholdBreached=True,
+            intraRunThroughputThresholdBreached=True,
             throughput={
                 "elapsedSeconds": 360,
-                "messagesPerSecondSamples": [2000, 1900, 1800, 1400, 1300, 1200],
+                "messagesPerSecondSamples": [1400, 1400, 1400],
             },
         )
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     outputs:
-      repeated_regression: ${{ steps.stress-trends.outputs.should_fail }}
+      regression_failure: ${{ steps.stress-trends.outputs.should_fail }}
 
     steps:
       - name: Checkout
@@ -634,7 +634,7 @@ jobs:
           done
 
   regression-gate:
-    name: Fail on Repeated Stress Regressions
+    name: Fail on Stress Regressions
     needs: [stress-test, generate-summary, publish-to-docs]
     runs-on: ubuntu-latest
     # Wait for the docs PR so valid regression observations are persisted before
@@ -644,9 +644,9 @@ jobs:
       needs.stress-test.result == 'success' &&
       needs.generate-summary.result == 'success' &&
       needs.publish-to-docs.result == 'success' &&
-      needs.generate-summary.outputs.repeated_regression == 'true'
+      needs.generate-summary.outputs.regression_failure == 'true'
     steps:
-      - name: Report Repeated Regression
+      - name: Report Regression
         run: |
-          echo "Repeated stress regression detected; see Stress Trend Analysis above."
+          echo "Stress regression detected; see Stress Trend Analysis above."
           exit 1

--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -25,6 +25,7 @@ public sealed class IntraRunThroughputReportingTests
                 ElapsedSeconds = 900,
                 AverageMessagesPerSecond = 1400,
                 AverageMegabytesPerSecond = 1.34,
+                SampledElapsedSeconds = 12,
                 MessagesPerSecondSamples =
                 [
                     1700, 1800, 1750, 2000, 2050, 1950,
@@ -48,5 +49,8 @@ public sealed class IntraRunThroughputReportingTests
         await Assert.That(json).Contains("\"steadyStatePeakThresholdBreached\": true");
         await Assert.That(json).Contains("\"throughputSlopeThresholdBreached\": true");
         await Assert.That(json).Contains("\"intraRunThroughputThresholdBreached\": true");
+        var slope = result.ThroughputSlopePercentPerMinute;
+        await Assert.That(slope).IsNotNull();
+        await Assert.That(slope!.Value).IsLessThan(-100);
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -8,8 +8,57 @@ public sealed class IntraRunThroughputReportingTests
     [Test]
     public async Task ToJson_SerializesMetricsThresholdsAndBreachFlags()
     {
+        var result = CreateResult(
+        [
+            1700, 1800, 1750, 2000, 2050, 1950,
+            1350, 1300, 1250, 1200, 1280, 1270
+        ], elapsedSeconds: 900, sampledElapsedSeconds: 12);
+
+        var json = result.ToJson();
+
+        await Assert.That(json).Contains("\"steadyStatePeakRatioThreshold\": 0.85");
+        await Assert.That(json).Contains("\"throughputSlopePercentPerMinuteThreshold\": -1");
+        await Assert.That(json).Contains("\"steadyStatePeakThresholdBreached\": true");
+        await Assert.That(json).Contains("\"throughputSlopeThresholdBreached\": true");
+        await Assert.That(json).Contains("\"intraRunThroughputThresholdBreached\": true");
+        await Assert.That(result.SteadyStatePeakRatio!.Value)
+            .IsBetween(0.60975609, 0.60975610);
+        await Assert.That(result.IntraRunDriftPercent!.Value)
+            .IsBetween(-31.03448277, -31.03448275);
+        await Assert.That(result.ThroughputSlopePercentPerMinute!.Value)
+            .IsBetween(-229.872197, -229.872196);
+    }
+
+    [Test]
+    [Arguments("message-bounded")]
+    [Arguments("zero-elapsed")]
+    [Arguments("too-few-samples")]
+    [Arguments("zero-baseline")]
+    public async Task IntraRunMetrics_UnsupportedMeasurement_ReturnsNull(string guard)
+    {
+        var result = guard switch
+        {
+            "message-bounded" => CreateResult([100, 90, 80], isMessageBounded: true),
+            "zero-elapsed" => CreateResult([100, 90, 80], elapsedSeconds: 0),
+            "too-few-samples" => CreateResult([100, 90]),
+            "zero-baseline" => CreateResult([0, 0, 100, 90, 80, 70]),
+            _ => throw new ArgumentOutOfRangeException(nameof(guard), guard, null)
+        };
+
+        await Assert.That(result.SteadyStatePeakRatio).IsNull();
+        await Assert.That(result.IntraRunDriftPercent).IsNull();
+        await Assert.That(result.ThroughputSlopePercentPerMinute).IsNull();
+        await Assert.That(result.IntraRunThroughputThresholdBreached).IsFalse();
+    }
+
+    private static StressTestResult CreateResult(
+        List<double> samples,
+        double elapsedSeconds = 12,
+        double sampledElapsedSeconds = 12,
+        bool isMessageBounded = false)
+    {
         var now = DateTime.UtcNow;
-        var result = new StressTestResult
+        return new StressTestResult
         {
             Scenario = "producer-acks-all",
             Client = "Dekaf",
@@ -17,20 +66,17 @@ public sealed class IntraRunThroughputReportingTests
             MessageSizeBytes = 1000,
             StartedAtUtc = now,
             CompletedAtUtc = now.AddMinutes(15),
+            IsMessageBounded = isMessageBounded,
             Throughput = new ThroughputSnapshot
             {
                 TotalMessages = 12_000,
                 TotalBytes = 12_000_000,
                 TotalErrors = 0,
-                ElapsedSeconds = 900,
+                ElapsedSeconds = elapsedSeconds,
                 AverageMessagesPerSecond = 1400,
                 AverageMegabytesPerSecond = 1.34,
-                SampledElapsedSeconds = 12,
-                MessagesPerSecondSamples =
-                [
-                    1700, 1800, 1750, 2000, 2050, 1950,
-                    1350, 1300, 1250, 1200, 1280, 1270
-                ],
+                SampledElapsedSeconds = sampledElapsedSeconds,
+                MessagesPerSecondSamples = samples,
                 ErrorSamples = []
             },
             GcStats = new GcSnapshot
@@ -41,16 +87,5 @@ public sealed class IntraRunThroughputReportingTests
                 AllocatedBytes = 0
             }
         };
-
-        var json = result.ToJson();
-
-        await Assert.That(json).Contains("\"steadyStatePeakRatioThreshold\": 0.85");
-        await Assert.That(json).Contains("\"throughputSlopePercentPerMinuteThreshold\": -1");
-        await Assert.That(json).Contains("\"steadyStatePeakThresholdBreached\": true");
-        await Assert.That(json).Contains("\"throughputSlopeThresholdBreached\": true");
-        await Assert.That(json).Contains("\"intraRunThroughputThresholdBreached\": true");
-        var slope = result.ThroughputSlopePercentPerMinute;
-        await Assert.That(slope).IsNotNull();
-        await Assert.That(slope!.Value).IsLessThan(-100);
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -1,0 +1,52 @@
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class IntraRunThroughputReportingTests
+{
+    [Test]
+    public async Task ToJson_SerializesMetricsThresholdsAndBreachFlags()
+    {
+        var now = DateTime.UtcNow;
+        var result = new StressTestResult
+        {
+            Scenario = "producer-acks-all",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            MessageSizeBytes = 1000,
+            StartedAtUtc = now,
+            CompletedAtUtc = now.AddMinutes(15),
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 12_000,
+                TotalBytes = 12_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 900,
+                AverageMessagesPerSecond = 1400,
+                AverageMegabytesPerSecond = 1.34,
+                MessagesPerSecondSamples =
+                [
+                    1700, 1800, 1750, 2000, 2050, 1950,
+                    1350, 1300, 1250, 1200, 1280, 1270
+                ],
+                ErrorSamples = []
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            }
+        };
+
+        var json = result.ToJson();
+
+        await Assert.That(json).Contains("\"steadyStatePeakRatioThreshold\": 0.85");
+        await Assert.That(json).Contains("\"throughputSlopePercentPerMinuteThreshold\": -1");
+        await Assert.That(json).Contains("\"steadyStatePeakThresholdBreached\": true");
+        await Assert.That(json).Contains("\"throughputSlopeThresholdBreached\": true");
+        await Assert.That(json).Contains("\"intraRunThroughputThresholdBreached\": true");
+    }
+}

--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -23,7 +23,8 @@ internal sealed class ThroughputTracker
     // the produce loop just to discard samples.
     private volatile bool _errorSamplesFull;
     private long _lastSampleMessageCount;
-    private DateTime _lastSampleTime;
+    private long _lastSampleTimestamp;
+    private double _sampledElapsedSeconds;
     private TimeSpan _cpuTimeStart;
     private double _cpuTimeSeconds;
 
@@ -44,8 +45,9 @@ internal sealed class ThroughputTracker
     {
         _stopwatch.Start();
         _cpuTimeStart = Environment.CpuUsage.TotalTime;
-        _lastSampleTime = DateTime.UtcNow;
+        _lastSampleTimestamp = Stopwatch.GetTimestamp();
         _lastSampleMessageCount = 0;
+        _sampledElapsedSeconds = 0;
     }
 
     public void Stop()
@@ -182,10 +184,10 @@ internal sealed class ThroughputTracker
 
     public void TakeSample()
     {
-        var now = DateTime.UtcNow;
+        var now = Stopwatch.GetTimestamp();
         var currentCount = MessageCount;
 
-        var elapsedSeconds = (now - _lastSampleTime).TotalSeconds;
+        var elapsedSeconds = Stopwatch.GetElapsedTime(_lastSampleTimestamp, now).TotalSeconds;
         if (elapsedSeconds > 0)
         {
             var messagesInInterval = currentCount - _lastSampleMessageCount;
@@ -194,10 +196,11 @@ internal sealed class ThroughputTracker
             lock (_samplesLock)
             {
                 _messagesPerSecondSamples.Add(rate);
+                _sampledElapsedSeconds += elapsedSeconds;
             }
         }
 
-        _lastSampleTime = now;
+        _lastSampleTimestamp = now;
         _lastSampleMessageCount = currentCount;
     }
 
@@ -229,9 +232,11 @@ internal sealed class ThroughputTracker
     public ThroughputSnapshot GetSnapshot()
     {
         List<double> samplesCopy;
+        double sampledElapsedSeconds;
         lock (_samplesLock)
         {
             samplesCopy = [.. _messagesPerSecondSamples];
+            sampledElapsedSeconds = _sampledElapsedSeconds;
         }
 
         List<ThroughputErrorSample> errorSamplesCopy;
@@ -250,6 +255,7 @@ internal sealed class ThroughputTracker
             AverageMessagesPerSecond = GetAverageMessagesPerSecond(),
             AverageMegabytesPerSecond = GetAverageMegabytesPerSecond(),
             MessagesPerSecondSamples = samplesCopy,
+            SampledElapsedSeconds = sampledElapsedSeconds,
             ErrorSamples = errorSamplesCopy
         };
     }
@@ -271,6 +277,13 @@ internal sealed class ThroughputSnapshot
     public required double AverageMessagesPerSecond { get; init; }
     public required double AverageMegabytesPerSecond { get; init; }
     public required List<double> MessagesPerSecondSamples { get; init; }
+
+    /// <summary>
+    /// Sum of intervals represented by <see cref="MessagesPerSecondSamples"/>. Excludes
+    /// unsampled work after sampler shutdown, such as a producer's final flush.
+    /// </summary>
+    public double SampledElapsedSeconds { get; init; }
+
     public List<ThroughputErrorSample> ErrorSamples { get; init; } = [];
 }
 

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -95,8 +95,8 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|--------|----------------|--------|------------|------------------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|------------------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
@@ -114,6 +114,8 @@ internal static class MarkdownReporter
                 var comparisonRate = ComparisonMessagesPerSecond(result);
                 var ratio = baseline > 0 ? comparisonRate / baseline : 1.0;
                 var median = result.MedianIntervalMessagesPerSecond is { } medianRate ? medianRate.ToString("N0") : "-";
+                var drift = result.IntraRunDriftPercent is { } driftPercent ? $"{driftPercent:+0.0;-0.0;0.0}%" : "-";
+                var slope = result.ThroughputSlopePercentPerMinute is { } slopePercent ? $"{slopePercent:+0.00;-0.00;0.00}%" : "-";
                 var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
                 var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
@@ -124,7 +126,7 @@ internal static class MarkdownReporter
                 var errors = deliveryErrors > 0
                     ? $"{result.Throughput.TotalErrors} (+{deliveryErrors} dlv)"
                     : result.Throughput.TotalErrors.ToString()!;
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {errors,6} | {coresUsed,10} | {ratio:F2}x |");
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {drift,7} | {slope,11} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {errors,6} | {coresUsed,10} | {ratio:F2}x |");
             }
 
             sb.AppendLine();
@@ -134,6 +136,12 @@ internal static class MarkdownReporter
                 sb.AppendLine("*Median msg/s is the median sampled client-side throughput interval; it shows steady-state throughput without letting a short late-run stall dominate the whole-run average.*");
                 sb.AppendLine();
                 sb.AppendLine("*Rows and Comparison Ratio use Median msg/s when available; older result files without interval samples fall back to Messages/sec.*");
+                sb.AppendLine();
+            }
+
+            if (sizeResults.Any(r => r.IntraRunDriftPercent is not null))
+            {
+                sb.AppendLine($"*Drift compares last-third with first-third average throughput. Slope is the normalized least-squares trend; steady-state below {StressTestResult.SteadyStatePeakThreshold:P0} of peak or slope below {StressTestResult.SlopePercentPerMinuteThreshold:F0}%/min fails the regression gate.*");
                 sb.AppendLine();
             }
 

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -101,10 +101,18 @@ internal sealed class StressTestResult
     public double? ThroughputSlopePercentPerMinute =>
         TryGetIntraRunThroughput(out var metrics) ? metrics.SlopePercentPerMinute : null;
 
+    public double SteadyStatePeakRatioThreshold => SteadyStatePeakThreshold;
+
+    public double ThroughputSlopePercentPerMinuteThreshold => SlopePercentPerMinuteThreshold;
+
+    public bool SteadyStatePeakThresholdBreached =>
+        SteadyStatePeakRatio is { } ratio && ratio < SteadyStatePeakThreshold;
+
+    public bool ThroughputSlopeThresholdBreached =>
+        ThroughputSlopePercentPerMinute is { } slope && slope < SlopePercentPerMinuteThreshold;
+
     public bool IntraRunThroughputThresholdBreached =>
-        TryGetIntraRunThroughput(out var metrics) &&
-        (metrics.SteadyStatePeakRatio < SteadyStatePeakThreshold ||
-         metrics.SlopePercentPerMinute < SlopePercentPerMinuteThreshold);
+        SteadyStatePeakThresholdBreached || ThroughputSlopeThresholdBreached;
 
     /// <summary>
     /// Client-side append rate, reported only when it is distinct from the headline

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -8,6 +8,9 @@ namespace Dekaf.StressTests.Reporting;
 
 internal sealed class StressTestResult
 {
+    internal const double SteadyStatePeakThreshold = 0.85;
+    internal const double SlopePercentPerMinuteThreshold = -1.0;
+
     public required string Scenario { get; init; }
     public required string Client { get; set; }
     public required int DurationMinutes { get; init; }
@@ -86,6 +89,23 @@ internal sealed class StressTestResult
     public double? MedianIntervalMessagesPerSecond =>
         IsMessageBounded ? null : GetMedian(Throughput.MessagesPerSecondSamples);
 
+    /// <summary>Last-third average divided by peak sampled throughput.</summary>
+    public double? SteadyStatePeakRatio =>
+        TryGetIntraRunThroughput(out var metrics) ? metrics.SteadyStatePeakRatio : null;
+
+    /// <summary>Percentage change from first-third to last-third average throughput.</summary>
+    public double? IntraRunDriftPercent =>
+        TryGetIntraRunThroughput(out var metrics) ? metrics.DriftPercent : null;
+
+    /// <summary>Least-squares sample trend normalized against first-third throughput.</summary>
+    public double? ThroughputSlopePercentPerMinute =>
+        TryGetIntraRunThroughput(out var metrics) ? metrics.SlopePercentPerMinute : null;
+
+    public bool IntraRunThroughputThresholdBreached =>
+        TryGetIntraRunThroughput(out var metrics) &&
+        (metrics.SteadyStatePeakRatio < SteadyStatePeakThreshold ||
+         metrics.SlopePercentPerMinute < SlopePercentPerMinuteThreshold);
+
     /// <summary>
     /// Client-side append rate, reported only when it is distinct from the headline
     /// number (i.e. when delivered throughput was measured). Null means the headline
@@ -131,6 +151,57 @@ internal sealed class StressTestResult
             var count => (sorted[(count / 2) - 1] + sorted[count / 2]) / 2.0
         };
     }
+
+    private bool TryGetIntraRunThroughput(out IntraRunThroughputMetrics metrics)
+    {
+        metrics = default;
+        if (IsMessageBounded || Throughput.ElapsedSeconds <= 0)
+            return false;
+
+        var samples = Throughput.MessagesPerSecondSamples
+            .Where(sample => double.IsFinite(sample) && sample >= 0)
+            .ToArray();
+        if (samples.Length < 3)
+            return false;
+
+        var thirdCount = Math.Max(1, samples.Length / 3);
+        var firstThirdTotal = 0.0;
+        var lastThirdTotal = 0.0;
+        for (var index = 0; index < thirdCount; index++)
+        {
+            firstThirdTotal += samples[index];
+            lastThirdTotal += samples[samples.Length - thirdCount + index];
+        }
+        var firstThirdAverage = firstThirdTotal / thirdCount;
+        var lastThirdAverage = lastThirdTotal / thirdCount;
+        var peak = samples.Max();
+        if (firstThirdAverage <= 0 || peak <= 0)
+            return false;
+
+        var mean = samples.Average();
+        var midpoint = (samples.Length - 1) / 2.0;
+        var numerator = 0.0;
+        var denominator = 0.0;
+        for (var index = 0; index < samples.Length; index++)
+        {
+            var centeredIndex = index - midpoint;
+            numerator += centeredIndex * (samples[index] - mean);
+            denominator += centeredIndex * centeredIndex;
+        }
+
+        var sampleMinutes = Throughput.ElapsedSeconds / samples.Length / 60.0;
+        var slopePerSample = numerator / denominator;
+        metrics = new IntraRunThroughputMetrics(
+            lastThirdAverage / peak,
+            (lastThirdAverage - firstThirdAverage) / firstThirdAverage * 100.0,
+            slopePerSample / sampleMinutes / firstThirdAverage * 100.0);
+        return true;
+    }
+
+    private readonly record struct IntraRunThroughputMetrics(
+        double SteadyStatePeakRatio,
+        double DriftPercent,
+        double SlopePercentPerMinute);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -197,7 +197,10 @@ internal sealed class StressTestResult
             denominator += centeredIndex * centeredIndex;
         }
 
-        var sampleMinutes = Throughput.ElapsedSeconds / samples.Length / 60.0;
+        var sampledElapsedSeconds = Throughput.SampledElapsedSeconds > 0
+            ? Throughput.SampledElapsedSeconds
+            : Throughput.ElapsedSeconds;
+        var sampleMinutes = sampledElapsedSeconds / samples.Length / 60.0;
         var slopePerSample = numerator / denominator;
         metrics = new IntraRunThroughputMetrics(
             lastThirdAverage / peak,


### PR DESCRIPTION
## Summary
- derive steady-state/peak ratio, first-to-last-third drift, and normalized linear slope from interval throughput samples
- surface drift and slope in local, CI, and documentation summary tables
- fail the stress regression gate immediately when steady-state falls below 85% of peak or slope falls below -1%/min
- keep scale-event instrumentation with the active producer root-cause work in #1796

## Test plan
- [x] `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj --configuration Release`
- [x] `python -m unittest discover -s .github/scripts -p 'test_*.py'` (38 tests)
- [x] replay issue sample series: 0.607 steady-state/peak, -28.36% drift, -2.27%/min, threshold breach

Closes #1797
