### PR TITLE
Fix pipelined admission rate estimation

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3149,7 +3149,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
                 pendingResponseAdded = true; // Array ownership transferred to PendingResponse
                 Interlocked.Increment(ref _totalPendingResponseCount);
-                Interlocked.Add(ref _totalPendingResponseBytes, encodedBytes);
+                var writtenUnackedBytes = Interlocked.Add(ref _totalPendingResponseBytes, encodedBytes);
+                _unackedBudget?.ObserveWrittenUnackedBytes(writtenUnackedBytes);
                 Interlocked.Add(ref _pendingResponseBytesByConnection[connectionIndex], encodedBytes);
 
                 // Diagnostic: log instance+task+partitions at PendingResponse creation time.

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -13,11 +13,11 @@ namespace Dekaf.Producer;
 /// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
-/// <see cref="IsOverBudgetAt"/>/<see cref="RecordAdmissionBlock"/> are cross-thread (producer
-/// appenders and terminal batch paths). <see cref="OnAcked"/> and <see cref="SetCap"/> are
-/// single-writer — only the owning
-/// broker's send loop calls them — so the estimator state needs no synchronization; the computed
-/// budget is published with a volatile write.
+/// <see cref="IsOverBudgetAt"/>/<see cref="RecordAdmissionBlock"/>/
+/// <see cref="ObserveWrittenUnackedBytes"/> are cross-thread (producer appenders, terminal batch
+/// paths, and parallel connection sends). <see cref="OnAcked"/> and <see cref="SetCap"/> are
+/// single-writer — only the owning broker's send loop calls them — so the remaining estimator
+/// state needs no synchronization; the computed budget is published with a volatile write.
 /// </para>
 /// </summary>
 internal sealed class BrokerUnackedByteBudget
@@ -30,8 +30,17 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     internal const int CapBatchMultiplier = 32;
 
-    /// <summary>Number of per-request delivery-rate samples retained by the maximum filter.</summary>
-    private const int RateWindowSamples = 10;
+    private const int WindowBucketCount = 20;
+    private const double WindowBucketSeconds = 0.100;
+    private const double OccupancySafetyMultiplier = 1.5;
+    private const double ProbeGrowthThreshold = 1.01;
+
+    /// <summary>
+    /// Delivery-rate and written-occupancy maxima cover two seconds in 100ms buckets.
+    /// This makes estimator memory independent of response-pass frequency while retaining
+    /// enough history to ignore short scheduler and broker stalls.
+    /// </summary>
+    private static readonly long WindowBucketTicks = Math.Max(1, (long)(WindowBucketSeconds * Stopwatch.Frequency));
 
     /// <summary>How long an observed base RTT remains valid before it is refreshed.</summary>
     private static readonly long MinRttWindowTicks = 10 * Stopwatch.Frequency;
@@ -65,19 +74,18 @@ internal sealed class BrokerUnackedByteBudget
     private long _admissionBlockEvents;
     private long _minimumRttMicros;
     private long _maxRateBytesPerSecond;
+    private long _pendingWrittenUnackedPeakBytes;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
     private readonly double _targetSeconds;
     private long _capBytes;
-    // Monotonically-decreasing deque for the last RateWindowSamples delivery-rate samples.
-    // Each sample enters and leaves once, keeping acknowledgement processing O(1) amortized.
-    private readonly double[] _rateMaxValues = new double[RateWindowSamples];
-    private readonly long[] _rateMaxSequences = new long[RateWindowSamples];
-    private int _rateMaxHead;
-    private int _rateMaxTail;
-    private int _rateMaxCount;
-    private long _rateSampleSequence;
+    private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
+    private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
+    private long _currentWindowBucket = long.MinValue;
+    private double _windowMaxRate;
+    private long _windowMaxOccupancyBytes;
+    private long _lastAckTimestamp;
     private double _minRttSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
@@ -86,7 +94,9 @@ internal sealed class BrokerUnackedByteBudget
     // the matching precomputed post-probe budgets.
     private long _minRttProbeUntilTimestamp;
     private long _nextProbeTimestamp;
