### PR TITLE
Fix Windows Schannel PEM client credentials

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -693,6 +693,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         CancellationToken callerCancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
+        KafkaConnection? connection = null;
 
         try
         {
@@ -703,7 +704,7 @@ public sealed partial class ConnectionPool : IConnectionPool
                 return factoryConnection;
             }
 
-            var connection = new KafkaConnection(
+            connection = new KafkaConnection(
                 brokerId, host, port,
                 _clientId, _connectionOptions,
                 _loggerFactory?.CreateLogger<KafkaConnection>(),
@@ -717,9 +718,16 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             return connection;
         }
-        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        catch (Exception)
         {
-            RecordReconnectFailure(endpoint, brokerId, host, port);
+            if (connection is not null)
+            {
+                try { await connection.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort cleanup of a failed connection attempt */ }
+            }
+
+            if (!callerCancellationToken.IsCancellationRequested)
+                RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
     }
@@ -850,6 +858,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         CancellationToken callerCancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
+        KafkaConnection? connection = null;
 
         // Note: Stale connection cleanup is handled by the caller (GetOrCreateConnectionAsync)
         // within the creation semaphore, so no duplicate cleanup is needed here.
@@ -869,7 +878,7 @@ public sealed partial class ConnectionPool : IConnectionPool
                 return factoryConnection;
             }
 
-            var connection = new KafkaConnection(
+            connection = new KafkaConnection(
                 brokerId, host, port,
                 _clientId, _connectionOptions,
                 _loggerFactory?.CreateLogger<KafkaConnection>(),
@@ -889,9 +898,16 @@ public sealed partial class ConnectionPool : IConnectionPool
 
             return connection;
         }
-        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        catch (Exception)
         {
-            RecordReconnectFailure(endpoint, brokerId, host, port);
+            if (connection is not null)
+            {
+                try { await connection.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort cleanup of a failed connection attempt */ }
+            }
+
+            if (!callerCancellationToken.IsCancellationRequested)
+                RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
     }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -7,6 +7,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks.Sources;
@@ -2044,7 +2045,7 @@ public sealed partial class KafkaConnection :
                         "Client key path is required when using PEM certificate format");
                 }
 
-                cert = ReimportPemClientCertificate(
+                cert = PreparePemClientCertificate(
                     CreateCertificateFromPemFile(certPath, tlsConfig.ClientKeyPath));
 #else
                 // PEM format - need separate key file
@@ -2057,7 +2058,7 @@ public sealed partial class KafkaConnection :
                 var pemCertificate = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
                     ? X509Certificate2.CreateFromPemFile(certPath, tlsConfig.ClientKeyPath)
                     : X509Certificate2.CreateFromEncryptedPemFile(certPath, tlsConfig.ClientKeyPassword, tlsConfig.ClientKeyPath);
-                cert = ReimportPemClientCertificate(pemCertificate);
+                cert = PreparePemClientCertificate(pemCertificate);
 #endif
             }
 
@@ -2073,8 +2074,11 @@ public sealed partial class KafkaConnection :
     /// a persisted key-provider handle. The ephemeral key returned by CreateFromPemFile can
     /// otherwise fail client-credential acquisition with SEC_E_UNKNOWN_CREDENTIALS.
     /// </summary>
-    private static X509Certificate2 ReimportPemClientCertificate(X509Certificate2 certificate)
+    private static X509Certificate2 PreparePemClientCertificate(X509Certificate2 certificate)
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return certificate;
+
         byte[]? pkcs12 = null;
         try
         {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -7,6 +7,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
@@ -2043,7 +2044,8 @@ public sealed partial class KafkaConnection :
                         "Client key path is required when using PEM certificate format");
                 }
 
-                cert = CreateCertificateFromPemFile(certPath, tlsConfig.ClientKeyPath);
+                cert = ReimportPemClientCertificate(
+                    CreateCertificateFromPemFile(certPath, tlsConfig.ClientKeyPath));
 #else
                 // PEM format - need separate key file
                 if (tlsConfig.ClientKeyPath is null)
@@ -2052,9 +2054,10 @@ public sealed partial class KafkaConnection :
                         "Client key path is required when using PEM certificate format");
                 }
 
-                cert = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
+                var pemCertificate = string.IsNullOrEmpty(tlsConfig.ClientKeyPassword)
                     ? X509Certificate2.CreateFromPemFile(certPath, tlsConfig.ClientKeyPath)
                     : X509Certificate2.CreateFromEncryptedPemFile(certPath, tlsConfig.ClientKeyPassword, tlsConfig.ClientKeyPath);
+                cert = ReimportPemClientCertificate(pemCertificate);
 #endif
             }
 
@@ -2063,6 +2066,39 @@ public sealed partial class KafkaConnection :
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Re-imports a PEM certificate/key pair through PKCS#12 so Windows Schannel receives
+    /// a persisted key-provider handle. The ephemeral key returned by CreateFromPemFile can
+    /// otherwise fail client-credential acquisition with SEC_E_UNKNOWN_CREDENTIALS.
+    /// </summary>
+    private static X509Certificate2 ReimportPemClientCertificate(X509Certificate2 certificate)
+    {
+        byte[]? pkcs12 = null;
+        try
+        {
+            pkcs12 = certificate.Export(X509ContentType.Pfx);
+#if NETSTANDARD2_0
+#pragma warning disable SYSLIB0057
+            return new X509Certificate2(
+                pkcs12,
+                password: (string?)null,
+                X509KeyStorageFlags.DefaultKeySet);
+#pragma warning restore SYSLIB0057
+#else
+            return X509CertificateLoader.LoadPkcs12(
+                pkcs12,
+                password: null,
+                X509KeyStorageFlags.DefaultKeySet);
+#endif
+        }
+        finally
+        {
+            if (pkcs12 is not null)
+                CryptographicOperations.ZeroMemory(pkcs12);
+            certificate.Dispose();
+        }
     }
 
 #if NETSTANDARD2_0

