### PR TITLE
fix(producer): bound per-broker unacked bytes at admission to cap delivery latency

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -76,6 +76,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithBatchSize(...)` | `BatchSize` | Bytes |
 | `WithBufferMemory(...)` | `BufferMemory` | Bytes; omit to keep auto-tuning |
 | `WithMaxBlock(...)` | `MaxBlockMs` | Milliseconds |
+| `WithDeliveryLatencyTarget(...)` | `DeliveryLatencyTargetMs` | TimeSpan; `TimeSpan.Zero` disables |
 | `WithDeliveryTimeout(...)` | `DeliveryTimeoutMs` | Milliseconds |
 | `WithRequestTimeout(...)` | `RequestTimeoutMs` | Milliseconds |
 | `WithIdempotence(...)` | `EnableIdempotence` | Boolean |
@@ -355,6 +356,17 @@ Maximum memory the producer uses for buffering unsent messages:
 
 Default: 2GB. When the buffer is full, `ProduceAsync` and `Send` block until space is freed (controlled by `WithMaxBlockMs`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
 
+### WithDeliveryLatencyTarget
+
+Soft target for per-broker queueing latency (append to broker acknowledgement):
+
+```csharp
+.WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(10)) // default
+.WithDeliveryLatencyTarget(TimeSpan.Zero)                 // disable the bound
+```
+
+Default: 10ms. The producer bounds each broker's unacknowledged bytes to `target × measured ack throughput`, so under sustained overload delivery latency stays near the target instead of growing with the full buffer (bufferbloat). A measured round-trip guard keeps the bound above the bandwidth-delay product, so throughput is never window-limited — on high-latency links the effective latency floor is ~1.5× the broker round-trip. When a broker exceeds its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Until the first drain measurement the bound sits at its ceiling, so short-lived producers are unaffected. Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to restore pre-bound behavior.
+
 ### WithSocketSendBufferBytes / WithSocketReceiveBufferBytes
 
 TCP socket buffer sizes:
@@ -400,6 +412,7 @@ Enable logging:
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
 | `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |
+| `WithDeliveryLatencyTarget` | 10ms | Per-broker queueing latency target; `TimeSpan.Zero` disables |
 | `WithMaxBlock` | 60000ms | Max time produce calls wait for metadata or buffer space |
 | `WithDeliveryTimeout` | 120000ms | Max time for delivery success or failure |
 | `WithRequestTimeout` | 30000ms | Per-request timeout |

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -781,6 +781,7 @@ internal static class DekafOptionsBinding
         builder.WithRetryBackoff(TimeSpan.FromMilliseconds(options.RetryBackoffMs));
         builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(options.RetryBackoffMaxMs));
         builder.WithMaxBlock(TimeSpan.FromMilliseconds(options.MaxBlockMs));
+        builder.WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
         builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(options.DeliveryTimeoutMs));
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
         builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
@@ -1139,6 +1140,8 @@ internal static class DekafConfigurationBinding
             builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(retryBackoffMaxMs));
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.MaxBlockMs), out var maxBlockMs))
             builder.WithMaxBlock(TimeSpan.FromMilliseconds(maxBlockMs));
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.DeliveryLatencyTargetMs), out var deliveryLatencyTargetMs))
+            builder.WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(deliveryLatencyTargetMs));
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.DeliveryTimeoutMs), out var deliveryTimeoutMs))
             builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(deliveryTimeoutMs));
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.RequestTimeoutMs), out var requestTimeoutMs))

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -63,6 +63,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private ulong? _bufferMemory;
     private int? _maxBlockMs;
+    private int? _deliveryLatencyTargetMs;
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
@@ -178,6 +179,28 @@ public sealed class ProducerBuilder<TKey, TValue>
         ArgumentOutOfRangeException.ThrowIfGreaterThan(maxBlock.TotalMilliseconds, int.MaxValue, nameof(maxBlock));
 
         _maxBlockMs = (int)maxBlock.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the soft target for per-broker producer queueing latency (append to ack).
