### PR TITLE
Expose producer admission and connection diagnostics

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -14,6 +14,7 @@ namespace Dekaf.Networking;
 /// </summary>
 public sealed partial class ConnectionPool : IConnectionPool
 {
+    private const int MaxConnectionReapDiagnosticEvents = 256;
     private readonly string? _clientId;
     private readonly ConnectionOptions _connectionOptions;
     private readonly ILoggerFactory? _loggerFactory;
@@ -24,6 +25,8 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
     private CancellationTokenSource? _idleReaperCts;
     private Task? _idleReaperTask;
+    private readonly object _connectionReapDiagnosticsLock = new();
+    private readonly List<ConnectionReapDiagnostic> _connectionReapEvents = [];
 
     /// <summary>
     /// Process-shared memory pool for all clients with this size configuration. Bounds total
@@ -1083,7 +1086,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         var removedByBrokerId = connection.BrokerId >= 0
             && TryRemoveExact(_connectionsById, connection.BrokerId, connection);
 
-        var disposed = await DisposeIdleConnectionAsync(connection, now).ConfigureAwait(false);
+        var disposed = await DisposeIdleConnectionAsync(connection, connectionIndex: 0, now).ConfigureAwait(false);
         if (!disposed)
         {
             if (connection.IsConnected)
@@ -1117,7 +1120,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         if (Interlocked.CompareExchange(ref group[index], null!, connection) != connection)
             return false;
 
-        var disposed = await DisposeIdleConnectionAsync(connection, now).ConfigureAwait(false);
+        var disposed = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
         if (!disposed && connection.IsConnected)
             Interlocked.CompareExchange(ref group[index], connection, null!);
 
@@ -1135,7 +1138,10 @@ public sealed partial class ConnectionPool : IConnectionPool
         return now - idleState.LastUsedTimestampMs >= _connectionOptions.ConnectionsMaxIdleMs;
     }
 
-    private async ValueTask<bool> DisposeIdleConnectionAsync(IKafkaConnection connection, long now)
+    private async ValueTask<bool> DisposeIdleConnectionAsync(
+        IKafkaConnection connection,
+        int connectionIndex,
+        long now)
     {
         if (!IsIdleReapable(connection, now))
             return false;
@@ -1145,11 +1151,13 @@ public sealed partial class ConnectionPool : IConnectionPool
             await connection.DisposeAsync().ConfigureAwait(false);
             if (connection is IIdleTrackedKafkaConnection idleState)
             {
+                var idleDurationMs = now - idleState.LastUsedTimestampMs;
                 LogReapedIdleConnection(
                     connection.BrokerId,
                     connection.Host,
                     connection.Port,
-                    now - idleState.LastUsedTimestampMs);
+                    idleDurationMs);
+                RecordConnectionReapDiagnostic(connection.BrokerId, connectionIndex, idleDurationMs);
             }
             return true;
         }
