### PR TITLE
feat(stress): correlate delivery stalls

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -441,6 +441,107 @@ def format_connection_scale_timeline(results, title):
     return lines
 
 
+def format_latency_outlier_timeline(results, title):
+    """Correlate sampled delivery stalls with scaling, throughput, and GC."""
+    rows = [
+        (result, sample)
+        for result in results
+        for sample in (result.get('latency') or {}).get('outlierSamples') or []
+    ]
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('startedAtUtc', ''))
+    lines = [
+        f"## Delivery Latency Outliers - {title}",
+        "",
+        "| Client | Message | Started UTC | Latency | Correlated owner | Scale events in stall | Throughput interval | GC interval delta |",
+        "|--------|--------:|-------------|--------:|------------------|-----------------------|---------------------|-------------------|",
+    ]
+    for result, outlier in rows:
+        started_at = _parse_timestamp(outlier.get('startedAtUtc'))
+        completed_at = _parse_timestamp(outlier.get('completedAtUtc'))
+        scale_events = []
+        for event in (result.get('producerDeliveryDiagnostics') or {}).get('connectionScaleEvents') or []:
+            occurred_at = _parse_timestamp(event.get('occurredAtUtc'))
+            if started_at is not None and completed_at is not None and occurred_at is not None:
+                if started_at <= occurred_at <= completed_at:
+                    scale_events.append(event)
+
+        timestamped_samples = sorted(
+            (
+                (sample, captured_at)
+                for sample in (result.get('throughput') or {}).get('intervalSamples') or []
+                if (captured_at := _parse_timestamp(sample.get('capturedAtUtc'))) is not None
+            ),
+            key=lambda item: item[1],
+        )
+        completion_sample = None
+        if completed_at is not None:
+            completion_sample = next(
+                (item for item in timestamped_samples if item[1] >= completed_at),
+                min(
+                    timestamped_samples,
+                    key=lambda item: abs((item[1] - completed_at).total_seconds()),
+                    default=None,
+                ),
+            )
+        baseline_sample = None
+        if started_at is not None:
+            baseline_sample = next(
+                (item for item in reversed(timestamped_samples) if item[1] <= started_at),
+                None,
+            )
+
+        completion = completion_sample[0] if completion_sample else None
+        baseline = baseline_sample[0] if baseline_sample else {}
+        gen2_delta = max(0, (completion or {}).get('gen2Collections', 0) - baseline.get('gen2Collections', 0))
+        pause_delta_ms = max(0, (completion or {}).get('gcPauseDurationMs', 0) - baseline.get('gcPauseDurationMs', 0))
+        client_rate = result.get('medianIntervalMessagesPerSecond')
+        if not isinstance(client_rate, (int, float)):
+            client_rate = (result.get('throughput') or {}).get('averageMessagesPerSecond', 0)
+
+        if scale_events:
+            owner = 'connection transition'
+        elif gen2_delta > 0 or pause_delta_ms >= 10:
+            owner = 'GC pause'
+        elif completion is not None and completion.get('messagesPerSecond', 0) < client_rate * 0.5:
+            owner = 'throughput collapse'
+        else:
+            owner = 'broker/backlog (no scale or GC event)'
+
+        scale_summary = '-'
+        if scale_events:
+            scale_summary = ', '.join(
+                f"{event.get('brokerId', '-')}:{event.get('oldConnectionCount', '-')}→{event.get('newConnectionCount', '-')}"
+                for event in scale_events
+            )
+        throughput_summary = '-'
+        gc_summary = '-'
+        if completion is not None:
+            throughput_summary = (
+                f"{completion.get('elapsedSeconds', 0):.1f}s / "
+                f"{completion.get('messagesPerSecond', 0):,.0f} msg/s"
+            )
+            gc_summary = f"Gen2 +{gen2_delta:,} / pause +{pause_delta_ms:.1f}ms"
+        latency_us = outlier.get('latencyUs', 0)
+        latency_text = f"{latency_us / 1_000_000:.1f}s" if latency_us >= 1_000_000 else f"{latency_us / 1000:.1f}ms"
+        message_index = outlier.get('messageIndex')
+        message_text = '-' if message_index is None else f"{message_index:,}"
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {message_text} | "
+            f"{outlier.get('startedAtUtc', '-')} | {latency_text} | {owner} | "
+            f"{scale_summary} | {throughput_summary} | {gc_summary} |"
+        )
+
+    lines.append("")
+    dropped = sum((result.get('latency') or {}).get('droppedOutlierSamples', 0) for result in results)
+    if dropped > 0:
+        lines.append(f"*{dropped:,} additional latency outlier sample(s) exceeded the bounded diagnostic capacity.*")
+        lines.append("")
+    return lines
+
+
 def _parse_timestamp(value):
     if not isinstance(value, str):
         return None
