### PR TITLE
test(networking): control write grace expiry

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -82,6 +82,7 @@ public sealed partial class KafkaConnection :
     private readonly ILogger _logger;
     private readonly ConnectionOptions _options;
     private readonly ResponseBufferPool _responseBufferPool;
+    private readonly Func<Task, TimeSpan, Task> _waitForAbandonedWriteAsync;
 
     private Socket? _socket;
     private string? _resolvedTargetHost;
@@ -229,7 +230,8 @@ public sealed partial class KafkaConnection :
         ConnectionOptions? options,
         ILogger<KafkaConnection>? logger,
         ResponseBufferPool responseBufferPool,
-        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null,
+        Func<Task, TimeSpan, Task>? waitForAbandonedWriteAsync = null)
     {
         _host = host;
         _port = port;
@@ -243,6 +245,7 @@ public sealed partial class KafkaConnection :
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConnection>.Instance;
         _responseBufferPool = responseBufferPool;
         _telemetryMetricCollector = telemetryMetricCollector;
+        _waitForAbandonedWriteAsync = waitForAbandonedWriteAsync ?? WaitForAbandonedWriteAsync;
         _receiveTimeoutStopwatchTicks =
             (long)(_options.RequestTimeout.Ticks * (double)Stopwatch.Frequency / TimeSpan.TicksPerSecond);
     }
@@ -1136,7 +1139,7 @@ public sealed partial class KafkaConnection :
     {
         try
         {
-            await writeTask.WaitAsync(_options.RequestTimeout).ConfigureAwait(false);
+            await _waitForAbandonedWriteAsync(writeTask, _options.RequestTimeout).ConfigureAwait(false);
 
             // Completed after the caller gave up: the frame is intact, the outgoing stream is
             // still frame-aligned, and the connection remains usable. Any late response is
@@ -1165,6 +1168,9 @@ public sealed partial class KafkaConnection :
             // already aborted the connection. Nothing to do beyond observing the exception.
         }
     }
+
+    private static Task WaitForAbandonedWriteAsync(Task writeTask, TimeSpan timeout)
+        => writeTask.WaitAsync(timeout);
 
     /// <summary>
     /// Marks the connection unusable after a frame write faulted or stayed stuck past its grace

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -540,10 +540,20 @@ public sealed class KafkaConnectionTests
     public async Task WriteTimeout_AbandonedWriteStuckPastGracePeriod_AbortsConnectionAndReleasesWriteLock(
         CancellationToken cancellationToken)
     {
+        var graceWaitStarted = new TaskCompletionSource();
+        var expireGracePeriod = new TaskCompletionSource();
         await using var connection = new KafkaConnection(
             "localhost",
             9092,
-            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(50) });
+            clientId: null,
+            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) },
+            logger: null,
+            responseBufferPool: ResponseBufferPool.Default,
+            waitForAbandonedWriteAsync: (_, _) =>
+            {
+                graceWaitStarted.TrySetResult();
+                return expireGracePeriod.Task;
+            });
         var stream = new PendingWriteStream();
         SetPrivateField(connection, "_stream", stream);
 
@@ -558,6 +568,8 @@ public sealed class KafkaConnectionTests
             .Throws<KafkaException>()
             .WithMessageContaining("Flush timeout");
 
+        await graceWaitStarted.Task.WaitAsync(cancellationToken);
+        expireGracePeriod.SetException(new TimeoutException("controlled grace-period expiry"));
         await stream.Disposed.WaitAsync(cancellationToken);
         await Assert.That(async () => await writeTask)
             .Throws<IOException>()


### PR DESCRIPTION
## Summary
- inject the abandoned-frame-write grace wait through the internal connection constructor while preserving the production Task.WaitAsync behavior
- replace the test's real 50 ms timer with explicit grace-start and grace-expiry signals
- keep assertions for connection abort, stream disposal, write fault observation, and write-lock release

## Test plan
- [x] focused abandoned-write test: net8 25 consecutive passes; net10 pass
- [x] KafkaConnectionTests: 33/33 on net8 and net10
- [x] full net8 suite at CI concurrency: 5,119/5,119
- [x] clean dual-target build and focused tests after rebasing merged #1867

Closes #1869
