### PR TITLE
Fix idle reaper invalidating producer group slots

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1052,21 +1052,8 @@ public sealed partial class ConnectionPool : IConnectionPool
                     reaped++;
             }
 
-            foreach (var (_, group) in _connectionGroupsById.ToArray())
-            {
-                var connectedCount = CountConnected(group);
-                for (var i = 0; i < group.Length; i++)
-                {
-                    var connection = group[i];
-                    if (connection is not null
-                        && await TryReapGroupConnectionAsync(group, i, connection, connectedCount, now).ConfigureAwait(false))
-                    {
-                        connectedCount--;
-                        reaped++;
-                    }
-                }
-            }
-
+            // Group slots are owned by senders that retain their width and index routing.
+            // Their lifecycle is coordinated through ShrinkConnectionGroupAsync instead.
             return reaped;
         }
         finally
@@ -1102,29 +1089,6 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
 
         return true;
-    }
-
-    private async ValueTask<bool> TryReapGroupConnectionAsync(
-        IKafkaConnection[] group,
-        int index,
-        IKafkaConnection connection,
-        int connectedCount,
-        long now)
-    {
-        if (!IsIdleReapable(connection, now))
-            return false;
-
-        if (connectedCount <= 1 && HasPendingRequests(group))
-            return false;
-
-        if (Interlocked.CompareExchange(ref group[index], null!, connection) != connection)
-            return false;
-
-        var disposed = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
-        if (!disposed && connection.IsConnected)
-            Interlocked.CompareExchange(ref group[index], connection, null!);
-
-        return disposed;
     }
 
     private bool IsIdleReapable(IKafkaConnection connection, long now)
@@ -1189,29 +1153,6 @@ public sealed partial class ConnectionPool : IConnectionPool
                 IdleDurationMs = idleDurationMs
             });
         }
-    }
-
-    private static int CountConnected(IKafkaConnection[] group)
-    {
-        var count = 0;
-        foreach (var connection in group)
-        {
-            if (connection is not null && connection.IsConnected)
-                count++;
-        }
-
-        return count;
-    }
-
-    private static bool HasPendingRequests(IKafkaConnection[] group)
-    {
-        foreach (var connection in group)
-        {
-            if (connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 })
-                return true;
-        }
-
-        return false;
     }
 
     private static bool TryRemoveExact<TKey, TValue>(

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -57,7 +57,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
     private readonly ConcurrentDictionary<(int BrokerId, int Index), SemaphoreSlim> _connectionReplacementLocks = new();
     private readonly Lock _connectionGroupRetentionLock = new();
-    private readonly Dictionary<int, int> _connectionGroupRetainers = [];
+    private readonly Dictionary<(int BrokerId, int Index), int> _connectionGroupRetainers = [];
 
     // Per-broker semaphores to deduplicate concurrent group creation
     private readonly ConcurrentDictionary<int, SemaphoreSlim> _groupCreationLocks = new();
@@ -568,32 +568,34 @@ public sealed partial class ConnectionPool : IConnectionPool
     }
 
     /// <summary>
-    /// Prevents idle reaping from changing a broker group's indexed slots while a sender
-    /// retains that routing width. Multiple senders sharing infrastructure are ref-counted.
+    /// Prevents idle reaping from changing one routed group slot while a sender uses it.
+    /// Multiple senders sharing the same broker/index are ref-counted.
     /// </summary>
-    internal void RetainConnectionGroup(int brokerId)
+    internal void RetainConnectionGroupIndex(int brokerId, int connectionIndex)
     {
         lock (_connectionGroupRetentionLock)
         {
             if (Volatile.Read(ref _disposed) != 0)
                 throw new ObjectDisposedException(nameof(ConnectionPool));
 
-            _connectionGroupRetainers.TryGetValue(brokerId, out var retainers);
-            _connectionGroupRetainers[brokerId] = retainers + 1;
+            var key = (brokerId, connectionIndex);
+            _connectionGroupRetainers.TryGetValue(key, out var retainers);
+            _connectionGroupRetainers[key] = retainers + 1;
         }
     }
 
-    internal void ReleaseConnectionGroup(int brokerId)
+    internal void ReleaseConnectionGroupIndex(int brokerId, int connectionIndex)
     {
         lock (_connectionGroupRetentionLock)
         {
-            if (!_connectionGroupRetainers.TryGetValue(brokerId, out var retainers))
+            var key = (brokerId, connectionIndex);
+            if (!_connectionGroupRetainers.TryGetValue(key, out var retainers))
                 return;
 
             if (retainers == 1)
-                _connectionGroupRetainers.Remove(brokerId);
+                _connectionGroupRetainers.Remove(key);
             else
-                _connectionGroupRetainers[brokerId] = retainers - 1;
+                _connectionGroupRetainers[key] = retainers - 1;
         }
     }
 
@@ -1153,7 +1155,7 @@ public sealed partial class ConnectionPool : IConnectionPool
 
         lock (_connectionGroupRetentionLock)
         {
-            if (_connectionGroupRetainers.ContainsKey(brokerId)
+            if (_connectionGroupRetainers.ContainsKey((brokerId, index))
                 || Interlocked.CompareExchange(ref group[index], null!, connection) != connection)
             {
                 return false;

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -571,16 +571,17 @@ public sealed partial class ConnectionPool : IConnectionPool
     /// Prevents idle reaping from changing one routed group slot while a sender uses it.
     /// Multiple senders sharing the same broker/index are ref-counted.
     /// </summary>
-    internal void RetainConnectionGroupIndex(int brokerId, int connectionIndex)
+    internal bool TryRetainConnectionGroupIndex(int brokerId, int connectionIndex)
     {
         lock (_connectionGroupRetentionLock)
         {
             if (Volatile.Read(ref _disposed) != 0)
-                throw new ObjectDisposedException(nameof(ConnectionPool));
+                return false;
 
             var key = (brokerId, connectionIndex);
             _connectionGroupRetainers.TryGetValue(key, out var retainers);
             _connectionGroupRetainers[key] = retainers + 1;
+            return true;
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -56,6 +56,8 @@ public sealed partial class ConnectionPool : IConnectionPool
     // Multi-connection support: connection groups and round-robin index
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
     private readonly ConcurrentDictionary<(int BrokerId, int Index), SemaphoreSlim> _connectionReplacementLocks = new();
+    private readonly Lock _connectionGroupRetentionLock = new();
+    private readonly Dictionary<int, int> _connectionGroupRetainers = [];
 
     // Per-broker semaphores to deduplicate concurrent group creation
     private readonly ConcurrentDictionary<int, SemaphoreSlim> _groupCreationLocks = new();
@@ -565,6 +567,36 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
     }
 
+    /// <summary>
+    /// Prevents idle reaping from changing a broker group's indexed slots while a sender
+    /// retains that routing width. Multiple senders sharing infrastructure are ref-counted.
+    /// </summary>
+    internal void RetainConnectionGroup(int brokerId)
+    {
+        lock (_connectionGroupRetentionLock)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(ConnectionPool));
+
+            _connectionGroupRetainers.TryGetValue(brokerId, out var retainers);
+            _connectionGroupRetainers[brokerId] = retainers + 1;
+        }
+    }
+
+    internal void ReleaseConnectionGroup(int brokerId)
+    {
+        lock (_connectionGroupRetentionLock)
+        {
+            if (!_connectionGroupRetainers.TryGetValue(brokerId, out var retainers))
+                return;
+
+            if (retainers == 1)
+                _connectionGroupRetainers.Remove(brokerId);
+            else
+                _connectionGroupRetainers[brokerId] = retainers - 1;
+        }
+    }
+
     private async ValueTask<IKafkaConnection> ReplaceConnectionInGroupAsync(int brokerId, BrokerInfo brokerInfo, int index, CancellationToken cancellationToken)
     {
         // Use a per-(broker,index) SemaphoreSlim instead of Lazy<ValueTask> to avoid
@@ -1052,8 +1084,22 @@ public sealed partial class ConnectionPool : IConnectionPool
                     reaped++;
             }
 
-            // Group slots are owned by senders that retain their width and index routing.
-            // Their lifecycle is coordinated through ShrinkConnectionGroupAsync instead.
+            foreach (var (brokerId, group) in _connectionGroupsById.ToArray())
+            {
+                var connectedCount = CountConnected(group);
+                for (var i = 0; i < group.Length; i++)
+                {
+                    var connection = group[i];
+                    if (connection is not null
+                        && await TryReapGroupConnectionAsync(
+                            brokerId, group, i, connection, connectedCount, now).ConfigureAwait(false))
+                    {
+                        connectedCount--;
+                        reaped++;
+                    }
+                }
+            }
+
             return reaped;
         }
         finally
@@ -1089,6 +1135,36 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
 
         return true;
+    }
+
+    private async ValueTask<bool> TryReapGroupConnectionAsync(
+        int brokerId,
+        IKafkaConnection[] group,
+        int index,
+        IKafkaConnection connection,
+        int connectedCount,
+        long now)
+    {
+        if (!IsIdleReapable(connection, now))
+            return false;
+
+        if (connectedCount <= 1 && HasPendingRequests(group))
+            return false;
+
+        lock (_connectionGroupRetentionLock)
+        {
+            if (_connectionGroupRetainers.ContainsKey(brokerId)
+                || Interlocked.CompareExchange(ref group[index], null!, connection) != connection)
+            {
+                return false;
+            }
+        }
+
+        var disposed = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
+        if (!disposed && connection.IsConnected)
+            Interlocked.CompareExchange(ref group[index], connection, null!);
+
+        return disposed;
     }
 
     private bool IsIdleReapable(IKafkaConnection connection, long now)
