### PR TITLE
Pipeline non-idempotent same-partition producer sends

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -450,13 +450,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Func<bool> _isTransactional;
     private readonly Func<TopicPartition, CancellationToken, ValueTask>? _ensurePartitionInTransaction;
 
-    // Send-time muting limits each partition to 1 in-flight batch when producer sequence
-    // numbers are unavailable, or when the configured request limit is already 1.
-    // Idempotent producers with MaxInFlight > 1 rely on sequence numbers instead.
+    // Send-time muting is needed when the configured request limit is already 1 or when
+    // Acks.None provides no broker acknowledgement boundary.
+    // With a deeper pipeline, partition affinity keeps every batch on one connection and
+    // Kafka processes requests on that connection in wire order. Errors still mute the
+    // partition through HandleRetriableBatch until its retry is ordered on the wire.
     private readonly bool _muteOnSend;
 
-    // Muted partitions: partitions with a retry in progress or limited to 1 in-flight
-    // batch by _muteOnSend. Prevents newer batches from being sent, maintaining
+    // Muted partitions: partitions with a retry in progress or configured for only one
+    // in-flight request. Prevents newer batches from being sent, maintaining
     // per-partition ordering. Aligned with Java Kafka producer's mute mechanism.
     // Uses ConcurrentDictionary as a concurrent set (byte value unused): with multi-connection
     // sends, concurrent Z handlers (catch blocks in SendCoalescedAsync) can write from
@@ -676,9 +678,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _maxInFlight = options.MaxInFlightRequestsPerConnection;
         _isIdempotent = options.EnableIdempotence;
 
-        // Non-idempotent batches have no sequence numbers, so concurrent requests for the
-        // same partition can be appended out of order even when no retry occurs.
-        _muteOnSend = !_isIdempotent || _maxInFlight <= 1;
+        // Kafka processes requests in wire order on each connection. Partition affinity
+        // therefore permits non-idempotent same-partition pipelining without sequence
+        // numbers; retry errors still install a partition mute before new work is drained.
+        _muteOnSend = _maxInFlight <= 1 || options.Acks == Acks.None;
 
         // All producers use partition affinity (partition % connectionCount) for CPU cache
         // locality. Idempotent producers additionally need affinity for sequence ordering.
@@ -1854,6 +1857,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 return;
             }
 
+            // Non-idempotent retries have no sequence numbers to reconcile requests that
+            // were already written after the failed batch. Keep the partition muted until
+            // that same-connection pipeline drains, then order the retry before new work.
+            if (!_isIdempotent && HasPendingResponseForPartition(batch.TopicPartition))
+            {
+                carryOver.Add(batchRef);
+                return;
+            }
+
             // Check if leader changed (synchronous cache check — no async needed)
             if (_rerouteBatch is not null)
             {
@@ -2088,6 +2100,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 UnmutePartition(batch.TopicPartition);
             }
         }
