### PR TITLE
test(integration): serialize registry tests

### DIFF
--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -55,7 +55,7 @@ for category in "${categories[@]}"; do
     Producer|Compression)
       args+=(--maximum-parallel-tests 4)
       ;;
-    NetworkPartition|ShareConsumer|ShareConsumerAdmin)
+    NetworkPartition|ShareConsumer|ShareConsumerAdmin|Serialization)
       args+=(--maximum-parallel-tests 1)
       ;;
   esac

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -29,5 +29,6 @@ grep -q 'Category=Serialization' "$CALLS_FILE"
 : > "$CALLS_FILE"
 bash scripts/run-integration-categories.sh net10.0 "Messaging,Interop,Serialization"
 grep -q 'Category=Interop' "$CALLS_FILE"
+grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
 echo "run-integration-categories tests passed"

--- a/tools/Dekaf.Pipeline/Modules/RunSerializationIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunSerializationIntegrationTestsModule.cs
@@ -3,4 +3,5 @@ namespace Dekaf.Pipeline.Modules;
 public class RunSerializationIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "Serialization";
+    protected override int? MaximumParallelTests => 1;
 }


### PR DESCRIPTION
Closes #1893

## Summary
- run the container-heavy `Serialization` integration category serially
- add script contract coverage for `--maximum-parallel-tests 1`

## Evidence
The #1830 clean-main audit scheduled 61 serialization tests at the default 80-way ceiling on a 20-core host. 39 completed while 22 Schema Registry fixtures remained active until the 5-minute hangdump killed the runner (exit 137). With the serial cap, the runner no longer hangs: it completes the 39 non-registry tests and reports one shared registry fixture failure promptly.

The remaining local fixture failure is environmental: Ubuntu WSL's Docker content store extracts `confluentinc/cp-schema-registry:7.9.0` with `/etc/confluent/docker/run` as a zero-byte executable, while the same digest on Docker Desktop has the correct 935-byte entrypoint. Full category success therefore requires healthy GitHub Ubuntu CI; this PR's messaging integration shard supplies that verification.

## Validation
- `bash scripts/tests/run-integration-categories-tests.sh`
- real net10 Serialization run confirms max parallelism 1 and eliminates the hang
- no product/runtime code changed