### PR TITLE
fix(producer): base admission budget on min RTT

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -192,9 +192,34 @@ def paired_latency_thresholds(results):
         client = str(result.get('client', ''))
         if client.casefold() != 'dekaf':
             continue
-        baseline = baselines.get(_latency_identity(result))
         latency = result.get('latency')
-        if baseline is None or not isinstance(latency, dict):
+        if not isinstance(latency, dict):
+            continue
+
+        target_ms = result.get('deliveryLatencyTargetMs')
+        p95_us = latency.get('p95Us')
+        if _positive_finite_number(target_ms) and _positive_finite_number(p95_us):
+            ratio = p95_us / (target_ms * 1_000)
+            breached = ratio > 3.0
+            evaluations.append({
+                'scenario': _latency_scenario_label(result),
+                'metric': 'latencyP95TargetRatio',
+                'metricLabel': 'Delivery latency p95 / target',
+                'current': ratio,
+                'baselineCount': 0,
+                'median': None,
+                'mad': None,
+                'lower': None,
+                'upper': 3.0,
+                'status': 'regression' if breached else 'stable',
+                'repeatedRegression': False,
+                'thresholdBreach': breached,
+                'thresholdDirection': 'maximum',
+                'latencyThreshold': True,
+            })
+
+        baseline = baselines.get(_latency_identity(result))
+        if baseline is None:
             continue
 
         for field, metric, label in (

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -190,7 +190,7 @@ def paired_latency_thresholds(results):
     evaluations = []
     for result in results:
         client = str(result.get('client', ''))
-        if client.casefold() != 'dekaf':
+        if not client.casefold().startswith('dekaf'):
             continue
         latency = result.get('latency')
         if not isinstance(latency, dict):
@@ -217,6 +217,11 @@ def paired_latency_thresholds(results):
                 'thresholdDirection': 'maximum',
                 'latencyThreshold': True,
             })
+
+        # Multi-connection Dekaf variants use their own throughput profile and have no
+        # like-for-like Confluent pair, but the absolute configured target still applies.
+        if client.casefold() != 'dekaf':
+            continue
 
         baseline = baselines.get(_latency_identity(result))
         if baseline is None:

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -151,16 +151,20 @@ class StressReportTests(unittest.TestCase):
         self.assertEqual(3.0, evaluation["upper"])
         self.assertTrue(evaluation["thresholdBreach"])
 
-    def test_paired_latency_thresholds_ignore_multi_connection_dekaf_results(self):
+    def test_paired_latency_thresholds_enforce_target_without_pairing_multi_connection_results(self):
         confluent = stress_result("Confluent", effective_rate=1000)
         confluent["latency"] = {"p50Us": 10_000, "p99Us": 50_000}
         multi_connection = stress_result("Dekaf (3conn)", effective_rate=2000)
-        multi_connection["latency"] = {"p50Us": 50_000, "p99Us": 500_000}
+        multi_connection.update({
+            "latency": {"p50Us": 50_000, "p95Us": 31_000, "p99Us": 500_000},
+            "deliveryLatencyTargetMs": 10,
+        })
 
-        self.assertEqual(
-            [],
-            paired_latency_thresholds([confluent, multi_connection]),
-        )
+        evaluations = paired_latency_thresholds([confluent, multi_connection])
+
+        self.assertEqual(1, len(evaluations))
+        self.assertEqual("latencyP95TargetRatio", evaluations[0]["metric"])
+        self.assertTrue(evaluations[0]["thresholdBreach"])
 
     def test_paired_latency_thresholds_require_matching_roundtrip_bound(self):
         confluent = stress_result("Confluent", effective_rate=1000)

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -135,6 +135,22 @@ class StressReportTests(unittest.TestCase):
 
         self.assertEqual([], paired_latency_thresholds([unpaired]))
 
+    def test_paired_latency_thresholds_enforce_absolute_p95_target(self):
+        dekaf = stress_result("Dekaf", effective_rate=1400)
+        dekaf.update({
+            "latency": {"p50Us": 5_000, "p95Us": 31_000, "p99Us": 40_000},
+            "deliveryLatencyTargetMs": 10,
+        })
+
+        evaluations = paired_latency_thresholds([dekaf])
+
+        self.assertEqual(1, len(evaluations))
+        evaluation = evaluations[0]
+        self.assertEqual("latencyP95TargetRatio", evaluation["metric"])
+        self.assertAlmostEqual(3.1, evaluation["current"])
+        self.assertEqual(3.0, evaluation["upper"])
+        self.assertTrue(evaluation["thresholdBreach"])
+
     def test_paired_latency_thresholds_ignore_multi_connection_dekaf_results(self):
         confluent = stress_result("Confluent", effective_rate=1000)
         confluent["latency"] = {"p50Us": 10_000, "p99Us": 50_000}

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -565,8 +565,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly long[] _pendingResponseBytesByConnection;
 
     // Per-broker unacked-byte admission budget (owned by the accumulator, shared with the
-    // producer's admission gate). This send loop is the single writer of its EWMA drain
-    // estimate (OnAcked) and cap (SetCap); null when the bound is disabled.
+    // producer's admission gate). This send loop is the single writer of its drain-rate
+    // and minimum-RTT estimates (OnAcked) and cap (SetCap); null when the bound is disabled.
     private readonly BrokerUnackedByteBudget? _unackedBudget;
 
     // Snapshot of the budget's admission-block counter for scale-pressure deltas. The gate
@@ -2834,7 +2834,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private void UpdateInFlightByteBudget(int connectionCount)
     {
         _totalMaxInFlightBytes = GetInFlightByteBudget(connectionCount);
-        _unackedBudget?.SetCap(_options.UnackedByteBudgetCapOverride ?? _totalMaxInFlightBytes);
+        _unackedBudget?.SetCap(
+            _options.UnackedByteBudgetCapOverride ?? _totalMaxInFlightBytes,
+            _getTimestamp());
     }
 
     private static long SumEncodedBytes(List<PendingResponse> pendingResponses)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -185,11 +185,15 @@ internal sealed class BrokerUnackedByteBudget
 
         if (_minRttProbeUntilTimestamp != 0)
         {
-            _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, rttSeconds);
             if (nowTicks >= _minRttProbeUntilTimestamp)
+            {
                 CompleteMinRttProbe(nowTicks);
-
-            return;
+            }
+            else
+            {
+                _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, rttSeconds);
+                return;
+            }
         }
 
         if (rttSeconds < _minRttSeconds)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -13,8 +13,9 @@ namespace Dekaf.Producer;
 /// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
-/// <see cref="RecordAdmissionBlock"/> are cross-thread (producer appenders and terminal batch
-/// paths). <see cref="OnAcked"/> and <see cref="SetCap"/> are single-writer — only the owning
+/// <see cref="IsOverBudgetAt"/>/<see cref="RecordAdmissionBlock"/> are cross-thread (producer
+/// appenders and terminal batch paths). <see cref="OnAcked"/> and <see cref="SetCap"/> are
+/// single-writer — only the owning
 /// broker's send loop calls them — so the estimator state needs no synchronization; the computed
 /// budget is published with a volatile write.
 /// </para>
