### PR TITLE
Correlate producer scaling with stress throughput

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -1,6 +1,7 @@
 """Shared utilities for stress test result reporting."""
 
 from collections import defaultdict
+from datetime import datetime
 from math import isfinite
 from statistics import median
 
@@ -388,6 +389,67 @@ def format_throughput_table(results, title, include_ratio=False):
     return lines
 
 
+def format_connection_scale_timeline(results, title):
+    """Correlate producer connection changes with the nearest throughput interval."""
+    rows = []
+    for result in results:
+        diagnostics = result.get('producerDeliveryDiagnostics') or {}
+        for event in diagnostics.get('connectionScaleEvents') or []:
+            rows.append((result, event))
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('occurredAtUtc', ''))
+    lines = [
+        f"## Connection Scale Timeline - {title}",
+        "",
+        "| Client | Event UTC | Broker | Connections | Buffer | Pressure (buffer/send) | Nearest throughput sample |",
+        "|--------|-----------|-------:|-------------|-------:|------------------------|---------------------------|",
+    ]
+    for result, event in rows:
+        event_time = _parse_timestamp(event.get('occurredAtUtc'))
+        samples = result.get('throughput', {}).get('intervalSamples') or []
+        timestamped_samples = [
+            (sample, _parse_timestamp(sample.get('capturedAtUtc')))
+            for sample in samples
+        ]
+        timestamped_samples = [
+            (sample, captured_at)
+            for sample, captured_at in timestamped_samples
+            if captured_at is not None
+        ]
+        nearest = min(
+            timestamped_samples,
+            key=lambda item: abs((item[1] - event_time).total_seconds()),
+            default=(None, None),
+        )[0] if event_time is not None else None
+        sample_text = '-'
+        if nearest is not None:
+            sample_text = (
+                f"{nearest.get('elapsedSeconds', 0):.1f}s / "
+                f"{nearest.get('messagesPerSecond', 0):,.0f} msg/s"
+            )
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | "
+            f"{event.get('occurredAtUtc', '-')} | {event.get('brokerId', '-')} | "
+            f"{event.get('oldConnectionCount', '-')}→{event.get('newConnectionCount', '-')} | "
+            f"{event.get('bufferUtilization', 0):.0%} | "
+            f"{event.get('bufferPressureDelta', 0):,}/{event.get('sendLoopPressureDelta', 0):,} | "
+            f"{sample_text} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _parse_timestamp(value):
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
 def format_comparison_callout(results, title):
     """Generate Docusaurus admonition comparing Dekaf vs Confluent throughput."""
     dekaf = next((r for r in results if r.get('client', '').lower() == 'dekaf'), None)
