### PR TITLE
Corroborate noisy stress throughput breaches

### DIFF
--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -264,7 +264,17 @@ def evaluate_and_update(history, current_results, run_started_at):
             )
             for metric, label, value, threshold, breached in threshold_metrics:
                 trend_field = f"{metric}Trend"
-                previous_trend = prior[-1].get(trend_field) if prior else None
+                previous = prior[-1] if prior else {}
+                previous_trend = previous.get(trend_field)
+                previous_value = previous.get(metric)
+                if (
+                    previous_trend is None
+                    and isinstance(previous_value, (int, float))
+                    and isfinite(previous_value)
+                ):
+                    previous_trend = (
+                        "regression" if previous_value < threshold else "stable"
+                    )
                 status = "regression" if breached else "stable"
                 repeated = status == "regression" and previous_trend == "regression"
                 corroborated = (
@@ -357,7 +367,9 @@ def format_markdown(evaluations):
 
         status = labels[item["status"]]
         if item.get("thresholdBreach"):
-            if item.get("failureEligible", True):
+            if item.get("latencyThreshold"):
+                status = "Threshold breach (fail)"
+            elif item.get("failureEligible"):
                 status = "Repeated threshold breach (fail)"
             elif item.get("corroborated") is False:
                 status = "Threshold breach (uncorroborated warning)"

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -184,6 +184,7 @@ def evaluate_and_update(history, current_results, run_started_at):
         observation["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
         observation["brokerCount"] = result.get("brokerCount", 1)
         observation["roundTripMessages"] = _roundtrip_messages(result)
+        throughput_regression = False
 
         for metric, definition in _METRICS.items():
             value = definition["extract"](result)
@@ -237,9 +238,14 @@ def evaluate_and_update(history, current_results, run_started_at):
             observation[metric] = value
             observation[f"{metric}Trend"] = evaluation["status"]
             evaluations.append(evaluation)
+            if metric == "messagesPerSecond":
+                throughput_regression = evaluation["status"] == "regression"
 
         intra_run = intra_run_throughput(result)
         if intra_run is not None:
+            slope_breached = intra_run["slopeThresholdBreached"]
+            client = str(result.get("client", "")).casefold()
+            is_confluent = client.startswith("confluent")
             threshold_metrics = (
                 (
                     "steadyStatePeakRatio",
@@ -257,6 +263,18 @@ def evaluate_and_update(history, current_results, run_started_at):
                 ),
             )
             for metric, label, value, threshold, breached in threshold_metrics:
+                trend_field = f"{metric}Trend"
+                previous_trend = prior[-1].get(trend_field) if prior else None
+                status = "regression" if breached else "stable"
+                repeated = status == "regression" and previous_trend == "regression"
+                corroborated = (
+                    breached
+                    if metric == "slopePercentPerMinute"
+                    else slope_breached or throughput_regression
+                )
+                failure_eligible = (
+                    breached and repeated and corroborated and not is_confluent
+                )
                 evaluations.append({
                     "scenario": _scenario_label(result),
                     "metric": metric,
@@ -267,12 +285,15 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "mad": None,
                     "lower": threshold,
                     "upper": None,
-                    "status": "regression" if breached else "stable",
-                    "repeatedRegression": False,
+                    "status": status,
+                    "repeatedRegression": repeated,
                     "thresholdBreach": breached,
+                    "corroborated": corroborated,
+                    "failureEligible": failure_eligible,
                 })
                 observation[metric] = value
-                should_fail = should_fail or breached
+                observation[trend_field] = status
+                should_fail = should_fail or failure_eligible
 
         observations.append(observation)
 
@@ -303,6 +324,11 @@ def format_markdown(evaluations):
             f"{RELATIVE_NOISE_FLOOR:.0%} of median); "
             "a second consecutive adverse excursion fails the job."
         ),
+        (
+            "Intra-run breaches warn first; repeated Dekaf breaches fail only when "
+            "corroborated by negative slope or baseline throughput regression. "
+            "Confluent intra-run breaches remain warnings."
+        ),
         "",
         "| Scenario | Metric | Current | Baseline median | Band | Status |",
         "|----------|--------|--------:|----------------:|------|--------|",
@@ -331,7 +357,12 @@ def format_markdown(evaluations):
 
         status = labels[item["status"]]
         if item.get("thresholdBreach"):
-            status = "Threshold breach (fail)"
+            if item.get("failureEligible", True):
+                status = "Repeated threshold breach (fail)"
+            elif item.get("corroborated") is False:
+                status = "Threshold breach (uncorroborated warning)"
+            else:
+                status = "Threshold breach (warning)"
         elif item["repeatedRegression"]:
             status = "Repeated regression (fail)"
         elif item["status"] == "regression":
@@ -356,7 +387,7 @@ def emit_annotations(evaluations):
             continue
 
         if item.get("thresholdBreach"):
-            level = "error"
+            level = "error" if item.get("failureEligible", True) else "warning"
             prefix = (
                 "Latency threshold breach"
                 if item.get("latencyThreshold")

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -5,7 +5,7 @@ from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
 
-from stress_trend import HISTORY_LIMIT, evaluate_and_update, main
+from stress_trend import HISTORY_LIMIT, evaluate_and_update, format_markdown, main
 
 
 def result(messages_per_second=1000.0, cpu_micros_per_message=2.0, **overrides):
@@ -40,6 +40,26 @@ def history_run(index, messages_per_second=1000.0, cpu_micros_per_message=2.0, *
     }
 
 
+def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
+    value = result(
+        client=client,
+        steadyStatePeakRatio=steady_ratio,
+        intraRunDriftPercent=-35.9,
+        throughputSlopePercentPerMinute=slope,
+        steadyStatePeakRatioThreshold=0.85,
+        throughputSlopePercentPerMinuteThreshold=-1.0,
+        steadyStatePeakThresholdBreached=steady_ratio < 0.85,
+        throughputSlopeThresholdBreached=slope < -1.0,
+        intraRunThroughputThresholdBreached=steady_ratio < 0.85 or slope < -1.0,
+        throughput={
+            "elapsedSeconds": 360,
+            "messagesPerSecondSamples": [1400, 1400, 1400],
+        },
+    )
+    value.update(overrides)
+    return value
+
+
 class StressTrendTests(unittest.TestCase):
     def test_paired_latency_threshold_breach_fails_without_history(self):
         confluent = result(
@@ -64,34 +84,127 @@ class StressTrendTests(unittest.TestCase):
         self.assertFalse(by_metric["latencyP50Ratio"]["thresholdBreach"])
         self.assertTrue(by_metric["latencyP99Ratio"]["thresholdBreach"])
 
-    def test_intra_run_threshold_breach_fails_without_history(self):
-        collapsing = result(
-            steadyStatePeakRatio=0.6,
-            intraRunDriftPercent=-35.9,
-            throughputSlopePercentPerMinute=-8.0,
-            steadyStatePeakRatioThreshold=0.85,
-            throughputSlopePercentPerMinuteThreshold=-1.0,
-            steadyStatePeakThresholdBreached=True,
-            throughputSlopeThresholdBreached=True,
-            intraRunThroughputThresholdBreached=True,
-            throughput={
-                "elapsedSeconds": 360,
-                "messagesPerSecondSamples": [1400, 1400, 1400],
-            },
-        )
-
-        evaluations, _, should_fail = evaluate_and_update(
+    def test_first_intra_run_threshold_breach_warns_without_failing(self):
+        evaluations, updated, should_fail = evaluate_and_update(
             {"version": 1, "runs": []},
-            [collapsing],
+            [intra_run_result()],
             "2026-07-01T02:00:00Z",
         )
 
         intra_run = [item for item in evaluations if item.get("thresholdBreach")]
-        self.assertTrue(should_fail)
+        self.assertFalse(should_fail)
         self.assertEqual(
             {"steadyStatePeakRatio", "slopePercentPerMinute"},
             {item["metric"] for item in intra_run},
         )
+        self.assertTrue(all(not item["repeatedRegression"] for item in intra_run))
+        self.assertIn("Threshold breach (warning)", format_markdown(intra_run))
+        current = updated["runs"][-1]["results"][0]
+        self.assertEqual("regression", current["steadyStatePeakRatioTrend"])
+        self.assertEqual("regression", current["slopePercentPerMinuteTrend"])
+
+    def test_flat_in_band_steady_state_breach_is_not_failure(self):
+        runs = [history_run(i) for i in range(1, 4)]
+        runs.append(history_run(
+            4,
+            steadyStatePeakRatio=0.7,
+            steadyStatePeakRatioTrend="regression",
+            slopePercentPerMinute=0.1,
+            slopePercentPerMinuteTrend="stable",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [intra_run_result(steady_ratio=0.7, slope=0.1)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        steady = next(
+            item for item in evaluations if item["metric"] == "steadyStatePeakRatio"
+        )
+        self.assertTrue(steady["repeatedRegression"])
+        self.assertFalse(steady["corroborated"])
+        self.assertFalse(steady["failureEligible"])
+        self.assertFalse(should_fail)
+
+    def test_second_consecutive_slope_breach_fails_for_dekaf(self):
+        runs = [history_run(i) for i in range(1, 4)]
+        runs.append(history_run(
+            4,
+            steadyStatePeakRatio=0.7,
+            steadyStatePeakRatioTrend="regression",
+            slopePercentPerMinute=-2.0,
+            slopePercentPerMinuteTrend="regression",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [intra_run_result(steady_ratio=0.7, slope=-2.5)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        slope = next(
+            item for item in evaluations if item["metric"] == "slopePercentPerMinute"
+        )
+        self.assertTrue(slope["repeatedRegression"])
+        self.assertTrue(slope["failureEligible"])
+        self.assertIn("Repeated threshold breach (fail)", format_markdown([slope]))
+        self.assertTrue(should_fail)
+
+    def test_second_corroborated_steady_state_breach_fails_for_dekaf(self):
+        runs = [history_run(i) for i in range(1, 4)]
+        runs.append(history_run(
+            4,
+            messages_per_second=700.0,
+            messagesPerSecondTrend="regression",
+            steadyStatePeakRatio=0.7,
+            steadyStatePeakRatioTrend="regression",
+            slopePercentPerMinute=0.1,
+            slopePercentPerMinuteTrend="stable",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [intra_run_result(
+                steady_ratio=0.7,
+                slope=0.1,
+                effectiveMessagesPerSecond=650.0,
+            )],
+            "2026-07-01T02:00:00Z",
+        )
+
+        steady = next(
+            item for item in evaluations if item["metric"] == "steadyStatePeakRatio"
+        )
+        self.assertTrue(steady["repeatedRegression"])
+        self.assertTrue(steady["corroborated"])
+        self.assertTrue(steady["failureEligible"])
+        self.assertTrue(should_fail)
+
+    def test_confluent_intra_run_breaches_warn_but_never_fail(self):
+        runs = [
+            history_run(
+                i,
+                client="Confluent",
+                steadyStatePeakRatio=0.7,
+                steadyStatePeakRatioTrend="regression",
+                slopePercentPerMinute=-2.0,
+                slopePercentPerMinuteTrend="regression",
+            )
+            for i in range(1, 5)
+        ]
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [intra_run_result(client="Confluent", steady_ratio=0.7, slope=-2.5)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        intra_run = [item for item in evaluations if item.get("thresholdBreach")]
+        self.assertTrue(all(item["repeatedRegression"] for item in intra_run))
+        self.assertTrue(all(not item["failureEligible"] for item in intra_run))
+        self.assertNotIn("(fail)", format_markdown(intra_run))
+        self.assertFalse(should_fail)
 
     def test_empty_history_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "Unsupported stress history version"):

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -83,6 +83,9 @@ class StressTrendTests(unittest.TestCase):
         by_metric = {item["metric"]: item for item in latency}
         self.assertFalse(by_metric["latencyP50Ratio"]["thresholdBreach"])
         self.assertTrue(by_metric["latencyP99Ratio"]["thresholdBreach"])
+        markdown = format_markdown(latency)
+        self.assertIn("Threshold breach (fail)", markdown)
+        self.assertNotIn("Repeated threshold breach", markdown)
 
     def test_first_intra_run_threshold_breach_warns_without_failing(self):
         evaluations, updated, should_fail = evaluate_and_update(
@@ -149,6 +152,28 @@ class StressTrendTests(unittest.TestCase):
         self.assertTrue(slope["repeatedRegression"])
         self.assertTrue(slope["failureEligible"])
         self.assertIn("Repeated threshold breach (fail)", format_markdown([slope]))
+        self.assertTrue(should_fail)
+
+    def test_legacy_intra_run_value_preserves_breach_streak(self):
+        runs = [history_run(i) for i in range(1, 4)]
+        runs.append(history_run(
+            4,
+            steadyStatePeakRatio=0.7,
+            slopePercentPerMinute=-2.0,
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [intra_run_result(steady_ratio=0.7, slope=-2.5)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        intra_run = [
+            item for item in evaluations
+            if item["metric"] in {"steadyStatePeakRatio", "slopePercentPerMinute"}
+        ]
+        self.assertTrue(all(item["repeatedRegression"] for item in intra_run))
+        self.assertTrue(all(item["failureEligible"] for item in intra_run))
         self.assertTrue(should_fail)
 
     def test_second_corroborated_steady_state_breach_fails_for_dekaf(self):


### PR DESCRIPTION
## Summary
- warn on the first intra-run throughput threshold breach and persist its trend
- fail only repeated Dekaf breaches corroborated by negative slope or baseline throughput regression
- keep Confluent intra-run breaches informational while preserving immediate latency-gate failures
- report warning/failure status clearly and cover all gate paths

## Test plan
- [x] `python -m unittest discover -s .github/scripts -p 'test_*.py'` (47 tests)
- [x] `python -m py_compile .github/scripts/stress_trend.py .github/scripts/test_stress_trend.py`

Closes #1823