@@ -1157,6 +1165,29 @@ public sealed partial class ConnectionPool : IConnectionPool
         {
             LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
             return false;
+        }
+    }
+
+    internal List<ConnectionReapDiagnostic> GetConnectionReapDiagnosticsSnapshot()
+    {
+        lock (_connectionReapDiagnosticsLock)
+            return [.. _connectionReapEvents];
+    }
+
+    private void RecordConnectionReapDiagnostic(int brokerId, int connectionIndex, long idleDurationMs)
+    {
+        lock (_connectionReapDiagnosticsLock)
+        {
+            if (_connectionReapEvents.Count >= MaxConnectionReapDiagnosticEvents)
+                return;
+
+            _connectionReapEvents.Add(new ConnectionReapDiagnostic
+            {
+                OccurredAtUtc = DateTimeOffset.UtcNow,
+                BrokerId = brokerId,
+                ConnectionIndex = connectionIndex,
+                IdleDurationMs = idleDurationMs
+            });
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionReapDiagnostic.cs
+++ b/src/Dekaf/Networking/ConnectionReapDiagnostic.cs
@@ -1,0 +1,9 @@
+namespace Dekaf.Networking;
+
+internal sealed class ConnectionReapDiagnostic
+{
+    public required DateTimeOffset OccurredAtUtc { get; init; }
+    public required int BrokerId { get; init; }
+    public required int ConnectionIndex { get; init; }
+    public required long IdleDurationMs { get; init; }
+}

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -581,6 +581,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // _lastUnackedBlockSnapshot because newly discovered partitions can make that pressure
     // scale-useful later.
     private long _lastPartitionLimitedUnackedBlockSnapshot;
+    private long _lastPartitionLimitedBufferPressureSnapshot;
 
     // Recency tracking for the scale-down veto: the counter value last seen by the scale
     // check, and the monotonic-ms time of its last observed movement. Kept separate from
@@ -4316,6 +4317,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         var utilization = _accumulator.BufferUtilization;
         var bufferPressureDelta = _accumulator.BufferPressureEvents - _lastPressureSnapshot;
+        var partitionLimitedBufferPressureDelta =
+            _accumulator.BufferPressureEvents - _lastPartitionLimitedBufferPressureSnapshot;
         var sendLoopPressureDelta = _sendLoopPressureEvents - _lastSendLoopPressureSnapshot;
         var partitionLimitedPressureDelta =
             _partitionLimitedPressureEvents - _lastPartitionLimitedPressureSnapshot;
@@ -4345,17 +4348,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             : 0;
         if (partitionLimitedScalePressure
             && (partitionLimitedPressureDelta >= ScalePressureDeltaThreshold
-                || partitionLimitedUnackedBlockDelta >= ScalePressureDeltaThreshold))
+                || partitionLimitedUnackedBlockDelta >= ScalePressureDeltaThreshold
+                || (utilization >= ScaleUtilizationThreshold
+                    && partitionLimitedBufferPressureDelta >= ScalePressureDeltaThreshold)))
         {
             _accumulator.RecordConnectionScaleEvent(
                 _brokerId,
                 _connectionCount,
                 _connectionCount,
                 utilization,
-                bufferPressureDelta + partitionLimitedUnackedBlockDelta,
+                partitionLimitedBufferPressureDelta + partitionLimitedUnackedBlockDelta,
                 partitionLimitedPressureDelta,
                 partitionLimited: true);
             _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
+            _lastPartitionLimitedBufferPressureSnapshot = _accumulator.BufferPressureEvents;
             _lastPartitionLimitedUnackedBlockSnapshot = unackedBlockEvents;
         }
         var scalePressureDelta = ComputeScalePressureDelta(
@@ -4555,6 +4561,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // connections than requested, stale pressure keeps accumulating so the next
         // cooldown window retries with the full delta rather than starting from zero.
         _lastPressureSnapshot = _accumulator.BufferPressureEvents;
+        _lastPartitionLimitedBufferPressureSnapshot = _lastPressureSnapshot;
         _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
         _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
         _lastUnackedBlockSnapshot = _unackedBudget?.AdmissionBlockEvents ?? 0;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -494,6 +494,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private long _lastPressureSnapshot;
     private long _sendLoopPressureEvents;
     private long _lastSendLoopPressureSnapshot;
+    private long _partitionLimitedPressureEvents;
+    private long _lastPartitionLimitedPressureSnapshot;
     private long _lastScaleTimeTicks;
     private Task<int>? _pendingScaleTask; // Background connection creation, polled by send loop
     private double _pendingScaleBufferUtilization;
@@ -2100,6 +2102,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _knownPartitions.Count))
         {
             _sendLoopPressureEvents++;
+        }
+        else if (IsPartitionLimitedScalePressure(
+                     _adaptiveScalingEnabled,
+                     _connectionCount,
+                     _maxConnectionsPerBroker,
+                     _knownPartitions.Count))
+        {
+            _partitionLimitedPressureEvents++;
         }
     }
 
@@ -4302,6 +4312,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var utilization = _accumulator.BufferUtilization;
         var bufferPressureDelta = _accumulator.BufferPressureEvents - _lastPressureSnapshot;
         var sendLoopPressureDelta = _sendLoopPressureEvents - _lastSendLoopPressureSnapshot;
+        var partitionLimitedPressureDelta =
+            _partitionLimitedPressureEvents - _lastPartitionLimitedPressureSnapshot;
         // The unacked-byte admission gate holds BufferUtilization near zero while it binds,
         // which would silently starve scale-up (and the budget would self-limit at the drain
         // rate of the initial width). Blocked admissions therefore feed scale pressure directly.
@@ -4312,6 +4324,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _lastUnackedBlockObserved = unackedBlockEvents;
             _lastUnackedBlockObservedMs = now;
         }