@@ -564,6 +626,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             title = scenario_title(scenario_key, fallback_prefix)
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
+            output.extend(format_connection_scale_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))
             if include_callout:

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -2,6 +2,7 @@ import unittest
 
 from stress_report import (
     format_roundtrip_validation_table,
+    format_connection_scale_timeline,
     format_throughput_table,
     generate_scenario_tables,
     intra_run_throughput,
@@ -34,6 +35,38 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 
 
 class StressReportTests(unittest.TestCase):
+    def test_connection_scale_timeline_correlates_nearest_throughput_sample(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"]["intervalSamples"] = [
+            {
+                "capturedAtUtc": "2026-07-12T02:20:40+00:00",
+                "elapsedSeconds": 10.0,
+                "messagesPerSecond": 1000.0,
+            },
+            {
+                "capturedAtUtc": "2026-07-12T02:20:50+00:00",
+                "elapsedSeconds": 20.0,
+                "messagesPerSecond": 2000.0,
+            },
+        ]
+        value["producerDeliveryDiagnostics"] = {
+            "connectionScaleEvents": [{
+                "occurredAtUtc": "2026-07-12T02:20:47+00:00",
+                "brokerId": 1,
+                "oldConnectionCount": 1,
+                "newConnectionCount": 2,
+                "bufferUtilization": 0.75,
+                "bufferPressureDelta": 120,
+                "sendLoopPressureDelta": 150,
+            }]
+        }
+
+        report = "\n".join(format_connection_scale_timeline([value], "Producer"))
+
+        self.assertIn("1→2", report)
+        self.assertIn("20.0s / 2,000 msg/s", report)
+        self.assertIn("120/150", report)
+
     def test_paired_latency_thresholds_flag_high_p99(self):
         confluent = stress_result("Confluent", effective_rate=1000)
         confluent.update({

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -480,6 +480,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private long _lastSendLoopPressureSnapshot;
     private long _lastScaleTimeTicks;
     private Task<int>? _pendingScaleTask; // Background connection creation, polled by send loop
+    private double _pendingScaleBufferUtilization;
+    private long _pendingScaleBufferPressureDelta;
+    private long _pendingScaleSendLoopPressureDelta;
 
     // Scale-down state (send-loop owned, single-threaded)
     private long _lowUtilizationStartTicks; // When low utilization was first detected (0 = not tracking)
@@ -4210,9 +4213,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // width so the extra connection isn't orphaned. _connectionCount cannot
                 // have changed since initiation: this Phase 1b poll runs before any
                 // other scale event can start.
+                var reducedConnectionCount = _connectionCount;
                 _connectionCount++;
                 _totalMaxInFlight = _connectionCount * _maxInFlight;
                 _totalMaxInFlightBytes = GetInFlightByteBudget(_connectionCount);
+                _accumulator.RecordConnectionScaleEvent(
+                    _brokerId,
+                    reducedConnectionCount,
+                    _connectionCount,
+                    _accumulator.BufferUtilization,
+                    _accumulator.BufferPressureEvents - _lastPressureSnapshot,
+                    _sendLoopPressureEvents - _lastSendLoopPressureSnapshot);
             }
 
             return 0;
@@ -4269,6 +4280,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             // Launch connection creation in the background — send loop continues immediately
             _lastScaleTimeTicks = now;
+            _pendingScaleBufferUtilization = utilization;
+            _pendingScaleBufferPressureDelta = bufferPressureDelta;
+            _pendingScaleSendLoopPressureDelta = sendLoopPressureDelta;
             _pendingScaleTask = _connectionPool.ScaleConnectionGroupAsync(
                 _brokerId, targetCount, _cts.Token).AsTask();
 
@@ -4365,6 +4379,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // partition keeps routing outside the reduced width.
         _migratingPartitions.Clear();
 
+        _accumulator.RecordConnectionScaleEvent(
+            _brokerId,
+            targetShrinkCount + 1,
+            targetShrinkCount,
+            utilization,
+            bufferPressureDelta,
+            sendLoopPressureDelta);
+
         _lastScaleTimeTicks = now;
         _lowUtilizationStartTicks = 0; // Reset for the next scale-down cycle
 
@@ -4439,6 +4461,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             actualCount * PoolSizing.SerializationArraysPerConnection);
 
         FenceAffectedPartitions(oldCount, actualCount);
+
+        _accumulator.RecordConnectionScaleEvent(
+            _brokerId,
+            oldCount,
+            actualCount,
+            _pendingScaleBufferUtilization,
+            _pendingScaleBufferPressureDelta,
+            _pendingScaleSendLoopPressureDelta);
 
         LogAdaptiveScaleUp(_brokerId, oldCount, actualCount);
         return actualCount;

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -254,6 +254,19 @@ internal sealed class ProducerDeliveryDiagnosticsSnapshot
     public DateTimeOffset CapturedAtUtc { get; init; }
     public long InFlightBatchCount { get; init; }
     public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
+    public List<ProducerConnectionScaleDiagnostic> ConnectionScaleEvents { get; init; } = [];
+}
+
+internal sealed class ProducerConnectionScaleDiagnostic
+{
+    public required DateTimeOffset OccurredAtUtc { get; init; }
+    public required int BrokerId { get; init; }
+    public required int OldConnectionCount { get; init; }
+    public required int NewConnectionCount { get; init; }
+    public string Direction => NewConnectionCount > OldConnectionCount ? "up" : "down";
+    public required double BufferUtilization { get; init; }
+    public required long BufferPressureDelta { get; init; }
+    public required long SendLoopPressureDelta { get; init; }
 }
 
 /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -865,6 +865,7 @@ internal readonly struct ArenaSlice
 /// </summary>
 public sealed partial class RecordAccumulator : IAsyncDisposable
 {
+    private const int MaxConnectionScaleDiagnosticEvents = 256;
     // ReadyBatch lifecycle (seal→send→response→cleanup) is longer than PartitionBatch
     // (create→fill→seal), so its pool needs proportionally more capacity.
     private const int ReadyBatchPoolSizeRatio = 2;
@@ -946,6 +947,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private SpinLock _inFlightBatchLock = new(enableThreadOwnerTracking: false);
     private ReadyBatch? _inFlightBatchHead;
     private ReadyBatch? _inFlightBatchTail;
+    private readonly object _connectionScaleDiagnosticsLock = new();
+    private readonly List<ProducerConnectionScaleDiagnostic> _connectionScaleEvents = [];
 
     // Optimization: Track the oldest batch creation time to skip unnecessary enumeration.
     // With LingerMs=5ms and 1ms timer, we'd enumerate 5x per batch without this optimization.
@@ -4354,10 +4357,42 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             InFlightBatchCount = Volatile.Read(ref _inFlightBatchCount)
         };
 
