### PR TITLE
Preserve buffered consumer order while scaling

### DIFF
--- a/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
+++ b/src/Dekaf/Consumer/ConsumerConnectionScaler.cs
@@ -300,4 +300,10 @@ internal sealed class ConsumerConnectionScaler : IDisposable
 
     internal void TestSetConnectionCount(int count)
         => _currentConnectionCount = count;
+
+    internal void RollbackFailedScaleUp(int failedTargetCount)
+        => Interlocked.CompareExchange(
+            ref _currentConnectionCount,
+            failedTargetCount - 1,
+            failedTargetCount);
 }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -849,6 +849,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private Task? _autoCommitTask;
     private int _fetchApiVersion = -1;
     private readonly ConsumerConnectionScaler? _connectionScaler;
+    private int _appliedConnectionCount;
+    private Task? _connectionRoutingTransitionTask;
     private readonly AdaptiveFetchSizer? _adaptiveFetchSizer;
     private int _adaptiveFetchMemoryPressureSignals;
 
@@ -1105,6 +1107,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _telemetryMetricCollector);
 
         _compressionCodecs = CompressionCodecRegistry.Default;
+        _appliedConnectionCount = options.ConnectionsPerBroker;
 
         // Initialize adaptive connection scaler if configured (before coordinator, which needs the connection count)
         if (options.EnableAdaptiveConnections && options.MaxConnectionsPerBroker > options.ConnectionsPerBroker)
@@ -1114,15 +1117,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _connectionScaler = new ConsumerConnectionScaler(
                 initialConnectionCount: options.ConnectionsPerBroker,
                 maxConnectionCount: options.MaxConnectionsPerBroker,
-                scaleUpAsync: async ct =>
-                {
-                    var newCount = _connectionScaler!.CurrentConnectionCount;
-                    foreach (var broker in _metadataManager.Metadata.GetBrokers())
-                        await _connectionPool.ScaleConnectionGroupAsync(broker.NodeId, newCount, ct).ConfigureAwait(false);
-                },
-                scaleDownAsync: ownsInfrastructure
-                    ? ScaleDownOwnedConnectionGroupsAsync
-                    : static _ => ValueTask.CompletedTask,
+                scaleUpAsync: ct => BeginConnectionRoutingTransitionAsync(scaleDown: false, ct),
+                scaleDownAsync: ct => BeginConnectionRoutingTransitionAsync(scaleDown: true, ct),
                 logError: ex => _logger.LogWarning(ex, "Adaptive connection scaling operation failed"));
         }
 
@@ -1141,7 +1137,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 _metadataManager,
                 loggerFactory?.CreateLogger<ConsumerCoordinator>(),
                 getConnectionCount: _connectionScaler is not null
-                    ? () => _connectionScaler.CurrentConnectionCount
+                    ? () => Volatile.Read(ref _appliedConnectionCount)
                     : null,
                 onPartitionsRevoked: null,
                 onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear);
@@ -1154,15 +1150,63 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Diagnostics.DekafMetrics.RegisterConsumerLagCallback(ObserveConsumerLag);
     }
 