+    }
+
+    private bool HasPendingResponseForPartition(TopicPartition topicPartition)
+    {
+        foreach (var pendingResponses in _pendingResponsesByConnection)
+        {
+            foreach (var pending in pendingResponses)
+            {
+                for (var i = 0; i < pending.Count; i++)
+                {
+                    if (pending.IsSameIncarnation(i)
+                        && pending.Batches[i].TopicPartition == topicPartition)
+                        return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2991,8 +3021,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             var resourcePinCount = count;
 
-            var requestStartTime = Stopwatch.GetTimestamp();
-
             try
             {
                 // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
@@ -3061,6 +3089,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     connection,
                     request,
                     (short)apiVersion).ConfigureAwait(false);
+                // Response RTT starts after the request is written. Including request
+                // construction and TCP write time biases admission-rate samples low.
+                var requestStartTime = Stopwatch.GetTimestamp();
 
                 // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
                 scratch.ClearReferences();
@@ -3142,10 +3173,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         .UnsafeOnCompleted(_responseCompletionCallback);
                 }
 
-                // Mute partitions when producer sequence numbers cannot preserve order, or when
-                // the configured request limit already permits only 1 in-flight request.
-                // This ensures at most one batch per partition in-flight across all requests.
-                // Idempotent producers with maxInFlight > 1 use sequence numbers instead.
+                // A request limit of one keeps its partition muted until the response.
+                // Deeper pipelines preserve order through same-connection wire ordering;
+                // retry errors install their own mute in HandleRetriableBatch.
                 MutePartitionsForSend(batches, count);
 
                 LogPipelinedSend(_brokerId, count, _totalPendingResponseCount);
@@ -4278,12 +4308,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         var now = Dekaf.MonotonicClock.GetMilliseconds();
-        var activeMutedPartitionCount = _muteOnSend
-            ? Volatile.Read(ref _mutedPartitionCount)
-            : 0;
-        var mutedPartitionHighWatermark = _muteOnSend
-            ? Interlocked.Exchange(ref _mutedPartitionHighWatermark, activeMutedPartitionCount)
-            : 0;
+        var activeMutedPartitionCount = Volatile.Read(ref _mutedPartitionCount);
+        var mutedPartitionHighWatermark =
+            Interlocked.Exchange(ref _mutedPartitionHighWatermark, activeMutedPartitionCount);
         if (Math.Max(activeMutedPartitionCount, mutedPartitionHighWatermark) >= _connectionCount)
         {
             _lastMutedPartitionLoadTicks = now;
@@ -4406,11 +4433,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var inFlightUtilization = effectiveInFlightCapacity > 0
             ? (double)pendingResponseCount / effectiveInFlightCapacity
             : 0;
-        var hasRecentMutedPartitionLoad = _muteOnSend
-            && _lastMutedPartitionLoadTicks > 0
+        var hasRecentMutedPartitionLoad = _lastMutedPartitionLoadTicks > 0
             && now - _lastMutedPartitionLoadTicks < _scaleDownSustainedMs;
-        var hasLoadBearingMutedWidth = _muteOnSend
-            && activeMutedPartitionCount >= _connectionCount;
+        var hasLoadBearingMutedWidth = activeMutedPartitionCount >= _connectionCount;
         if (inFlightUtilization >= ScaleDownInFlightUtilizationThreshold
             || hasLoadBearingMutedWidth
             || hasRecentMutedPartitionLoad
@@ -4476,7 +4501,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private bool HasMutedPartitionLoad(PartitionCarryOver carryOver, bool hasUnreadEvent)
     {
-        if (!_muteOnSend || _mutedPartitions.IsEmpty)
+        if (_mutedPartitions.IsEmpty)
             return false;
 
         // The channel is unified, so its unread tail can include wake-up signals as

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -158,7 +158,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         int[] BatchGenerations,
         int Count,
         long EncodedBytes,
-        long RequestStartTime)
+        long RequestStartTime,
+        long RttStartTime)
     {
         /// <summary>
         /// Wraps a pipelined response with the batch-generation snapshot the send captured
@@ -169,8 +170,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </summary>
         public static PendingResponse Create(
             Task<ProduceResponse> responseTask, ReadyBatch[] batches, int[] generations,
-            int count, long encodedBytes, long requestStartTime)
-            => new(responseTask, batches, generations, count, encodedBytes, requestStartTime);
+            int count, long encodedBytes, long requestStartTime, long rttStartTime)
+            => new(responseTask, batches, generations, count, encodedBytes,
+                requestStartTime, rttStartTime);
 
         /// <summary>
         /// Returns true if the batch at index <paramref name="i"/> is the same incarnation
@@ -400,6 +402,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             queue.RemoveAt(index);
             _count--;
+        }
+
+        public bool HasRetry(TopicPartition topicPartition)
+        {
+            if (!_partitions.TryGetValue(topicPartition, out var queue))
+                return false;
+
+            for (var i = 0; i < queue.Count; i++)
+            {
+                if (queue[i].IsCurrentIncarnation() && queue[i].Batch.IsRetry)
+                    return true;
+            }
+
+            return false;
         }
     }
 
@@ -1365,7 +1381,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                         // Finalize retry batches now that we know they will actually be sent
                         // (epoch bump check passed). Clear IsRetry and unmute partitions.
-                        FinalizeCoalescedRetries(coalescedBatches, coalescedCount);
+                        FinalizeCoalescedRetries(coalescedBatches, coalescedCount, carryOver);
 
                         LogSendingCoalesced(_brokerId, coalescedCount);
                         for (var si = 0; si < coalescedCount; si++)
@@ -2089,7 +2105,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// an epoch bump check that moves batches back to carry-over would lose the retry
     /// state — causing the batch to be treated as a normal batch and sent out of order.
     /// </summary>
-    private void FinalizeCoalescedRetries(ReadyBatch[] batches, int count)
+    private void FinalizeCoalescedRetries(
+        ReadyBatch[] batches,
+        int count,
+        PartitionCarryOver carryOver)
     {
         for (var i = 0; i < count; i++)
         {
@@ -2097,28 +2116,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (batch.IsRetry)
             {
                 batch.IsRetry = false;
-                UnmutePartition(batch.TopicPartition);
+                if (!carryOver.HasRetry(batch.TopicPartition))
+                    UnmutePartition(batch.TopicPartition);
             }
         }
     }
 
     private bool HasPendingResponseForPartition(TopicPartition topicPartition)
-    {
-        foreach (var pendingResponses in _pendingResponsesByConnection)
-        {
-            foreach (var pending in pendingResponses)
-            {
-                for (var i = 0; i < pending.Count; i++)
-                {
-                    if (pending.IsSameIncarnation(i)
-                        && pending.Batches[i].TopicPartition == topicPartition)
-                        return true;
-                }
-            }
-        }
-
-        return false;
-    }
+        => HasInflightForPartition(GetConnectionForPartition(topicPartition), topicPartition);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RecordSendLoopPressureIfScaleUseful()
@@ -2290,7 +2295,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 if (allPartitionsSucceeded)
-                    ackedPass.Add(pending.EncodedBytes, pending.RequestStartTime);
+                    ackedPass.Add(pending.EncodedBytes, pending.RttStartTime);
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
                 if (_logger.IsEnabled(LogLevel.Debug))
@@ -2477,8 +2482,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     continue;
                 }
 
-                // Only unmute on success when mute-on-send is active (non-idempotent or maxInFlight <= 1).
-                // Idempotent producers with maxInFlight > 1 mute partitions only on error.
+                // Only unmute on success when send-time muting is active.
+                // Deeper pipelines mute partitions only on error.
                 // Unconditionally unmuting on success would prematurely clear the mute set by a
                 // DIFFERENT failed batch for the same partition still pending retry. This allows
                 // newer carry-over batches to skip ahead of the older retry batch, violating
@@ -3020,6 +3025,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
 
             var resourcePinCount = count;
+            var requestStartTime = Stopwatch.GetTimestamp();
 
             try
             {
@@ -3091,7 +3097,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     (short)apiVersion).ConfigureAwait(false);
                 // Response RTT starts after the request is written. Including request
                 // construction and TCP write time biases admission-rate samples low.
-                var requestStartTime = Stopwatch.GetTimestamp();
+                var rttStartTime = Stopwatch.GetTimestamp();
 
                 // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
                 scratch.ClearReferences();
@@ -3128,7 +3134,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     generations,
                     count,
                     encodedBytes,
-                    requestStartTime);
+                    requestStartTime,
+                    rttStartTime);
                 _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
                 pendingResponseAdded = true; // Array ownership transferred to PendingResponse
                 Interlocked.Increment(ref _totalPendingResponseCount);
