### PR TITLE
Preserve all release matrix results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
     needs: [changes, build]
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         framework: [net8.0, net10.0]
         kafka: ['4.0.2', '4.1.2', '4.2.1', '4.3.1']
@@ -276,19 +276,21 @@ jobs:
     with:
       framework: ${{ matrix.framework }}
       kafka-tag: ${{ matrix.kafka }}
+      fail-fast: false
 
   release-matrix-aot:
     name: Release Matrix AOT
     needs: [changes, aot-integration-publish]
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         kafka: ['4.0.2', '4.3.1']
     uses: ./.github/workflows/integration-groups.yml
     with:
       framework: aot
       kafka-tag: ${{ matrix.kafka }}
+      fail-fast: false
 
   # Both NativeAOT smoke exes publish and run sequentially in one job — the
   # compute is the same as two matrix jobs but saves one runner slot + setup.

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: '4.3.1'
+      fail-fast:
+        description: 'Cancel sibling integration groups after the first failure'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   groups:
@@ -25,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
-      fail-fast: true
+      fail-fast: ${{ inputs.fail-fast }}
       matrix:
         group: [tls, security, faults, produce, consume, messaging]
         include:


### PR DESCRIPTION
## Summary
- keep PR/push integration matrices fail-fast
- disable fail-fast for both release caller matrices
- disable fail-fast for each release integration-group matrix

## Test plan
- [x] Parse both changed workflow files as YAML
- [x] Assert release caller and inner matrices use `fail-fast: false`
- [x] Assert PR/push caller retains `fail-fast: true`
- [x] `git diff --check`

Closes #1829
