### PR TITLE
test: isolate net8 producer ordering test

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -302,6 +302,9 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
+    // Mock response continuations intentionally run on the ThreadPool. Isolate this timing-sensitive
+    // integration of the sender state machine so unrelated concurrency tests cannot starve its wakeups.
+    [NotInParallel]
     [Timeout(30_000)]
     public async Task NonIdempotentProducer_MultipleInFlight_SerializesSamePartitionBatches(
         CancellationToken ct)


### PR DESCRIPTION
## Summary
- isolate the timing-sensitive non-idempotent ordering test from suite-wide ThreadPool contention
- keep the existing 30-second timeout and ordering assertions unchanged
- document why asynchronous mock response wakeups require runner isolation

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net8.0`
- [x] focused net8 ordering test (1/1 passed)
- [ ] full net8 suite: target passed; 5,114/5,117 passed, with unrelated existing contention failures in `BrokerSenderTests` and `AdaptiveScaleDownTests`

Closes #1851
