### PR TITLE
ci: split producer mutation campaign into per-file matrix legs

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -25,9 +25,7 @@ env:
 jobs:
   mutation-test:
     name: Mutation test (${{ matrix.campaign }})
-    # 8-core runner: MTP cannot select covering tests per mutant, so surviving
-    # mutants each run the full suite — wall time scales with cores.
-    runs-on: ubicloud-standard-8
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
@@ -88,11 +86,9 @@ jobs:
 
       - name: Run focused mutation tests
         working-directory: src/Dekaf
-        # --concurrency matches the 8-core runner; configs keep 4 for local runs.
         run: >-
           dotnet stryker
           --config-file "${{ matrix.config }}"
-          --concurrency 8
           ${{ matrix.extra_args }}
           --output "${{ github.workspace }}/artifacts/mutation/${{ matrix.campaign }}"
 

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -25,16 +25,27 @@ env:
 jobs:
   mutation-test:
     name: Mutation test (${{ matrix.campaign }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    # 8-core runner: MTP cannot select covering tests per mutant, so surviving
+    # mutants each run the full suite — wall time scales with cores.
+    runs-on: ubicloud-standard-8
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
         include:
           - campaign: protocol
             config: stryker-config.json
-          - campaign: producer
+          # Producer campaign split per mutated file so the legs run on
+          # parallel runners; --mutate overrides the config's combined list.
+          - campaign: producer-accumulator
             config: stryker-producer-config.json
+            extra_args: --mutate "Producer/RecordAccumulator.cs"
+          - campaign: producer-sender
+            config: stryker-producer-config.json
+            extra_args: --mutate "Producer/BrokerSender.cs"
+          - campaign: producer-client
+            config: stryker-producer-config.json
+            extra_args: --mutate "Producer/KafkaProducer.cs"
 
     steps:
       - name: Checkout
@@ -77,9 +88,12 @@ jobs:
 
       - name: Run focused mutation tests
         working-directory: src/Dekaf
+        # --concurrency matches the 8-core runner; configs keep 4 for local runs.
         run: >-
           dotnet stryker
           --config-file "${{ matrix.config }}"
+          --concurrency 8
+          ${{ matrix.extra_args }}
           --output "${{ github.workspace }}/artifacts/mutation/${{ matrix.campaign }}"
 
       - name: Report trend and enforce large-drop gate


### PR DESCRIPTION
## Problem

Producer mutation leg of run [29122042755](https://github.com/thomhurst/Dekaf/actions/runs/29122042755/job/86459141988) took **3h45m**. No Docker involved — the mutation test project links pure unit tests. The cost driver: Stryker's MTP runner cannot select covering tests per mutant (config says `coverage-analysis: all` but the log shows it degrades to `SkipUncoveredMutants`), so every **surviving** mutant runs the full 339-test suite. At a 32.98% mutation score, ~2,000 survivors × ~25-30s suite passes ÷ 4 cores ≈ the entire 3h45.

## Change

Wall time ≈ survivors × suite duration ÷ (cores × runners), so this multiplies the runner count — using only free GitHub-hosted runners:

- **Split the producer campaign into 3 matrix legs** (`producer-accumulator` / `producer-sender` / `producer-client`), one mutated file each via CLI `--mutate` override (CLI input takes precedence over the config file's combined list). Legs run on parallel `ubuntu-latest` runners — free for public repos, so 3 legs cost nothing extra.
- **Reduce `timeout-minutes` 360 → 180** — worst leg should land around 1-1.5h (KafkaProducer.cs is the biggest of the three files, so legs won't split evenly).

## Notes

- Per-leg baseline artifacts (`mutation-baseline-producer-accumulator` etc.) start fresh; the first run finds no previous report and the score-drop gate skips comparison, exactly as the existing `previous_report` empty-check handles. The old combined `mutation-baseline-producer` artifact becomes orphaned and ages out at 90 days.
- Not addressed here (follow-ups from the same investigation): delay-based waits in linked producer test files multiply every survivor's cost — the biggest remaining lever now that runner scaling is off the table; 2,405 compile-error mutants silently exclude whole methods (`ProduceAsyncCore`, `ReceiveLoopAsync`) from mutation coverage; the 32.98% score itself.