### PR TITLE
Gate stress delivery latency regressions

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -18,6 +18,8 @@ SCENARIO_TITLES = {
     'consumer-raw-batch': 'Consumer (Raw Batch)',
 }
 
+LATENCY_RATIO_THRESHOLD = 2.0
+
 
 def group_by_scenario(results):
     """Group results by (scenario, broker_count) tuple, split into producer and consumer."""
@@ -171,6 +173,86 @@ def intra_run_throughput(result):
         return None
 
     return numeric_fields | boolean_fields
+
+
+def paired_latency_thresholds(results):
+    """Compare each Dekaf p50/p99 with its matching Confluent result."""
+    baselines = {}
+    for result in results:
+        if str(result.get('client', '')).casefold() != 'confluent':
+            continue
+        latency = result.get('latency')
+        if not isinstance(latency, dict):
+            continue
+        baselines[_latency_identity(result)] = latency
+
+    evaluations = []
+    for result in results:
+        client = str(result.get('client', ''))
+        if client.casefold() == 'confluent':
+            continue
+        baseline = baselines.get(_latency_identity(result))
+        latency = result.get('latency')
+        if baseline is None or not isinstance(latency, dict):
+            continue
+
+        for field, metric, label in (
+            ('p50Us', 'latencyP50Ratio', 'Delivery latency p50 / Confluent'),
+            ('p99Us', 'latencyP99Ratio', 'Delivery latency p99 / Confluent'),
+        ):
+            current = latency.get(field)
+            reference = baseline.get(field)
+            if (
+                not _positive_finite_number(current)
+                or not _positive_finite_number(reference)
+            ):
+                continue
+            ratio = current / reference
+            breached = ratio > LATENCY_RATIO_THRESHOLD
+            evaluations.append({
+                'scenario': _latency_scenario_label(result),
+                'metric': metric,
+                'metricLabel': label,
+                'current': ratio,
+                'baselineCount': 0,
+                'median': None,
+                'mad': None,
+                'lower': None,
+                'upper': LATENCY_RATIO_THRESHOLD,
+                'status': 'regression' if breached else 'stable',
+                'repeatedRegression': False,
+                'thresholdBreach': breached,
+                'thresholdDirection': 'maximum',
+                'latencyThreshold': True,
+            })
+    return evaluations
+
+
+def _positive_finite_number(value):
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and isfinite(value)
+        and value > 0
+    )
+
+
+def _latency_identity(result):
+    return (
+        str(result.get('scenario', 'unknown')).casefold(),
+        result.get('brokerCount', 1),
+        result.get('durationMinutes'),
+        result.get('messageSizeBytes'),
+    )
+
+
+def _latency_scenario_label(result):
+    brokers = result.get('brokerCount', 1)
+    return (
+        f"{result.get('scenario', 'unknown')} / {result.get('client', 'unknown')} / "
+        f"{brokers} broker{'s' if brokers != 1 else ''} / "
+        f"{result.get('messageSizeBytes', '?')}B / {result.get('durationMinutes', '?')}m"
+    )
 
 
 def comparison_rate(result):

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -243,7 +243,24 @@ def _latency_identity(result):
         result.get('brokerCount', 1),
         result.get('durationMinutes'),
         result.get('messageSizeBytes'),
+        _latency_consumer_seed_batch_size(result),
+        _latency_roundtrip_messages(result),
     )
+
+
+def _latency_consumer_seed_batch_size(result):
+    value = result.get('consumerSeedBatchSizeBytes')
+    if value is not None:
+        return value
+    scenario = str(result.get('scenario', '')).casefold()
+    return 16_384 if scenario.startswith('consumer') else None
+
+
+def _latency_roundtrip_messages(result):
+    validation = result.get('roundTripValidation')
+    if isinstance(validation, dict):
+        return validation.get('expectedMessages', result.get('roundTripMessages'))
+    return result.get('roundTripMessages')
 
 
 def _latency_scenario_label(result):

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -189,7 +189,7 @@ def paired_latency_thresholds(results):
     evaluations = []
     for result in results:
         client = str(result.get('client', ''))
