### PR TITLE
Retry transient Kafka registry failures

### DIFF
--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -93,14 +93,23 @@ jobs:
 
       - name: Pre-pull Kafka image
         run: |
-          for attempt in 1 2 3 4 5; do
-            docker pull "apache/kafka:${{ inputs.kafka-tag }}" && exit 0
-            if [ "$attempt" -eq 5 ]; then
-              exit 1
-            fi
-            delay=$((attempt * 15))
-            echo "Kafka image pull failed (attempt $attempt); retrying in ${delay}s"
-            sleep "$delay"
+          case "${{ matrix.group }}" in
+            tls|security) kafka_tags="4.0.2" ;;
+            faults|messaging) kafka_tags="${{ inputs.kafka-tag }} 4.0.2" ;;
+            consume) kafka_tags="${{ inputs.kafka-tag }} 4.2.1" ;;
+            *) kafka_tags="${{ inputs.kafka-tag }}" ;;
+          esac
+
+          for tag in $(printf '%s\n' $kafka_tags | sort -u); do
+            for attempt in 1 2 3 4 5; do
+              docker pull "apache/kafka:$tag" && break
+              if [ "$attempt" -eq 5 ]; then
+                exit 1
+              fi
+              delay=$((attempt * 15))
+              echo "Kafka image pull failed for $tag (attempt $attempt); retrying in ${delay}s"
+              sleep "$delay"
+            done
           done
 
       - name: Run integration tests

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -91,6 +91,18 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
+      - name: Pre-pull Kafka image
+        run: |
+          for attempt in 1 2 3 4 5; do
+            docker pull "apache/kafka:${{ inputs.kafka-tag }}" && exit 0
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            delay=$((attempt * 15))
+            echo "Kafka image pull failed (attempt $attempt); retrying in ${delay}s"
+            sleep "$delay"
+          done
+
       - name: Run integration tests
         env:
           KAFKA_TEST_IMAGE_TAG: ${{ inputs.kafka-tag }}

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -95,8 +95,10 @@ jobs:
         run: |
           case "${{ matrix.group }}" in
             tls|security) kafka_tags="4.0.2" ;;
-            faults|messaging) kafka_tags="${{ inputs.kafka-tag }} 4.0.2" ;;
+            faults) kafka_tags="${{ inputs.kafka-tag }} 4.0.2 4.2.1" ;;
+            messaging) kafka_tags="${{ inputs.kafka-tag }} 4.0.2" ;;
             consume) kafka_tags="${{ inputs.kafka-tag }} 4.2.1" ;;
+            produce) kafka_tags="${{ inputs.kafka-tag }} 4.2.1" ;;
             *) kafka_tags="${{ inputs.kafka-tag }}" ;;
           esac
 

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
@@ -10,8 +10,11 @@ internal static class ContainerStartupRetry
     internal static async Task RunAsync(
         Func<Task> startAttemptAsync,
         Func<ValueTask> cleanupAttemptAsync,
-        Func<Exception, bool> isTransient)
+        Func<Exception, bool> isTransient,
+        Func<TimeSpan, Task>? delayAsync = null)
     {
+        delayAsync ??= static delay => Task.Delay(delay);
+
         for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
             try
@@ -28,9 +31,16 @@ internal static class ContainerStartupRetry
 
                 Console.WriteLine(
                     $"[ContainerStartupRetry] Transient container startup failure on attempt {attempt}; retrying with fresh resources: {exception.Message}");
+
+                await delayAsync(GetRetryDelay(attempt)).ConfigureAwait(false);
             }
         }
     }
+
+    internal static bool IsKnownTransient(Exception exception) =>
+        IsPortBindingCollision(exception) ||
+        IsKafkaStartupScriptBusy(exception) ||
+        IsRegistryUnavailable(exception);
 
     internal static bool IsPortBindingCollision(Exception exception) =>
         Contains(exception, static candidate =>
@@ -43,6 +53,26 @@ internal static class ContainerStartupRetry
             candidate.Message.Contains(
                 "/testcontainers.sh: Text file busy",
                 StringComparison.Ordinal));
+
+    internal static bool IsRegistryUnavailable(Exception exception) =>
+        Contains(exception, static candidate =>
+        {
+            if (candidate is not DockerApiException dockerException)
+                return false;
+
+            var statusCode = (int)dockerException.StatusCode;
+            return statusCode is >= 500 and <= 599 &&
+                   candidate.Message.Contains("/manifests/", StringComparison.OrdinalIgnoreCase) &&
+                   candidate.Message.Contains(
+                       "received unexpected HTTP status",
+                       StringComparison.OrdinalIgnoreCase);
+        });
+
+    private static TimeSpan GetRetryDelay(int failedAttempt) => failedAttempt switch
+    {
+        1 => TimeSpan.FromSeconds(5),
+        _ => TimeSpan.FromSeconds(15)
+    };
 
     private static bool Contains(Exception exception, Func<Exception, bool> predicate)
     {

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -24,7 +24,8 @@ public sealed class ContainerStartupRetryTests
                 cleanups++;
                 return ValueTask.CompletedTask;
             },