+    /// The producer bounds each broker's unacknowledged bytes to
+    /// <c>target × measured ack throughput</c>, so delivery latency stays near the target
+    /// instead of growing with the full buffer under sustained overload. A measured
+    /// round-trip guard keeps the bound above the bandwidth-delay product, so throughput
+    /// is never window-limited.
+    /// </summary>
+    /// <param name="target">The latency target. <see cref="TimeSpan.Zero"/> disables the bound.</param>
+    /// <remarks>
+    /// Default is 10 milliseconds.
+    /// </remarks>
+    public ProducerBuilder<TKey, TValue> WithDeliveryLatencyTarget(TimeSpan target)
+    {
+        if (target < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(target), "DeliveryLatencyTarget cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(target.TotalMilliseconds, int.MaxValue, nameof(target));
+
+        _deliveryLatencyTargetMs = (int)target.TotalMilliseconds;
         return this;
     }
 
@@ -1163,6 +1186,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs,
             MaxBlockMs = _maxBlockMs ?? 60000, // 60 seconds default
+            DeliveryLatencyTargetMs = _deliveryLatencyTargetMs ?? 10,
             DeliveryTimeoutMs = _deliveryTimeoutMs ?? 120000,
             RequestTimeoutMs = _requestTimeoutMs ?? 30000,
             ReconnectBackoffMs = _reconnectBackoffMs,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2074,7 +2074,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RecordSendLoopPressureIfScaleUseful()
     {
-        if (IsSendLoopPressureScaleUseful(
+        if (IsPartitionPressureScaleUseful(
             _adaptiveScalingEnabled,
             _connectionCount,
             _maxConnectionsPerBroker,
@@ -4309,13 +4309,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _lastUnackedBlockObserved = unackedBlockEvents;
             _lastUnackedBlockObservedMs = now;
         }
+        var usefulUnackedBlockDelta = IsPartitionPressureScaleUseful(
+            _adaptiveScalingEnabled,
+            _connectionCount,
+            _maxConnectionsPerBroker,
+            _knownPartitions.Count)
+            ? unackedBlockDelta
+            : 0;
         var scalePressureDelta = ComputeScalePressureDelta(
-            bufferPressureDelta + unackedBlockDelta, sendLoopPressureDelta);
+            bufferPressureDelta + usefulUnackedBlockDelta, sendLoopPressureDelta);
         var hasScalePressure = scalePressureDelta >= ScalePressureDeltaThreshold;
 
         // Phase 2: Check if we should start a new scale-up
         if (sendLoopPressureDelta >= ScalePressureDeltaThreshold
-            || unackedBlockDelta >= ScalePressureDeltaThreshold
+            || usefulUnackedBlockDelta >= ScalePressureDeltaThreshold
             || (utilization >= ScaleUtilizationThreshold && hasScalePressure))
         {
             // High utilization — reset low-utilization tracking
@@ -4645,7 +4652,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     internal static long ComputeScalePressureDelta(long bufferPressureDelta, long sendLoopPressureDelta) =>
         Math.Max(bufferPressureDelta, sendLoopPressureDelta);
 
-    internal static bool IsSendLoopPressureScaleUseful(
+    internal static bool IsPartitionPressureScaleUseful(
         bool adaptiveScalingEnabled,
         int connectionCount,
         int maxConnectionsPerBroker,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2224,9 +2224,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 var response = task.Result;
-                ackedBytes += pending.EncodedBytes;
-                lastAckedRequestStart = pending.RequestStartTime;
                 ObserveBrokerThrottle(response.ThrottleTimeMs);
+                var allPartitionsSucceeded = true;
                 // Reuse caller-provided dictionary to avoid per-response allocation.
                 // The dictionary is cleared after use in ProcessResponseBatches.
                 var responseLookup = reusableResponseLookup;
@@ -2235,9 +2234,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     ref var topicResp = ref response.Responses[t];
                     for (var p = 0; p < topicResp.PartitionCount; p++)
                     {
+                        if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
+                            allPartitionsSucceeded = false;
                         responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
                         responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] = topicResp.PartitionResponses[p];
                     }
+                }
+
+                if (allPartitionsSucceeded)
+                {
+                    ackedBytes += pending.EncodedBytes;
+                    lastAckedRequestStart = pending.RequestStartTime;
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -119,8 +119,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // The historical multi-broker workload drains about 1 GB/s with roughly 30 ms broker
     // acknowledgement latency, making 32 MB a practical default BDP per connection. This
     // also prevents the 100-request non-idempotent count limit from turning BufferMemory
-    // into an acknowledgement queue.
-    private const int InFlightByteBudgetBatchMultiplier = 32;
+    // into an acknowledgement queue. Shared with the per-broker unacked-byte admission
+    // budget so the pipeline ceiling and the admission ceiling stay consistent.
+    private const int InFlightByteBudgetBatchMultiplier = BrokerUnackedByteBudget.CapBatchMultiplier;
 
     private static int s_instanceCounter;
     private readonly int _instanceId = Interlocked.Increment(ref s_instanceCounter);
@@ -545,6 +546,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly long _maxInFlightBytesPerConnection;
     private readonly long[] _pendingResponseBytesByConnection;
 
+    // Per-broker unacked-byte admission budget (owned by the accumulator, shared with the
+    // producer's admission gate). This send loop is the single writer of its EWMA drain
+    // estimate (OnAcked) and cap (SetCap); null when the bound is disabled.
+    private readonly BrokerUnackedByteBudget? _unackedBudget;
+
+    // Snapshot of the budget's admission-block counter for scale-pressure deltas. The gate
+    // keeps BufferUtilization near zero, so blocked admissions must feed scale-up directly.
+    // Reset only on successful scale-up (like _lastPressureSnapshot) so pressure keeps
+    // accumulating across failed grow attempts.
+    private long _lastUnackedBlockSnapshot;
+
+    // Recency tracking for the scale-down veto: the counter value last seen by the scale
+    // check, and the monotonic-ms time of its last observed movement. Kept separate from
+    // the scale-up snapshot above, whose reset-on-scale-up policy would otherwise pin the
+    // veto forever on workloads that can never grow (at the ceiling or partition-capped).
+    private long _lastUnackedBlockObserved;
+    private long _lastUnackedBlockObservedMs;
+
     // Broker quota throttling is scoped per broker, not per connection. A positive
     // ProduceResponse.ThrottleTimeMs pauses every connection owned by this BrokerSender.
     // Zero is the common fast path and leaves this sentinel at zero.
@@ -604,8 +623,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Action<int>? onBrokerThrottle = null,
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
-        Action? onBlockedBucketRequeued = null)
+        Action? onBlockedBucketRequeued = null,
+        BrokerUnackedByteBudget? unackedBudget = null)
     {
+        _unackedBudget = unackedBudget;
         _brokerId = brokerId;
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
@@ -645,7 +666,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _connectionCount = options.ConnectionsPerBroker;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
         _maxInFlightBytesPerConnection = GetInFlightByteBudget(connectionCount: 1);
-        _totalMaxInFlightBytes = GetInFlightByteBudget(_connectionCount);
+        UpdateInFlightByteBudget(_connectionCount);
 
         // Transactions are excluded because coordinator requests require a single connection.
         // Acks.None is excluded because no broker acknowledgement establishes a safe boundary
@@ -2140,6 +2161,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
+        // Drain-rate estimate feed: bytes and the latest round-trip from successfully acked
+        // requests this pass. Faulted/cancelled responses are not drain and are excluded.
+        long ackedBytes = 0;
+        long lastAckedRequestStart = 0;
+
         // CRITICAL: Process responses in FORWARD order (oldest request first).
         // With multi-inflight, R1 and R2 may both complete with errors for the same partition.
         // Forward iteration ensures R1's retry batches are added to carry-over before R2's,
@@ -2198,6 +2224,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 var response = task.Result;
+                ackedBytes += pending.EncodedBytes;
+                lastAckedRequestStart = pending.RequestStartTime;
                 ObserveBrokerThrottle(response.ThrottleTimeMs);
                 // Reuse caller-provided dictionary to avoid per-response allocation.
                 // The dictionary is cleared after use in ProcessResponseBatches.
@@ -2269,6 +2297,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         LogPartitionMigrationComplete(_brokerId, beforeCount);
                 }
             }
+        }
+
+        if (ackedBytes > 0 && _unackedBudget is { } unackedBudget)
+        {
+            // One timestamp per pass; RequestStartTime is on the raw Stopwatch clock (it
+            // feeds the request-timeout sweep), so the round-trip uses the same clock.
+            var ackRttTicks = Stopwatch.GetTimestamp() - lastAckedRequestStart;
+            unackedBudget.OnAcked(ackedBytes, ackRttTicks, _getTimestamp());
         }
     }
 
@@ -2762,9 +2798,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         => Math.Min(ResponsePollIntervalMs, Math.Min(throttleDelayMs, batchDeadlineMs));
 
     private long GetInFlightByteBudget(int connectionCount)
-        => (long)connectionCount
-            * Math.Max(1, _options.BatchSize)
-            * InFlightByteBudgetBatchMultiplier;
+        => BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, connectionCount);
+
+    /// <summary>
+    /// Recomputes the written-unacked pipeline ceiling for the given routing width and
+    /// republishes the admission budget's cap in lockstep. Every path that changes
+    /// <c>_connectionCount</c> must go through this so the two ceilings never desync.
+    /// </summary>
+    private void UpdateInFlightByteBudget(int connectionCount)
+    {
+        _totalMaxInFlightBytes = GetInFlightByteBudget(connectionCount);
+        _unackedBudget?.SetCap(_options.UnackedByteBudgetCapOverride ?? _totalMaxInFlightBytes);
+    }
 
     private static long SumEncodedBytes(List<PendingResponse> pendingResponses)
     {
@@ -4216,7 +4261,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var reducedConnectionCount = _connectionCount;
                 _connectionCount++;
                 _totalMaxInFlight = _connectionCount * _maxInFlight;
-                _totalMaxInFlightBytes = GetInFlightByteBudget(_connectionCount);
+                UpdateInFlightByteBudget(_connectionCount);
                 _accumulator.RecordConnectionScaleEvent(
                     _brokerId,
                     reducedConnectionCount,
@@ -4254,11 +4299,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var utilization = _accumulator.BufferUtilization;
         var bufferPressureDelta = _accumulator.BufferPressureEvents - _lastPressureSnapshot;
         var sendLoopPressureDelta = _sendLoopPressureEvents - _lastSendLoopPressureSnapshot;
-        var scalePressureDelta = ComputeScalePressureDelta(bufferPressureDelta, sendLoopPressureDelta);
+        // The unacked-byte admission gate holds BufferUtilization near zero while it binds,
+        // which would silently starve scale-up (and the budget would self-limit at the drain
+        // rate of the initial width). Blocked admissions therefore feed scale pressure directly.
+        var unackedBlockEvents = _unackedBudget?.AdmissionBlockEvents ?? 0;
+        var unackedBlockDelta = unackedBlockEvents - _lastUnackedBlockSnapshot;
+        if (unackedBlockEvents != _lastUnackedBlockObserved)
+        {
+            _lastUnackedBlockObserved = unackedBlockEvents;
+            _lastUnackedBlockObservedMs = now;
+        }
+        var scalePressureDelta = ComputeScalePressureDelta(
+            bufferPressureDelta + unackedBlockDelta, sendLoopPressureDelta);
         var hasScalePressure = scalePressureDelta >= ScalePressureDeltaThreshold;
 
         // Phase 2: Check if we should start a new scale-up
         if (sendLoopPressureDelta >= ScalePressureDeltaThreshold
+            || unackedBlockDelta >= ScalePressureDeltaThreshold
             || (utilization >= ScaleUtilizationThreshold && hasScalePressure))
         {
             // High utilization — reset low-utilization tracking
@@ -4293,6 +4350,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (_connectionCount <= _minConnectionCount)
         {
             _lowUtilizationStartTicks = 0; // At minimum — nothing to scale down
+            return 0;
+        }
+
+        // Recent admission-gate blocks mean the workload is throttled by the unacked-byte
+        // budget, not idle — buffer utilization is a false-idle signal here (same inversion
+        // as the mute-on-send guards below). Never shrink while the gate was recently
+        // binding, using the same sustained window as the muted-partition-load guard.
+        if (_lastUnackedBlockObservedMs > 0
+            && now - _lastUnackedBlockObservedMs < _scaleDownSustainedMs)
+        {
+            _lowUtilizationStartTicks = 0;
             return 0;
         }
 
@@ -4372,7 +4440,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // its pending list stays in place because per-connection arrays are never resized.
         _connectionCount = targetShrinkCount;
         _totalMaxInFlight = targetShrinkCount * _maxInFlight;
-        _totalMaxInFlightBytes = GetInFlightByteBudget(targetShrinkCount);
+        UpdateInFlightByteBudget(targetShrinkCount);
 
         // The drain gates above guarantee no in-flight batches that require routing to the
         // removed slot, so any leftover migration fences are stale — clear them so no
@@ -4443,12 +4511,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _hasScaledConnectionGroup = true;
         _connectionCount = actualCount;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
-        _totalMaxInFlightBytes = GetInFlightByteBudget(_connectionCount);
+        UpdateInFlightByteBudget(_connectionCount);
         // Only reset on successful growth — intentional. If the pool returned fewer
         // connections than requested, stale pressure keeps accumulating so the next
         // cooldown window retries with the full delta rather than starting from zero.
         _lastPressureSnapshot = _accumulator.BufferPressureEvents;
         _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
+        _lastUnackedBlockSnapshot = _unackedBudget?.AdmissionBlockEvents ?? 0;
 
         // Per-connection arrays are pre-sized at the scaling ceiling — nothing to grow.
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Bounds the bytes a single broker may hold unacknowledged (sealed but not yet acked)
+/// so that producer queueing latency stays near <see cref="ProducerOptions.DeliveryLatencyTargetMs"/>
+/// instead of growing to the full <see cref="ProducerOptions.BufferMemory"/> reservoir.
+/// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
+/// by the broker's drain rate; capping the standing bytes to
+/// <c>target × measured drain rate</c> caps the latency.
+/// <para>
+/// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
+/// <see cref="RecordAdmissionBlock"/> are cross-thread (producer appenders and terminal batch
+/// paths). <see cref="OnAcked"/> and <see cref="SetCap"/> are single-writer — only the owning
+/// broker's send loop calls them — so the EWMA state needs no synchronization; the computed
+/// budget is published with a volatile write.
+/// </para>
+/// </summary>
+internal sealed class BrokerUnackedByteBudget
+{
+    /// <summary>
+    /// Budget ceiling in batches per connection. Sized so a ~1 GB/s drain with ~30 ms ack
+    /// round-trips keeps the pipe full at the 1 MB default batch size (~32 MB BDP). Shared
+    /// with <see cref="BrokerSender"/>'s written-unacked pipeline ceiling so the two bounds
+    /// stay consistent.
+    /// </summary>
+    internal const int CapBatchMultiplier = 32;
+
+    /// <summary>EWMA time constant for the acked-bytes rate. A sample spanning dt seconds
+    /// gets weight min(1, dt/τ), so history older than ~τ decays away and a long idle gap
+    /// snaps the rate to the newly observed value.</summary>
+    private const double RateEwmaTauSeconds = 1.0;
+
+    /// <summary>Fixed smoothing factor for the per-request ack round-trip EWMA.</summary>
+    private const double RttEwmaAlpha = 0.25;
+
+    /// <summary>Budget never drops below this multiple of the measured bandwidth-delay
+    /// product (rate × RTT). Without this guard a target below the broker RTT would shrink
+    /// the budget below BDP, underfill the pipe, lower the measured rate, and ratchet the
+    /// budget down to the floor — collapsing throughput on high-latency links.</summary>
+    private const double RttSafetyMultiplier = 1.5;
+
+    /// <summary>Rate samples shorter than this are carried into the next sample so a burst
+    /// of sub-millisecond ack passes cannot produce wildly noisy instantaneous rates.</summary>
+    private const double MinRateSampleSeconds = 0.001;
+
+    // Cross-thread state.
+    private long _unackedBytes;
+    private long _budgetBytes;
+    private long _admissionBlockEvents;
+
+    // Single-writer state (owning send loop only; constructor runs before the loop starts).
+    private readonly long _floorBytes;
+    private readonly double _targetSeconds;
+    private long _capBytes;
+    private double _ewmaBytesPerSecond;
+    private double _ewmaRttSeconds;
+    private long _pendingAckedBytes;
+    private long _lastRateSampleTimestamp;
+    private bool _hasRateSample;
+    private bool _hasRttSample;
+
+    public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
+    {
+        _targetSeconds = targetSeconds;
+        _floorBytes = Math.Max(1, floorBytes);
+        _capBytes = Math.Max(_floorBytes, initialCapBytes);
+        Volatile.Write(ref _budgetBytes, _capBytes);
+    }
+
+    /// <summary>
+    /// Budget ceiling for a broker: the same formula as the written-unacked pipeline ceiling
+    /// (<c>BrokerSender.GetInFlightByteBudget</c>), which delegates here so the admission
+    /// ceiling and the pipeline ceiling can never drift apart.
+    /// </summary>
+    internal static long ComputeCap(int batchSize, int connectionCount)
+        => (long)Math.Max(1, batchSize) * CapBatchMultiplier * Math.Max(1, connectionCount);
+
+    /// <summary>Current standing unacked bytes charged to this broker.</summary>
+    internal long UnackedBytes => Volatile.Read(ref _unackedBytes);
+
+    /// <summary>Currently published budget in bytes.</summary>
+    internal long BudgetBytes => Volatile.Read(ref _budgetBytes);
+
+    /// <summary>Total admission-gate blocks observed; consumed as a delta by adaptive
+    /// connection scaling, which cannot see buffer pressure while the gate holds the
+    /// accumulator near-empty.</summary>
+    internal long AdmissionBlockEvents => Volatile.Read(ref _admissionBlockEvents);
+
+    // Volatile.Read (a plain acquire load) rather than Interlocked.Read: this runs per
+    // message from every appender thread, and a locked read would take the cache line
+    // exclusive on every call, turning a read-mostly gate into a contention point.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsOverBudget()
+        => Volatile.Read(ref _unackedBytes) >= Volatile.Read(ref _budgetBytes);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Charge(long bytes)
+        => Interlocked.Add(ref _unackedBytes, bytes);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Release(long bytes)
+    {
+        var remaining = Interlocked.Add(ref _unackedBytes, -bytes);
+        Debug.Assert(remaining >= 0, "Unacked byte accounting went negative — release without matching charge.");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void RecordAdmissionBlock()
+        => Interlocked.Increment(ref _admissionBlockEvents);
+
+    /// <summary>
+    /// Updates the ceiling (routing-width-dependent) and republishes the budget.
+    /// Called by the owning send loop at construction and on connection scale events.
+    /// </summary>
+    public void SetCap(long capBytes)
+    {
+        _capBytes = Math.Max(_floorBytes, capBytes);
+        RecomputeBudget();
+    }
+
+    /// <summary>
+    /// Feeds acked bytes and the latest request round-trip into the drain estimate, then
+    /// republishes the budget. Called only from the owning send loop after a response
+    /// pass completes successfully-acked requests. O(1), allocation-free.
+    /// </summary>
+    public void OnAcked(long ackedBytes, long rttTicks, long nowTicks)
+    {
+        _pendingAckedBytes += ackedBytes;
+
+        if (rttTicks > 0)
+        {
+            var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
+            _ewmaRttSeconds = _hasRttSample
+                ? _ewmaRttSeconds + (RttEwmaAlpha * (rttSeconds - _ewmaRttSeconds))
+                : rttSeconds;
+            _hasRttSample = true;
+        }
+
+        if (_lastRateSampleTimestamp == 0)
+        {
+            // First observation anchors the sampling window; no rate can be derived yet.
+            _lastRateSampleTimestamp = nowTicks;
+            return;
+        }
+
+        var elapsedSeconds = (double)(nowTicks - _lastRateSampleTimestamp) / Stopwatch.Frequency;
+        if (elapsedSeconds < MinRateSampleSeconds)
+            return;
+
+        var sampleBytesPerSecond = _pendingAckedBytes / elapsedSeconds;
+        _pendingAckedBytes = 0;
+        _lastRateSampleTimestamp = nowTicks;
+
+        var alpha = Math.Min(1.0, elapsedSeconds / RateEwmaTauSeconds);
+        _ewmaBytesPerSecond = _hasRateSample
+            ? _ewmaBytesPerSecond + (alpha * (sampleBytesPerSecond - _ewmaBytesPerSecond))
+            : sampleBytesPerSecond;
+        _hasRateSample = true;
+
+        RecomputeBudget();
+    }
+
+    private void RecomputeBudget()
+    {
+        long budget;
+        if (!_hasRateSample)
+        {
+            // Cold start: no drain estimate yet — keep today's semantics (cap) so short-lived
+            // producers and tests never see admission throttling.
+            budget = _capBytes;
+        }
+        else
+        {
+            var horizonSeconds = _hasRttSample
+                ? Math.Max(_targetSeconds, RttSafetyMultiplier * _ewmaRttSeconds)
+                : _targetSeconds;
+            budget = (long)(_ewmaBytesPerSecond * horizonSeconds);
+            budget = Math.Clamp(budget, _floorBytes, _capBytes);
+        }
+
+        Volatile.Write(ref _budgetBytes, budget);
+    }
+}

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -153,7 +153,6 @@ internal sealed class BrokerUnackedByteBudget
             // broker drain time. Preserve the established rate and start a fresh window with
             // this first resumed ack; folding the idle gap into the sample would collapse the
             // budget to the floor and unnecessarily throttle the resumed burst.
-            _pendingAckedBytes = ackedBytes;
             _lastRateSampleTimestamp = nowTicks;
             return;
         }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -28,9 +28,9 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     internal const int CapBatchMultiplier = 32;
 
-    /// <summary>EWMA time constant for the acked-bytes rate. A sample spanning dt seconds
-    /// gets weight min(1, dt/τ), so history older than ~τ decays away and a long idle gap
-    /// snaps the rate to the newly observed value.</summary>
+    /// <summary>EWMA time constant for the acked-bytes rate. An active sample spanning dt
+    /// seconds gets weight min(1, dt/τ), so history older than ~τ decays away. A gap longer
+    /// than τ with no remaining unacked bytes is treated as idle and re-anchors the window.</summary>
     private const double RateEwmaTauSeconds = 1.0;
 
     /// <summary>Fixed smoothing factor for the per-request ack round-trip EWMA.</summary>
@@ -147,6 +147,17 @@ internal sealed class BrokerUnackedByteBudget
         }
 
         var elapsedSeconds = (double)(nowTicks - _lastRateSampleTimestamp) / Stopwatch.Frequency;
+        if (elapsedSeconds > RateEwmaTauSeconds && UnackedBytes == 0)
+        {
+            // No backlog survived the gap, so elapsed time is producer idle time rather than
+            // broker drain time. Preserve the established rate and start a fresh window with
+            // this first resumed ack; folding the idle gap into the sample would collapse the
+            // budget to the floor and unnecessarily throttle the resumed burst.
+            _pendingAckedBytes = ackedBytes;
+            _lastRateSampleTimestamp = nowTicks;
+            return;
+        }
+
         if (elapsedSeconds < MinRateSampleSeconds)
             return;
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -389,7 +389,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _compressionCodecs,
             loggerFactory?.CreateLogger<RecordAccumulator>(),
             batchCompletionCallback,
-            recordAppendedCallback);
+            recordAppendedCallback,
+            ResolveLeaderIdForUnackedBudget);
         _uniformStickyPartitioner?.SetPartitionQueueByteProvider(_accumulator.GetPartitionQueueBytes);
 
         // Inflight tracker enables coordinated retry with multiple in-flight batches per partition.
@@ -2883,8 +2884,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _interceptors is not null ? InvokeOnAcknowledgementForBatch : null,
             _logger,
             canPhysicallyShrinkConnections: _ownsInfrastructure,
-            onBrokerThrottle: _options.EnableDeliveryDiagnostics ? ObserveBrokerThrottle : null);
+            onBrokerThrottle: _options.EnableDeliveryDiagnostics ? ObserveBrokerThrottle : null,
+            unackedBudget: _accumulator.GetBrokerUnackedBudget(brokerId));
     }
+
+    /// <summary>
+    /// Resolves the current leader broker id for the unacked-byte admission budget.
+    /// Returns -1 when the leader is not cached yet (the budget then skips the batch).
+    /// </summary>
+    private int ResolveLeaderIdForUnackedBudget(string topic, int partition)
+        => _metadataManager.TryGetCachedPartitionLeader(topic, partition)?.NodeId ?? -1;
 
     /// <summary>
     /// Routes a batch to the current leader's BrokerSender.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2945,6 +2945,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             LogReroutedBatch(topicPartition.Topic, topicPartition.Partition, leader.NodeId);
+            _accumulator.ReattributeUnackedBudget(batch, leader.NodeId);
             GetOrCreateBrokerSender(leader.NodeId).Enqueue(batch, expectedGeneration);
         }
         catch (Exception ex)

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -56,6 +56,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private long _startTicks;
     private long _deadlineTickCount;
     private RecordAccumulator _accumulator = null!;