@@ -627,6 +728,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
             output.extend(format_connection_scale_timeline(scenario_results, title))
+            output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))
             if include_callout:

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -67,6 +67,43 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("20.0s / 2,000 msg/s", report)
         self.assertIn("120/150", report)
 
+    def test_scenario_tables_surface_latency_outlier_diagnostics(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["scenario"] = "producer"
+        value["throughput"]["intervalSamples"] = [
+            {
+                "capturedAtUtc": "2026-07-12T02:20:42+00:00",
+                "elapsedSeconds": 2.0,
+                "messagesPerSecond": 1400.0,
+                "gen2Collections": 0,
+                "gcPauseDurationMs": 0,
+            },
+            {
+                "capturedAtUtc": "2026-07-12T02:20:46+00:00",
+                "elapsedSeconds": 6.0,
+                "messagesPerSecond": 1300.0,
+                "gen2Collections": 1,
+                "gcPauseDurationMs": 12.5,
+            },
+        ]
+        value["latency"] = {
+            "droppedOutlierSamples": 2,
+            "outlierSamples": [{
+                "messageIndex": 42,
+                "startedAtUtc": "2026-07-12T02:20:44+00:00",
+                "completedAtUtc": "2026-07-12T02:20:46+00:00",
+                "latencyUs": 2_000_000,
+            }],
+        }
+
+        report = "\n".join(generate_scenario_tables([value]))
+
+        self.assertIn("Delivery Latency Outliers", report)
+        self.assertIn("| Dekaf | 42 |", report)
+        self.assertIn("GC pause", report)
+        self.assertIn("Gen2 +1 / pause +12.5ms", report)
+        self.assertIn("2 additional latency outlier sample(s)", report)
+
     def test_paired_latency_thresholds_flag_high_p99(self):
         confluent = stress_result("Confluent", effective_rate=1000)
         confluent.update({

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -53,6 +53,14 @@ public sealed class ConnectionScaleReportingTests
                         MessagesPerSecond = 2_400,
                         Gen2Collections = 2,
                         GcPauseDurationMs = 25
+                    },
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(14),
+                        ElapsedSeconds = 14,
+                        MessagesPerSecond = 2_300,
+                        Gen2Collections = 3,
+                        GcPauseDurationMs = 37.5
                     }
                 ]
             },
@@ -65,6 +73,7 @@ public sealed class ConnectionScaleReportingTests
                 P95Us = 2_000_000,
                 P99Us = 2_000_000,
                 OverflowCount = 0,
+                DroppedOutlierSamples = 3,
                 OutlierSamples =
                 [
                     new LatencyOutlierSample
@@ -80,6 +89,13 @@ public sealed class ConnectionScaleReportingTests
                         StartedAtUtc = startedAt.AddSeconds(8),
                         CompletedAtUtc = startedAt.AddSeconds(10),
                         LatencyUs = 2_000_000
+                    },
+                    new LatencyOutlierSample
+                    {
+                        MessageIndex = 44,
+                        StartedAtUtc = startedAt.AddSeconds(7),
+                        CompletedAtUtc = startedAt.AddSeconds(14),
+                        LatencyUs = 7_000_000
                     }
                 ]
             },
@@ -131,5 +147,8 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("Gen2 +1 / pause +12.5ms");
         await Assert.That(markdown).Contains("43");
         await Assert.That(markdown).Contains("GC pause");
+        await Assert.That(markdown).Contains("44");
+        await Assert.That(markdown).Contains("Gen2 +2 / pause +25.0ms");
+        await Assert.That(markdown).Contains("3 additional latency outlier sample(s) exceeded the bounded diagnostic capacity");
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -61,6 +61,14 @@ public sealed class ConnectionScaleReportingTests
                         MessagesPerSecond = 2_300,
                         Gen2Collections = 3,
                         GcPauseDurationMs = 37.5
