### PR TITLE
test(producer): isolate sender disposal tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -586,6 +586,7 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(120_000)]
     public async Task SendLoop_SequentialRequests_SecondSendsAfterFirstResponseCompletes(CancellationToken cancellationToken)
     {
@@ -712,6 +713,7 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(120_000)]
     public async Task SendLoop_InFlightByteBudget_DoesNotBlockIdleConnection(
         CancellationToken cancellationToken)
@@ -948,6 +950,7 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(30_000)]
     public async Task SendLoop_SendFailure_RefreshesMetadataAndReroutes(CancellationToken cancellationToken)
     {
@@ -1111,6 +1114,7 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(30_000)]
     public async Task SendLoop_ParallelSendFailures_RefreshMetadataOncePerTopic(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderTests.cs
@@ -63,6 +63,7 @@ public sealed class BrokerSenderTests
     }
 
     [Test]
+    [NotInParallel]
     public async Task Disposal_AfterChannelComplete_NoDeadlock()
     {
         var connectionPool = Substitute.For<IConnectionPool>();


### PR DESCRIPTION
Closes #1871

## What changed
- globally isolate only the five observed sender scheduling/disposal tests
- prevent full-suite ThreadPool pressure from delaying async send-loop continuations during deterministic coordination
- keep production behavior, assertions, and existing timeouts unchanged

## Validation
- BrokerSenderSendLoopTests + BrokerSenderTests net8.0: 39/39
- same suites net10.0: 39/39
- full net8.0 under heavy concurrent process pressure: 5122/5122 (58.1s)
- repeated captured full net8.0: 5122/5122 (24.4s)