@@ -53,6 +54,8 @@ internal sealed class BrokerUnackedByteBudget
     // Cross-thread state.
     private long _unackedBytes;
     private long _budgetBytes;
+    private long _budgetAfterMinRttProbeBytes;
+    private long _probeBudgetAfterMinRttProbeBytes;
     private long _admissionBlockEvents;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
@@ -71,6 +74,8 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
     private long _minRttTimestamp;
+    // Written only by the send loop; acquire-read by appenders after _budgetBytes publishes
+    // the matching precomputed post-probe budgets.
     private long _minRttProbeUntilTimestamp;
     private long _nextProbeTimestamp;
     private long _probeUntilTimestamp;
@@ -81,6 +86,8 @@ internal sealed class BrokerUnackedByteBudget
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, initialCapBytes);
         Volatile.Write(ref _budgetBytes, _capBytes);
+        Volatile.Write(ref _budgetAfterMinRttProbeBytes, _capBytes);
+        Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, _capBytes);
     }
 
     /// <summary>
@@ -108,6 +115,22 @@ internal sealed class BrokerUnackedByteBudget
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsOverBudget()
         => Volatile.Read(ref _unackedBytes) >= Volatile.Read(ref _budgetBytes);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsOverBudgetAt(long nowTicks)
+    {
+        var budget = Volatile.Read(ref _budgetBytes);
+        var minRttProbeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
+        if (minRttProbeUntilTimestamp != 0 && nowTicks >= minRttProbeUntilTimestamp)
+        {
+            var capacityProbeUntilTimestamp = Volatile.Read(ref _probeUntilTimestamp);
+            budget = capacityProbeUntilTimestamp != 0 && nowTicks < capacityProbeUntilTimestamp
+                ? Volatile.Read(ref _probeBudgetAfterMinRttProbeBytes)
+                : Volatile.Read(ref _budgetAfterMinRttProbeBytes);
+        }
+
+        return Volatile.Read(ref _unackedBytes) >= budget;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Charge(long bytes)
@@ -260,6 +283,26 @@ internal sealed class BrokerUnackedByteBudget
 
     private void RecomputeBudget()
     {
+        var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
+        var budget = ComputeBudget(minRttProbeActive, _probeUntilTimestamp != 0);
+        if (minRttProbeActive)
+        {
+            Volatile.Write(ref _budgetAfterMinRttProbeBytes,
+                ComputeBudget(minRttProbeActive: false, capacityProbeActive: false));
+            Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes,
+                ComputeBudget(minRttProbeActive: false, capacityProbeActive: true));
+        }
+        else
+        {
+            Volatile.Write(ref _budgetAfterMinRttProbeBytes, budget);
+            Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, budget);
+        }
+
+        Volatile.Write(ref _budgetBytes, budget);
+    }
+
+    private long ComputeBudget(bool minRttProbeActive, bool capacityProbeActive)
+    {
         long budget;
         if (_rateMaxCount == 0)
         {
@@ -269,17 +312,17 @@ internal sealed class BrokerUnackedByteBudget
         }
         else
         {
-            var horizonSeconds = _hasMinRttSample && _minRttProbeUntilTimestamp == 0
+            var horizonSeconds = _hasMinRttSample && !minRttProbeActive
                 ? Math.Max(_targetSeconds, RttSafetyMultiplier * _minRttSeconds)
                 : _targetSeconds;
             var estimatedBytes = _rateMaxValues[_rateMaxHead] * horizonSeconds;
-            if (_probeUntilTimestamp != 0 && _minRttProbeUntilTimestamp == 0)
+            if (capacityProbeActive && !minRttProbeActive)
                 estimatedBytes *= ProbeBudgetMultiplier;
 
             budget = (long)estimatedBytes;
             budget = Math.Clamp(budget, _floorBytes, _capBytes);
         }
 
-        Volatile.Write(ref _budgetBytes, budget);
+        return budget;
     }
 }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -42,6 +42,12 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     private static readonly long MinRttProbeDurationTicks = Stopwatch.Frequency / 20;
 
+    /// <summary>
+    /// Maximum target-only drain interval. An RTT outlier must not disable the retained
+    /// RTT safety floor for its full (potentially multi-second) duration.
+    /// </summary>
+    private static readonly long MaxMinRttProbeDurationTicks = Stopwatch.Frequency / 4;
+
     /// <summary>Budget never drops below this multiple of the measured bandwidth-delay
     /// product (rate × RTT). Without this guard a target below the broker RTT would shrink
     /// the budget below BDP, underfill the pipe, lower the measured rate, and ratchet the
@@ -267,7 +273,11 @@ internal sealed class BrokerUnackedByteBudget
     {
         _minRttProbeMinimumSeconds = double.MaxValue;
         var observedRttTicks = (long)(observedRttSeconds * Stopwatch.Frequency);
-        _minRttProbeUntilTimestamp = nowTicks + Math.Max(MinRttProbeDurationTicks, observedRttTicks);
+        var probeDurationTicks = Math.Clamp(
+            observedRttTicks,
+            MinRttProbeDurationTicks,
+            MaxMinRttProbeDurationTicks);
+        _minRttProbeUntilTimestamp = nowTicks + probeDurationTicks;
     }
 
     private void AddRateSample(double bytesPerSecond)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -128,9 +128,12 @@ internal sealed class BrokerUnackedByteBudget
     /// Updates the ceiling (routing-width-dependent) and republishes the budget.
     /// Called by the owning send loop at construction and on connection scale events.
     /// </summary>
-    public void SetCap(long capBytes)
+    public void SetCap(long capBytes, long nowTicks)
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
+        CompleteExpiredMinRttProbe(nowTicks);
+        if (_probeUntilTimestamp != 0 && nowTicks >= _probeUntilTimestamp)
+            _probeUntilTimestamp = 0;
         RecomputeBudget();
     }
 
@@ -184,11 +187,7 @@ internal sealed class BrokerUnackedByteBudget
         {
             _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, rttSeconds);
             if (nowTicks >= _minRttProbeUntilTimestamp)
-            {
-                _minRttSeconds = _minRttProbeMinimumSeconds;
-                _minRttTimestamp = nowTicks;
-                _minRttProbeUntilTimestamp = 0;
-            }
+                CompleteMinRttProbe(nowTicks);
 
             return;
         }
@@ -201,7 +200,24 @@ internal sealed class BrokerUnackedByteBudget
         }
 
         if (nowTicks - _minRttTimestamp >= MinRttWindowTicks)
-            StartMinRttProbe(nowTicks, _minRttSeconds);
+            StartMinRttProbe(nowTicks, rttSeconds);
+    }
+
+    private void CompleteExpiredMinRttProbe(long nowTicks)
+    {
+        if (_minRttProbeUntilTimestamp != 0 && nowTicks >= _minRttProbeUntilTimestamp)
+            CompleteMinRttProbe(nowTicks);
+    }
+
+    private void CompleteMinRttProbe(long nowTicks)
+    {
+        if (_minRttProbeMinimumSeconds != double.MaxValue)
+            _minRttSeconds = _minRttProbeMinimumSeconds;
+
+        // If the probe expired without an ack, retain the prior minimum and re-arm its
+        // freshness window. An idle gap is not a base-RTT measurement.
+        _minRttTimestamp = nowTicks;
+        _minRttProbeUntilTimestamp = 0;
     }
 
     private void StartMinRttProbe(long nowTicks, double observedRttSeconds)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -9,7 +9,8 @@ namespace Dekaf.Producer;
 /// instead of growing to the full <see cref="ProducerOptions.BufferMemory"/> reservoir.
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
 /// by the broker's drain rate; capping the standing bytes to
