### PR TITLE
fix(stress): preserve per-pass allocation

### DIFF
--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -457,13 +457,14 @@ public class RoundTripMessageCodecTests
         await Assert.That(snapshot).IsNotNull();
         await Assert.That(snapshot!.DiagnosticsEnabled).IsTrue();
 
+        using var gcStats = new GcStats();
         var result = RoundTripScenarioHelpers.CreateResult(
             "producer-roundtrip",
             "Dekaf",
             options,
             DateTime.UtcNow,
             new ThroughputTracker(),
-            new GcStats(),
+            gcStats,
             delivered: 0,
             new RoundTripValidationSnapshot
             {

--- a/tests/Dekaf.Tests.Unit/StressTests/GcStatsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/GcStatsTests.cs
@@ -1,0 +1,44 @@
+using Dekaf.StressTests.Metrics;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class GcStatsTests
+{
+    [Test]
+    public async Task Capture_ReportsAllocationDeltaForPass()
+    {
+        var readings = new Queue<long>([100, 160, 225]);
+        using var stats = new GcStats(readings.Dequeue, sampleInterval: null);
+
+        stats.SampleAllocation();
+        stats.Capture();
+
+        await Assert.That(stats.AllocatedBytes).IsEqualTo(125);
+    }
+
+    [Test]
+    public async Task Capture_CounterRebase_ContinuesFromNewBaseline()
+    {
+        var readings = new Queue<long>([100, 160, 20, 55]);
+        using var stats = new GcStats(readings.Dequeue, sampleInterval: null);
+
+        stats.SampleAllocation();
+        stats.SampleAllocation();
+        stats.Capture();
+
+        await Assert.That(stats.AllocatedBytes).IsEqualTo(95);
+    }
+
+    [Test]
+    public async Task Capture_CalledTwice_DoesNotReadOrAccumulateAgain()
+    {
+        var readings = new Queue<long>([100, 175]);
+        using var stats = new GcStats(readings.Dequeue, sampleInterval: null);
+
+        stats.Capture();
+        stats.Capture();
+
+        await Assert.That(stats.AllocatedBytes).IsEqualTo(75);
+        await Assert.That(readings).IsEmpty();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
@@ -82,10 +82,21 @@ public sealed class TransactionalReportingTests
         await Assert.That(failed).IsFalse();
     }
 
+    [Test]
+    public async Task CheckForFailures_MissingAllocationMeasurement_FailsRun()
+    {
+        var failed = Dekaf.StressTests.Program.CheckForFailures([
+            CreateResult(CreateVerification(), allocatedBytes: null)
+        ]);
+
+        await Assert.That(failed).IsTrue();
+    }
+
     private static StressTestResult CreateResult(
         TransactionVerificationSnapshot verification,
         string client = "Dekaf",
-        double elapsedSeconds = 900)
+        double elapsedSeconds = 900,
+        long? allocatedBytes = 0)
     {
         var now = DateTime.UtcNow;
         return new StressTestResult
@@ -113,7 +124,7 @@ public sealed class TransactionalReportingTests
                 Gen0Collections = 0,
                 Gen1Collections = 0,
                 Gen2Collections = 0,
-                AllocatedBytes = 0
+                AllocatedBytes = allocatedBytes
             },
             TransactionVerification = verification
         };

--- a/tools/Dekaf.StressTests/Metrics/GcStats.cs
+++ b/tools/Dekaf.StressTests/Metrics/GcStats.cs
@@ -1,52 +1,105 @@
 namespace Dekaf.StressTests.Metrics;
 
 /// <summary>
-/// Tracks GC collection counts across all generations.
+/// Tracks process-wide managed allocations and GC collection counts for one test pass.
 /// Create before the operation, then call Capture() after to calculate deltas.
 /// </summary>
-internal struct GcStats
+internal sealed class GcStats : IDisposable
 {
     private readonly int _gen0Before;
     private readonly int _gen1Before;
     private readonly int _gen2Before;
-    private readonly long _allocatedBefore;
+    private readonly Func<long> _readAllocatedBytes;
+    private readonly object _gate = new();
+    private readonly Timer? _allocationSampler;
+    private long _lastAllocatedBytes;
+    private long _allocatedBytes;
+    private long _largestCounterRebase;
+    private bool _captured;
 
     public int Gen0 { get; private set; }
     public int Gen1 { get; private set; }
     public int Gen2 { get; private set; }
     public long? AllocatedBytes { get; private set; }
 
-    public GcStats()
+    public GcStats() : this(
+        // A single lifetime-counter delta can go negative when allocation contexts from
+        // threads used by a previous client are retired. Frequent cheap snapshots bound
+        // that correction to one interval and let the next segment continue normally.
+        () => GC.GetTotalAllocatedBytes(precise: false),
+        TimeSpan.FromSeconds(1))
     {
+    }
+
+    internal GcStats(Func<long> readAllocatedBytes, TimeSpan? sampleInterval)
+    {
+        _readAllocatedBytes = readAllocatedBytes;
         _gen0Before = GC.CollectionCount(0);
         _gen1Before = GC.CollectionCount(1);
         _gen2Before = GC.CollectionCount(2);
-        _allocatedBefore = GC.GetTotalAllocatedBytes(precise: true);
+        _lastAllocatedBytes = readAllocatedBytes();
         Gen0 = Gen1 = Gen2 = 0;
         AllocatedBytes = null;
+
+        if (sampleInterval is { } interval)
+        {
+            _allocationSampler = new Timer(
+                static state => ((GcStats)state!).SampleAllocation(),
+                this,
+                interval,
+                interval);
+        }
     }
 
     public void Capture()
     {
-        Gen0 = GC.CollectionCount(0) - _gen0Before;
-        Gen1 = GC.CollectionCount(1) - _gen1Before;
-        Gen2 = GC.CollectionCount(2) - _gen2Before;
+        _allocationSampler?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-        // precise: true forces cross-heap synchronization, giving an accurate
-        // cumulative total regardless of which thread takes the snapshot.
-        // On Server GC, compaction can rarely produce a negative delta — report null
-        // rather than a misleading negative number.
-        var delta = GC.GetTotalAllocatedBytes(precise: true) - _allocatedBefore;
-
-        if (delta < 0)
+        lock (_gate)
         {
-            Console.WriteLine($"[GcStats] Warning: precise allocation delta was negative ({delta:N0} B). Reporting as N/A.");
-            AllocatedBytes = null;
-            return;
+            if (_captured)
+                return;
+
+            SampleAllocationCore();
+            Gen0 = GC.CollectionCount(0) - _gen0Before;
+            Gen1 = GC.CollectionCount(1) - _gen1Before;
+            Gen2 = GC.CollectionCount(2) - _gen2Before;
+            AllocatedBytes = _allocatedBytes;
+            _captured = true;
         }
 
-        AllocatedBytes = delta;
+        _allocationSampler?.Dispose();
+
+        if (_largestCounterRebase > 0)
+        {
+            Console.WriteLine(
+                $"[GcStats] Warning: allocation counter rebased by up to {_largestCounterRebase:N0} B; " +
+                "continued measuring from the new baseline.");
+        }
     }
+
+    internal void SampleAllocation()
+    {
+        lock (_gate)
+        {
+            if (!_captured)
+                SampleAllocationCore();
+        }
+    }
+
+    private void SampleAllocationCore()
+    {
+        var current = _readAllocatedBytes();
+        var delta = current - _lastAllocatedBytes;
+        if (delta >= 0)
+            _allocatedBytes += delta;
+        else
+            _largestCounterRebase = Math.Max(_largestCounterRebase, -delta);
+
+        _lastAllocatedBytes = current;
+    }
+
+    public void Dispose() => _allocationSampler?.Dispose();
 
     public GcSnapshot ToSnapshot() => new()
     {

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -411,6 +411,11 @@ public static class Program
             var transactionVerification = result.TransactionVerification;
             var lost = 0L;
 
+            if (result.GcStats.AllocatedBytes is null)
+            {
+                reasons.Add("managed allocation measurement unavailable");
+            }
+
             if (errors > 0)
             {
                 reasons.Add($"{errors:N0} errors");

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -55,7 +55,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAcksAllStressTest.cs
@@ -47,7 +47,7 @@ internal sealed class ConfluentProducerAcksAllStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncIdempotentStressTest.cs
@@ -49,7 +49,7 @@ internal sealed class ConfluentProducerAsyncIdempotentStressTest : IStressTestSc
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerAsyncStressTest.cs
@@ -48,7 +48,7 @@ internal sealed class ConfluentProducerAsyncStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerIdempotentStressTest.cs
@@ -48,7 +48,7 @@ internal sealed class ConfluentProducerIdempotentStressTest : IStressTestScenari
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentProducerStressTest.cs
@@ -47,7 +47,7 @@ internal sealed class ConfluentProducerStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentTransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentTransactionalProducerStressTest.cs
@@ -45,7 +45,7 @@ internal sealed class ConfluentTransactionalProducerStressTest : IStressTestScen
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         runCts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -49,7 +49,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -49,7 +49,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -51,7 +51,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -44,7 +44,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -56,7 +56,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -55,7 +55,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -55,7 +55,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -55,7 +55,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -63,7 +63,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
         throughput.Start();
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
@@ -291,7 +291,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         throughput.Start();
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -56,7 +56,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -94,7 +94,7 @@ internal sealed class SoakStressTest : IStressTestScenario
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            var gcStats = new GcStats();
+        using var gcStats = new GcStats();
             using var measurementCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             measurementCts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
             var monitor = new ResourceTrendMonitor(

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -51,7 +51,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        var gcStats = new GcStats();
+        using var gcStats = new GcStats();
         using var runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         runCts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
 


### PR DESCRIPTION
## Summary
- sample and accumulate managed allocations within each stress-test pass so runtime counter rebases cannot erase a later paired client
- dispose the per-pass sampler across every scenario and warn when a counter rebase is observed
- fail completed runs when managed allocation data is unavailable
- add regression coverage for normal deltas, counter rebases, repeated capture, and missing-measurement failure

## Test plan
- [x] dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net10.0 --no-restore
- [x] net10 unit suite (5,206 passed)
- [x] 1-minute paired producer stress run with STRESS_CLIENT_ORDER=confluent-first (both allocation rows populated; zero errors)

Closes #1860
