### PR TITLE
Remove cheap-path transaction allocations

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4106,21 +4106,30 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
     }
 
-    public async ValueTask<RecordMetadata> ProduceAsync(
+    public ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfProducerDisposed();
-        _producer.ThrowIfFatalTransactionError("Cannot produce");
+        try
+        {
+            ThrowIfProducerDisposed();
+            _producer.ThrowIfFatalTransactionError("Cannot produce");
 
-        if (_committed || _aborted)
-            throw new InvalidOperationException("Transaction is already completed");
+            if (_committed || _aborted)
+                throw new InvalidOperationException("Transaction is already completed");
 
-        _producer.ThrowIfInPreparedTransaction();
+            _producer.ThrowIfInPreparedTransaction();
 
-        // Partition registration with AddPartitionsToTxn is handled automatically
-        // by BrokerSender before the ProduceRequest is sent to the broker.
-        return await _producer.ProduceAsync(message, cancellationToken).ConfigureAwait(false);
+            // Partition registration with AddPartitionsToTxn is handled automatically
+            // by BrokerSender before the ProduceRequest is sent to the broker.
+            return _producer.ProduceAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Preserve async-method exception timing: validation failures fault the returned
+            // ValueTask instead of escaping synchronously from ProduceAsync.
+            return new ValueTask<RecordMetadata>(Task.FromException<RecordMetadata>(exception));
+        }
     }
 
     public ValueTask CommitAsync(CancellationToken cancellationToken = default) =>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4124,6 +4124,15 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             // by BrokerSender before the ProduceRequest is sent to the broker.
             return _producer.ProduceAsync(message, cancellationToken);
         }
+        catch (OperationCanceledException exception)
+        {
+            var canceledToken = exception.CancellationToken.IsCancellationRequested
+                ? exception.CancellationToken
+                : cancellationToken.IsCancellationRequested
+                    ? cancellationToken
+                    : new CancellationToken(canceled: true);
+            return new ValueTask<RecordMetadata>(Task.FromCanceled<RecordMetadata>(canceledToken));
+        }
         catch (Exception exception)
         {
             // Preserve async-method exception timing: validation failures fault the returned

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4289,8 +4289,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         _partitionQueueBytes.AddOrUpdate(
             batch.TopicPartition,
-            batch.DataSize,
-            (_, current) => SaturatingAdd(current, batch.DataSize));
+            static (_, batch) => batch.DataSize,
+            static (_, current, batch) => SaturatingAdd(current, batch.DataSize),
+            batch);
 
         // Counter first, list second. If a batch races between the counter increment
         // and the list add, the sweep will miss it in the snapshot — but that's acceptable

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -116,6 +116,29 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task ProduceAsync_ValidationFailure_ReturnsFaultedValueTask()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+        var kafkaProducer = (KafkaProducer<string, string>)producer;
+        kafkaProducer._transactionState = TransactionState.FatalError;
+        kafkaProducer._lastTransactionError = ErrorCode.ProducerFenced;
+        await using var transaction = new Transaction<string, string>(kafkaProducer);
+
+        var operation = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "test-topic",
+            Key = "key",
+            Value = "value"
+        });
+
+        await Assert.That(operation.IsCompleted).IsTrue();
+        await Assert.That(() => operation.AsTask()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
     public async Task DisposeAsync_WhenAbortIsFenced_PreservesFatalError()
     {
         var preparedState = new PreparedTransactionState(42, 5);

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -139,6 +139,33 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task ProduceAsync_PreCanceledToken_ReturnsCanceledValueTask()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("test-txn-id")
+            .Build();
+        var kafkaProducer = (KafkaProducer<string, string>)producer;
+        SetInstanceField(kafkaProducer, "_initialized", true);
+        kafkaProducer._transactionState = TransactionState.Ready;
+        await using var transaction = new Transaction<string, string>(kafkaProducer);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var operation = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "test-topic",
+            Key = "key",
+            Value = "value"
+        }, cancellation.Token);
+        var task = operation.AsTask();
+
+        await Assert.That(() => task).Throws<OperationCanceledException>();
+        await Assert.That(task.IsCanceled).IsTrue();
+        await Assert.That(task.IsFaulted).IsFalse();
+    }
+
+    [Test]
     public async Task DisposeAsync_WhenAbortIsFenced_PreservesFatalError()
     {
         var preparedState = new PreparedTransactionState(42, 5);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -1,0 +1,110 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Producer;
+using System.Reflection;
+
+namespace Dekaf.Benchmarks.Benchmarks.Client;
+
+[MemoryDiagnoser]
+[Config(typeof(AllocationJobConfig))]
+public class TransactionalProduceAllocationBenchmarks
+{
+    private const int MessagesPerIteration = 1_000;
+
+    private sealed class AllocationJobConfig : ManualConfig
+    {
+        public AllocationJobConfig()
+        {
+            AddJob(Job.Default
+                .WithStrategy(RunStrategy.Throughput)
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(3)
+                .WithInvocationCount(MessagesPerIteration)
+                .WithUnrollFactor(1));
+        }
+    }
+
+    private IKafkaProducer<string, string> _producer = null!;
+    private ITransaction<string, string> _transaction = null!;
+    private ProducerMessage<string, string> _message = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("benchmark-transaction-allocation")
+            .WithBufferMemory(ulong.MaxValue)
+            .Build();
+        var producer = (KafkaProducer<string, string>)_producer;
+        var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
+        await senderCts.CancelAsync();
+        await Task.WhenAll(
+            GetField<Task>(producer, "_senderTask"),
+            GetField<Task>(producer, "_lingerTask"));
+
+        SeedMetadata(GetField<MetadataManager>(producer, "_metadataManager"));
+        SetField(producer, "_initialized", true);
+        SetField(producer, "_transactionState", TransactionState.Ready);
+        _transaction = _producer.BeginTransaction();
+        _message = new ProducerMessage<string, string>
+        {
+            Topic = "benchmark-transaction-allocation",
+            Partition = 0,
+            Key = "key",
+            Value = "value"
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public void ProducerProduceAsync() =>
+        _ = _producer.ProduceAsync(_message);
+
+    [Benchmark]
+    public void TransactionProduceAsync() =>
+        _ = _transaction.ProduceAsync(_message);
+
+    private static void SeedMetadata(MetadataManager metadataManager) =>
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+            ],
+            ClusterId = "benchmark-cluster",
+            ControllerId = 0,
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "benchmark-transaction-allocation",
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0]
+                        }
+                    ]
+                }
+            ]
+        });
+
+    private static T GetField<T>(object target, string name) =>
+        (T)target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(target)!;
+
+    private static void SetField<T>(object target, string name, T value) =>
+        target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(target, value);
+}


### PR DESCRIPTION
Closes #1923

## Summary
- forwards successful transactional produces without an async state machine
- preserves faulted `ValueTask` timing for synchronous validation failures
- removes captured closures from partition queue byte accounting
- adds a bounded no-network allocation benchmark

## Allocation result
- old transactional wrapper: 1,311,816 B/message in the benchmark harness
- new transactional wrapper: 1,311,552 B/message
- reduction: 264 B/message
- plain producer: 1,311,552 B/message (transaction now matches it)

## Validation
- `dotnet build tools/Dekaf.Benchmarks --configuration Release`
- `dotnet run --project tests/Dekaf.Tests.Unit --framework net10.0 --configuration Release --no-build` (5,230 passed)
- `dotnet run --project tests/Dekaf.Tests.Unit --framework net8.0 --configuration Release --no-build` (5,141 passed)
- `TransactionalProduceAllocationBenchmarks` completed; allocation ratio transaction/plain = 1.00