### PR TITLE
Version consumer stress baselines by connection count

### DIFF
--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -27,6 +27,7 @@ _IDENTITY_FIELDS = (
     "durationMinutes",
     "messageSizeBytes",
     "consumerSeedBatchSizeBytes",
+    "consumerConnectionsPerBroker",
     "roundTripMessages",
 )
 
@@ -63,6 +64,21 @@ def _consumer_seed_batch_size(result):
     return 16_384 if scenario.startswith("consumer") else None
 
 
+def _consumer_connections_per_broker(result):
+    value = result.get("consumerConnectionsPerBroker")
+    if value is not None:
+        return value
+
+    scenario = str(result.get("scenario", "")).casefold()
+    client = str(result.get("client", "")).casefold()
+    if not scenario.startswith("consumer"):
+        return None
+
+    # Results written before the connection count became part of the performance
+    # identity used the old two-connection Dekaf preset or Confluent's one connection.
+    return 1 if client.startswith("confluent") else 2
+
+
 def _identity(result):
     return (
         str(result.get("scenario", "unknown")).casefold(),
@@ -71,6 +87,7 @@ def _identity(result):
         result.get("durationMinutes"),
         result.get("messageSizeBytes"),
         _consumer_seed_batch_size(result),
+        _consumer_connections_per_broker(result),
         _roundtrip_messages(result),
     )
 
@@ -182,6 +199,7 @@ def evaluate_and_update(history, current_results, run_started_at):
         prior = _matching_observations(baseline_runs, result)
         observation = {field: result.get(field) for field in _IDENTITY_FIELDS}
         observation["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
+        observation["consumerConnectionsPerBroker"] = _consumer_connections_per_broker(result)
         observation["brokerCount"] = result.get("brokerCount", 1)
         observation["roundTripMessages"] = _roundtrip_messages(result)
         throughput_regression = False

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -403,6 +403,36 @@ class StressTrendTests(unittest.TestCase):
             {item["status"] for item in large_batch_evaluations},
         )
 
+    def test_consumer_connection_count_separates_new_performance_profile(self):
+        history = {
+            "version": 1,
+            "runs": [history_run(i, scenario="consumer-batch") for i in range(1, 4)],
+        }
+
+        legacy_evaluations, _, _ = evaluate_and_update(
+            history,
+            [result(scenario="consumer-batch", consumerConnectionsPerBroker=2)],
+            "2026-07-01T02:00:00Z",
+        )
+        three_connection_evaluations, updated, _ = evaluate_and_update(
+            history,
+            [result(scenario="consumer-batch", consumerConnectionsPerBroker=3)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertNotEqual(
+            {"insufficient-history"},
+            {item["status"] for item in legacy_evaluations},
+        )
+        self.assertEqual(
+            {"insufficient-history"},
+            {item["status"] for item in three_connection_evaluations},
+        )
+        self.assertEqual(
+            3,
+            updated["runs"][-1]["results"][0]["consumerConnectionsPerBroker"],
+        )
+
     def test_different_roundtrip_bound_does_not_supply_baseline(self):
         history = {
             "version": 1,

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -16,6 +16,12 @@ internal sealed class StressTestResult
     public required int DurationMinutes { get; init; }
     public required int MessageSizeBytes { get; init; }
     public int? ConsumerSeedBatchSizeBytes { get; init; }
+
+    /// <summary>
+    /// Consumer connections per broker used by this performance profile. Null for
+    /// non-consumer scenarios.
+    /// </summary>
+    public int? ConsumerConnectionsPerBroker { get; init; }
     public required DateTime StartedAtUtc { get; init; }
     public required DateTime CompletedAtUtc { get; init; }
     public required ThroughputSnapshot Throughput { get; init; }

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -127,6 +127,7 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
             ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = 1,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -115,6 +115,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
             ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -115,6 +115,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
             ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -111,6 +111,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
             ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -104,6 +104,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
             ConsumerSeedBatchSizeBytes = options.ConsumerSeedBatchSizeBytes,
+            ConsumerConnectionsPerBroker = StressTestOptions.HighThroughputConsumerConnectionsPerBroker,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -13,6 +13,8 @@ internal interface IStressTestScenario
 
 internal sealed class StressTestOptions
 {
+    public const int HighThroughputConsumerConnectionsPerBroker = 3;
+
     public required string BootstrapServers { get; init; }
     public required string Topic { get; init; }
     public required int DurationMinutes { get; init; }


### PR DESCRIPTION
Closes #1861

## Summary
- record consumer connections-per-broker in stress result artifacts
- include connection count in noise-aware trend identity
- preserve legacy baselines by interpreting old Dekaf consumer rows as the prior 2-connection preset
- add regression coverage proving the new 3-connection profile starts a clean baseline

## Investigation
- the referenced consumer-raw samples do not show first-sample warm-up overshoot; the first third averaged above the last third, while p95 peaks occurred throughout the run
- consumer-raw breached the same 0.85 ratio before #1847, so weakening the steady-state gate or excluding warm-up would not address the observed signal
- controlled 1-minute, 500k-message local comparison found consumer-batch at 3 connections 37% faster than 1 (227k vs 166k msg/s), rejecting a batch-specific 1-connection preset

## Validation
- `python -m unittest discover -s .github/scripts -p "test_*.py"` (51 passed)
- `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj -c Release --no-restore`
- `git diff --check`