### PR TITLE
Remove steady-heartbeat test timing flake

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -524,7 +524,10 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
-    public async Task ConsumerProtocol_SteadyHeartbeat_CrossesMaxPollWhileAwaitingResponse_DiscardsResponse()
+    [Timeout(30_000)]
+    [NotInParallel]
+    public async Task ConsumerProtocol_SteadyHeartbeat_CrossesMaxPollWhileAwaitingResponse_DiscardsResponse(
+        CancellationToken cancellationToken)
     {
         SetupSuccessfulConsumerProtocolJoin();
         var options = CreateConsumerProtocolOptions(
@@ -548,7 +551,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             });
 
         var heartbeat = InvokeSteadyConsumerGroupHeartbeatAsync(coordinator).AsTask();
-        await heartbeatSent.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await heartbeatSent.Task.WaitAsync(cancellationToken);
         SetCoordinatorLongField(
             coordinator,
             "_lastPollTimestamp",
@@ -561,7 +564,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             HeartbeatIntervalMs = 60_000
         });
 
-        await heartbeat.WaitAsync(TimeSpan.FromSeconds(1));
+        await heartbeat.WaitAsync(cancellationToken);
 
         await Assert.That(coordinator.GenerationId).IsEqualTo(1);
     }


### PR DESCRIPTION
## Summary
- serialize the stateful steady-heartbeat response-discard test so parallel fixture tests cannot overwrite its substitute route
- replace fixed one-second synchronization deadlines with TUnit cancellation-token bounded waits
- leave production timing and behavior unchanged

## Test plan
- [x] focused test: 1 passed
- [x] `ConsumerCoordinatorKip848Tests` repeated 10 times: 780 passed
- [x] full unit suite: 5,133 passed

Closes #1801