+        var partitionLimitedScalePressure = IsPartitionLimitedScalePressure(
+            _adaptiveScalingEnabled,
+            _connectionCount,
+            _maxConnectionsPerBroker,
+            _knownPartitions.Count);
         var usefulUnackedBlockDelta = IsPartitionPressureScaleUseful(
             _adaptiveScalingEnabled,
             _connectionCount,
@@ -4319,6 +4336,21 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _knownPartitions.Count)
             ? unackedBlockDelta
             : 0;
+        if (partitionLimitedScalePressure
+            && (partitionLimitedPressureDelta >= ScalePressureDeltaThreshold
+                || unackedBlockDelta >= ScalePressureDeltaThreshold))
+        {
+            _accumulator.RecordConnectionScaleEvent(
+                _brokerId,
+                _connectionCount,
+                _connectionCount,
+                utilization,
+                bufferPressureDelta + unackedBlockDelta,
+                partitionLimitedPressureDelta,
+                partitionLimited: true);
+            _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
+            _lastUnackedBlockSnapshot = unackedBlockEvents;
+        }
         var scalePressureDelta = ComputeScalePressureDelta(
             bufferPressureDelta + usefulUnackedBlockDelta, sendLoopPressureDelta);
         var hasScalePressure = scalePressureDelta >= ScalePressureDeltaThreshold;
@@ -4517,6 +4549,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // cooldown window retries with the full delta rather than starting from zero.
         _lastPressureSnapshot = _accumulator.BufferPressureEvents;
         _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
+        _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
         _lastUnackedBlockSnapshot = _unackedBudget?.AdmissionBlockEvents ?? 0;
 
         // Per-connection arrays are pre-sized at the scaling ceiling — nothing to grow.
@@ -4653,6 +4686,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         adaptiveScalingEnabled
         && connectionCount < maxConnectionsPerBroker
         && knownPartitionCount > connectionCount;
+
+    internal static bool IsPartitionLimitedScalePressure(
+        bool adaptiveScalingEnabled,
+        int connectionCount,
+        int maxConnectionsPerBroker,
+        int knownPartitionCount) =>
+        adaptiveScalingEnabled
+        && connectionCount < maxConnectionsPerBroker
+        && knownPartitionCount > 0
+        && connectionCount >= knownPartitionCount;
 
     #region Logging
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -577,6 +577,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // accumulating across failed grow attempts.
     private long _lastUnackedBlockSnapshot;
 
+    // Separate capped-diagnostic snapshot. Partition-limited observations must not consume
+    // _lastUnackedBlockSnapshot because newly discovered partitions can make that pressure
+    // scale-useful later.
+    private long _lastPartitionLimitedUnackedBlockSnapshot;
+
     // Recency tracking for the scale-down veto: the counter value last seen by the scale
     // check, and the monotonic-ms time of its last observed movement. Kept separate from
     // the scale-up snapshot above, whose reset-on-scale-up policy would otherwise pin the
@@ -4319,6 +4324,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // rate of the initial width). Blocked admissions therefore feed scale pressure directly.
         var unackedBlockEvents = _unackedBudget?.AdmissionBlockEvents ?? 0;
         var unackedBlockDelta = unackedBlockEvents - _lastUnackedBlockSnapshot;
+        var partitionLimitedUnackedBlockDelta =
+            unackedBlockEvents - _lastPartitionLimitedUnackedBlockSnapshot;
         if (unackedBlockEvents != _lastUnackedBlockObserved)
         {
             _lastUnackedBlockObserved = unackedBlockEvents;
@@ -4338,18 +4345,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             : 0;
         if (partitionLimitedScalePressure
             && (partitionLimitedPressureDelta >= ScalePressureDeltaThreshold
-                || unackedBlockDelta >= ScalePressureDeltaThreshold))
+                || partitionLimitedUnackedBlockDelta >= ScalePressureDeltaThreshold))
         {
             _accumulator.RecordConnectionScaleEvent(
                 _brokerId,
                 _connectionCount,
                 _connectionCount,
                 utilization,
-                bufferPressureDelta + unackedBlockDelta,
+                bufferPressureDelta + partitionLimitedUnackedBlockDelta,
                 partitionLimitedPressureDelta,
                 partitionLimited: true);
             _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
-            _lastUnackedBlockSnapshot = unackedBlockEvents;
+            _lastPartitionLimitedUnackedBlockSnapshot = unackedBlockEvents;
         }
         var scalePressureDelta = ComputeScalePressureDelta(
             bufferPressureDelta + usefulUnackedBlockDelta, sendLoopPressureDelta);