+    private int _pendingCounted;
 
     // Pool return
     private PendingAppendPool _pool = null!;
@@ -132,6 +133,8 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _cancellationToken = cancellationToken;
         _accumulator = accumulator;
         _pool = pool;
+        accumulator.IncrementSlowPathAppendCount(topic, partition);
+        Volatile.Write(ref _pendingCounted, 1);
         Volatile.Write(ref _completed, 0);
 
         // Arm timeout timer. Compute remaining ms from deadline.
@@ -174,6 +177,12 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     }
 
     /// <summary>
+    /// Releases per-partition FIFO ownership after a claimed append has entered its batch.
+    /// Must run before completing the value task, which can return this object to its pool.
+    /// </summary>
+    internal void ReleasePendingCountAfterClaim() => ReleasePendingCount();
+
+    /// <summary>
     /// Sets the successful result after <see cref="TryClaim"/> + AppendAfterReservation.
     /// Must only be called after <see cref="TryClaim"/> returned true.
     /// Resources are consumed by AppendAfterReservation — no cleanup needed.
@@ -199,6 +208,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
             return false;
 
+        ReleasePendingCount();
         DisarmTimerAndCancellation();
 
         // Clean up owned resources since drain will not process this operation
@@ -272,8 +282,16 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _cancellationToken = default;
         _deadlineTickCount = 0;
         _accumulator = null!;
+        _pendingCounted = 0;
         _core.Reset();
         _pool.Return(this);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ReleasePendingCount()
+    {
+        if (Interlocked.Exchange(ref _pendingCounted, 0) != 0)
+            _accumulator.DecrementSlowPathAppendCount(_topic, _partition);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -139,6 +139,28 @@ public sealed class ProducerOptions
     internal bool IsAutoTuned { get; init; }
 
     /// <summary>
+    /// Soft target, in milliseconds, for per-broker producer queueing latency (append to ack).
+    /// Bounds the bytes each broker may hold unacknowledged to
+    /// <c>target × measured ack throughput</c>, with a measured round-trip lower guard so
+    /// throughput is never window-limited. When a broker exceeds its budget, message admission
+    /// blocks the same way <see cref="BufferMemory"/> exhaustion does (subject to
+    /// <see cref="MaxBlockMs"/> and cancellation). Until the first drain measurement the bound
+    /// equals its ceiling, so short-lived producers are unaffected.
+    /// Set to 0 to disable the bound entirely. Default: 10.
+    /// </summary>
+    public int DeliveryLatencyTargetMs
+    {
+        get => _deliveryLatencyTargetMs;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _deliveryLatencyTargetMs = value;
+        }
+    }
+
+    private readonly int _deliveryLatencyTargetMs = 10;
+
+    /// <summary>
     /// Compression type.
     /// </summary>
     public CompressionType CompressionType { get; init; } = CompressionType.None;
@@ -571,6 +593,13 @@ public sealed class ProducerOptions
     /// required before a scale-down. Null uses the production constant.
     /// </summary>
     internal long? ScaleDownSustainedMsOverride { get; init; }
+
+    /// <summary>
+    /// Test-only override for the unacked-byte budget ceiling (bytes). Null derives the
+    /// ceiling from <see cref="BatchSize"/> and the connection count. Internal so unit
+    /// tests can bind the admission gate with small payloads; not part of the public API.
+    /// </summary>
+    internal long? UnackedByteBudgetCapOverride { get; init; }
 
     /// <summary>
     /// Producer interceptors, called in order during the produce pipeline.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1768,6 +1768,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
             return;
 
+        var ownsDrainGuard = true;
         try
         {
             while (true)
@@ -1853,6 +1854,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
                 // Release the drain lock before re-checking so a concurrent ReleaseMemory
                 // can enter if we decide not to loop again.
+                ownsDrainGuard = false;
                 Volatile.Write(ref _draining, 0);
 
                 // Re-check: a ReleaseMemory may have arrived while we held the drain lock,
@@ -1868,16 +1870,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // Re-acquire the drain lock for another pass
                 if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
                     return; // Another thread took over
+
+                ownsDrainGuard = true;
             }
         }
         finally
         {
-            _blockedPendingPartitions.Clear();
-            _pendingAppendScan.Clear();
-            _drainablePendingAppends.Clear();
-            // Ensure drain lock is released even on exception (inner loop already releases
-            // on normal exit, but exception path needs the finally).
-            Volatile.Write(ref _draining, 0);
+            if (ownsDrainGuard)
+            {
+                _blockedPendingPartitions.Clear();
+                _pendingAppendScan.Clear();
+                _drainablePendingAppends.Clear();
+                // Ensure drain lock is released on exception. Once ownership passes to
+                // another drainer, its invocation owns both the guard and shared scratch.
+                Volatile.Write(ref _draining, 0);
+            }
         }
     }
 
@@ -4847,9 +4854,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private int FailPendingAppendsForPurge(Exception exception)
     {
-        if (_pendingAppends.IsEmpty)
-            return 0;
-
         var spinWait = new SpinWait();
         while (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
             spinWait.SpinOnce();

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1119,7 +1119,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // When TryReserveMemory fails, PendingAppend instances are enqueued here and drained by ReleaseMemory.
     private readonly PendingAppendPool _pendingAppendPool;
     private readonly ConcurrentQueue<PendingAppend> _pendingAppends = new();
+    private readonly object _pendingAppendQueueLock = new();
     private readonly HashSet<TopicPartition> _blockedPendingPartitions = [];
+    private readonly List<PendingAppend> _pendingAppendScan = [];
+    private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
 
     /// <summary>
@@ -1159,13 +1162,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public bool AppendInProgress;
 
         /// <summary>
-        /// Cached unacked-byte budget and broker identity from the latest batch seal. Admission
-        /// compares the identity with the current leader before applying the budget. Written
-        /// under <see cref="Lock"/> and read lock-free; volatile publication keeps appenders
-        /// from indefinitely observing the pre-seal null on weak-memory architectures.
+        /// Budget for the current cached leader. Admission refreshes it outside
+        /// <see cref="Lock"/>; sealing reads it inside the lock.
         /// </summary>
         public volatile BrokerUnackedByteBudget? UnackedBudget;
-        public volatile int UnackedBudgetBrokerId = -1;
+        public int SlowPathAppendCount;
 
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;
@@ -1776,39 +1777,50 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     return;
 
                 var madeProgress = false;
-                var remainingToInspect = _pendingAppends.Count;
-                _blockedPendingPartitions.Clear();
-
-                while (remainingToInspect-- > 0 && _pendingAppends.TryPeek(out var op))
+                lock (_pendingAppendQueueLock)
                 {
-                    // Skip already-completed operations (timeout/cancel/dispose won the race).
-                    // Don't set madeProgress — clearing expired ops doesn't free memory.
-                    if (op.IsCompleted)
+                    _pendingAppendScan.Clear();
+                    _drainablePendingAppends.Clear();
+                    _blockedPendingPartitions.Clear();
+
+                    var remainingToInspect = _pendingAppends.Count;
+                    while (remainingToInspect-- > 0 && _pendingAppends.TryDequeue(out var candidate))
+                        _pendingAppendScan.Add(candidate);
+
+                    var memoryExhausted = false;
+                    foreach (var candidate in _pendingAppendScan)
                     {
-                        _pendingAppends.TryDequeue(out _);
-                        continue;
+                        // Timeout/cancel/dispose already released this operation's FIFO count.
+                        if (candidate.IsCompleted)
+                            continue;
+
+                        var topicPartition = new TopicPartition(candidate.Topic, candidate.Partition);
+                        if (memoryExhausted
+                            || _blockedPendingPartitions.Contains(topicPartition)
+                            || IsBrokerAdmissionBlocked(candidate.Topic, candidate.Partition, recordBlockEvent: false))
+                        {
+                            _pendingAppends.Enqueue(candidate);
+                            if (!memoryExhausted)
+                                _blockedPendingPartitions.Add(topicPartition);
+                            continue;
+                        }
+
+                        if (!TryReserveMemory(candidate.RecordSize))
+                        {
+                            memoryExhausted = true;
+                            _pendingAppends.Enqueue(candidate);
+                            continue;
+                        }
+
+                        _drainablePendingAppends.Add(candidate);
                     }
 
-                    var topicPartition = new TopicPartition(op.Topic, op.Partition);
-                    if (_blockedPendingPartitions.Contains(topicPartition)
-                        || IsBrokerAdmissionBlocked(op.Topic, op.Partition, recordBlockEvent: false))
-                    {
-                        // Preserve FIFO within this partition, but rotate it behind other
-                        // brokers so one saturated broker cannot convoy the global queue.
-                        _pendingAppends.TryDequeue(out _);
-                        _pendingAppends.Enqueue(op);
-                        _blockedPendingPartitions.Add(topicPartition);
-                        continue;
-                    }
+                    _pendingAppendScan.Clear();
+                    madeProgress = _drainablePendingAppends.Count > 0;
+                }
 
-                    // Try to reserve memory for this operation
-                    if (!TryReserveMemory(op.RecordSize))
-                        break; // No space — stop draining, next ReleaseMemory will retry
-
-                    // Dequeue — we own the reservation now
-                    _pendingAppends.TryDequeue(out _);
-                    madeProgress = true;
-
+                foreach (var op in _drainablePendingAppends)
+                {
                     // Claim the operation with CAS BEFORE touching resources.
                     // This prevents timeout/cancel from cleaning up key/value/headers
                     // while AppendAfterReservation is using them.
@@ -1827,14 +1839,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             op.Key, op.Value, op.Headers, op.HeaderCount,
                             op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount);
 
+                        op.ReleasePendingCountAfterClaim();
                         op.CompleteResult(result);
                     }
                     catch (Exception ex)
                     {
                         // AppendAfterReservation handles its own resource cleanup on throw
+                        op.ReleasePendingCountAfterClaim();
                         op.CompleteException(ex);
                     }
                 }
+                _drainablePendingAppends.Clear();
 
                 // Release the drain lock before re-checking so a concurrent ReleaseMemory
                 // can enter if we decide not to loop again.
@@ -1858,6 +1873,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         finally
         {
             _blockedPendingPartitions.Clear();
+            _pendingAppendScan.Clear();
+            _drainablePendingAppends.Clear();
             // Ensure drain lock is released even on exception (inner loop already releases
             // on normal exit, but exception path needs the finally).
             Volatile.Write(ref _draining, 0);
@@ -2158,6 +2175,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 workItem.Completion.TrySetException(ex);
             }
+            finally
+            {
+                DecrementSlowPathAppendCount(workItem.Topic, workItem.Partition);
+            }
         }
     }
 
@@ -2202,8 +2223,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var workItem = new AppendWorkItem(topic, partition, partitionCount, timestamp, key, value,
             headers, headerCount, completion, cancellationToken);
 
+        IncrementSlowPathAppendCount(topic, partition);
         if (!_appendWorkerChannels[workerIndex].Writer.TryWrite(workItem))
         {
+            DecrementSlowPathAppendCount(topic, partition);
             CleanupWorkItemResources(in workItem);
             completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
         }
@@ -2655,7 +2678,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
-        _pendingAppends.Enqueue(op);
+        lock (_pendingAppendQueueLock)
+            _pendingAppends.Enqueue(op);
 
         // Close TOCTOU window: if DisposeAsync ran between the _disposed check above and the
         // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
@@ -4240,13 +4264,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!InFlightBatchListRemove(batch))
             return false;
 
-        if (batch.UnackedBudget is { } unackedBudget)
+        if (Interlocked.Exchange(ref batch.UnackedBudget, null) is { } unackedBudget)
         {
             // DataSize is exactly what ChargeUnackedBudget charged; it stays valid until
             // Reset() at pool return, which cannot precede this first-exit path.
             unackedBudget.Release(batch.DataSize);
-            batch.UnackedBudget = null;
-
             // Freed unacked headroom can unblock appenders gated on this broker's budget —
             // wake them through the same machinery BufferMemory releases use.
             DrainPendingAppends();
@@ -4278,26 +4300,48 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Charges a freshly sealed batch against its leader broker's unacked-byte budget.
+    /// Charges a freshly sealed batch against its cached leader broker's unacked-byte budget.
     /// Called under pd.Lock (same ordering domain as InFlightBatchListAdd) so a fast ack
-    /// can never release before the charge lands. The resolved budget and broker identity are
-    /// cached on the partition deque and validated against the current leader at admission.
+    /// can never release before the charge lands. Admission resolves and creates the budget
+    /// outside this partition lock; rerouting transfers the charge if the leader changes later.
     /// </summary>
-    private void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
+    private static void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
     {
-        var leaderId = _resolveLeaderId!(batch.TopicPartition.Topic, batch.TopicPartition.Partition);
-        if (leaderId < 0)
-        {
-            pd.UnackedBudgetBrokerId = -1;
-            pd.UnackedBudget = null;
+        if (pd.UnackedBudget is not { } budget)
             return;
-        }
 
-        var budget = GetBrokerUnackedBudget(leaderId)!;
-        pd.UnackedBudget = budget;
-        pd.UnackedBudgetBrokerId = leaderId;
         budget.Charge(batch.DataSize);
         batch.UnackedBudget = budget;
+    }
+
+    /// <summary>Transfers a live batch's charge when retry routing selects another broker.</summary>
+    internal void ReattributeUnackedBudget(ReadyBatch batch, int brokerId)
+    {
+        if (GetBrokerUnackedBudget(brokerId) is not { } newBudget)
+            return;
+
+        var lockTaken = false;
+        try
+        {
+            _inFlightBatchLock.Enter(ref lockTaken);
+
+            // Terminal cleanup removes the batch under this lock before releasing its
+            // charge. Checking linkage prevents installing a new charge after that exit.
+            if (!batch.InFlightLinked || ReferenceEquals(batch.UnackedBudget, newBudget))
+                return;
+
+            newBudget.Charge(batch.DataSize);
+            var oldBudget = batch.UnackedBudget;
+            batch.UnackedBudget = newBudget;
+            oldBudget?.Release(batch.DataSize);
+        }
+        finally
+        {
+            if (lockTaken) _inFlightBatchLock.Exit();
+        }
+
+        DrainPendingAppends();
+        SignalBufferSpaceAvailable();
     }
 
     /// <summary>
@@ -4327,22 +4371,26 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Uses the hot path only when no queued or actively draining append owns FIFO priority,
-    /// then checks the broker admission gate and reserves buffer memory — in that order, so
-    /// a gate-blocked append never leaks a reservation. This is the single choke point for
-    /// every append entry path; call this instead of <see cref="TryReserveMemory"/> directly.
+    /// Checks the broker gate before per-partition FIFO priority and buffer reservation, so
+    /// every blocked attempt records pressure and never leaks a reservation. This is the
+    /// single choke point for every append entry path.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAdmitAndReserve(string topic, int partition, int recordSize)
-        => Volatile.Read(ref _draining) == 0
-            && _pendingAppends.IsEmpty
-            && !IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true)
+    {
+        var partitionDeque = GetOrCreateDeque(topic, partition);
+        if (_unackedBudgetEnabled
+            && IsBrokerAdmissionBlocked(topic, partition, partitionDeque, recordBlockEvent: true))
+            return false;
+
+        return Volatile.Read(ref partitionDeque.SlowPathAppendCount) == 0
             && TryReserveMemory(recordSize);
+    }
 
     /// <summary>
     /// True when the destination broker for (topic, partition) is over its unacked-byte
