### PR TITLE
test(consumer): isolate max poll races

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -451,6 +451,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [NotInParallel]
     public async Task RecordPollAsync_ActiveForegroundPollActivity_DoesNotExpireMember()
     {
         SetupSuccessfulConsumerProtocolJoin();
@@ -649,6 +650,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(5_000)]
     public async Task ConsumerProtocol_StaticMaxPollExpiry_RejoinsWithNegativeTwoAndSameMemberId(
         CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #1866

## What changed
- globally isolate the foreground poll activity/max-poll test whose canceled heartbeat setup can outlive StopHeartbeatAsync's bounded wait under suite contention
- isolate the independently observed static-member max-poll sibling using the same heartbeat timing setup
- keep production behavior, assertions, and timeouts unchanged

## Validation
- ConsumerCoordinatorKip848Tests net8.0: 80/80
- ConsumerCoordinatorKip848Tests net10.0: 80/80
- full net8.0: 5122/5122
- full net10.0: 5211/5211