@@ -1153,6 +1229,29 @@ public sealed partial class ConnectionPool : IConnectionPool
                 IdleDurationMs = idleDurationMs
             });
         }
+    }
+
+    private static int CountConnected(IKafkaConnection[] group)
+    {
+        var count = 0;
+        foreach (var connection in group)
+        {
+            if (connection is not null && connection.IsConnected)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static bool HasPendingRequests(IKafkaConnection[] group)
+    {
+        foreach (var connection in group)
+        {
+            if (connection is IIdleTrackedKafkaConnection { PendingRequestCount: > 0 })
+                return true;
+        }
+
+        return false;
     }
 
     private static bool TryRemoveExact<TKey, TValue>(

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -129,7 +129,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly int _brokerId;
     private readonly IConnectionPool _connectionPool;
     private readonly ConnectionPool? _retainedConnectionGroupPool;
-    private uint _retainedConnectionIndexMask;
+    private readonly bool[] _retainedConnectionIndices;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
     private readonly ProducerOptions _options;
@@ -726,6 +726,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ? Math.Max(_connectionCount, _maxConnectionsPerBroker)
             : _connectionCount;
         _pinnedConnections = new IKafkaConnection?[connectionCapacity];
+        _retainedConnectionIndices = new bool[connectionCapacity];
         _pendingResponsesByConnection = new List<PendingResponse>[connectionCapacity];
         _pendingResponseBytesByConnection = new long[connectionCapacity];
         for (var i = 0; i < connectionCapacity; i++)
@@ -758,12 +759,21 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (_retainedConnectionGroupPool is null)
             return;
 
-        var bit = 1u << connectionIndex;
-        if ((_retainedConnectionIndexMask & bit) != 0)
+        if (_retainedConnectionIndices[connectionIndex])
             return;
 
         _retainedConnectionGroupPool.RetainConnectionGroupIndex(_brokerId, connectionIndex);
-        _retainedConnectionIndexMask |= bit;
+        _retainedConnectionIndices[connectionIndex] = true;
+    }
+
+    private void ReleaseConnectionIndex(int connectionIndex)
+    {
+        if (_retainedConnectionGroupPool is null
+            || !_retainedConnectionIndices[connectionIndex])
+            return;
+
+        _retainedConnectionIndices[connectionIndex] = false;
+        _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
     }
 
     private void ReleaseConnectionIndices()
@@ -771,12 +781,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (_retainedConnectionGroupPool is null)
             return;
 
-        var retainedMask = _retainedConnectionIndexMask;
-        _retainedConnectionIndexMask = 0;
-        for (var connectionIndex = 0; retainedMask != 0; connectionIndex++, retainedMask >>= 1)
+        for (var connectionIndex = 0; connectionIndex < _retainedConnectionIndices.Length; connectionIndex++)
         {
-            if ((retainedMask & 1) != 0)
-                _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
+            if (_retainedConnectionIndices[connectionIndex])
+                ReleaseConnectionIndex(connectionIndex);
         }
     }
 
@@ -3886,7 +3894,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Shared pools may retain an expanded group owned by another client. An owning
         // sender also retains a one-slot group after scaling back down. Keep those slots
         // indexed, while preserving the singleton path before this sender first scales up.
-        var connectionLease = _connectionCount > 1 || !_canPhysicallyShrinkConnections || _hasScaledConnectionGroup
+        var usesIndexedGroup = _connectionCount > 1
+            || !_canPhysicallyShrinkConnections
+            || _hasScaledConnectionGroup;
+        if (usesIndexedGroup)
+            RetainConnectionIndex(connIdx);
+
+        var connectionLease = usesIndexedGroup
             ? await _connectionPool.LeaseConnectionByIndexAsync(_brokerId, connIdx, cancellationToken)
                 .ConfigureAwait(false)
             : await _connectionPool.LeaseConnectionAsync(_brokerId, cancellationToken)
@@ -4453,6 +4467,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 // Nothing was removed (pool group already at or below target) —
                 // the reduced routing width stands on its own.
+                ReleaseConnectionIndex(_connectionCount);
             }
             else if (task.Exception is not null)
             {
@@ -4694,6 +4709,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (!_canPhysicallyShrinkConnections)
         {
             _pinnedConnections[targetShrinkCount] = null;
+            ReleaseConnectionIndex(targetShrinkCount);
             LogAdaptiveScaleDown(_brokerId, targetShrinkCount + 1, targetShrinkCount);
             return targetShrinkCount;
         }
@@ -4791,6 +4807,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private int ApplyScaleDown(IKafkaConnection removedConnection)
     {
         var removedIdx = _connectionCount; // Width was reduced at initiation — removed slot is one past it.
+        ReleaseConnectionIndex(removedIdx);
 
         // Reset the sustained-low-utilization timer so the next scale-down cycle
         // must observe the full sustained window from this point forward.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -129,7 +129,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly int _brokerId;
     private readonly IConnectionPool _connectionPool;
     private readonly ConnectionPool? _retainedConnectionGroupPool;
-    private int _connectionGroupRetained;
+    private uint _retainedConnectionIndexMask;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
     private readonly ProducerOptions _options;
@@ -738,8 +738,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         };
         _cts = new CancellationTokenSource();
         _retainedConnectionGroupPool = connectionPool as ConnectionPool;
-        if (_connectionCount > 1 || !_canPhysicallyShrinkConnections)
-            RetainConnectionGroup();
         try
         {
             _sendLoopTask = Task.Factory.StartNew(
@@ -750,34 +748,36 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         catch
         {
-            ReleaseConnectionGroup();
+            ReleaseConnectionIndices();
             throw;
         }
     }
 
-    private void RetainConnectionGroup()
+    private void RetainConnectionIndex(int connectionIndex)
     {
-        if (_retainedConnectionGroupPool is null
-            || Interlocked.CompareExchange(ref _connectionGroupRetained, 1, 0) != 0)
-        {
+        if (_retainedConnectionGroupPool is null)
             return;
-        }
 
-        try
-        {
-            _retainedConnectionGroupPool.RetainConnectionGroup(_brokerId);
-        }
-        catch
-        {
-            Volatile.Write(ref _connectionGroupRetained, 0);
-            throw;
-        }
+        var bit = 1u << connectionIndex;
+        if ((_retainedConnectionIndexMask & bit) != 0)
+            return;
+
+        _retainedConnectionGroupPool.RetainConnectionGroupIndex(_brokerId, connectionIndex);
+        _retainedConnectionIndexMask |= bit;
     }
 
-    private void ReleaseConnectionGroup()
+    private void ReleaseConnectionIndices()
     {
-        if (Interlocked.Exchange(ref _connectionGroupRetained, 0) != 0)
-            _retainedConnectionGroupPool!.ReleaseConnectionGroup(_brokerId);
+        if (_retainedConnectionGroupPool is null)
+            return;
+
+        var retainedMask = _retainedConnectionIndexMask;
+        _retainedConnectionIndexMask = 0;
+        for (var connectionIndex = 0; retainedMask != 0; connectionIndex++, retainedMask >>= 1)
+        {
+            if ((retainedMask & 1) != 0)
+                _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
+        }
     }
 
     private static ValueTask DelayForThrottleAsync(int delayMs, CancellationToken cancellationToken) =>
@@ -3679,21 +3679,28 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         // Common case: no migrations active — dictionary Count check is a single branch on 0.
         // During migration: one hash lookup per batch, negligible vs TCP write cost.
+        int connectionIndex;
         if (_migratingPartitions.Count > 0
             && _migratingPartitions.TryGetValue(topicPartition, out var oldConn))
         {
-            return oldConn;
+            connectionIndex = oldConn;
+        }
+        else
+        {
+            if (!_partitionOrdinals.TryGetValue(topicPartition, out var ordinal))
+            {
+                // First route can precede CoalesceBatch in focused callers/tests. Production
+                // normally refreshes once per coalesced batch, before connection selection.
+                RefreshPartitionRouting();
+            }
+
+            connectionIndex = _partitionOrdinals.TryGetValue(topicPartition, out ordinal)
+                ? ordinal % _connectionCount
+                : topicPartition.Partition % _connectionCount;
         }
 
-        if (_partitionOrdinals.TryGetValue(topicPartition, out var ordinal))
-            return ordinal % _connectionCount;
-
-        // First route can precede CoalesceBatch in focused callers/tests. Production normally
-        // refreshes once per coalesced batch, before connection selection.
-        RefreshPartitionRouting();
-        return _partitionOrdinals.TryGetValue(topicPartition, out ordinal)
-            ? ordinal % _connectionCount
-            : topicPartition.Partition % _connectionCount;
+        RetainConnectionIndex(connectionIndex);
+        return connectionIndex;
     }
 
     /// <summary>
@@ -4218,7 +4225,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         finally
         {
-            ReleaseConnectionGroup();
+            ReleaseConnectionIndices();
         }
     }
 
