### PR TITLE
Fix dense producer partition routing

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -249,7 +249,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// Sets the number of TCP connections to maintain per broker.
     /// Multiple connections enable parallel request handling, improving throughput by
     /// reducing write lock contention. Idempotent producers use partition affinity
-    /// (partition % connectionCount) to preserve sequence ordering.
+    /// (dense broker-partition ordinal % connectionCount) to preserve sequence ordering.
     /// </summary>
     /// <param name="connectionsPerBroker">
     /// Number of connections per broker. Must be between 1 and 32.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -478,12 +478,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     // Partition-affined connections: each partition pins to _pinnedConnections[GetConnectionForPartition(topicPartition)].
     // For single-connection mode (_connectionCount == 1), degenerates to the original pinned behavior.
-    // All producers use partition affinity (partition % N) for CPU cache locality.
+    // All producers use dense per-broker partition ordinals for CPU cache locality and
+    // even distribution when raw Kafka partition IDs are congruent modulo the width.
     // Idempotent producers additionally require affinity for per-partition sequence ordering;
-    // during scaling, _migratingPartitions overrides the modulo to preserve ordering.
+    // during routing changes, _migratingPartitions preserves ordering.
     private readonly IKafkaConnection?[] _pinnedConnections;
     private int _connectionCount;
     private readonly bool _isIdempotent;
+
+    // Dense routing ranks derived from the immutable metadata snapshot's broker reverse index.
+    // The dictionary keeps GetConnectionForPartition O(1); the reusable list is sorted only
+    // when metadata replaces the broker's partition-list snapshot. Send-loop owned.
+    private readonly Dictionary<TopicPartition, int> _partitionOrdinals = new();
+    private readonly List<TopicPartition> _rankedPartitions = [];
+    private IReadOnlyList<TopicPartition>? _partitionRoutingSnapshot;
 
     // Adaptive connection scaling state (send-loop owned, single-threaded)
     private bool _adaptiveScalingEnabled;
@@ -520,11 +528,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private volatile bool _loopExited;
     private volatile bool _redeliverAfterLoopExit;
 
-    // Per-partition migration fencing for all acknowledged producers: during a scale-UP,
-    // partitions whose connection assignment changes (partition % oldCount != partition % newCount)
-    // are fenced here if they have in-flight batches on the old connection. The partition
-    // continues routing to the old connection until its in-flight clears, then is removed
-    // from this dictionary and routes via the new partition % _connectionCount.
+    // Per-partition migration fencing for all acknowledged producers: when connection width
+    // or metadata changes an assignment, partitions with in-flight batches stay on their old
+    // connection until those batches clear, then use the latest ordinal assignment.
     // Scale-down never fences (its drain gates guarantee no in-flight) and clears any
     // stale entries at initiation. Send-loop owned (single-threaded) — no synchronization needed.
     private readonly Dictionary<TopicPartition, int> _migratingPartitions = new();
@@ -680,7 +686,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // same partition can be appended out of order even when no retry occurs.
         _muteOnSend = !_isIdempotent || _maxInFlight <= 1;
 
-        // All producers use partition affinity (partition % connectionCount) for CPU cache
+        // All producers use dense broker-partition affinity for CPU cache
         // locality. Idempotent producers additionally need affinity for sequence ordering.
         _connectionCount = options.ConnectionsPerBroker;
         _totalMaxInFlight = _connectionCount * _maxInFlight;
@@ -1452,9 +1458,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             metadataRefreshTopics.Clear();
 
                             // Distribute coalesced batches into per-connection buckets.
-                            // Partition affinity (partition % N) keeps each partition's batches
-                            // on the same connection for CPU cache locality. This also preserves
-                            // per-partition sequence ordering for idempotent producers.
+                            // Dense broker-partition affinity keeps each partition's batches on
+                            // one connection for CPU cache locality and sequence ordering.
                             // Note: when ConnectionsPerBroker exceeds the partition count, some
                             // connections will be idle. Adaptive scaling handles this naturally
                             // by scaling down unused connections.
@@ -1821,6 +1826,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         var batch = batchRef.Batch;
+
+        RefreshPartitionRouting();
 
         // Track distinct partitions this broker serves for MicroLinger skip optimization.
         _knownPartitions.Add(batch.TopicPartition);
