### PR TITLE
Prevent adaptive producer scale-down churn

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -438,6 +438,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // different threads. HashSet<T> is not thread-safe for concurrent writes.
     private readonly ConcurrentDictionary<TopicPartition, byte> _mutedPartitions = new();
     private int _mutedPartitionCount;
+    private long _mutedPartitionActivityVersion;
 
     // Epoch bump recovery flag (Java Kafka Sender pattern): set by response handlers
     // when OutOfOrderSequenceNumber is received. The single-threaded send loop checks
@@ -474,6 +475,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Scale-down state (send-loop owned, single-threaded)
     private long _lowUtilizationStartTicks; // When low utilization was first detected (0 = not tracking)
     private long _lastMutedPartitionLoadTicks; // Last observed mute-on-send activity
+    private long _lastObservedMutedPartitionActivityVersion;
     private Task<IKafkaConnection?>? _pendingShrinkTask; // Background shrink, polled by send loop
     private IKafkaConnection? _drainingConnection; // Connection being drained before disposal
 
@@ -3639,6 +3641,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (_mutedPartitions.TryAdd(tp, 0))
         {
             Interlocked.Increment(ref _mutedPartitionCount);
+            Interlocked.Increment(ref _mutedPartitionActivityVersion);
             _accumulator.MutePartition(tp);
         }
     }
@@ -4166,8 +4169,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var activeMutedPartitionCount = _muteOnSend
             ? Volatile.Read(ref _mutedPartitionCount)
             : 0;
-        if (activeMutedPartitionCount > 0)
+        var mutedPartitionActivityVersion = Volatile.Read(ref _mutedPartitionActivityVersion);
+        if (activeMutedPartitionCount > 0
+            || mutedPartitionActivityVersion != _lastObservedMutedPartitionActivityVersion)
+        {
             _lastMutedPartitionLoadTicks = now;
+            _lastObservedMutedPartitionActivityVersion = mutedPartitionActivityVersion;
+        }
 
         // Cooldown applies to both scale-up and scale-down
         if (now - _lastScaleTimeTicks < _scaleCooldownMs)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -437,6 +437,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // sends, concurrent Z handlers (catch blocks in SendCoalescedAsync) can write from
     // different threads. HashSet<T> is not thread-safe for concurrent writes.
     private readonly ConcurrentDictionary<TopicPartition, byte> _mutedPartitions = new();
+    private int _mutedPartitionCount;
 
     // Epoch bump recovery flag (Java Kafka Sender pattern): set by response handlers
     // when OutOfOrderSequenceNumber is received. The single-threaded send loop checks
@@ -472,6 +473,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     // Scale-down state (send-loop owned, single-threaded)
     private long _lowUtilizationStartTicks; // When low utilization was first detected (0 = not tracking)
+    private long _lastMutedPartitionLoadTicks; // Last observed mute-on-send activity
     private Task<IKafkaConnection?>? _pendingShrinkTask; // Background shrink, polled by send loop
     private IKafkaConnection? _drainingConnection; // Connection being drained before disposal
 
@@ -1741,6 +1743,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 foreach (var (tp, _) in _mutedPartitions)
                     _accumulator.UnmutePartition(tp);
                 _mutedPartitions.Clear();
+                Interlocked.Exchange(ref _mutedPartitionCount, 0);
             }
         }
     }
@@ -3634,7 +3637,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void MutePartition(TopicPartition tp)
     {
         if (_mutedPartitions.TryAdd(tp, 0))
+        {
+            Interlocked.Increment(ref _mutedPartitionCount);
             _accumulator.MutePartition(tp);
+        }
     }
 
     private void MutePartitionsForSend(ReadyBatch[] batches, int count)
@@ -3653,7 +3659,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void UnmutePartition(TopicPartition tp)
     {
         if (_mutedPartitions.TryRemove(tp, out _))
+        {
+            Interlocked.Decrement(ref _mutedPartitionCount);
             _accumulator.UnmutePartition(tp);
+        }
         _eventChannel.Writer.TryWrite(SendLoopEvent.Unmute());
     }
 