@@ -4569,7 +4576,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return 0; // Cap left nothing to add
 
             // Launch connection creation in the background — send loop continues immediately
-            RetainConnectionGroup();
             _lastScaleTimeTicks = now;
             _pendingScaleBufferUtilization = utilization;
             _pendingScaleBufferPressureDelta = bufferPressureDelta;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -130,6 +130,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly ConnectionPool? _retainedConnectionGroupPool;
     private readonly bool[] _retainedConnectionIndices;
+    private int _retainedConnectionIndexCount;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
     private readonly ProducerOptions _options;
@@ -764,6 +765,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         _retainedConnectionGroupPool.RetainConnectionGroupIndex(_brokerId, connectionIndex);
         _retainedConnectionIndices[connectionIndex] = true;
+        _retainedConnectionIndexCount++;
     }
 
     private void ReleaseConnectionIndex(int connectionIndex)
@@ -773,6 +775,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
 
         _retainedConnectionIndices[connectionIndex] = false;
+        _retainedConnectionIndexCount--;
         _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
     }
 
@@ -1687,8 +1690,33 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && !eventReader.TryPeek(out _))
                 {
                     // No carry-over, no pending responses, no retries, no events — wait for new batch.
-                    if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    ReleaseRetainedConnectionsIfBrokerIdle();
+                    RefreshPartitionRouting();
+                    if (_retainedConnectionIndexCount > 0 && _options.ConnectionsMaxIdleMs >= 0)
+                    {
+                        using var routingRefreshCts = CancellationTokenSource.CreateLinkedTokenSource(
+                            cancellationToken);
+                        routingRefreshCts.CancelAfter(Math.Clamp(
+                            _options.ConnectionsMaxIdleMs / 2,
+                            1000,
+                            60000));
+                        try
+                        {
+                            if (!await eventReader.WaitToReadAsync(routingRefreshCts.Token)
+                                    .ConfigureAwait(false))
+                            {
+                                break;
+                            }
+                        }
+                        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                        {
+                            // Re-check the immutable broker-partition snapshot on the next pass.
+                        }
+                    }
+                    else if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
                         break;
+                    }
                 }
             }
         }
@@ -3792,6 +3820,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
 
         _partitionRoutingSnapshot = metadataPartitions;
+    }
+
+    private void ReleaseRetainedConnectionsIfBrokerIdle()
+    {
+        if (_retainedConnectionIndexCount > 0
+            && _metadataManager.GetPartitionsForNode(_brokerId).Count == 0)
+        {
+            ReleaseConnectionIndices();
+        }
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1608,9 +1608,36 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     if (hasPendingSingleConnectionFireAndForgetSend && !eventReader.TryPeek(out _))
                         await AwaitPendingSingleConnectionFireAndForgetSendAsync().ConfigureAwait(false);
 
-                    // Fully idle — wait for any event (new batch, response, unmute).
-                    if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    ReleaseRetainedConnectionsIfBrokerIdle();
+
+                    // Fully idle — wait for any event (new batch, response, unmute). While an
+                    // indexed route remains retained, periodically recheck whether this broker
+                    // still leads any partitions so an unused socket can become reapable.
+                    if (_retainedConnectionIndexCount > 0 && _options.ConnectionsMaxIdleMs >= 0)
+                    {
+                        using var routingRefreshCts = CancellationTokenSource.CreateLinkedTokenSource(
+                            cancellationToken);
+                        routingRefreshCts.CancelAfter(Math.Clamp(
+                            _options.ConnectionsMaxIdleMs / 2,
+                            1000,
+                            60000));
+                        try
+                        {
+                            if (!await eventReader.WaitToReadAsync(routingRefreshCts.Token)
+                                    .ConfigureAwait(false))
+                            {
+                                break;
+                            }
+                        }
+                        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                        {
+                            // Re-check the immutable broker-partition snapshot on the next pass.
+                        }
+                    }
+                    else if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
                         break;
+                    }
                 }
                 else if (carryOver.Count > 0 && sentThisIteration)
                 {
@@ -1683,39 +1710,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     if (wakeupMs > 0)
                     {
                         await Task.Delay(Math.Min(wakeupMs, 100), cancellationToken).ConfigureAwait(false);
-                    }
-                }
-                else if (_sendFailedRetries.IsEmpty
-                    && _loopExitRedeliveries.IsEmpty
-                    && !eventReader.TryPeek(out _))
-                {
-                    // No carry-over, no pending responses, no retries, no events — wait for new batch.
-                    ReleaseRetainedConnectionsIfBrokerIdle();
-                    RefreshPartitionRouting();
-                    if (_retainedConnectionIndexCount > 0 && _options.ConnectionsMaxIdleMs >= 0)
-                    {
-                        using var routingRefreshCts = CancellationTokenSource.CreateLinkedTokenSource(
-                            cancellationToken);
-                        routingRefreshCts.CancelAfter(Math.Clamp(
-                            _options.ConnectionsMaxIdleMs / 2,
-                            1000,
-                            60000));
-                        try
-                        {
-                            if (!await eventReader.WaitToReadAsync(routingRefreshCts.Token)
-                                    .ConfigureAwait(false))
-                            {
-                                break;
-                            }
-                        }
-                        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-                        {
-                            // Re-check the immutable broker-partition snapshot on the next pass.
-                        }
-                    }
-                    else if (!await eventReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
-                    {
-                        break;
                     }
                 }
             }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -128,6 +128,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private readonly int _brokerId;
     private readonly IConnectionPool _connectionPool;