-        if client.casefold() == 'confluent':
+        if client.casefold() != 'dekaf':
             continue
         baseline = baselines.get(_latency_identity(result))
         latency = result.get('latency')

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -10,6 +10,7 @@ from stress_report import (
     cpu_micros_per_message,
     effective_rate,
     intra_run_throughput,
+    paired_latency_thresholds,
 )
 
 
@@ -275,6 +276,12 @@ def evaluate_and_update(history, current_results, run_started_at):
 
         observations.append(observation)
 
+    latency_evaluations = paired_latency_thresholds(current_results)
+    evaluations.extend(latency_evaluations)
+    should_fail = should_fail or any(
+        item['thresholdBreach'] for item in latency_evaluations
+    )
+
     updated_runs = baseline_runs + [{
         "runStartedAtUtc": run_started_at,
         "results": observations,
@@ -311,7 +318,10 @@ def format_markdown(evaluations):
     for item in evaluations:
         if "thresholdBreach" in item:
             center = "-"
-            band = f">= {item['lower']:,.2f}"
+            if item.get("thresholdDirection") == "maximum":
+                band = f"<= {item['upper']:,.2f}"
+            else:
+                band = f">= {item['lower']:,.2f}"
         elif item["median"] is None:
             center = "-"
             band = f"{item['baselineCount']}/{MIN_BASELINE_RUNS} runs"
@@ -347,7 +357,11 @@ def emit_annotations(evaluations):
 
         if item.get("thresholdBreach"):
             level = "error"
-            prefix = "Intra-run threshold breach"
+            prefix = (
+                "Latency threshold breach"
+                if item.get("latencyThreshold")
+                else "Intra-run threshold breach"
+            )
         elif item["repeatedRegression"]:
             level = "error"
             prefix = "Repeated regression"
@@ -359,9 +373,13 @@ def emit_annotations(evaluations):
             prefix = "Improvement"
 
         if "thresholdBreach" in item:
+            if item.get("thresholdDirection") == "maximum":
+                requirement = f"required <= {item['upper']:.2f}"
+            else:
+                requirement = f"required >= {item['lower']:.2f}"
             message = (
                 f"{prefix}: {item['scenario']} {item['metricLabel']}={item['current']:.2f}; "
-                f"required >= {item['lower']:.2f}"
+                f"{requirement}"
             )
         else:
             message = (

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -65,6 +65,17 @@ class StressReportTests(unittest.TestCase):
 
         self.assertEqual([], paired_latency_thresholds([unpaired]))
 
+    def test_paired_latency_thresholds_ignore_multi_connection_dekaf_results(self):
+        confluent = stress_result("Confluent", effective_rate=1000)
+        confluent["latency"] = {"p50Us": 10_000, "p99Us": 50_000}
+        multi_connection = stress_result("Dekaf (3conn)", effective_rate=2000)
+        multi_connection["latency"] = {"p50Us": 50_000, "p99Us": 500_000}
+
+        self.assertEqual(
+            [],
+            paired_latency_thresholds([confluent, multi_connection]),
+        )
+
     def test_paired_latency_thresholds_require_matching_roundtrip_bound(self):
         confluent = stress_result("Confluent", effective_rate=1000)
         confluent.update({

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -65,6 +65,22 @@ class StressReportTests(unittest.TestCase):
 
         self.assertEqual([], paired_latency_thresholds([unpaired]))
 
+    def test_paired_latency_thresholds_require_matching_roundtrip_bound(self):
+        confluent = stress_result("Confluent", effective_rate=1000)
+        confluent.update({
+            "scenario": "producer-roundtrip",
+            "roundTripValidation": {"expectedMessages": 250_000},
+            "latency": {"p50Us": 10_000, "p99Us": 50_000},
+        })
+        dekaf = stress_result("Dekaf", effective_rate=1400)
+        dekaf.update({
+            "scenario": "producer-roundtrip",
+            "roundTripValidation": {"expectedMessages": 1_000_000},
+            "latency": {"p50Us": 50_000, "p99Us": 500_000},
+        })
+
+        self.assertEqual([], paired_latency_thresholds([confluent, dekaf]))
+
     def test_intra_run_throughput_detects_front_loaded_collapse(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value.update({

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -5,6 +5,7 @@ from stress_report import (
     format_throughput_table,
     generate_scenario_tables,
     intra_run_throughput,
+    paired_latency_thresholds,
 )
 
 
@@ -33,6 +34,37 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 
 
 class StressReportTests(unittest.TestCase):
+    def test_paired_latency_thresholds_flag_high_p99(self):
+        confluent = stress_result("Confluent", effective_rate=1000)
+        confluent.update({
+            "scenario": "producer-acks-all",
+            "brokerCount": 3,
+            "latency": {"p50Us": 7_250, "p99Us": 39_550},
+        })
+        dekaf = stress_result("Dekaf", effective_rate=1400)
+        dekaf.update({
+            "scenario": "producer-acks-all",
+            "brokerCount": 3,
+            "latency": {"p50Us": 48_850, "p99Us": 3_019_550},
+        })
+
+        evaluations = paired_latency_thresholds([confluent, dekaf])
+
+        self.assertEqual(2, len(evaluations))
+        by_metric = {item["metric"]: item for item in evaluations}
+        self.assertTrue(by_metric["latencyP50Ratio"]["thresholdBreach"])
+        self.assertTrue(by_metric["latencyP99Ratio"]["thresholdBreach"])
+        self.assertAlmostEqual(
+            3_019_550 / 39_550,
+            by_metric["latencyP99Ratio"]["current"],
+        )
+
+    def test_paired_latency_thresholds_ignore_unpaired_and_confluent_results(self):
+        unpaired = stress_result("Dekaf", effective_rate=1400)
+        unpaired["latency"] = {"p50Us": 50_000, "p99Us": 3_000_000}
+
+        self.assertEqual([], paired_latency_thresholds([unpaired]))
+
     def test_intra_run_throughput_detects_front_loaded_collapse(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value.update({

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -41,6 +41,29 @@ def history_run(index, messages_per_second=1000.0, cpu_micros_per_message=2.0, *
 
 
 class StressTrendTests(unittest.TestCase):
+    def test_paired_latency_threshold_breach_fails_without_history(self):
+        confluent = result(
+            client="Confluent",
+            latency={"p50Us": 10_000, "p99Us": 50_000},
+        )
+        dekaf = result(
+            client="Dekaf",
+            latency={"p50Us": 15_000, "p99Us": 150_000},
+        )
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": []},
+            [confluent, dekaf],
+            "2026-07-01T02:00:00Z",
+        )
+
+        latency = [item for item in evaluations if item.get("latencyThreshold")]
+        self.assertTrue(should_fail)
+        self.assertEqual(2, len(latency))
+        by_metric = {item["metric"]: item for item in latency}
+        self.assertFalse(by_metric["latencyP50Ratio"]["thresholdBreach"])
+        self.assertTrue(by_metric["latencyP99Ratio"]["thresholdBreach"])
+
     def test_intra_run_threshold_breach_fails_without_history(self):
         collapsing = result(
             steadyStatePeakRatio=0.6,

--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -30,6 +30,16 @@ public sealed class IntraRunThroughputReportingTests
     }
 
     [Test]
+    public async Task SteadyStatePeakRatio_IgnoresSingleTransientSpike()
+    {
+        var samples = Enumerable.Repeat(1_000.0, 99).Append(10_000.0).ToList();
+        var result = CreateResult(samples, elapsedSeconds: 100, sampledElapsedSeconds: 100);
+
+        await Assert.That(result.SteadyStatePeakRatio!.Value).IsEqualTo(1.0);
+        await Assert.That(result.SteadyStatePeakThresholdBreached).IsFalse();
+    }
+
+    [Test]
     [Arguments("message-bounded")]
     [Arguments("zero-elapsed")]
     [Arguments("too-few-samples")]

--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -40,6 +40,20 @@ public sealed class IntraRunThroughputReportingTests
     }
 
     [Test]
+    public async Task IntraRunMetrics_FrontLoadedBurstThenZero_ReportsCollapse()
+    {
+        var samples = Enumerable.Repeat(1_000.0, 5)
+            .Concat(Enumerable.Repeat(0.0, 95))
+            .ToList();
+        var result = CreateResult(samples, elapsedSeconds: 100, sampledElapsedSeconds: 100);
+
+        await Assert.That(result.SteadyStatePeakRatio).IsEqualTo(0.0);
+        await Assert.That(result.IntraRunDriftPercent).IsEqualTo(-100.0);
+        await Assert.That(result.SteadyStatePeakThresholdBreached).IsTrue();
+        await Assert.That(result.IntraRunThroughputThresholdBreached).IsTrue();
+    }
+
+    [Test]
     [Arguments("message-bounded")]
     [Arguments("zero-elapsed")]
     [Arguments("too-few-samples")]

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -89,7 +89,7 @@ internal sealed class StressTestResult
     public double? MedianIntervalMessagesPerSecond =>
         IsMessageBounded ? null : GetMedian(Throughput.MessagesPerSecondSamples);
 
-    /// <summary>Last-third average divided by peak sampled throughput.</summary>
+    /// <summary>Last-third average divided by p95 sampled throughput.</summary>
     public double? SteadyStatePeakRatio =>
         TryGetIntraRunThroughput(out var metrics) ? metrics.SteadyStatePeakRatio : null;
 
@@ -182,7 +182,7 @@ internal sealed class StressTestResult
         }
         var firstThirdAverage = firstThirdTotal / thirdCount;
         var lastThirdAverage = lastThirdTotal / thirdCount;
-        var peak = samples.Max();
+        var peak = GetPercentile(samples, 0.95);
         if (firstThirdAverage <= 0 || peak <= 0)
             return false;
 
@@ -203,10 +203,18 @@ internal sealed class StressTestResult
         var sampleMinutes = sampledElapsedSeconds / samples.Length / 60.0;
         var slopePerSample = numerator / denominator;
         metrics = new IntraRunThroughputMetrics(
-            lastThirdAverage / peak,
+            Math.Min(lastThirdAverage / peak, 1.0),
             (lastThirdAverage - firstThirdAverage) / firstThirdAverage * 100.0,
             slopePerSample / sampleMinutes / firstThirdAverage * 100.0);
         return true;
+    }
+
+    private static double GetPercentile(double[] samples, double percentile)
+    {
+        var sorted = samples.ToArray();
+        Array.Sort(sorted);
+        var rank = Math.Max(0, (int)Math.Ceiling(percentile * sorted.Length) - 1);
+        return sorted[rank];
     }
 
     private readonly record struct IntraRunThroughputMetrics(

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -183,6 +183,8 @@ internal sealed class StressTestResult
         var firstThirdAverage = firstThirdTotal / thirdCount;
         var lastThirdAverage = lastThirdTotal / thirdCount;
         var peak = GetPercentile(samples, 0.95);
+        if (peak <= 0)
+            peak = samples.Max();
         if (firstThirdAverage <= 0 || peak <= 0)
             return false;
 


### PR DESCRIPTION
## Summary
- gate delivery p50 and p99 at 2x the paired Confluent result
- use p95 sampled throughput so one transient spike cannot create a false steady-state breach
- cover paired latency failures and spike-resistant peak behavior

## Test plan
- [x] Python stress-script suite (41 passed)
- [x] .NET Release build (0 warnings, 0 errors)
- [x] .NET unit suite (5,144 passed)
- [x] replay run 29163729642 (12 latency breaches; 3-broker and 3conn regressions flagged)

Closes #1808
