### PR TITLE
Document producer roundtrip CPU attribution

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -571,6 +571,7 @@ jobs:
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured; table headings report the 16KB seed batch size because it amplifies per-batch costs relative to well-batched workloads")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
           output.append("- **Round-Trip Correctness**: Bounded sequenced payloads are consumed back and checked for corruption, wrong partitions, gaps, duplicates, and reordering")
+          output.append("- **Round-Trip CPU Scope**: CPU time covers both bulk production and consumer validation; it is not a producer-only metric")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")
           output.append("- **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow")
           output.append("- **Parallel Execution**: Each scenario runs in its own isolated environment")

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -410,3 +410,26 @@ Capture detailed traces:
 ```bash
 dotnet-trace collect --process-id <pid> --providers Microsoft-DotNETCore-SampleProfiler
 ```
+
+#### Interpreting round-trip CPU results
+
+The `producer-roundtrip` stress scenario measures one process across both phases: bulk
+production, then consumption and strict record validation. Its CPU-per-message result is
+therefore not a producer-only measurement.
+
+A controlled 250,000-message CPU-sampling investigation compared the three Dekaf consumer
+surfaces in that validation phase. Absolute times include tracing overhead, so use the
+relative differences:
+
+| Consumer surface | CPU µs/message | Ordering violations | Relative result |
+|------------------|---------------:|--------------------:|-----------------|
+| `ConsumeAsync` | 25.875 | 0 | Correct baseline |
+| `ConsumeOneAsync` | 24.063 | 982 | 7% lower CPU, invalid result |
+| `ConsumeBatchAsync` | 15.620 | 11,784 | 40% lower CPU, invalid result |
+
+This attributes a material part of the round-trip CPU gap to per-record async-enumerable
+work rather than producer acknowledgement handling. The strict stress scenario remains on
+`ConsumeAsync`, the only surface that preserved per-partition ordering in this experiment.
+The buffered-path correctness defect is tracked in
+[#1813](https://github.com/thomhurst/Dekaf/issues/1813); lower CPU is not accepted when it
+changes record order.

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -271,6 +271,7 @@ Stress tests measure sustained performance over extended periods:
 - **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured; table headings report the 16KB seed batch size because it amplifies per-batch costs relative to well-batched workloads
 - **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency
 - **Round-Trip Correctness**: Bounded sequenced payloads are consumed back and checked for corruption, wrong partitions, gaps, duplicates, and reordering
+- **Round-Trip CPU Scope**: CPU time covers both bulk production and consumer validation; it is not a producer-only metric
 - **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput
 - **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow
 - **Parallel Execution**: Each scenario runs in its own isolated environment

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -201,6 +201,9 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
 
         try
         {
+            // ConsumeAsync is intentional: ConsumeOneAsync and ConsumeBatchAsync currently
+            // violate per-partition order across buffered fetches (#1813), which would make
+            // this strict validator report false client correctness failures.
             await foreach (var record in consumer.ConsumeAsync(timeout.Token).ConfigureAwait(false))
             {
                 recordProgress?.Invoke();


### PR DESCRIPTION
## Summary
- document that roundtrip CPU covers production plus consumer validation
- publish controlled CPU-sampling results for all three Dekaf consumer surfaces
- keep strict validation on order-safe ConsumeAsync and link buffered ordering bug #1813
- persist CPU-scope guidance in generated stress documentation

## Trace findings
| Path | CPU us/msg | Ordering violations |
|---|---:|---:|
| ConsumeAsync | 25.875 | 0 |
| ConsumeOneAsync | 24.063 | 982 |
| ConsumeBatchAsync | 15.620 | 11,784 |

Absolute values include tracing overhead. Batch path lowers CPU ~40%, attributing material cost to per-record async enumeration, but cannot replace current path until #1813 is fixed.

## Test plan
- [x] CPU-sampling traces: three 250,000-message local Testcontainers runs
- [x] Python workflow-script suite (38 passed)
- [x] Docusaurus production build
- [x] .NET Release build (0 warnings, 0 errors)
- [x] .NET unit suite (5,143 passed)

Closes #1809