+    private readonly ConnectionPool? _retainedConnectionGroupPool;
+    private int _connectionGroupRetained;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
     private readonly ProducerOptions _options;
@@ -735,11 +737,47 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _anyResponseCompleted.Signal();
         };
         _cts = new CancellationTokenSource();
-        _sendLoopTask = Task.Factory.StartNew(
-            () => SendLoopAsync(_cts.Token),
-            CancellationToken.None,
-            TaskCreationOptions.LongRunning,
-            TaskScheduler.Default).Unwrap();
+        _retainedConnectionGroupPool = connectionPool as ConnectionPool;
+        if (_connectionCount > 1 || !_canPhysicallyShrinkConnections)
+            RetainConnectionGroup();
+        try
+        {
+            _sendLoopTask = Task.Factory.StartNew(
+                () => SendLoopAsync(_cts.Token),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default).Unwrap();
+        }
+        catch
+        {
+            ReleaseConnectionGroup();
+            throw;
+        }
+    }
+
+    private void RetainConnectionGroup()
+    {
+        if (_retainedConnectionGroupPool is null
+            || Interlocked.CompareExchange(ref _connectionGroupRetained, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _retainedConnectionGroupPool.RetainConnectionGroup(_brokerId);
+        }
+        catch
+        {
+            Volatile.Write(ref _connectionGroupRetained, 0);
+            throw;
+        }
+    }
+
+    private void ReleaseConnectionGroup()
+    {
+        if (Interlocked.Exchange(ref _connectionGroupRetained, 0) != 0)
+            _retainedConnectionGroupPool!.ReleaseConnectionGroup(_brokerId);
     }
 
     private static ValueTask DelayForThrottleAsync(int delayMs, CancellationToken cancellationToken) =>
@@ -4174,6 +4212,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        try
+        {
+            await DisposeCoreAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            ReleaseConnectionGroup();
+        }
+    }
+
+    private async ValueTask DisposeCoreAsync()
+    {
         LogDisposing(_brokerId);
 
         // Complete the channel so no new events are accepted, then cancel the CTS so
@@ -4519,6 +4569,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return 0; // Cap left nothing to add
 
             // Launch connection creation in the background — send loop continues immediately
+            RetainConnectionGroup();
             _lastScaleTimeTicks = now;
             _pendingScaleBufferUtilization = utilization;
             _pendingScaleBufferPressureDelta = bufferPressureDelta;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -130,6 +130,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly ConnectionPool? _retainedConnectionGroupPool;
     private readonly bool[] _retainedConnectionIndices;
+    private readonly System.Threading.Lock _retainedConnectionIndicesLock = new();
     private int _retainedConnectionIndexCount;
     private readonly MetadataManager _metadataManager;
     private readonly RecordAccumulator _accumulator;
@@ -757,26 +758,42 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private void RetainConnectionIndex(int connectionIndex)
     {
-        if (_retainedConnectionGroupPool is null)
+        if (_retainedConnectionGroupPool is null
+            || Volatile.Read(ref _disposed) != 0)
             return;
 
         if (_retainedConnectionIndices[connectionIndex])
             return;
 
-        _retainedConnectionGroupPool.RetainConnectionGroupIndex(_brokerId, connectionIndex);
-        _retainedConnectionIndices[connectionIndex] = true;
-        _retainedConnectionIndexCount++;
+        lock (_retainedConnectionIndicesLock)
+        {
+            if (Volatile.Read(ref _disposed) != 0
+                || _retainedConnectionIndices[connectionIndex]
+                || !_retainedConnectionGroupPool.TryRetainConnectionGroupIndex(
+                    _brokerId, connectionIndex))
+            {
+                return;
+            }
+
+            _retainedConnectionIndices[connectionIndex] = true;
+            _retainedConnectionIndexCount++;
+        }
     }
 
     private void ReleaseConnectionIndex(int connectionIndex)
     {
-        if (_retainedConnectionGroupPool is null
-            || !_retainedConnectionIndices[connectionIndex])
+        if (_retainedConnectionGroupPool is null)
             return;
 
-        _retainedConnectionIndices[connectionIndex] = false;
-        _retainedConnectionIndexCount--;
-        _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
+        lock (_retainedConnectionIndicesLock)
+        {
+            if (!_retainedConnectionIndices[connectionIndex])
+                return;
+
+            _retainedConnectionIndices[connectionIndex] = false;
+            _retainedConnectionIndexCount--;
+            _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(_brokerId, connectionIndex);
+        }
     }
 
     private void ReleaseConnectionIndices()
@@ -784,10 +801,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (_retainedConnectionGroupPool is null)
             return;
 
-        for (var connectionIndex = 0; connectionIndex < _retainedConnectionIndices.Length; connectionIndex++)
+        lock (_retainedConnectionIndicesLock)
         {
-            if (_retainedConnectionIndices[connectionIndex])
-                ReleaseConnectionIndex(connectionIndex);
+            for (var connectionIndex = 0;
+                 connectionIndex < _retainedConnectionIndices.Length;
+                 connectionIndex++)
+            {
+                if (!_retainedConnectionIndices[connectionIndex])
+                    continue;
+
+                _retainedConnectionIndices[connectionIndex] = false;
+                _retainedConnectionIndexCount--;
+                _retainedConnectionGroupPool.ReleaseConnectionGroupIndex(
+                    _brokerId, connectionIndex);
+            }
         }
     }
 
@@ -1613,7 +1640,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // Fully idle — wait for any event (new batch, response, unmute). While an
                     // indexed route remains retained, periodically recheck whether this broker
                     // still leads any partitions so an unused socket can become reapable.