@@ -4154,6 +4163,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         var now = Dekaf.MonotonicClock.GetMilliseconds();
+        var activeMutedPartitionCount = _muteOnSend
+            ? Volatile.Read(ref _mutedPartitionCount)
+            : 0;
+        if (activeMutedPartitionCount > 0)
+            _lastMutedPartitionLoadTicks = now;
 
         // Cooldown applies to both scale-up and scale-down
         if (now - _lastScaleTimeTicks < _scaleCooldownMs)
@@ -4226,15 +4240,26 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0; // Not sustained long enough
 
         // Low buffer occupancy can mean the expanded connection group is keeping up, not
-        // that it is idle. In particular, acks=all non-idempotent producers mute each
-        // partition while its request is in flight; shrinking that load-bearing width
-        // reintroduces head-of-line blocking. Require both low aggregate in-flight use and
-        // no queued work behind a muted partition before retiring a connection.
+        // that it is idle. Mute-on-send limits each active partition to one request, so
+        // connectionCount * maxInFlight overstates usable capacity by up to two orders of
+        // magnitude. Compare occupancy with active partition capacity and require a full
+        // sustained window without muted load before retiring a connection. The latter
+        // prevents a momentary ack-to-next-send gap from triggering a late-run shrink.
         var pendingResponseCount = Volatile.Read(ref _totalPendingResponseCount);
-        var inFlightUtilization = _totalMaxInFlight > 0
-            ? (double)pendingResponseCount / _totalMaxInFlight
+        var effectiveInFlightCapacity = activeMutedPartitionCount > 0
+            ? Math.Min(_totalMaxInFlight, activeMutedPartitionCount)
+            : _totalMaxInFlight;
+        var inFlightUtilization = effectiveInFlightCapacity > 0
+            ? (double)pendingResponseCount / effectiveInFlightCapacity
             : 0;
+        var hasRecentMutedPartitionLoad = _muteOnSend
+            && _lastMutedPartitionLoadTicks > 0
+            && now - _lastMutedPartitionLoadTicks < _scaleDownSustainedMs;
+        var hasLoadBearingMutedWidth = _muteOnSend
+            && activeMutedPartitionCount >= _connectionCount;
         if (inFlightUtilization >= ScaleDownInFlightUtilizationThreshold
+            || hasLoadBearingMutedWidth
+            || hasRecentMutedPartitionLoad
             || HasMutedPartitionLoad(carryOver, hasUnreadEvent))
         {
             _lowUtilizationStartTicks = 0;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -438,7 +438,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // different threads. HashSet<T> is not thread-safe for concurrent writes.
     private readonly ConcurrentDictionary<TopicPartition, byte> _mutedPartitions = new();
     private int _mutedPartitionCount;
-    private long _mutedPartitionActivityVersion;
+    private int _mutedPartitionHighWatermark;
 
     // Epoch bump recovery flag (Java Kafka Sender pattern): set by response handlers
     // when OutOfOrderSequenceNumber is received. The single-threaded send loop checks
@@ -474,8 +474,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     // Scale-down state (send-loop owned, single-threaded)
     private long _lowUtilizationStartTicks; // When low utilization was first detected (0 = not tracking)
-    private long _lastMutedPartitionLoadTicks; // Last observed mute-on-send activity
-    private long _lastObservedMutedPartitionActivityVersion;
+    private long _lastMutedPartitionLoadTicks; // Last observed load-bearing muted width
     private Task<IKafkaConnection?>? _pendingShrinkTask; // Background shrink, polled by send loop
     private IKafkaConnection? _drainingConnection; // Connection being drained before disposal
 
@@ -1746,6 +1745,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     _accumulator.UnmutePartition(tp);
                 _mutedPartitions.Clear();
                 Interlocked.Exchange(ref _mutedPartitionCount, 0);
+                Interlocked.Exchange(ref _mutedPartitionHighWatermark, 0);
             }
         }
     }