-    /// budget and message admission should block. Lock-free: a cached leader lookup, one
-    /// thread-cached deque lookup, and volatile reads; returns false before the first seal.
+    /// budget and message admission should block. Lock-free: a cached metadata lookup, one
+    /// deque lookup, and volatile reads.
     /// Block events feed adaptive connection scaling; the pending-append drain passes false
     /// because the operation already recorded one when it was first gated.
     /// </summary>
@@ -4352,19 +4400,39 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_unackedBudgetEnabled)
             return false;
 
+        return IsBrokerAdmissionBlocked(
+            topic, partition, GetOrCreateDeque(topic, partition), recordBlockEvent);
+    }
+
+    private bool IsBrokerAdmissionBlocked(
+        string topic,
+        int partition,
+        PartitionDeque partitionDeque,
+        bool recordBlockEvent)
+    {
         var leaderId = _resolveLeaderId!(topic, partition);
-        var partitionDeque = GetOrCreateDeque(topic, partition);
+        var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
+        partitionDeque.UnackedBudget = currentBudget;
         if (leaderId < 0
-            || partitionDeque.UnackedBudgetBrokerId != leaderId
-            || partitionDeque.UnackedBudget is not { } budget
-            || !budget.IsOverBudget())
+            || currentBudget is null
+            || !currentBudget.IsOverBudget())
         {
             return false;
         }
 
         if (recordBlockEvent)
-            budget.RecordAdmissionBlock();
+            currentBudget.RecordAdmissionBlock();
         return true;
+    }
+
+    internal void IncrementSlowPathAppendCount(string topic, int partition)
+        => Interlocked.Increment(ref GetOrCreateDeque(topic, partition).SlowPathAppendCount);
+
+    internal void DecrementSlowPathAppendCount(string topic, int partition)
+    {
+        var remaining = Interlocked.Decrement(
+            ref GetOrCreateDeque(topic, partition).SlowPathAppendCount);
+        Debug.Assert(remaining >= 0, "Slow-path append count went negative.");
     }
 
     /// <summary>
@@ -6316,10 +6384,9 @@ internal sealed class ReadyBatch
     // Set by KafkaProducer when registering with PartitionInflightTracker, cleared in Reset().
     internal InflightEntry? InflightEntry { get; set; }
 
-    // Unacked-byte budget this batch's DataSize was charged against at seal time. Released
+    // Unacked-byte budget this batch's DataSize is currently charged against. Released
     // once (first terminal path wins, guarded by OnBatchExitsPipeline's InFlightBatchListRemove)
-    // and cleared in Reset(). A rerouted batch stays charged to its seal-time broker until
-    // terminal — bounded and self-correcting at the next seal.
+    // and cleared in Reset(). Rerouting transfers this charge to the selected leader.
     internal BrokerUnackedByteBudget? UnackedBudget;
 
     // Intrusive linked list pointers for RecordAccumulator._inFlightBatchList.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1161,11 +1161,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         /// </summary>
         public bool AppendInProgress;
 
-        /// <summary>
-        /// Budget for the current cached leader. Admission refreshes it outside
-        /// <see cref="Lock"/>; sealing reads it inside the lock.
-        /// </summary>
-        public volatile BrokerUnackedByteBudget? UnackedBudget;
         public int SlowPathAppendCount;
 
         /// <summary>Number of batches in the deque.</summary>
@@ -1573,6 +1568,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     FailOversizedBatch(batch, batchRequestSize, maxRequestSize);
                     continue;
                 }
+
+                // Ready/Drain selected this exact broker after revalidating leadership.
+                // Transfer the seal-time charge before handing the batch to its sender.
+                ReattributeUnackedBudget(batch, nodeId);
 
                 if (_options.EnableDeliveryDiagnostics)
                     batch.AppendDiag('D');
@@ -3543,8 +3542,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private void EnqueueCompletedBatchUnderLock(PartitionDeque pd, ReadyBatch readyBatch)
     {
-        if (_unackedBudgetEnabled)
-            pd.UnackedBudget = readyBatch.UnackedBudget;
         OnBatchEntersPipeline(pd, readyBatch);
         pd.AddLast(readyBatch);
         ProducerDebugCounters.RecordBatchQueuedToReady();
@@ -4255,10 +4252,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Tracks a batch entering the pipeline: increments counter and adds to reference-tracking dictionary.
     /// Called when a batch is completed and enqueued to a partition deque.
     /// </summary>
-    private void OnBatchEntersPipeline(PartitionDeque pd, ReadyBatch batch)
+    private void OnBatchEntersPipeline(PartitionDeque _, ReadyBatch batch)
     {
         if (_unackedBudgetEnabled)
-            ChargeUnackedBudget(pd, batch);
+            ChargeUnackedBudget(batch);
 
         _partitionQueueBytes.AddOrUpdate(
             batch.TopicPartition,
@@ -4329,21 +4326,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Charges a freshly sealed batch against its current leader broker's unacked-byte budget.
-    /// Called under pd.Lock (same ordering domain as InFlightBatchListAdd) so a fast ack
+    /// Called under the partition lock (same ordering domain as InFlightBatchListAdd) so a fast ack
     /// can never release before the charge lands. The budget is resolved outside this partition
     /// lock after completion, closing the append-to-seal leader-change window without adding
-    /// metadata or dictionary work inside the lock. Rerouting transfers later leader changes.
+    /// metadata or dictionary work inside the lock. Drain and rerouting transfer later leader changes.
     /// </summary>
-    private static void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
+    private static void ChargeUnackedBudget(ReadyBatch batch)
     {
-        if (pd.UnackedBudget is not { } budget)
+        if (batch.UnackedBudget is not { } budget)
             return;
 
         budget.Charge(batch.DataSize);
-        batch.UnackedBudget = budget;
     }
 
-    /// <summary>Transfers a live batch's charge when retry routing selects another broker.</summary>
+    /// <summary>Transfers a live batch's charge when drain or retry routing selects another broker.</summary>
     internal void ReattributeUnackedBudget(ReadyBatch batch, int brokerId)
     {
         if (GetBrokerUnackedBudget(brokerId) is not { } newBudget)
@@ -4409,7 +4405,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var partitionDeque = GetOrCreateDeque(topic, partition);
         if (_unackedBudgetEnabled
-            && IsBrokerAdmissionBlocked(topic, partition, partitionDeque, recordBlockEvent: true))
+            && IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true))
             return false;
 
         return Volatile.Read(ref partitionDeque.SlowPathAppendCount) == 0
@@ -4418,8 +4414,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// True when the destination broker for (topic, partition) is over its unacked-byte
-    /// budget and message admission should block. Lock-free: a cached metadata lookup, one
-    /// deque lookup, and volatile reads.
+    /// budget and message admission should block. Lock-free: a cached metadata lookup and
+    /// volatile reads.
     /// Block events feed adaptive connection scaling; the pending-append drain passes false
     /// because the operation already recorded one when it was first gated.
     /// </summary>
@@ -4429,19 +4425,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_unackedBudgetEnabled)
             return false;
 
-        return IsBrokerAdmissionBlocked(
-            topic, partition, GetOrCreateDeque(topic, partition), recordBlockEvent);
-    }
-
-    private bool IsBrokerAdmissionBlocked(
-        string topic,
-        int partition,
-        PartitionDeque partitionDeque,
-        bool recordBlockEvent)
-    {
         var leaderId = _resolveLeaderId!(topic, partition);
         var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
-        partitionDeque.UnackedBudget = currentBudget;
         if (leaderId < 0
             || currentBudget is null
             || !currentBudget.IsOverBudget())

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1119,6 +1119,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // When TryReserveMemory fails, PendingAppend instances are enqueued here and drained by ReleaseMemory.
     private readonly PendingAppendPool _pendingAppendPool;
     private readonly ConcurrentQueue<PendingAppend> _pendingAppends = new();
+    private readonly HashSet<TopicPartition> _blockedPendingPartitions = [];
     private int _draining; // CAS guard for DrainPendingAppends
 
     /// <summary>
@@ -1158,12 +1159,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public bool AppendInProgress;
 
         /// <summary>
-        /// Cached unacked-byte budget for this partition's current leader broker, refreshed at
-        /// each batch seal so per-message admission checks need no metadata lookup. Written
-        /// under <see cref="Lock"/> and read lock-free at admission; volatile publication keeps
-        /// appenders from indefinitely observing the pre-seal null on weak-memory architectures.
+        /// Cached unacked-byte budget and broker identity from the latest batch seal. Admission
+        /// compares the identity with the current leader before applying the budget. Written
+        /// under <see cref="Lock"/> and read lock-free; volatile publication keeps appenders
+        /// from indefinitely observing the pre-seal null on weak-memory architectures.
         /// </summary>
         public volatile BrokerUnackedByteBudget? UnackedBudget;
+        public volatile int UnackedBudgetBrokerId = -1;
 
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;
@@ -1748,8 +1750,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Drains the <see cref="_pendingAppends"/> queue, serving queued operations FIFO
-    /// when buffer memory becomes available. Called from <see cref="ReleaseMemory"/>.
+    /// Drains the <see cref="_pendingAppends"/> queue, preserving per-partition FIFO while
+    /// rotating budget-blocked partitions so healthy brokers can progress.
     /// </summary>
     /// <remarks>
     /// CAS on <c>_draining</c> ensures only one thread drains at a time. After releasing
@@ -1774,8 +1776,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     return;
 
                 var madeProgress = false;
+                var remainingToInspect = _pendingAppends.Count;
+                _blockedPendingPartitions.Clear();
 
-                while (_pendingAppends.TryPeek(out var op))
+                while (remainingToInspect-- > 0 && _pendingAppends.TryPeek(out var op))
                 {
                     // Skip already-completed operations (timeout/cancel/dispose won the race).
                     // Don't set madeProgress — clearing expired ops doesn't free memory.
@@ -1785,10 +1789,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         continue;
                     }
 
-                    // Head-of-line semantics identical to memory exhaustion: a broker over
-                    // its unacked-byte budget stops the drain; the next release/ack retries.
-                    if (IsBrokerAdmissionBlocked(op.Topic, op.Partition, recordBlockEvent: false))
-                        break;
+                    var topicPartition = new TopicPartition(op.Topic, op.Partition);
+                    if (_blockedPendingPartitions.Contains(topicPartition)
+                        || IsBrokerAdmissionBlocked(op.Topic, op.Partition, recordBlockEvent: false))
+                    {
+                        // Preserve FIFO within this partition, but rotate it behind other
+                        // brokers so one saturated broker cannot convoy the global queue.
+                        _pendingAppends.TryDequeue(out _);
+                        _pendingAppends.Enqueue(op);
+                        _blockedPendingPartitions.Add(topicPartition);
+                        continue;
+                    }
 
                     // Try to reserve memory for this operation
                     if (!TryReserveMemory(op.RecordSize))
@@ -1846,6 +1857,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         finally
         {
+            _blockedPendingPartitions.Clear();
             // Ensure drain lock is released even on exception (inner loop already releases
             // on normal exit, but exception path needs the finally).
             Volatile.Write(ref _draining, 0);
@@ -4268,17 +4280,22 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <summary>
     /// Charges a freshly sealed batch against its leader broker's unacked-byte budget.
     /// Called under pd.Lock (same ordering domain as InFlightBatchListAdd) so a fast ack
-    /// can never release before the charge lands. The resolved budget is cached on the
-    /// partition deque so admission checks stay metadata-free.
+    /// can never release before the charge lands. The resolved budget and broker identity are
+    /// cached on the partition deque and validated against the current leader at admission.
     /// </summary>
     private void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
     {
         var leaderId = _resolveLeaderId!(batch.TopicPartition.Topic, batch.TopicPartition.Partition);
         if (leaderId < 0)
-            return; // Leader unknown (metadata gap) — skip; the gate cannot bind for this partition yet.
+        {
+            pd.UnackedBudgetBrokerId = -1;
+            pd.UnackedBudget = null;
+            return;
+        }
 
         var budget = GetBrokerUnackedBudget(leaderId)!;
         pd.UnackedBudget = budget;
+        pd.UnackedBudgetBrokerId = leaderId;
         budget.Charge(batch.DataSize);
         batch.UnackedBudget = budget;
     }
@@ -4324,8 +4341,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// True when the destination broker for (topic, partition) is over its unacked-byte
-    /// budget and message admission should block. Lock-free: one thread-cached deque lookup
-    /// plus two volatile reads per message; returns false before the partition's first seal.
+    /// budget and message admission should block. Lock-free: a cached leader lookup, one
+    /// thread-cached deque lookup, and volatile reads; returns false before the first seal.
     /// Block events feed adaptive connection scaling; the pending-append drain passes false
     /// because the operation already recorded one when it was first gated.
     /// </summary>
@@ -4335,7 +4352,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_unackedBudgetEnabled)
             return false;
 
-        if (GetOrCreateDeque(topic, partition).UnackedBudget is not { } budget
+        var leaderId = _resolveLeaderId!(topic, partition);
+        var partitionDeque = GetOrCreateDeque(topic, partition);
+        if (leaderId < 0
+            || partitionDeque.UnackedBudgetBrokerId != leaderId
+            || partitionDeque.UnackedBudget is not { } budget
             || !budget.IsOverBudget())
         {
             return false;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -887,6 +887,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly ConcurrentDictionary<TopicPartition, PartitionDeque> _partitionDeques = new();
 
     /// <summary>
+    /// Per-broker unacked-byte budgets bounding delivery latency under sustained overload.
+    /// Populated lazily at the first batch seal for a broker; entries are never removed
+    /// (brokers are few and long-lived). Null-pattern: the registry is consulted only when
+    /// <see cref="_unackedBudgetEnabled"/> is true.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, BrokerUnackedByteBudget> _brokerUnackedBudgets = new();
+    private readonly Func<string, int, int>? _resolveLeaderId;
+    private readonly bool _unackedBudgetEnabled;
+
+    /// <summary>
     /// Muted partitions — skipped by Ready() and Drain(). The value is a reference count:
     /// independent BrokerSenders and crash-recovery barriers may overlap for the same partition.
     /// Updates are serialized by <see cref="_partitionMuteLock"/>, while Ready/Drain perform
@@ -1146,6 +1156,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         /// Appenders and linger sealing wait until the reserved record metadata is committed.
         /// </summary>
         public bool AppendInProgress;
+
+        /// <summary>
+        /// Cached unacked-byte budget for this partition's current leader broker, refreshed at
+        /// each batch seal so per-message admission checks need no metadata lookup. Written
+        /// under <see cref="Lock"/>; read lock-free at admission (reference writes are atomic,
+        /// and a briefly stale budget after a leader move is benign).
+        /// </summary>
+        public BrokerUnackedByteBudget? UnackedBudget;
 
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;
@@ -1767,6 +1785,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         continue;
                     }
 
+                    // Head-of-line semantics identical to memory exhaustion: a broker over
+                    // its unacked-byte budget stops the drain; the next release/ack retries.
+                    if (IsBrokerAdmissionBlocked(op.Topic, op.Partition, recordBlockEvent: false))
+                        break;
+
                     // Try to reserve memory for this operation
                     if (!TryReserveMemory(op.RecordSize))
                         break; // No space — stop draining, next ReleaseMemory will retry
@@ -1872,7 +1895,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         CompressionCodecRegistry? compressionCodecs = null,
         ILogger? logger = null,
         Action<string, int>? onBatchComplete = null,
-        Action<string, int, int, int>? onRecordAppended = null)
+        Action<string, int, int, int>? onRecordAppended = null,
+        Func<string, int, int>? resolveLeaderId = null)
     {
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         _options = options;
@@ -1881,6 +1905,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _compressionCodecs = compressionCodecs;
         _onBatchComplete = onBatchComplete;
         _onRecordAppended = onRecordAppended;
+        _resolveLeaderId = resolveLeaderId;
+        _unackedBudgetEnabled = options.DeliveryLatencyTargetMs > 0 && resolveLeaderId is not null;
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
 
@@ -2306,12 +2332,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
-        // Hot path: non-blocking CAS reservation — no async state machine allocated
-        if (TryReserveMemory(recordSize))
+        // Hot path: non-blocking gate check + CAS reservation — no async state machine
+        // allocated. An over-budget broker applies the same backpressure as a full buffer.
+        if (TryAdmitAndReserve(topic, partition, recordSize))
             return new ValueTask<bool>(AppendAfterReservation(topic, partition, timestamp, key, value,
                 headers, headerCount, completionSource, callback, recordSize, partitionCount));
 
-        // Cold path: buffer full — enqueue pooled PendingAppend (zero async state machine allocation)
+        // Cold path: buffer full or broker over budget — enqueue pooled PendingAppend
+        // (zero async state machine allocation)
         return AppendSlowPathPooled(topic, partition, timestamp, key, value,
             headers, headerCount, completionSource, callback, recordSize, cancellationToken, partitionCount);
     }