+                    },
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(18),
+                        ElapsedSeconds = 18,
+                        MessagesPerSecond = 400,
+                        Gen2Collections = 3,
+                        GcPauseDurationMs = 37.5
                     }
                 ]
             },
@@ -96,6 +104,13 @@ public sealed class ConnectionScaleReportingTests
                         StartedAtUtc = startedAt.AddSeconds(7),
                         CompletedAtUtc = startedAt.AddSeconds(14),
                         LatencyUs = 7_000_000
+                    },
+                    new LatencyOutlierSample
+                    {
+                        MessageIndex = 45,
+                        StartedAtUtc = startedAt.AddSeconds(15),
+                        CompletedAtUtc = startedAt.AddSeconds(18),
+                        LatencyUs = 3_000_000
                     }
                 ]
             },
@@ -149,6 +164,7 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("GC pause");
         await Assert.That(markdown).Contains("44");
         await Assert.That(markdown).Contains("Gen2 +2 / pause +25.0ms");
+        await Assert.That(markdown).Contains("| Dekaf | 45 | 02:00:15.000 | 3.0s | throughput collapse |");
         await Assert.That(markdown).Contains("3 additional latency outlier sample(s) exceeded the bounded diagnostic capacity");
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -34,13 +34,52 @@ public sealed class ConnectionScaleReportingTests
                     {
                         CapturedAtUtc = startedAt.AddSeconds(2),
                         ElapsedSeconds = 2,
-                        MessagesPerSecond = 1_000
+                        MessagesPerSecond = 1_000,
+                        Gen2Collections = 0,
+                        GcPauseDurationMs = 0
                     },
                     new ThroughputIntervalSample
                     {
                         CapturedAtUtc = startedAt.AddSeconds(6),
                         ElapsedSeconds = 6,
-                        MessagesPerSecond = 2_500
+                        MessagesPerSecond = 2_500,
+                        Gen2Collections = 1,
+                        GcPauseDurationMs = 12.5
+                    },
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(10),
+                        ElapsedSeconds = 10,
+                        MessagesPerSecond = 2_400,
+                        Gen2Collections = 2,
+                        GcPauseDurationMs = 25
+                    }
+                ]
+            },
+            Latency = new LatencySnapshot
+            {
+                Count = 1,
+                MinUs = 2_000_000,
+                MaxUs = 2_000_000,
+                P50Us = 2_000_000,
+                P95Us = 2_000_000,
+                P99Us = 2_000_000,
+                OverflowCount = 0,
+                OutlierSamples =
+                [
+                    new LatencyOutlierSample
+                    {
+                        MessageIndex = 42,
+                        StartedAtUtc = startedAt.AddSeconds(4),
+                        CompletedAtUtc = startedAt.AddSeconds(6),
+                        LatencyUs = 2_000_000
+                    },
+                    new LatencyOutlierSample
+                    {
+                        MessageIndex = 43,
+                        StartedAtUtc = startedAt.AddSeconds(8),
+                        CompletedAtUtc = startedAt.AddSeconds(10),
+                        LatencyUs = 2_000_000
                     }
                 ]
             },
@@ -86,5 +125,11 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("75%");
         await Assert.That(markdown).Contains("120/340");
         await Assert.That(markdown).Contains("6.0s / 2,500 msg/s");
