### PR TITLE
fix(producer): preserve ordering across scaling

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -461,7 +461,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Single-threaded send loop — no locks needed.
     private readonly HashSet<TopicPartition> _partitionsNeedingSequenceReset = new();
 
-    // Partition-affined connections: each partition pins to _pinnedConnections[GetConnectionForPartition(partition)].
+    // Partition-affined connections: each partition pins to _pinnedConnections[GetConnectionForPartition(topicPartition)].
     // For single-connection mode (_connectionCount == 1), degenerates to the original pinned behavior.
     // All producers use partition affinity (partition % N) for CPU cache locality.
     // Idempotent producers additionally require affinity for per-partition sequence ordering;
@@ -505,14 +505,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private volatile bool _loopExited;
     private volatile bool _redeliverAfterLoopExit;
 
-    // Per-partition migration fencing for idempotent producers: during a scale-UP,
+    // Per-partition migration fencing for all acknowledged producers: during a scale-UP,
     // partitions whose connection assignment changes (partition % oldCount != partition % newCount)
     // are fenced here if they have in-flight batches on the old connection. The partition
     // continues routing to the old connection until its in-flight clears, then is removed
     // from this dictionary and routes via the new partition % _connectionCount.
     // Scale-down never fences (its drain gates guarantee no in-flight) and clears any
     // stale entries at initiation. Send-loop owned (single-threaded) — no synchronization needed.
-    private readonly Dictionary<int, int> _migratingPartitions = new();
+    private readonly Dictionary<TopicPartition, int> _migratingPartitions = new();
 
     // Scaling thresholds
     // Also the per-connection unit of pressure for step estimation (step = delta / threshold),
@@ -1441,7 +1441,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             // by scaling down unused connections.
                             for (var i = 0; i < coalescedCount; i++)
                             {
-                                var connIdx = GetConnectionForPartition(coalescedBatches[i].TopicPartition.Partition);
+                                var connIdx = GetConnectionForPartition(coalescedBatches[i].TopicPartition);
                                 ref var bucket = ref connectionBuckets[connIdx];
                                 bucket.Batches[bucket.Count] = coalescedBatches[i];
                                 bucket.Generations[bucket.Count] = coalescedGenerations[i];
@@ -3565,17 +3565,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// <summary>
     /// Returns the connection index for a partition, respecting any active migration fence.
     /// During migration, fenced partitions continue routing to their old connection
-    /// until in-flight batches complete, preserving per-partition sequence ordering.
+    /// until in-flight batches complete, preserving per-partition broker append order.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetConnectionForPartition(int partitionIndex)
+    private int GetConnectionForPartition(TopicPartition topicPartition)
     {
         // Common case: no migrations active — dictionary Count check is a single branch on 0.
         // During migration: one hash lookup per batch, negligible vs TCP write cost.
         return _migratingPartitions.Count > 0
-            && _migratingPartitions.TryGetValue(partitionIndex, out var oldConn)
+            && _migratingPartitions.TryGetValue(topicPartition, out var oldConn)
             ? oldConn
-            : partitionIndex % _connectionCount;
+            : topicPartition.Partition % _connectionCount;
     }
 
     /// <summary>
@@ -3583,7 +3583,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Scans pending responses (at most _maxInFlight entries, typically 5) for the connection.
     /// Only called during migration transitions — not on the hot path.
     /// </summary>
-    private bool HasInflightForPartition(int connectionIndex, int partitionIndex)
+    private bool HasInflightForPartition(int connectionIndex, TopicPartition topicPartition)
     {
         if ((uint)connectionIndex >= (uint)_pendingResponsesByConnection.Length)
             return false;
@@ -3596,7 +3596,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 // Entries within Count can legally be null: batches with stale generations
                 // are nulled out before PendingResponse.Create captures the array.
-                if (pr.Batches[j] is { } batch && batch.TopicPartition.Partition == partitionIndex)
+                if (pr.Batches[j] is { } batch && batch.TopicPartition == topicPartition)
                     return true;
             }
         }