-    private long _probeUntilTimestamp;
+    private long _capacityProbeStartTimestamp;
+    private double _capacityProbeBaselineRate;
+    private bool _capacityProbeActive;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
     {
@@ -135,8 +145,7 @@ internal sealed class BrokerUnackedByteBudget
         var minRttProbeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
         if (minRttProbeUntilTimestamp != 0 && nowTicks >= minRttProbeUntilTimestamp)
         {
-            var capacityProbeUntilTimestamp = Volatile.Read(ref _probeUntilTimestamp);
-            budget = capacityProbeUntilTimestamp != 0 && nowTicks < capacityProbeUntilTimestamp
+            budget = Volatile.Read(ref _capacityProbeActive)
                 ? Volatile.Read(ref _probeBudgetAfterMinRttProbeBytes)
                 : Volatile.Read(ref _budgetAfterMinRttProbeBytes);
         }
@@ -176,6 +185,23 @@ internal sealed class BrokerUnackedByteBudget
         => Interlocked.Increment(ref _admissionBlockEvents);
 
     /// <summary>
+    /// Records broker bytes written and awaiting responses. Parallel connection sends may
+    /// call this concurrently; the owning send loop consumes the peak on its next ack pass.
+    /// </summary>
+    public void ObserveWrittenUnackedBytes(long bytes)
+    {
+        var observed = Volatile.Read(ref _pendingWrittenUnackedPeakBytes);
+        while (bytes > observed)
+        {
+            var prior = Interlocked.CompareExchange(ref _pendingWrittenUnackedPeakBytes, bytes, observed);
+            if (prior == observed)
+                return;
+
+            observed = prior;
+        }
+    }
+
+    /// <summary>
     /// Updates the ceiling (routing-width-dependent) and republishes the budget.
     /// Called by the owning send loop at construction and on connection scale events.
     /// </summary>
@@ -183,8 +209,6 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
         CompleteExpiredMinRttProbe(nowTicks);
-        if (_probeUntilTimestamp != 0 && nowTicks >= _probeUntilTimestamp)
-            _probeUntilTimestamp = 0;
         RecomputeBudget();
     }
 
@@ -202,25 +226,28 @@ internal sealed class BrokerUnackedByteBudget
         UpdateMinRtt(rttSeconds, nowTicks);
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
 
-        AddRateSample(ackedBytes / rttSeconds);
-        Volatile.Write(ref _maxRateBytesPerSecond, (long)_rateMaxValues[_rateMaxHead]);
+        var requestStartTimestamp = nowTicks - rttTicks;
+        var rateIntervalStartTimestamp = _lastAckTimestamp == 0
+            ? requestStartTimestamp
+            : Math.Max(_lastAckTimestamp, requestStartTimestamp);
+        _lastAckTimestamp = nowTicks;
 
-        if (_probeUntilTimestamp != 0 && nowTicks >= _probeUntilTimestamp)
-            _probeUntilTimestamp = 0;
-
-        var probeIntervalTicks = ProbeIntervalRtts * rttTicks;
-        if (_nextProbeTimestamp == 0)
-            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
-
-        if (_probeUntilTimestamp == 0 && nowTicks >= _nextProbeTimestamp)
+        AdvanceWindow(nowTicks);
+        var intervalTicks = nowTicks - rateIntervalStartTimestamp;
+        var bytesPerSecond = intervalTicks > 0
+            ? ackedBytes * (double)Stopwatch.Frequency / intervalTicks
+            : 0;
+        if (bytesPerSecond > 0)
         {
-            if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
-                _probeUntilTimestamp = nowTicks + rttTicks;
-
-            // A schedule missed by a full interval represents producer idle time, not an
-            // active-pipeline probe opportunity. Re-arm instead of probing on resume.
-            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+            AddRateSample(bytesPerSecond);
+            Volatile.Write(ref _maxRateBytesPerSecond, (long)_windowMaxRate);
         }
