### PR TITLE
fix(consumer): remove MPSC commit convoy

### DIFF
--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -16,17 +16,19 @@ namespace Dekaf.Consumer;
 internal sealed class MpscFetchBuffer
 {
     private readonly PendingFetchData?[] _buffer;
+    private readonly long[] _committedSequences;
     private readonly int _mask;
 
     private PaddedIndex _headReserved;
-    private PaddedIndex _headCommitted;
     private PaddedIndex _tail;
+    private int _count;
 
     private readonly ManualResetEventSlim _dataAvailable = new(false);
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
     private readonly object _dataAvailableWaiterLock = new();
     private readonly Action? _afterProducerWaiterCountIncrementedForTesting;
     private readonly Action? _beforeConsumerWaitSpinForTesting;
+    private readonly Action<long>? _afterProducerSlotReservedForTesting;
     private TaskCompletionSource<bool>? _dataAvailableWaiter;
     private int _producerWaiterCount;
     private int _consumerWaiting;
@@ -37,14 +39,16 @@ internal sealed class MpscFetchBuffer
         : this(
             capacity,
             afterProducerWaiterCountIncrementedForTesting: null,
-            beforeConsumerWaitSpinForTesting: null)
+            beforeConsumerWaitSpinForTesting: null,
+            afterProducerSlotReservedForTesting: null)
     {
     }
 
     internal MpscFetchBuffer(
         int capacity,
         Action? afterProducerWaiterCountIncrementedForTesting,
-        Action? beforeConsumerWaitSpinForTesting = null)
+        Action? beforeConsumerWaitSpinForTesting = null,
+        Action<long>? afterProducerSlotReservedForTesting = null)
     {
         if (capacity < 1)
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
@@ -57,24 +61,24 @@ internal sealed class MpscFetchBuffer
         var size = 1;
         while (size < capacity) size <<= 1;
         _buffer = new PendingFetchData?[size];
+        _committedSequences = new long[size];
         _mask = size - 1;
         _afterProducerWaiterCountIncrementedForTesting = afterProducerWaiterCountIncrementedForTesting;
         _beforeConsumerWaitSpinForTesting = beforeConsumerWaitSpinForTesting;
+        _afterProducerSlotReservedForTesting = afterProducerSlotReservedForTesting;
     }
 
     internal int Capacity => _buffer.Length;
 
-    internal int Count => (int)Math.Clamp(
-        Volatile.Read(ref _headCommitted.Value) - Volatile.Read(ref _tail.Value),
-        0,
-        _buffer.Length);
+    internal int Count => Volatile.Read(ref _count);
 
     internal int ProducerWaiterCount => Volatile.Read(ref _producerWaiterCount);
 
     /// <summary>
     /// Attempts to write an item. Safe for concurrent callers (multiple prefetch tasks).
-    /// Uses CAS on the head reservation index, then stores the item and advances the
-    /// committed index so the reader sees the item only after it is fully written.
+    /// Uses CAS on the head reservation index, then publishes a per-slot sequence so the
+    /// reader sees the item only after it is fully written. Later producers never wait for
+    /// an earlier reserved slot to commit.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryWrite(PendingFetchData item)
@@ -90,15 +94,12 @@ internal sealed class MpscFetchBuffer
             if (Interlocked.CompareExchange(ref _headReserved.Value, head + 1, head) != head)
                 continue;
 
-            _buffer[head & _mask] = item;
+            _afterProducerSlotReservedForTesting?.Invoke(head);
 
-            // Wait for prior slots to commit so the reader sees items in order
-            var spin = new SpinWait();
-            while (Volatile.Read(ref _headCommitted.Value) != head)
-                spin.SpinOnce();
-
-            Volatile.Write(ref _headCommitted.Value, head + 1);
-            Interlocked.MemoryBarrier();
+            var index = (int)(head & _mask);
+            _buffer[index] = item;
+            Volatile.Write(ref _committedSequences[index], head + 1);
+            Interlocked.Increment(ref _count);
 
             if (Volatile.Read(ref _consumerWaiting) != 0)
                 SignalConsumerWaitingForData();