@@ -3593,10 +3600,68 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         // Common case: no migrations active — dictionary Count check is a single branch on 0.
         // During migration: one hash lookup per batch, negligible vs TCP write cost.
-        return _migratingPartitions.Count > 0
-            && _migratingPartitions.TryGetValue(topicPartition, out var oldConn)
-            ? oldConn
+        if (_migratingPartitions.Count > 0
+            && _migratingPartitions.TryGetValue(topicPartition, out var oldConn))
+        {
+            return oldConn;
+        }
+
+        if (_partitionOrdinals.TryGetValue(topicPartition, out var ordinal))
+            return ordinal % _connectionCount;
+
+        // First route can precede CoalesceBatch in focused callers/tests. Production normally
+        // refreshes once per coalesced batch, before connection selection.
+        RefreshPartitionRouting();
+        return _partitionOrdinals.TryGetValue(topicPartition, out ordinal)
+            ? ordinal % _connectionCount
             : topicPartition.Partition % _connectionCount;
+    }
+
+    /// <summary>
+    /// Rebuilds dense, deterministic broker-partition ordinals when metadata changes.
+    /// Any acknowledged partition whose route changes while a request is in flight stays
+    /// fenced to its old connection until response processing clears the migration.
+    /// </summary>
+    private void RefreshPartitionRouting()
+    {
+        var metadataPartitions = _metadataManager.GetPartitionsForNode(_brokerId);
+        if (ReferenceEquals(metadataPartitions, _partitionRoutingSnapshot))
+            return;
+
+        _rankedPartitions.Clear();
+        for (var i = 0; i < metadataPartitions.Count; i++)
+            _rankedPartitions.Add(metadataPartitions[i]);
+        _rankedPartitions.Sort(static (left, right) =>
+        {
+            var topicComparison = string.CompareOrdinal(left.Topic, right.Topic);
+            return topicComparison != 0
+                ? topicComparison
+                : left.Partition.CompareTo(right.Partition);
+        });
+
+        for (var newOrdinal = 0; newOrdinal < _rankedPartitions.Count; newOrdinal++)
+        {
+            var topicPartition = _rankedPartitions[newOrdinal];
+            if (!_partitionOrdinals.TryGetValue(topicPartition, out var oldOrdinal))
+                continue;
+
+            var oldConnection = oldOrdinal % _connectionCount;
+            var newConnection = newOrdinal % _connectionCount;
+            if (oldConnection != newConnection
+                && HasInflightForPartition(oldConnection, topicPartition))
+            {
+                _migratingPartitions.TryAdd(topicPartition, oldConnection);
+            }
+        }
+
+        _partitionOrdinals.Clear();
+        for (var ordinal = 0; ordinal < _rankedPartitions.Count; ordinal++)
+            _partitionOrdinals.Add(_rankedPartitions[ordinal], ordinal);
+
+        if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
+            _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;
+
+        _partitionRoutingSnapshot = metadataPartitions;
     }
 
     /// <summary>