+        await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
+        await Assert.That(markdown).Contains("42");
+        await Assert.That(markdown).Contains("connection transition");
+        await Assert.That(markdown).Contains("Gen2 +1 / pause +12.5ms");
+        await Assert.That(markdown).Contains("43");
+        await Assert.That(markdown).Contains("GC pause");
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class LatencyTrackerTests
+{
+    [Test]
+    public async Task RecordTicks_AboveOneSecond_CapturesOutlierContext()
+    {
+        var tracker = new LatencyTracker();
+
+        tracker.RecordTicks(Stopwatch.Frequency * 2, messageIndex: 42);
+
+        var snapshot = tracker.GetSnapshot();
+        await Assert.That(snapshot.OutlierSamples).Count().IsEqualTo(1);
+        var sample = snapshot.OutlierSamples[0];
+        await Assert.That(sample.MessageIndex).IsEqualTo(42);
+        await Assert.That(sample.LatencyUs).IsBetween(1_999_000, 2_001_000);
+        await Assert.That(sample.CompletedAtUtc - sample.StartedAtUtc)
+            .IsBetween(TimeSpan.FromMilliseconds(1_999), TimeSpan.FromMilliseconds(2_001));
+        await Assert.That(snapshot.DroppedOutlierSamples).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordTicks_BelowOneSecond_DoesNotCaptureOutlier()
+    {
+        var tracker = new LatencyTracker();
+
+        tracker.RecordTicks(Stopwatch.Frequency - 1, messageIndex: 42);
+
+        var snapshot = tracker.GetSnapshot();
+        await Assert.That(snapshot.OutlierSamples).IsEmpty();
+        await Assert.That(snapshot.DroppedOutlierSamples).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RecordTicks_AboveDiagnosticCapacity_TracksDroppedCount()
+    {
+        var tracker = new LatencyTracker();
+        for (var index = 0; index < 257; index++)
+        {
+            tracker.RecordTicks(Stopwatch.Frequency, messageIndex: index);
+        }
+
+        var snapshot = tracker.GetSnapshot();
+        await Assert.That(snapshot.OutlierSamples).Count().IsEqualTo(256);
+        await Assert.That(snapshot.DroppedOutlierSamples).IsEqualTo(1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
@@ -47,4 +47,24 @@ public sealed class LatencyTrackerTests
         await Assert.That(snapshot.OutlierSamples).Count().IsEqualTo(256);
         await Assert.That(snapshot.DroppedOutlierSamples).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task GetSnapshot_ConcurrentWithOutliers_NeverPublishesDefaultSample()
+    {
+        var tracker = new LatencyTracker();
+        var recording = Task.Run(() => Parallel.For(0, 10_000, index =>
+            tracker.RecordTicks(Stopwatch.Frequency, messageIndex: index)));
+
+        while (!recording.IsCompleted)
+        {
+            var snapshot = tracker.GetSnapshot();
+            await Assert.That(snapshot.OutlierSamples.All(
+                sample => sample.StartedAtUtc != default && sample.LatencyUs > 0)).IsTrue();
+        }
+
+        await recording;
+        var completed = tracker.GetSnapshot();
+        await Assert.That(completed.OutlierSamples.All(
+            sample => sample.StartedAtUtc != default && sample.LatencyUs > 0)).IsTrue();
+    }
 }

--- a/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
@@ -15,6 +15,7 @@ internal sealed class LatencyTracker
     private static readonly long OutlierThresholdTicks = Stopwatch.Frequency;
 
     private readonly long[] _buckets;
+    private readonly object _outlierLock = new();
     private readonly LatencyOutlierSample[] _outlierSamples = new LatencyOutlierSample[MaxOutlierSamples];
     private readonly double _bucketWidthUs;
     private readonly double _maxValueUs;
@@ -63,21 +64,24 @@ internal sealed class LatencyTracker
 
     private void RecordOutlier(long ticks, long? messageIndex)
     {
-        var slot = Interlocked.Increment(ref _outlierCount) - 1;
-        if ((ulong)slot >= MaxOutlierSamples)
+        lock (_outlierLock)
         {
-            return;
-        }
+            var slot = _outlierCount++;
+            if ((ulong)slot >= MaxOutlierSamples)
+            {
+                return;
+            }
 
-        var completedAt = DateTimeOffset.UtcNow;
-        var latency = Stopwatch.GetElapsedTime(0, ticks);
-        _outlierSamples[slot] = new LatencyOutlierSample
-        {
-            MessageIndex = messageIndex,
-            StartedAtUtc = completedAt - latency,
-            CompletedAtUtc = completedAt,
-            LatencyUs = latency.TotalMicroseconds
-        };
+            var completedAt = DateTimeOffset.UtcNow;
+            var latency = Stopwatch.GetElapsedTime(0, ticks);
+            _outlierSamples[slot] = new LatencyOutlierSample
+            {
+                MessageIndex = messageIndex,
+                StartedAtUtc = completedAt - latency,
+                CompletedAtUtc = completedAt,
+                LatencyUs = latency.TotalMicroseconds
+            };
+        }
     }
 
     public void Record(double milliseconds)
@@ -163,12 +167,18 @@ internal sealed class LatencyTracker
         var maxTicks = Interlocked.Read(ref _maxTicks);
         var (p50, p95, p99) = GetPercentilesUs();
 
-        var outlierCount = Interlocked.Read(ref _outlierCount);
-        var capturedOutlierCount = (int)Math.Min(outlierCount, MaxOutlierSamples);
-        var outlierSamples = new List<LatencyOutlierSample>(capturedOutlierCount);
-        for (var index = 0; index < capturedOutlierCount; index++)
+        List<LatencyOutlierSample> outlierSamples;
+        long droppedOutlierSamples;
+        lock (_outlierLock)
         {
-            outlierSamples.Add(_outlierSamples[index]);
+            var capturedOutlierCount = (int)Math.Min(_outlierCount, MaxOutlierSamples);
+            outlierSamples = new List<LatencyOutlierSample>(capturedOutlierCount);
+            for (var index = 0; index < capturedOutlierCount; index++)
+            {
+                outlierSamples.Add(_outlierSamples[index]);
+            }
+
+            droppedOutlierSamples = Math.Max(0, _outlierCount - MaxOutlierSamples);
         }
 
         return new LatencySnapshot
@@ -181,7 +191,7 @@ internal sealed class LatencyTracker
             P99Us = p99,
             OverflowCount = Interlocked.Read(ref _overflowCount),
             OutlierSamples = outlierSamples,
-            DroppedOutlierSamples = Math.Max(0, outlierCount - MaxOutlierSamples)
+            DroppedOutlierSamples = droppedOutlierSamples
         };
     }
 

--- a/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
@@ -11,13 +11,18 @@ namespace Dekaf.StressTests.Metrics;
 /// </summary>
 internal sealed class LatencyTracker
 {
+    private const int MaxOutlierSamples = 256;
+    private static readonly long OutlierThresholdTicks = Stopwatch.Frequency;
+
     private readonly long[] _buckets;
+    private readonly LatencyOutlierSample[] _outlierSamples = new LatencyOutlierSample[MaxOutlierSamples];
     private readonly double _bucketWidthUs;
     private readonly double _maxValueUs;
     private long _count;
     private long _overflowCount;
     private long _minTicks = long.MaxValue;
     private long _maxTicks;
+    private long _outlierCount;
 
     /// <param name="maxValueMs">Upper bound of the histogram in milliseconds. Values above this are counted as overflow.</param>
     /// <param name="bucketWidthUs">Width of each bucket in microseconds. Smaller = higher resolution but more memory.</param>
@@ -29,10 +34,15 @@ internal sealed class LatencyTracker
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void RecordTicks(long ticks)
+    public void RecordTicks(long ticks, long? messageIndex = null)
     {
         Interlocked.Increment(ref _count);
         UpdateMinMax(ticks);
+
+        if (ticks >= OutlierThresholdTicks)
+        {
+            RecordOutlier(ticks, messageIndex);
+        }
 
         var microseconds = ticks * 1_000_000.0 / Stopwatch.Frequency;
 
@@ -49,6 +59,25 @@ internal sealed class LatencyTracker
         }
 
         Interlocked.Increment(ref _buckets[bucketIndex]);
+    }
+
+    private void RecordOutlier(long ticks, long? messageIndex)
+    {
+        var slot = Interlocked.Increment(ref _outlierCount) - 1;
+        if ((ulong)slot >= MaxOutlierSamples)
+        {
+            return;
+        }
+
+        var completedAt = DateTimeOffset.UtcNow;
+        var latency = Stopwatch.GetElapsedTime(0, ticks);
+        _outlierSamples[slot] = new LatencyOutlierSample
+        {
+            MessageIndex = messageIndex,
+            StartedAtUtc = completedAt - latency,
+            CompletedAtUtc = completedAt,
+            LatencyUs = latency.TotalMicroseconds
+        };
     }
 
     public void Record(double milliseconds)
@@ -134,6 +163,14 @@ internal sealed class LatencyTracker
         var maxTicks = Interlocked.Read(ref _maxTicks);
         var (p50, p95, p99) = GetPercentilesUs();
 
+        var outlierCount = Interlocked.Read(ref _outlierCount);
+        var capturedOutlierCount = (int)Math.Min(outlierCount, MaxOutlierSamples);
+        var outlierSamples = new List<LatencyOutlierSample>(capturedOutlierCount);
+        for (var index = 0; index < capturedOutlierCount; index++)
+        {
+            outlierSamples.Add(_outlierSamples[index]);
+        }
+
         return new LatencySnapshot
         {
             Count = Interlocked.Read(ref _count),
@@ -142,7 +179,9 @@ internal sealed class LatencyTracker
             P50Us = p50,
             P95Us = p95,
             P99Us = p99,
-            OverflowCount = Interlocked.Read(ref _overflowCount)
+            OverflowCount = Interlocked.Read(ref _overflowCount),
+            OutlierSamples = outlierSamples,
+            DroppedOutlierSamples = Math.Max(0, outlierCount - MaxOutlierSamples)
         };
     }
 