@@ -144,24 +145,25 @@ internal sealed class MpscFetchBuffer
 
     /// <summary>
     /// Attempts to read an item. Called only from the single consumer thread.
-    /// Only reads up to <c>_headCommitted</c> to ensure items are fully written.
+    /// Reads only a slot whose sequence matches the next tail position, ensuring items are
+    /// returned in reservation order after they are fully written.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryRead([NotNullWhen(true)] out PendingFetchData? item)
     {
         var tail = Volatile.Read(ref _tail.Value);
-        var head = Volatile.Read(ref _headCommitted.Value);
+        var index = (int)(tail & _mask);
 
-        if (tail >= head)
+        if (Volatile.Read(ref _committedSequences[index]) != tail + 1)
         {
             item = null;
             return false; // Empty
         }
 
-        item = _buffer[tail & _mask]!;
-        _buffer[tail & _mask] = null;
+        item = _buffer[index]!;
+        _buffer[index] = null;
         Volatile.Write(ref _tail.Value, tail + 1);
-        Interlocked.MemoryBarrier();
+        Interlocked.Decrement(ref _count);
 
         if (Volatile.Read(ref _producerWaiterCount) > 0)
             _spaceAvailable.Release();
@@ -345,8 +347,11 @@ internal sealed class MpscFetchBuffer
     public bool IsCompleted => _completed;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool HasDataAvailable() =>
-        Volatile.Read(ref _headCommitted.Value) > Volatile.Read(ref _tail.Value);
+    internal bool HasDataAvailable()
+    {
+        var tail = Volatile.Read(ref _tail.Value);
+        return Volatile.Read(ref _committedSequences[tail & _mask]) == tail + 1;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool HasSpaceAvailable() =>

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -21,7 +21,6 @@ internal sealed class MpscFetchBuffer
 
     private PaddedIndex _headReserved;
     private PaddedIndex _tail;
-    private int _count;
 
     private readonly ManualResetEventSlim _dataAvailable = new(false);
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
@@ -70,7 +69,15 @@ internal sealed class MpscFetchBuffer
 
     internal int Capacity => _buffer.Length;
 
-    internal int Count => Volatile.Read(ref _count);
+    internal int Count
+    {
+        get
+        {
+            var head = Volatile.Read(ref _headReserved.Value);
+            var tail = Volatile.Read(ref _tail.Value);
+            return (int)Math.Clamp(head - tail, 0, _buffer.Length);
+        }
+    }
 
     internal int ProducerWaiterCount => Volatile.Read(ref _producerWaiterCount);
 
@@ -99,9 +106,15 @@ internal sealed class MpscFetchBuffer
             var index = (int)(head & _mask);
             _buffer[index] = item;
             Volatile.Write(ref _committedSequences[index], head + 1);
-            Interlocked.Increment(ref _count);
 
-            if (Volatile.Read(ref _consumerWaiting) != 0)
+            // StoreLoad fence: the item publication must precede observing the waiter flag,
+            // otherwise a producer and consumer can both miss each other's publication.
+            Interlocked.MemoryBarrier();
+
+            // A later reservation may commit first, but the consumer can only read its current
+            // tail. Let that tail producer own the wake so waits cannot complete spuriously.
+            if (head == Volatile.Read(ref _tail.Value)
+                && Volatile.Read(ref _consumerWaiting) != 0)
                 SignalConsumerWaitingForData();
 
             return true;
@@ -163,7 +176,10 @@ internal sealed class MpscFetchBuffer
         item = _buffer[index]!;
         _buffer[index] = null;
         Volatile.Write(ref _tail.Value, tail + 1);
-        Interlocked.Decrement(ref _count);
+
+        // StoreLoad fence pairs slot release with the producer-waiter check, preventing a
+        // producer from publishing its waiter count while this consumer misses it.
+        Interlocked.MemoryBarrier();
 
         if (Volatile.Read(ref _producerWaiterCount) > 0)
             _spaceAvailable.Release();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -320,6 +320,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [NotInParallel]
     public async Task ConsumerProtocol_SuccessfulSlowJoin_RefreshesPollDeadline()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -554,6 +554,46 @@ public class MpscFetchBufferTests
         await Assert.That(sorted.Distinct().Count()).IsEqualTo(totalItems);
     }
 
+    [Test]
+    public async Task LaterProducer_DoesNotWaitForEarlierReservedSlotToCommit()
+    {
+        using var firstReserved = new ManualResetEventSlim();
+        using var allowFirstCommit = new ManualResetEventSlim();
+        var buffer = new MpscFetchBuffer(
+            capacity: 2,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            afterProducerSlotReservedForTesting: sequence =>
+            {
+                if (sequence == 0)
+                {
+                    firstReserved.Set();
+                    allowFirstCommit.Wait();
+                }
+            });
+        var first = CreateDummy("topic", 1);
+        var second = CreateDummy("topic", 2);
+
+        var firstWrite = Task.Run(() => buffer.TryWrite(first));
+        try
+        {
+            await Assert.That(firstReserved.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            var secondWrite = Task.Run(() => buffer.TryWrite(second));
+            await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        }
+        finally
+        {
+            allowFirstCommit.Set();
+        }
+
+        await Assert.That(await firstWrite).IsTrue();
+        await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
+        await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
+        firstRead.Dispose();
+        await Assert.That(buffer.TryRead(out var secondRead)).IsTrue();
+        await Assert.That(secondRead!.PartitionIndex).IsEqualTo(2);
+        secondRead.Dispose();
+    }
+
     #endregion
 
     #region Capacity rounding

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -574,11 +574,20 @@ public class MpscFetchBufferTests
         var second = CreateDummy("topic", 2);
 
         var firstWrite = Task.Run(() => buffer.TryWrite(first));
+        Task<bool>? waitForReadable = null;
         try
         {
             await Assert.That(firstReserved.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            waitForReadable = buffer.WaitToReadAsync(30_000, CancellationToken.None).AsTask();
+            await TestWait.UntilAsync(
+                () => GetConsumerWaiting(buffer) == 1 && GetDataAvailableWaiter(buffer) is not null,
+                TimeSpan.FromSeconds(5));
+
             var secondWrite = Task.Run(() => buffer.TryWrite(second));
             await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(buffer.Count).IsEqualTo(2);
+            await Assert.That(GetDataAvailableWaiter(buffer)!.Task.IsCompleted).IsFalse();
+            await Assert.That(waitForReadable.IsCompleted).IsFalse();
         }
         finally
         {
@@ -586,6 +595,7 @@ public class MpscFetchBufferTests
         }
 
         await Assert.That(await firstWrite).IsTrue();
+        await Assert.That(await waitForReadable!).IsTrue();
         await Assert.That(buffer.TryRead(out var firstRead)).IsTrue();
         await Assert.That(firstRead!.PartitionIndex).IsEqualTo(1);
         firstRead.Dispose();


### PR DESCRIPTION
## Summary
- replace ordered producer commit spinning with per-slot commit sequences
- preserve FIFO consumption without making later producers wait for an earlier reservation
- isolate the 50ms max-poll timing test consistently with neighboring background-heartbeat tests

## Diagnosis
A captured net8 full-suite hang showed all four producer tasks spinning in MpscFetchBuffer.TryWrite behind an earlier reservation. After that fix, a second dump isolated ConsumerProtocol_SuccessfulSlowJoin_RefreshesPollDeadline under parallel suite load.

## Validation
- MpscFetchBufferTests net8: 25/25
- net8 full suite: four consecutive patched passes, 5128/5128 each
- net10 full suite: 5217/5217

Closes #1864