-/// <c>target × measured drain rate</c> caps the latency.
+/// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
+/// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
 /// <see cref="RecordAdmissionBlock"/> are cross-thread (producer appenders and terminal batch
@@ -31,8 +32,14 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>Number of per-request delivery-rate samples retained by the maximum filter.</summary>
     private const int RateWindowSamples = 10;
 
-    /// <summary>Fixed smoothing factor for the per-request ack round-trip EWMA.</summary>
-    private const double RttEwmaAlpha = 0.25;
+    /// <summary>How long an observed base RTT remains valid before it is refreshed.</summary>
+    private static readonly long MinRttWindowTicks = 10 * Stopwatch.Frequency;
+
+    /// <summary>
+    /// Minimum target-only drain interval used to refresh base RTT without standing
+    /// queue delay. Long-base-RTT links probe for at least one observed round-trip.
+    /// </summary>
+    private static readonly long MinRttProbeDurationTicks = Stopwatch.Frequency / 20;
 
     /// <summary>Budget never drops below this multiple of the measured bandwidth-delay
     /// product (rate × RTT). Without this guard a target below the broker RTT would shrink
@@ -60,8 +67,11 @@ internal sealed class BrokerUnackedByteBudget
     private int _rateMaxTail;
     private int _rateMaxCount;
     private long _rateSampleSequence;
-    private double _ewmaRttSeconds;
-    private bool _hasRttSample;
+    private double _minRttSeconds;
+    private double _minRttProbeMinimumSeconds;
+    private bool _hasMinRttSample;
+    private long _minRttTimestamp;
+    private long _minRttProbeUntilTimestamp;
     private long _nextProbeTimestamp;
     private long _probeUntilTimestamp;
 
@@ -135,10 +145,7 @@ internal sealed class BrokerUnackedByteBudget
             return;
 
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
-        _ewmaRttSeconds = _hasRttSample
-            ? _ewmaRttSeconds + (RttEwmaAlpha * (rttSeconds - _ewmaRttSeconds))
-            : rttSeconds;
-        _hasRttSample = true;
+        UpdateMinRtt(rttSeconds, nowTicks);
 
         AddRateSample(ackedBytes / rttSeconds);
 
@@ -160,6 +167,48 @@ internal sealed class BrokerUnackedByteBudget
         }
 
         RecomputeBudget();
+    }
+
+    private void UpdateMinRtt(double rttSeconds, long nowTicks)
+    {
+        if (!_hasMinRttSample)
+        {
+            _minRttSeconds = rttSeconds;
+            _minRttTimestamp = nowTicks;
+            _hasMinRttSample = true;
+            StartMinRttProbe(nowTicks, rttSeconds);
+            return;
+        }
+
+        if (_minRttProbeUntilTimestamp != 0)
+        {
+            _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, rttSeconds);
+            if (nowTicks >= _minRttProbeUntilTimestamp)
+            {
+                _minRttSeconds = _minRttProbeMinimumSeconds;
+                _minRttTimestamp = nowTicks;
+                _minRttProbeUntilTimestamp = 0;
+            }
+
+            return;
+        }
+
+        if (rttSeconds < _minRttSeconds)
+        {
+            _minRttSeconds = rttSeconds;
+            _minRttTimestamp = nowTicks;
+            return;
+        }
+
+        if (nowTicks - _minRttTimestamp >= MinRttWindowTicks)
+            StartMinRttProbe(nowTicks, _minRttSeconds);
+    }
+
+    private void StartMinRttProbe(long nowTicks, double observedRttSeconds)
+    {
+        _minRttProbeMinimumSeconds = double.MaxValue;
+        var observedRttTicks = (long)(observedRttSeconds * Stopwatch.Frequency);
+        _minRttProbeUntilTimestamp = nowTicks + Math.Max(MinRttProbeDurationTicks, observedRttTicks);
     }
 
     private void AddRateSample(double bytesPerSecond)
@@ -200,11 +249,11 @@ internal sealed class BrokerUnackedByteBudget
         }
         else
         {
-            var horizonSeconds = _hasRttSample
-                ? Math.Max(_targetSeconds, RttSafetyMultiplier * _ewmaRttSeconds)
+            var horizonSeconds = _hasMinRttSample && _minRttProbeUntilTimestamp == 0
+                ? Math.Max(_targetSeconds, RttSafetyMultiplier * _minRttSeconds)
                 : _targetSeconds;
             var estimatedBytes = _rateMaxValues[_rateMaxHead] * horizonSeconds;
-            if (_probeUntilTimestamp != 0)
+            if (_probeUntilTimestamp != 0 && _minRttProbeUntilTimestamp == 0)
                 estimatedBytes *= ProbeBudgetMultiplier;
 
             budget = (long)estimatedBytes;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -300,13 +300,25 @@ internal sealed class BrokerUnackedByteBudget
     private void RecomputeBudget()
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
-        var budget = ComputeBudget(minRttProbeActive, _probeUntilTimestamp != 0);
+        var budget = ComputeBudget(
+            minRttProbeActive,
+            _probeUntilTimestamp != 0,
+            _minRttSeconds);
         if (minRttProbeActive)
         {
+            var postProbeMinRttSeconds = _minRttProbeMinimumSeconds != double.MaxValue
+                ? _minRttProbeMinimumSeconds
+                : _minRttSeconds;
             Volatile.Write(ref _budgetAfterMinRttProbeBytes,
-                ComputeBudget(minRttProbeActive: false, capacityProbeActive: false));
+                ComputeBudget(
+                    minRttProbeActive: false,
+                    capacityProbeActive: false,
+                    minRttSeconds: postProbeMinRttSeconds));
             Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes,
-                ComputeBudget(minRttProbeActive: false, capacityProbeActive: true));
+                ComputeBudget(
+                    minRttProbeActive: false,
+                    capacityProbeActive: true,
+                    minRttSeconds: postProbeMinRttSeconds));
         }
         else
         {
@@ -317,7 +329,10 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _budgetBytes, budget);
     }
 