@@ -2674,9 +2702,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
-        // Try non-blocking memory reservation. If buffer is full, return false so the
+        // Try the admission gate + non-blocking memory reservation. If the buffer is full
+        // or the destination broker is over its unacked-byte budget, return false so the
         // caller (ProduceAsync fast path) falls back to the async path.
-        if (!TryReserveMemory(recordSize))
+        if (!TryAdmitAndReserve(topic, partition, recordSize))
             return false;
 
         return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
@@ -2711,7 +2740,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             topic, partition, keyIsNull, keyLength, valueIsNull, valueLength,
             headers, headerCount, recordSize);
 
-        if (!TryReserveMemory(recordSize))
+        if (!TryAdmitAndReserve(topic, partition, recordSize))
             return false;
 
         return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
@@ -3107,8 +3136,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
-        // Hot path: non-blocking CAS reservation — no async state machine allocated
-        if (TryReserveMemory(recordSize))
+        // Hot path: non-blocking gate check + CAS reservation — no async state machine
+        // allocated. An over-budget broker applies the same backpressure as a full buffer.
+        if (TryAdmitAndReserve(topic, partition, recordSize))
             return new ValueTask<bool>(AppendFromSpansAfterReservation(topic, partition, timestamp,
                 keyData, keyIsNull, valueData, valueIsNull, headers, headerCount, callback, recordSize, partitionCount));
 
@@ -3451,7 +3481,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private void EnqueueCompletedBatchUnderLock(PartitionDeque pd, ReadyBatch readyBatch)
     {
-        OnBatchEntersPipeline(readyBatch);
+        OnBatchEntersPipeline(pd, readyBatch);
         pd.AddLast(readyBatch);
         ProducerDebugCounters.RecordBatchQueuedToReady();
     }
@@ -4161,8 +4191,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Tracks a batch entering the pipeline: increments counter and adds to reference-tracking dictionary.
     /// Called when a batch is completed and enqueued to a partition deque.
     /// </summary>
-    private void OnBatchEntersPipeline(ReadyBatch batch)
+    private void OnBatchEntersPipeline(PartitionDeque pd, ReadyBatch batch)
     {
+        if (_unackedBudgetEnabled)
+            ChargeUnackedBudget(pd, batch);
+
         _partitionQueueBytes.AddOrUpdate(
             batch.TopicPartition,
             batch.DataSize,
@@ -4195,6 +4228,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!InFlightBatchListRemove(batch))
             return false;
 
+        if (batch.UnackedBudget is { } unackedBudget)
+        {
+            // DataSize is exactly what ChargeUnackedBudget charged; it stays valid until
+            // Reset() at pool return, which cannot precede this first-exit path.
+            unackedBudget.Release(batch.DataSize);
+            batch.UnackedBudget = null;
+
+            // Freed unacked headroom can unblock appenders gated on this broker's budget —
+            // wake them through the same machinery BufferMemory releases use.
+            DrainPendingAppends();
+            SignalBufferSpaceAvailable();
+        }
+
         _partitionQueueBytes.AddOrUpdate(
             batch.TopicPartition,
             0,
@@ -4216,6 +4262,84 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 SignalWakeup();
         }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Charges a freshly sealed batch against its leader broker's unacked-byte budget.
+    /// Called under pd.Lock (same ordering domain as InFlightBatchListAdd) so a fast ack
+    /// can never release before the charge lands. The resolved budget is cached on the
+    /// partition deque so admission checks stay metadata-free.
+    /// </summary>
+    private void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
+    {
+        var leaderId = _resolveLeaderId!(batch.TopicPartition.Topic, batch.TopicPartition.Partition);
+        if (leaderId < 0)
+            return; // Leader unknown (metadata gap) — skip; the gate cannot bind for this partition yet.
+
+        var budget = GetBrokerUnackedBudget(leaderId)!;
+        pd.UnackedBudget = budget;
+        budget.Charge(batch.DataSize);
+        batch.UnackedBudget = budget;
+    }
+
+    /// <summary>
+    /// Returns the unacked-byte budget for a broker, creating it on first use.
+    /// Null when the bound is disabled (<see cref="ProducerOptions.DeliveryLatencyTargetMs"/> = 0
+    /// or no leader resolver was wired).
+    /// </summary>
+    internal BrokerUnackedByteBudget? GetBrokerUnackedBudget(int brokerId)
+    {
+        if (!_unackedBudgetEnabled)
+            return null;
+
+        return _brokerUnackedBudgets.GetOrAdd(
+            brokerId,
+            static (_, accumulator) => accumulator.CreateBrokerUnackedBudget(),
+            this);
+    }
+
+    private BrokerUnackedByteBudget CreateBrokerUnackedBudget()
+    {
+        var cap = _options.UnackedByteBudgetCapOverride
+            ?? BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, _options.ConnectionsPerBroker);
+        // Floor keeps the pipe full (≥ 2 batches, ≥ 1MiB BDP headroom) but must not exceed a
+        // deliberately tiny test cap, or the gate could never bind in unit tests.
+        var floor = Math.Min(Math.Max(2L * Math.Max(1, _options.BatchSize), 1L << 20), cap);
+        return new BrokerUnackedByteBudget(_options.DeliveryLatencyTargetMs / 1000.0, floor, cap);
+    }
+
+    /// <summary>
+    /// Checks the broker admission gate, then reserves buffer memory — in that order, so a
+    /// gate-blocked append never leaks a reservation. This is the single choke point for
+    /// every append entry path; call this instead of <see cref="TryReserveMemory"/> directly.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAdmitAndReserve(string topic, int partition, int recordSize)
+        => !IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true)
+            && TryReserveMemory(recordSize);
+
+    /// <summary>
+    /// True when the destination broker for (topic, partition) is over its unacked-byte
+    /// budget and message admission should block. Lock-free: one thread-cached deque lookup
+    /// plus two volatile reads per message; returns false before the partition's first seal.
+    /// Block events feed adaptive connection scaling; the pending-append drain passes false
+    /// because the operation already recorded one when it was first gated.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsBrokerAdmissionBlocked(string topic, int partition, bool recordBlockEvent)
+    {
+        if (!_unackedBudgetEnabled)
+            return false;
+
+        if (GetOrCreateDeque(topic, partition).UnackedBudget is not { } budget
+            || !budget.IsOverBudget())
+        {
+            return false;
+        }
+
+        if (recordBlockEvent)
+            budget.RecordAdmissionBlock();
         return true;
     }
 
@@ -6168,6 +6292,12 @@ internal sealed class ReadyBatch
     // Set by KafkaProducer when registering with PartitionInflightTracker, cleared in Reset().
     internal InflightEntry? InflightEntry { get; set; }
 
+    // Unacked-byte budget this batch's DataSize was charged against at seal time. Released
+    // once (first terminal path wins, guarded by OnBatchExitsPipeline's InFlightBatchListRemove)
+    // and cleared in Reset(). A rerouted batch stays charged to its seal-time broker until
+    // terminal — bounded and self-correcting at the next seal.
+    internal BrokerUnackedByteBudget? UnackedBudget;
+
     // Intrusive linked list pointers for RecordAccumulator._inFlightBatchList.
     // Using embedded pointers eliminates per-batch ConcurrentDictionary.Node allocations
     // that caused pathological Gen2 GC promotion (nodes survived Gen0 during network
@@ -6740,6 +6870,7 @@ internal sealed class ReadyBatch
         _callbackCount = 0;
         _arrayReuseQueue = null;
         InflightEntry = null;
+        UnackedBudget = null;
         InFlightPrev = null;
         InFlightNext = null;
         InFlightLinked = false;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2624,6 +2624,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             batchToComplete,
                             out sealedBatchBytesToRelease,
                             releaseMemoryOnFailure: false);
+                        if (sealedBatchToEnqueue is not null)
+                        {
+                            sealedBatchToEnqueue.UnackedBudget = ResolveUnackedBudget(
+                                topic,
+                                partition);
+                        }
                     }
                     catch
                     {
@@ -3088,6 +3094,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             batchToComplete,
                             out sealedBatchBytesToRelease,
                             releaseMemoryOnFailure: false);
+                        if (sealedBatchToEnqueue is not null)
+                        {
+                            sealedBatchToEnqueue.UnackedBudget = ResolveUnackedBudget(
+                                topic,
+                                partition);
+                        }
                     }
                     catch
                     {
@@ -3505,6 +3517,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             throw;
         }
 
+        if (readyBatch is not null)
+        {
+            readyBatch.UnackedBudget = ResolveUnackedBudget(
+                readyBatch.TopicPartition.Topic,
+                readyBatch.TopicPartition.Partition);
+        }
+
         {
             using var guard = new SpinLockGuard(ref pd.Lock);
             if (readyBatch is not null)
@@ -3524,6 +3543,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private void EnqueueCompletedBatchUnderLock(PartitionDeque pd, ReadyBatch readyBatch)
     {
+        if (_unackedBudgetEnabled)
+            pd.UnackedBudget = readyBatch.UnackedBudget;
         OnBatchEntersPipeline(pd, readyBatch);
         pd.AddLast(readyBatch);
         ProducerDebugCounters.RecordBatchQueuedToReady();
@@ -4307,10 +4328,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Charges a freshly sealed batch against its cached leader broker's unacked-byte budget.
+    /// Charges a freshly sealed batch against its current leader broker's unacked-byte budget.
     /// Called under pd.Lock (same ordering domain as InFlightBatchListAdd) so a fast ack
-    /// can never release before the charge lands. Admission resolves and creates the budget
-    /// outside this partition lock; rerouting transfers the charge if the leader changes later.
+    /// can never release before the charge lands. The budget is resolved outside this partition
+    /// lock after completion, closing the append-to-seal leader-change window without adding
+    /// metadata or dictionary work inside the lock. Rerouting transfers later leader changes.
     /// </summary>
     private static void ChargeUnackedBudget(PartitionDeque pd, ReadyBatch batch)
     {
@@ -4430,6 +4452,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (recordBlockEvent)
             currentBudget.RecordAdmissionBlock();
         return true;
+    }
+
+    private BrokerUnackedByteBudget? ResolveUnackedBudget(string topic, int partition)
+    {
+        if (!_unackedBudgetEnabled)
+            return null;
+
+        var leaderId = _resolveLeaderId!(topic, partition);
+        return leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
     }
 
     internal void IncrementSlowPathAppendCount(string topic, int partition)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4310,13 +4310,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Checks the broker admission gate, then reserves buffer memory — in that order, so a
-    /// gate-blocked append never leaks a reservation. This is the single choke point for
+    /// Uses the hot path only when no queued or actively draining append owns FIFO priority,
+    /// then checks the broker admission gate and reserves buffer memory — in that order, so
+    /// a gate-blocked append never leaks a reservation. This is the single choke point for
     /// every append entry path; call this instead of <see cref="TryReserveMemory"/> directly.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryAdmitAndReserve(string topic, int partition, int recordSize)
-        => !IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true)
+        => Volatile.Read(ref _draining) == 0
+            && _pendingAppends.IsEmpty
+            && !IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true)
             && TryReserveMemory(recordSize);
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1160,10 +1160,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         /// <summary>
         /// Cached unacked-byte budget for this partition's current leader broker, refreshed at
         /// each batch seal so per-message admission checks need no metadata lookup. Written
-        /// under <see cref="Lock"/>; read lock-free at admission (reference writes are atomic,
-        /// and a briefly stale budget after a leader move is benign).
+        /// under <see cref="Lock"/> and read lock-free at admission; volatile publication keeps
+        /// appenders from indefinitely observing the pre-seal null on weak-memory architectures.
         /// </summary>