+        lock (_connectionScaleDiagnosticsLock)
+            snapshot.ConnectionScaleEvents.AddRange(_connectionScaleEvents);
+
         foreach (var batch in batches)
             snapshot.Batches.Add(batch.Batch.CreateDeliveryDiagnostic(batch.Generation, batch.TopicPartition));
 
         return snapshot;
+    }
+
+    internal void RecordConnectionScaleEvent(
+        int brokerId,
+        int oldConnectionCount,
+        int newConnectionCount,
+        double bufferUtilization,
+        long bufferPressureDelta,
+        long sendLoopPressureDelta)
+    {
+        if (!_options.EnableDeliveryDiagnostics)
+            return;
+
+        lock (_connectionScaleDiagnosticsLock)
+        {
+            if (_connectionScaleEvents.Count >= MaxConnectionScaleDiagnosticEvents)
+                return;
+
+            _connectionScaleEvents.Add(new ProducerConnectionScaleDiagnostic
+            {
+                OccurredAtUtc = DateTimeOffset.UtcNow,
+                BrokerId = brokerId,
+                OldConnectionCount = oldConnectionCount,
+                NewConnectionCount = newConnectionCount,
+                BufferUtilization = bufferUtilization,
+                BufferPressureDelta = bufferPressureDelta,
+                SendLoopPressureDelta = sendLoopPressureDelta
+            });
+        }
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -31,6 +31,46 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
+    public async Task ConnectionScaleDiagnostics_Disabled_DoesNotRecordEvents()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions());
+
+        accumulator.RecordConnectionScaleEvent(
+            brokerId: 1,
+            oldConnectionCount: 1,
+            newConnectionCount: 2,
+            bufferUtilization: 0.75,
+            bufferPressureDelta: 120,
+            sendLoopPressureDelta: 150);
+
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.ConnectionScaleEvents).IsEmpty();
+    }
+
+    [Test]
+    public async Task ConnectionScaleDiagnostics_Enabled_CapturesOrderedEvents()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(enableDeliveryDiagnostics: true));
+
+        accumulator.RecordConnectionScaleEvent(1, 1, 2, 0.75, 120, 150);
+        accumulator.RecordConnectionScaleEvent(1, 2, 5, 0.82, 0, 340);
+
+        var events = accumulator.GetDeliveryDiagnosticsSnapshot().ConnectionScaleEvents;
+
+        await Assert.That(events.Count).IsEqualTo(2);
+        await Assert.That(events[0].BrokerId).IsEqualTo(1);
+        await Assert.That(events[0].OldConnectionCount).IsEqualTo(1);
+        await Assert.That(events[0].NewConnectionCount).IsEqualTo(2);
+        await Assert.That(events[0].Direction).IsEqualTo("up");
+        await Assert.That(events[0].BufferUtilization).IsEqualTo(0.75);
+        await Assert.That(events[0].BufferPressureDelta).IsEqualTo(120);
+        await Assert.That(events[0].SendLoopPressureDelta).IsEqualTo(150);
+        await Assert.That(events[1].OccurredAtUtc).IsGreaterThanOrEqualTo(events[0].OccurredAtUtc);
+    }
+
+    [Test]
     public async Task DeliveryDiagnostics_Disabled_DoesNotTrackTrace()
     {
         await using var accumulator = new RecordAccumulator(CreateOptions());

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -1,0 +1,90 @@
+using Dekaf.Producer;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ConnectionScaleReportingTests
+{
+    [Test]
+    public async Task Generate_ConnectionScaleEvent_CorrelatesNearestThroughputSample()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 12, 2, 0, 0, TimeSpan.Zero);
+        var result = new StressTestResult
+        {
+            Scenario = "producer",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            BrokerCount = 1,
+            MessageSizeBytes = 1000,
+            StartedAtUtc = startedAt.UtcDateTime,
+            CompletedAtUtc = startedAt.AddMinutes(15).UtcDateTime,
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 10_000,
+                TotalBytes = 10_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 900,
+                AverageMessagesPerSecond = 1_000,
+                AverageMegabytesPerSecond = 1,
+                MessagesPerSecondSamples = [1_000, 2_500],
+                IntervalSamples =
+                [
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(2),
+                        ElapsedSeconds = 2,
+                        MessagesPerSecond = 1_000
+                    },
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(6),
+                        ElapsedSeconds = 6,
+                        MessagesPerSecond = 2_500
+                    }
+                ]
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            ProducerDeliveryDiagnostics = new ProducerDeliveryDiagnosticsSnapshot
+            {
+                DiagnosticsEnabled = true,
+                CapturedAtUtc = startedAt.AddMinutes(15),
+                ConnectionScaleEvents =
+                [
+                    new ProducerConnectionScaleDiagnostic
+                    {
+                        OccurredAtUtc = startedAt.AddSeconds(5),
+                        BrokerId = 1,
+                        OldConnectionCount = 1,
+                        NewConnectionCount = 3,
+                        BufferUtilization = 0.75,
+                        BufferPressureDelta = 120,
+                        SendLoopPressureDelta = 340
+                    }
+                ]
+            }
+        };
+        var results = new StressTestResults
+        {
+            RunStartedAtUtc = result.StartedAtUtc,
+            RunCompletedAtUtc = result.CompletedAtUtc,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        };
+
+        var markdown = MarkdownReporter.Generate(results);
+
+        await Assert.That(markdown).Contains("Connection Scale Timeline - Fire-and-Forget");
+        await Assert.That(markdown).Contains("1→3");
+        await Assert.That(markdown).Contains("75%");
+        await Assert.That(markdown).Contains("120/340");
+        await Assert.That(markdown).Contains("6.0s / 2,500 msg/s");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/ThroughputTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ThroughputTrackerTests.cs
@@ -1,0 +1,25 @@
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ThroughputTrackerTests
+{
+    [Test]
+    public async Task TakeSample_CapturesTimestampedIntervalAlongsideLegacyRate()
+    {
+        var tracker = new ThroughputTracker();
+        tracker.Start();
+        tracker.RecordMessages(100, 100_000);
+
+        tracker.TakeSample();
+        tracker.Stop();
+        var snapshot = tracker.GetSnapshot();
+
+        await Assert.That(snapshot.MessagesPerSecondSamples.Count).IsEqualTo(1);
+        await Assert.That(snapshot.IntervalSamples.Count).IsEqualTo(1);
+        await Assert.That(snapshot.IntervalSamples[0].MessagesPerSecond)
+            .IsEqualTo(snapshot.MessagesPerSecondSamples[0]);
+        await Assert.That(snapshot.IntervalSamples[0].ElapsedSeconds).IsGreaterThan(0);
+        await Assert.That(snapshot.IntervalSamples[0].CapturedAtUtc).IsGreaterThan(DateTimeOffset.MinValue);
+    }
+}