+
+        var writtenUnackedPeak = Interlocked.Exchange(ref _pendingWrittenUnackedPeakBytes, 0);
+        if (writtenUnackedPeak > 0)
+            AddOccupancySample(writtenUnackedPeak);
+
+        UpdateCapacityProbe(bytesPerSecond, requestStartTimestamp, rttTicks, nowTicks);
 
         RecomputeBudget();
     }
@@ -288,31 +315,126 @@ internal sealed class BrokerUnackedByteBudget
         _minRttProbeUntilTimestamp = nowTicks + probeDurationTicks;
     }
 
+    private void AdvanceWindow(long nowTicks)
+    {
+        var bucket = nowTicks / WindowBucketTicks;
+        if (_currentWindowBucket == long.MinValue)
+        {
+            _currentWindowBucket = bucket;
+            return;
+        }
+
+        if (bucket <= _currentWindowBucket)
+            return;
+
+        var elapsed = bucket - _currentWindowBucket;
+        if (elapsed >= WindowBucketCount)
+        {
+            Array.Clear(_rateBucketMaxValues);
+            Array.Clear(_occupancyBucketMaxValues);
+            _windowMaxRate = 0;
+            _windowMaxOccupancyBytes = 0;
+        }
+        else
+        {
+            var recomputeRate = false;
+            var recomputeOccupancy = false;
+            for (var i = 1L; i <= elapsed; i++)
+            {
+                var slot = (int)((_currentWindowBucket + i) % WindowBucketCount);
+                recomputeRate |= _windowMaxRate > 0 && _rateBucketMaxValues[slot] >= _windowMaxRate;
+                recomputeOccupancy |= _windowMaxOccupancyBytes > 0
+                    && _occupancyBucketMaxValues[slot] >= _windowMaxOccupancyBytes;
+                _rateBucketMaxValues[slot] = 0;
+                _occupancyBucketMaxValues[slot] = 0;
+            }
+
+            if (recomputeRate)
+                _windowMaxRate = Max(_rateBucketMaxValues);
+            if (recomputeOccupancy)
+                _windowMaxOccupancyBytes = Max(_occupancyBucketMaxValues);
+        }
+
+        _currentWindowBucket = bucket;
+    }
+
     private void AddRateSample(double bytesPerSecond)
     {
-        var sequence = ++_rateSampleSequence;
-        var oldestSequence = sequence - RateWindowSamples;
+        var slot = (int)(_currentWindowBucket % WindowBucketCount);
+        _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
+        _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
+    }
 
