### PR TITLE
fix(consumer): refresh coordinator before commit

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -776,10 +776,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return new Dictionary<TopicPartition, TopicPartitionOffset>();
 
-        // If coordinator hasn't been discovered yet, return empty (no committed offsets known)
-        if (_coordinatorId < 0)
-            return new Dictionary<TopicPartition, TopicPartitionOffset>();
-
         // Lock is intentionally held across retries to protect the shared _fetchTopicGroups dictionary,
         // which is reused across calls to avoid allocations. With up to 3 retries x ~600ms each,
         // the lock can be held for up to ~1.8 seconds. Concurrent callers will block for the full retry duration.
@@ -788,8 +784,22 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             return await RetryHelper.WithRetryAsync(async () =>
             {
+                if (_coordinatorId < 0)
+                    await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+
+                var coordinatorId = _coordinatorId;
+                if (coordinatorId < 0)
+                {
+                    throw new Errors.GroupException(
+                        ErrorCode.CoordinatorNotAvailable,
+                        "Coordinator was invalidated during offset fetch discovery")
+                    {
+                        GroupId = _options.GroupId
+                    };
+                }
+
                 using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-                    _coordinatorId,
+                    coordinatorId,
                     _getCoordinationConnectionIndex(),
                     cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -667,8 +667,22 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 // Expiration can happen while this call waits for the commit lock.
                 ThrowIfMaxPollIntervalExpired();
 
+                if (_coordinatorId < 0)
+                    await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+
+                var coordinatorId = _coordinatorId;
+                if (coordinatorId < 0)
+                {
+                    throw new Errors.GroupException(
+                        ErrorCode.CoordinatorNotAvailable,
+                        "Coordinator was invalidated during offset commit discovery")
+                    {
+                        GroupId = _options.GroupId
+                    };
+                }
+
                 using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-                    _coordinatorId,
+                    coordinatorId,
                     _getCoordinationConnectionIndex(),
                     cancellationToken)
                     .ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -2169,6 +2169,72 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task FetchOffsetsAsync_UnknownCoordinator_RediscoversBeforeFetch()
+    {
+        var findCoordinatorCount = 0;
+        _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref findCoordinatorCount);
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = "test-group",
+                            NodeId = 0,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+        SetupConsumerGroupHeartbeat();
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetFetch,
+            OffsetFetchRequest.LowestSupportedVersion,
+            OffsetFetchRequest.HighestSupportedVersion);
+
+        var fetchRequestCount = 0;
+        _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref fetchRequestCount);
+                return ValueTask.FromResult(new OffsetFetchResponse
+                {
+                    Topics = [],
+                    ErrorCode = ErrorCode.None
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetPrivateField(coordinator, "_coordinatorId", -1);
+        _connectionPool.GetConnectionByIndexAsync(
+                Arg.Is<int>(brokerId => brokerId < 0),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                throw new InvalidOperationException("Unknown broker ID: -1"));
+
+        await coordinator.FetchOffsetsAsync(
+            [new TopicPartition("test-topic", 0)],
+            CancellationToken.None);
+
+        await Assert.That(findCoordinatorCount).IsEqualTo(2);
+        await Assert.That(fetchRequestCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task FetchOffsetsAsync_Kip848Member_SendsMemberIdentity()
     {
         _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1337,6 +1337,68 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task CommitOffsetsAsync_UnknownCoordinator_RediscoversBeforeCommit()
+    {
+        var findCoordinatorCount = 0;
+        _connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref findCoordinatorCount);
+                return ValueTask.FromResult(new FindCoordinatorResponse
+                {
+                    Coordinators =
+                    [
+                        new Coordinator
+                        {
+                            Key = "test-group",
+                            NodeId = 0,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                });
+            });
+        SetupConsumerGroupHeartbeat();
+        _metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var commitRequestCount = 0;
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref commitRequestCount);
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetPrivateField(coordinator, "_coordinatorId", -1);
+        _connectionPool.GetConnectionByIndexAsync(
+                Arg.Is<int>(brokerId => brokerId < 0),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                throw new InvalidOperationException("Unknown broker ID: -1"));
+
+        await coordinator.CommitOffsetsAsync(
+            [new TopicPartitionOffset("test-topic", 0, 1)],
+            CancellationToken.None);
+
+        await Assert.That(findCoordinatorCount).IsEqualTo(2);
+        await Assert.That(commitRequestCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
     {
         SetupFindCoordinator();
@@ -2035,6 +2097,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     [Test]
     public async Task CommitOffsetsAsync_RemovesEmptyPooledTopicGroups()
     {
+        SetupFindCoordinator();
         _metadataManager.SetApiVersion(ApiKey.OffsetCommit, OffsetCommitRequest.LowestSupportedVersion, OffsetCommitRequest.HighestSupportedVersion);
 
         var topicSnapshots = new List<(string Name, int PartitionCount)[]>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -130,6 +130,33 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
+    public async Task CloseAsync_UnknownCoordinator_RediscoversAndCommitsPendingOffset()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+
+        try
+        {
+            consumer.StoreOffset(CreateConsumeResult(offset: 41, leaderEpoch: 7));
+
+            await consumer.CloseAsync(CancellationToken.None);
+
+            await Assert.That(GetCommittedOffsets(requests.Single())).IsEquivalentTo(
+            [
+                new TopicPartitionOffset("topic-a", 0, 42, leaderEpoch: 7)
+            ]);
+        }
+        finally
+        {
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task AutoCommit_WhenAutoOffsetStoreDisabled_DoesNotCommitConsumedPosition()
     {
         var requests = new List<OffsetCommitRequest>();
@@ -246,6 +273,25 @@ public sealed class ConsumerDirtyCommitTests
         connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(connection));
 
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "group-a",
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+
         connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
                 Arg.Any<OffsetCommitRequest>(),
                 Arg.Any<short>(),
@@ -260,6 +306,15 @@ public sealed class ConsumerDirtyCommitTests
             });
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }],
+            Topics = []
+        });
+        metadataManager.SetApiVersion(
+            ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion,
+            FindCoordinatorRequest.HighestSupportedVersion);
         metadataManager.SetApiVersion(
             ApiKey.OffsetCommit,
             OffsetCommitRequest.LowestSupportedVersion,


### PR DESCRIPTION
## Summary
- rediscover an invalid consumer-group coordinator before leasing the offset-commit connection
- snapshot and validate the resolved broker ID so concurrent invalidation never sends sentinel `-1` to the pool
- cover direct coordinator commit and `KafkaConsumer.CloseAsync` pending-offset commit paths

## Test plan
- [x] `ConsumerCoordinatorKip848Tests` (79 passed)
- [x] `ConsumerDirtyCommitTests` (13 passed)
- [x] real Kafka `AutoCommit_OnClose_CommitsFinalOffsets` integration test
- [x] full net10 suite: 5,203 passed; unrelated foreground-poll timing flake filed as #1866

Closes #1859
