### PR TITLE
fix(producer): prevent admission budget ratchet

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2164,11 +2164,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
-        // Drain-rate estimate feed: bytes and the latest round-trip from successfully acked
-        // requests this pass. Faulted/cancelled responses are not drain and are excluded.
-        long ackedBytes = 0;
-        long lastAckedRequestStart = 0;
-
         // CRITICAL: Process responses in FORWARD order (oldest request first).
         // With multi-inflight, R1 and R2 may both complete with errors for the same partition.
         // Forward iteration ensures R1's retry batches are added to carry-over before R2's,
@@ -2246,8 +2241,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 if (allPartitionsSucceeded)
                 {
-                    ackedBytes += pending.EncodedBytes;
-                    lastAckedRequestStart = pending.RequestStartTime;
+                    // Per-request bytes / RTT measures pipeline-busy delivery time. It does
+                    // not fold admission-blocked gaps between response passes into the rate.
+                    var ackTimestamp = Stopwatch.GetTimestamp();
+                    _unackedBudget?.OnAcked(
+                        pending.EncodedBytes,
+                        ackTimestamp - pending.RequestStartTime,
+                        ackTimestamp);
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
@@ -2307,14 +2307,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         LogPartitionMigrationComplete(_brokerId, beforeCount);
                 }
             }
-        }
-
-        if (ackedBytes > 0 && _unackedBudget is { } unackedBudget)
-        {
-            // One timestamp per pass; RequestStartTime is on the raw Stopwatch clock (it
-            // feeds the request-timeout sweep), so the round-trip uses the same clock.
-            var ackRttTicks = Stopwatch.GetTimestamp() - lastAckedRequestStart;
-            unackedBudget.OnAcked(ackedBytes, ackRttTicks, _getTimestamp());
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2164,6 +2164,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
+        // Aggregate every successful request completed in this pass. Multiple connection
+        // lanes drain concurrently, so per-request samples understate broker-wide capacity.
+        long ackedBytes = 0;
+        var earliestAckedRequestStart = long.MaxValue;
+
         // CRITICAL: Process responses in FORWARD order (oldest request first).
         // With multi-inflight, R1 and R2 may both complete with errors for the same partition.
         // Forward iteration ensures R1's retry batches are added to carry-over before R2's,
@@ -2241,13 +2246,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 if (allPartitionsSucceeded)
                 {
-                    // Per-request bytes / RTT measures pipeline-busy delivery time. It does
-                    // not fold admission-blocked gaps between response passes into the rate.
-                    var ackTimestamp = Stopwatch.GetTimestamp();
-                    _unackedBudget?.OnAcked(
-                        pending.EncodedBytes,
-                        ackTimestamp - pending.RequestStartTime,
-                        ackTimestamp);
+                    ackedBytes += pending.EncodedBytes;
+                    earliestAckedRequestStart = Math.Min(
+                        earliestAckedRequestStart,
+                        pending.RequestStartTime);
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
@@ -2307,6 +2309,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         LogPartitionMigrationComplete(_brokerId, beforeCount);
                 }
             }
+        }
+
+        if (ackedBytes > 0 && _unackedBudget is { } unackedBudget)
+        {
+            // Oldest start spans the whole concurrent completion window. Dividing total
+            // bytes by that busy time captures aggregate broker drain without counting
+            // admission-blocked gaps between response passes.
+            var ackTimestamp = Stopwatch.GetTimestamp();
+            unackedBudget.OnAcked(
+                ackedBytes,
+                ackTimestamp - earliestAckedRequestStart,
+                ackTimestamp);
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -602,6 +602,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// no ambient context (e.g. <c>AsyncLocal</c>, <c>SecurityContext</c>) needs to flow.
     /// </remarks>
     private readonly Action _responseCompletionCallback;
+    // Test-only synchronization seam for making several task completions visible to one
+    // response pass. Null in production.
+    private readonly Action? _beforeProcessCompletedResponses;
 
     private int _disposed;
 
@@ -627,7 +630,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
-        BrokerUnackedByteBudget? unackedBudget = null)
+        BrokerUnackedByteBudget? unackedBudget = null,
+        Action? beforeProcessCompletedResponses = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -650,6 +654,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _getTimestamp = getTimestamp ?? Stopwatch.GetTimestamp;
         _delayForThrottle = delayForThrottle ?? DelayForThrottleAsync;
         _onBlockedBucketRequeued = onBlockedBucketRequeued;
