### PR TITLE
test(networking): complete timeout abort inline

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -202,7 +202,10 @@ public sealed class KafkaConnectionPipelinedTests
             "localhost",
             9092,
             options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(50) });
-        using var stream = new ScriptedReadStream([], blockAfterChunks: true);
+        using var stream = new ScriptedReadStream(
+            [],
+            blockAfterChunks: true,
+            runContinuationsAsynchronously: false);
         using var frameReader = CreateFrameReader(stream);
         using var receiveCts = new CancellationTokenSource();
         SetPrivateField(connection, "_frameReader", frameReader);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -310,11 +310,17 @@ internal static class ResponseFrameTestHelpers
 /// semantics. After the chunks are exhausted it either reports EOF or blocks
 /// until disposed (to simulate an idle connection).
 /// </summary>
-internal sealed class ScriptedReadStream(byte[][] chunks, bool blockAfterChunks = false) : Stream
+internal sealed class ScriptedReadStream(
+    byte[][] chunks,
+    bool blockAfterChunks = false,
+    bool runContinuationsAsynchronously = true) : Stream
 {
     private readonly Queue<byte[]> _chunks = new(chunks);
     private readonly TaskCompletionSource _readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly TaskCompletionSource _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _disposed = new(
+        runContinuationsAsynchronously
+            ? TaskCreationOptions.RunContinuationsAsynchronously
+            : TaskCreationOptions.None);
     private byte[]? _current;
     private int _currentOffset;
 


### PR DESCRIPTION
Closes #1862

## What changed
- allow ScriptedReadStream disposal continuations to run inline when explicitly requested
- use inline disposal only in the timeout-aborted receive regression, so abort deterministically resumes receive teardown and fails the pending request before scheduler contention can mask behavior
- preserve default test-stream and production behavior

## Validation
- KafkaConnectionPipelinedTests + ResponseFrameReaderTests net8.0: 32/32
- same suites net10.0: 32/32
- exact regression net8.0 fresh processes: 10/10
- full net8.0: 5122/5122