--- a/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
@@ -27,6 +27,10 @@ internal sealed class TestCertificateGenerator : IDisposable
     /// </summary>
     public X509Certificate2 ClientCertificate { get; }
 
+    internal string ServerPrivateKeyPem { get; }
+
+    internal string ClientPrivateKeyPem { get; }
+
     /// <summary>
     /// Directory containing the generated certificate files.
     /// </summary>
@@ -74,13 +78,17 @@ internal sealed class TestCertificateGenerator : IDisposable
         ServerCertificate = GenerateSignedCertificate(
             CaCertificate,
             "CN=kafka-broker, O=Dekaf Test, C=US",
-            isServer: true);
+            isServer: true,
+            out var serverPrivateKeyPem);
+        ServerPrivateKeyPem = serverPrivateKeyPem;
 
         // Generate client certificate signed by CA
         ClientCertificate = GenerateSignedCertificate(
             CaCertificate,
             "CN=dekaf-client, O=Dekaf Test, C=US",
-            isServer: false);
+            isServer: false,
+            out var clientPrivateKeyPem);
+        ClientPrivateKeyPem = clientPrivateKeyPem;
 
         // Export certificates to files
         CaCertPemPath = Path.Combine(CertificateDirectory, "ca-cert.pem");
@@ -130,7 +138,8 @@ internal sealed class TestCertificateGenerator : IDisposable
     private static X509Certificate2 GenerateSignedCertificate(
         X509Certificate2 caCert,
         string subjectName,
-        bool isServer)
+        bool isServer,
+        out string privateKeyPem)
     {
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest(
@@ -197,6 +206,7 @@ internal sealed class TestCertificateGenerator : IDisposable
 
         // Combine signed certificate with private key
         using var certWithKey = cert.CopyWithPrivateKey(rsa);
+        privateKeyPem = rsa.ExportPkcs8PrivateKeyPem();
 
         // Re-import to ensure private key is exportable
         return LoadPkcs12(
@@ -225,28 +235,15 @@ internal sealed class TestCertificateGenerator : IDisposable
         File.WriteAllText(ClientCertPemPath, clientCertPem);
 
         // Export client private key as PEM
-        var clientKeyPem = ExportPrivateKeyToPem(ClientCertificate);
-        File.WriteAllText(ClientKeyPemPath, clientKeyPem);
+        File.WriteAllText(ClientKeyPemPath, ClientPrivateKeyPem);
     }
 
     internal static string ExportCertificateToPem(X509Certificate2 cert)
         => cert.ExportCertificatePem();
 
-    internal static string ExportPrivateKeyToPem(X509Certificate2 cert)
-    {
-        using var rsa = cert.GetRSAPrivateKey()
-            ?? throw new InvalidOperationException("Certificate does not have an RSA private key");
-        return rsa.ExportPkcs8PrivateKeyPem();
-    }
-
     internal static void ExportCertificateToPemFile(X509Certificate2 cert, string path)
     {
         File.WriteAllText(path, ExportCertificateToPem(cert));
-    }
-
-    internal static void ExportPrivateKeyToPemFile(X509Certificate2 cert, string path)
-    {
-        File.WriteAllText(path, ExportPrivateKeyToPem(cert));
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -81,7 +81,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         var serverCertPemPath = Path.Combine(_certGenerator.CertificateDirectory, "server-cert.pem");
         var serverKeyPemPath = Path.Combine(_certGenerator.CertificateDirectory, "server-key.pem");
         TestCertificateGenerator.ExportCertificateToPemFile(_certGenerator.ServerCertificate, serverCertPemPath);
-        TestCertificateGenerator.ExportPrivateKeyToPemFile(_certGenerator.ServerCertificate, serverKeyPemPath);
+        File.WriteAllText(serverKeyPemPath, _certGenerator.ServerPrivateKeyPem);
 
         _container = new KafkaBuilder("apache/kafka:4.0.2")
             .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")


### PR DESCRIPTION
Closes #1899.

## Summary
- re-import PEM certificate/key pairs through PKCS#12 so Windows Schannel receives a supported persisted key-provider handle
- zero the temporary PKCS#12 private-key buffer after import
- capture generated TLS test keys before legacy net8 PKCS#12 import, avoiding non-exportable CNG handles

## Validation
- focused factory test: 3 consecutive Windows net10 passes
- PEM file-path test: Windows net10 pass
- in-memory + factory tests: Windows net8 passes
- full TLS category: 16/16 net10 and 16/16 net8
- CertificateLoadingTests: 11/11 net10 and 11/11 net8
- full net8 units: 5140/5140
- integration/unit builds: 0 warnings, 0 errors

Local NativeAOT analysis completed without new trimming errors; final link could not run because this Windows host lacks the Visual Studio C++ linker. Linux CI provides the required toolchain.