+        _beforeProcessCompletedResponses = beforeProcessCompletedResponses;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
         {
@@ -2164,6 +2169,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
+        _beforeProcessCompletedResponses?.Invoke();
+
         // Aggregate every successful request completed in this pass. Multiple connection
         // lanes drain concurrently, so per-request samples understate broker-wide capacity.
         long ackedBytes = 0;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -190,6 +190,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
+    internal struct AckedResponsePass
+    {
+        public long Bytes { get; private set; }
+        public long EarliestRequestStart { get; private set; }
+
+        public void Add(long bytes, long requestStart)
+        {
+            EarliestRequestStart = Bytes == 0
+                ? requestStart
+                : Math.Min(EarliestRequestStart, requestStart);
+            Bytes += bytes;
+        }
+    }
+
     private enum SendLoopEventType : byte
     {
         NewBatch,
@@ -602,10 +616,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// no ambient context (e.g. <c>AsyncLocal</c>, <c>SecurityContext</c>) needs to flow.
     /// </remarks>
     private readonly Action _responseCompletionCallback;
-    // Test-only synchronization seam for making several task completions visible to one
-    // response pass. Null in production.
-    private readonly Action? _beforeProcessCompletedResponses;
-
     private int _disposed;
 
     public BrokerSender(
@@ -630,8 +640,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
-        BrokerUnackedByteBudget? unackedBudget = null,
-        Action? beforeProcessCompletedResponses = null)
+        BrokerUnackedByteBudget? unackedBudget = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -654,7 +663,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _getTimestamp = getTimestamp ?? Stopwatch.GetTimestamp;
         _delayForThrottle = delayForThrottle ?? DelayForThrottleAsync;
         _onBlockedBucketRequeued = onBlockedBucketRequeued;
-        _beforeProcessCompletedResponses = beforeProcessCompletedResponses;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
         {
@@ -2169,12 +2177,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
-        _beforeProcessCompletedResponses?.Invoke();
-
         // Aggregate every successful request completed in this pass. Multiple connection
         // lanes drain concurrently, so per-request samples understate broker-wide capacity.
-        long ackedBytes = 0;
-        var earliestAckedRequestStart = long.MaxValue;
+        var ackedPass = new AckedResponsePass();
 
         // CRITICAL: Process responses in FORWARD order (oldest request first).
         // With multi-inflight, R1 and R2 may both complete with errors for the same partition.
@@ -2252,12 +2257,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 if (allPartitionsSucceeded)
-                {
-                    ackedBytes += pending.EncodedBytes;
-                    earliestAckedRequestStart = Math.Min(
-                        earliestAckedRequestStart,
-                        pending.RequestStartTime);
-                }
+                    ackedPass.Add(pending.EncodedBytes, pending.RequestStartTime);
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
                 if (_logger.IsEnabled(LogLevel.Debug))
@@ -2318,15 +2318,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
-        if (ackedBytes > 0 && _unackedBudget is { } unackedBudget)
+        if (ackedPass.Bytes > 0 && _unackedBudget is { } unackedBudget)
         {
             // Oldest start spans the whole concurrent completion window. Dividing total
             // bytes by that busy time captures aggregate broker drain without counting
             // admission-blocked gaps between response passes.
             var ackTimestamp = Stopwatch.GetTimestamp();
             unackedBudget.OnAcked(
-                ackedBytes,
-                ackTimestamp - earliestAckedRequestStart,
+                ackedPass.Bytes,
+                ackTimestamp - ackedPass.EarliestRequestStart,
                 ackTimestamp);
         }
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -14,7 +14,7 @@ namespace Dekaf.Producer;
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
 /// <see cref="RecordAdmissionBlock"/> are cross-thread (producer appenders and terminal batch
 /// paths). <see cref="OnAcked"/> and <see cref="SetCap"/> are single-writer — only the owning
-/// broker's send loop calls them — so the EWMA state needs no synchronization; the computed
+/// broker's send loop calls them — so the estimator state needs no synchronization; the computed
 /// budget is published with a volatile write.
 /// </para>
 /// </summary>
@@ -28,10 +28,8 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     internal const int CapBatchMultiplier = 32;
 
-    /// <summary>EWMA time constant for the acked-bytes rate. An active sample spanning dt
-    /// seconds gets weight min(1, dt/τ), so history older than ~τ decays away. A gap longer
-    /// than τ with no remaining unacked bytes is treated as idle and re-anchors the window.</summary>
-    private const double RateEwmaTauSeconds = 1.0;
+    /// <summary>Number of per-request delivery-rate samples retained by the maximum filter.</summary>
+    private const int RateWindowSamples = 10;
 
     /// <summary>Fixed smoothing factor for the per-request ack round-trip EWMA.</summary>
     private const double RttEwmaAlpha = 0.25;
@@ -42,9 +40,8 @@ internal sealed class BrokerUnackedByteBudget
     /// budget down to the floor — collapsing throughput on high-latency links.</summary>
     private const double RttSafetyMultiplier = 1.5;
 
-    /// <summary>Rate samples shorter than this are carried into the next sample so a burst
-    /// of sub-millisecond ack passes cannot produce wildly noisy instantaneous rates.</summary>
-    private const double MinRateSampleSeconds = 0.001;
+    private const int ProbeIntervalRtts = 8;
+    private const double ProbeBudgetMultiplier = 1.25;
 
     // Cross-thread state.
     private long _unackedBytes;
@@ -55,12 +52,18 @@ internal sealed class BrokerUnackedByteBudget
     private readonly long _floorBytes;
     private readonly double _targetSeconds;
     private long _capBytes;
-    private double _ewmaBytesPerSecond;
+    // Monotonically-decreasing deque for the last RateWindowSamples delivery-rate samples.
+    // Each sample enters and leaves once, keeping acknowledgement processing O(1) amortized.
+    private readonly double[] _rateMaxValues = new double[RateWindowSamples];
+    private readonly long[] _rateMaxSequences = new long[RateWindowSamples];
+    private int _rateMaxHead;
+    private int _rateMaxTail;
+    private int _rateMaxCount;
+    private long _rateSampleSequence;
     private double _ewmaRttSeconds;
-    private long _pendingAckedBytes;
-    private long _lastRateSampleTimestamp;
-    private bool _hasRateSample;
     private bool _hasRttSample;
+    private long _nextProbeTimestamp;
+    private long _probeUntilTimestamp;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
     {
@@ -122,61 +125,74 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     /// <summary>
-    /// Feeds acked bytes and the latest request round-trip into the drain estimate, then
+    /// Feeds one successfully acknowledged request into the drain estimate, then
     /// republishes the budget. Called only from the owning send loop after a response
     /// pass completes successfully-acked requests. O(1), allocation-free.
     /// </summary>
     public void OnAcked(long ackedBytes, long rttTicks, long nowTicks)
     {
-        _pendingAckedBytes += ackedBytes;
-
-        if (rttTicks > 0)
-        {
-            var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
-            _ewmaRttSeconds = _hasRttSample
-                ? _ewmaRttSeconds + (RttEwmaAlpha * (rttSeconds - _ewmaRttSeconds))
-                : rttSeconds;
-            _hasRttSample = true;
-        }
-
-        if (_lastRateSampleTimestamp == 0)
-        {
-            // First observation anchors the sampling window; no rate can be derived yet.
-            _lastRateSampleTimestamp = nowTicks;
-            return;
-        }
-
-        var elapsedSeconds = (double)(nowTicks - _lastRateSampleTimestamp) / Stopwatch.Frequency;
-        if (elapsedSeconds > RateEwmaTauSeconds && UnackedBytes == 0)
-        {
-            // No backlog survived the gap, so elapsed time is producer idle time rather than
-            // broker drain time. Preserve the established rate and start a fresh window with
-            // this first resumed ack; folding the idle gap into the sample would collapse the
-            // budget to the floor and unnecessarily throttle the resumed burst.
-            _lastRateSampleTimestamp = nowTicks;
-            return;
-        }
-
-        if (elapsedSeconds < MinRateSampleSeconds)
+        if (ackedBytes <= 0 || rttTicks <= 0)
             return;
 
-        var sampleBytesPerSecond = _pendingAckedBytes / elapsedSeconds;
-        _pendingAckedBytes = 0;
-        _lastRateSampleTimestamp = nowTicks;
+        var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
+        _ewmaRttSeconds = _hasRttSample
+            ? _ewmaRttSeconds + (RttEwmaAlpha * (rttSeconds - _ewmaRttSeconds))
+            : rttSeconds;
+        _hasRttSample = true;
 
-        var alpha = Math.Min(1.0, elapsedSeconds / RateEwmaTauSeconds);
-        _ewmaBytesPerSecond = _hasRateSample
-            ? _ewmaBytesPerSecond + (alpha * (sampleBytesPerSecond - _ewmaBytesPerSecond))
-            : sampleBytesPerSecond;
-        _hasRateSample = true;
+        AddRateSample(ackedBytes / rttSeconds);
+
+        if (_probeUntilTimestamp != 0 && nowTicks >= _probeUntilTimestamp)
+            _probeUntilTimestamp = 0;
+
+        var probeIntervalTicks = ProbeIntervalRtts * rttTicks;
+        if (_nextProbeTimestamp == 0)
+            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+
+        if (_probeUntilTimestamp == 0 && nowTicks >= _nextProbeTimestamp)
+        {
+            if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
+                _probeUntilTimestamp = nowTicks + rttTicks;
+
+            // A schedule missed by a full interval represents producer idle time, not an
+            // active-pipeline probe opportunity. Re-arm instead of probing on resume.
+            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+        }
 
         RecomputeBudget();
+    }
+
+    private void AddRateSample(double bytesPerSecond)
+    {
+        var sequence = ++_rateSampleSequence;
+        var oldestSequence = sequence - RateWindowSamples;
+
+        if (_rateMaxCount > 0 && _rateMaxSequences[_rateMaxHead] <= oldestSequence)
+        {
+            _rateMaxHead = (_rateMaxHead + 1) % RateWindowSamples;
+            _rateMaxCount--;
+        }
+
+        while (_rateMaxCount > 0)
+        {
+            var last = (_rateMaxTail + RateWindowSamples - 1) % RateWindowSamples;
+            if (_rateMaxValues[last] > bytesPerSecond)
+                break;
+
+            _rateMaxTail = last;
+            _rateMaxCount--;
+        }
+
+        _rateMaxValues[_rateMaxTail] = bytesPerSecond;
+        _rateMaxSequences[_rateMaxTail] = sequence;
+        _rateMaxTail = (_rateMaxTail + 1) % RateWindowSamples;
+        _rateMaxCount++;
     }
 
     private void RecomputeBudget()
     {
         long budget;
-        if (!_hasRateSample)
+        if (_rateMaxCount == 0)
         {
             // Cold start: no drain estimate yet — keep today's semantics (cap) so short-lived
             // producers and tests never see admission throttling.
@@ -187,7 +203,11 @@ internal sealed class BrokerUnackedByteBudget
             var horizonSeconds = _hasRttSample
                 ? Math.Max(_targetSeconds, RttSafetyMultiplier * _ewmaRttSeconds)
                 : _targetSeconds;
-            budget = (long)(_ewmaBytesPerSecond * horizonSeconds);
+            var estimatedBytes = _rateMaxValues[_rateMaxHead] * horizonSeconds;
+            if (_probeUntilTimestamp != 0)
+                estimatedBytes *= ProbeBudgetMultiplier;
+
+            budget = (long)estimatedBytes;
             budget = Math.Clamp(budget, _floorBytes, _capBytes);
         }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -125,9 +125,9 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     /// <summary>
-    /// Feeds one successfully acknowledged request into the drain estimate, then
-    /// republishes the budget. Called only from the owning send loop after a response
-    /// pass completes successfully-acked requests. O(1), allocation-free.
+    /// Feeds successfully acknowledged requests from one response pass into the drain
+    /// estimate, then republishes the budget. Called only from the owning send loop after
+    /// a response pass completes successfully-acked requests. O(1), allocation-free.
     /// </summary>
     public void OnAcked(long ackedBytes, long rttTicks, long nowTicks)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -254,8 +254,7 @@ public sealed class BrokerSenderSendLoopTests
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
-        BrokerUnackedByteBudget? unackedBudget = null,
-        Action? beforeProcessCompletedResponses = null) =>
+        BrokerUnackedByteBudget? unackedBudget = null) =>
         new(
             brokerId: 1, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
@@ -275,8 +274,7 @@ public sealed class BrokerSenderSendLoopTests
             getTimestamp: getTimestamp,
             delayForThrottle: delayForThrottle,
             onBlockedBucketRequeued: onBlockedBucketRequeued,
-            unackedBudget: unackedBudget,
-            beforeProcessCompletedResponses: beforeProcessCompletedResponses);
+            unackedBudget: unackedBudget);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {
@@ -2273,72 +2271,16 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
-    [Timeout(120_000)]
-    public async Task ProcessCompletedResponses_AggregatesConcurrentAckedBytes(
-        CancellationToken cancellationToken)
+    public async Task AckedResponsePass_AggregatesBytesAndKeepsOldestRequestStart()
     {
-        const int dataSize = 5_000;
-        var responses = Enumerable.Range(0, 2)
-            .Select(_ => new TaskCompletionSource<ProduceResponse>(
-                TaskCreationOptions.RunContinuationsAsynchronously))
-            .ToArray();
-        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
-        var sendSignals = Enumerable.Range(0, 2)
-            .Select(_ => new TaskCompletionSource(
-                TaskCreationOptions.RunContinuationsAsynchronously))
-            .ToArray();
-        var sendCount = 0;
-        var (pool, _) = CreateMockConnection(responseQueue, () =>
-        {
-            var index = Interlocked.Increment(ref sendCount) - 1;
-            sendSignals[index].TrySetResult();
-        });
-        var options = CreateOptions(maxInFlight: 2, unackedByteBudgetCapOverride: 1_000_000);
-        var accumulator = new RecordAccumulator(options);
-        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
-        var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.000001,
-            floorBytes: 200,
-            initialCapBytes: 1);
-        using var releaseResponsePass = new ManualResetEventSlim();
-        var holdResponsePass = 0;
-        var sender = CreateSender(
-            pool,
-            options,
-            accumulator,
-            (_, _, _, _, _) => { },
-            unackedBudget: budget,
-            beforeProcessCompletedResponses: () =>
-            {
-                if (Volatile.Read(ref holdResponsePass) != 0)
-                    releaseResponsePass.Wait(cancellationToken);
-            });
+        var pass = new BrokerSender.AckedResponsePass();
 
-        try
-        {
-            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: dataSize));
-            await sendSignals[0].Task.WaitAsync(cancellationToken);
-            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1, dataSize: dataSize));
-            await sendSignals[1].Task.WaitAsync(cancellationToken);
+        pass.Add(bytes: 5_000, requestStart: 200);
+        pass.Add(bytes: 7_000, requestStart: 100);
+        pass.Add(bytes: 3_000, requestStart: 300);
 