-        if (_rateMaxCount > 0 && _rateMaxSequences[_rateMaxHead] <= oldestSequence)
+    private void AddOccupancySample(long bytes)
+    {
+        var slot = (int)(_currentWindowBucket % WindowBucketCount);
+        _occupancyBucketMaxValues[slot] = Math.Max(_occupancyBucketMaxValues[slot], bytes);
+        _windowMaxOccupancyBytes = Math.Max(_windowMaxOccupancyBytes, bytes);
+    }
+
+    private void UpdateCapacityProbe(
+        double bytesPerSecond,
+        long requestStartTimestamp,
+        long rttTicks,
+        long nowTicks)
+    {
+        var probeIntervalTicks = ProbeIntervalRtts * rttTicks;
+        if (_nextProbeTimestamp == 0)
+            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+
+        if (_capacityProbeActive)
         {
-            _rateMaxHead = (_rateMaxHead + 1) % RateWindowSamples;
-            _rateMaxCount--;
+            // A response can confirm the probe only when its oldest request was created
+            // after the larger budget was published. If observed rate grows, retain the
+            // probe and require another wholly-probed sample at the new level.
+            if (requestStartTimestamp < _capacityProbeStartTimestamp)
+                return;
+
+            if (bytesPerSecond > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            {
+                _capacityProbeBaselineRate = bytesPerSecond;
+                _capacityProbeStartTimestamp = nowTicks;
+            }
+            else
+            {
+                _capacityProbeActive = false;
+                _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+            }
+
+            return;
         }
 
-        while (_rateMaxCount > 0)
-        {
-            var last = (_rateMaxTail + RateWindowSamples - 1) % RateWindowSamples;
-            if (_rateMaxValues[last] > bytesPerSecond)
-                break;
+        if (nowTicks < _nextProbeTimestamp)
+            return;
 
-            _rateMaxTail = last;
-            _rateMaxCount--;
+        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
+        {
+            _capacityProbeActive = true;
+            _capacityProbeStartTimestamp = nowTicks;
+            _capacityProbeBaselineRate = _windowMaxRate;
         }
 
-        _rateMaxValues[_rateMaxTail] = bytesPerSecond;
-        _rateMaxSequences[_rateMaxTail] = sequence;
-        _rateMaxTail = (_rateMaxTail + 1) % RateWindowSamples;
-        _rateMaxCount++;
+        // A schedule missed by a full interval represents producer idle time, not an
+        // active-pipeline probe opportunity. Re-arm instead of probing on resume.
+        _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+    }
+
+    private static double Max(double[] values)
+    {
+        var maximum = 0.0;
+        for (var i = 0; i < values.Length; i++)
+            maximum = Math.Max(maximum, values[i]);
+
+        return maximum;
+    }
+
+    private static long Max(long[] values)
+    {
+        var maximum = 0L;
+        for (var i = 0; i < values.Length; i++)
+            maximum = Math.Max(maximum, values[i]);
+
+        return maximum;
     }
 
     private void RecomputeBudget()
@@ -320,7 +442,7 @@ internal sealed class BrokerUnackedByteBudget
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
         var budget = ComputeBudget(
             minRttProbeActive,
-            _probeUntilTimestamp != 0,
+            _capacityProbeActive,
             _minRttSeconds);
         if (minRttProbeActive)
         {
@@ -353,7 +475,7 @@ internal sealed class BrokerUnackedByteBudget
         double minRttSeconds)
     {
         long budget;
-        if (_rateMaxCount == 0)
+        if (_windowMaxRate == 0)
         {
             // Cold start: no drain estimate yet — keep today's semantics (cap) so short-lived
             // producers and tests never see admission throttling.
@@ -364,13 +486,15 @@ internal sealed class BrokerUnackedByteBudget
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
                 ? Math.Max(_targetSeconds, RttSafetyMultiplier * minRttSeconds)
                 : _targetSeconds;
-            var estimatedBytes = _rateMaxValues[_rateMaxHead] * horizonSeconds;
+            var estimatedBytes = _windowMaxRate * horizonSeconds;
             if (capacityProbeActive && !minRttProbeActive)
                 estimatedBytes *= ProbeBudgetMultiplier;
 
             budget = (long)estimatedBytes;
-            budget = Math.Clamp(budget, _floorBytes, _capBytes);
         }
+
+        var occupancyFloor = (long)(_windowMaxOccupancyBytes * OccupancySafetyMultiplier);
+        budget = Math.Clamp(Math.Max(budget, occupancyFloor), _floorBytes, _capBytes);
 
         return budget;
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -95,6 +95,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _minRttProbeUntilTimestamp;
     private long _nextProbeTimestamp;
     private long _capacityProbeStartTimestamp;
+    private long _capacityProbeDeadlineTimestamp;
     private double _capacityProbeBaselineRate;
     private bool _capacityProbeActive;
 
@@ -142,12 +143,21 @@ internal sealed class BrokerUnackedByteBudget
     public bool IsOverBudgetAt(long nowTicks)
     {
         var budget = Volatile.Read(ref _budgetBytes);
+        var capacityProbeActive = Volatile.Read(ref _capacityProbeActive);
+        var capacityProbeDeadline = Volatile.Read(ref _capacityProbeDeadlineTimestamp);
+        var capacityProbeCurrent = capacityProbeActive
+            && capacityProbeDeadline != 0
+            && nowTicks < capacityProbeDeadline;
         var minRttProbeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
         if (minRttProbeUntilTimestamp != 0 && nowTicks >= minRttProbeUntilTimestamp)
         {
-            budget = Volatile.Read(ref _capacityProbeActive)
+            budget = capacityProbeCurrent
                 ? Volatile.Read(ref _probeBudgetAfterMinRttProbeBytes)
                 : Volatile.Read(ref _budgetAfterMinRttProbeBytes);
+        }
+        else if (capacityProbeActive && !capacityProbeCurrent)
+        {
+            budget = Volatile.Read(ref _budgetAfterMinRttProbeBytes);
         }
 
         return Volatile.Read(ref _unackedBytes) >= budget;
@@ -159,11 +169,22 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     internal int GetAdmissionRecheckDelayMilliseconds(long nowTicks)
     {
-        var probeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
-        if (probeUntilTimestamp == 0 || nowTicks >= probeUntilTimestamp)
+        var recheckTimestamp = long.MaxValue;
+        var minRttProbeUntilTimestamp = Volatile.Read(ref _minRttProbeUntilTimestamp);
+        if (minRttProbeUntilTimestamp > nowTicks)
+            recheckTimestamp = minRttProbeUntilTimestamp;
+
+        if (Volatile.Read(ref _capacityProbeActive))
+        {
+            var capacityProbeDeadline = Volatile.Read(ref _capacityProbeDeadlineTimestamp);
+            if (capacityProbeDeadline > nowTicks)
+                recheckTimestamp = Math.Min(recheckTimestamp, capacityProbeDeadline);
+        }
+
+        if (recheckTimestamp == long.MaxValue)
             return Timeout.Infinite;
 
-        var remainingTicks = probeUntilTimestamp - nowTicks;
+        var remainingTicks = recheckTimestamp - nowTicks;
         return Math.Max(1, (int)Math.Min(
             int.MaxValue,
             Math.Ceiling((double)remainingTicks * 1000 / Stopwatch.Frequency)));
@@ -209,6 +230,8 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
         CompleteExpiredMinRttProbe(nowTicks);
+        if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
+            DeactivateCapacityProbe();
         RecomputeBudget();
     }
 
@@ -384,6 +407,13 @@ internal sealed class BrokerUnackedByteBudget
 
         if (_capacityProbeActive)
         {
+            if (nowTicks >= _capacityProbeDeadlineTimestamp)
+            {
+                DeactivateCapacityProbe();
+                _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+                return;
+            }
+
             // A response can confirm the probe only when its oldest request was created
             // after the larger budget was published. If observed rate grows, retain the
             // probe and require another wholly-probed sample at the new level.
@@ -394,10 +424,11 @@ internal sealed class BrokerUnackedByteBudget
             {
                 _capacityProbeBaselineRate = bytesPerSecond;
                 _capacityProbeStartTimestamp = nowTicks;
+                Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
             }
             else
             {
-                _capacityProbeActive = false;
+                DeactivateCapacityProbe();
                 _nextProbeTimestamp = nowTicks + probeIntervalTicks;
             }
 
@@ -409,14 +440,21 @@ internal sealed class BrokerUnackedByteBudget
 
         if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
         {
-            _capacityProbeActive = true;
             _capacityProbeStartTimestamp = nowTicks;
             _capacityProbeBaselineRate = _windowMaxRate;
+            Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
+            Volatile.Write(ref _capacityProbeActive, true);
         }
 
         // A schedule missed by a full interval represents producer idle time, not an
         // active-pipeline probe opportunity. Re-arm instead of probing on resume.
         _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+    }
+
+    private void DeactivateCapacityProbe()
+    {
+        Volatile.Write(ref _capacityProbeActive, false);
+        Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
     }
 
     private static double Max(double[] values)
@@ -440,30 +478,31 @@ internal sealed class BrokerUnackedByteBudget
     private void RecomputeBudget()
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
-        var budget = ComputeBudget(
-            minRttProbeActive,
-            _capacityProbeActive,
-            _minRttSeconds);
+        var postProbeMinRttSeconds = _minRttSeconds;
+        if (minRttProbeActive && _minRttProbeMinimumSeconds != double.MaxValue)
+            postProbeMinRttSeconds = _minRttProbeMinimumSeconds;
+        var normalBudget = ComputeBudget(
+            minRttProbeActive: false,
+            capacityProbeActive: false,
+            postProbeMinRttSeconds);
+        var probeBudget = ComputeBudget(
+            minRttProbeActive: false,
+            capacityProbeActive: true,
+            postProbeMinRttSeconds);
+        Volatile.Write(ref _budgetAfterMinRttProbeBytes, normalBudget);
+        Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, probeBudget);
+
+        long budget;
         if (minRttProbeActive)
         {
-            var postProbeMinRttSeconds = _minRttProbeMinimumSeconds != double.MaxValue
-                ? _minRttProbeMinimumSeconds
-                : _minRttSeconds;
-            Volatile.Write(ref _budgetAfterMinRttProbeBytes,
-                ComputeBudget(
-                    minRttProbeActive: false,
-                    capacityProbeActive: false,
-                    minRttSeconds: postProbeMinRttSeconds));
-            Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes,
-                ComputeBudget(
-                    minRttProbeActive: false,
-                    capacityProbeActive: true,
-                    minRttSeconds: postProbeMinRttSeconds));
+            budget = ComputeBudget(
+                minRttProbeActive: true,
+                capacityProbeActive: false,
+                _minRttSeconds);
         }
         else
         {
-            Volatile.Write(ref _budgetAfterMinRttProbeBytes, budget);
-            Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, budget);
+            budget = _capacityProbeActive ? probeBudget : normalBudget;
         }
 
         Volatile.Write(ref _budgetBytes, budget);
@@ -493,8 +532,13 @@ internal sealed class BrokerUnackedByteBudget
             budget = (long)estimatedBytes;
         }
 