@@ -159,6 +198,8 @@ internal sealed class LatencySnapshot
     public required double P95Us { get; init; }
     public required double P99Us { get; init; }
     public required long OverflowCount { get; init; }
+    public List<LatencyOutlierSample> OutlierSamples { get; init; } = [];
+    public long DroppedOutlierSamples { get; init; }
 
     // Convenience properties for backward compatibility (excluded from JSON output)
     [JsonIgnore] public double MinMs => MinUs / 1000.0;
@@ -166,4 +207,12 @@ internal sealed class LatencySnapshot
     [JsonIgnore] public double P50Ms => P50Us / 1000.0;
     [JsonIgnore] public double P95Ms => P95Us / 1000.0;
     [JsonIgnore] public double P99Ms => P99Us / 1000.0;
+}
+
+internal readonly record struct LatencyOutlierSample
+{
+    public long? MessageIndex { get; init; }
+    public required DateTimeOffset StartedAtUtc { get; init; }
+    public required DateTimeOffset CompletedAtUtc { get; init; }
+    public required double LatencyUs { get; init; }
 }

--- a/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ThroughputTracker.cs
@@ -28,6 +28,10 @@ internal sealed class ThroughputTracker
     private double _sampledElapsedSeconds;
     private TimeSpan _cpuTimeStart;
     private double _cpuTimeSeconds;