-        public BrokerUnackedByteBudget? UnackedBudget;
+        public volatile BrokerUnackedByteBudget? UnackedBudget;
 
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -165,6 +165,7 @@ public class DependencyInjectionTests
             BootstrapServers = ["broker1:9092"],
             ClientId = "typed-producer",
             LingerMs = 7,
+            DeliveryLatencyTargetMs = 23,
             EnableAdaptiveConnections = false,
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha512,
@@ -185,6 +186,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.BootstrapServers[0]).IsEqualTo("broker1:9092");
         await Assert.That(boundOptions.ClientId).IsEqualTo("override-producer");
         await Assert.That(boundOptions.LingerMs).IsEqualTo(7);
+        await Assert.That(boundOptions.DeliveryLatencyTargetMs).IsEqualTo(23);
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
@@ -562,6 +564,7 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:RetryBackoffMs"] = "25",
             ["Kafka:Producers:Orders:RetryBackoffMaxMs"] = "250",
             ["Kafka:Producers:Orders:MaxBlockMs"] = "1000",
+            ["Kafka:Producers:Orders:DeliveryLatencyTargetMs"] = "17",
             ["Kafka:Producers:Orders:DeliveryTimeoutMs"] = "2000",
             ["Kafka:Producers:Orders:RequestTimeoutMs"] = "3000",
             ["Kafka:Producers:Orders:ReconnectBackoffMs"] = "75",
@@ -610,6 +613,7 @@ public class DependencyInjectionTests
         await Assert.That(options.RetryBackoffMs).IsEqualTo(25);
         await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(250);
         await Assert.That(options.MaxBlockMs).IsEqualTo(1000);
+        await Assert.That(options.DeliveryLatencyTargetMs).IsEqualTo(17);
         await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(2000);
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(3000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(75);

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
+using Dekaf.Metadata;
 using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -32,6 +35,42 @@ internal static class AccumulatorTestHelpers
 
         var completeMethod = partitionBatch.GetType().GetMethod("Complete");
         return (ReadyBatch)completeMethod!.Invoke(partitionBatch, null)!;
+    }
+
+    /// <summary>
+    /// Creates a MetadataManager with a single broker leading every partition of the topic.
+    /// </summary>
+    public static MetadataManager CreateMetadataManager(string topic, int partitionCount, int nodeId = 1)
+    {
+        var manager = new MetadataManager(connectionPool: null!, bootstrapServers: ["localhost:9092"]);
+
+        var partitions = new List<PartitionMetadata>();
+        for (var i = 0; i < partitionCount; i++)
+        {
+            partitions.Add(new PartitionMetadata
+            {
+                ErrorCode = ErrorCode.None,
+                PartitionIndex = i,
+                LeaderId = nodeId,
+                ReplicaNodes = [nodeId],
+                IsrNodes = [nodeId]
+            });
+        }
+
+        manager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = nodeId, Host = "localhost", Port = 9092 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = topic,
+                    Partitions = partitions
+                }
+            ]
+        });
+        return manager;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -152,17 +152,18 @@ public class AdaptiveScalingTests
 
     [Test]
     [Arguments(true, 1, 10, 2, true)]
+    [Arguments(true, 1, 10, 0, false)]
     [Arguments(true, 1, 10, 1, false)]
     [Arguments(true, 10, 10, 20, false)]
     [Arguments(false, 1, 10, 20, false)]
-    public async Task IsSendLoopPressureScaleUseful_GatesOnAdaptiveCeilingAndPartitionFanout(
+    public async Task IsPartitionPressureScaleUseful_GatesOnAdaptiveCeilingAndPartitionFanout(
         bool adaptiveScalingEnabled,
         int connectionCount,
         int maxConnectionsPerBroker,
         int knownPartitionCount,
         bool expected)
     {
-        var isUseful = BrokerSender.IsSendLoopPressureScaleUseful(
+        var isUseful = BrokerSender.IsPartitionPressureScaleUseful(
             adaptiveScalingEnabled,
             connectionCount,
             maxConnectionsPerBroker,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -29,7 +29,8 @@ public sealed class BrokerSenderSendLoopTests
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
         int connectionsPerBroker = 1, bool enableAdaptiveConnections = true,
-        bool enableIdempotence = true, int batchSize = 1_048_576) => new()
+        bool enableIdempotence = true, int batchSize = 1_048_576,
+        long? unackedByteBudgetCapOverride = null, long? scaleCooldownMsOverride = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -42,7 +43,9 @@ public sealed class BrokerSenderSendLoopTests
             RetryBackoffMaxMs = retryBackoffMaxMs,
             RequestTimeoutMs = requestTimeoutMs,
             BatchSize = batchSize,
-            LingerMs = 0
+            LingerMs = 0,
+            UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride,
+            ScaleCooldownMsOverride = scaleCooldownMsOverride
         };
 
     /// <summary>
@@ -77,6 +80,30 @@ public sealed class BrokerSenderSendLoopTests
             .Returns(connection);
 
         return (pool, connection);
+    }
+
+    /// <summary>
+    /// Creates a mock pool whose ScaleConnectionGroupAsync resolves the requested width and
+    /// signals the returned TCS — shared by the scale-up trigger tests.
+    /// </summary>
+    private static (IConnectionPool pool, TaskCompletionSource<int> scaleRequested) CreateScaleTrackingPool(
+        TestKafkaConnection connection)
+    {
+        var scaleRequested = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.ScaleConnectionGroupAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var targetCount = (int)callInfo[1];
+                scaleRequested.TrySetResult(targetCount);
+                return new ValueTask<int>(targetCount);
+            });
+
+        return (pool, scaleRequested);
     }
 
     /// <summary>
@@ -203,7 +230,8 @@ public sealed class BrokerSenderSendLoopTests
         Action<int>? onBrokerThrottle = null,
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
-        Action? onBlockedBucketRequeued = null) =>
+        Action? onBlockedBucketRequeued = null,
+        BrokerUnackedByteBudget? unackedBudget = null) =>
         new(
             brokerId: 1, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
@@ -222,7 +250,8 @@ public sealed class BrokerSenderSendLoopTests
             onBrokerThrottle: onBrokerThrottle,
             getTimestamp: getTimestamp,
             delayForThrottle: delayForThrottle,
-            onBlockedBucketRequeued: onBlockedBucketRequeued);
+            onBlockedBucketRequeued: onBlockedBucketRequeued,
+            unackedBudget: unackedBudget);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {
@@ -252,19 +281,7 @@ public sealed class BrokerSenderSendLoopTests
                 Task.FromResult(CreateSuccessResponseForPartitions("test-topic", partitionCount)));
         };
 
-        var scaleRequested = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var pool = Substitute.For<IConnectionPool>();
-        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(connection);
-        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(connection);
-        pool.ScaleConnectionGroupAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var targetCount = (int)callInfo[1];
-                scaleRequested.TrySetResult(targetCount);
-                return new ValueTask<int>(targetCount);
-            });
+        var (pool, scaleRequested) = CreateScaleTrackingPool(connection);
 
         var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
 
@@ -2144,6 +2161,181 @@ public sealed class BrokerSenderSendLoopTests
             await Assert.That(progress).IsSameReferenceAs(deliveryFailure.Task);
             await Assert.That(await deliveryFailure.Task).IsTypeOf<KafkaTimeoutException>();
             await Assert.That(sendSignals[1].Task.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Constructor_AppliesUnackedBudgetCap()
+    {
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions(unackedByteBudgetCapOverride: 4_096);
+        var accumulator = new RecordAccumulator(options);
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 100, initialCapBytes: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { }, unackedBudget: budget);
+
+        try
+        {
+            // Cold start: budget follows the cap the sender applied at construction.
+            await Assert.That(budget.BudgetBytes).IsEqualTo(4_096);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task ProcessCompletedResponses_FeedsAckedBytesIntoUnackedBudget(
+        CancellationToken cancellationToken)
+    {
+        const int batchCount = 5;
+        const int dataSize = 5_000;
+
+        var responses = Enumerable.Range(0, batchCount)
+            .Select(_ => new TaskCompletionSource<ProduceResponse>())
+            .ToArray();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
+        var sendSignals = Enumerable.Range(0, batchCount)
+            .Select(_ => new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var sendCount = 0;
+
+        var (pool, _) = CreateMockConnection(responseQueue, onSend: () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+
+        // maxInFlight 1 + one partition serializes sends, so each response is processed alone:
+        // one OnAcked call per completed request, with the fake clock advanced 1s in between.
+        var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1);
+        var fakeTimestamp = Stopwatch.GetTimestamp();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
+            getTimestamp: () => Volatile.Read(ref fakeTimestamp),
+            unackedBudget: budget);
+
+        try
+        {
+            for (var i = 0; i < batchCount; i++)
+                sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: dataSize));
+
+            for (var i = 0; i < batchCount; i++)
+            {
+                await sendSignals[i].Task.WaitAsync(cancellationToken);
+                Interlocked.Add(ref fakeTimestamp, Stopwatch.Frequency); // 1s between ack windows
+                responses[i].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: i * 10));
+            }
+
+            // Steady state: 5,000 B/s measured drain (fake clock advances 1s per ack window),
+            // while the round-trip — sampled on the real Stopwatch clock — is microseconds,
+            // so the 0.5s target dominates the RTT guard: budget = 5,000 × 0.5 = 2,500.
+            await WaitUntilAsync(() => budget.BudgetBytes == 2_500, cancellationToken);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(2_500);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task FaultedResponses_DoNotFeedUnackedBudgetDrainRate(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var retryResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, retryResponse]);
+        var sendSignals = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var sendCount = 0;
+
+        var (pool, _) = CreateMockConnection(responseQueue, onSend: () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
+            unackedBudget: budget);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: 5_000));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            firstResponse.SetException(new IOException("connection reset"));
+
+            // The retry send proves the faulted response was fully processed — and a faulted
+            // response must not count as drain, so the budget still has no rate sample.
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+
+            retryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task AdmissionBlockPressure_TriggersScaleUp_WithoutBufferUtilization(
+        CancellationToken cancellationToken)
+    {
+        const int partitionCount = 4;
+
+        var options = CreateOptions(maxInFlight: 1,
+            unackedByteBudgetCapOverride: 1_000_000, scaleCooldownMsOverride: 0);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var connection = new TestKafkaConnection();
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(
+            Task.FromResult(CreateSuccessResponseForPartitions("test-topic", partitionCount)));
+
+        var (pool, scaleRequested) = CreateScaleTrackingPool(connection);
+
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
+            unackedBudget: budget);
+
+        try
+        {
+            // Simulate a workload throttled by the admission gate: buffer utilization stays
+            // near zero, but blocked admissions accumulate. This alone must trigger scale-up.
+            for (var i = 0; i < 200; i++)
+                budget.RecordAdmissionBlock();
+
+            // Keep the send loop iterating so it reaches the scale check.
+            for (var i = 0; i < 32; i++)
+                sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", i % partitionCount));
+
+            var targetCount = await scaleRequested.Task.WaitAsync(cancellationToken);
+            await Assert.That(targetCount).IsGreaterThan(1);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -164,6 +164,29 @@ public sealed class BrokerSenderSendLoopTests
             ]
         };
 
+    private static ProduceResponse CreateErrorResponse(string topic, int partition, ErrorCode errorCode) =>
+        new()
+        {
+            TopicCount = 1,
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = topic,
+                    PartitionCount = 1,
+                    PartitionResponses =
+                    [
+                        new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = errorCode,
+                            BaseOffset = -1
+                        }
+                    ]
+                }
+            ]
+        };
+
     private static ProduceResponse CreateSuccessResponseForPartitions(string topic, int partitionCount) =>
         new()
         {
@@ -2289,6 +2312,56 @@ public sealed class BrokerSenderSendLoopTests
 
             // The retry send proves the faulted response was fully processed — and a faulted
             // response must not count as drain, so the budget still has no rate sample.
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+
+            retryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task PartitionErrors_DoNotFeedUnackedBudgetDrainRate(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var retryResponse = new TaskCompletionSource<ProduceResponse>();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, retryResponse]);
+        var sendSignals = new[]
+        {
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, onSend: () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 1, retryBackoffMs: 0,
+            unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
+            unackedBudget: budget);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: 5_000));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+
+            firstResponse.SetResult(CreateErrorResponse("test-topic", 0, ErrorCode.RequestTimedOut));
+
+            // Retry proves the partition error was processed. It must not establish a
+            // successful drain-rate sample from the failed request's encoded bytes.
             await sendSignals[1].Task.WaitAsync(cancellationToken);
             await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -177,6 +177,52 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task QueuedAppend_PreventsLaterFastPathBypass(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await AppendUntilSealedAsync(accumulator, "test-topic", stopOnceCharged: budget);
+
+            var first = accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+            await Assert.That(first.IsCompleted).IsFalse();
+
+            // Model the race where an ack reopens the gate before its drain call wins.
+            // A later hot-path append must not leapfrog the already queued record.
+            var chargedBytes = budget.UnackedBytes;
+            budget.Release(chargedBytes);
+            var completion = pool.Rent();
+            var bypassed = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, completion);
+            await Assert.That(bypassed).IsFalse();
+            pool.Return(completion);
+
+            // Restore the real batch charge, then exit it through production cleanup. Its
+            // release drains the original append without double-releasing the budget.
+            budget.Charge(chargedBytes);
+            foreach (var batch in DrainSealedBatches(accumulator, metadataManager))
+                ExitAndReturn(accumulator, batch);
+
+            await Assert.That(await first).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task AsyncAppend_TimesOutWithMaxBlock_WhenGateStaysClosed()
     {
         // Generous MaxBlockMs for CI thread-pool starvation, same rationale as MaxBlockMsTests.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -80,6 +80,15 @@ public sealed class BrokerUnackedAdmissionTests
         accumulator.ReturnReadyBatch(batch);
     }
 