-    private long ComputeBudget(bool minRttProbeActive, bool capacityProbeActive)
+    private long ComputeBudget(
+        bool minRttProbeActive,
+        bool capacityProbeActive,
+        double minRttSeconds)
     {
         long budget;
         if (_rateMaxCount == 0)
@@ -329,7 +344,7 @@ internal sealed class BrokerUnackedByteBudget
         else
         {
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
-                ? Math.Max(_targetSeconds, RttSafetyMultiplier * _minRttSeconds)
+                ? Math.Max(_targetSeconds, RttSafetyMultiplier * minRttSeconds)
                 : _targetSeconds;
             var estimatedBytes = _rateMaxValues[_rateMaxHead] * horizonSeconds;
             if (capacityProbeActive && !minRttProbeActive)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -132,6 +132,22 @@ internal sealed class BrokerUnackedByteBudget
         return Volatile.Read(ref _unackedBytes) >= budget;
     }
 
+    /// <summary>
+    /// Returns the delay until an active minimum-RTT probe changes the admission budget,
+    /// or <see cref="Timeout.Infinite"/> when no time-based recheck is needed.
+    /// </summary>
+    internal int GetAdmissionRecheckDelayMilliseconds(long nowTicks)
+    {
+        var probeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
+        if (probeUntilTimestamp == 0 || nowTicks >= probeUntilTimestamp)
+            return Timeout.Infinite;
+
+        var remainingTicks = probeUntilTimestamp - nowTicks;
+        return Math.Max(1, (int)Math.Min(
+            int.MaxValue,
+            Math.Ceiling((double)remainingTicks * 1000 / Stopwatch.Frequency)));
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Charge(long bytes)
         => Interlocked.Add(ref _unackedBytes, bytes);

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -260,11 +260,18 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             if (recheckAt != 0 && now >= recheckAt
                 && Interlocked.CompareExchange(ref _admissionRecheckTickCount, 0, recheckAt) == recheckAt)
             {
-                _accumulator?.DrainPendingAppends();
+                var drainStarted = _accumulator?.DrainPendingAppends() ?? true;
                 if (Volatile.Read(ref _completed) != 0)
                     return;
 
                 now = Dekaf.MonotonicClock.GetMilliseconds();
+                if (!drainStarted)
+                {
+                    // A concurrent drainer may have taken its queue snapshot before this
+                    // append was re-enqueued. Preserve a near-term retry instead of silently
+                    // falling back to the max.block.ms deadline.
+                    Interlocked.CompareExchange(ref _admissionRecheckTickCount, now + 1, 0);
+                }
             }
 
             ArmNextTimer(now);

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -55,6 +55,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private CancellationToken _cancellationToken;
     private long _startTicks;
     private long _deadlineTickCount;
+    private long _admissionRecheckTickCount;
     private RecordAccumulator _accumulator = null!;
     private int _pendingCounted;
 
@@ -86,6 +87,8 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
     public PendingAppend()
     {
+        _core.RunContinuationsAsynchronously = true;
+
         // Allocate timer once; it starts dormant (Timeout.Infinite).
         // Reused across pool rentals via Change().
         _timer = new Timer(static state =>
@@ -130,6 +133,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _recordSize = recordSize;
         _startTicks = startTicks;
         _deadlineTickCount = deadlineTickCount;
+        _admissionRecheckTickCount = 0;
         _cancellationToken = cancellationToken;
         _accumulator = accumulator;
         _pool = pool;
@@ -174,6 +178,21 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
         DisarmTimerAndCancellation();
         return true;
+    }
+
+    /// <summary>
+    /// Arms the reusable timeout timer to re-evaluate admission when a temporary broker
+    /// budget probe expires. The max.block.ms deadline remains the final deadline.
+    /// </summary>
+    internal void ScheduleAdmissionRecheck(int delayMilliseconds)
+    {
+        if (delayMilliseconds == Timeout.Infinite || Volatile.Read(ref _completed) != 0)
+            return;
+
+        var now = Dekaf.MonotonicClock.GetMilliseconds();
+        var recheckAt = now + Math.Max(1, delayMilliseconds);
+        Volatile.Write(ref _admissionRecheckTickCount, recheckAt);
+        ArmNextTimer(now);
     }
 
     /// <summary>
@@ -237,7 +256,18 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         var deadlineTickCount = Volatile.Read(ref _deadlineTickCount);
         if (now < deadlineTickCount)
         {
-            _timer.Change(deadlineTickCount - now, Timeout.Infinite);
+            var recheckAt = Volatile.Read(ref _admissionRecheckTickCount);
+            if (recheckAt != 0 && now >= recheckAt
+                && Interlocked.CompareExchange(ref _admissionRecheckTickCount, 0, recheckAt) == recheckAt)
+            {
+                _accumulator?.DrainPendingAppends();
+                if (Volatile.Read(ref _completed) != 0)
+                    return;
+
+                now = Dekaf.MonotonicClock.GetMilliseconds();
+            }
+
+            ArmNextTimer(now);
             return;
         }
 
@@ -281,6 +311,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _callback = null;
         _cancellationToken = default;
         _deadlineTickCount = 0;
+        _admissionRecheckTickCount = 0;
         _accumulator = null!;
         _pendingCounted = 0;
         _core.Reset();
@@ -298,11 +329,20 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private void DisarmTimerAndCancellation()
     {
         // Disarm timer (dormant until next rental)
+        Volatile.Write(ref _admissionRecheckTickCount, 0);
         _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
         // Dispose cancellation registration
         _cancellationRegistration.Dispose();
         _cancellationRegistration = default;
+    }
+
+    private void ArmNextTimer(long now)
+    {
+        var deadline = Volatile.Read(ref _deadlineTickCount);
+        var recheckAt = Volatile.Read(ref _admissionRecheckTickCount);
+        var next = recheckAt == 0 ? deadline : Math.Min(deadline, recheckAt);
+        _timer.Change(Math.Max(0, next - now), Timeout.Infinite);
     }
 
     bool IValueTaskSource<bool>.GetResult(short token)

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -182,17 +182,30 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
 
     /// <summary>
     /// Arms the reusable timeout timer to re-evaluate admission when a temporary broker
-    /// budget probe expires. The max.block.ms deadline remains the final deadline.
+    /// budget probe expires. An existing earlier deadline is retained so repeated drain
+    /// scans do not issue another <see cref="Timer.Change(long, long)"/> per waiter.
+    /// The max.block.ms deadline remains the final deadline.
     /// </summary>
-    internal void ScheduleAdmissionRecheck(int delayMilliseconds)
+    internal void ScheduleAdmissionRecheck(long recheckAt)
     {
-        if (delayMilliseconds == Timeout.Infinite || Volatile.Read(ref _completed) != 0)
+        if (recheckAt == 0 || Volatile.Read(ref _completed) != 0)
             return;
 
-        var now = Dekaf.MonotonicClock.GetMilliseconds();
-        var recheckAt = now + Math.Max(1, delayMilliseconds);
-        Volatile.Write(ref _admissionRecheckTickCount, recheckAt);
-        ArmNextTimer(now);
+        while (true)
+        {
+            var existingRecheckAt = Volatile.Read(ref _admissionRecheckTickCount);
+            if (existingRecheckAt != 0 && existingRecheckAt <= recheckAt)
+                return;
+
+            if (Interlocked.CompareExchange(
+                    ref _admissionRecheckTickCount,
+                    recheckAt,
+                    existingRecheckAt) == existingRecheckAt)
+            {
+                ArmNextTimer(Dekaf.MonotonicClock.GetMilliseconds());
+                return;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1122,7 +1122,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly PendingAppendPool _pendingAppendPool;
     private readonly ConcurrentQueue<PendingAppend> _pendingAppends = new();
     private readonly object _pendingAppendQueueLock = new();
-    private readonly HashSet<TopicPartition> _blockedPendingPartitions = [];
+    private readonly Dictionary<TopicPartition, int> _blockedPendingPartitionRecheckDelays = [];
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
@@ -1783,7 +1783,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     _pendingAppendScan.Clear();
                     _drainablePendingAppends.Clear();
-                    _blockedPendingPartitions.Clear();
+                    _blockedPendingPartitionRecheckDelays.Clear();
 
                     var remainingToInspect = _pendingAppends.Count;
                     while (remainingToInspect-- > 0 && _pendingAppends.TryDequeue(out var candidate))
@@ -1797,9 +1797,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
 
                         var topicPartition = new TopicPartition(candidate.Topic, candidate.Partition);
-                        if (memoryExhausted || _blockedPendingPartitions.Contains(topicPartition))
+                        if (memoryExhausted)
                         {
                             _pendingAppends.Enqueue(candidate);
+                            continue;
+                        }
+
+                        if (_blockedPendingPartitionRecheckDelays.TryGetValue(
+                                topicPartition,
+                                out var existingRecheckDelayMs))
+                        {
+                            _pendingAppends.Enqueue(candidate);
+                            candidate.ScheduleAdmissionRecheck(existingRecheckDelayMs);
                             continue;
                         }
 
@@ -1812,7 +1821,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         {
                             _pendingAppends.Enqueue(candidate);
                             candidate.ScheduleAdmissionRecheck(admissionRecheckDelayMs);
-                            _blockedPendingPartitions.Add(topicPartition);
+                            _blockedPendingPartitionRecheckDelays.Add(
+                                topicPartition,
+                                admissionRecheckDelayMs);
                             continue;
                         }
 
@@ -1888,7 +1899,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             if (ownsDrainGuard)
             {
-                _blockedPendingPartitions.Clear();
+                _blockedPendingPartitionRecheckDelays.Clear();
                 _pendingAppendScan.Clear();
                 _drainablePendingAppends.Clear();
                 // Ensure drain lock is released on exception. Once ownership passes to

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1122,7 +1122,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly PendingAppendPool _pendingAppendPool;
     private readonly ConcurrentQueue<PendingAppend> _pendingAppends = new();
     private readonly object _pendingAppendQueueLock = new();
-    private readonly Dictionary<TopicPartition, int> _blockedPendingPartitionRecheckDelays = [];
+    private readonly Dictionary<TopicPartition, long> _blockedPendingPartitionRecheckTimes = [];
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
@@ -1787,7 +1787,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     _pendingAppendScan.Clear();
                     _drainablePendingAppends.Clear();
-                    _blockedPendingPartitionRecheckDelays.Clear();
+                    _blockedPendingPartitionRecheckTimes.Clear();
 
                     var remainingToInspect = _pendingAppends.Count;
                     while (remainingToInspect-- > 0 && _pendingAppends.TryDequeue(out var candidate))
@@ -1807,12 +1807,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
                         }
 
-                        if (_blockedPendingPartitionRecheckDelays.TryGetValue(
+                        if (_blockedPendingPartitionRecheckTimes.TryGetValue(
                                 topicPartition,
-                                out var existingRecheckDelayMs))
+                                out var existingRecheckAt))
                         {
                             _pendingAppends.Enqueue(candidate);
-                            candidate.ScheduleAdmissionRecheck(existingRecheckDelayMs);
+                            candidate.ScheduleAdmissionRecheck(existingRecheckAt);
                             continue;
                         }
 
@@ -1823,11 +1823,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             out var admissionRecheckDelayMs);
                         if (admissionBlocked)
                         {
+                            var recheckAt = admissionRecheckDelayMs == Timeout.Infinite
+                                ? 0
+                                : Dekaf.MonotonicClock.GetMilliseconds()
+                                  + Math.Max(1, admissionRecheckDelayMs);
                             _pendingAppends.Enqueue(candidate);
-                            candidate.ScheduleAdmissionRecheck(admissionRecheckDelayMs);
-                            _blockedPendingPartitionRecheckDelays.Add(
+                            candidate.ScheduleAdmissionRecheck(recheckAt);
+                            _blockedPendingPartitionRecheckTimes.Add(
                                 topicPartition,
-                                admissionRecheckDelayMs);
+                                recheckAt);
                             continue;
                         }
 
@@ -1903,7 +1907,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             if (ownsDrainGuard)
             {
-                _blockedPendingPartitionRecheckDelays.Clear();
+                _blockedPendingPartitionRecheckTimes.Clear();
                 _pendingAppendScan.Clear();
                 _drainablePendingAppends.Clear();
                 // Ensure drain lock is released on exception. Once ownership passes to

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1760,14 +1760,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// the drain lock, we re-check for pending items with available memory to prevent
     /// missed signals (a release could arrive while we hold the lock).
     /// </remarks>
-    internal void DrainPendingAppends()
+    /// <returns>
+    /// <see langword="false"/> only when another thread already owns the drain guard;
+    /// otherwise <see langword="true"/>.
+    /// </returns>
+    internal bool DrainPendingAppends()
     {
         if (_pendingAppends.IsEmpty)
-            return;
+            return true;
 
         // Only one thread drains at a time — others return immediately.
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
-            return;
+            return false;
 
         var ownsDrainGuard = true;
         try
@@ -1776,7 +1780,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 // Bail if accumulator is being disposed — DisposeAsync will drain the queue.
                 if (Volatile.Read(ref _disposed) != 0)
-                    return;
+                    return true;
 
                 var madeProgress = false;
                 lock (_pendingAppendQueueLock)
@@ -1885,12 +1889,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     || _pendingAppends.IsEmpty
                     || (ulong)Volatile.Read(ref _bufferedBytes) >= (ulong)Volatile.Read(ref _maxBufferMemory))
                 {
-                    return;
+                    return true;
                 }
 
                 // Re-acquire the drain lock for another pass
                 if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
-                    return; // Another thread took over
+                    return true; // Another thread took over
 
                 ownsDrainGuard = true;
             }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4431,7 +4431,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
         if (leaderId < 0
             || currentBudget is null
-            || !currentBudget.IsOverBudget())
+            || !currentBudget.IsOverBudget()
+            || !currentBudget.IsOverBudgetAt(Stopwatch.GetTimestamp()))
         {
             return false;
         }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1797,11 +1797,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
 
                         var topicPartition = new TopicPartition(candidate.Topic, candidate.Partition);
+                        var admissionBlocked = IsBrokerAdmissionBlocked(
+                            candidate.Topic,
+                            candidate.Partition,
+                            recordBlockEvent: false,
+                            out var admissionRecheckDelayMs);
                         if (memoryExhausted
                             || _blockedPendingPartitions.Contains(topicPartition)
-                            || IsBrokerAdmissionBlocked(candidate.Topic, candidate.Partition, recordBlockEvent: false))
+                            || admissionBlocked)
                         {
                             _pendingAppends.Enqueue(candidate);
+                            if (admissionBlocked)
+                                candidate.ScheduleAdmissionRecheck(admissionRecheckDelayMs);
                             if (!memoryExhausted)
                                 _blockedPendingPartitions.Add(topicPartition);
                             continue;
@@ -4423,20 +4430,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsBrokerAdmissionBlocked(string topic, int partition, bool recordBlockEvent)
+        => IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent, out _);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsBrokerAdmissionBlocked(
+        string topic,
+        int partition,
+        bool recordBlockEvent,
+        out int recheckDelayMilliseconds)
     {
+        recheckDelayMilliseconds = Timeout.Infinite;
         if (!_unackedBudgetEnabled)
             return false;
 
         var leaderId = _resolveLeaderId!(topic, partition);
         var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
+        var nowTicks = Stopwatch.GetTimestamp();
         if (leaderId < 0
             || currentBudget is null
             || !currentBudget.IsOverBudget()
-            || !currentBudget.IsOverBudgetAt(Stopwatch.GetTimestamp()))
+            || !currentBudget.IsOverBudgetAt(nowTicks))
         {
             return false;
         }
 
+        recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
             currentBudget.RecordAdmissionBlock();
         return true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1797,20 +1797,22 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
 
                         var topicPartition = new TopicPartition(candidate.Topic, candidate.Partition);
+                        if (memoryExhausted || _blockedPendingPartitions.Contains(topicPartition))
+                        {
+                            _pendingAppends.Enqueue(candidate);
+                            continue;
+                        }
+
                         var admissionBlocked = IsBrokerAdmissionBlocked(
                             candidate.Topic,
                             candidate.Partition,
                             recordBlockEvent: false,
                             out var admissionRecheckDelayMs);
-                        if (memoryExhausted
-                            || _blockedPendingPartitions.Contains(topicPartition)
-                            || admissionBlocked)
+                        if (admissionBlocked)
                         {
                             _pendingAppends.Enqueue(candidate);
-                            if (admissionBlocked)
-                                candidate.ScheduleAdmissionRecheck(admissionRecheckDelayMs);
-                            if (!memoryExhausted)
-                                _blockedPendingPartitions.Add(topicPartition);
+                            candidate.ScheduleAdmissionRecheck(admissionRecheckDelayMs);
+                            _blockedPendingPartitions.Add(topicPartition);
                             continue;
                         }
 
@@ -4445,14 +4447,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var leaderId = _resolveLeaderId!(topic, partition);
         var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
-        var nowTicks = Stopwatch.GetTimestamp();
         if (leaderId < 0
             || currentBudget is null
-            || !currentBudget.IsOverBudget()
-            || !currentBudget.IsOverBudgetAt(nowTicks))
+            || !currentBudget.IsOverBudget())
         {
             return false;
         }
+
+        var nowTicks = Stopwatch.GetTimestamp();
+        if (!currentBudget.IsOverBudgetAt(nowTicks))
+            return false;
 
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Reflection;
+using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 using Dekaf.Serialization;
@@ -10,6 +13,71 @@ namespace Dekaf.Tests.Integration;
 [Category("Producer")]
 public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    [Test]
+    [Timeout(30_000)]
+    public async Task Producer_AdmissionProbeExpiry_DeliversQueuedRecord(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var producer = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-admission-probe")
+            .WithBatchSize(64 * 1024)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Partition = 0,
+            Key = "seed",
+            Value = "seed"
+        }, cancellationToken);
+
+        await using var admin = new AdminClientBuilder()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-admin-admission-probe")
+            .Build();
+        var cluster = await admin.DescribeClusterAsync(cancellationToken).ConfigureAwait(false);
+        var leaderId = cluster.Nodes[0].NodeId;
+        var budget = producer.RecordAccumulator.GetBrokerUnackedBudget(leaderId)!;
+        var nowTicks = Stopwatch.GetTimestamp();
+
+        SetPrivateField(budget, "_hasMinRttSample", true);
+        SetPrivateField(budget, "_minRttSeconds", 0.050);
+        SetPrivateField(budget, "_minRttTimestamp", nowTicks - 11 * Stopwatch.Frequency);
+        SetPrivateField(budget, "_minRttProbeUntilTimestamp", 0L);
+        budget.OnAcked(1_000_000, Stopwatch.Frequency / 20, nowTicks);
+        budget.Charge(1_200_000);
+
+        try
+        {
+            var queuedProduce = producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = "queued",
+                Value = "queued"
+            }, cancellationToken);
+
+            await Assert.That(queuedProduce.IsCompleted).IsFalse();
+            var metadata = await queuedProduce;
+            await Assert.That(metadata.Topic).IsEqualTo(topic);
+            await Assert.That(metadata.Partition).IsEqualTo(0);
+        }
+        finally
+        {
+            budget.Release(1_200_000);
+        }
+    }
+
+    private static void SetPrivateField<T>(object instance, string fieldName, T value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(instance, value);
+    }
+
     [Test]
     public async Task Producer_ProduceWithAcksAll_SuccessfullyProduces()
     {

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -72,9 +72,11 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         }
     }
 