@@ -3647,7 +3654,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 // Entries within Count can legally be null: batches with stale generations
                 // are nulled out before PendingResponse.Create captures the array.
-                if (pr.Batches[j] is { } batch && batch.TopicPartition == topicPartition)
+                if (pr.IsSameIncarnation(j)
+                    && pr.Batches[j].TopicPartition == topicPartition)
                     return true;
             }
         }
@@ -4308,9 +4316,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         var now = Dekaf.MonotonicClock.GetMilliseconds();
-        var activeMutedPartitionCount = Volatile.Read(ref _mutedPartitionCount);
-        var mutedPartitionHighWatermark =
-            Interlocked.Exchange(ref _mutedPartitionHighWatermark, activeMutedPartitionCount);
+        var trackMutedPartitionLoad = _muteOnSend || !_isIdempotent;
+        var activeMutedPartitionCount = trackMutedPartitionLoad
+            ? Volatile.Read(ref _mutedPartitionCount)
+            : 0;
+        var mutedPartitionHighWatermark = trackMutedPartitionLoad
+            ? Interlocked.Exchange(ref _mutedPartitionHighWatermark, activeMutedPartitionCount)
+            : 0;
         if (Math.Max(activeMutedPartitionCount, mutedPartitionHighWatermark) >= _connectionCount)
         {
             _lastMutedPartitionLoadTicks = now;
@@ -4501,7 +4513,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private bool HasMutedPartitionLoad(PartitionCarryOver carryOver, bool hasUnreadEvent)
     {
-        if (_mutedPartitions.IsEmpty)
+        if ((_isIdempotent && !_muteOnSend) || _mutedPartitions.IsEmpty)
             return false;
 
         // The channel is unified, so its unread tail can include wake-up signals as

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -21,7 +21,8 @@ namespace Dekaf.Producer;
 /// Per-broker sender that serializes all writes to a single broker connection.
 /// A single-threaded send loop drains events from a unified channel, coalesces batches into
 /// ProduceRequests, and sends them via pipelined writes. This guarantees wire-order
-/// for same-partition batches.
+/// for same-partition requests, but non-idempotent retries can still reorder records
+/// that were already written in later requests.
 ///
 /// All wake-up sources (new batches, response completions, partition unmutes) flow through
 /// a single <see cref="_eventChannel"/> — like Java Kafka's Sender.poll() model. Response
@@ -29,10 +30,10 @@ namespace Dekaf.Producer;
 /// the send loop then polls <c>_pendingResponsesByConnection</c> for completed tasks (like main's
 /// ProcessCompletedResponses). This avoids cross-thread reference sharing of batches arrays.
 ///
-/// Per-partition ordering during retries uses a mute set (aligned with the Java Kafka
-/// producer): when a batch enters retry, its partition is muted so no newer batches
-/// can be sent until the retry completes. Retry batches (IsRetry=true) unmute the
-/// partition when coalesced, ensuring they are sent before any waiting batches.
+/// Retry handling uses a mute set (aligned with the Java Kafka producer): when a batch
+/// enters retry, its partition is muted so no additional batches can be sent until the
+/// outstanding pipeline drains and the retry is written. This cannot undo a later
+/// non-idempotent request that the broker already appended before the error was observed.
 ///
 /// Epoch recovery for OutOfOrderSequenceNumber uses the Java Kafka Sender pattern:
 /// response handlers signal a flag, and the single-threaded send loop bumps the epoch
@@ -694,9 +695,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _maxInFlight = options.MaxInFlightRequestsPerConnection;
         _isIdempotent = options.EnableIdempotence;
 
-        // Kafka processes requests in wire order on each connection. Partition affinity
-        // therefore permits non-idempotent same-partition pipelining without sequence
-        // numbers; retry errors still install a partition mute before new work is drained.
+        // Kafka processes healthy requests in wire order on each connection. Partition
+        // affinity therefore permits non-idempotent same-partition pipelining, matching
+        // librdkafka. If an earlier request fails after a later request was written, a retry
+        // can reorder records; callers requiring retry-safe order must enable idempotence
+        // or configure MaxInFlightRequestsPerConnection = 1.
         _muteOnSend = _maxInFlight <= 1 || options.Acks == Acks.None;
 
         // All producers use partition affinity (partition % connectionCount) for CPU cache

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2602,8 +2602,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         // PER-BROKER SENDER ARCHITECTURE: Each broker gets a dedicated BrokerSender with its own
         // channel and single-threaded send loop. This guarantees wire-order for same-partition
-        // batches. The per-broker in-flight semaphore enables pipelining across different partitions.
-        // Ordering across retries relies on broker idempotent producer support (sequence numbers + epoch).
+        // requests. Retry-safe record ordering requires idempotence (sequence numbers + epoch);
+        // non-idempotent pipelining accepts Kafka's documented retry-reordering trade-off.
         //
         // Ready → Drain → Distribute loop:
         // 1. Ready() checks which brokers have sendable data (sealed batches in partition deques)

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -186,9 +186,10 @@ public sealed class ProducerOptions
     /// producers at 5. When idempotence is disabled and this value is not explicitly set,
     /// Dekaf uses 100 to keep the non-idempotent pipeline full.
     /// <para>
-    /// Non-idempotent producers use this capacity across partitions, while Dekaf keeps at most
-    /// one batch per partition in flight because those batches have no sequence numbers.
-    /// Per-partition order is preserved, but retries may still produce duplicates.
+    /// Non-idempotent producers can also pipeline same-partition batches on their affined
+    /// connection. This improves throughput, but an earlier request that fails after a later
+    /// request was written can be retried after that later record and reorder the partition.
+    /// Enable idempotence or set this value to 1 when retry-safe ordering is required.
     /// </para>
     /// </summary>
     public int MaxInFlightRequestsPerConnection
@@ -233,7 +234,10 @@ public sealed class ProducerOptions
     public int ConnectionsPerBroker { get; init; } = 1;
 
     /// <summary>
-    /// Number of retries.
+    /// Number of retries. With idempotence disabled and
+    /// <see cref="MaxInFlightRequestsPerConnection"/> greater than 1, retries can reorder
+    /// records within a partition. Enable idempotence or use one in-flight request when
+    /// retry-safe ordering is required.
     /// </summary>
     public int Retries { get; init; } = int.MaxValue;
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1965,8 +1965,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         _options = options;
-        _serializeBatchesPerPartition = !options.EnableIdempotence
-            || options.MaxInFlightRequestsPerConnection <= 1;
+        _serializeBatchesPerPartition = options.MaxInFlightRequestsPerConnection <= 1;
         _compressionCodecs = compressionCodecs;
         _onBatchComplete = onBatchComplete;
         _onRecordAppended = onRecordAppended;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -306,7 +306,7 @@ public sealed class BrokerSenderMuteOrderingTests
     // integration of the sender state machine so unrelated concurrency tests cannot starve its wakeups.
     [NotInParallel]
     [Timeout(30_000)]
-    public async Task NonIdempotentProducer_MultipleInFlight_SerializesSamePartitionBatches(
+    public async Task NonIdempotentProducer_MultipleInFlight_PipelinesSamePartitionBatches(
         CancellationToken ct)
     {
         var responses = Enumerable.Range(0, 2)
@@ -346,21 +346,19 @@ public sealed class BrokerSenderMuteOrderingTests
             sender.Enqueue(firstBatch);
             await sendLogger.SendSignals[0].Task.WaitAsync(ct);
 
-            await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsTrue();
+            await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsFalse();
 
             var secondBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
             sender.Enqueue(secondBatch);
 
-            await WaitForDiagAsync(secondBatch, 'O', TimeSpan.FromSeconds(5), ct);
-            await Assert.That(sendLogger.SendCount).IsEqualTo(1);
+            await sendLogger.SendSignals[1].Task.WaitAsync(ct);
+            await Assert.That(sendLogger.SendCount).IsEqualTo(2);
 
             responses[0].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 100));
-            await sendLogger.SendSignals[1].Task.WaitAsync(ct);
             responses[1].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 101));
 
             await allAcknowledged.Task.WaitAsync(ct);