@@ -3640,8 +3640,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         if (_mutedPartitions.TryAdd(tp, 0))
         {
-            Interlocked.Increment(ref _mutedPartitionCount);
-            Interlocked.Increment(ref _mutedPartitionActivityVersion);
+            var mutedPartitionCount = Interlocked.Increment(ref _mutedPartitionCount);
+            AtomicMax(ref _mutedPartitionHighWatermark, mutedPartitionCount);
             _accumulator.MutePartition(tp);
         }
     }
@@ -3667,6 +3667,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _accumulator.UnmutePartition(tp);
         }
         _eventChannel.Writer.TryWrite(SendLoopEvent.Unmute());
+    }
+
+    private static void AtomicMax(ref int target, int value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value > current)
+        {
+            var original = Interlocked.CompareExchange(ref target, value, current);
+            if (original == current)
+                return;
+
+            current = original;
+        }
     }
 
     private bool RegisterLoopExitRecovery(ReadyBatch batch, int expectedGeneration)
@@ -4169,12 +4182,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var activeMutedPartitionCount = _muteOnSend
             ? Volatile.Read(ref _mutedPartitionCount)
             : 0;
-        var mutedPartitionActivityVersion = Volatile.Read(ref _mutedPartitionActivityVersion);
-        if (activeMutedPartitionCount > 0
-            || mutedPartitionActivityVersion != _lastObservedMutedPartitionActivityVersion)
+        var mutedPartitionHighWatermark = _muteOnSend
+            ? Interlocked.Exchange(ref _mutedPartitionHighWatermark, activeMutedPartitionCount)
+            : 0;
+        if (Math.Max(activeMutedPartitionCount, mutedPartitionHighWatermark) >= _connectionCount)
         {
             _lastMutedPartitionLoadTicks = now;
-            _lastObservedMutedPartitionActivityVersion = mutedPartitionActivityVersion;
         }
 
         // Cooldown applies to both scale-up and scale-down
@@ -4251,8 +4264,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // that it is idle. Mute-on-send limits each active partition to one request, so
         // connectionCount * maxInFlight overstates usable capacity by up to two orders of
         // magnitude. Compare occupancy with active partition capacity and require a full
-        // sustained window without muted load before retiring a connection. The latter
-        // prevents a momentary ack-to-next-send gap from triggering a late-run shrink.
+        // sustained window after the muted width was large enough to occupy every
+        // connection. Tracking the peak catches mute/unmute cycles between scale checks
+        // without treating continuous single-partition trickle as full-width load.
         var pendingResponseCount = Volatile.Read(ref _totalPendingResponseCount);
         var effectiveInFlightCapacity = activeMutedPartitionCount > 0
             ? Math.Min(_totalMaxInFlight, activeMutedPartitionCount)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -552,7 +552,7 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
