### PR TITLE
Fix single-broker KIP-848 stress setup

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/KafkaEnvironmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/KafkaEnvironmentTests.cs
@@ -1,0 +1,20 @@
+using Dekaf.StressTests.Infrastructure;
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class KafkaEnvironmentTests
+{
+    [Test]
+    public async Task SingleBrokerConfiguration_EnablesKip848ConsumerProtocol()
+    {
+        await Assert.That(KafkaEnvironment.SingleBrokerImage)
+            .IsEqualTo("confluentinc/cp-kafka:7.8.0");
+        await Assert.That(KafkaEnvironment.SingleBrokerConsensusProtocol)
+            .IsEqualTo(ConsensusProtocol.KRaft);
+        await Assert.That(KafkaEnvironment.SingleBrokerEnvironment)
+            .ContainsKey("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS");
+        await Assert.That(KafkaEnvironment.SingleBrokerEnvironment["KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS"])
+            .IsEqualTo("classic,consumer");
+    }
+}

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -14,6 +14,17 @@ namespace Dekaf.StressTests.Infrastructure;
 /// </summary>
 internal sealed class KafkaEnvironment : IAsyncDisposable
 {
+    internal const string SingleBrokerImage = "confluentinc/cp-kafka:7.8.0";
+    internal static ConsensusProtocol SingleBrokerConsensusProtocol { get; } = ConsensusProtocol.KRaft;
+
+    internal static IReadOnlyDictionary<string, string> SingleBrokerEnvironment { get; } =
+        new Dictionary<string, string>
+        {
+            // Kafka 3.8 ships KIP-848 disabled by default. Dekaf defaults to the
+            // consumer protocol, so local consumer stress runs must enable it.
+            ["KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS"] = "classic,consumer",
+        };
+
     // Retention tuned to balance two constraints:
     // 1. Original 5s retention was too aggressive — caused constant "offset out of range" resets
     // 2. Long time-based retention (e.g. 30 min) would retain ~360 GB at high throughput,
@@ -144,11 +155,24 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
         Console.WriteLine("Starting Kafka container via Testcontainers...");
         // 7.8.x = Kafka 3.8, the first release with log.initial.task.delay.ms — see
         // RetentionConfig; older images silently ignore it and die on tmpfs fill.
-        var builder = new KafkaBuilder("confluentinc/cp-kafka:7.8.0")
+        var builder = new KafkaBuilder(SingleBrokerImage);
+        builder = SingleBrokerConsensusProtocol switch
+        {
+            ConsensusProtocol.KRaft => builder.WithKRaft(),
+            ConsensusProtocol.ZooKeeper => builder,
+            _ => throw new ArgumentOutOfRangeException(nameof(SingleBrokerConsensusProtocol)),
+        };
+
+        builder = builder
             .WithPortBinding(9092, true)
             // Explicit log dir so the optional tmpfs mount target always matches
             .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
             .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
+
+        foreach (var (key, value) in SingleBrokerEnvironment)
+        {
+            builder = builder.WithEnvironment(key, value);
+        }
 
         foreach (var (key, value) in RetentionConfig)
         {


### PR DESCRIPTION
## Summary
- run the existing cp-kafka 7.8.0 single-broker stress image in KRaft mode
- enable both classic and KIP-848 consumer rebalance protocols
- lock the selected image, consensus mode, and broker protocol configuration with a unit regression

## Root cause
Kafka 3.8 exposes `ConsumerGroupHeartbeat`, but its `consumer` rebalance protocol is disabled by default and supported only in KRaft mode. The stress harness used Testcontainers KafkaBuilder's ZooKeeper default, so enabling the protocol alone made broker startup fail. KRaft plus `group.coordinator.rebalance.protocols=classic,consumer` lets Dekaf's default consumer join.

## Test plan
- [x] multi-target unit build: 0 warnings/errors
- [x] focused `KafkaEnvironmentTests`: 1/1 passed
- [x] full net10 unit suite: 5,160/5,160 passed
- [x] one-minute local single-broker `consumer-raw`: 9,972,435 consumed, zero errors
- [x] one-minute local single-broker `producer`: 15,239,937 accepted and broker-confirmed, 100% delivery, zero errors

Closes #1846