@@ -4551,6 +4558,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _lastSendLoopPressureSnapshot = _sendLoopPressureEvents;
         _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
         _lastUnackedBlockSnapshot = _unackedBudget?.AdmissionBlockEvents ?? 0;
+        _lastPartitionLimitedUnackedBlockSnapshot = _lastUnackedBlockSnapshot;
 
         // Per-connection arrays are pre-sized at the scaling ceiling — nothing to grow.
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -63,6 +63,8 @@ internal sealed class BrokerUnackedByteBudget
     private long _budgetAfterMinRttProbeBytes;
     private long _probeBudgetAfterMinRttProbeBytes;
     private long _admissionBlockEvents;
+    private long _minimumRttMicros;
+    private long _maxRateBytesPerSecond;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
@@ -114,6 +116,10 @@ internal sealed class BrokerUnackedByteBudget
     /// connection scaling, which cannot see buffer pressure while the gate holds the
     /// accumulator near-empty.</summary>
     internal long AdmissionBlockEvents => Volatile.Read(ref _admissionBlockEvents);
+
+    internal long MinimumRttMicros => Volatile.Read(ref _minimumRttMicros);
+
+    internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
 
     // Volatile.Read (a plain acquire load) rather than Interlocked.Read: this runs per
     // message from every appender thread, and a locked read would take the cache line
@@ -194,8 +200,10 @@ internal sealed class BrokerUnackedByteBudget
 
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
         UpdateMinRtt(rttSeconds, nowTicks);
+        Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
 
         AddRateSample(ackedBytes / rttSeconds);
+        Volatile.Write(ref _maxRateBytesPerSecond, (long)_rateMaxValues[_rateMaxHead]);
 
         if (_probeUntilTimestamp != 0 && nowTicks >= _probeUntilTimestamp)
             _probeUntilTimestamp = 0;

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -1,3 +1,4 @@
+using Dekaf.Networking;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 
@@ -254,7 +255,21 @@ internal sealed class ProducerDeliveryDiagnosticsSnapshot
     public DateTimeOffset CapturedAtUtc { get; init; }
     public long InFlightBatchCount { get; init; }
     public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
+    public List<ProducerBrokerBudgetDiagnostic> BrokerBudgets { get; init; } = [];
+    public List<ProducerBrokerBudgetDiagnostic> BrokerBudgetSamples { get; init; } = [];
+    public List<ConnectionReapDiagnostic> ConnectionReapEvents { get; init; } = [];
     public List<ProducerConnectionScaleDiagnostic> ConnectionScaleEvents { get; init; } = [];
+}
+
+internal sealed class ProducerBrokerBudgetDiagnostic
+{
+    public required DateTimeOffset CapturedAtUtc { get; init; }
+    public required int BrokerId { get; init; }
+    public required long BudgetBytes { get; init; }
+    public required long UnackedBytes { get; init; }
+    public required long MinRttMicros { get; init; }
+    public required long MaxRateBytesPerSec { get; init; }
+    public required long AdmissionBlockCount { get; init; }
 }
 
 internal sealed class ProducerConnectionScaleDiagnostic
@@ -263,7 +278,17 @@ internal sealed class ProducerConnectionScaleDiagnostic
     public required int BrokerId { get; init; }
     public required int OldConnectionCount { get; init; }
     public required int NewConnectionCount { get; init; }
-    public string Direction => NewConnectionCount > OldConnectionCount ? "up" : "down";
+    public string Direction
+    {
+        get
+        {
+            if (PartitionLimited)
+                return "capped";
+
+            return NewConnectionCount > OldConnectionCount ? "up" : "down";
+        }
+    }
+    public bool PartitionLimited { get; init; }
     public required double BufferUtilization { get; init; }
     public required long BufferPressureDelta { get; init; }
     public required long SendLoopPressureDelta { get; init; }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2577,7 +2577,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     ProducerDeliveryDiagnosticsSnapshot IProducerDiagnostics.GetDeliveryDiagnosticsSnapshot()