-            ContainerStartupRetry.IsPortBindingCollision);
+            ContainerStartupRetry.IsPortBindingCollision,
+            NoDelayAsync);
 
         await Assert.That(attempts).IsEqualTo(2);
         await Assert.That(cleanups).IsEqualTo(1);
@@ -50,10 +51,53 @@ public sealed class ContainerStartupRetryTests
                 cleanups++;
                 return ValueTask.CompletedTask;
             },
-            ContainerStartupRetry.IsKafkaStartupScriptBusy);
+            ContainerStartupRetry.IsKafkaStartupScriptBusy,
+            NoDelayAsync);
 
         await Assert.That(attempts).IsEqualTo(2);
         await Assert.That(cleanups).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RunAsync_RegistryUnavailable_RetriesWithBackoff()
+    {
+        var attempts = 0;
+        var delays = new List<TimeSpan>();
+
+        await ContainerStartupRetry.RunAsync(
+            () => ++attempts < 3
+                ? Task.FromException(new DockerApiException(
+                    HttpStatusCode.BadGateway,
+                    "Head \"https://registry-1.docker.io/v2/apache/kafka/manifests/4.3.1\": received unexpected HTTP status: 502 Bad Gateway"))
+                : Task.CompletedTask,
+            () => ValueTask.CompletedTask,
+            ContainerStartupRetry.IsRegistryUnavailable,
+            delay =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(delays).IsEquivalentTo([
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(15)
+        ]);
+    }
+
+    [Test]
+    [Arguments(HttpStatusCode.NotFound)]
+    [Arguments(HttpStatusCode.InternalServerError)]
+    public async Task IsRegistryUnavailable_NonTransientFailure_ReturnsFalse(
+        HttpStatusCode statusCode)
+    {
+        var message = statusCode == HttpStatusCode.NotFound
+            ? "Head \"https://registry-1.docker.io/v2/apache/kafka/manifests/missing\": received unexpected HTTP status: 404 Not Found"
+            : "Docker daemon returned an unrelated 500 error";
+
+        var exception = new DockerApiException(statusCode, message);
+
+        await Assert.That(ContainerStartupRetry.IsRegistryUnavailable(exception)).IsFalse();
     }
 
     [Test]
@@ -75,7 +119,8 @@ public sealed class ContainerStartupRetryTests
                 cleanups++;
                 return ValueTask.CompletedTask;
             },
-            ContainerStartupRetry.IsPortBindingCollision);
+            ContainerStartupRetry.IsPortBindingCollision,
+            NoDelayAsync);
 
         await Assert.That(action).Throws<DockerApiException>();
         await Assert.That(attempts).IsEqualTo(1);
@@ -101,7 +146,8 @@ public sealed class ContainerStartupRetryTests
                 cleanups++;
                 return ValueTask.CompletedTask;
             },
-            ContainerStartupRetry.IsPortBindingCollision);
+            ContainerStartupRetry.IsPortBindingCollision,
+            NoDelayAsync);
 
         await Assert.That(action).Throws<DockerApiException>();
         await Assert.That(attempts).IsEqualTo(3);
@@ -119,4 +165,6 @@ public sealed class ContainerStartupRetryTests
         await Assert.That(KafkaTestContainer.StartupCommand).Contains("wc -c");
         await Assert.That(KafkaTestContainer.StartupCommand).Contains("exec /bin/sh /testcontainers.sh");
     }
+
+    private static Task NoDelayAsync(TimeSpan _) => Task.CompletedTask;
 }

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -97,7 +97,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
                 await _container.StartAsync().ConfigureAwait(false);
             },
             ResetContainerAsync,
-            ContainerStartupRetry.IsKafkaStartupScriptBusy).ConfigureAwait(false);
+            ContainerStartupRetry.IsKnownTransient).ConfigureAwait(false);
 
         var rawAddress = _container!.GetBootstrapAddress();
         // GetBootstrapAddress() may return "plaintext://host:port/" - extract just host:port

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -27,7 +27,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         await ContainerStartupRetry.RunAsync(
             StartClusterAttemptAsync,
             DisposeClusterAttemptAsync,
-            ContainerStartupRetry.IsPortBindingCollision).ConfigureAwait(false);
+            ContainerStartupRetry.IsKnownTransient).ConfigureAwait(false);
     }
 
     private async Task StartClusterAttemptAsync()


### PR DESCRIPTION
## Summary
- pre-pull each requested Kafka image with bounded workflow retry
- classify registry manifest 5xx responses as transient startup failures
- back off 5s then 15s before fresh container startup attempts
- cover registry classification, backoff, and non-transient failures

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore`
- [x] `Dekaf.Tests.Integration.exe --treenode-filter '/*/*/ContainerStartupRetryTests/*'` (8 passed)
- [x] parse `integration-groups.yml` as YAML
- [x] `bash -n` pre-pull retry loop
- [x] `git diff --check`

Closes #1828