@@ -3612,68 +3612,39 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         var pendingList = _pendingResponsesByConnection[connectionIndex];
 
-        // Fast path: if this connection has no remaining pending responses,
-        // all partitions fenced on this connection can migrate immediately.
-        if (pendingList.Count == 0)
+        foreach (var topicPartition in _knownPartitions)
         {
-            var keysToRemove = _migratingPartitions.Count <= 64
-                ? (Span<int>)stackalloc int[_migratingPartitions.Count]
-                : new int[_migratingPartitions.Count];
-            var removeCount = 0;
+            if (!_migratingPartitions.TryGetValue(topicPartition, out var oldConnection)
+                || oldConnection != connectionIndex)
+                continue;
 
-            foreach (var kvp in _migratingPartitions)
+            // Empty connection is the common completion case and avoids rescanning batches.
+            if (pendingList.Count == 0 || !HasInflightForPartition(connectionIndex, topicPartition))
             {
-                if (kvp.Value == connectionIndex)
-                    keysToRemove[removeCount++] = kvp.Key;
+                _migratingPartitions.Remove(topicPartition);
             }
-
-            for (var i = 0; i < removeCount; i++)
-                _migratingPartitions.Remove(keysToRemove[i]);
-
-            return;
-        }
-
-        // Connection still has pending responses — check partition by partition
-        var keysToCheck = _migratingPartitions.Count <= 64
-            ? (Span<int>)stackalloc int[_migratingPartitions.Count]
-            : new int[_migratingPartitions.Count];
-        var checkCount = 0;
-
-        foreach (var kvp in _migratingPartitions)
-        {
-            if (kvp.Value == connectionIndex)
-                keysToCheck[checkCount++] = kvp.Key;
-        }
-
-        for (var i = 0; i < checkCount; i++)
-        {
-            if (!HasInflightForPartition(connectionIndex, keysToCheck[i]))
-                _migratingPartitions.Remove(keysToCheck[i]);
         }
     }
 
     /// <summary>
     /// Fences partitions whose connection assignment changes during a scale-up.
-    /// For idempotent producers, partitions with in-flight batches on their old connection
-    /// are added to <see cref="_migratingPartitions"/> so they continue routing to the old
-    /// connection until in-flight clears, preventing OutOfOrderSequenceNumber errors.
-    /// Scale-down does not fence: its drain gates guarantee no in-flight batches whose
-    /// routing would change (all connections drained for idempotent producers).
+    /// Partitions with in-flight batches on their old connection are added to
+    /// <see cref="_migratingPartitions"/> so they continue routing to the old connection
+    /// until in-flight clears. This preserves broker append order for non-idempotent
+    /// producers and sequence order for idempotent producers. Scale-down does not fence:
+    /// its drain gate guarantees no in-flight batches before any routing assignment changes.
     /// </summary>
     private void FenceAffectedPartitions(int oldConnCount, int newConnCount)
     {
-        if (!_isIdempotent)
-            return;
-
         foreach (var tp in _knownPartitions)
         {
             var partition = tp.Partition;
             var oldConn = partition % oldConnCount;
             var newConn = partition % newConnCount;
 
-            if (oldConn != newConn && HasInflightForPartition(oldConn, partition))
+            if (oldConn != newConn && HasInflightForPartition(oldConn, tp))
             {
-                _migratingPartitions.TryAdd(partition, oldConn);
+                _migratingPartitions.TryAdd(tp, oldConn);
             }
         }
 
@@ -4424,22 +4395,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return 0;
         }
 
