### PR TITLE
test(producer): control muted scale check

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -609,13 +609,14 @@ public sealed class AdaptiveScaleDownTests
             var mutePartition = typeof(BrokerSender).GetMethod(
                 "MutePartition",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
-            var unmutePartition = typeof(BrokerSender).GetMethod(
-                "UnmutePartition",
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
             for (var partition = 0; partition < 3; partition++)
                 mutePartition.Invoke(sender, [new TopicPartition(Topic, partition)]);
-            for (var partition = 0; partition < 3; partition++)
-                unmutePartition.Invoke(sender, [new TopicPartition(Topic, partition)]);
+
+            // Simulate all partitions clearing between scale checks without calling
+            // UnmutePartition, whose wake event lets the live sender loop race this
+            // test's direct MaybeScaleConnections invocation.
+            GetField<ConcurrentDictionary<TopicPartition, byte>>(sender, "_mutedPartitions").Clear();
+            SetField(sender, "_mutedPartitionCount", 0);
             SetField(sender, "_totalPendingResponseCount", 0);
             SetField(sender, "_lowUtilizationStartTicks", 1L);
             InvokeMaybeScaleConnections(sender);


### PR DESCRIPTION
Closes #1880

## What changed
- retain real MutePartition calls to establish the muted-width high watermark
- simulate the between-check momentary clear directly instead of calling UnmutePartition, whose wake events let the live sender loop race the test's private scale-check invocation
- preserve the no-shrink assertion and production behavior

## Validation
- AdaptiveScaleDownTests net8.0: 28/28
- AdaptiveScaleDownTests net10.0: 28/28
- exact regression, fresh net8.0 processes: 20/20
- full net8.0: 5127/5127