-            Volatile.Write(ref holdResponsePass, 1);
-            responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
-            responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 20));
-            releaseResponsePass.Set();
-
-            await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
-
-            // 10,000 bytes / oldest request RTT × 1.5 × the same RTT = 15,000.
-            await Assert.That(budget.BudgetBytes).IsBetween(14_980, 15_020);
-        }
-        finally
-        {
-            responses[0].TrySetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
-            responses[1].TrySetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 20));
-            await sender.DisposeAsync();
-            await accumulator.DisposeAsync();
-            await valueTaskSourcePool.DisposeAsync();
-        }
+        await Assert.That(pass.Bytes).IsEqualTo(15_000);
+        await Assert.That(pass.EarliestRequestStart).IsEqualTo(100);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -254,7 +254,8 @@ public sealed class BrokerSenderSendLoopTests
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
-        BrokerUnackedByteBudget? unackedBudget = null) =>
+        BrokerUnackedByteBudget? unackedBudget = null,
+        Action? beforeProcessCompletedResponses = null) =>
         new(
             brokerId: 1, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
@@ -274,7 +275,8 @@ public sealed class BrokerSenderSendLoopTests
             getTimestamp: getTimestamp,
             delayForThrottle: delayForThrottle,
             onBlockedBucketRequeued: onBlockedBucketRequeued,
-            unackedBudget: unackedBudget);
+            unackedBudget: unackedBudget,
+            beforeProcessCompletedResponses: beforeProcessCompletedResponses);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {
@@ -2298,12 +2300,19 @@ public sealed class BrokerSenderSendLoopTests
             targetSeconds: 0.000001,
             floorBytes: 200,
             initialCapBytes: 1);