@@ -3660,9 +3725,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     {
         foreach (var tp in _knownPartitions)
         {
-            var partition = tp.Partition;
-            var oldConn = partition % oldConnCount;
-            var newConn = partition % newConnCount;
+            var routeKey = _partitionOrdinals.TryGetValue(tp, out var ordinal)
+                ? ordinal
+                : tp.Partition;
+            var oldConn = routeKey % oldConnCount;
+            var newConn = routeKey % newConnCount;
 
             if (oldConn != newConn && HasInflightForPartition(oldConn, tp))
             {
@@ -4336,7 +4403,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             var targetCount = ComputeScaleTarget(scalePressureDelta, _connectionCount, _maxConnectionsPerBroker);
 
-            // Partition affinity (partition % N) means connections beyond the partition
+            // Dense partition affinity means connections beyond the partition
             // count can never receive traffic — they'd sit idle and immediately arm
             // scale-down churn. Cap the target at the partitions this broker serves.
             if (_knownPartitions.Count > 0 && targetCount > _knownPartitions.Count)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -491,6 +491,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // when metadata replaces the broker's partition-list snapshot. Send-loop owned.
     private readonly Dictionary<TopicPartition, int> _partitionOrdinals = new();
     private readonly List<TopicPartition> _rankedPartitions = [];
+    private readonly HashSet<TopicPartition> _rankedPartitionSet = [];
     private IReadOnlyList<TopicPartition>? _partitionRoutingSnapshot;
     private int _nextStablePartitionOrdinal;
 
@@ -2598,6 +2599,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -removedBytes);
             pendingList.Clear();
 
+            if (_migratingPartitions.Count > 0)
+                CompleteMigrations(connIdx);
+
             // After clearing all entries due to timeout, trim the internal array to
             // prevent capacity from ratcheting up across repeated timeout/recovery cycles.
             // The > 16 guard avoids trimming tiny lists: with MaxInFlightRequestsPerConnection
@@ -3630,8 +3634,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             return;
 
         _rankedPartitions.Clear();
+        _rankedPartitionSet.Clear();
         for (var i = 0; i < metadataPartitions.Count; i++)
-            _rankedPartitions.Add(metadataPartitions[i]);
+        {
+            var topicPartition = metadataPartitions[i];
+            _rankedPartitions.Add(topicPartition);
+            _rankedPartitionSet.Add(topicPartition);
+        }
         _rankedPartitions.Sort(static (left, right) =>
         {
             var topicComparison = string.CompareOrdinal(left.Topic, right.Topic);
@@ -3668,6 +3677,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 && HasInflightForPartition(oldConnection, topicPartition))
             {
                 _migratingPartitions.TryAdd(topicPartition, oldConnection);
+            }
+        }
+
+        // Metadata can temporarily omit a partition while an older request remains in
+        // flight (unknown leader, leader move, or a partial refresh). Remember its old
+        // connection even though it has no current dense ordinal. If it returns before
+        // the request completes, the migration fence prevents a cross-stream reorder.
+        foreach (var (topicPartition, oldOrdinal) in _partitionOrdinals)
+        {
+            if (!_rankedPartitionSet.Contains(topicPartition))
+            {
+                var oldConnection = oldOrdinal % _connectionCount;
+                if (HasInflightForPartition(oldConnection, topicPartition))
+                    _migratingPartitions.TryAdd(topicPartition, oldConnection);
             }
         }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -492,6 +492,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Dictionary<TopicPartition, int> _partitionOrdinals = new();
     private readonly List<TopicPartition> _rankedPartitions = [];
     private IReadOnlyList<TopicPartition>? _partitionRoutingSnapshot;
+    private int _nextStablePartitionOrdinal;
 
     // Adaptive connection scaling state (send-loop owned, single-threaded)
     private bool _adaptiveScalingEnabled;
@@ -3639,6 +3640,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 : left.Partition.CompareTo(right.Partition);
         });
 
+        if (_options.Acks == Acks.None && _partitionRoutingSnapshot is not null)
+        {
+            // Without acknowledgements there is no safe point to move an existing
+            // partition to another TCP stream. Preserve every assigned ordinal for this
+            // sender's lifetime and distribute only newly discovered partitions.
+            for (var i = 0; i < _rankedPartitions.Count; i++)
+            {
+                var topicPartition = _rankedPartitions[i];
+                if (_partitionOrdinals.TryAdd(topicPartition, _nextStablePartitionOrdinal))
+                    _nextStablePartitionOrdinal++;
+            }
+
+            _partitionRoutingSnapshot = metadataPartitions;
+            return;
+        }
+
         for (var newOrdinal = 0; newOrdinal < _rankedPartitions.Count; newOrdinal++)
         {
             var topicPartition = _rankedPartitions[newOrdinal];
@@ -3657,6 +3674,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _partitionOrdinals.Clear();
         for (var ordinal = 0; ordinal < _rankedPartitions.Count; ordinal++)
             _partitionOrdinals.Add(_rankedPartitions[ordinal], ordinal);
+        _nextStablePartitionOrdinal = _rankedPartitions.Count;
 
         if (_migrationRemovalBuffer.Capacity < _migratingPartitions.Count)
             _migrationRemovalBuffer.Capacity = _migratingPartitions.Count;

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -217,10 +217,8 @@ public sealed class ProducerOptions
 
     /// <summary>
     /// Number of connections to maintain per broker for parallel request handling.
-    /// When set greater than 1, connections are selected based on the producer mode:
-    /// idempotent producers use partition affinity (partition % connectionCount) to preserve
-    /// per-partition sequence ordering, while non-idempotent producers use round-robin
-    /// to distribute load across TCP streams.
+    /// When set greater than 1, dense broker-partition affinity distributes partitions
+    /// across connections while preserving per-partition ordering.
     /// <para>
     /// For transactional producers (<see cref="TransactionalId"/> is set), this must be 1
     /// because transaction coordinator requests require a single connection per broker.
@@ -554,8 +552,8 @@ public sealed class ProducerOptions
     /// when sustained buffer backpressure is detected, improving drain throughput.
     /// <para>
     /// Applies to idempotent and acknowledged non-idempotent producers. Idempotent producers
-    /// use partition affinity (partition % connectionCount) to preserve per-partition
-    /// sequence ordering across multiple connections, so adaptive scaling is safe.
+    /// use dense broker-partition affinity to preserve per-partition sequence ordering
+    /// across multiple connections, so adaptive scaling is safe.
     /// </para>
     /// <para>
     /// Automatically disabled for transactional producers (<see cref="TransactionalId"/> is set),

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -438,6 +438,53 @@ public sealed class BrokerSenderMuteOrderingTests
         }
     }
 