+    private static async ValueTask SealAllAsync(RecordAccumulator accumulator)
+    {
+        var method = typeof(RecordAccumulator).GetMethod(
+            "SealBatchesAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var seal = (ValueTask)method!.Invoke(accumulator, [true, CancellationToken.None])!;
+        await seal;
+    }
+
     [Test]
     public async Task Seal_ChargesLeaderBudget_AndBatchExitReleases()
     {
@@ -397,6 +406,36 @@ public sealed class BrokerUnackedAdmissionTests
             var broker2 = accumulator.GetBrokerUnackedBudget(2)!;
             await Assert.That(broker2.UnackedBytes).IsGreaterThan(0);
             await Assert.That(broker1.UnackedBytes).IsEqualTo(broker1BytesAfterFirstSeals);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task LeaderChange_BeforeFlush_ChargesNewBrokerBudget()
+    {
+        var options = CreateOptions(capOverride: null, batchSize: 16_384);
+        var currentLeader = 1;
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => currentLeader);
+
+        try
+        {
+            var appended = await accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, CancellationToken.None);
+            await Assert.That(appended).IsTrue();
+
+            var broker1 = accumulator.GetBrokerUnackedBudget(1)!;
+            await Assert.That(broker1.UnackedBytes).IsEqualTo(0);
+
+            currentLeader = 2;
+            await SealAllAsync(accumulator);
+
+            var broker2 = accumulator.GetBrokerUnackedBudget(2)!;
+            await Assert.That(broker1.UnackedBytes).IsEqualTo(0);
+            await Assert.That(broker2.UnackedBytes).IsGreaterThan(0);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -223,6 +223,42 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task BlockedBroker_DoesNotStallHealthyBroker(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options,
+            resolveLeaderId: (_, partition) => partition == 0 ? 1 : 2);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+
+        try
+        {
+            var blockedBudget = accumulator.GetBrokerUnackedBudget(1)!;
+            await AppendUntilSealedAsync(accumulator, "test-topic", stopOnceCharged: blockedBudget);
+
+            var blockedAppend = accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+            await Assert.That(blockedAppend.IsCompleted).IsFalse();
+
+            var healthyAppend = accumulator.AppendAsync(
+                "test-topic", 1, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+            await Assert.That(await healthyAppend).IsTrue();
+            await Assert.That(blockedAppend.IsCompleted).IsFalse();
+
+            foreach (var batch in DrainSealedBatches(accumulator, metadataManager))
+                ExitAndReturn(accumulator, batch);
+            await Assert.That(await blockedAppend).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task AsyncAppend_TimesOutWithMaxBlock_WhenGateStaysClosed()
     {
         // Generous MaxBlockMs for CI thread-pool starvation, same rationale as MaxBlockMsTests.
@@ -354,6 +390,35 @@ public sealed class BrokerUnackedAdmissionTests
         finally
         {
             await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task LeaderChange_DoesNotBlockOnPreviousLeaderBudget()
+    {
+        var currentLeader = 1;
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => currentLeader);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var oldBudget = accumulator.GetBrokerUnackedBudget(1)!;
+            await AppendUntilSealedAsync(accumulator, "test-topic", stopOnceCharged: oldBudget);
+            await Assert.That(oldBudget.IsOverBudget()).IsTrue();
+
+            currentLeader = 2;
+            var completion = pool.Rent();
+            var accepted = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, completion);
+
+            await Assert.That(accepted).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -195,6 +195,17 @@ public sealed class BrokerUnackedAdmissionTests
                 PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
             await Assert.That(first.IsCompleted).IsFalse();
 
+            // Existing partition backlog must not hide continued gate pressure from
+            // adaptive scale-down. Every blocked admission records another event.
+            var blockEvents = budget.AdmissionBlockEvents;
+            var blockedCompletion = pool.Rent();
+            var admittedWhileBlocked = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, blockedCompletion);
+            await Assert.That(admittedWhileBlocked).IsFalse();
+            await Assert.That(budget.AdmissionBlockEvents).IsGreaterThan(blockEvents);
+            pool.Return(blockedCompletion);
+
             // Model the race where an ack reopens the gate before its drain call wins.
             // A later hot-path append must not leapfrog the already queued record.
             var chargedBytes = budget.UnackedBytes;
@@ -390,6 +401,41 @@ public sealed class BrokerUnackedAdmissionTests
         finally
         {
             await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Reroute_TransfersExistingBatchCharge_ToNewBrokerBudget()
+    {
+        var options = CreateOptions(capOverride: null);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+            var batches = DrainSealedBatches(accumulator, metadataManager);
+            var batch = batches[0];
+            var originalBudget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            var newBudget = accumulator.GetBrokerUnackedBudget(2)!;
+            var batchBytes = batch.DataSize;
+            var originalBytes = originalBudget.UnackedBytes;
+
+            accumulator.ReattributeUnackedBudget(batch, brokerId: 2);
+
+            await Assert.That(originalBudget.UnackedBytes).IsEqualTo(originalBytes - batchBytes);
+            await Assert.That(newBudget.UnackedBytes).IsEqualTo(batchBytes);
+
+            foreach (var drainedBatch in batches)
+                ExitAndReturn(accumulator, drainedBatch);
+
+            await Assert.That(originalBudget.UnackedBytes).IsEqualTo(0);
+            await Assert.That(newBudget.UnackedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -1,0 +1,313 @@
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for the per-broker unacked-byte admission gate: charging at batch seal, releasing
+/// at batch exit, blocking appends while a broker is over budget, and the escape hatches
+/// (disabled target, unknown leader). Batches are sealed through the real rotation path
+/// (small BatchSize + repeated appends), so charges flow through
+/// EnqueueCompletedBatchUnderLock exactly as in production.
+/// </summary>
+public sealed class BrokerUnackedAdmissionTests
+{
+    private const int LeaderNodeId = 1;
+
+    private static ProducerOptions CreateOptions(
+        long? capOverride,
+        int deliveryLatencyTargetMs = 10,
+        int maxBlockMs = 60_000,
+        int batchSize = 50) => new()
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = 10_000_000,
+            BatchSize = batchSize,
+            LingerMs = 60_000, // No linger-driven seals: rotation on full batches only.
+            MaxBlockMs = maxBlockMs,
+            DeliveryLatencyTargetMs = deliveryLatencyTargetMs,
+            UnackedByteBudgetCapOverride = capOverride
+        };
+
+
+    /// <summary>
+    /// Appends empty-payload records until at least one batch has been sealed (batch rotation
+    /// with the small BatchSize). When <paramref name="stopOnceCharged"/> is set (tiny-cap
+    /// tests), the loop stops as soon as the broker budget is charged — one more append would
+    /// be gated and never complete.
+    /// </summary>
+    private static async Task AppendUntilSealedAsync(
+        RecordAccumulator accumulator, string topic, BrokerUnackedByteBudget? stopOnceCharged = null)
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            if (stopOnceCharged?.UnackedBytes > 0)
+                return;
+
+            var appended = await accumulator.AppendAsync(
+                topic, 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, CancellationToken.None);
+            if (!appended)
+                throw new InvalidOperationException("Append failed before any batch sealed.");
+        }
+
+        if (stopOnceCharged is { UnackedBytes: 0 })
+            throw new InvalidOperationException("No batch sealed after 10 appends.");
+    }
+
+    private static List<ReadyBatch> DrainSealedBatches(RecordAccumulator accumulator, MetadataManager metadataManager)
+    {
+        // Drain takes at most one batch per partition per pass (Java parity) — loop until dry.
+        var drained = new List<ReadyBatch>();
+        while (true)
+        {
+            var drainResult = new Dictionary<int, List<ReadyBatch>>();
+            accumulator.Drain(metadataManager, [LeaderNodeId], int.MaxValue, drainResult, new Stack<List<ReadyBatch>>());
+            if (!drainResult.TryGetValue(LeaderNodeId, out var batches) || batches.Count == 0)
+                return drained;
+            drained.AddRange(batches);
+        }
+    }
+
+    private static void ExitAndReturn(RecordAccumulator accumulator, ReadyBatch batch)
+    {
+        accumulator.OnBatchExitsPipeline(batch);
+        batch.CompleteSend(0, DateTimeOffset.UtcNow);
+        accumulator.ReturnReadyBatch(batch);
+    }
+
+    [Test]
+    public async Task Seal_ChargesLeaderBudget_AndBatchExitReleases()
+    {
+        var options = CreateOptions(capOverride: null);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId);
+            await Assert.That(budget).IsNotNull();
+            await Assert.That(budget!.UnackedBytes).IsGreaterThan(0);
+
+            var batches = DrainSealedBatches(accumulator, metadataManager);
+            await Assert.That(batches.Count).IsGreaterThan(0);
+
+            var chargedBytes = batches.Sum(b => (long)b.DataSize);
+            await Assert.That(budget.UnackedBytes).IsEqualTo(chargedBytes);
+
+            foreach (var batch in batches)
+                ExitAndReturn(accumulator, batch);
+
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FastPathAppends_AreBlocked_WhileBrokerOverBudget()
+    {
+        // Cap of 1 byte: the first sealed batch puts the broker over budget.
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await AppendUntilSealedAsync(accumulator, "test-topic", stopOnceCharged: budget);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            var completion = pool.Rent();
+            var accepted = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, completion);
+
+            await Assert.That(accepted).IsFalse();
+            await Assert.That(budget.AdmissionBlockEvents).IsGreaterThan(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task AsyncAppend_Unblocks_WhenChargedBatchExits(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
+
+        try
+        {
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await AppendUntilSealedAsync(accumulator, "test-topic", stopOnceCharged: budget);
+            await Assert.That(budget.IsOverBudget()).IsTrue();
+
+            // Gated append parks in the pending-append queue instead of completing.
+            var gatedAppend = accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+            await Assert.That(gatedAppend.IsCompleted).IsFalse();
+
+            // Acking (exiting) the charged batches reopens the gate and serves the queue.
+            foreach (var batch in DrainSealedBatches(accumulator, metadataManager))
+                ExitAndReturn(accumulator, batch);
+
+            var appended = await gatedAppend;
+            await Assert.That(appended).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task AsyncAppend_TimesOutWithMaxBlock_WhenGateStaysClosed()
+    {
+        // Generous MaxBlockMs for CI thread-pool starvation, same rationale as MaxBlockMsTests.
+        var options = CreateOptions(capOverride: 1, maxBlockMs: 2_000);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic",
+                stopOnceCharged: accumulator.GetBrokerUnackedBudget(LeaderNodeId));
+
+            var ex = await Assert.ThrowsAsync<KafkaTimeoutException>(async () =>
+                await accumulator.AppendAsync(
+                    "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    PooledMemory.Null, PooledMemory.Null, null, 0, null, null, CancellationToken.None));
+
+            await Assert.That(ex!.TimeoutKind).IsEqualTo(TimeoutKind.MaxBlock);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task AsyncAppend_HonorsCancellation_WhileGated(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic",
+                stopOnceCharged: accumulator.GetBrokerUnackedBudget(LeaderNodeId));
+
+            var gatedAppend = accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cts.Token);
+            await Assert.That(gatedAppend.IsCompleted).IsFalse();
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await gatedAppend);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Gate_IsDisabled_WhenDeliveryLatencyTargetIsZero()
+    {
+        var options = CreateOptions(capOverride: 1, deliveryLatencyTargetMs: 0);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+
+            await Assert.That(accumulator.GetBrokerUnackedBudget(LeaderNodeId)).IsNull();
+
+            var completion = pool.Rent();
+            var accepted = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, completion);
+            await Assert.That(accepted).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Gate_NeverBinds_WhenLeaderIsUnknown()
+    {
+        var options = CreateOptions(capOverride: 1);
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => -1);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+
+            // Sealed batches were not charged: the leader could not be resolved.
+            var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+            await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+
+            var completion = pool.Rent();
+            var accepted = accumulator.TryAppendWithCompletion(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, completion);
+            await Assert.That(accepted).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task LeaderChange_ChargesSubsequentSeals_ToNewBrokerBudget()
+    {
+        var options = CreateOptions(capOverride: null);
+        var currentLeader = 1;
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => currentLeader);
+
+        try
+        {
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+            var broker1 = accumulator.GetBrokerUnackedBudget(1)!;
+            var broker1BytesAfterFirstSeals = broker1.UnackedBytes;
+            await Assert.That(broker1BytesAfterFirstSeals).IsGreaterThan(0);
+
+            currentLeader = 2;
+            await AppendUntilSealedAsync(accumulator, "test-topic");
+
+            // New seals charge broker 2; broker 1 keeps only its pre-move charges.
+            var broker2 = accumulator.GetBrokerUnackedBudget(2)!;
+            await Assert.That(broker2.UnackedBytes).IsGreaterThan(0);
+            await Assert.That(broker1.UnackedBytes).IsEqualTo(broker1BytesAfterFirstSeals);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -444,6 +444,55 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    public async Task LeaderChange_BeforeDrain_TransfersChargeToSelectedBroker()
+    {
+        var options = CreateOptions(capOverride: null, batchSize: 16_384);
+        var currentLeader = 1;
+        var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => currentLeader);
+        var originalMetadata = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, nodeId: 1);
+        var newMetadata = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, nodeId: 2);
+
+        try
+        {
+            var appended = await accumulator.AppendAsync(
+                "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                PooledMemory.Null, PooledMemory.Null, null, 0, null, null, CancellationToken.None);
+            await Assert.That(appended).IsTrue();
+            await SealAllAsync(accumulator);
+
+            var broker1 = accumulator.GetBrokerUnackedBudget(1)!;
+            var batchBytes = broker1.UnackedBytes;
+            await Assert.That(batchBytes).IsGreaterThan(0);
+
+            var readyNodes = new HashSet<int>();
+            accumulator.Ready(originalMetadata, readyNodes);
+            await Assert.That(readyNodes).Contains(1);
+
+            currentLeader = 2;
+            var drainResult = new Dictionary<int, List<ReadyBatch>>();
+            accumulator.Drain(newMetadata, readyNodes, int.MaxValue, drainResult, new Stack<List<ReadyBatch>>());
+            await Assert.That(drainResult).IsEmpty();
+
+            readyNodes.Clear();
+            accumulator.Ready(newMetadata, readyNodes);
+            accumulator.Drain(newMetadata, readyNodes, int.MaxValue, drainResult, new Stack<List<ReadyBatch>>());
+
+            var batch = drainResult[2].Single();
+            var broker2 = accumulator.GetBrokerUnackedBudget(2)!;
+            await Assert.That(broker1.UnackedBytes).IsEqualTo(0);
+            await Assert.That(broker2.UnackedBytes).IsEqualTo(batchBytes);
+
+            ExitAndReturn(accumulator, batch);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await originalMetadata.DisposeAsync();
+            await newMetadata.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task Reroute_TransfersExistingBatchCharge_ToNewBrokerBudget()
     {
         var options = CreateOptions(capOverride: null);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// State-machine tests for <see cref="BrokerUnackedByteBudget"/>: budget publication from
+/// the acked-bytes EWMA, floor/cap clamping, the RTT safety guard, and counter accounting.
+/// All timestamps are explicit Stopwatch-tick values, so nothing here is timing-dependent.
+/// </summary>
+public sealed class BrokerUnackedByteBudgetTests
+{
+    private static readonly long Frequency = Stopwatch.Frequency;
+
+    /// <summary>An arbitrary positive anchor: tick 0 means "no window anchored yet".</summary>
+    private static readonly long T0 = Frequency;
+
+    private static long Seconds(double seconds) => (long)(seconds * Frequency);
+
+    /// <summary>
+    /// Establishes a drain-rate EWMA of <paramref name="bytesPerSecond"/> with the given
+    /// round-trip, using one anchoring call and one full one-second sample window.
+    /// </summary>
+    private static void EstablishRate(BrokerUnackedByteBudget budget, long bytesPerSecond, double rttSeconds)
+    {
+        budget.OnAcked(ackedBytes: 1, rttTicks: Seconds(rttSeconds), nowTicks: T0);
+        budget.OnAcked(bytesPerSecond - 1, Seconds(rttSeconds), T0 + Seconds(1.0));
+    }
+
+    [Test]
+    public async Task Budget_BeforeFirstRateSample_EqualsCap()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
+
+        // The first OnAcked call only anchors the sampling window — still no rate sample.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
+    }
+
+    [Test]
+    public async Task Budget_AfterRateSample_TracksTargetTimesRate()
+    {
+        // 3,000 B/s at negligible RTT with a 0.5s target => budget 1,500, inside [200, 3,200].
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
+
+        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+    }
+
+    [Test]
+    public async Task Budget_ClampsToFloor_WhenRateCollapses()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);
+
+        // 1,000 B/s × 10ms = 10 bytes — far below the floor.
+        EstablishRate(budget, bytesPerSecond: 1_000, rttSeconds: 0.001);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task Budget_ClampsToCap_WhenRateExplodes()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
+
+        // 1,000,000 B/s × 0.5s = 500,000 bytes — far above the cap.
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
+    }
+
+    [Test]
+    public async Task Budget_RttGuard_DominatesWhenRttExceedsTarget()
+    {
+        // Target 10ms but the measured round-trip is 100ms: the guard keeps the budget at
+        // 1.5 × BDP (rate × RTT) so throughput is never window-limited.
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.100);
+
+        // 100,000 B/s × max(0.010, 1.5 × 0.100) = 15,000 bytes (±tick-quantization of the RTT).
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(14_990);
+        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(15_010);
+    }
+
+    [Test]
+    public async Task Ewma_LongGapSample_SnapsToNewRate()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+
+        // A sample spanning 10s (≥ τ = 1s) gets alpha 1.0 — the EWMA snaps to the new rate
+        // instead of blending stale history.
+        budget.OnAcked(ackedBytes: 60_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_000); // 6,000 B/s × 0.5s
+    }
+
+    [Test]
+    public async Task Budget_RecoversWhenRateRises()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
+        var shrunken = budget.BudgetBytes;
+
+        // Faster drain in the next window must grow the budget back (no ratchet-down).
+        budget.OnAcked(ackedBytes: 12_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(2.0));
+
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(shrunken);
+    }
+
+    [Test]
+    public async Task SubMillisecondAcks_CarryIntoNextSample()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
+        // Sub-1ms since the anchor: bytes are carried, no sample folds, budget stays at cap.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(0.0001));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+
+        // The full window closes 1s after the anchor and includes the carried bytes.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(1.0));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500); // 3,000 B/s × 0.5s
+    }
+
+    [Test]
+    public async Task SetCap_RecomputesAndRepublishesBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
+
+        // Cold start follows the cap in both directions.
+        budget.SetCap(6_400);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_400);
+
+        // With a rate established, a cap below the computed budget clamps it...
+        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001); // budget 1,500
+        budget.SetCap(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+
+        // ...and raising the cap re-releases the computed value.
+        budget.SetCap(6_400);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+    }
+
+    [Test]
+    public async Task ChargeRelease_IsExactlyBalanced_UnderConcurrency()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);
+
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < 10_000; i++)
+            {
+                budget.Charge(17);
+                budget.Release(17);
+            }
+        })));
+
+        await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task IsOverBudget_TransitionsWithChargesAndReleases()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 100, initialCapBytes: 100);
+
+        await Assert.That(budget.IsOverBudget()).IsFalse();
+
+        budget.Charge(100);
+        await Assert.That(budget.IsOverBudget()).IsTrue();
+
+        budget.Release(1);
+        await Assert.That(budget.IsOverBudget()).IsFalse();
+        budget.Release(99);
+    }
+
+    [Test]
+    public async Task RecordAdmissionBlock_CountsEvents()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);
+
+        await Assert.That(budget.AdmissionBlockEvents).IsEqualTo(0);
+
+        budget.RecordAdmissionBlock();
+        budget.RecordAdmissionBlock();
+
+        await Assert.That(budget.AdmissionBlockEvents).IsEqualTo(2);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -94,11 +94,31 @@ public sealed class BrokerUnackedByteBudgetTests
         EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
 
