### PR TITLE
Restore high-throughput consumer fetch parallelism

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2248,6 +2248,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <item><description>FetchMaxBytes: 100MB (allow larger total fetch responses; note that the response buffer pool
     /// may retain up to 8 arrays of this size per consumer instance)</description></item>
     /// <item><description>PrefetchPipelineDepth: 5 (aggressive prefetching to hide network latency)</description></item>
+    /// <item><description>ConnectionsPerBroker: 3 for standalone consumers (two fetch connections plus one coordination connection)</description></item>
     /// <item><description>AdaptiveFetchSizing: enabled (auto-grows fetch sizes when consumer keeps up, shrinks under prefetch memory pressure)</description></item>
     /// <item><description>CheckCrcs: disabled (skips client-side CRC32C re-validation of fetched batches; TCP checksums and
     /// broker-side validation already cover corruption in transit — matches librdkafka's default. Re-enable with
@@ -2268,6 +2269,14 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _fetchMaxBytes = 100 * 1024 * 1024;
         _prefetchPipelineDepth = 5;
         _checkCrcs = false;
+        if (_clientInfrastructure is null)
+        {
+            // Start with two usable fetch connections. Waiting for adaptive scale-up left
+            // high-throughput consumers under-provisioned after routing transitions were
+            // made partition-affine; the third connection remains isolated for coordination.
+            _connectionsPerBroker = 3;
+            _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, 3);
+        }
         _enableAdaptiveFetchSizing = true; // Intentional: ForHighThroughput always enables adaptive sizing
         if (_adaptiveFetchSizingOptions is null || _usesHighThroughputAdaptiveDefaults)
         {

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -383,6 +383,50 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_StartsWithTwoFetchConnections()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(3);
+        await Assert.That(options.EnableAdaptiveConnections).IsTrue();
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task ForHighThroughput_PreservesConnectionInvariantAfterLowerAdaptiveMaximum()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAdaptiveConnections(2)
+            .ForHighThroughput()
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(3);
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ForHighThroughput_ThenConnectionOverride_UsesOverride()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .WithConnectionsPerBroker(2)
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ForHighThroughput_AdaptiveFloorsMatchPresetFetchSizes()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()


### PR DESCRIPTION
## Summary
- start standalone `ForHighThroughput` consumers with three broker connections: two fetch connections plus one coordination connection
- preserve KafkaClient-owned connection settings and caller overrides applied after the preset
- keep adaptive maximum valid when a lower maximum was configured before the preset

## Root cause and performance evidence
#1815 correctly made routing transitions partition-affine. The previous 2-connection preset had only one usable fetch connection and depended on unsafe eager routing during adaptive scale-up for its old throughput.

The next scheduled run 29177729437 confirmed a second consecutive regression: consumer-raw 2.97M msg/s / 0.460 us/msg; consumer-batch 3.15M / 0.499 us/msg.

Controlled same-host 1-minute, 3-broker raw runs with 200k replay messages:

| Variant | msg/s | CPU us/msg |
|---|---:|---:|
| pre-#1815 baseline | 585,617 | 1.452 |
| current main | 486,761 | 1.310 |
| fixed initial 3 connections | 643,541 | 1.290 |

The fix is +32.2% over current and +9.9% over the pre-#1815 baseline while retaining the ordering fix.

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `ConsumerBuilderValidationTests` net10.0: 48 passed
- [x] `ConsumerBuilderValidationTests` net8.0: 48 passed
- [x] `ConsumerConnectionScalingTests` net10.0: 15 passed
- [x] `ConsumerConnectionOwnershipTests` net10.0: 16 passed
- [x] controlled local stress comparison above

Local single-broker Testcontainers cannot run this consumer scenario because its cp-kafka 7.8.0 configuration rejects `ConsumerGroupHeartbeat`; follow-up #1846 records that harness bug. CI's Apache Kafka 4.3.1 path is unaffected.

Closes #1825