+    [Test]
+    public async Task MetadataRerank_FireAndForgetKeepsExistingPartitionRoute()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var options = CreateOptions(
+            acks: Acks.None,
+            enableIdempotence: false,
+            connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2));
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: (_, _, _, _, _) => { },
+            metadataManager);
+        var getConnection = typeof(BrokerSender).GetMethod(
+            "GetConnectionForPartition",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        try
+        {
+            var existingPartition = new TopicPartition("test-topic", 3);
+            await Assert.That((int)getConnection.Invoke(sender, [existingPartition])!).IsEqualTo(0);
+
+            metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 1));
+            typeof(BrokerSender).GetMethod(
+                    "RefreshPartitionRouting",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, null);
+
+            await Assert.That((int)getConnection.Invoke(sender, [existingPartition])!).IsEqualTo(0)
+                .Because("Acks.None has no acknowledgement boundary for cross-connection rerouting");
+            await Assert.That((int)getConnection.Invoke(
+                    sender,
+                    [new TopicPartition("test-topic", 0)])!)
+                .IsEqualTo(1)
+                .Because("new partitions should still distribute across the configured width");
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
     private static MetadataResponse CreateRoutingMetadata(int partitionZeroLeader) => new()
     {
         Brokers =

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -439,6 +439,101 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
+    [NotInParallel]
+    [Timeout(30_000)]
+    public async Task MetadataRerank_OmittedInflightPartitionStaysFencedWhenItReturns(CancellationToken ct)
+    {
+        var response = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (pool, connection) = CreateMockConnection(new Queue<TaskCompletionSource<ProduceResponse>>([response]));
+        pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(connection);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: false, connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2));
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sendLogger = new PipelinedSendLogger(expectedSends: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { }, metadataManager,
+            logger: sendLogger);
+        var getConnection = typeof(BrokerSender).GetMethod(
+            "GetConnectionForPartition", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var refreshRouting = typeof(BrokerSender).GetMethod(
+            "RefreshPartitionRouting", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var topicPartition = new TopicPartition("test-topic", 3);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(vtPool, topicPartition.Topic, topicPartition.Partition));
+            await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+
+            metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2, partitionThreeLeader: 2));
+            refreshRouting.Invoke(sender, null);
+            metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 1));
+            refreshRouting.Invoke(sender, null);
+
+            await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(0)
+                .Because("a temporarily omitted in-flight partition must keep its old TCP stream");
+        }
+        finally
+        {
+            response.TrySetResult(CreateSuccessResponse(topicPartition.Topic, topicPartition.Partition, 100));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    [Timeout(30_000)]
+    public async Task MetadataRerank_RequestTimeoutClearsMigrationFence(CancellationToken ct)
+    {
+        var timedOutResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([timedOutResponse]);
+        var (pool, connection) = CreateMockConnection(responseQueue);
+        pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(connection);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: false,
+            deliveryTimeoutMs: 1, requestTimeoutMs: 1, connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2));
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sendLogger = new PipelinedSendLogger(expectedSends: 1);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { }, metadataManager,
+            logger: sendLogger);
+        var getConnection = typeof(BrokerSender).GetMethod(
+            "GetConnectionForPartition", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var topicPartition = new TopicPartition("test-topic", 3);
+        var batch = CreateTestBatch(vtPool, topicPartition.Topic, topicPartition.Partition);
+
+        try
+        {
+            sender.Enqueue(batch);
+            await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+            metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 1));
+            typeof(BrokerSender).GetMethod(
+                    "RefreshPartitionRouting", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, null);
+
+            await Task.Delay(20, ct);
+            typeof(BrokerSender).GetMethod(
+                    "HandleTimedOutRequests", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, [CreateCarryOver(), ct]);
+
+            await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
+                .Because("timeout removal leaves no old request that can justify a migration fence");
+        }
+        finally
+        {
+            timedOutResponse.TrySetResult(CreateSuccessResponse(topicPartition.Topic, topicPartition.Partition, 100));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task MetadataRerank_FireAndForgetKeepsExistingPartitionRoute()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -485,7 +580,9 @@ public sealed class BrokerSenderMuteOrderingTests
         }
     }
 
