### PR TITLE
test(producer): make invalid-host failure deterministic

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -755,6 +755,7 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     internal ProducerBuilder<TKey, TValue> WithDnsResolver(ClientDnsEndpointResolver resolver)
     {
+        ThrowIfClientOwnedConnectionSettings();
         _dnsResolver = resolver;
         return this;
     }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -67,6 +67,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private ClientDnsEndpointResolver _dnsResolver = ClientDnsEndpointResolver.Default;
     private bool _enableIdempotence = true;
     private int _connectionsPerBroker = 1;
     private int _socketSendBufferBytes;
@@ -752,6 +753,12 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    internal ProducerBuilder<TKey, TValue> WithDnsResolver(ClientDnsEndpointResolver resolver)
+    {
+        _dnsResolver = resolver;
+        return this;
+    }
+
     /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
@@ -1225,6 +1232,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            DnsResolver = _dnsResolver,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
             ValueTaskSourcePoolSize = _valueTaskSourcePoolSize,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -247,7 +247,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
                 MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
-                ClientDnsLookup = options.ClientDnsLookup
+                ClientDnsLookup = options.ClientDnsLookup,
+                DnsResolver = options.DnsResolver
             },
             loggerFactory,
             options.ConnectionsPerBroker,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -528,6 +528,8 @@ public sealed class ProducerOptions
     /// </summary>
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
+    internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
+
     /// <summary>
     /// Application-level retry policy for <see cref="KafkaProducer{TKey,TValue}.ProduceAsync"/>.
     /// When set, retriable exceptions that escape the internal protocol-level retries will be

--- a/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
@@ -1,4 +1,7 @@
+using System.Net;
+using System.Net.Sockets;
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Integration;
@@ -61,7 +64,7 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
     [Test]
     public async Task MaxBlock_ExceededWaitingForMetadata_ErrorPropagated()
     {
-        // Arrange & Act - Use an invalid bootstrap server so metadata lookup will fail.
+        // Arrange & Act - Resolve the invalid bootstrap server deterministically so metadata lookup will fail.
         // BuildAsync() eagerly initializes and connects, so an unreachable broker
         // should cause initialization to fail quickly rather than hanging indefinitely.
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -70,6 +73,7 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
         {
             await using var producer = await Kafka.CreateProducer<string, string>()
                 .WithBootstrapServers("invalid-host-that-does-not-exist:9092")
+                .WithDnsResolver(new ClientDnsEndpointResolver(new FailingDnsLookup()))
                 .WithClientId("test-maxblock-exceeded")
                 .WithMaxBlock(TimeSpan.FromSeconds(2))
                 .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
@@ -79,8 +83,8 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
         sw.Stop();
 
         // The error should propagate within a reasonable time frame.
-        // We use a generous upper bound (30s) to avoid flaky tests in slow CI,
-        // but the key invariant is that it does NOT hang indefinitely.
+        // The injected resolver avoids depending on the host DNS timeout.
+        // The key invariant is that the error does NOT hang indefinitely.
         await Assert.That(sw.Elapsed.TotalSeconds).IsLessThan(30);
     }
 
@@ -270,5 +274,14 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
         }
 
         await Assert.That(messages).Count().IsEqualTo(10);
+    }
+
+    private sealed class FailingDnsLookup : IDnsLookup
+    {
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+            => ValueTask.FromException<IPAddress[]>(new SocketException((int)SocketError.HostNotFound));
+
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+            => ValueTask.FromException<IPHostEntry>(new SocketException((int)SocketError.HostNotFound));
     }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -93,6 +93,9 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithClientDnsLookup(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>()
+                .WithDnsResolver(new ClientDnsEndpointResolver(new SystemDnsLookup())))
+            .Throws<InvalidOperationException>();
 
         await Assert.That(() => client.CreateConsumer<string, string>().UseTls())
             .Throws<InvalidOperationException>();


### PR DESCRIPTION
## Summary
- add an internal producer-builder DNS resolver seam for tests
- propagate the injected resolver into producer connections
- make the MaxBlock invalid-host test fail DNS immediately and deterministically

## Validation
- net10 unit suite: 5216/5216
- ClientDnsLookupTests: 4/4
- MaxBlock_ExceededWaitingForMetadata_ErrorPropagated: 1/1

Closes #1891