+        using var releaseResponsePass = new ManualResetEventSlim();
+        var holdResponsePass = 0;
         var sender = CreateSender(
             pool,
             options,
             accumulator,
             (_, _, _, _, _) => { },
-            unackedBudget: budget);
+            unackedBudget: budget,
+            beforeProcessCompletedResponses: () =>
+            {
+                if (Volatile.Read(ref holdResponsePass) != 0)
+                    releaseResponsePass.Wait(cancellationToken);
+            });
 
         try
         {
@@ -2312,10 +2321,10 @@ public sealed class BrokerSenderSendLoopTests
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1, dataSize: dataSize));
             await sendSignals[1].Task.WaitAsync(cancellationToken);
 
-            // RunContinuationsAsynchronously keeps both completions available to the next
-            // response pass, exercising broker-wide aggregation across concurrent requests.
+            Volatile.Write(ref holdResponsePass, 1);
             responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
             responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 20));
+            releaseResponsePass.Set();
 
             await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2220,7 +2220,7 @@ public sealed class BrokerSenderSendLoopTests
     public async Task ProcessCompletedResponses_FeedsAckedBytesIntoUnackedBudget(
         CancellationToken cancellationToken)
     {
-        const int batchCount = 5;
+        const int batchCount = 1;
         const int dataSize = 5_000;
 
         var responses = Enumerable.Range(0, batchCount)
@@ -2238,15 +2238,12 @@ public sealed class BrokerSenderSendLoopTests
             sendSignals[index].TrySetResult();
         });
 