-    private static MetadataResponse CreateRoutingMetadata(int partitionZeroLeader) => new()
+    private static MetadataResponse CreateRoutingMetadata(
+        int partitionZeroLeader,
+        int partitionThreeLeader = 1) => new()
     {
         Brokers =
         [
@@ -513,10 +610,10 @@ public sealed class BrokerSenderMuteOrderingTests
                     {
                         ErrorCode = ErrorCode.None,
                         PartitionIndex = 3,
-                        LeaderId = 1,
-                        LeaderEpoch = 1,
-                        ReplicaNodes = [1],
-                        IsrNodes = [1]
+                        LeaderId = partitionThreeLeader,
+                        LeaderEpoch = partitionThreeLeader == 1 ? 1 : 2,
+                        ReplicaNodes = [partitionThreeLeader],
+                        IsrNodes = [partitionThreeLeader]
                     }
                 ]
             }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -39,7 +39,8 @@ public sealed class BrokerSenderMuteOrderingTests
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 0, int retryBackoffMaxMs = 0,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
-        int maxRequestSize = 1_048_576, bool enableIdempotence = true) => new()
+        int maxRequestSize = 1_048_576, bool enableIdempotence = true,
+        int connectionsPerBroker = 1) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -50,6 +51,7 @@ public sealed class BrokerSenderMuteOrderingTests
             RetryBackoffMaxMs = retryBackoffMaxMs,
             RequestTimeoutMs = requestTimeoutMs,
             MaxRequestSize = maxRequestSize,
+            ConnectionsPerBroker = connectionsPerBroker,
             LingerMs = 0
         };
 
@@ -222,9 +224,10 @@ public sealed class BrokerSenderMuteOrderingTests
         Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
         MetadataManager? metadataManager = null,
         Action<ReadyBatch, int>? rerouteBatch = null,
-        ILogger? logger = null) =>
+        ILogger? logger = null,
+        int brokerId = 1) =>
         new(
-            brokerId: 1, pool,
+            brokerId, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
             accumulator, options,
             new CompressionCodecRegistry(),
@@ -288,6 +291,190 @@ public sealed class BrokerSenderMuteOrderingTests
         CoalesceBatchMethod.Invoke(sender, args);
         coalescedCount = (int)args[3]!;
     }
