### PR TITLE
test(internal): isolate stack allocation probe

### DIFF
--- a/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
@@ -103,22 +103,26 @@ public class LockFreeStackTests
     [Test]
     public async Task TryPush_TryPop_DoNotAllocateInSteadyState()
     {
-        var stack = new LockFreeStack<Item>(1);
-        var item = new Item { Value = 42 };
-
-        for (var i = 0; i < 100; i++)
+        var allocated = await Task.Factory.StartNew(static () =>
         {
-            stack.TryPush(item);
-            stack.TryPop(out _);
-        }
+            var stack = new LockFreeStack<Item>(1);
+            var item = new Item { Value = 42 };
 
-        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-        for (var i = 0; i < 10_000; i++)
-        {
-            stack.TryPush(item);
-            stack.TryPop(out _);
-        }
-        var allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            for (var i = 0; i < 100; i++)
+            {
+                stack.TryPush(item);
+                stack.TryPop(out _);
+            }
+
+            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < 10_000; i++)
+            {
+                stack.TryPush(item);
+                stack.TryPop(out _);
+            }
+
+            return GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
         await Assert.That(allocated).IsEqualTo(0);
     }


### PR DESCRIPTION
Closes #1876

## What changed
- run LockFreeStack warm-up and allocation measurement inside a static LongRunning delegate on a dedicated thread
- keep scheduler/task setup outside the measured interval
- preserve the exact zero-byte steady-state assertion

## Validation
- LockFreeStackTests Release net10.0: 14/14
- LockFreeStackTests Release net8.0: 14/14
- exact zero-allocation test, fresh net10.0 processes: 20/20
- full Release net10.0: 5211/5211