-        => _accumulator.GetDeliveryDiagnosticsSnapshot();
+    {
+        var snapshot = _accumulator.GetDeliveryDiagnosticsSnapshot();
+        if (snapshot.DiagnosticsEnabled)
+            snapshot.ConnectionReapEvents.AddRange(_connectionPool.GetConnectionReapDiagnosticsSnapshot());
+
+        return snapshot;
+    }
 
     int IProducerDiagnostics.MaxObservedBrokerThrottleTimeMs =>
         Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -866,6 +866,8 @@ internal readonly struct ArenaSlice
 public sealed partial class RecordAccumulator : IAsyncDisposable
 {
     private const int MaxConnectionScaleDiagnosticEvents = 256;
+    private const int MaxBrokerBudgetDiagnosticSamples = 4096;
+    private const int BrokerBudgetDiagnosticIntervalMs = 1_000;
     // ReadyBatch lifecycle (seal→send→response→cleanup) is longer than PartitionBatch
     // (create→fill→seal), so its pool needs proportionally more capacity.
     private const int ReadyBatchPoolSizeRatio = 2;
@@ -957,8 +959,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private SpinLock _inFlightBatchLock = new(enableThreadOwnerTracking: false);
     private ReadyBatch? _inFlightBatchHead;
     private ReadyBatch? _inFlightBatchTail;
-    private readonly object _connectionScaleDiagnosticsLock = new();
+    private readonly object _deliveryDiagnosticsLock = new();
     private readonly List<ProducerConnectionScaleDiagnostic> _connectionScaleEvents = [];
+    private readonly List<ProducerBrokerBudgetDiagnostic> _brokerBudgetSamples = [];
+    private long _nextBrokerBudgetDiagnosticTimestampMs;
 
     // Optimization: Track the oldest batch creation time to skip unnecessary enumeration.
     // With LingerMs=5ms and 1ms timer, we'd enumerate 5x per batch without this optimization.
@@ -4058,6 +4062,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </remarks>
     public ValueTask ExpireLingerAsync(CancellationToken cancellationToken)
     {
+        MaybeRecordBrokerBudgetDiagnosticSample();
+
         // Fast path 1: no unsealed batches to check - avoid queue draining and async overhead entirely
         if (!HasUnsealedBatches())
         {
@@ -4640,8 +4646,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             InFlightBatchCount = Volatile.Read(ref _inFlightBatchCount)
         };
 
-        lock (_connectionScaleDiagnosticsLock)
+        var capturedAtUtc = snapshot.CapturedAtUtc;
+        foreach (var (brokerId, budget) in _brokerUnackedBudgets)
+            snapshot.BrokerBudgets.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc));
+
+        lock (_deliveryDiagnosticsLock)
+        {
             snapshot.ConnectionScaleEvents.AddRange(_connectionScaleEvents);
+            snapshot.BrokerBudgetSamples.AddRange(_brokerBudgetSamples);
+        }
 
         foreach (var batch in batches)
             snapshot.Batches.Add(batch.Batch.CreateDeliveryDiagnostic(batch.Generation, batch.TopicPartition));
@@ -4655,12 +4668,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int newConnectionCount,
         double bufferUtilization,
         long bufferPressureDelta,
-        long sendLoopPressureDelta)
+        long sendLoopPressureDelta,
+        bool partitionLimited = false)
     {
         if (!_options.EnableDeliveryDiagnostics)
             return;
 
-        lock (_connectionScaleDiagnosticsLock)
+        lock (_deliveryDiagnosticsLock)
         {
             if (_connectionScaleEvents.Count >= MaxConnectionScaleDiagnosticEvents)
                 return;
@@ -4673,10 +4687,60 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 NewConnectionCount = newConnectionCount,
                 BufferUtilization = bufferUtilization,
                 BufferPressureDelta = bufferPressureDelta,
-                SendLoopPressureDelta = sendLoopPressureDelta
+                SendLoopPressureDelta = sendLoopPressureDelta,
+                PartitionLimited = partitionLimited
             });
         }
     }