-        // maxInFlight 1 + one partition serializes sends, so each response is processed alone:
-        // one OnAcked call per completed request, with the fake clock advanced 1s in between.
+        // One successful request must feed its encoded bytes and request RTT into the budget.
         var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
-        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1);
-        var fakeTimestamp = Stopwatch.GetTimestamp();
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.000001, floorBytes: 200, initialCapBytes: 1);
         var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
-            getTimestamp: () => Volatile.Read(ref fakeTimestamp),
             unackedBudget: budget);
 
         try
@@ -2257,15 +2254,13 @@ public sealed class BrokerSenderSendLoopTests
             for (var i = 0; i < batchCount; i++)
             {
                 await sendSignals[i].Task.WaitAsync(cancellationToken);
-                Interlocked.Add(ref fakeTimestamp, Stopwatch.Frequency); // 1s between ack windows
                 responses[i].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: i * 10));
             }
 
-            // Steady state: 5,000 B/s measured drain (fake clock advances 1s per ack window),
-            // while the round-trip — sampled on the real Stopwatch clock — is microseconds,
-            // so the 0.5s target dominates the RTT guard: budget = 5,000 × 0.5 = 2,500.
-            await WaitUntilAsync(() => budget.BudgetBytes == 2_500, cancellationToken);
-            await Assert.That(budget.BudgetBytes).IsEqualTo(2_500);
+            // The deliberately tiny target makes the 1.5 × RTT safety horizon dominate,
+            // cancelling RTT from bytes/RTT × 1.5×RTT: budget = 5,000 × 1.5 = 7,500.
+            await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
+            await Assert.That(budget.BudgetBytes).IsBetween(7_490, 7_510);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2272,6 +2272,68 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(120_000)]
+    public async Task ProcessCompletedResponses_AggregatesConcurrentAckedBytes(
+        CancellationToken cancellationToken)
+    {
+        const int dataSize = 5_000;
+        var responses = Enumerable.Range(0, 2)
+            .Select(_ => new TaskCompletionSource<ProduceResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
+        var sendSignals = Enumerable.Range(0, 2)
+            .Select(_ => new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously))
+            .ToArray();
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+        var options = CreateOptions(maxInFlight: 2, unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.000001,
+            floorBytes: 200,
+            initialCapBytes: 1);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            unackedBudget: budget);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: dataSize));
+            await sendSignals[0].Task.WaitAsync(cancellationToken);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1, dataSize: dataSize));
+            await sendSignals[1].Task.WaitAsync(cancellationToken);
+
+            // RunContinuationsAsynchronously keeps both completions available to the next
+            // response pass, exercising broker-wide aggregation across concurrent requests.
+            responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
+            responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 20));
+
+            await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
+
+            // 10,000 bytes / oldest request RTT × 1.5 × the same RTT = 15,000.
+            await Assert.That(budget.BudgetBytes).IsBetween(14_980, 15_020);
+        }
+        finally
+        {
+            responses[0].TrySetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 10));
+            responses[1].TrySetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 20));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task FaultedResponses_DoNotFeedUnackedBudgetDrainRate(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -5,7 +5,7 @@ namespace Dekaf.Tests.Unit.Producer;
 
 /// <summary>
 /// State-machine tests for <see cref="BrokerUnackedByteBudget"/>: budget publication from
-/// the acked-bytes EWMA, floor/cap clamping, the RTT safety guard, and counter accounting.
+/// the request-rate maximum filter, floor/cap clamping, probing, and counter accounting.
 /// All timestamps are explicit Stopwatch-tick values, so nothing here is timing-dependent.
 /// </summary>
 public sealed class BrokerUnackedByteBudgetTests
@@ -18,13 +18,11 @@ public sealed class BrokerUnackedByteBudgetTests
     private static long Seconds(double seconds) => (long)(seconds * Frequency);
 
     /// <summary>
-    /// Establishes a drain-rate EWMA of <paramref name="bytesPerSecond"/> with the given
-    /// round-trip, using one anchoring call and one full one-second sample window.
+    /// Establishes a per-request drain-rate sample of <paramref name="bytesPerSecond"/>.
     /// </summary>
     private static void EstablishRate(BrokerUnackedByteBudget budget, long bytesPerSecond, double rttSeconds)
     {
-        budget.OnAcked(ackedBytes: 1, rttTicks: Seconds(rttSeconds), nowTicks: T0);
-        budget.OnAcked(bytesPerSecond - 1, Seconds(rttSeconds), T0 + Seconds(1.0));
+        budget.OnAcked((long)(bytesPerSecond * rttSeconds), Seconds(rttSeconds), T0);
     }
 
     [Test]
@@ -32,10 +30,6 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
-
-        // The first OnAcked call only anchors the sampling window — still no rate sample.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
     }
 