-        var occupancyFloor = (long)(_windowMaxOccupancyBytes * OccupancySafetyMultiplier);
-        budget = Math.Clamp(Math.Max(budget, occupancyFloor), _floorBytes, _capBytes);
+        if (!minRttProbeActive)
+        {
+            var occupancyFloor = (long)(_windowMaxOccupancyBytes * OccupancySafetyMultiplier);
+            budget = Math.Max(budget, occupancyFloor);
+        }
+
+        budget = Math.Clamp(budget, _floorBytes, _capBytes);
 
         return budget;
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -160,7 +160,9 @@ internal sealed class BrokerUnackedByteBudget
                 ? Volatile.Read(ref _probeBudgetAfterMinRttProbeBytes)
                 : Volatile.Read(ref _budgetAfterMinRttProbeBytes);
         }
-        else if (capacityProbeActive && !capacityProbeCurrent)
+        else if (minRttProbeUntilTimestamp == 0
+            && capacityProbeActive
+            && !capacityProbeCurrent)
         {
             budget = Volatile.Read(ref _budgetAfterMinRttProbeBytes);
         }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -135,9 +135,14 @@ internal sealed class BrokerUnackedByteBudget
     // Volatile.Read (a plain acquire load) rather than Interlocked.Read: this runs per
     // message from every appender thread, and a locked read would take the cache line
     // exclusive on every call, turning a read-mostly gate into a contention point.