+
+    private void MaybeRecordBrokerBudgetDiagnosticSample()
+    {
+        if (!_options.EnableDeliveryDiagnostics || !_unackedBudgetEnabled)
+            return;
+
+        var now = Dekaf.MonotonicClock.GetMilliseconds();
+        var next = Volatile.Read(ref _nextBrokerBudgetDiagnosticTimestampMs);
+        if (now < next
+            || Interlocked.CompareExchange(
+                ref _nextBrokerBudgetDiagnosticTimestampMs,
+                now + BrokerBudgetDiagnosticIntervalMs,
+                next) != next)
+            return;
+
+        RecordBrokerBudgetDiagnosticSample();
+    }
+
+    internal void RecordBrokerBudgetDiagnosticSample()
+    {
+        if (!_options.EnableDeliveryDiagnostics || !_unackedBudgetEnabled)
+            return;
+
+        var capturedAtUtc = DateTimeOffset.UtcNow;
+        lock (_deliveryDiagnosticsLock)
+        {
+            foreach (var (brokerId, budget) in _brokerUnackedBudgets)
+            {
+                if (_brokerBudgetSamples.Count >= MaxBrokerBudgetDiagnosticSamples)
+                    _brokerBudgetSamples.RemoveAt(0);
+
+                _brokerBudgetSamples.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc));
+            }
+        }
+    }
+
+    private static ProducerBrokerBudgetDiagnostic CreateBrokerBudgetDiagnostic(
+        int brokerId,
+        BrokerUnackedByteBudget budget,
+        DateTimeOffset capturedAtUtc) => new()
+    {
+        CapturedAtUtc = capturedAtUtc,
+        BrokerId = brokerId,
+        BudgetBytes = budget.BudgetBytes,
+        UnackedBytes = budget.UnackedBytes,
+        MinRttMicros = budget.MinimumRttMicros,
+        MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
+        AdmissionBlockCount = budget.AdmissionBlockEvents
+    };
 
     /// <summary>
     /// Sweeps the in-flight batch list for batches whose delivery timeout has expired

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -454,6 +454,11 @@ public sealed class ConnectionPoolTests
             await Assert.That(created.Count).IsEqualTo(2);
             await Assert.That(created[0].DisposeCount).IsEqualTo(1);
             await Assert.That(first).IsNotSameReferenceAs(second);
+
+            var diagnostic = pool.GetConnectionReapDiagnosticsSnapshot().Single();
+            await Assert.That(diagnostic.BrokerId).IsEqualTo(1);
+            await Assert.That(diagnostic.ConnectionIndex).IsEqualTo(0);
+            await Assert.That(diagnostic.IdleDurationMs).IsGreaterThanOrEqualTo(IdleThresholdMs);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -463,6 +463,30 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionReapDiagnostics_DropsEventsBeyond256()
+    {
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1);
+
+        await using (pool)
+        {
+            var recordDiagnostic = typeof(ConnectionPool).GetMethod(
+                "RecordConnectionReapDiagnostic",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            for (var i = 0; i < 257; i++)
+                recordDiagnostic.Invoke(pool, [i, 0, 1_000L + i]);
+
+            var diagnostics = pool.GetConnectionReapDiagnosticsSnapshot();
+
+            await Assert.That(diagnostics.Count).IsEqualTo(256);
+            await Assert.That(diagnostics[0].BrokerId).IsEqualTo(0);
+            await Assert.That(diagnostics[^1].BrokerId).IsEqualTo(255);
+        }
+    }
+
+    [Test]
     public async Task ReapIdleConnectionsAsync_PendingRequest_DoesNotDisposeConnection()
     {
         var connection = new TestIdleConnection(1, "localhost", 9092)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -98,6 +98,43 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task PartitionLimitedBufferPressure_RecordsCappedEventOncePerDelta()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+            GetField<HashSet<TopicPartition>>(sender, "_knownPartitions")
+                .Add(new TopicPartition(Topic, 0));
+            SetField(accumulator, "_bufferedBytes", (long)options.BufferMemory);
+            SetField(accumulator, "_bufferPressureEvents", 100L);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot()
+                .ConnectionScaleEvents.Single();
+            await Assert.That(diagnostic.Direction).IsEqualTo("capped");
+            await Assert.That(diagnostic.BufferPressureDelta).IsEqualTo(100);
+            await Assert.That(GetField<long>(sender, "_lastPartitionLimitedBufferPressureSnapshot"))
+                .IsEqualTo(100);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task PartitionLimitedAdmissionPressure_ScalesAfterAnotherPartitionAppears()
     {
         var options = CreateOptions(idempotent: false, scaleCooldownMs: 0);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -36,7 +36,8 @@ public sealed class AdaptiveScaleDownTests
         int deliveryTimeoutMs = 30_000,
         int maxInFlightRequests = 1,
         long? scaleCooldownMs = null,
-        long? scaleDownSustainedMs = null) => new()
+        long? scaleDownSustainedMs = null,
+        bool enableDeliveryDiagnostics = false) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlightRequests,
@@ -50,9 +51,51 @@ public sealed class AdaptiveScaleDownTests
             ConnectionsPerBroker = 1,
             EnableAdaptiveConnections = true,
             MaxConnectionsPerBroker = 4,
+            EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
             ScaleCooldownMsOverride = scaleCooldownMs,
             ScaleDownSustainedMsOverride = scaleDownSustainedMs
         };