-        // Idempotent producers require ALL connections to be drained before shrinking
-        // because partitions remap (P % N -> P % (N-1)) and in-flight batches on any
-        // connection could conflict with new batches post-remap, causing sequence errors.
-        // Non-idempotent producers only need the last connection idle — no sequence numbers
-        // means partition remapping mid-flight cannot cause ordering violations.
-        if (_isIdempotent)
-        {
-            if (_totalPendingResponseCount > 0)
-                return 0; // Still has in-flight requests across connections — wait for drain
-        }
-        else
-        {
-            var lastConnIdx = _connectionCount - 1;
-            if (_pendingResponsesByConnection[lastConnIdx].Count > 0)
-                return 0; // Still has in-flight requests on last connection — wait
-        }
+        // Every acknowledged producer requires ALL connections to drain before shrinking.
+        // Modulo routing changes for partitions on retained slots too (P % N -> P % (N-1));
+        // moving a non-idempotent partition while its old request remains unacknowledged can
+        // reorder broker appends just as surely as it can violate idempotent sequence order.
+        if (_totalPendingResponseCount > 0)
+            return 0;
 
         // Sustained low utilization with no in-flight on the connection being removed —
         // initiate scale-down.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -513,6 +513,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Scale-down never fences (its drain gates guarantee no in-flight) and clears any
     // stale entries at initiation. Send-loop owned (single-threaded) — no synchronization needed.
     private readonly Dictionary<TopicPartition, int> _migratingPartitions = new();
+    // Reused removal buffer keeps CompleteMigrations O(migrating) and allocation-free.
+    // Capacity grows during scale-up, outside response completion processing.
+    private readonly List<TopicPartition> _migrationRemovalBuffer = [];
 
     // Scaling thresholds
     // Also the per-connection unit of pressure for step estimation (step = delta / threshold),
@@ -3611,19 +3614,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void CompleteMigrations(int connectionIndex)
     {
         var pendingList = _pendingResponsesByConnection[connectionIndex];
+        _migrationRemovalBuffer.Clear();
 
-        foreach (var topicPartition in _knownPartitions)
+        foreach (var (topicPartition, oldConnection) in _migratingPartitions)
         {
-            if (!_migratingPartitions.TryGetValue(topicPartition, out var oldConnection)
-                || oldConnection != connectionIndex)
+            if (oldConnection != connectionIndex)
                 continue;
 
             // Empty connection is the common completion case and avoids rescanning batches.
             if (pendingList.Count == 0 || !HasInflightForPartition(connectionIndex, topicPartition))
-            {
-                _migratingPartitions.Remove(topicPartition);
-            }
+                _migrationRemovalBuffer.Add(topicPartition);
         }
+
+        for (var i = 0; i < _migrationRemovalBuffer.Count; i++)
+            _migratingPartitions.Remove(_migrationRemovalBuffer[i]);
     }
 
     /// <summary>
@@ -3647,6 +3651,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 _migratingPartitions.TryAdd(tp, oldConn);
             }
         }
+
+        if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
+            _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
 
         if (_migratingPartitions.Count > 0)
             LogPartitionMigrationStarted(_brokerId, _migratingPartitions.Count, oldConnCount, newConnCount);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -420,6 +420,41 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task ScaleDown_NonIdempotentPendingRequestOnRetainedConnection_DoesNotRemap()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            maxInFlightRequests: 100,