-    private static void SetPrivateField<T>(object instance, string fieldName, T value)
+    private static void SetPrivateField<T>(BrokerUnackedByteBudget instance, string fieldName, T value)
     {
-        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        var field = typeof(BrokerUnackedByteBudget).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance);
         field!.SetValue(instance, value);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2261,10 +2261,10 @@ public sealed class BrokerSenderSendLoopTests
                 responses[i].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: i * 10));
             }
 
-            // The deliberately tiny target makes the 1.5 × RTT safety horizon dominate,
-            // cancelling RTT from bytes/RTT × 1.5×RTT: budget = 5,000 × 1.5 = 7,500.
+            // The first ack establishes a rate and starts the target-only base-RTT probe.
+            // Its tiny target clamps the published estimate to the 200-byte floor.
             await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
-            await Assert.That(budget.BudgetBytes).IsBetween(7_490, 7_510);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(200);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -212,6 +212,41 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task AsyncAppend_SiblingUnblocks_WhenFirstProbeWaiterIsCancelled(
+        CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 2_000_000);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) => LeaderNodeId);
+        using var firstCancellation = new CancellationTokenSource();
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+        var nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+
+        budget.OnAcked(
+            ackedBytes: 1_000_000,
+            rttTicks: System.Diagnostics.Stopwatch.Frequency,
+            nowTicks);
+        budget.Charge(1_200_000);
+
+        var firstAppend = accumulator.AppendAsync(
+            "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null, PooledMemory.Null, null, 0, null, null, firstCancellation.Token);
+        var siblingAppend = accumulator.AppendAsync(
+            "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+
+        await Assert.That(firstAppend.IsCompleted).IsFalse();
+        await Assert.That(siblingAppend.IsCompleted).IsFalse();
+        firstCancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await firstAppend);
+        await Assert.That(await siblingAppend).IsTrue();
+        await Assert.That(budget.UnackedBytes).IsEqualTo(1_200_000);
+    }
+
+    [Test]
     [Timeout(30_000)]
     public async Task QueuedAppend_PreventsLaterFastPathBypass(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -186,6 +186,32 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task AsyncAppend_Unblocks_WhenMinRttProbeExpiresWithoutAck(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions(capOverride: 2_000_000);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) => LeaderNodeId);
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+        var nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+
+        budget.OnAcked(
+            ackedBytes: 1_000_000,
+            rttTicks: System.Diagnostics.Stopwatch.Frequency / 100,
+            nowTicks);
+        budget.Charge(1_200_000);
+
+        var gatedAppend = accumulator.AppendAsync(
+            "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
+
+        await Assert.That(gatedAppend.IsCompleted).IsFalse();
+        await Assert.That(await gatedAppend).IsTrue();
+        await Assert.That(budget.UnackedBytes).IsEqualTo(1_200_000);
+    }
+
+    [Test]
     [Timeout(30_000)]
     public async Task QueuedAppend_PreventsLaterFastPathBypass(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -117,6 +117,40 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
+        budget.OnAcked(ackedBytes: 5_000, rttTicks: Seconds(0.050), nowTicks: T0 + Seconds(10.16));
+
+        // The 100ms sample that starts the refresh keeps the target-only drain active.
+        // Sizing from the stale 5ms minimum would have ended after the 50ms floor and
+        // accepted the still-loaded 50ms sample as base RTT, inflating this to 7,500.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+    }
+
+    [Test]
+    public async Task SetCap_ExpiredMinRttProbeRestoresSafetyFloorWithoutAck()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
+
+        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+
+        budget.SetCap(1_000_000, T0 + Seconds(10.401));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
+    }
+
+    [Test]
     public async Task WindowedMaximum_LongGap_DoesNotDeflateRate()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -232,16 +266,16 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
 
         // Cold start follows the cap in both directions.