-                    if (_retainedConnectionIndexCount > 0 && _options.ConnectionsMaxIdleMs >= 0)
+                    if (Volatile.Read(ref _retainedConnectionIndexCount) > 0
+                        && _options.ConnectionsMaxIdleMs >= 0)
                     {
                         using var routingRefreshCts = CancellationTokenSource.CreateLinkedTokenSource(
                             cancellationToken);
@@ -3810,15 +3838,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _partitionOrdinals.Add(_rankedPartitions[ordinal], ordinal);
         _nextStablePartitionOrdinal = _rankedPartitions.Count;
 
-        if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
-            _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+        lock (_migrationRemovalBuffer)
+        {
+            if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
+                _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+        }
 
         _partitionRoutingSnapshot = metadataPartitions;
     }
 
     private void ReleaseRetainedConnectionsIfBrokerIdle()
     {
-        if (_retainedConnectionIndexCount > 0
+        if (Volatile.Read(ref _retainedConnectionIndexCount) > 0
             && _metadataManager.GetPartitionsForNode(_brokerId).Count == 0)
         {
             ReleaseConnectionIndices();
@@ -3857,8 +3888,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void CompleteMigrations(int connectionIndex)
     {
-        // The send loop is the production owner. Serialize the reflection-driven timeout
-        // test path too so it cannot race this reusable scratch buffer with the loop.
+        // The send loop is the production owner. Serialize maintenance/test callers too so
+        // they cannot race migration state or this reusable scratch buffer with the loop.
         lock (_migrationRemovalBuffer)
         {
             var pendingList = _pendingResponsesByConnection[connectionIndex];
@@ -3889,22 +3920,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void FenceAffectedPartitions(int oldConnCount, int newConnCount)
     {
-        foreach (var tp in _knownPartitions)
+        lock (_migrationRemovalBuffer)
         {
-            var routeKey = _partitionOrdinals.TryGetValue(tp, out var ordinal)
-                ? ordinal
-                : tp.Partition;
-            var oldConn = routeKey % oldConnCount;
-            var newConn = routeKey % newConnCount;
-
-            if (oldConn != newConn && HasInflightForPartition(oldConn, tp))
+            foreach (var tp in _knownPartitions)
             {
-                _migratingPartitions.TryAdd(tp, oldConn);
-            }
-        }
+                var routeKey = _partitionOrdinals.TryGetValue(tp, out var ordinal)
+                    ? ordinal
+                    : tp.Partition;
+                var oldConn = routeKey % oldConnCount;
+                var newConn = routeKey % newConnCount;
 
-        if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
-            _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+                if (oldConn != newConn && HasInflightForPartition(oldConn, tp))
+                    _migratingPartitions.TryAdd(tp, oldConn);
+            }
+
+            if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
+                _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+        }
 
         if (_migratingPartitions.Count > 0)
             LogPartitionMigrationStarted(_brokerId, _migratingPartitions.Count, oldConnCount, newConnCount);
@@ -4790,6 +4822,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         actualCount = Math.Min(actualCount, _pendingResponsesByConnection.Length);
 
         var oldCount = _connectionCount;
+        // A true singleton comes from the endpoint cache, while the new indexed group owns
+        // a different slot 0. Drop the old pin so routing adopts the group's real connection.
+        if (oldCount == 1 && !_hasScaledConnectionGroup)
+            _pinnedConnections[0] = null;
+
         _hasScaledConnectionGroup = true;
         _connectionCount = actualCount;
         _totalMaxInFlight = _connectionCount * _maxInFlight;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -542,6 +542,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // Scale-down never fences (its drain gates guarantee no in-flight) and clears any
     // stale entries at initiation. Send-loop owned (single-threaded) — no synchronization needed.
     private readonly Dictionary<TopicPartition, int> _migratingPartitions = new();
+    private volatile bool _hasMigratingPartitions;
     // Reused removal buffer keeps CompleteMigrations O(migrating) and allocation-free.
     // Capacity grows during scale-up, outside response completion processing.
     private readonly List<TopicPartition> _migrationRemovalBuffer = [];
@@ -2451,12 +2452,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 // Check if any migrating partitions can be unfenced after responses completed
-                if (_migratingPartitions.Count > 0)
+                if (_hasMigratingPartitions)
                 {
-                    var beforeCount = _migratingPartitions.Count;
+                    var beforeCount = GetMigratingPartitionCount();
                     CompleteMigrations(connIdx);
 
-                    if (_migratingPartitions.Count == 0)
+                    if (!_hasMigratingPartitions)
                         LogPartitionMigrationComplete(_brokerId, beforeCount);
                 }
             }
@@ -2731,7 +2732,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -removedBytes);
             pendingList.Clear();
 
-            if (_migratingPartitions.Count > 0)
+            if (_hasMigratingPartitions)
                 CompleteMigrations(connIdx);
 
             // After clearing all entries due to timeout, trim the internal array to
@@ -3738,8 +3739,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Common case: no migrations active — dictionary Count check is a single branch on 0.
         // During migration: one hash lookup per batch, negligible vs TCP write cost.
         int connectionIndex;
-        if (_migratingPartitions.Count > 0
-            && _migratingPartitions.TryGetValue(topicPartition, out var oldConn))
+        if (TryGetMigratingConnection(topicPartition, out var oldConn))
         {
             connectionIndex = oldConn;
         }
@@ -3815,7 +3815,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (oldConnection != newConnection
                 && HasInflightForPartition(oldConnection, topicPartition))
             {
-                _migratingPartitions.TryAdd(topicPartition, oldConnection);
+                AddMigratingPartition(topicPartition, oldConnection);
             }
         }
 
@@ -3829,7 +3829,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 var oldConnection = oldOrdinal % _connectionCount;
                 if (HasInflightForPartition(oldConnection, topicPartition))
-                    _migratingPartitions.TryAdd(topicPartition, oldConnection);
+                    AddMigratingPartition(topicPartition, oldConnection);
             }
         }
 
@@ -3881,6 +3881,44 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return false;
     }
 
+    private bool TryGetMigratingConnection(
+        TopicPartition topicPartition,
+        out int connectionIndex)
+    {
+        if (!_hasMigratingPartitions)
+        {
+            connectionIndex = default;
+            return false;
+        }
+
+        lock (_migrationRemovalBuffer)
+            return _migratingPartitions.TryGetValue(topicPartition, out connectionIndex);
+    }
+
+    private void AddMigratingPartition(TopicPartition topicPartition, int connectionIndex)
+    {
+        lock (_migrationRemovalBuffer)
+        {
+            _migratingPartitions.TryAdd(topicPartition, connectionIndex);
+            _hasMigratingPartitions = true;
+        }
+    }
+
+    private int GetMigratingPartitionCount()
+    {
+        lock (_migrationRemovalBuffer)
+            return _migratingPartitions.Count;
+    }
+
+    private void ClearMigratingPartitions()
+    {
+        lock (_migrationRemovalBuffer)
+        {
+            _migratingPartitions.Clear();
+            _hasMigratingPartitions = false;
+        }
+    }
+
     /// <summary>
     /// Checks migrating partitions whose old connection is <paramref name="connectionIndex"/>
     /// and unfences them if they no longer have in-flight batches on that connection.
@@ -3907,6 +3945,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             for (var i = 0; i < _migrationRemovalBuffer.Count; i++)
                 _migratingPartitions.Remove(_migrationRemovalBuffer[i]);
+
+            _hasMigratingPartitions = _migratingPartitions.Count > 0;
         }
     }
 
@@ -3936,10 +3976,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
                 _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+
+            _hasMigratingPartitions = _migratingPartitions.Count > 0;
         }
 
-        if (_migratingPartitions.Count > 0)
-            LogPartitionMigrationStarted(_brokerId, _migratingPartitions.Count, oldConnCount, newConnCount);
+        var migratingPartitionCount = GetMigratingPartitionCount();
+        if (migratingPartitionCount > 0)
+            LogPartitionMigrationStarted(_brokerId, migratingPartitionCount, oldConnCount, newConnCount);
     }
 
     /// <summary>
@@ -4381,7 +4424,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _retiringConnection = null;
         }
 
-        _migratingPartitions.Clear();
+        ClearMigratingPartitions();
 
         var totalPending = _totalPendingResponseCount;
         if (totalPending > 0)
@@ -4758,7 +4801,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // The drain gates above guarantee no in-flight batches that require routing to the
         // removed slot, so any leftover migration fences are stale — clear them so no
         // partition keeps routing outside the reduced width.