+            scaleCooldownMs: 0,
+            scaleDownSustainedMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            SetField(sender, "_connectionCount", 2);
+            SetField(sender, "_totalMaxInFlight", 200);
+            SetField(sender, "_totalPendingResponseCount", 1);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.DidNotReceive().ShrinkConnectionGroupAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>());
+            await Assert.That(GetField<int>(sender, "_connectionCount")).IsEqualTo(2)
+                .Because("retained connection slots also remap partitions when routing width shrinks");
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ScaleDown_MutedPartitionWithQueuedBatch_DoesNotShrink()
     {
         var options = CreateOptions(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -373,6 +373,74 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
+    [NotInParallel]
+    [Timeout(30_000)]
+    public async Task NonIdempotentProducer_ScaleUp_PinsPartitionUntilPendingRequestCompletes(
+        CancellationToken ct)
+    {
+        var response = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([response]);
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sendLogger = new PipelinedSendLogger(expectedSends: 1);
+        var acknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, ex) =>
+            {
+                if (ex is null)
+                    acknowledged.TrySetResult();
+            },
+            logger: sendLogger);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(vtPool, "test-topic", partition: 1));
+            await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+
+            typeof(BrokerSender).GetMethod(
+                "ApplyScaleUp",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [2]);
+
+            var getConnection = typeof(BrokerSender).GetMethod(
+                "GetConnectionForPartition",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var topicPartition = new TopicPartition("test-topic", 1);
+            var routeWhilePending = (int)getConnection.Invoke(sender, [topicPartition])!;
+
+            await Assert.That(routeWhilePending).IsEqualTo(0)
+                .Because("scale-up must not move a non-idempotent partition before its old request is acknowledged");
+
+            response.SetResult(CreateSuccessResponse("test-topic", partition: 1, baseOffset: 100));
+            await acknowledged.Task.WaitAsync(ct);
+
+            var deadline = Stopwatch.GetTimestamp() + (5 * Stopwatch.Frequency);
+            while ((int)getConnection.Invoke(sender, [topicPartition])! != 1
+                   && Stopwatch.GetTimestamp() < deadline)
+            {
+                await Task.Delay(1, ct);
+            }
+
+            await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
+                .Because("partition should migrate after its old request is acknowledged");
+        }
+        finally
+        {
+            response.TrySetResult(CreateSuccessResponse("test-topic", partition: 1, baseOffset: 100));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task NonIdempotentFireAndForget_DisablesAdaptiveConnectionRemapping()
     {
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -404,6 +404,12 @@ public sealed class BrokerSenderMuteOrderingTests
             sender.Enqueue(CreateTestBatch(vtPool, "test-topic", partition: 1));
             await sendLogger.SendSignals[0].Task.WaitAsync(ct);
 
+            var otherTopicPartition = new TopicPartition("other-topic", 1);
+            var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+                "_knownPartitions",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+            knownPartitions.Add(otherTopicPartition);
+
             typeof(BrokerSender).GetMethod(
                 "ApplyScaleUp",
                 BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -414,9 +420,12 @@ public sealed class BrokerSenderMuteOrderingTests
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
             var topicPartition = new TopicPartition("test-topic", 1);
             var routeWhilePending = (int)getConnection.Invoke(sender, [topicPartition])!;
+            var otherTopicRoute = (int)getConnection.Invoke(sender, [otherTopicPartition])!;
 
             await Assert.That(routeWhilePending).IsEqualTo(0)
                 .Because("scale-up must not move a non-idempotent partition before its old request is acknowledged");
+            await Assert.That(otherTopicRoute).IsEqualTo(1)
+                .Because("same-numbered partitions on other topics must not inherit the migration fence");
 
             response.SetResult(CreateSuccessResponse("test-topic", partition: 1, baseOffset: 100));
             await acknowledged.Task.WaitAsync(ct);


### PR DESCRIPTION
## Summary
- fence non-idempotent partitions to their old connection during adaptive scale-up until pending requests acknowledge
- key migration state by full TopicPartition so same-numbered partitions across topics cannot interfere
- require all acknowledged producer requests to drain before scale-down changes modulo routing
- add deterministic scale-up and retained-slot scale-down regressions

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit --configuration Release
- [x] net10 BrokerSenderMuteOrderingTests + AdaptiveScaleDownTests (45/45)
- [x] net8 scale-up regression (1/1)
- [x] net10 full unit suite (5,200/5,200)
- [x] net10 ProducerOrderingTests + MultiInflightProducerTests integration (23/23)
- [x] producer-roundtrip stress, 250,000 messages, real 1→2 scale event: 0 missing, duplicates, corrupt, out-of-order, mispartitioned, unexpected
- [ ] net8 full unit suite: unrelated repeated timeout/cancellation failures tracked in #1864

Closes #1858