--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -16,6 +16,7 @@ internal sealed class ThroughputTracker
     private long _deliveryErrorCount;
     private readonly Stopwatch _stopwatch = new();
     private readonly List<double> _messagesPerSecondSamples = [];
+    private readonly List<ThroughputIntervalSample> _intervalSamples = [];
     private readonly object _samplesLock = new();
     private readonly List<ThroughputErrorSample> _errorSamples = [];
     private readonly object _errorsLock = new();
@@ -196,6 +197,12 @@ internal sealed class ThroughputTracker
             lock (_samplesLock)
             {
                 _messagesPerSecondSamples.Add(rate);
+                _intervalSamples.Add(new ThroughputIntervalSample
+                {
+                    CapturedAtUtc = DateTimeOffset.UtcNow,
+                    ElapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
+                    MessagesPerSecond = rate
+                });
                 _sampledElapsedSeconds += elapsedSeconds;
             }
         }
@@ -232,10 +239,12 @@ internal sealed class ThroughputTracker
     public ThroughputSnapshot GetSnapshot()
     {
         List<double> samplesCopy;
+        List<ThroughputIntervalSample> intervalSamplesCopy;
         double sampledElapsedSeconds;
         lock (_samplesLock)
         {
             samplesCopy = [.. _messagesPerSecondSamples];
+            intervalSamplesCopy = [.. _intervalSamples];
             sampledElapsedSeconds = _sampledElapsedSeconds;
         }
 
@@ -255,6 +264,7 @@ internal sealed class ThroughputTracker
             AverageMessagesPerSecond = GetAverageMessagesPerSecond(),
             AverageMegabytesPerSecond = GetAverageMegabytesPerSecond(),
             MessagesPerSecondSamples = samplesCopy,
+            IntervalSamples = intervalSamplesCopy,
             SampledElapsedSeconds = sampledElapsedSeconds,
             ErrorSamples = errorSamplesCopy
         };