-            await Assert.That(acknowledgedOffsets[0]).IsEqualTo(100);
-            await Assert.That(acknowledgedOffsets[1]).IsEqualTo(101);
+            await Assert.That(acknowledgedOffsets).IsEquivalentTo([100L, 101L]);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -383,6 +383,73 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(120_000)]
+    public async Task SendLoop_NonIdempotent_ErrorMutesUntilSamePartitionPipelineDrains(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var retryResponse = new TaskCompletionSource<ProduceResponse>();
+        var thirdResponse = new TaskCompletionSource<ProduceResponse>();
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, secondResponse, retryResponse, thirdResponse]);
+        var sends = Enumerable.Range(0, 4).Select(_ => new TaskCompletionSource()).ToArray();
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responses, onSend: () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            if (index < sends.Length)
+                sends[index].TrySetResult();
+        });
+        var options = CreateOptions(
+            maxInFlight: 5,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0,
+            enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledged = 0;
+        var allAcknowledged = new TaskCompletionSource();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, exception) =>
+        {
+            if (exception is null && Interlocked.Increment(ref acknowledged) == 3)
+                allAcknowledged.TrySetResult();
+        });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+            await sends[0].Task.WaitAsync(cancellationToken);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+            await sends[1].Task.WaitAsync(cancellationToken);
+
+            firstResponse.SetResult(CreateErrorResponse("test-topic", 0, ErrorCode.RequestTimedOut));
+            await WaitUntilAsync(
+                () => accumulator.IsMuted(new TopicPartition("test-topic", 0)),
+                cancellationToken);
+            var thirdBatch = CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0);
+            sender.Enqueue(thirdBatch);
+
+            await WaitUntilAsync(() => thirdBatch.DiagTrace.Contains('O'), cancellationToken);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
+
+            secondResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
+            await sends[2].Task.WaitAsync(cancellationToken);
+            await sends[3].Task.WaitAsync(cancellationToken);
+
+            retryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 43));
+            thirdResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 44));
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task SendLoop_PipelinedProduce_ReleasesBufferMemoryOnlyAfterWriteCompletes(CancellationToken cancellationToken)
     {
         var responseTcs = new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -456,6 +456,62 @@ public sealed class BrokerSenderSendLoopTests
 
     [Test]
     [Timeout(120_000)]
+    public async Task SendLoop_NonIdempotent_EarlierError_RetriesAfterLaterSuccess(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondResponse = new TaskCompletionSource<ProduceResponse>();
+        var retryResponse = new TaskCompletionSource<ProduceResponse>();
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, secondResponse, retryResponse]);
+        var sends = Enumerable.Range(0, 3).Select(_ => new TaskCompletionSource()).ToArray();
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(responses, () =>
+        {
+            sends[Interlocked.Increment(ref sendCount) - 1].TrySetResult();
+        });
+        var options = CreateOptions(
+            maxInFlight: 5,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0,
+            enableIdempotence: false);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledged = 0;
+        var allAcknowledged = new TaskCompletionSource();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, exception) =>
+        {
+            if (exception is null && Interlocked.Increment(ref acknowledged) == 2)
+                allAcknowledged.TrySetResult();
+        });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+            await sends[0].Task.WaitAsync(cancellationToken);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+            await sends[1].Task.WaitAsync(cancellationToken);
+
+            firstResponse.SetResult(CreateErrorResponse(
+                "test-topic", partition: 0, ErrorCode.RequestTimedOut));
+            secondResponse.SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 42));
+
+            // The later request may already be appended. The retry waits for it to drain,
+            // then writes afterward: this is Kafka's non-idempotent retry-reordering trade-off.
+            await sends[2].Task.WaitAsync(cancellationToken);
+            retryResponse.SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 43));
+            await allAcknowledged.Task.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task SendLoop_PipelinedProduce_ReleasesBufferMemoryOnlyAfterWriteCompletes(CancellationToken cancellationToken)
     {
         var responseTcs = new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -388,11 +388,12 @@ public sealed class BrokerSenderSendLoopTests
     {
         var firstResponse = new TaskCompletionSource<ProduceResponse>();
         var secondResponse = new TaskCompletionSource<ProduceResponse>();
-        var retryResponse = new TaskCompletionSource<ProduceResponse>();
+        var firstRetryResponse = new TaskCompletionSource<ProduceResponse>();
+        var secondRetryResponse = new TaskCompletionSource<ProduceResponse>();
         var thirdResponse = new TaskCompletionSource<ProduceResponse>();
         var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
-            [firstResponse, secondResponse, retryResponse, thirdResponse]);
-        var sends = Enumerable.Range(0, 4).Select(_ => new TaskCompletionSource()).ToArray();
+            [firstResponse, secondResponse, firstRetryResponse, secondRetryResponse, thirdResponse]);
+        var sends = Enumerable.Range(0, 5).Select(_ => new TaskCompletionSource()).ToArray();
         var sendCount = 0;
         var (pool, _) = CreateMockConnection(responses, onSend: () =>
         {
@@ -432,11 +433,16 @@ public sealed class BrokerSenderSendLoopTests
             await WaitUntilAsync(() => thirdBatch.DiagTrace.Contains('O'), cancellationToken);
             await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(2);
 
-            secondResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
+            secondResponse.SetResult(CreateErrorResponse("test-topic", 0, ErrorCode.RequestTimedOut));
             await sends[2].Task.WaitAsync(cancellationToken);
-            await sends[3].Task.WaitAsync(cancellationToken);
+            await Assert.That(accumulator.IsMuted(thirdBatch.TopicPartition)).IsTrue();
 
-            retryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 43));
+            firstRetryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 42));
+            await sends[3].Task.WaitAsync(cancellationToken);
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(4);
+
+            secondRetryResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 43));
+            await sends[4].Task.WaitAsync(cancellationToken);
             thirdResponse.SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 44));
             await allAcknowledged.Task.WaitAsync(cancellationToken);
         }

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -165,9 +165,10 @@ public sealed class ReadyBatchIncarnationTests
         var generations = new[] { capturedGeneration };
         var responseTask = Task.FromResult(new ProduceResponse());
         var create = PendingResponseType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+        var timestamp = Stopwatch.GetTimestamp();
         var pending = create.Invoke(
             null,
-            [responseTask, batches, generations, 1, (long)batch.EncodedSize, Stopwatch.GetTimestamp()])!;
+            [responseTask, batches, generations, 1, (long)batch.EncodedSize, timestamp, timestamp])!;
         var isSameIncarnation = PendingResponseType.GetMethod("IsSameIncarnation")!;
 
         Interlocked.Exchange(ref batch._returnedToPool, 1);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -23,7 +23,8 @@ public class RecordAccumulatorReadyTests
         int batchSize = 1000,
         int lingerMs = 10,
         CompressionType compressionType = CompressionType.None,