+    // During a capacity probe, use the lower normal budget as the fast threshold. The
+    // deadline-aware gate then admits against the larger probe budget while it is current,
+    // but expired probes cannot bypass that gate merely because _budgetBytes is stale.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsOverBudget()
-        => Volatile.Read(ref _unackedBytes) >= Volatile.Read(ref _budgetBytes);
+        => Volatile.Read(ref _unackedBytes) >= Math.Min(
+            Volatile.Read(ref _budgetBytes),
+            Volatile.Read(ref _budgetAfterMinRttProbeBytes));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsOverBudgetAt(long nowTicks)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2307,10 +2307,10 @@ public sealed class BrokerSenderSendLoopTests
             }
 
             // The first ack establishes a rate and starts the target-only base-RTT probe.
-            // Its tiny target would clamp to 200 bytes, but demonstrated 5,000-byte wire
-            // occupancy retains 1.5x headroom so admission cannot starve the pipeline.
+            // Its tiny target clamps to 200 bytes; recent occupancy is deliberately ignored
+            // until the standing queue drains and the minimum-RTT probe completes.
             await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
-            await Assert.That(budget.BudgetBytes).IsEqualTo(7_500);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(200);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2307,9 +2307,10 @@ public sealed class BrokerSenderSendLoopTests
             }
 
             // The first ack establishes a rate and starts the target-only base-RTT probe.