+    private int _startGen0Collections;
+    private int _startGen1Collections;
+    private int _startGen2Collections;
+    private double _startGcPauseDurationMs;
 
     public long MessageCount => Interlocked.Read(ref _messageCount);
     public long ByteCount => Interlocked.Read(ref _byteCount);
@@ -49,6 +53,10 @@ internal sealed class ThroughputTracker
         _lastSampleTimestamp = Stopwatch.GetTimestamp();
         _lastSampleMessageCount = 0;
         _sampledElapsedSeconds = 0;
+        _startGen0Collections = GC.CollectionCount(0);
+        _startGen1Collections = GC.CollectionCount(1);
+        _startGen2Collections = GC.CollectionCount(2);
+        _startGcPauseDurationMs = GC.GetTotalPauseDuration().TotalMilliseconds;
     }
 
     public void Stop()
@@ -201,7 +209,13 @@ internal sealed class ThroughputTracker
                 {
                     CapturedAtUtc = DateTimeOffset.UtcNow,
                     ElapsedSeconds = _stopwatch.Elapsed.TotalSeconds,
-                    MessagesPerSecond = rate
+                    MessagesPerSecond = rate,
+                    Gen0Collections = GC.CollectionCount(0) - _startGen0Collections,
+                    Gen1Collections = GC.CollectionCount(1) - _startGen1Collections,
+                    Gen2Collections = GC.CollectionCount(2) - _startGen2Collections,
+                    GcPauseDurationMs = Math.Max(
+                        0,
+                        GC.GetTotalPauseDuration().TotalMilliseconds - _startGcPauseDurationMs)
                 });
                 _sampledElapsedSeconds += elapsedSeconds;
             }
@@ -303,6 +317,10 @@ internal sealed class ThroughputIntervalSample
     public required DateTimeOffset CapturedAtUtc { get; init; }
     public required double ElapsedSeconds { get; init; }
     public required double MessagesPerSecond { get; init; }
+    public int Gen0Collections { get; init; }
+    public int Gen1Collections { get; init; }
+    public int Gen2Collections { get; init; }
+    public double GcPauseDurationMs { get; init; }
 }
 
 internal sealed class ThroughputErrorSample

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Dekaf.StressTests.Metrics;
 
 namespace Dekaf.StressTests.Reporting;
 
@@ -27,6 +28,7 @@ internal static class MarkdownReporter
 
             GenerateThroughputTable(sb, title, groupResults);
             GenerateConnectionScaleTimeline(sb, groupResults, label);