-    private async ValueTask ScaleDownOwnedConnectionGroupsAsync(CancellationToken cancellationToken)
+    private ValueTask BeginConnectionRoutingTransitionAsync(
+        bool scaleDown,
+        CancellationToken cancellationToken)
     {
-        var newCount = _connectionScaler!.CurrentConnectionCount;
+        var targetCount = _connectionScaler!.CurrentConnectionCount;
+        var transition = ApplyConnectionRoutingTransitionAsync(
+            targetCount,
+            scaleDown,
+            cancellationToken);
+        Volatile.Write(ref _connectionRoutingTransitionTask, transition);
+        return new ValueTask(transition);
+    }
+
+    private async Task ApplyConnectionRoutingTransitionAsync(
+        int targetCount,
+        bool scaleDown,
+        CancellationToken cancellationToken)
+    {
+        // Routing width changes remap partitions across fetch connections. Drain every
+        // request issued with the old mapping before publishing the new width, otherwise
+        // old and new connections can fetch overlapping offsets for the same partition.
+        var drainError = await _brokerPrefetchScheduler
+            .DrainAllSafelyAsync(LogPrefetchLoopError, IsFatalPrefetchError)
+            .ConfigureAwait(false);
+        if (drainError is not null)
+            ExceptionDispatchInfo.Capture(drainError).Throw();
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (scaleDown)
+        {
+            if (_ownsInfrastructure)
+                await ScaleDownOwnedConnectionGroupsAsync(targetCount, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            foreach (var broker in _metadataManager.Metadata.GetBrokers())
+            {
+                await _connectionPool.ScaleConnectionGroupAsync(
+                    broker.NodeId,
+                    targetCount,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        Volatile.Write(ref _appliedConnectionCount, targetCount);
+    }
+
+    private async ValueTask ScaleDownOwnedConnectionGroupsAsync(
+        int targetCount,
+        CancellationToken cancellationToken)
+    {
         var brokers = _metadataManager.Metadata.GetBrokers();
         var scaleDownTasks = new Task[brokers.Count];
         for (var i = 0; i < brokers.Count; i++)
             scaleDownTasks[i] = ScaleDownOwnedConnectionGroupAsync(
                 brokers[i].NodeId,
-                newCount,
+                targetCount,
                 cancellationToken).AsTask();
 
         await Task.WhenAll(scaleDownTasks).ConfigureAwait(false);
@@ -2216,6 +2260,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         continue;
                     }
 
+                    if (await WaitForConnectionRoutingTransitionAsync().ConfigureAwait(false))
+                        continue;
+
                     var drained = await _brokerPrefetchScheduler.DrainCompletedAsync().ConfigureAwait(false);
                     if (PrefetchLoopControl.ShouldResetConsecutiveErrors(drained))
                         consecutiveErrors = 0;
@@ -2319,6 +2366,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private async ValueTask<bool> WaitForConnectionRoutingTransitionAsync()
+    {
+        var transition = Volatile.Read(ref _connectionRoutingTransitionTask);
+        if (transition is null)
+            return false;
+
+        try
+        {
+            await transition.ConfigureAwait(false);
+        }
+        finally
+        {
+            _ = Interlocked.CompareExchange(ref _connectionRoutingTransitionTask, null, transition);
+        }
+
+        return true;
+    }
+
     private async ValueTask<(int Started, int TargetCount)> DispatchReadyBrokerPrefetchesAsync(CancellationToken cancellationToken)
     {
         var partitionsByBroker = await GroupPartitionsByBrokerAsync(cancellationToken).ConfigureAwait(false);
@@ -2326,7 +2391,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var fetchSessionSnapshot = ShouldUseFetchSessions && !_fetchSessions.IsEmpty
             ? _fetchSessions.ToArray()
             : Array.Empty<KeyValuePair<(int BrokerId, int ConnectionIndex), FetchSessionHandler>>();
-        var currentConnections = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
+        var currentConnections = Volatile.Read(ref _appliedConnectionCount);
         var fetchConnectionCount = ConsumerConnectionScaler.GetFetchConnectionCount(currentConnections);
 
         // Lazily prune stale entries from scaled-down connections.
@@ -5202,7 +5267,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         // Keep offset-control requests off fetch connections. A delayed fetch response must not
         // block assignment position initialization or watermark queries during a rebalance.
-        var connectionCount = _connectionScaler?.CurrentConnectionCount ?? _options.ConnectionsPerBroker;
+        var connectionCount = Volatile.Read(ref _appliedConnectionCount);
         var connectionIndex = ConsumerCoordinator.GetCoordinationConnectionIndex(connectionCount);
         return await _connectionPool.LeaseConnectionByIndexAsync(leader.NodeId, connectionIndex, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -851,6 +851,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConsumerConnectionScaler? _connectionScaler;
     private int _appliedConnectionCount;
     private Task? _connectionRoutingTransitionTask;
+    private readonly ConcurrentDictionary<Task, byte> _retiredConnectionDisposalTasks = new();
     private readonly AdaptiveFetchSizer? _adaptiveFetchSizer;
     private int _adaptiveFetchMemoryPressureSignals;
 
@@ -1228,11 +1229,30 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (removedConnection is null)
             return;
 
-        // Once detached from the pool, the retired connection must finish draining even if
-        // consumer shutdown cancels further pool operations; otherwise it has no remaining owner.
-        await RetiredConnectionDisposer.DrainAndDisposeAsync(
-            removedConnection,
-            CancellationToken.None).ConfigureAwait(false);
+        // Pool detachment completes the routing transition. Drain leases and operations in
+        // the background so a slow retired socket cannot pause all consumer prefetch.
+        StartRetiredConnectionDisposal(removedConnection);
+    }
+
+    private void StartRetiredConnectionDisposal(IKafkaConnection connection)
+    {
+        var disposalTask = RetiredConnectionDisposer.DrainAndDisposeAsync(
+            connection,
+            CancellationToken.None).AsTask();
+        _retiredConnectionDisposalTasks.TryAdd(disposalTask, 0);
+        _ = disposalTask.ContinueWith(
+            static (task, state) =>
+                ((KafkaConsumer<TKey, TValue>)state!).ObserveRetiredConnectionDisposal(task),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void ObserveRetiredConnectionDisposal(Task task)
+    {
+        _retiredConnectionDisposalTasks.TryRemove(task, out _);
+        _ = task.Exception;
     }
 
     public StringSet Subscription => _subscriptionSnapshot;
@@ -7271,6 +7291,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 await _connectionScaler.StopAndDrainAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
             _connectionScaler.Dispose();
+        }
+
+        var retiredConnectionDisposals = _retiredConnectionDisposalTasks.Keys.ToArray();
+        if (retiredConnectionDisposals.Length > 0)
+        {
+            try
+            {
+                await Task.WhenAll(retiredConnectionDisposals).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Completion continuations observe individual disposal failures.
+            }
         }
 
         autoCommitCts?.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1180,6 +1180,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         cancellationToken.ThrowIfCancellationRequested();
         if (scaleDown)
         {
+            // The narrower mapping is valid against both the old and target pool sizes.
+            // Publish it before physical shrink so a partial broker failure cannot leave
+            // routing pointed at a connection index another broker already retired.
+            Volatile.Write(ref _appliedConnectionCount, targetCount);
             if (_ownsInfrastructure)
                 await ScaleDownOwnedConnectionGroupsAsync(targetCount, cancellationToken).ConfigureAwait(false);
         }
@@ -1192,9 +1196,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     targetCount,
                     cancellationToken).ConfigureAwait(false);
             }
-        }
 
-        Volatile.Write(ref _appliedConnectionCount, targetCount);
+            Volatile.Write(ref _appliedConnectionCount, targetCount);
+        }
     }
 
     private async ValueTask ScaleDownOwnedConnectionGroupsAsync(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1190,15 +1190,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         else
         {
-            foreach (var broker in _metadataManager.Metadata.GetBrokers())
+            try
             {
-                await _connectionPool.ScaleConnectionGroupAsync(
-                    broker.NodeId,
-                    targetCount,
-                    cancellationToken).ConfigureAwait(false);
-            }
+                foreach (var broker in _metadataManager.Metadata.GetBrokers())
+                {
+                    await _connectionPool.ScaleConnectionGroupAsync(
+                        broker.NodeId,
+                        targetCount,
+                        cancellationToken).ConfigureAwait(false);
+                }
 
-            Volatile.Write(ref _appliedConnectionCount, targetCount);
+                Volatile.Write(ref _appliedConnectionCount, targetCount);
+            }
+            catch
+            {
+                // The new routing width was never published. Roll scaler bookkeeping
+                // back so sustained saturation can retry, including failures at max.
+                _connectionScaler!.RollbackFailedScaleUp(targetCount);
+                throw;
+            }
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -50,10 +50,16 @@ public sealed class ConsumerConnectionOwnershipTests
     public async Task ScaleDown_DrainsOldRoutingBeforeApplyingNewWidth()
     {
         var pool = CreatePool();
+        var shrinkStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var shrinkCanComplete = new TaskCompletionSource<IKafkaConnection?>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<IKafkaConnection?>(shrinkCanComplete.Task));
+            .Returns(_ =>
+            {
+                shrinkStarted.TrySetResult();
+                return new ValueTask<IKafkaConnection?>(shrinkCanComplete.Task);
+            });
         await using var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
         var scheduler = GetField<BrokerPrefetchScheduler>(consumer, "_brokerPrefetchScheduler");
         var oldFetchCanComplete = new TaskCompletionSource(
@@ -78,6 +84,7 @@ public sealed class ConsumerConnectionOwnershipTests
             await TestWait.UntilAsync(
                 () => GetField<int>(consumer, "_appliedConnectionCount") == 2,
                 TimeSpan.FromSeconds(5));
+            await shrinkStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
             _ = pool.Received(1).ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>());
         }
         finally
@@ -236,6 +243,45 @@ public sealed class ConsumerConnectionOwnershipTests
         await TestWait.UntilAsync(
             () => removedConnection.DisposeCount == 1,
             TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task StandaloneConsumer_Dispose_WaitsForRetiredConnectionDisposal()
+    {
+        var pool = CreatePool();
+        var removedConnection = new TrackedConnection(
+            hasPendingRequest: false,
+            hasLease: true);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection?>(removedConnection));
+        var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+        var leaseReleased = false;
+
+        TriggerScaleDown(consumer);
+        await TestWait.UntilAsync(
+            () => GetField<Task>(consumer, "_connectionRoutingTransitionTask").IsCompleted,
+            TimeSpan.FromSeconds(5));
+        var disposeTask = consumer.DisposeAsync().AsTask();
+
+        try
+        {
+            await Task.Delay(100);
+            await Assert.That(disposeTask.IsCompleted).IsFalse();
+            _ = pool.DidNotReceive().DisposeAsync();
+
+            removedConnection.ReleaseLease();
+            leaseReleased = true;
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            if (!leaseReleased)
+                removedConnection.ReleaseLease();
+            await consumer.DisposeAsync();
+        }
+
+        await Assert.That(removedConnection.DisposeCount).IsEqualTo(1);
+        _ = pool.Received(1).DisposeAsync();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -228,6 +228,9 @@ public sealed class ConsumerConnectionOwnershipTests
         TriggerScaleDown(consumer);
 
         await Assert.That(removedConnection.DisposeCount).IsEqualTo(0);
+        await TestWait.UntilAsync(
+            () => GetField<Task>(consumer, "_connectionRoutingTransitionTask").IsCompleted,
+            TimeSpan.FromSeconds(5));
 
         removedConnection.ReleaseLease();
         await TestWait.UntilAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -47,6 +47,47 @@ public sealed class ConsumerConnectionOwnershipTests
     }
 
     [Test]
+    public async Task ScaleDown_DrainsOldRoutingBeforeApplyingNewWidth()
+    {
+        var pool = CreatePool();
+        var shrinkCanComplete = new TaskCompletionSource<IKafkaConnection?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IKafkaConnection?>(shrinkCanComplete.Task));
+        await using var consumer = CreateStandaloneConsumer(pool, CreateMetadataManager(pool));
+        var scheduler = GetField<BrokerPrefetchScheduler>(consumer, "_brokerPrefetchScheduler");
+        var oldFetchCanComplete = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), async () =>
+        {
+            await oldFetchCanComplete.Task.ConfigureAwait(false);
+        });
+        SetField(consumer, "_appliedConnectionCount", 3);
+
+        try
+        {
+            TriggerScaleDown(consumer);
+
+            await Assert.That(GetField<int>(consumer, "_appliedConnectionCount")).IsEqualTo(3);
+            _ = pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+
+            oldFetchCanComplete.SetResult();
+            await TestWait.UntilAsync(
+                () => GetField<int>(consumer, "_appliedConnectionCount") == 2,
+                TimeSpan.FromSeconds(5));
+            _ = pool.Received(1).ShrinkConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            oldFetchCanComplete.TrySetResult();
+            shrinkCanComplete.TrySetResult(null);
+        }
+    }
+
+    [Test]
     public async Task SharedConsumer_ScaleDown_DoesNotShrinkSiblingConnection()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -102,12 +143,9 @@ public sealed class ConsumerConnectionOwnershipTests
 
         try
         {
-            var fetchSessionsField = typeof(KafkaConsumer<string, string>).GetField(
-                "_fetchSessions",
-                BindingFlags.Instance | BindingFlags.NonPublic)
-                ?? throw new InvalidOperationException("_fetchSessions field not found");
-            var fetchSessions = (ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler>)
-                fetchSessionsField.GetValue(consumer)!;
+            var fetchSessions = GetField<ConcurrentDictionary<
+                (int BrokerId, int ConnectionIndex),
+                FetchSessionHandler>>(consumer, "_fetchSessions");
             var handler = new FetchSessionHandler();
             _ = handler.Build([], clusterMetadata: null);
             _ = handler.HandleResponse(new FetchResponse
@@ -416,12 +454,7 @@ public sealed class ConsumerConnectionOwnershipTests
 
     private static void TriggerScaleDown(KafkaConsumer<string, string> consumer)
     {
-        var scalerField = typeof(KafkaConsumer<string, string>).GetField(
-            "_connectionScaler",
-            BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("_connectionScaler field not found");
-        var scaler = (ConsumerConnectionScaler?)scalerField.GetValue(consumer)
-            ?? throw new InvalidOperationException("Connection scaler was not created");
+        var scaler = GetField<ConsumerConnectionScaler>(consumer, "_connectionScaler");
 
         scaler.TestSetConnectionCount(3);
         scaler.ReportPipelineUtilization(0, pipelineDepth: 3);
@@ -437,6 +470,13 @@ public sealed class ConsumerConnectionOwnershipTests
             BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException($"{fieldName} field not found"))
         .GetValue(instance)!;
+
+    private static void SetField<T>(object instance, string fieldName, T value) =>
+        (instance.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{fieldName} field not found"))
+        .SetValue(instance, value);
 
     private sealed class TrackedConnection(
         bool hasPendingRequest,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -28,10 +28,7 @@ public sealed class ConsumerConnectionOwnershipTests
         });
 
         var scaler = GetField<ConsumerConnectionScaler>(consumer, "_connectionScaler");
-        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
-        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
-        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
-        scaler.MaybeScale();
+        TriggerScaleUp(scaler);
 
         await Assert.That(GetField<int>(consumer, "_appliedConnectionCount")).IsEqualTo(2);
         _ = pool.DidNotReceive().ScaleConnectionGroupAsync(
@@ -44,6 +41,35 @@ public sealed class ConsumerConnectionOwnershipTests
             () => GetField<int>(consumer, "_appliedConnectionCount") == 3,
             TimeSpan.FromSeconds(5));
         _ = pool.Received(1).ScaleConnectionGroupAsync(1, 3, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FailedScaleUp_RollsBackTargetAndRetries()
+    {
+        var pool = CreatePool();
+        pool.ScaleConnectionGroupAsync(1, 3, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(3));
+        pool.ScaleConnectionGroupAsync(2, 3, Arg.Any<CancellationToken>())
+            .Returns(
+                ValueTask.FromException<int>(new IOException("scale failed")),
+                ValueTask.FromResult(3));
+        await using var consumer = CreateStandaloneConsumer(
+            pool,
+            CreateMetadataManager(pool, includeSecondBroker: true));
+        var scaler = GetField<ConsumerConnectionScaler>(consumer, "_connectionScaler");
+
+        TriggerScaleUp(scaler);
+        await TestWait.UntilAsync(
+            () => scaler.CurrentConnectionCount == 2,
+            TimeSpan.FromSeconds(5));
+        await Assert.That(GetField<int>(consumer, "_appliedConnectionCount")).IsEqualTo(2);
+
+        TriggerScaleUp(scaler);
+        await TestWait.UntilAsync(
+            () => GetField<int>(consumer, "_appliedConnectionCount") == 3,
+            TimeSpan.FromSeconds(5));
+        _ = pool.Received(2).ScaleConnectionGroupAsync(1, 3, Arg.Any<CancellationToken>());
+        _ = pool.Received(2).ScaleConnectionGroupAsync(2, 3, Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -510,6 +536,14 @@ public sealed class ConsumerConnectionOwnershipTests
         scaler.MaybeScale();
         scaler.TestAdvanceTime(TimeSpan.FromSeconds(121));
         scaler.ReportPipelineUtilization(0, pipelineDepth: 3);
+        scaler.MaybeScale();
+    }
+
+    private static void TriggerScaleUp(ConsumerConnectionScaler scaler)
+    {
+        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
         scaler.MaybeScale();
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerConnectionOwnershipTests.cs
@@ -14,6 +14,39 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class ConsumerConnectionOwnershipTests
 {
     [Test]
+    public async Task ScaleUp_DrainsOldRoutingBeforeApplyingNewWidth()
+    {
+        var pool = CreatePool();
+        var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateStandaloneConsumer(pool, metadataManager);
+        var scheduler = GetField<BrokerPrefetchScheduler>(consumer, "_brokerPrefetchScheduler");
+        var oldFetchCanComplete = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.TryStart((BrokerId: 1, ConnectionIndex: 0), async () =>
+        {
+            await oldFetchCanComplete.Task.ConfigureAwait(false);
+        });
+
+        var scaler = GetField<ConsumerConnectionScaler>(consumer, "_connectionScaler");
+        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
+        scaler.TestAdvanceTime(TimeSpan.FromSeconds(6));
+        scaler.ReportPipelineUtilization(3, pipelineDepth: 3);
+        scaler.MaybeScale();
+
+        await Assert.That(GetField<int>(consumer, "_appliedConnectionCount")).IsEqualTo(2);
+        _ = pool.DidNotReceive().ScaleConnectionGroupAsync(
+            Arg.Any<int>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+
+        oldFetchCanComplete.SetResult();
+        await TestWait.UntilAsync(
+            () => GetField<int>(consumer, "_appliedConnectionCount") == 3,
+            TimeSpan.FromSeconds(5));
+        _ = pool.Received(1).ScaleConnectionGroupAsync(1, 3, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task SharedConsumer_ScaleDown_DoesNotShrinkSiblingConnection()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -397,6 +430,13 @@ public sealed class ConsumerConnectionOwnershipTests
         scaler.ReportPipelineUtilization(0, pipelineDepth: 3);
         scaler.MaybeScale();
     }
+
+    private static T GetField<T>(object instance, string fieldName) =>
+        (T)(instance.GetType().GetField(
+            fieldName,
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{fieldName} field not found"))
+        .GetValue(instance)!;
 
     private sealed class TrackedConnection(
         bool hasPendingRequest,


### PR DESCRIPTION
## Summary
- drain fetches issued with the old connection routing before applying an adaptive width change
- keep coordinator and fetch routing on the last fully applied connection count during transitions
- cover scale-up with a blocked old-route fetch regression

## Validation
- `dotnet build Dekaf.sln -c Release` (0 warnings, 0 errors)
- 5,144 unit tests passed on net10.0
- 38 Python reporting tests passed
- 250,000-message `ConsumeOneAsync` round trip: 0 missing, duplicate, corrupt, or out-of-order
- 250,000-message `ConsumeBatchAsync` round trip: 0 missing, duplicate, corrupt, or out-of-order

Closes #1813