+
+    [Test]
+    public async Task PartitionLimitedPressure_RealSendLoopWiring_RecordsOncePerDelta()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+            GetField<HashSet<TopicPartition>>(sender, "_knownPartitions")
+                .Add(new TopicPartition(Topic, 0));
+
+            var recordPressure = typeof(BrokerSender).GetMethod(
+                "RecordSendLoopPressureIfScaleUseful",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            for (var i = 0; i < 100; i++)
+                recordPressure.Invoke(sender, null);
+
+            InvokeMaybeScaleConnections(sender);
+            InvokeMaybeScaleConnections(sender);
+
+            var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot()
+                .ConnectionScaleEvents.Single();
+            await Assert.That(diagnostic.Direction).IsEqualTo("capped");
+            await Assert.That(diagnostic.SendLoopPressureDelta).IsEqualTo(100);
+            await Assert.That(GetField<long>(sender, "_lastPartitionLimitedPressureSnapshot"))
+                .IsEqualTo(100);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
 
     private static ReadyBatch CreateTestBatch(
         ValueTaskSourcePool<RecordMetadata> pool, int partition, int dataSize = 100)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -97,6 +97,50 @@ public sealed class AdaptiveScaleDownTests
         }
     }
 
+    [Test]
+    public async Task PartitionLimitedAdmissionPressure_ScalesAfterAnotherPartitionAppears()
+    {
+        var options = CreateOptions(idempotent: false, scaleCooldownMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.ScaleConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<int>(2));
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 100,
+            initialCapBytes: 100);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            unackedBudget: budget);
+
+        try
+        {
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+            var knownPartitions = GetField<HashSet<TopicPartition>>(sender, "_knownPartitions");
+            knownPartitions.Add(new TopicPartition(Topic, 0));
+            for (var i = 0; i < 100; i++)
+                budget.RecordAdmissionBlock();
+
+            InvokeMaybeScaleConnections(sender);
+            await pool.DidNotReceive().ScaleConnectionGroupAsync(
+                Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+
+            knownPartitions.Add(new TopicPartition(Topic, 1));
+            InvokeMaybeScaleConnections(sender);
+
+            await pool.Received(1).ScaleConnectionGroupAsync(1, 2, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
     private static ReadyBatch CreateTestBatch(
         ValueTaskSourcePool<RecordMetadata> pool, int partition, int dataSize = 100)
     {
@@ -143,7 +187,8 @@ public sealed class AdaptiveScaleDownTests
         Action<TopicPartition, long, DateTimeOffset, int, Exception?>? onAcknowledgement,
         Action<ReadyBatch, int>? rerouteBatch = null,
         bool canPhysicallyShrinkConnections = true,
-        TimeSpan? disposalDrainTimeout = null) =>
+        TimeSpan? disposalDrainTimeout = null,
+        BrokerUnackedByteBudget? unackedBudget = null) =>
         new(
             brokerId: 1, pool,
             new MetadataManager(pool, options.BootstrapServers),
@@ -160,6 +205,7 @@ public sealed class AdaptiveScaleDownTests
             onAcknowledgement: onAcknowledgement,
             logger: null,
             canPhysicallyShrinkConnections: canPhysicallyShrinkConnections,
+            unackedBudget: unackedBudget,
             disposalDrainTimeout: disposalDrainTimeout);
 
     private static IKafkaConnection?[] GetPinnedConnections(BrokerSender sender)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -172,6 +172,29 @@ public class AdaptiveScalingTests
         await Assert.That(isUseful).IsEqualTo(expected);
     }
 
+    [Test]
+    [Arguments(true, 2, 5, 2, true)]
+    [Arguments(true, 2, 5, 1, true)]
+    [Arguments(true, 2, 5, 3, false)]
+    [Arguments(false, 2, 5, 2, false)]
+    [Arguments(true, 5, 5, 2, false)]
+    [Arguments(true, 2, 5, 0, false)]
+    public async Task IsPartitionLimitedScalePressure_IdentifiesDiscardedPressure(
+        bool enabled,
+        int connectionCount,
+        int maxConnections,
+        int partitionCount,
+        bool expected)
+    {
+        var partitionLimited = BrokerSender.IsPartitionLimitedScalePressure(
+            enabled,
+            connectionCount,
+            maxConnections,
+            partitionCount);
+
+        await Assert.That(partitionLimited).IsEqualTo(expected);
+    }
+
     #endregion
 
     #region Scale-Down Computation Tests

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -1,17 +1,21 @@
+using System.Diagnostics;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
 
 public sealed class ProducerDeliveryDiagnosticsTests
 {
-    private static ProducerOptions CreateOptions(bool enableDeliveryDiagnostics = false) => new()
+    private static ProducerOptions CreateOptions(
+        bool enableDeliveryDiagnostics = false,
+        int deliveryLatencyTargetMs = 0) => new()
     {
         BootstrapServers = ["localhost:9092"],
         ClientId = "diagnostics-test",
         BufferMemory = ulong.MaxValue,
         BatchSize = 60,
         LingerMs = 10_000,
-        EnableDeliveryDiagnostics = enableDeliveryDiagnostics
+        EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
+        DeliveryLatencyTargetMs = deliveryLatencyTargetMs
     };
 
     [Test]
@@ -68,6 +72,50 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(events[0].BufferPressureDelta).IsEqualTo(120);
         await Assert.That(events[0].SendLoopPressureDelta).IsEqualTo(150);
         await Assert.That(events[1].OccurredAtUtc).IsGreaterThanOrEqualTo(events[0].OccurredAtUtc);
+    }
+
+    [Test]
+    public async Task ConnectionScaleDiagnostics_PartitionLimit_RecordsCappedDirection()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(enableDeliveryDiagnostics: true));
+
+        accumulator.RecordConnectionScaleEvent(1, 2, 2, 0.5, 0, 200, partitionLimited: true);
+
+        var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot().ConnectionScaleEvents.Single();
+
+        await Assert.That(diagnostic.Direction).IsEqualTo("capped");
+        await Assert.That(diagnostic.PartitionLimited).IsTrue();
+        await Assert.That(diagnostic.SendLoopPressureDelta).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task BrokerBudgetDiagnostics_CapturesCurrentStateAndPeriodicSample()
+    {
+        var options = CreateOptions(
+            enableDeliveryDiagnostics: true,
+            deliveryLatencyTargetMs: 10);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: static (_, _) => 7);
+        var budget = accumulator.GetBrokerUnackedBudget(7)!;
+        budget.Charge(600);
+        budget.RecordAdmissionBlock();
+        budget.OnAcked(1_000, Stopwatch.Frequency / 1_000, Stopwatch.GetTimestamp());
+
+        await accumulator.ExpireLingerAsync(CancellationToken.None);
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+        var current = snapshot.BrokerBudgets.Single();
+        var sample = snapshot.BrokerBudgetSamples.Single();
+
+        await Assert.That(current.BrokerId).IsEqualTo(7);
+        await Assert.That(current.BudgetBytes).IsGreaterThan(0);
+        await Assert.That(current.UnackedBytes).IsEqualTo(600);
+        await Assert.That(current.MinRttMicros).IsGreaterThan(0);
+        await Assert.That(current.MaxRateBytesPerSec).IsGreaterThan(0);
+        await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
+        await Assert.That(sample.BrokerId).IsEqualTo(7);
+        await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -119,6 +119,30 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
+    public async Task BrokerBudgetDiagnostics_RollingWindowKeepsNewest4096Samples()
+    {
+        var options = CreateOptions(
+            enableDeliveryDiagnostics: true,
+            deliveryLatencyTargetMs: 10);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: static (_, _) => 7);
+        var budget = accumulator.GetBrokerUnackedBudget(7)!;
+
+        for (var i = 0; i < 4_097; i++)
+        {
+            budget.RecordAdmissionBlock();
+            accumulator.RecordBrokerBudgetDiagnosticSample();
+        }
+
+        var samples = accumulator.GetDeliveryDiagnosticsSnapshot().BrokerBudgetSamples;
+
+        await Assert.That(samples.Count).IsEqualTo(4_096);
+        await Assert.That(samples[0].AdmissionBlockCount).IsEqualTo(2);
+        await Assert.That(samples[^1].AdmissionBlockCount).IsEqualTo(4_097);
+    }
+
+    [Test]
     public async Task DeliveryDiagnostics_Disabled_DoesNotTrackTrace()
     {
         await using var accumulator = new RecordAccumulator(CreateOptions());


### PR DESCRIPTION
## Summary
- add current and once-per-second per-broker admission-budget diagnostics
- record bounded idle-connection reap events with broker, index, and idle duration
- preserve discarded partition-limited scale pressure as explicit `capped` events

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused producer diagnostics, adaptive scaling, and idle reaper tests
- [x] full unit suite (5,237 passed)

Closes #1913