-        // A sample spanning 10s (≥ τ = 1s) gets alpha 1.0 — the EWMA snaps to the new rate
-        // instead of blending stale history.
+        // Remaining unacked work means this is an active 10s sample rather than producer
+        // idle time. Alpha is 1.0, so the EWMA snaps to the new rate.
+        budget.Charge(1);
         budget.OnAcked(ackedBytes: 60_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+        budget.Release(1);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(3_000); // 6,000 B/s × 0.5s
+    }
+
+    [Test]
+    public async Task Ewma_IdleGap_ReanchorsWithoutCollapsingBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+
+        // With no remaining unacked work, the ten-second gap is producer idle time. The
+        // first resumed ack anchors a fresh window instead of appearing to drain at 100 B/s.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+
+        // The next active interval includes the anchor ack and publishes the resumed rate.
+        budget.OnAcked(ackedBytes: 99_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(12.0));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -122,6 +122,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task Ewma_IdleReanchor_PreservesSubMillisecondCarry()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(0.0001));
+
+        // Idle reanchor retains bytes accumulated before the minimum sample interval.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+        budget.OnAcked(ackedBytes: 97_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(12.0));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+    }
+
+    [Test]
     public async Task Budget_RecoversWhenRateRises()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -2865,13 +2865,18 @@ public class RecordAccumulatorTests
     }
 
     /// <summary>
-    /// Calls the private OnBatchEntersPipeline method via reflection.
+    /// Calls the private OnBatchEntersPipeline method via reflection, supplying a fresh
+    /// PartitionDeque (the method uses it only to cache the unacked-byte budget, which is
+    /// disabled in these tests because no leader resolver is wired).
     /// </summary>
     private static void InvokeOnBatchEntersPipeline(RecordAccumulator accumulator, ReadyBatch batch)
     {
+        var pdType = typeof(RecordAccumulator).GetNestedType("PartitionDeque",
+            System.Reflection.BindingFlags.NonPublic)!;
+        var pd = Activator.CreateInstance(pdType)!;
         var method = typeof(RecordAccumulator).GetMethod("OnBatchEntersPipeline",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        method!.Invoke(accumulator, [batch]);
+        method!.Invoke(accumulator, [pd, batch]);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3498,7 +3498,7 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task AppendFromSpansAsync_SealRefund_DrainsPendingAppendAfterPartitionLockReleased()
+    public async Task AppendFromSpansAsync_ReopenedMemory_PreservesPendingAppendFifo()
     {
         var options = new ProducerOptions
         {
@@ -3542,8 +3542,8 @@ public class RecordAccumulatorTests
 
             await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
 
-            // Free memory without draining. Hot append no longer refunds per-record
-            // overestimates; the pending append should wait for the seal-time refund.
+            // Free memory without draining. The next append must join behind the queued
+            // operation; its immediate drain serves the older append before completing.
             SetBufferedBytesForTest(accumulator, 3000);
 
             var hotResult = await accumulator.AppendFromSpansAsync(
@@ -3554,7 +3554,8 @@ public class RecordAccumulatorTests
                 null, 0, null, CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(hotResult).IsTrue();
-            await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
+            await Assert.That(await pendingAppendTask).IsTrue();
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
 
             var drainTask = Task.Run(async () =>
             {
@@ -3575,13 +3576,11 @@ public class RecordAccumulatorTests
             await accumulator.FlushAsync(cts.Token);
             await drainTask;
 
-            var pendingResult = await pendingAppendTask.WaitAsync(TimeSpan.FromSeconds(5));
-            await Assert.That(pendingResult).IsTrue();
         }
         finally
         {
-            var currentBatch = GetCurrentPartitionBatch(accumulator, topicPartition);
-            SetBufferedBytesForTest(accumulator, currentBatch.ReservedSize);
+            var currentBatch = GetCurrentPartitionBatchOrDefault(accumulator, topicPartition);
+            SetBufferedBytesForTest(accumulator, currentBatch?.ReservedSize ?? 0);
             await accumulator.DisposeAsync();
         }
     }
@@ -3613,10 +3612,16 @@ public class RecordAccumulatorTests
         => new(ProduceErrorKind.Purged, "purged");
 
     private static PartitionBatch GetCurrentPartitionBatch(RecordAccumulator accumulator, TopicPartition topicPartition)
+        => GetCurrentPartitionBatchOrDefault(accumulator, topicPartition)
+           ?? throw new InvalidOperationException("Partition deque has no current batch.");
+
+    private static PartitionBatch? GetCurrentPartitionBatchOrDefault(
+        RecordAccumulator accumulator,
+        TopicPartition topicPartition)
     {
         var partitionDeque = GetPartitionDeque(accumulator, topicPartition);
         var currentBatchField = partitionDeque.GetType().GetField("CurrentBatch");
-        return (PartitionBatch)currentBatchField!.GetValue(partitionDeque)!;
+        return (PartitionBatch?)currentBatchField!.GetValue(partitionDeque);
     }
 
     private static object GetPartitionDeque(RecordAccumulator accumulator, TopicPartition topicPartition)


### PR DESCRIPTION
## Summary

Fixes the 3-broker producer delivery-latency gate failures (p50 up to 20×, p99 up to 43× Confluent in stress run 29170234096) by bounding **unacknowledged bytes per broker at message admission**, sized adaptively from the measured ack drain rate.

- New `BrokerUnackedByteBudget` (one per broker): unacked bytes are **charged when a batch seals** (`OnBatchEntersPipeline`, under `pd.Lock`) and **released once on the batch's terminal path** (`OnBatchExitsPipeline`, guarded by the existing first-caller-wins `InFlightBatchListRemove`) — retries, reroutes, and sender crashes need no extra touch points because the batch stays unacked through all of them.
- Budget formula: `clamp(ewmaAckedBytesPerSec × max(target, 1.5 × ewmaRtt), floor, cap)` with `floor = max(2×BatchSize, 1MiB)`, `cap = BatchSize × 32 × connectionCount` (the existing pipeline ceiling). Cold start = cap, so short-lived producers and existing tests see no behavior change. The RTT guard keeps the budget ≥ 1.5× the bandwidth-delay product so throughput is never window-limited (no ratchet-down spiral on high-latency links).
- The EWMA is fed O(1), allocation-free from `ProcessCompletedResponses` using `PendingResponse.EncodedBytes`/`RequestStartTime`; faulted responses are excluded from the drain estimate.
- Admission: all four append entry points check the destination broker's budget before `TryReserveMemory`; over-budget appends take the existing `PendingAppend` backpressure path (MaxBlockMs deadline, cancellation, `KafkaTimeoutException(TimeoutKind.MaxBlock)`) — identical semantics to BufferMemory exhaustion. Acks wake blocked appenders through the existing `DrainPendingAppends`/`SignalBufferSpaceAvailable` machinery.
- Adaptive scaling integration: the gate holds `BufferUtilization` near zero, which would starve scale-up and self-limit the drain rate — blocked-admission events now feed the Phase-2 scale-up trigger (delta vs the scale-up snapshot, accumulating across failed grows like `_lastPressureSnapshot`), and scale-down is vetoed while blocks were observed within the existing `_scaleDownSustainedMs` window (time-based recency, so a workload pinned at the connection ceiling doesn't veto shrink forever).
- New public option `DeliveryLatencyTargetMs` (default **10 ms**, `0` disables) + `WithDeliveryLatencyTarget(TimeSpan)`; internal `UnackedByteBudgetCapOverride` test knob. Docs updated.

## Why admission, not the pipeline

#1818 bounds *written-but-unacked* bytes, but BufferMemory is refunded at socket-write time (`SendCoalescedAsync` → `ReleaseBatchMemory`), so under open-loop saturation the queue pools **upstream** as appended-but-unwritten bytes bounded only by BufferMemory (512MB in stress). In the failing acks-all scenario the producer is non-idempotent (mute-on-send ⇒ ~2MB/broker in the pipeline), so the ~46MB standing queue implied by p50=124.65ms lives almost entirely upstream: shrinking the pipeline bound cannot fix append→ack latency. Little's law: p50 ≈ standing bytes ÷ per-broker drain (~370MB/s) — the ≤2×-Confluent gate (~13ms) needs ≲5MB standing per broker, which only an admission-level bound delivers (10ms × 370MB/s ≈ 3.7MB).

## Expected impact

- 3-broker scenarios (broker-bound): standing queue capped at ~`target × drain` ⇒ p50 ≈ max(target, 1.5×RTT) ≈ 10–12ms vs gate limit ~13ms.
- 1-broker scenarios (client-bound): queues stay far below budget; the gate never binds — Dekaf's existing 1-broker latency win is preserved. Throughput guarded by the floor + RTT guard + cold-start-at-cap.
- Behavior change to note: against a stalled/acking-slowly broker, admission now blocks at ~budget instead of buffering up to BufferMemory. That is the intended semantics (bounded latency), and `WithDeliveryLatencyTarget(TimeSpan.Zero)` restores the old behavior.

## Known limitations (follow-ups)

- Charge uses uncompressed `DataSize` while the drain rate uses wire `EncodedBytes` — conservative under compression (tighter latency than target).
- A rerouted batch stays charged to its seal-time broker until terminal — bounded and self-correcting at the next seal.

## Validation

- Release build: 0 warnings, 0 errors.
- Unit suite: 5,180/5,180 passed (includes 24 new tests: budget state machine, admission gate block/unblock/timeout/cancellation/leader-unknown/disabled, send-loop EWMA feed, faulted-response exclusion, admission-pressure scale-up).
- Focused producer integration categories green locally (Docker).
- **CI stress gates are authoritative** for the latency fix itself (same as #1818): the 3-broker `Delivery latency p50/p99 / Confluent ≤ 2.00` rows in the next scheduled stress run validate this change end-to-end.

Closes #1821