+            GenerateLatencyOutlierTimeline(sb, groupResults, label);
 
             var transactionalResults = groupResults
                 .Where(r => r.TransactionVerification is not null)
@@ -197,6 +199,94 @@ internal static class MarkdownReporter
 
     private static double ComparisonMessagesPerSecond(StressTestResult result) =>
         result.MedianIntervalMessagesPerSecond ?? result.EffectiveMessagesPerSecond;
+
+    private static void GenerateLatencyOutlierTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.Latency?.OutlierSamples ?? [])
+                .Select(sample => (Result: result, Sample: sample)))
+            .OrderBy(row => row.Sample.StartedAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        sb.AppendLine($"## Delivery Latency Outliers - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Message | Started UTC | Latency | Correlated owner | Scale events in stall | Throughput interval | GC interval delta |");
+        sb.AppendLine("|--------|--------:|-------------|--------:|------------------|-----------------------|---------------------|-------------------|");
+        foreach (var row in rows)
+        {
+            var scaleEvents = (row.Result.ProducerDeliveryDiagnostics?.ConnectionScaleEvents ?? [])
+                .Where(scaleEvent =>
+                    scaleEvent.OccurredAtUtc >= row.Sample.StartedAtUtc &&
+                    scaleEvent.OccurredAtUtc <= row.Sample.CompletedAtUtc)
+                .ToList();
+            var samples = row.Result.Throughput.IntervalSamples;
+            var throughputSample = samples.FirstOrDefault(sample => sample.CapturedAtUtc >= row.Sample.CompletedAtUtc)
+                ?? samples.MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CompletedAtUtc).TotalMilliseconds));
+            var sampleIndex = throughputSample is null ? -1 : samples.IndexOf(throughputSample);
+            var previousSample = sampleIndex > 0 ? samples[sampleIndex - 1] : null;
+            var gen2Delta = throughputSample is null
+                ? 0
+                : throughputSample.Gen2Collections - (previousSample?.Gen2Collections ?? 0);
+            var pauseDeltaMs = throughputSample is null
+                ? 0
+                : Math.Max(0, throughputSample.GcPauseDurationMs - (previousSample?.GcPauseDurationMs ?? 0));
+            var owner = ClassifyLatencyOutlier(
+                scaleEvents.Count,
+                gen2Delta,
+                pauseDeltaMs,
+                throughputSample,
+                row.Result.EffectiveMessagesPerSecond);
+            var scaleSummary = scaleEvents.Count == 0
+                ? "-"
+                : string.Join(", ", scaleEvents.Select(scaleEvent =>
+                    $"{scaleEvent.BrokerId}:{scaleEvent.OldConnectionCount}→{scaleEvent.NewConnectionCount}"));
+            var throughputSummary = throughputSample is null
+                ? "-"
+                : $"{throughputSample.ElapsedSeconds:F1}s / {throughputSample.MessagesPerSecond:N0} msg/s";
+            var gcSummary = throughputSample is null
+                ? "-"
+                : $"Gen2 +{gen2Delta:N0} / pause +{pauseDeltaMs:F1}ms";
+            var messageIndex = row.Sample.MessageIndex?.ToString("N0") ?? "-";
+
+            sb.AppendLine(
+                $"| {row.Result.Client} | {messageIndex} | {row.Sample.StartedAtUtc:HH:mm:ss.fff} | " +
+                $"{FormatLatencyUs(row.Sample.LatencyUs).Trim()} | {owner} | {scaleSummary} | " +
+                $"{throughputSummary} | {gcSummary} |");
+        }
+
+        sb.AppendLine();
+        var dropped = results.Sum(result => result.Latency?.DroppedOutlierSamples ?? 0);
+        if (dropped > 0)
+        {
+            sb.AppendLine($"*{dropped:N0} additional latency outlier sample(s) exceeded the bounded diagnostic capacity.*");
+            sb.AppendLine();
+        }
+    }
+
+    private static string ClassifyLatencyOutlier(
+        int scaleEventCount,
+        int gen2Delta,
+        double pauseDeltaMs,
+        ThroughputIntervalSample? throughputSample,
+        double averageMessagesPerSecond)
+    {
+        if (scaleEventCount > 0)
+            return "connection transition";
+        if (gen2Delta > 0 || pauseDeltaMs >= 10)
+            return "GC pause";
+        if (throughputSample is not null &&
+            throughputSample.MessagesPerSecond < averageMessagesPerSecond * 0.5)
+        {
+            return "throughput collapse";
+        }
+
+        return "broker/backlog (no scale or GC event)";
+    }
 
     private static void GenerateLatencyTable(StringBuilder sb, List<StressTestResult> results, string title = "Latency Percentiles")
     {

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -227,14 +227,13 @@ internal static class MarkdownReporter
             var samples = row.Result.Throughput.IntervalSamples;
             var throughputSample = samples.FirstOrDefault(sample => sample.CapturedAtUtc >= row.Sample.CompletedAtUtc)
                 ?? samples.MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CompletedAtUtc).TotalMilliseconds));