-        _migratingPartitions.Clear();
+        ClearMigratingPartitions();
 
         _accumulator.RecordConnectionScaleEvent(
             _brokerId,

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3857,21 +3857,26 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void CompleteMigrations(int connectionIndex)
     {
-        var pendingList = _pendingResponsesByConnection[connectionIndex];
-        _migrationRemovalBuffer.Clear();
-
-        foreach (var (topicPartition, oldConnection) in _migratingPartitions)
+        // The send loop is the production owner. Serialize the reflection-driven timeout
+        // test path too so it cannot race this reusable scratch buffer with the loop.
+        lock (_migrationRemovalBuffer)
         {
-            if (oldConnection != connectionIndex)
-                continue;
+            var pendingList = _pendingResponsesByConnection[connectionIndex];
+            _migrationRemovalBuffer.Clear();
 
-            // Empty connection is the common completion case and avoids rescanning batches.
-            if (pendingList.Count == 0 || !HasInflightForPartition(connectionIndex, topicPartition))
-                _migrationRemovalBuffer.Add(topicPartition);
+            foreach (var (topicPartition, oldConnection) in _migratingPartitions)
+            {
+                if (oldConnection != connectionIndex)
+                    continue;
+
+                // Empty connection is the common completion case and avoids rescanning batches.
+                if (pendingList.Count == 0 || !HasInflightForPartition(connectionIndex, topicPartition))
+                    _migrationRemovalBuffer.Add(topicPartition);
+            }
+
+            for (var i = 0; i < _migrationRemovalBuffer.Count; i++)
+                _migratingPartitions.Remove(_migrationRemovalBuffer[i]);
         }
-
-        for (var i = 0; i < _migrationRemovalBuffer.Count; i++)
-            _migratingPartitions.Remove(_migrationRemovalBuffer[i]);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -525,10 +525,7 @@ public sealed class ConnectionPoolTests
             connectionsPerBroker: 2,
             connectionFactory: (brokerId, host, port, index, _) =>
             {
-                var connection = new TestIdleConnection(brokerId, host, port)
-                {
-                    PendingRequestCount = index == 0 ? 1 : 0
-                };
+                var connection = new TestIdleConnection(brokerId, host, port);
                 created[index] = connection;
                 return new ValueTask<IKafkaConnection>(connection);
             });
@@ -536,8 +533,8 @@ public sealed class ConnectionPoolTests
         await using (pool)
         {
             pool.RegisterBroker(1, "localhost", 9092);
-            pool.RetainConnectionGroup(1);
-            pool.RetainConnectionGroup(1);
+            pool.RetainConnectionGroupIndex(1, 0);
+            pool.RetainConnectionGroupIndex(1, 0);
 
             try
             {
@@ -546,23 +543,22 @@ public sealed class ConnectionPoolTests
                 created[1].LastUsedTimestampMs = StaleIdleTimestamp();
                 var reaped = await pool.ReapIdleConnectionsAsync();
 
-                await Assert.That(reaped).IsEqualTo(0);
+                await Assert.That(reaped).IsEqualTo(1);
                 await Assert.That(created[0].DisposeCount).IsEqualTo(0);
-                await Assert.That(created[1].DisposeCount).IsEqualTo(0);
-                await Assert.That(created[1].IsConnected).IsTrue();
+                await Assert.That(created[1].DisposeCount).IsEqualTo(1);
 
-                pool.ReleaseConnectionGroup(1);
+                pool.ReleaseConnectionGroupIndex(1, 0);
                 var reapedWithOneOwner = await pool.ReapIdleConnectionsAsync();
                 await Assert.That(reapedWithOneOwner).IsEqualTo(0);
             }
             finally
             {
-                pool.ReleaseConnectionGroup(1);
+                pool.ReleaseConnectionGroupIndex(1, 0);
             }
 
             var reapedAfterRelease = await pool.ReapIdleConnectionsAsync();
             await Assert.That(reapedAfterRelease).IsEqualTo(1);
-            await Assert.That(created[1].DisposeCount).IsEqualTo(1);
+            await Assert.That(created[0].DisposeCount).IsEqualTo(1);
         }
     }
 
@@ -848,7 +844,7 @@ public sealed class ConnectionPoolTests
         return connection;
     }
 