-    public async Task ScaleDown_RecentMutedLoad_SurvivesMomentaryClear()
+    public async Task ScaleDown_MutedActivityBetweenChecks_SurvivesMomentaryClear()
     {
         var options = CreateOptions(
             idempotent: false,
@@ -574,8 +574,6 @@ public sealed class AdaptiveScaleDownTests
                 "MutePartition",
                 BindingFlags.Instance | BindingFlags.NonPublic)!
                 .Invoke(sender, [topicPartition]);
-            InvokeMaybeScaleConnections(sender);
-
             typeof(BrokerSender).GetMethod(
                 "UnmutePartition",
                 BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -552,7 +552,7 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
-    public async Task ScaleDown_MutedActivityBetweenChecks_SurvivesMomentaryClear()
+    public async Task ScaleDown_LoadBearingMutedActivityBetweenChecks_SurvivesMomentaryClear()
     {
         var options = CreateOptions(
             idempotent: false,
@@ -562,7 +562,6 @@ public sealed class AdaptiveScaleDownTests
         var accumulator = new RecordAccumulator(options);
         var pool = Substitute.For<IConnectionPool>();
         var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
-        var topicPartition = new TopicPartition(Topic, 0);
 
         try
         {
@@ -570,14 +569,16 @@ public sealed class AdaptiveScaleDownTests
             SetField(sender, "_totalMaxInFlight", 300);
             SetField(sender, "_totalPendingResponseCount", 1);
             SetField(sender, "_lowUtilizationStartTicks", 1L);
-            typeof(BrokerSender).GetMethod(
+            var mutePartition = typeof(BrokerSender).GetMethod(
                 "MutePartition",
-                BindingFlags.Instance | BindingFlags.NonPublic)!
-                .Invoke(sender, [topicPartition]);
-            typeof(BrokerSender).GetMethod(
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var unmutePartition = typeof(BrokerSender).GetMethod(
                 "UnmutePartition",
-                BindingFlags.Instance | BindingFlags.NonPublic)!
-                .Invoke(sender, [topicPartition]);
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            for (var partition = 0; partition < 3; partition++)
+                mutePartition.Invoke(sender, [new TopicPartition(Topic, partition)]);
+            for (var partition = 0; partition < 3; partition++)
+                unmutePartition.Invoke(sender, [new TopicPartition(Topic, partition)]);
             SetField(sender, "_totalPendingResponseCount", 0);
             SetField(sender, "_lowUtilizationStartTicks", 1L);
             InvokeMaybeScaleConnections(sender);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -34,11 +34,12 @@ public sealed class AdaptiveScaleDownTests
     private static ProducerOptions CreateOptions(
         bool idempotent,
         int deliveryTimeoutMs = 30_000,
+        int maxInFlightRequests = 1,
         long? scaleCooldownMs = null,
         long? scaleDownSustainedMs = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
-            MaxInFlightRequestsPerConnection = 1,
+            MaxInFlightRequestsPerConnection = maxInFlightRequests,
             Acks = Acks.All,
             EnableIdempotence = idempotent,
             DeliveryTimeoutMs = deliveryTimeoutMs,
@@ -466,7 +467,7 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
-    public async Task ScaleDown_MutedPartitionWithOnlyInFlightBatch_Shrinks()
+    public async Task ScaleDown_MutedPartitionWithOnlyInFlightBatch_DoesNotShrink()
     {
         var options = CreateOptions(
             idempotent: false,
@@ -496,9 +497,96 @@ public sealed class AdaptiveScaleDownTests
             InvokeMaybeScaleConnections(sender);
             InvokeMaybeScaleConnections(sender);
 
-            await pool.Received(1).ShrinkConnectionGroupAsync(
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
                 Arg.Any<int>(),
-                3,
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(4);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(4)]
+    public async Task ScaleDown_MuteOnSend_ActiveLoadDoesNotShrink(int activePartitionCount)
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            maxInFlightRequests: 100,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 3);
+            SetField(sender, "_totalMaxInFlight", 300);
+            SetField(sender, "_totalPendingResponseCount", 1);
+            var mutePartition = typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            for (var partition = 0; partition < activePartitionCount; partition++)
+                mutePartition.Invoke(sender, [new TopicPartition(Topic, partition)]);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(3);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ScaleDown_RecentMutedLoad_SurvivesMomentaryClear()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            maxInFlightRequests: 100,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 60_000);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        var topicPartition = new TopicPartition(Topic, 0);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 3);
+            SetField(sender, "_totalMaxInFlight", 300);
+            SetField(sender, "_totalPendingResponseCount", 1);
+            SetField(sender, "_lowUtilizationStartTicks", 1L);
+            typeof(BrokerSender).GetMethod(
+                "MutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+            InvokeMaybeScaleConnections(sender);
+
+            typeof(BrokerSender).GetMethod(
+                "UnmutePartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [topicPartition]);
+            SetField(sender, "_totalPendingResponseCount", 0);
+            SetField(sender, "_lowUtilizationStartTicks", 1L);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
                 Arg.Any<CancellationToken>());
             await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(3);
         }


### PR DESCRIPTION
## Summary
- compute mute-on-send in-flight utilization against active partition capacity
- suppress shrink while connection width is load-bearing
- require one sustained clear window after muted activity before scale-down
- maintain active muted-partition count with O(1) atomic updates

## Test plan
- [x] AdaptiveScaleDownTests (27 passed)
- [x] .NET Release build (0 warnings, 0 errors)
- [x] .NET unit suite (5,146 passed)
- [ ] Scheduled 15-minute stress run confirms drift/slope thresholds

Closes #1807
