### PR TITLE
Arm producer linger scheduling on demand

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1197,7 +1197,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
-                    && Volatile.Read(ref _totalPendingResponseCount) < _totalMaxInFlight)
+                    && Volatile.Read(ref _totalPendingResponseCount) < _totalMaxInFlight
+                    && ShouldMicroLinger(
+                        coalescedBatches,
+                        coalescedCount,
+                        _options.TransactionalId is not null))
                 {
                     var spinWait = new SpinWait();
                     for (var spin = 0; spin < MicroLingerMaxSpins && coalescedCount < maxCoalesce; spin++)
@@ -1942,6 +1946,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ref coalescedCount,
             ref coalescedRequestBudgetUsed,
             normalBatchRequestBodySize);
+    }
+
+    /// <summary>
+    /// Serial transactional ProduceAsync traffic cannot enqueue another record until its sole
+    /// completion resolves, so spinning for a co-temporal batch can never improve coalescing.
+    /// </summary>
+    internal static bool ShouldMicroLinger(
+        ReadyBatch[] coalescedBatches,
+        int coalescedCount,
+        bool isTransactional)
+    {
+        if (!isTransactional || coalescedCount != 1)
+            return true;
+
+        var batch = coalescedBatches[0];
+        return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -61,7 +61,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly CancellationTokenSource _senderCts;
     private readonly Task _senderTask;
     private readonly Task _lingerTask;
-    private readonly PeriodicTimer _lingerTimer;
 
     // Per-broker sender threads: each broker gets a dedicated BrokerSender with its own
     // channel and send loop. The per-broker in-flight semaphore enables pipelining across
@@ -410,11 +409,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
 
         _senderCts = new CancellationTokenSource();
-        // Use 1ms check interval for low-latency awaited produces.
-        // ShouldFlush() is smart: it returns true immediately for batches with completion
-        // sources (awaited produces), but waits for full LingerMs for fire-and-forget batches.
-        // This provides low latency for ProduceAsync while maintaining efficient batching for Send.
-        _lingerTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
         _senderTask = Task.Factory.StartNew(
             () => SenderLoopAsync(_senderCts.Token),
             CancellationToken.None,
@@ -2977,27 +2971,32 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
     private async Task LingerLoopAsync(CancellationToken cancellationToken)
     {
-        // Use PeriodicTimer instead of Task.Delay to avoid allocations on each tick.
-        // PeriodicTimer.WaitForNextTickAsync is allocation-free after the timer is constructed.
-
         // Orphan sweep interval: check for expired in-flight batches every ~5 seconds.
         // This catches batches whose references were lost from BrokerSender data structures
         // (root cause under investigation) — without this sweep, ProduceAsync hangs indefinitely.
         var orphanSweepIntervalTicks = (long)(5.0 * Stopwatch.Frequency);
         var lastOrphanSweepTicks = Stopwatch.GetTimestamp();
 
-        using var cancellationRegistration = cancellationToken.UnsafeRegister(
-            static state => ((PeriodicTimer)state!).Dispose(),
-            _lingerTimer);
+        _accumulator.RegisterLingerWakeupShutdownToken(cancellationToken);
 
-        while (await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
+        while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
+                var now = Stopwatch.GetTimestamp();
+                var ticksUntilOrphanSweep = orphanSweepIntervalTicks - (now - lastOrphanSweepTicks);
+                var orphanWaitMs = ticksUntilOrphanSweep <= 0
+                    ? 0
+                    : Math.Max(1, (int)Math.Ceiling(ticksUntilOrphanSweep * 1000.0 / Stopwatch.Frequency));
+                var waitMs = _accumulator.HasPendingLingerBatches && orphanWaitMs > 0
+                    ? 1
+                    : orphanWaitMs;
+
+                await _accumulator.WaitForLingerWakeupAsync(waitMs).ConfigureAwait(false);
                 await _accumulator.ExpireLingerAsync(cancellationToken).ConfigureAwait(false);
 
                 // Periodic orphan sweep: fail in-flight batches that exceeded delivery timeout.
-                var now = Stopwatch.GetTimestamp();
+                now = Stopwatch.GetTimestamp();
                 if (now - lastOrphanSweepTicks >= orphanSweepIntervalTicks)
                 {
                     lastOrphanSweepTicks = now;
@@ -3880,7 +3879,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         _accumulator.ForceFailAllInFlightBatches();
 
         _senderCts.Dispose();
-        _lingerTimer.Dispose();
         _transactionLock.Dispose();
         _initLock.Dispose();
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -918,6 +918,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private readonly AsyncAutoResetSignal _wakeupSignal = new();
 
+    /// <summary>
+    /// Signals the linger loop when an unsealed batch is created or gains its first awaiter.
+    /// This keeps the 1 ms linger cadence armed only while batches need it.
+    /// </summary>
+    private readonly AsyncAutoResetSignal _lingerWakeupSignal = new();
+
     // Per-partition-affine append workers: each worker owns a channel and processes
     // appends for a subset of partitions (partition % workerCount). This reduces
     // contention on ConcurrentDictionary lookups when many threads fall through
@@ -1939,6 +1945,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return _wakeupSignal.WaitAsync(timeoutMs);
     }
 
+    internal ValueTask<bool> WaitForLingerWakeupAsync(int timeoutMs) =>
+        _lingerWakeupSignal.WaitAsync(timeoutMs);
+
+    internal bool HasPendingLingerBatches => HasUnsealedBatches();
+
     /// <summary>
     /// Registers a shutdown token with the wakeup signal so cancellation wakes the sender loop
     /// without per-wait allocation. Must be called once before the sender loop starts waiting.
@@ -1947,6 +1958,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         _wakeupSignal.RegisterShutdownToken(cancellationToken);
     }
+
+    internal void RegisterLingerWakeupShutdownToken(CancellationToken cancellationToken) =>
+        _lingerWakeupSignal.RegisterShutdownToken(cancellationToken);
 
     internal long GetPartitionQueueBytes(string topic, int partition)
     {
@@ -2353,10 +2367,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void QueueLingerPartition(PartitionDeque pd, TopicPartition topicPartition)
+    private void QueueLingerPartition(
+        PartitionDeque pd,
+        TopicPartition topicPartition,
+        bool signalLingerLoop = true)
     {
         if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
             _lingerPartitions.Enqueue(topicPartition);
+
+        if (signalLingerLoop)
+            _lingerWakeupSignal.Signal();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -4248,7 +4268,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         newOldestTicks = batchCreatedTicks;
 
                     if (!sealAll)
-                        QueueLingerPartition(pd, topicPartition);
+                        QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
                     break;
                 }
             }
@@ -4258,7 +4278,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             if (!sealAll)
             {
-                QueueLingerPartition(pd, topicPartition);
+                QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
                 break;
             }
 
@@ -5326,6 +5346,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Signal wakeup so the sender loop can exit if still waiting
         SignalWakeup();
+        _lingerWakeupSignal.Signal();
 
         // Sweep for orphaned batches whose references were lost from BrokerSender data structures.
         // This is the last line of defense: if a batch was tracked via OnBatchEntersPipeline but
@@ -5337,6 +5358,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Dispose resources to prevent leaks
         _wakeupSignal?.Dispose();
+        _lingerWakeupSignal.Dispose();
         _disposalCts?.Dispose();
         // _bufferSpaceSignal is a TaskCompletionSource — no Dispose needed.
         // Signal any remaining waiters so they can observe disposal.
@@ -6402,6 +6424,11 @@ internal sealed class ReadyBatch
     /// Number of completion sources (messages) in this batch.
     /// </summary>
     public int CompletionSourcesCount => _completionSourcesCount;
+
+    /// <summary>
+    /// Total number of records sealed into this batch.
+    /// </summary>
+    public int RecordCount => _recordCount;
 
     /// <summary>
     /// Uncompressed encoded record bytes reserved against BufferMemory.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -25,6 +25,51 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerSenderSendLoopTests
 {
+    [Test]
+    public async Task ShouldMicroLinger_TransactionalAwaitedBatch_ReturnsFalse()
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("test-topic", 0),
+            new RecordBatch(),
+            completionSourcesArray: null,
+            completionSourcesCount: 1,
+            dataSize: 1,
+            recordCount: 1);
+
+        var shouldLinger = BrokerSender.ShouldMicroLinger([batch], 1, isTransactional: true);
+
+        await Assert.That(shouldLinger).IsFalse();
+    }
+
+    [Test]
+    public async Task ShouldMicroLinger_FireAndForgetOrPlainProducer_ReturnsTrue()
+    {
+        var fireAndForget = new ReadyBatch();
+        fireAndForget.Initialize(
+            new TopicPartition("test-topic", 0),
+            new RecordBatch(),
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            dataSize: 1,
+            recordCount: 1);
+        var awaited = new ReadyBatch();
+        awaited.Initialize(
+            new TopicPartition("test-topic", 1),
+            new RecordBatch(),
+            completionSourcesArray: null,
+            completionSourcesCount: 1,
+            dataSize: 1,
+            recordCount: 1);
+
+        await Assert.That(BrokerSender.ShouldMicroLinger([fireAndForget], 1, isTransactional: true))
+            .IsTrue();
+        await Assert.That(BrokerSender.ShouldMicroLinger([awaited], 1, isTransactional: false))
+            .IsTrue();
+        await Assert.That(BrokerSender.ShouldMicroLinger([awaited, awaited], 2, isTransactional: true))
+            .IsTrue();
+    }
+
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -10,6 +10,41 @@ namespace Dekaf.Tests.Unit.Producer;
 public class ProducerCancellationTests
 {
     [Test]
+    public async Task LingerWakeup_WaitsWhileIdle_AndSignalsOnFirstBatch()
+    {
+        var accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            LingerMs = 10_000
+        });
+
+        try
+        {
+            var wakeup = accumulator.WaitForLingerWakeupAsync(5_000).AsTask();
+            await Assert.That(wakeup.IsCompleted).IsFalse();
+
+            await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None);
+
+            await Assert.That(await wakeup.WaitAsync(TimeSpan.FromSeconds(1))).IsTrue();
+            await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task DisposeAsync_StopsPendingLingerTimerPromptly()
     {
         var producer = Kafka.CreateProducer<string, string>()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionalSchedulerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionalSchedulerBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class TransactionalSchedulerBenchmarks
+{
+    private const int LegacyMicroLingerMaxSpins = 20;
+    private ReadyBatch[] _awaitedBatch = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("benchmark-transaction-scheduler", 0),
+            new RecordBatch(),
+            completionSourcesArray: null,
+            completionSourcesCount: 1,
+            dataSize: 1,
+            recordCount: 1);
+        _awaitedBatch = [batch];
+    }
+
+    [Benchmark(Baseline = true)]
+    public void LegacySerialAwaitedMicroLinger()
+    {
+        var spinWait = new SpinWait();
+        for (var spin = 0; spin < LegacyMicroLingerMaxSpins; spin++)
+            spinWait.SpinOnce();
+    }
+
+    [Benchmark]
+    public bool AwaitedTransactionalDecision() =>
+        BrokerSender.ShouldMicroLinger(_awaitedBatch, 1, isTransactional: true);
+}


### PR DESCRIPTION
Closes #1922

## Summary
- replaces the unconditional 1 ms producer linger timer with a zero-allocation signal wait
- arms 1 ms checks only while unsealed batches exist; idle producers wake only for the 5 s orphan sweep
- skips BrokerSender micro-linger for the single-record/single-await serial transactional case
- preserves micro-linger for plain, fire-and-forget, multi-record, and pipelined transactional batches

## Benchmark
`TransactionalSchedulerBenchmarks`:
- legacy serial-awaited micro-linger: 4,175.2 ns/message
- awaited transactional decision: indistinguishable from empty-method overhead
- allocations: 0 B for both

## Validation
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- net10 unit suite: 5,232 passed
- net8 unit suite: 5,143 passed
- benchmark project build: clean
- `TransactionalSchedulerBenchmarks`: completed