### PR TITLE
Skip Confluent interop tests under NativeAOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,9 @@ jobs:
           PYTHONPATH: .github/scripts
         run: python3 -m unittest discover -s .github/scripts -p 'test_stress_*.py'
 
+      - name: Test Integration Category Runner
+        run: bash scripts/tests/run-integration-categories-tests.sh
+
   # Pushes NuGet packages and creates the GitHub release — only reachable when
   # the entire release matrix (plus the regular lanes) is green. Re-runs the
   # pipeline on the same commit, so GitVersion yields the same version the

--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -38,6 +38,11 @@ chmod +x "$exe"
 export DOTNET_GCConserveMemory=9
 
 for category in "${categories[@]}"; do
+  if [ "$tfm" = "aot" ] && [ "$category" = "Interop" ]; then
+    echo "Skipping Interop for NativeAOT because Confluent.Kafka requires runtime reflection"
+    continue
+  fi
+
   echo "::group::Category $category"
   args=(
     --hangdump

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"' EXIT
+
+mkdir -p "$temp_root/scripts" \
+  "$temp_root/artifacts/aot/integration" \
+  "$temp_root/tests/Dekaf.Tests.Integration/bin/Release/net10.0"
+cp "$repo_root/scripts/run-integration-categories.sh" "$temp_root/scripts/"
+
+fake_runner='#!/usr/bin/env bash
+printf "%s\n" "$*" >> "$CALLS_FILE"'
+printf '%s\n' "$fake_runner" > "$temp_root/artifacts/aot/integration/Dekaf.Tests.Integration"
+printf '%s\n' "$fake_runner" > "$temp_root/tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration"
+
+export CALLS_FILE="$temp_root/calls.log"
+cd "$temp_root"
+
+bash scripts/run-integration-categories.sh aot "Messaging,Interop,Serialization"
+if grep -q 'Category=Interop' "$CALLS_FILE"; then
+  echo "NativeAOT run included Interop category" >&2
+  exit 1
+fi
+grep -q 'Category=Messaging' "$CALLS_FILE"
+grep -q 'Category=Serialization' "$CALLS_FILE"
+
+: > "$CALLS_FILE"
+bash scripts/run-integration-categories.sh net10.0 "Messaging,Interop,Serialization"
+grep -q 'Category=Interop' "$CALLS_FILE"
+
+echo "run-integration-categories tests passed"


### PR DESCRIPTION
## Summary
- skip the Confluent.Kafka `Interop` category for NativeAOT integration runs
- preserve `Interop` coverage on managed .NET integration runs
- add executable-level regression coverage for both paths

## Test plan
- [x] `bash scripts/tests/run-integration-categories-tests.sh`
- [x] `bash -n scripts/run-integration-categories.sh`
- [x] `bash -n scripts/tests/run-integration-categories-tests.sh`
- [x] `shellcheck scripts/run-integration-categories.sh scripts/tests/run-integration-categories-tests.sh`

Closes #1827
