### PR TITLE
test(integration): cap pipeline producer

### DIFF
--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -31,4 +31,7 @@ bash scripts/run-integration-categories.sh net10.0 "Messaging,Interop,Serializat
 grep -q 'Category=Interop' "$CALLS_FILE"
 grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
+grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
+  "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
+
 echo "run-integration-categories tests passed"

--- a/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs
+++ b/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs
@@ -3,4 +3,6 @@ namespace Dekaf.Pipeline.Modules;
 public class RunProducerIntegrationTestsModule : RunIntegrationTestsModule
 {
     protected override string Category => "Producer";
+
+    protected override int? MaximumParallelTests => 4;
 }


### PR DESCRIPTION
## Summary\n- cap the Dekaf.Pipeline Producer integration module at four parallel tests, matching the release-matrix shell runner\n- extend the existing category-runner contract test so the Pipeline override cannot silently drift\n\n## Validation\n- ash scripts/tests/run-integration-categories-tests.sh\n- dotnet build tools/Dekaf.Pipeline/Dekaf.Pipeline.csproj --configuration Release (0 warnings/errors)\n\nCloses #1897