@@ -87,51 +81,36 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task Ewma_LongGapSample_SnapsToNewRate()
+    public async Task WindowedMaximum_LongGap_DoesNotDeflateRate()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
 
-        // Remaining unacked work means this is an active 10s sample rather than producer
-        // idle time. Alpha is 1.0, so the EWMA snaps to the new rate.
-        budget.Charge(1);
-        budget.OnAcked(ackedBytes: 60_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
-        budget.Release(1);
+        budget.OnAcked(ackedBytes: 1, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(3_000); // 6,000 B/s × 0.5s
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 
     [Test]
-    public async Task Ewma_IdleGap_ReanchorsWithoutCollapsingBudget()
+    public async Task IdleGap_IsNotCountedAsRequestDrainTime()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
 
-        // With no remaining unacked work, the ten-second gap is producer idle time. The
-        // first resumed ack anchors a fresh window instead of appearing to drain at 100 B/s.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
-
-        // The next active interval includes the anchor ack and publishes the resumed rate.
-        budget.OnAcked(ackedBytes: 99_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(12.0));
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
 
     [Test]
-    public async Task Ewma_IdleReanchor_PreservesSubMillisecondCarry()
+    public async Task SubMillisecondRequest_ProducesRateSampleImmediately()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(0.0001));
-
-        // Idle reanchor retains bytes accumulated before the minimum sample interval.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
-        budget.OnAcked(ackedBytes: 97_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(12.0));
+        budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.0001), nowTicks: T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
@@ -151,18 +130,64 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task SubMillisecondAcks_CarryIntoNextSample()
+    public async Task RateSample_UsesRequestBusyTime_NotGapBetweenAckPasses()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0);
-        // Sub-1ms since the anchor: bytes are carried, no sample folds, budget stays at cap.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(0.0001));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
 