-            var sampleIndex = throughputSample is null ? -1 : samples.IndexOf(throughputSample);
-            var previousSample = sampleIndex > 0 ? samples[sampleIndex - 1] : null;
+            var baselineSample = samples.LastOrDefault(sample => sample.CapturedAtUtc <= row.Sample.StartedAtUtc);
             var gen2Delta = throughputSample is null
                 ? 0
-                : throughputSample.Gen2Collections - (previousSample?.Gen2Collections ?? 0);
+                : throughputSample.Gen2Collections - (baselineSample?.Gen2Collections ?? 0);
             var pauseDeltaMs = throughputSample is null
                 ? 0
-                : Math.Max(0, throughputSample.GcPauseDurationMs - (previousSample?.GcPauseDurationMs ?? 0));
+                : Math.Max(0, throughputSample.GcPauseDurationMs - (baselineSample?.GcPauseDurationMs ?? 0));
             var owner = ClassifyLatencyOutlier(
                 scaleEvents.Count,
                 gen2Delta,

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -239,7 +239,7 @@ internal static class MarkdownReporter
                 gen2Delta,
                 pauseDeltaMs,
                 throughputSample,
-                row.Result.EffectiveMessagesPerSecond);
+                row.Result.MedianIntervalMessagesPerSecond ?? row.Result.Throughput.AverageMessagesPerSecond);
             var scaleSummary = scaleEvents.Count == 0
                 ? "-"
                 : string.Join(", ", scaleEvents.Select(scaleEvent =>
@@ -272,14 +272,14 @@ internal static class MarkdownReporter
         int gen2Delta,
         double pauseDeltaMs,
         ThroughputIntervalSample? throughputSample,
-        double averageMessagesPerSecond)
+        double clientMessagesPerSecond)
     {
         if (scaleEventCount > 0)
             return "connection transition";
         if (gen2Delta > 0 || pauseDeltaMs >= 10)
             return "GC pause";
         if (throughputSample is not null &&
-            throughputSample.MessagesPerSecond < averageMessagesPerSecond * 0.5)
+            throughputSample.MessagesPerSecond < clientMessagesPerSecond * 0.5)
         {
             return "throughput collapse";
         }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -155,7 +155,7 @@ internal static class ConfluentStressTestHelpers
             }
             else
             {
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start, messageIndex);
             }
         }, cancellationToken);
     }

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -380,7 +380,7 @@ internal static class StressTestHelpers
             try
             {
                 await producer.ProduceAsync(topic, key, value).ConfigureAwait(false);
-                latency.RecordTicks(Stopwatch.GetTimestamp() - start);
+                latency.RecordTicks(Stopwatch.GetTimestamp() - start, messageIndex);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- capture up to 256 sampled delivery stalls over one second with message index and UTC start/completion timestamps, without allocating on the normal latency path
- add cumulative GC collection and pause-duration evidence to throughput intervals
- correlate each outlier with overlapping connection scale events, GC pauses, throughput collapse, or the broker/backlog path in Markdown/JSON stress reports
- retain dropped-sample counts when bounded diagnostic capacity is exceeded

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release` (net8/net10, 0 warnings/errors)
- [x] focused `LatencyTrackerTests` + `ConnectionScaleReportingTests` (4/4)
- [x] full net10 unit suite (5,201/5,201)
- [ ] repeated Docker stress run: local Docker daemon became unavailable during validation; one attempted run captured a daemon-loss watchdog stall 193s after the last scale event, so it was not valid transition evidence

## Follow-up
- #1851 tracks an unrelated net8 same-partition ordering test timeout found during broad validation (5,116 passed, 1 timed out under machine contention).

Closes #1837