-            // Its tiny target clamps the published estimate to the 200-byte floor.
+            // Its tiny target would clamp to 200 bytes, but demonstrated 5,000-byte wire
+            // occupancy retains 1.5x headroom so admission cannot starve the pipeline.
             await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
-            await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+            await Assert.That(budget.BudgetBytes).IsEqualTo(7_500);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -392,6 +392,24 @@ public sealed class BrokerUnackedByteBudgetTests
 
         budget.ObserveWrittenUnackedBytes(20_000);
         budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000);
+    }
+
+    [Test]
+    public async Task MinimumRttProbe_IgnoresRecentOccupancyUntilQueueDrains()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.ObserveWrittenUnackedBytes(20_000);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200)
+            .Because("minimum-RTT probes must publish a target-only budget that drains standing queueing");
+
+        budget.ObserveWrittenUnackedBytes(20_000);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(30_000);
     }
@@ -406,6 +424,24 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(2.1));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_WithoutFurtherAck_RevertsAfterEightRtts()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        budget.Charge(5_500);
+
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse();
+        await Assert.That(budget.GetAdmissionRecheckDelayMilliseconds(T0 + Seconds(0.900)))
+            .IsEqualTo(700);
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(1.601))).IsTrue();
+
+        budget.Release(5_500);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -5,7 +5,7 @@ namespace Dekaf.Tests.Unit.Producer;
 
 /// <summary>
 /// State-machine tests for <see cref="BrokerUnackedByteBudget"/>: budget publication from
-/// the request-rate maximum filter, minimum-RTT refresh, floor/cap clamping, probing,
+/// the time-windowed delivery-rate filter, minimum-RTT refresh, floor/cap clamping, probing,
 /// and counter accounting.
 /// All timestamps are explicit Stopwatch-tick values, so nothing here is timing-dependent.
 /// </summary>
@@ -113,7 +113,9 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(10.31));
         budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.4));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        // Final 10,000-byte pass lands 90ms after the preceding ack, measuring
+        // 111,111 B/s from inter-ack delivery time rather than 100ms request sojourn.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_111);
     }
 
     [Test]
@@ -214,7 +216,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task WindowedMaximum_LongGap_DoesNotDeflateRate()
+    public async Task WindowedMaximum_LongGap_ExpiresStaleRate()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
@@ -223,7 +225,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         budget.OnAcked(ackedBytes: 1, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
 
     [Test]
@@ -275,6 +277,19 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task RateSample_UsesInterAckDeliveryTime_ForPipelinedRequests()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.005), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.001));
+
+        // Both requests overlapped on the wire. The second 1,000-byte delivery took 1ms
+        // since the preceding acknowledgement, independent of its 5ms request sojourn.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+    }
+
+    [Test]
     public async Task WindowedMaximum_LowerSamples_DoNotRatchetBudgetDown()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -286,15 +301,33 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task WindowedMaximum_PeakExpires_AfterTenNewerSamples()
+    public async Task WindowedMaximum_PeakExpires_AfterTwoSeconds()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        for (var i = 1; i <= 10; i++)
+        for (var i = 1; i <= 20; i++)
             budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