-        // The full window closes 1s after the anchor and includes the carried bytes.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(1.0));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500); // 3,000 B/s × 0.5s
+        // 1,000 bytes / 100ms request RTT = 10,000 B/s. The first request is enough to
+        // establish rate; no preceding wall-clock ack timestamp is required.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task WindowedMaximum_LowerSamples_DoNotRatchetBudgetDown()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.100));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task WindowedMaximum_PeakExpires_AfterTenNewerSamples()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        for (var i = 1; i <= 10; i++)
+            budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RaisesBudgetForOneRtt_ThenRevertsWithoutRateGain()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.900));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task AckPassGap_DoesNotChangeRequestRateSample()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.010), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.010), nowTicks: T0 + Seconds(1.0));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>Measures allocation and CPU cost of the producer acknowledgement budget update.</summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class BrokerUnackedByteBudgetBenchmarks
+{
+    private const int Operations = 1_000;
+    private static readonly long RttTicks = Stopwatch.Frequency / 1_000;
+
+    private BrokerUnackedByteBudget _budget = null!;
+    private long _timestamp;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 2 * 1024 * 1024,
+            initialCapBytes: 32 * 1024 * 1024);
+        _timestamp = Stopwatch.GetTimestamp();
+    }
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public long RecordAcknowledgements()
+    {
+        for (var i = 0; i < Operations; i++)
+        {
+            _timestamp += RttTicks;
+            _budget.OnAcked(ackedBytes: 1024 * 1024, RttTicks, _timestamp);
+        }
+
+        return _budget.BudgetBytes;
+    }
+}


### PR DESCRIPTION
## Summary
- replace admitted-rate EWMA with per-request `bytes / RTT` samples and a 10-sample rolling maximum
- probe 25% extra admission capacity for one RTT every eight RTTs without resetting estimator state on connection-cap changes
- keep acknowledgement updates O(1), allocation-free, and measured by a dedicated benchmark

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] `BrokerUnackedByteBudgetTests` (18 passed)
- [x] `BrokerSenderSendLoopTests` (35 passed)
- [x] full net10 unit suite (5,202 passed)
- [x] full net8 unit suite (5,120 passed; unrelated networking timeout flake filed as #1862)
- [x] BenchmarkDotNet short run: 6.27 ns/ack, 0 B allocated
- [x] paired 1-broker idempotent stress: zero errors, Dekaf 192,525 msg/s vs Confluent 73,580 msg/s
- [x] paired 3-broker acks-all stress: zero errors, Dekaf 213,983 msg/s average vs Confluent 182,200 msg/s; Dekaf p99 271ms vs Confluent 17.5s

Closes #1856