-        budget.SetCap(6_400);
+        budget.SetCap(6_400, T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_400);
 
         // With a rate established, a cap below the computed budget clamps it...
         EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001); // budget 1,500
-        budget.SetCap(1_000);
+        budget.SetCap(1_000, T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 
         // ...and raising the cap re-releases the computed value.
-        budget.SetCap(6_400);
+        budget.SetCap(6_400, T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -151,6 +151,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task Admission_ExpiredIdleMinRttProbeUsesSafetyFloorWithoutAck()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
+        budget.Charge(2_000);
+
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
+        await Assert.That(budget.IsOverBudget()).IsTrue();
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.401))).IsFalse();
+    }
+
+    [Test]
     public async Task MinimumRtt_LateAckAfterEmptyProbeRetainsPriorMinimum()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -151,6 +151,22 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_LateAckAfterEmptyProbeRetainsPriorMinimum()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.25));
+
+        // No ack landed inside the 100ms target-only drain. The late loaded sample must
+        // not replace the retained 5ms base RTT and inflate the horizon to 150ms.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+    }
+
+    [Test]
     public async Task WindowedMaximum_LongGap_DoesNotDeflateRate()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -5,7 +5,8 @@ namespace Dekaf.Tests.Unit.Producer;
 
 /// <summary>
 /// State-machine tests for <see cref="BrokerUnackedByteBudget"/>: budget publication from