-    private sealed class TestIdleConnection(int brokerId, string host, int port) : IKafkaConnection, IIdleTrackedKafkaConnection
+    internal sealed class TestIdleConnection(int brokerId, string host, int port) : IKafkaConnection, IIdleTrackedKafkaConnection
     {
         private int _connected = 1;
         private long _lastUsedTimestampMs = Environment.TickCount64;

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -533,8 +533,8 @@ public sealed class ConnectionPoolTests
         await using (pool)
         {
             pool.RegisterBroker(1, "localhost", 9092);
-            pool.RetainConnectionGroupIndex(1, 0);
-            pool.RetainConnectionGroupIndex(1, 0);
+            await Assert.That(pool.TryRetainConnectionGroupIndex(1, 0)).IsTrue();
+            await Assert.That(pool.TryRetainConnectionGroupIndex(1, 0)).IsTrue();
 
             try
             {
@@ -560,6 +560,15 @@ public sealed class ConnectionPoolTests
             await Assert.That(reapedAfterRelease).IsEqualTo(1);
             await Assert.That(created[0].DisposeCount).IsEqualTo(1);
         }
+    }
+
+    [Test]
+    public async Task TryRetainConnectionGroupIndex_DisposedPool_ReturnsFalse()
+    {
+        var pool = new ConnectionPool("test-client");
+        await pool.DisposeAsync();
+
+        await Assert.That(pool.TryRetainConnectionGroupIndex(1, 0)).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -536,16 +536,66 @@ public sealed class ConnectionPoolTests
         await using (pool)
         {
             pool.RegisterBroker(1, "localhost", 9092);
+            pool.RetainConnectionGroup(1);
+            pool.RetainConnectionGroup(1);
+
+            try
+            {
+                await pool.GetConnectionAsync(1);
+                created[0].LastUsedTimestampMs = StaleIdleTimestamp();
+                created[1].LastUsedTimestampMs = StaleIdleTimestamp();
+                var reaped = await pool.ReapIdleConnectionsAsync();
+
+                await Assert.That(reaped).IsEqualTo(0);
+                await Assert.That(created[0].DisposeCount).IsEqualTo(0);
+                await Assert.That(created[1].DisposeCount).IsEqualTo(0);
+                await Assert.That(created[1].IsConnected).IsTrue();
+
+                pool.ReleaseConnectionGroup(1);
+                var reapedWithOneOwner = await pool.ReapIdleConnectionsAsync();
+                await Assert.That(reapedWithOneOwner).IsEqualTo(0);
+            }
+            finally
+            {
+                pool.ReleaseConnectionGroup(1);
+            }
+
+            var reapedAfterRelease = await pool.ReapIdleConnectionsAsync();
+            await Assert.That(reapedAfterRelease).IsEqualTo(1);
+            await Assert.That(created[1].DisposeCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_UnownedGroup_ReapsIdleConnection()
+    {
+        var created = new TestIdleConnection[2];
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 2,
+            connectionFactory: (brokerId, host, port, index, _) =>
+            {
+                var connection = new TestIdleConnection(brokerId, host, port)
+                {
+                    PendingRequestCount = index == 0 ? 1 : 0
+                };
+                created[index] = connection;
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
 
             await pool.GetConnectionAsync(1);
             created[0].LastUsedTimestampMs = StaleIdleTimestamp();
             created[1].LastUsedTimestampMs = StaleIdleTimestamp();
             var reaped = await pool.ReapIdleConnectionsAsync();
 
-            await Assert.That(reaped).IsEqualTo(0);
+            await Assert.That(reaped).IsEqualTo(1);
             await Assert.That(created[0].DisposeCount).IsEqualTo(0);
-            await Assert.That(created[1].DisposeCount).IsEqualTo(0);
-            await Assert.That(created[1].IsConnected).IsTrue();
+            await Assert.That(created[1].DisposeCount).IsEqualTo(1);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -516,7 +516,7 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task ReapIdleConnectionsAsync_Group_ReapsOnlyConnectionsWithoutPendingRequests()
+    public async Task ReapIdleConnectionsAsync_Group_DoesNotDisposeOwnerAttachedConnections()
     {
         var created = new TestIdleConnection[2];
         var pool = new ConnectionPool(
@@ -542,9 +542,10 @@ public sealed class ConnectionPoolTests
             created[1].LastUsedTimestampMs = StaleIdleTimestamp();
             var reaped = await pool.ReapIdleConnectionsAsync();
 
-            await Assert.That(reaped).IsEqualTo(1);
+            await Assert.That(reaped).IsEqualTo(0);
             await Assert.That(created[0].DisposeCount).IsEqualTo(0);
-            await Assert.That(created[1].DisposeCount).IsEqualTo(1);
+            await Assert.That(created[1].DisposeCount).IsEqualTo(0);
+            await Assert.That(created[1].IsConnected).IsTrue();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -255,6 +255,8 @@ public sealed class AdaptiveScaleDownTests
             {
                 pool.RegisterBroker(1, "localhost", 9092);
                 await pool.GetConnectionAsync(1, cancellationToken);
+                var metadataManager = GetField<MetadataManager>(sender, "_metadataManager");
+                metadataManager.Metadata.Update(CreateMetadata(leaderId: 1));
 
                 typeof(BrokerSender).GetMethod(
                         "GetConnectionForPartition",
@@ -264,34 +266,7 @@ public sealed class AdaptiveScaleDownTests
                 await Assert.That(reapedBeforeLeadershipLoss).IsEqualTo(1)
                     .Because("the routed slot remains retained while the broker still owns work");
 
-                var metadataManager = GetField<MetadataManager>(sender, "_metadataManager");
-                metadataManager.Metadata.Update(new MetadataResponse
-                {
-                    Brokers =
-                    [
-                        new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
-                        new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
-                    ],
-                    Topics =
-                    [
-                        new TopicMetadata
-                        {
-                            ErrorCode = ErrorCode.None,
-                            Name = Topic,
-                            Partitions =
-                            [
-                                new PartitionMetadata
-                                {
-                                    ErrorCode = ErrorCode.None,
-                                    PartitionIndex = 0,
-                                    LeaderId = 2,
-                                    ReplicaNodes = [2],
-                                    IsrNodes = [2]
-                                }
-                            ]
-                        }
-                    ]
-                });
+                metadataManager.Metadata.Update(CreateMetadata(leaderId: 2));
                 typeof(BrokerSender).GetMethod(
                         "UnmutePartition",
                         BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -337,6 +312,8 @@ public sealed class AdaptiveScaleDownTests
             {
                 pool.RegisterBroker(1, "localhost", 9092);
                 await pool.GetConnectionAsync(1);
+                GetField<MetadataManager>(sender, "_metadataManager")
+                    .Metadata.Update(CreateMetadata(leaderId: 1));
 
                 var getConnection = typeof(BrokerSender).GetMethod(
                     "GetConnectionForPartition",
@@ -427,6 +404,34 @@ public sealed class AdaptiveScaleDownTests
         batch.TrySetMemoryReleased(); // Skip accumulator memory tracking in tests
         return batch;
     }
+
+    private static MetadataResponse CreateMetadata(int leaderId) => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
+            new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
+        ],
+        Topics =
+        [
+            new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None,
+                Name = Topic,
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None,
+                        PartitionIndex = 0,
+                        LeaderId = leaderId,
+                        ReplicaNodes = [leaderId],
+                        IsrNodes = [leaderId]
+                    }
+                ]
+            }
+        ]
+    };
 
     private static ProduceResponse CreateSuccessResponseForAllPartitions() =>
         new()

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -180,10 +180,10 @@ public sealed class AdaptiveScaleDownTests
         }
     }
 
-    [Test]
-    public async Task FloorWidth_ReapsNeverRoutedSlots_ButKeepsRoutedSlot()
+    private static (
+        ConnectionPool Pool,
+        ConnectionPoolTests.TestIdleConnection[] Connections) CreateIdleConnectionPool(int connectionCount)
     {
-        const int connectionCount = 3;
         var connections = new ConnectionPoolTests.TestIdleConnection[connectionCount];
         var pool = new ConnectionPool(
             clientId: "test-client",
@@ -198,6 +198,14 @@ public sealed class AdaptiveScaleDownTests
                 connections[index] = connection;
                 return new ValueTask<IKafkaConnection>(connection);
             });
+        return (pool, connections);
+    }
+
+    [Test]
+    public async Task FloorWidth_ReapsNeverRoutedSlots_ButKeepsRoutedSlot()
+    {
+        const int connectionCount = 3;
+        var (pool, connections) = CreateIdleConnectionPool(connectionCount);
         var options = CreateOptions(idempotent: false, connectionsPerBroker: connectionCount);
         var accumulator = new RecordAccumulator(options);
         var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
@@ -222,6 +230,94 @@ public sealed class AdaptiveScaleDownTests
                 await Assert.That(connections[0].DisposeCount).IsEqualTo(0);
                 await Assert.That(connections[1].DisposeCount).IsEqualTo(1);
                 await Assert.That(connections[2].DisposeCount).IsEqualTo(1);
+            }
+            finally
+            {
+                await sender.DisposeAsync();
+                await accumulator.DisposeAsync();
+            }
+        }
+    }
+
+    [Test]
+    public async Task HighIndexRetention_DoesNotAliasIndexZero()
+    {
+        const int connectionCount = 33;
+        var (pool, connections) = CreateIdleConnectionPool(connectionCount);
+        var options = CreateOptions(idempotent: false, connectionsPerBroker: connectionCount);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        await using (pool)
+        {
+            try
+            {
+                pool.RegisterBroker(1, "localhost", 9092);
+                await pool.GetConnectionAsync(1);
+
+                var getConnection = typeof(BrokerSender).GetMethod(
+                    "GetConnectionForPartition",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+                getConnection.Invoke(sender, [new TopicPartition(Topic, 0)]);
+                getConnection.Invoke(sender, [new TopicPartition(Topic, 32)]);
+
+                var reaped = await pool.ReapIdleConnectionsAsync();
+
+                await Assert.That(reaped).IsEqualTo(31);
+                await Assert.That(connections[0].DisposeCount).IsEqualTo(0);
+                await Assert.That(connections[32].DisposeCount).IsEqualTo(0);
+            }
+            finally
+            {
+                await sender.DisposeAsync();
+                await accumulator.DisposeAsync();
+            }
+        }
+    }
+
+    [Test]
+    public async Task ScaleDown_ReleasesRemovedIndex_AndWidthOneRetainsGroupSlot()
+    {
+        const int initialConnectionCount = 2;
+        var (pool, connections) = CreateIdleConnectionPool(initialConnectionCount);
+        var options = CreateOptions(idempotent: false, connectionsPerBroker: initialConnectionCount);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        await using (pool)
+        {
+            try
+            {
+                pool.RegisterBroker(1, "localhost", 9092);
+                await pool.GetConnectionAsync(1);
+
+                var senderType = typeof(BrokerSender);
+                var getConnection = senderType.GetMethod(
+                    "GetConnectionForPartition",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+                getConnection.Invoke(sender, [new TopicPartition(Topic, 1)]);
+
+                var removedConnection = await pool.ShrinkConnectionGroupAsync(1, 1);
+                senderType.GetField("_connectionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(sender, 1);
+                senderType.GetField("_hasScaledConnectionGroup", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .SetValue(sender, true);
+                senderType.GetMethod("ApplyScaleDown", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(sender, [removedConnection!]);
+
+                using (await GetConnectionLeaseAtIndexAsync(sender, 0)) { }
+
+                await pool.ScaleConnectionGroupAsync(1, 2);
+                senderType.GetMethod("ApplyScaleUp", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(sender, [2]);
+                connections[0].LastUsedTimestampMs = 0;
+                connections[1].LastUsedTimestampMs = 0;
+
+                var reaped = await pool.ReapIdleConnectionsAsync();
+
+                await Assert.That(reaped).IsEqualTo(1);
+                await Assert.That(connections[0].DisposeCount).IsEqualTo(0);
+                await Assert.That(connections[1].DisposeCount).IsEqualTo(1);
             }
             finally
             {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -9,6 +9,7 @@ using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Dekaf.Tests.Unit.Networking;
 using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -37,7 +38,8 @@ public sealed class AdaptiveScaleDownTests
         int maxInFlightRequests = 1,
         long? scaleCooldownMs = null,
         long? scaleDownSustainedMs = null,
-        bool enableDeliveryDiagnostics = false) => new()
+        bool enableDeliveryDiagnostics = false,
+        int connectionsPerBroker = 1) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlightRequests,
@@ -48,9 +50,9 @@ public sealed class AdaptiveScaleDownTests
             RetryBackoffMaxMs = 1000,
             RequestTimeoutMs = 30_000,
             LingerMs = 0,
-            ConnectionsPerBroker = 1,
+            ConnectionsPerBroker = connectionsPerBroker,
             EnableAdaptiveConnections = true,
-            MaxConnectionsPerBroker = 4,
+            MaxConnectionsPerBroker = Math.Max(4, connectionsPerBroker),
             EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
             ScaleCooldownMsOverride = scaleCooldownMs,
             ScaleDownSustainedMsOverride = scaleDownSustainedMs
@@ -175,6 +177,57 @@ public sealed class AdaptiveScaleDownTests
         {
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FloorWidth_ReapsNeverRoutedSlots_ButKeepsRoutedSlot()
+    {
+        const int connectionCount = 3;
+        var connections = new ConnectionPoolTests.TestIdleConnection[connectionCount];
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = 1 },
+            connectionsPerBroker: connectionCount,
+            connectionFactory: (brokerId, host, port, index, _) =>
+            {
+                var connection = new ConnectionPoolTests.TestIdleConnection(brokerId, host, port)
+                {
+                    LastUsedTimestampMs = 0
+                };
+                connections[index] = connection;
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+        var options = CreateOptions(idempotent: false, connectionsPerBroker: connectionCount);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        await using (pool)
+        {
+            try
+            {
+                pool.RegisterBroker(1, "localhost", 9092);
+                await pool.GetConnectionAsync(1);
+
+                var getConnection = typeof(BrokerSender).GetMethod(
+                    "GetConnectionForPartition",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!;
+                var routedIndex = (int)getConnection.Invoke(
+                    sender,
+                    [new TopicPartition(Topic, 0)])!;
+                var reaped = await pool.ReapIdleConnectionsAsync();
+
+                await Assert.That(routedIndex).IsEqualTo(0);
+                await Assert.That(reaped).IsEqualTo(2);
+                await Assert.That(connections[0].DisposeCount).IsEqualTo(0);
+                await Assert.That(connections[1].DisposeCount).IsEqualTo(1);
+                await Assert.That(connections[2].DisposeCount).IsEqualTo(1);
+            }
+            finally
+            {
+                await sender.DisposeAsync();
+                await accumulator.DisposeAsync();
+            }
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -240,6 +240,83 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task MetadataWithoutBrokerPartitions_ReleasesRoutedSlot()
+    {
+        var (pool, connections) = CreateIdleConnectionPool(connectionCount: 2);
+        var options = CreateOptions(idempotent: false, connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        await using (pool)
+        {
+            try
+            {
+                sender.RequestCancellation();
+                await GetField<Task>(sender, "_sendLoopTask");
+                pool.RegisterBroker(1, "localhost", 9092);
+                await pool.GetConnectionAsync(1);
+
+                typeof(BrokerSender).GetMethod(
+                        "GetConnectionForPartition",
+                        BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(sender, [new TopicPartition(Topic, 0)]);
+                var reapedBeforeLeadershipLoss = await pool.ReapIdleConnectionsAsync();
+                await Assert.That(reapedBeforeLeadershipLoss).IsEqualTo(1)
+                    .Because("the routed slot remains retained while the broker still owns work");
+
+                var metadataManager = GetField<MetadataManager>(sender, "_metadataManager");
+                metadataManager.Metadata.Update(new MetadataResponse
+                {
+                    Brokers =
+                    [
+                        new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
+                        new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
+                    ],
+                    Topics =
+                    [
+                        new TopicMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            Name = Topic,
+                            Partitions =
+                            [
+                                new PartitionMetadata
+                                {
+                                    ErrorCode = ErrorCode.None,
+                                    PartitionIndex = 0,
+                                    LeaderId = 2,
+                                    ReplicaNodes = [2],
+                                    IsrNodes = [2]
+                                }
+                            ]
+                        }
+                    ]
+                });
+                typeof(BrokerSender).GetMethod(
+                        "ReleaseRetainedConnectionsIfBrokerIdle",
+                        BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(sender, null);
+
+                await Assert.That(metadataManager.GetPartitionsForNode(1)).IsEmpty();
+                await Assert.That(GetField<int>(sender, "_retainedConnectionIndexCount")).IsEqualTo(0);
+                foreach (var connection in connections)
+                    connection.LastUsedTimestampMs = 0;
+
+                var reaped = await pool.ReapIdleConnectionsAsync();
+
+                await Assert.That(reaped).IsEqualTo(1);
+                await Assert.That(connections.Sum(static connection => connection.DisposeCount))
+                    .IsEqualTo(2);
+            }
+            finally
+            {
+                await sender.DisposeAsync();
+                await accumulator.DisposeAsync();
+            }
+        }
+    }
+
+    [Test]
     public async Task HighIndexRetention_DoesNotAliasIndexZero()
     {
         const int connectionCount = 33;

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -240,7 +240,9 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
-    public async Task MetadataWithoutBrokerPartitions_ReleasesRoutedSlot()
+    [Timeout(30_000)]
+    public async Task MetadataWithoutBrokerPartitions_ReleasesRoutedSlot(
+        CancellationToken cancellationToken)
     {
         var (pool, connections) = CreateIdleConnectionPool(connectionCount: 2);
         var options = CreateOptions(idempotent: false, connectionsPerBroker: 2);
@@ -251,10 +253,8 @@ public sealed class AdaptiveScaleDownTests
         {
             try
             {
-                sender.RequestCancellation();
-                await GetField<Task>(sender, "_sendLoopTask");
                 pool.RegisterBroker(1, "localhost", 9092);
-                await pool.GetConnectionAsync(1);
+                await pool.GetConnectionAsync(1, cancellationToken);
 
                 typeof(BrokerSender).GetMethod(
                         "GetConnectionForPartition",
@@ -293,9 +293,15 @@ public sealed class AdaptiveScaleDownTests
                     ]
                 });
                 typeof(BrokerSender).GetMethod(
-                        "ReleaseRetainedConnectionsIfBrokerIdle",
+                        "UnmutePartition",
                         BindingFlags.Instance | BindingFlags.NonPublic)!
-                    .Invoke(sender, null);
+                    .Invoke(sender, [new TopicPartition(Topic, 0)]);
+
+                while (GetField<int>(sender, "_retainedConnectionIndexCount") > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Yield();
+                }
 
                 await Assert.That(metadataManager.GetPartitionsForNode(1)).IsEmpty();
                 await Assert.That(GetField<int>(sender, "_retainedConnectionIndexCount")).IsEqualTo(0);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -1115,6 +1115,42 @@ public sealed class AdaptiveScaleDownTests
             BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
 
     [Test]
+    public async Task FirstScaleUp_InvalidatesEndpointPinnedSingleton()
+    {
+        var options = CreateOptions(idempotent: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var endpointConnection = Substitute.For<IKafkaConnection>();
+        endpointConnection.IsConnected.Returns(true);
+        var indexedConnection = Substitute.For<IKafkaConnection>();
+        indexedConnection.IsConnected.Returns(true);
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(endpointConnection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(indexedConnection);
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            using (var endpointLease = await GetConnectionLeaseAtIndexAsync(sender, 0))
+                await Assert.That(endpointLease.Connection).IsSameReferenceAs(endpointConnection);
+
+            typeof(BrokerSender).GetMethod(
+                    "ApplyScaleUp",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [2]);
+
+            using var indexedLease = await GetConnectionLeaseAtIndexAsync(sender, 0);
+            await Assert.That(indexedLease.Connection).IsSameReferenceAs(indexedConnection);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Arguments(false, false, true)]
     [Arguments(true, true, true)]
     [Arguments(true, false, false)]


### PR DESCRIPTION
## Summary
- exempt sender-owned connection-group slots from idle reaping
- retain endpoint idle reaping for unowned connections
- cover stale idle group slots with a regression test

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused `ConnectionPoolTests/ReapIdleConnectionsAsync_*` (4 passed)
- [x] full unit suite (5,229 passed)

Closes #1910