### PR TITLE
test(producer): stabilize span append tests

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1016,6 +1016,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private int _disposed;
     private int _closed;
 
+    internal Action? PurgeAppendWaitObservedForTest;
+
     /// <summary>
     /// True after CloseAsync has been called. Used by the sender loop to know
     /// when to exit after draining remaining batches.
@@ -4786,6 +4788,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var purgedCount = FailPendingAppendsForPurge(exception);
         List<PartitionBatch>? currentBatches = null;
         List<ReadyBatch>? readyBatches = null;
+        var appendWaitObserved = false;
 
         foreach (var kvp in _partitionDeques)
         {
@@ -4800,6 +4803,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     if (pd.AppendInProgress)
                     {
                         waitForAppend = true;
+                        if (!appendWaitObserved)
+                        {
+                            appendWaitObserved = true;
+                            PurgeAppendWaitObservedForTest?.Invoke();
+                        }
                     }
                     else
                     {

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -263,8 +263,8 @@ public class RecordAccumulatorTests
         var headerValue = new BlockingReadOnlyMemoryManager(new byte[] { 1, 2, 3, 4 });
         var headers = ProducerContainerPools.Headers.Rent(1);
         headers[0] = new Header("blocked", headerValue.ReadOnlyMemory);
-        var appendTask = Task.Run(async () =>
-            await accumulator.AppendFromSpansAsync(
+        var appendTask = RunOnDedicatedThread(() =>
+            accumulator.AppendFromSpansAsync(
                 topicPartition.Topic,
                 topicPartition.Partition,
                 timestamp,
@@ -275,16 +275,19 @@ public class RecordAccumulatorTests
                 headers,
                 headerCount: 1,
                 callback: null,
-                CancellationToken.None));
+                CancellationToken.None).AsTask().GetAwaiter().GetResult());
 
         try
         {
             await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
-            var purgeTask = Task.Run(() => accumulator.Purge(PurgeOptions.Queue, CreatePurgedException()));
-            await WaitUntilAsync(
-                () => purgeTask.Status == TaskStatus.Running || purgeTask.IsCompleted,
-                TimeSpan.FromSeconds(5));
+            using var purgeStarted = new ManualResetEventSlim();
+            var purgeTask = RunOnDedicatedThread(() =>
+            {
+                purgeStarted.Set();
+                return accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());
+            });
+            await Assert.That(purgeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             await Assert.That(purgeTask.IsCompleted).IsFalse();
 
             headerValue.Release();
@@ -413,8 +416,8 @@ public class RecordAccumulatorTests
         var headers = ProducerContainerPools.Headers.Rent(1);
         headers[0] = new Header("blocked", headerValue.ReadOnlyMemory);
         var disposed = false;
-        var appendTask = Task.Run(async () =>
-            await accumulator.AppendFromSpansAsync(
+        var appendTask = RunOnDedicatedThread(() =>
+            accumulator.AppendFromSpansAsync(
                 topicPartition.Topic,
                 topicPartition.Partition,
                 timestamp,
@@ -425,7 +428,7 @@ public class RecordAccumulatorTests
                 headers,
                 headerCount: 1,
                 callback: null,
-                CancellationToken.None));
+                CancellationToken.None).AsTask().GetAwaiter().GetResult());
 
         try
         {
@@ -434,7 +437,11 @@ public class RecordAccumulatorTests
                 () => IsAppendInProgress(accumulator, topicPartition),
                 TimeSpan.FromSeconds(5));
 
-            var disposeTask = Task.Run(async () => await accumulator.DisposeAsync());
+            var disposeTask = RunOnDedicatedThread(() =>
+            {
+                accumulator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                return true;
+            });
             await WaitUntilAsync(
                 () => GetPrivateField<int>(accumulator, "_disposed") != 0 || disposeTask.IsCompleted,
                 TimeSpan.FromSeconds(5));
@@ -1639,7 +1646,6 @@ public class RecordAccumulatorTests
         var accumulator = new RecordAccumulator(options);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         ReadyBatch? drainedBatch = null;
 
         try
@@ -1677,24 +1683,13 @@ public class RecordAccumulatorTests
             await Assert.That(secondResult).IsTrue();
             await Assert.That(GetPrivateField<int>(accumulator, "_pendingAwaitedProduceCount")).IsEqualTo(1);
 
-            var drainTask = Task.Run(async () =>
-            {
-                while (!cts.Token.IsCancellationRequested)
-                {
-                    if (accumulator.TryDrainBatch(out var batch))
-                    {
-                        drainedBatch = batch;
-                        batch.CompleteSend(baseOffset: 20, DateTimeOffset.UtcNow);
-                        accumulator.OnBatchExitsPipeline(batch);
-                        return;
-                    }
+            var flushTask = accumulator.FlushAsync(CancellationToken.None).AsTask();
 
-                    await accumulator.WaitForWakeupAsync(100).ConfigureAwait(false);
-                }
-            }, cts.Token);
+            await Assert.That(accumulator.TryDrainBatch(out drainedBatch)).IsTrue();
+            drainedBatch!.CompleteSend(baseOffset: 20, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(drainedBatch);
 
-            await accumulator.FlushAsync(cts.Token);
-            await drainTask;
+            await flushTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(GetPrivateField<int>(accumulator, "_pendingAwaitedProduceCount")).IsEqualTo(0);
             await Assert.That(drainedBatch).IsNotNull();
@@ -3734,6 +3729,30 @@ public class RecordAccumulatorTests
 
             await Task.Yield();
         }
+    }
+
+    private static Task<T> RunOnDedicatedThread<T>(Func<T> action)
+    {
+        // These tests intentionally block one operation behind another. A dedicated
+        // thread keeps that coordination independent of full-suite ThreadPool pressure.
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                completion.SetResult(action());
+            }
+            catch (Exception exception)
+            {
+                completion.SetException(exception);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "record-accumulator-test-worker"
+        };
+        thread.Start();
+        return completion.Task;
     }
 
     private sealed class LockAssertingReadOnlyMemoryManager(

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -281,13 +281,11 @@ public class RecordAccumulatorTests
         {
             await headerValue.WaitUntilEnteredAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
-            using var purgeStarted = new ManualResetEventSlim();
-            var purgeTask = RunOnDedicatedThread(() =>
-            {
-                purgeStarted.Set();
-                return accumulator.Purge(PurgeOptions.Queue, CreatePurgedException());
-            });
-            await Assert.That(purgeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            var purgeWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            accumulator.PurgeAppendWaitObservedForTest = () => purgeWaitObserved.TrySetResult();
+            var purgeTask = RunOnDedicatedThread(
+                () => accumulator.Purge(PurgeOptions.Queue, CreatePurgedException()));
+            await purgeWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(purgeTask.IsCompleted).IsFalse();
 
             headerValue.Release();


### PR DESCRIPTION
Closes #1870

## What changed
- run intentionally blocked span-append operations on dedicated threads, independent of full-suite ThreadPool pressure
- replace the pending-count test's asynchronous polling drainer with deterministic flush/seal/drain completion
- retain exact once-only pending-awaited-batch accounting assertions without increasing timeouts

## Validation
- RecordAccumulatorTests net8.0: 80/80
- RecordAccumulatorTests net10.0: 80/80
- full net8.0 unit suite, consecutive run 1: 5122/5122
- full net8.0 unit suite, consecutive run 2: 5122/5122