+
+    [Test]
+    public async Task ConnectionRouting_UsesDenseBrokerPartitionOrdinal()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var options = CreateOptions(connectionsPerBroker: 3);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094 },
+                new BrokerMetadata { NodeId = 3, Host = "broker-3", Port = 9095 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "test-topic",
+                    Partitions = Enumerable.Range(0, 6)
+                        .Select(partition => new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = partition,
+                            LeaderId = (partition % 3) + 1,
+                            LeaderEpoch = 1,
+                            ReplicaNodes = [(partition % 3) + 1],
+                            IsrNodes = [(partition % 3) + 1]
+                        })
+                        .ToArray()
+                }
+            ]
+        });
+
+        var getConnection = typeof(BrokerSender).GetMethod(
+            "GetConnectionForPartition",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        for (var brokerId = 1; brokerId <= 3; brokerId++)
+        {
+            var accumulator = new RecordAccumulator(options);
+            var sender = CreateSender(
+                pool,
+                options,
+                accumulator,
+                onAcknowledgement: (_, _, _, _, _) => { },
+                metadataManager,
+                brokerId: brokerId);
+
+            try
+            {
+                var firstPartition = brokerId - 1;
+                var firstRoute = (int)getConnection.Invoke(
+                    sender,
+                    [new TopicPartition("test-topic", firstPartition)])!;
+                var secondRoute = (int)getConnection.Invoke(
+                    sender,
+                    [new TopicPartition("test-topic", firstPartition + 3)])!;
+
+                await Assert.That(firstRoute).IsEqualTo(0);
+                await Assert.That(secondRoute).IsEqualTo(1)
+                    .Because("partitions led by one broker need dense ordinals instead of raw partition modulo");
+            }
+            finally
+            {
+                await sender.DisposeAsync();
+                await accumulator.DisposeAsync();
+            }
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    [Timeout(30_000)]
+    public async Task MetadataRerank_PinsPartitionUntilPendingRequestCompletes(CancellationToken ct)
+    {
+        var response = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([response]);
+        var (pool, connection) = CreateMockConnection(responseQueue);
+        pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        var options = CreateOptions(
+            maxInFlight: 2,
+            enableIdempotence: false,
+            connectionsPerBroker: 2);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2));
+        var vtPool = new ValueTaskSourcePool<RecordMetadata>();
+        var sendLogger = new PipelinedSendLogger(expectedSends: 1);
+        var acknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, ex) =>
+            {
+                if (ex is null)
+                    acknowledged.TrySetResult();
+            },
+            metadataManager,
+            logger: sendLogger);
+        var getConnection = typeof(BrokerSender).GetMethod(
+            "GetConnectionForPartition",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        try
+        {
+            var topicPartition = new TopicPartition("test-topic", 3);
+            sender.Enqueue(CreateTestBatch(vtPool, topicPartition.Topic, topicPartition.Partition));
+            await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+
+            metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 1));
+            typeof(BrokerSender).GetMethod(
+                    "RefreshPartitionRouting",
+                    BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, null);
+
+            await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(0)
+                .Because("metadata reranking must not move a partition with an in-flight request");
+
+            response.SetResult(CreateSuccessResponse(topicPartition.Topic, topicPartition.Partition, baseOffset: 100));
+            await acknowledged.Task.WaitAsync(ct);
+
+            var deadline = Stopwatch.GetTimestamp() + (5 * Stopwatch.Frequency);
+            while ((int)getConnection.Invoke(sender, [topicPartition])! != 1
+                   && Stopwatch.GetTimestamp() < deadline)
+            {
+                await Task.Delay(1, ct);
+            }
+
+            await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
+                .Because("partition should adopt its dense ordinal after the old request completes");
+        }
+        finally
+        {
+            response.TrySetResult(CreateSuccessResponse("test-topic", partition: 3, baseOffset: 100));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await vtPool.DisposeAsync();
+        }
+    }
+
+    private static MetadataResponse CreateRoutingMetadata(int partitionZeroLeader) => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 },
+            new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094 }
+        ],
+        Topics =
+        [
+            new TopicMetadata
+            {
+                ErrorCode = ErrorCode.None,
+                Name = "test-topic",
+                Partitions =
+                [
+                    new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None,
+                        PartitionIndex = 0,
+                        LeaderId = partitionZeroLeader,
+                        LeaderEpoch = partitionZeroLeader == 1 ? 2 : 1,
+                        ReplicaNodes = [partitionZeroLeader],
+                        IsrNodes = [partitionZeroLeader]
+                    },
+                    new PartitionMetadata
+                    {
+                        ErrorCode = ErrorCode.None,
+                        PartitionIndex = 3,
+                        LeaderId = 1,
+                        LeaderEpoch = 1,
+                        ReplicaNodes = [1],
+                        IsrNodes = [1]
+                    }
+                ]
+            }
+        ]
+    };
 
     private static ReadyBatch CreateMinimalBatch(string topic, int partition)
     {


### PR DESCRIPTION
## Summary
- route producer batches by deterministic dense per-broker partition ordinal
- fence metadata-driven route changes until old in-flight requests complete
- cover congruent six-partition/three-broker layouts and metadata reranking

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused producer routing/scaling tests (108 passed)
- [x] full unit suite (5,231 passed)
- [ ] full integration suite: 797 passed, 2 unrelated `AdminTransactionRemediationTests` failed during `FindCoordinator` before changed routing executes
- [ ] 15-minute three-broker stress comparison (deferred to stress CI)

Closes #1909