+    }
+
+    [Test]
+    public async Task WindowedMaximum_UsesElapsedTime_NotResponsePassCount()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        for (var i = 1; i <= 20; i++)
+            budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.025), nowTicks: T0 + Seconds(i * 0.025));
+
+        // Twenty fast response passes cover only 500ms, so the 2-second maximum window
+        // must retain the original 10,000 B/s observation.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+
+        budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.025), nowTicks: T0 + Seconds(2.1));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
 
     [Test]
@@ -310,6 +343,69 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.900));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_WaitsForSampleWhollyAdmittedUnderProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        // This request began before the probe opened at 800ms, so it cannot confirm
+        // capacity under the larger admission budget even though it completes later.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(0.900));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        // First request wholly admitted under the probe confirms no rate gain and ends it.
+        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.000));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RatchetsWhileWhollyProbedRateRises()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        budget.OnAcked(ackedBytes: 1_250, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.900));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
+
+        budget.OnAcked(ackedBytes: 1_562, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.000));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+
+        // A second wholly-probed sample at the same rate confirms capacity and publishes
+        // the newly discovered base budget without the temporary 1.25x multiplier.
+        budget.OnAcked(ackedBytes: 1_562, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.100));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
+    }
+
+    [Test]
+    public async Task OccupancyFloor_RetainsHeadroomAboveDemonstratedWireDemand()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.ObserveWrittenUnackedBytes(20_000);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000);
+    }
+
+    [Test]
+    public async Task OccupancyFloor_ExpiresAfterTwoSeconds()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        budget.ObserveWrittenUnackedBytes(20_000);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
+        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(2.1));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Producer;
@@ -17,6 +18,11 @@ public sealed class BrokerUnackedByteBudgetTests
     private static readonly long T0 = Frequency;
 
     private static long Seconds(double seconds) => (long)(seconds * Frequency);
+
+    private static void SetField<T>(BrokerUnackedByteBudget budget, string fieldName, T value)
+        => typeof(BrokerUnackedByteBudget)
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(budget, value);
 
     /// <summary>
     /// Establishes a per-request drain-rate sample of <paramref name="bytesPerSecond"/>.
@@ -365,6 +371,24 @@ public sealed class BrokerUnackedByteBudgetTests
             .Because("the active probe still admits against its larger budget");
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(1.601))).IsTrue()
             .Because("the expired probe must fall back without requiring another ack");
+    }
+
+    [Test]
+    public async Task ExpiredCapacityProbe_DoesNotOverrideActiveMinimumRttProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        budget.Charge(1_000);
+        SetField(budget, "_budgetBytes", 500L);
+        SetField(budget, "_budgetAfterMinRttProbeBytes", 5_000L);
+        SetField(budget, "_capacityProbeActive", true);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(0.010));
+        SetField(budget, "_minRttProbeUntilTimestamp", T0 + Seconds(0.050));
+
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.020))).IsTrue()
+            .Because("an active minimum-RTT probe must retain its target-only drain budget");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -346,6 +346,28 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_FastGateFallsThroughForDeadlineCheck()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        budget.Charge(5_500);
+
+        await Assert.That(budget.IsOverBudget()).IsTrue()
+            .Because("occupancy above the normal budget must reach the deadline-aware gate");
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse()
+            .Because("the active probe still admits against its larger budget");
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(1.601))).IsTrue()
+            .Because("the expired probe must fall back without requiring another ack");
+    }
+
+    [Test]
     public async Task PeriodicProbe_WaitsForSampleWhollyAdmittedUnderProbe()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);


### PR DESCRIPTION
## Summary
- measure broker delivery rate between acknowledgement passes, independent of request pipeline depth
- retain capacity probes until wholly-probed samples confirm or raise the discovered rate
- use two-second rate and written-occupancy windows, with 1.5x demonstrated wire headroom

## Test plan
- [x] 5,233 unit tests
- [x] Producer admission-probe integration test
- [x] Concurrent idempotent producer integration test
- [x] BrokerUnackedByteBudget benchmark: 12.27 ns/op, 0 B allocated
- [x] One-minute paired idempotent smoke: 100% delivery, zero errors; Dekaf median throughput 3.51x Confluent

Closes #1911