-/// the request-rate maximum filter, floor/cap clamping, probing, and counter accounting.
+/// the request-rate maximum filter, minimum-RTT refresh, floor/cap clamping, probing,
+/// and counter accounting.
 /// All timestamps are explicit Stopwatch-tick values, so nothing here is timing-dependent.
 /// </summary>
 public sealed class BrokerUnackedByteBudgetTests
@@ -74,10 +75,45 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.100);
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
 
         // 100,000 B/s × max(0.010, 1.5 × 0.100) = 15,000 bytes (±tick-quantization of the RTT).
         await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(14_990);
         await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(15_010);
+    }
+
+    [Test]
+    public async Task MinimumRtt_LoadedSamplesDoNotInflateBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.0));
+
+        // Both samples measure 100,000 B/s. The 5ms base RTT leaves the 10ms target
+        // in control; the later queue-loaded 100ms sample must not grow the horizon.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+    }
+
+    [Test]
+    public async Task MinimumRtt_ExpiredWindowDrainsQueueBeforeRefreshing()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+
+        // Expiring the minimum with a loaded sample starts a brief target-only drain,
+        // rather than immediately accepting the 100ms queueing delay as base RTT.
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+
+        budget.OnAcked(ackedBytes: 5_000, rttTicks: Seconds(0.050), nowTicks: T0 + Seconds(10.2));
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(10.31));
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.4));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -166,6 +166,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task Admission_ExpiredProbeUsesMinimumObservedDuringProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+
+        // Refresh the old 100ms minimum, then observe 5ms while the drain probe is open.
+        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
+        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(10.25));
+        budget.Charge(2_000);
+
+        // Once the probe expires without another ack, admission must use the refreshed
+        // 5ms minimum (1,000-byte budget), not the stale 100ms minimum (15,000 bytes).
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.401))).IsTrue();
+    }
+
+    [Test]
     public async Task MinimumRtt_LateAckAfterEmptyProbeRetainsPriorMinimum()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -134,6 +134,20 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_OutlierProbeDurationIsBounded()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        budget.OnAcked(ackedBytes: 200_000, rttTicks: Seconds(2.000), nowTicks: T0 + Seconds(10.2));
+        budget.Charge(2_000);
+
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.451))).IsFalse();
+    }
+
+    [Test]
     public async Task SetCap_ExpiredMinRttProbeRestoresSafetyFloorWithoutAck()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3433,40 +3433,6 @@ public class RecordAccumulatorTests
     }
 
     [Test]