-        bool enableIdempotence = true)
+        bool enableIdempotence = true,
+        int maxInFlight = 5)
     {
         return new ProducerOptions
         {
@@ -33,7 +34,8 @@ public class RecordAccumulatorReadyTests
             BatchSize = batchSize,
             LingerMs = lingerMs,
             CompressionType = compressionType,
-            EnableIdempotence = enableIdempotence
+            EnableIdempotence = enableIdempotence,
+            MaxInFlightRequestsPerConnection = maxInFlight
         };
     }
 
@@ -943,7 +945,8 @@ public class RecordAccumulatorReadyTests
         var options = CreateTestOptions(
             batchSize: 100_000,
             lingerMs: 0,
-            enableIdempotence: false);
+            enableIdempotence: false,
+            maxInFlight: 1);
         await using var accumulator = new RecordAccumulator(options);
 
         var firstAppended = await accumulator.AppendFromSpansAsync(
@@ -983,6 +986,38 @@ public class RecordAccumulatorReadyTests
 
         await accumulator.ExpireLingerAsync(CancellationToken.None);
         await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task ZeroLinger_NonIdempotentPipeline_SealsWhilePreviousBatchQueued()
+    {
+        var options = CreateTestOptions(
+            batchSize: 100_000,
+            lingerMs: 0,
+            enableIdempotence: false,
+            maxInFlight: 2);
+        await using var accumulator = new RecordAccumulator(options);
+
+        foreach (var value in new[] { "first"u8.ToArray(), "second"u8.ToArray() })
+        {
+            var appended = await accumulator.AppendFromSpansAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                callback: null,
+                CancellationToken.None,
+                partitionCount: 1);
+
+            await Assert.That(appended).IsTrue();
+            await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsFalse()
+                .Because("max-in-flight greater than one must expose another sealed batch to the sender");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- pipeline acknowledged non-idempotent same-partition requests on their affined connection
- mute on retry errors until outstanding same-partition responses drain
- preserve `Acks.None` and max-in-flight=1 serialization
- keep request timeout pre-write while measuring admission RTT post-write

## Ordering contract
This intentionally matches librdkafka/Kafka behavior requested by #1912: healthy same-connection requests retain wire order, but with idempotence disabled and max-in-flight greater than 1, an earlier failed request may be retried after a later request already appended. Callers requiring retry-safe partition ordering must enable idempotence or set `MaxInFlightRequestsPerConnection = 1`. API and internal docs now state this explicitly, and a regression covers the earlier-error/later-success sequence.

## Test plan
- [x] focused send-loop and mute-ordering tests
- [x] full unit suite (5,231 passed)
- [x] real Kafka `NonIdempotentMultiInflight_SinglePartition_OrderingPreserved` (10,000 ordered records on healthy path)

Closes #1912