@@ -277,6 +287,7 @@ internal sealed class ThroughputSnapshot
     public required double AverageMessagesPerSecond { get; init; }
     public required double AverageMegabytesPerSecond { get; init; }
     public required List<double> MessagesPerSecondSamples { get; init; }
+    public List<ThroughputIntervalSample> IntervalSamples { get; init; } = [];
 
     /// <summary>
     /// Sum of intervals represented by <see cref="MessagesPerSecondSamples"/>. Excludes
@@ -285,6 +296,13 @@ internal sealed class ThroughputSnapshot
     public double SampledElapsedSeconds { get; init; }
 
     public List<ThroughputErrorSample> ErrorSamples { get; init; } = [];
+}
+
+internal sealed class ThroughputIntervalSample
+{
+    public required DateTimeOffset CapturedAtUtc { get; init; }
+    public required double ElapsedSeconds { get; init; }
+    public required double MessagesPerSecond { get; init; }
 }
 
 internal sealed class ThroughputErrorSample

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -189,7 +189,7 @@ internal static class MarkdownReporter
             sb.AppendLine(
                 $"| {row.Result.Client} | {row.Event.OccurredAtUtc:HH:mm:ss.fff} | " +
                 $"{row.Event.BrokerId} | {row.Event.OldConnectionCount}→{row.Event.NewConnectionCount} | " +
-                $"{row.Event.BufferUtilization:P0} | " +
+                $"{row.Event.BufferUtilization * 100:F0}% | " +
                 $"{row.Event.BufferPressureDelta:N0}/{row.Event.SendLoopPressureDelta:N0} | {throughput} |");
         }
         sb.AppendLine();

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -26,6 +26,7 @@ internal static class MarkdownReporter
             var label = FormatGroupTitle(FormatScenarioLabel(group.Key.Scenario), group.Key.BrokerCount);
 
             GenerateThroughputTable(sb, title, groupResults);
+            GenerateConnectionScaleTimeline(sb, groupResults, label);
 
             var transactionalResults = groupResults
                 .Where(r => r.TransactionVerification is not null)
@@ -160,6 +161,39 @@ internal static class MarkdownReporter
         results
             .OrderByDescending(ComparisonMessagesPerSecond)
             .ThenBy(r => r.CpuMicrosPerMessage ?? double.MaxValue);
+
+    private static void GenerateConnectionScaleTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.ConnectionScaleEvents ?? [])
+                .Select(scaleEvent => (Result: result, Event: scaleEvent)))
+            .OrderBy(row => row.Event.OccurredAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        sb.AppendLine($"## Connection Scale Timeline - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Event UTC | Broker | Connections | Buffer | Pressure (buffer/send) | Nearest throughput sample |");
+        sb.AppendLine("|--------|-----------|-------:|-------------|-------:|------------------------|---------------------------|");
+        foreach (var row in rows)
+        {
+            var nearest = row.Result.Throughput.IntervalSamples
+                .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Event.OccurredAtUtc).TotalMilliseconds));
+            var throughput = nearest is null
+                ? "-"
+                : $"{nearest.ElapsedSeconds:F1}s / {nearest.MessagesPerSecond:N0} msg/s";
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Event.OccurredAtUtc:HH:mm:ss.fff} | " +
+                $"{row.Event.BrokerId} | {row.Event.OldConnectionCount}→{row.Event.NewConnectionCount} | " +
+                $"{row.Event.BufferUtilization:P0} | " +
+                $"{row.Event.BufferPressureDelta:N0}/{row.Event.SendLoopPressureDelta:N0} | {throughput} |");
+        }
+        sb.AppendLine();
+    }
 
     private static double ComparisonMessagesPerSecond(StressTestResult result) =>
         result.MedianIntervalMessagesPerSecond ?? result.EffectiveMessagesPerSecond;


### PR DESCRIPTION
## Summary
- record bounded adaptive connection scale events only when producer delivery diagnostics are enabled
- add timestamped throughput intervals while preserving legacy rate samples
- correlate each scale event with its nearest throughput interval in local and CI Markdown reports
- cover disabled/enabled recording, timestamp sampling, and report rendering

## Evidence
A one-minute live Docker/Kafka stress run captured 59 intervals and these events:
- 1→2 at 2.0s (271,207 msg/s)
- 2→5 at 7.1s (88,124 msg/s)
- 5→6 at 12.1s (85,874 msg/s)

This proves #1824's minutes-long ramp occurs after adaptive scaling converges and unblocks focused runtime profiling in #1836.

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- [x] full net10 unit suite: 5,159 passed
- [x] Python reporting suite: 44 passed
- [x] one-minute live Docker/Kafka producer stress run; JSON and Markdown timeline verified

Closes #1835
