### PR TITLE
test(internal): isolate pool sizing statics

### DIFF
--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -3,6 +3,7 @@ using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Internal;
 
+[NotInParallel]
 public class PoolSizingTests
 {
     // --- ForProducer tests ---


### PR DESCRIPTION
Closes #1874

## What changed
- run PoolSizingTests globally non-parallel so unlabelled producer tests cannot ratchet shared static pools between reference assertions
- preserve production monotonic capacity semantics unchanged

## Validation
- PoolSizingTests net8.0: 39/39
- PoolSizingTests net10.0: 39/39
- full net8.0 run 1: 5122/5122
- full net8.0 run 2: no pool-sizing failures; 5121/5122 due known unrelated #1866 consumer cancellation