### PR TITLE
test(internal): suppress probe context flow

### DIFF
--- a/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
@@ -103,27 +103,35 @@ public class LockFreeStackTests
     [Test]
     public async Task TryPush_TryPop_DoNotAllocateInSteadyState()
     {
-        var allocated = await Task.Factory.StartNew(static () =>
+        Task<long> allocationProbe;
+        // LongRunning creates a dedicated thread but still captures TUnit's ambient
+        // ExecutionContext. Keep framework AsyncLocals off the measured thread so only
+        // LockFreeStack's steady-state operations contribute to its allocation counter.
+        using (ExecutionContext.SuppressFlow())
         {
-            var stack = new LockFreeStack<Item>(1);
-            var item = new Item { Value = 42 };
-
-            for (var i = 0; i < 100; i++)
+            allocationProbe = Task.Factory.StartNew(static () =>
             {
-                stack.TryPush(item);
-                stack.TryPop(out _);
-            }
+                var stack = new LockFreeStack<Item>(1);
+                var item = new Item { Value = 42 };
 
-            var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-            for (var i = 0; i < 10_000; i++)
-            {
-                stack.TryPush(item);
-                stack.TryPop(out _);
-            }
+                for (var i = 0; i < 100; i++)
+                {
+                    stack.TryPush(item);
+                    stack.TryPop(out _);
+                }
 
-            return GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
-        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+                var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+                for (var i = 0; i < 10_000; i++)
+                {
+                    stack.TryPush(item);
+                    stack.TryPop(out _);
+                }
 
+                return GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        var allocated = await allocationProbe;
         await Assert.That(allocated).IsEqualTo(0);
     }
 


### PR DESCRIPTION
## Summary\n- suppress TUnit's ambient ExecutionContext when creating the dedicated allocation-probe task\n- keep task/thread setup and context restoration outside the measured interval\n- preserve the exact zero-byte assertion\n\nThe previous dedicated-thread fix still flowed TUnit AsyncLocals onto that thread; under the release audit this contaminated the current-thread allocation counter by 7,784 bytes.\n\n## Validation\n- exact allocation test, fresh processes: net10 30/30; net8 20/20\n- full Release net10 suite: 3 consecutive passes, 5229/5229 each\n- full Release net8 suite: 2 consecutive passes, 5140/5140 each\n\nCloses #1876