-    public async Task PendingAppend_AdmissionRecheckDrainsBeforeMaxBlockDeadline()
-    {
-        var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
-        var topicPartition = new TopicPartition("test-topic", 0);
-        try
-        {
-            var recordSize = PartitionBatch.EstimateRecordSize(0, 128, null, 0);
-            await Assert.That(accumulator.TryReserveMemoryForTest((int)accumulator.MaxBufferMemory)).IsTrue();
-
-            var appendTask = accumulator.AppendFromSpansAsync(
-                topicPartition.Topic, topicPartition.Partition,
-                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                ReadOnlySpan<byte>.Empty, keyIsNull: true,
-                new byte[128], valueIsNull: false,
-                null, 0, null, CancellationToken.None).AsTask();
-
-            await TestWait.UntilAsync(
-                () => accumulator.PendingAppendCountForTest == 1,
-                TimeSpan.FromSeconds(5));
-
-            SetBufferedBytesForTest(accumulator, (long)accumulator.MaxBufferMemory - recordSize);
-            GetOnlyPendingAppend(accumulator).ScheduleAdmissionRecheck(1);
-
-            await Assert.That(await appendTask.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
-        }
-        finally
-        {
-            var currentBatch = GetCurrentPartitionBatchOrDefault(accumulator, topicPartition);
-            SetBufferedBytesForTest(accumulator, currentBatch?.ReservedSize ?? 0);
-            await accumulator.DisposeAsync();
-        }
-    }
-
-    [Test]
     public async Task AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased()
     {
         var options = new ProducerOptions
@@ -3704,15 +3670,6 @@ public class RecordAccumulatorTests
             pool: pool,
             cancellationToken: CancellationToken.None);
         return op;
-    }
-
-    private static PendingAppend GetOnlyPendingAppend(RecordAccumulator accumulator)
-    {
-        var field = typeof(RecordAccumulator).GetField(
-            "_pendingAppends",
-            BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var queue = (System.Collections.Concurrent.ConcurrentQueue<PendingAppend>)field.GetValue(accumulator)!;
-        return queue.Single();
     }
 
     private static ProducerOptions CreatePendingAppendTestOptions() => new()

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
@@ -3427,6 +3428,35 @@ public class RecordAccumulatorTests
         }
         finally
         {
+            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                op.ReturnToPoolAfterTryFail();
+        }
+    }
+
+    [Test]
+    public async Task PendingAppend_AdmissionRecheckRetriesWhenDrainGuardIsBusy()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var pool = new PendingAppendPool(1);
+        var op = CreatePendingAppend(accumulator, pool);
+        var queue = GetPrivateField<ConcurrentQueue<PendingAppend>>(accumulator, "_pendingAppends");
+
+        queue.Enqueue(op);
+        SetPrivateField(accumulator, "_draining", 1);
+        SetPrivateField(op, "_admissionRecheckTickCount", Dekaf.MonotonicClock.GetMilliseconds() - 1);
+
+        try
+        {
+            InvokePendingAppendTimeout(op);
+            var retryAt = GetPrivateField<long>(op, "_admissionRecheckTickCount");
+
+            await Assert.That(retryAt).IsGreaterThan(0);
+            await Assert.That(op.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            SetPrivateField(accumulator, "_draining", 0);
+            queue.TryDequeue(out _);
             if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
                 op.ReturnToPoolAfterTryFail();
         }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3463,6 +3463,29 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task PendingAppend_AdmissionRecheckKeepsEarlierDeadline()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var pool = new PendingAppendPool(1);
+        var op = CreatePendingAppend(accumulator, pool);
+        var firstRecheckAt = Dekaf.MonotonicClock.GetMilliseconds() + 10_000;
+
+        try
+        {
+            op.ScheduleAdmissionRecheck(firstRecheckAt);
+            op.ScheduleAdmissionRecheck(firstRecheckAt + 1_000);
+
+            await Assert.That(GetPrivateField<long>(op, "_admissionRecheckTickCount"))
+                .IsEqualTo(firstRecheckAt);
+        }
+        finally
+        {
+            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                op.ReturnToPoolAfterTryFail();
+        }
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased()
     {
         var options = new ProducerOptions

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3433,6 +3433,40 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task PendingAppend_AdmissionRecheckDrainsBeforeMaxBlockDeadline()
+    {
+        var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var topicPartition = new TopicPartition("test-topic", 0);
+        try
+        {
+            var recordSize = PartitionBatch.EstimateRecordSize(0, 128, null, 0);
+            await Assert.That(accumulator.TryReserveMemoryForTest((int)accumulator.MaxBufferMemory)).IsTrue();
+
+            var appendTask = accumulator.AppendFromSpansAsync(
+                topicPartition.Topic, topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                new byte[128], valueIsNull: false,
+                null, 0, null, CancellationToken.None).AsTask();
+
+            await TestWait.UntilAsync(
+                () => accumulator.PendingAppendCountForTest == 1,
+                TimeSpan.FromSeconds(5));
+
+            SetBufferedBytesForTest(accumulator, (long)accumulator.MaxBufferMemory - recordSize);
+            GetOnlyPendingAppend(accumulator).ScheduleAdmissionRecheck(1);
+
+            await Assert.That(await appendTask.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        }
+        finally
+        {
+            var currentBatch = GetCurrentPartitionBatchOrDefault(accumulator, topicPartition);
+            SetBufferedBytesForTest(accumulator, currentBatch?.ReservedSize ?? 0);
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_SlowPath_CompletesWhenMemoryReleased()
     {
         var options = new ProducerOptions
@@ -3670,6 +3704,15 @@ public class RecordAccumulatorTests
             pool: pool,
             cancellationToken: CancellationToken.None);
         return op;
+    }
+
+    private static PendingAppend GetOnlyPendingAppend(RecordAccumulator accumulator)
+    {
+        var field = typeof(RecordAccumulator).GetField(
+            "_pendingAppends",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var queue = (System.Collections.Concurrent.ConcurrentQueue<PendingAppend>)field.GetValue(accumulator)!;
+        return queue.Single();
     }
 
     private static ProducerOptions CreatePendingAppendTestOptions() => new()

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -15,6 +15,7 @@ internal sealed class StressTestResult
     public required string Client { get; set; }
     public required int DurationMinutes { get; init; }
     public required int MessageSizeBytes { get; init; }
+    public int? DeliveryLatencyTargetMs { get; init; }
     public int? ConsumerSeedBatchSizeBytes { get; init; }
 
     /// <summary>

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -22,6 +22,7 @@ internal sealed class StressTestOptions
     public int Partitions { get; init; } = 6;
     public int LingerMs { get; init; } = 5;
     public int BatchSize { get; init; } = 16384;
+    public int DeliveryLatencyTargetMs { get; init; } = 10;
     public int? ConsumerSeedBatchSizeBytes { get; init; }
     public string Compression { get; init; } = "none";
     public int BrokerCount { get; init; } = 1;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -32,7 +32,8 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch
         {
@@ -144,6 +145,7 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            DeliveryLatencyTargetMs = options.DeliveryLatencyTargetMs,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -28,7 +28,8 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch
         {
@@ -144,6 +145,7 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            DeliveryLatencyTargetMs = options.DeliveryLatencyTargetMs,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -28,7 +28,8 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch
         {
@@ -144,6 +145,7 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            DeliveryLatencyTargetMs = options.DeliveryLatencyTargetMs,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -31,7 +31,8 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch
         {
@@ -143,6 +144,7 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            DeliveryLatencyTargetMs = options.DeliveryLatencyTargetMs,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -32,7 +32,8 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch
         {
@@ -144,6 +145,7 @@ internal sealed class ProducerStressTest : IStressTestScenario
             DurationMinutes = options.DurationMinutes,
             BrokerCount = options.BrokerCount,
             MessageSizeBytes = options.MessageSizeBytes,
+            DeliveryLatencyTargetMs = options.DeliveryLatencyTargetMs,
             StartedAtUtc = startedAt,
             CompletedAtUtc = completedAt,
             Throughput = throughput.GetSnapshot(),


### PR DESCRIPTION
Closes #1857

## Summary
- replace loaded-RTT EWMA horizon with a 10-second minimum-RTT estimate
- drain to the configured target for an initial and periodic ProbeRTT refresh (minimum 50ms, at least one observed RTT)
- suppress upward capacity probing while the base-RTT drain is active
- serialize the producer latency target and fail stress trends when p95 exceeds 3x target

## Why
Loaded acknowledgement RTT contains standing queue delay. Feeding its EWMA back into `max(target, 1.5 * RTT)` lets the allowed queue inflate itself. Minimum RTT approximates propagation plus broker service, while brief target-only drains refresh that estimate after path changes.

## Validation
- estimator + sender suites: 56/56 net10, 56/56 net8
- full net8 unit suite: 5,129/5,129
- full net10 unit suite: 5,217/5,218; unrelated `SharedInfrastructure_DoesNotShrinkConnectionGroup` failed under suite load and passed isolated, tracked in #1887
- Python stress/report tests: 52/52
- paired local one-broker stress completed with zero errors or delivery loss; throughput stayed within 1.6% (222.6k before initial ProbeRTT refinement, 219.1k after). This workstation was broker/host-limited and did not reproduce CI's 1.3GB/s budget-binding regime, so the high-rate p95/p99 acceptance remains for stress CI to verify.