### PR TITLE
Pool pipelined response operations

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks.Sources;
 using Dekaf.Protocol;
 
 namespace Dekaf.Networking;
@@ -104,17 +105,75 @@ public interface IKafkaConnection : IAsyncDisposable
 
 internal interface IKafkaPipelinedWriteCompletionConnection
 {
-    ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+    ValueTask<PipelinedResponse<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken = default)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse;
 
-    ValueTask<Task<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+    ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken = default)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse;
+}
+
+internal interface IPipelinedResponseSource<TResponse> : IValueTaskSource<TResponse>
+{
+    void Abandon(short token);
+}
+
+internal readonly struct PipelinedResponse<TResponse>
+{
+    private readonly Task<TResponse>? _task;
+    private readonly IPipelinedResponseSource<TResponse>? _source;
+    private readonly short _token;
+
+    public PipelinedResponse(Task<TResponse> task) => _task = task;
+
+    public PipelinedResponse(IPipelinedResponseSource<TResponse> source, short token)
+    {
+        _source = source;
+        _token = token;
+    }
+
+    public bool IsCompleted => _task?.IsCompleted
+        ?? _source!.GetStatus(_token) != ValueTaskSourceStatus.Pending;
+
+    public bool IsFaulted => _task?.IsFaulted
+        ?? _source!.GetStatus(_token) == ValueTaskSourceStatus.Faulted;
+
+    public bool IsCanceled => _task?.IsCanceled
+        ?? _source!.GetStatus(_token) == ValueTaskSourceStatus.Canceled;
+
+    public int Id => _task?.Id ?? 0;
+
+    public TResponse GetResult() => _task is not null
+        ? _task.GetAwaiter().GetResult()
+        : _source!.GetResult(_token);
+
+    public ValueTask<TResponse> AsValueTask() => _task is not null
+        ? new ValueTask<TResponse>(_task)
+        : new ValueTask<TResponse>(_source!, _token);
+
+    public Task<TResponse> AsTask() => _task ?? AsValueTask().AsTask();
+
+    public void UnsafeOnCompleted(Action continuation)
+    {
+        if (_task is not null)
+        {
+            _task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(continuation);
+            return;
+        }
+
+        _source!.OnCompleted(
+            static state => ((Action)state!).Invoke(),
+            continuation,
+            _token,
+            ValueTaskSourceOnCompletedFlags.None);
+    }
+
+    public void Abandon() => _source?.Abandon(_token);
 }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -785,6 +785,8 @@ public sealed partial class KafkaConnection :
         where TResponse : IKafkaResponse
         => PooledPipelinedResponse<TRequest, TResponse>.ApproximatePoolCount;
 
+    internal static Action? PipelinedResponseBeforePublishTestHook;
+
     private sealed class PooledPipelinedResponse<TRequest, TResponse> :
         IPipelinedResponseSource<TResponse>
         where TRequest : IKafkaRequest<TResponse>
@@ -794,6 +796,9 @@ public sealed partial class KafkaConnection :
         private const int ConsumerActive = 0;
         private const int ConsumerAbandoned = 1;
         private const int ConsumerReturned = 2;
+        private const int CompletionReady = 1;
+        private const int ConsumerReady = 2;
+        private const int ReturnReady = CompletionReady | ConsumerReady;
 
         private static readonly ConcurrentStack<PooledPipelinedResponse<TRequest, TResponse>> Pool = new();
         private static int s_poolCount;
@@ -815,6 +820,7 @@ public sealed partial class KafkaConnection :
         private bool _canceled;
         private long _telemetryStartTimestamp;
         private int _consumerState;
+        private int _returnReadiness;
 
         private PooledPipelinedResponse()
         {
@@ -870,6 +876,7 @@ public sealed partial class KafkaConnection :
             _cancellationToken = cancellationToken;
             _canceled = false;
             _consumerState = ConsumerActive;
+            _returnReadiness = 0;
             connection.LogWaitingForResponse(correlationId);
 
             if (callerOwnsTimeout && cancellationToken.CanBeCanceled)
@@ -955,6 +962,7 @@ public sealed partial class KafkaConnection :
                 ConsumerReturned,
                 ConsumerAbandoned) == ConsumerAbandoned;
             var token = _core.Version;
+            Volatile.Read(ref PipelinedResponseBeforePublishTestHook)?.Invoke();
             if (exception is null)
             {
                 _core.SetResult(response);
@@ -965,10 +973,14 @@ public sealed partial class KafkaConnection :
                 _core.SetException(exception);
             }
 
-            // An abandoned response has no consumer that can recycle this source. Ownership
-            // was claimed before publication, so no GetResult path can race this return.
-            // Active responses must not touch mutable state after SetResult/SetException:
-            // their consumer may already have returned and re-rented this instance.
+            // Abandon can win after the pre-publication check. Claim it again only after
+            // publishing the terminal result. The return handshake prevents an active
+            // consumer from pooling/re-renting this source until this completion frame has
+            // finished both checks, avoiding an ABA race on _consumerState.
+            returnAbandoned |= Interlocked.CompareExchange(
+                ref _consumerState,
+                ConsumerReturned,
+                ConsumerAbandoned) == ConsumerAbandoned;
             if (returnAbandoned)
             {
                 try
@@ -980,8 +992,10 @@ public sealed partial class KafkaConnection :
                     // Abandoned callers intentionally discard terminal errors.
                 }
 
-                ReturnToPool();
+                SignalReturnReady(ConsumerReady);
             }
+
+            SignalReturnReady(CompletionReady);
         }
 
         public void Abandon(short token)
@@ -1018,7 +1032,14 @@ public sealed partial class KafkaConnection :
                 // Abandoned callers intentionally discard terminal errors.
             }
 
-            ReturnToPool();
+            SignalReturnReady(ConsumerReady);
+        }
+
+        private void SignalReturnReady(int readiness)
+        {
+            var previous = Interlocked.Or(ref _returnReadiness, readiness);
+            if (previous != ReturnReady && (previous | readiness) == ReturnReady)
+                ReturnToPool();
         }
 
         private void ReturnToPool()
@@ -1032,6 +1053,7 @@ public sealed partial class KafkaConnection :
             _callerOwnsTimeout = false;
             _canceled = false;
             _telemetryStartTimestamp = 0;
+            _returnReadiness = 0;
             _core.Reset();
 
             if (Interlocked.Increment(ref s_poolCount) <= MaxPoolSize)
@@ -1057,7 +1079,7 @@ public sealed partial class KafkaConnection :
                     ConsumerReturned,
                     ConsumerActive) == ConsumerActive)
                 {
-                    ReturnToPool();
+                    SignalReturnReady(ConsumerReady);
                 }
             }
         }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -659,7 +659,7 @@ public sealed partial class KafkaConnection :
             callerOwnsTimeout: true,
             cancellationToken);
 
-    ValueTask<Task<TResponse>> IKafkaPipelinedWriteCompletionConnection.SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+    ValueTask<PipelinedResponse<TResponse>> IKafkaPipelinedWriteCompletionConnection.SendPipelinedAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken)
@@ -669,7 +669,7 @@ public sealed partial class KafkaConnection :
             callerOwnsTimeout: false,
             cancellationToken);
 
-    ValueTask<Task<TResponse>>
+    ValueTask<PipelinedResponse<TResponse>>
         IKafkaPipelinedWriteCompletionConnection.SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
             TRequest request,
             short apiVersion,
@@ -694,10 +694,10 @@ public sealed partial class KafkaConnection :
             callerOwnsTimeout,
             cancellationToken).ConfigureAwait(false);
 
-        return await responseTask.ConfigureAwait(false);
+        return await responseTask.AsValueTask().ConfigureAwait(false);
     }
 
-    private async ValueTask<Task<TResponse>> SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
+    private async ValueTask<PipelinedResponse<TResponse>> SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         bool callerOwnsTimeout,
@@ -745,7 +745,8 @@ public sealed partial class KafkaConnection :
             await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
                 .ConfigureAwait(false);
 
-            return AwaitPipelinedResponseAsync<TRequest, TResponse>(
+            return PooledPipelinedResponse<TRequest, TResponse>.Rent(
+                this,
                 pending,
                 correlationId,
                 apiVersion,
@@ -765,25 +766,316 @@ public sealed partial class KafkaConnection :
         }
     }
 
-    private async Task<TResponse> AwaitPipelinedResponseAsync<TRequest, TResponse>(
+    private void CompletePipelinedResponse(
         PooledPendingRequest pending,
         int correlationId,
-        short apiVersion,
-        bool callerOwnsTimeout,
-        long telemetryStartTimestamp,
-        CancellationToken cancellationToken)
+        bool responseReceived)
+    {
+        if (!TryRemovePendingRequest(correlationId, out var removed))
+            return;
+
+        Debug.Assert(ReferenceEquals(removed.Request, pending));
+        _pendingRequestPool.Return(removed.Request);
+        if (!responseReceived)
+            _cancelledCorrelationIds.TryAdd(correlationId);
+    }
+
+    internal static int GetPipelinedResponsePoolCount<TRequest, TResponse>()
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        => PooledPipelinedResponse<TRequest, TResponse>.ApproximatePoolCount;
+
+    private sealed class PooledPipelinedResponse<TRequest, TResponse> :
+        IPipelinedResponseSource<TResponse>
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        var response = await AwaitAndParseResponseAsync<TRequest, TResponse>(
-            pending,
-            correlationId,
-            apiVersion,
-            callerOwnsTimeout,
-            cancellationToken).ConfigureAwait(false);
-        Touch();
-        _telemetryMetricCollector?.RecordRequestLatency(BrokerId, telemetryStartTimestamp);
-        return response;
+        private const int MaxPoolSize = 256;
+        private const int ConsumerActive = 0;
+        private const int ConsumerAbandoned = 1;
+        private const int ConsumerReturned = 2;
+
+        private static readonly ConcurrentStack<PooledPipelinedResponse<TRequest, TResponse>> Pool = new();
+        private static int s_poolCount;
+
+        private ManualResetValueTaskSourceCore<TResponse> _core = new()
+        {
+            RunContinuationsAsynchronously = true
+        };
+        private readonly Action _pendingContinuation;
+        private KafkaConnection? _connection;
+        private PooledPendingRequest? _pending;
+        private ValueTask<PooledResponseBuffer> _pendingTask;
+        private CancellationToken _cancellationToken;
+        private CancellationTokenRegistration _callerRegistration;
+        private CancellationTokenSourcePool.PooledCancellationTokenSource? _timeoutCts;
+        private int _correlationId;
+        private short _apiVersion;
+        private bool _callerOwnsTimeout;
+        private bool _canceled;
+        private long _telemetryStartTimestamp;
+        private int _consumerState;
+
+        private PooledPipelinedResponse()
+        {
+            _pendingContinuation = CompletePendingResponse;
+        }
+
+        internal static int ApproximatePoolCount => Volatile.Read(ref s_poolCount);
+
+        public static PipelinedResponse<TResponse> Rent(
+            KafkaConnection connection,
+            PooledPendingRequest pending,
+            int correlationId,
+            short apiVersion,
+            bool callerOwnsTimeout,
+            long telemetryStartTimestamp,
+            CancellationToken cancellationToken)
+        {
+            if (!Pool.TryPop(out var operation))
+            {
+                operation = new PooledPipelinedResponse<TRequest, TResponse>();
+            }
+            else
+            {
+                Interlocked.Decrement(ref s_poolCount);
+            }
+
+            operation.Initialize(
+                connection,
+                pending,
+                correlationId,
+                apiVersion,
+                callerOwnsTimeout,
+                telemetryStartTimestamp,
+                cancellationToken);
+            return new PipelinedResponse<TResponse>(operation, operation._core.Version);
+        }
+
+        private void Initialize(
+            KafkaConnection connection,
+            PooledPendingRequest pending,
+            int correlationId,
+            short apiVersion,
+            bool callerOwnsTimeout,
+            long telemetryStartTimestamp,
+            CancellationToken cancellationToken)
+        {
+            _connection = connection;
+            _pending = pending;
+            _correlationId = correlationId;
+            _apiVersion = apiVersion;
+            _callerOwnsTimeout = callerOwnsTimeout;
+            _telemetryStartTimestamp = telemetryStartTimestamp;
+            _cancellationToken = cancellationToken;
+            _canceled = false;
+            _consumerState = ConsumerActive;
+            connection.LogWaitingForResponse(correlationId);
+
+            if (callerOwnsTimeout && cancellationToken.CanBeCanceled)
+            {
+                pending.RegisterCancellation(cancellationToken);
+            }
+            else
+            {
+                _timeoutCts = connection._timeoutCtsPool.Rent();
+                _timeoutCts.CancelAfter(connection._options.RequestTimeout);
+                if (cancellationToken.CanBeCanceled)
+                {
+                    _callerRegistration = cancellationToken.Register(
+                        static state => ((CancellationTokenSource)state!).Cancel(),
+                        _timeoutCts);
+                }
+
+                pending.RegisterCancellation(_timeoutCts.Token);
+            }
+
+            _pendingTask = pending.AsValueTask();
+            var awaiter = _pendingTask.GetAwaiter();
+            if (awaiter.IsCompleted)
+                CompletePendingResponse();
+            else
+                awaiter.UnsafeOnCompleted(_pendingContinuation);
+        }
+
+        private void CompletePendingResponse()
+        {
+            var connection = _connection!;
+            var pending = _pending!;
+            var responseReceived = false;
+            TResponse response = default!;
+            Exception? exception = null;
+
+            try
+            {
+                var pooledBuffer = _pendingTask.GetAwaiter().GetResult();
+                responseReceived = true;
+                connection.LogResponseReceived(_correlationId);
+
+                response = ParsePipelinedResponse<TRequest, TResponse>(
+                    pooledBuffer,
+                    _apiVersion,
+                    pending.CheckCrcs);
+
+                connection.Touch();
+                connection._telemetryMetricCollector?.RecordRequestLatency(
+                    connection.BrokerId,
+                    _telemetryStartTimestamp);
+            }
+            catch (OperationCanceledException) when (_cancellationToken.IsCancellationRequested)
+            {
+                exception = _callerOwnsTimeout
+                    ? connection.CreateResponseTimeoutException(
+                        KafkaMessageMetadata<TRequest, TResponse>.ApiKey,
+                        _correlationId)
+                    : new OperationCanceledException(_cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                exception = connection.CreateResponseTimeoutException(
+                    KafkaMessageMetadata<TRequest, TResponse>.ApiKey,
+                    _correlationId);
+            }
+            catch (Exception responseException)
+            {
+                exception = responseException;
+            }
+            finally
+            {
+                pending.DisposeRegistration();
+                _callerRegistration.Dispose();
+                _callerRegistration = default;
+                _timeoutCts?.Dispose();
+                _timeoutCts = null;
+                connection.CompletePipelinedResponse(pending, _correlationId, responseReceived);
+            }
+
+            var returnAbandoned = Interlocked.CompareExchange(
+                ref _consumerState,
+                ConsumerReturned,
+                ConsumerAbandoned) == ConsumerAbandoned;
+            var token = _core.Version;
+            if (exception is null)
+            {
+                _core.SetResult(response);
+            }
+            else
+            {
+                _canceled = exception is OperationCanceledException;
+                _core.SetException(exception);
+            }
+
+            // An abandoned response has no consumer that can recycle this source. Ownership
+            // was claimed before publication, so no GetResult path can race this return.
+            // Active responses must not touch mutable state after SetResult/SetException:
+            // their consumer may already have returned and re-rented this instance.
+            if (returnAbandoned)
+            {
+                try
+                {
+                    _ = _core.GetResult(token);
+                }
+                catch
+                {
+                    // Abandoned callers intentionally discard terminal errors.
+                }
+
+                ReturnToPool();
+            }
+        }
+
+        public void Abandon(short token)
+        {
+            if (token != _core.Version
+                || Interlocked.CompareExchange(
+                    ref _consumerState,
+                    ConsumerAbandoned,
+                    ConsumerActive) != ConsumerActive)
+            {
+                return;
+            }
+
+            ReturnIfAbandoned();
+        }
+
+        private void ReturnIfAbandoned()
+        {
+            if (_core.GetStatus(_core.Version) == ValueTaskSourceStatus.Pending
+                || Interlocked.CompareExchange(
+                    ref _consumerState,
+                    ConsumerReturned,
+                    ConsumerAbandoned) != ConsumerAbandoned)
+            {
+                return;
+            }
+
+            try
+            {
+                _ = _core.GetResult(_core.Version);
+            }
+            catch
+            {
+                // Abandoned callers intentionally discard terminal errors.
+            }
+
+            ReturnToPool();
+        }
+
+        private void ReturnToPool()
+        {
+            _connection = null;
+            _pending = null;
+            _pendingTask = default;
+            _cancellationToken = default;
+            _correlationId = 0;
+            _apiVersion = 0;
+            _callerOwnsTimeout = false;
+            _canceled = false;
+            _telemetryStartTimestamp = 0;
+            _core.Reset();
+
+            if (Interlocked.Increment(ref s_poolCount) <= MaxPoolSize)
+            {
+                Pool.Push(this);
+            }
+            else
+            {
+                Interlocked.Decrement(ref s_poolCount);
+            }
+        }
+
+        TResponse IValueTaskSource<TResponse>.GetResult(short token)
+        {
+            try
+            {
+                return _core.GetResult(token);
+            }
+            finally
+            {
+                if (Interlocked.CompareExchange(
+                    ref _consumerState,
+                    ConsumerReturned,
+                    ConsumerActive) == ConsumerActive)
+                {
+                    ReturnToPool();
+                }
+            }
+        }
+
+        ValueTaskSourceStatus IValueTaskSource<TResponse>.GetStatus(short token)
+        {
+            var status = _core.GetStatus(token);
+            return _canceled && status == ValueTaskSourceStatus.Faulted
+                ? ValueTaskSourceStatus.Canceled
+                : status;
+        }
+
+        void IValueTaskSource<TResponse>.OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
     }
 
     /// <summary>
@@ -852,43 +1144,35 @@ public sealed partial class KafkaConnection :
 
             LogResponseReceived(correlationId);
 
-            var isFetchResponse = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.Fetch;
-
-            if (isFetchResponse)
-            {
-                return ParseFetchResponse<TRequest, TResponse>(
-                    pooledBuffer,
-                    apiVersion,
-                    pending.CheckCrcs);
-            }
-            else
-            {
-                try
-                {
-                    var reader = new KafkaProtocolReader(pooledBuffer.Data);
-                    return KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
-                }
-                finally
-                {
-                    pooledBuffer.Dispose();
-                }
-            }
+            return ParsePipelinedResponse<TRequest, TResponse>(
+                pooledBuffer,
+                apiVersion,
+                pending.CheckCrcs);
         }
         finally
         {
-            if (TryRemovePendingRequest(correlationId, out var removed))
-            {
-                _pendingRequestPool.Return(removed.Request);
+            CompletePipelinedResponse(pending, correlationId, responseReceived);
+        }
+    }
 
-                // Broker may still send a response for a timed-out/cancelled request.
-                // Record it so the receive loop discards silently instead of warning.
-                // If the receive loop already called TryComplete (and lost the CAS),
-                // this entry becomes a harmless no-op cleaned up by DisposeAsync.
-                if (!responseReceived)
-                {
-                    _cancelledCorrelationIds.TryAdd(correlationId);
-                }
-            }
+    private static TResponse ParsePipelinedResponse<TRequest, TResponse>(
+        PooledResponseBuffer pooledBuffer,
+        short apiVersion,
+        bool checkCrcs)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        if (KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.Fetch)
+            return ParseFetchResponse<TRequest, TResponse>(pooledBuffer, apiVersion, checkCrcs);
+
+        try
+        {
+            var reader = new KafkaProtocolReader(pooledBuffer.Data);
+            return KafkaMessageMetadata<TRequest, TResponse>.ReadResponse(ref reader, apiVersion);
+        }
+        finally
+        {
+            pooledBuffer.Dispose();
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -141,6 +141,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly Action<int>? _onBrokerThrottle;
     private readonly Action? _onBlockedBucketRequeued;
+    private readonly Action? _onPipelinedResponseAcquired;
     private readonly Func<long> _getTimestamp;
     private readonly Func<int, CancellationToken, ValueTask> _delayForThrottle;
     private readonly TimeSpan _disposalDrainTimeout;
@@ -679,7 +680,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         Action? onBlockedBucketRequeued = null,
         BrokerUnackedByteBudget? unackedBudget = null,
         TimeSpan? disposalDrainTimeout = null,
-        Func<bool>? usesTransactionV2 = null)
+        Func<bool>? usesTransactionV2 = null,
+        Action? onPipelinedResponseAcquired = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -703,6 +705,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _getTimestamp = getTimestamp ?? Stopwatch.GetTimestamp;
         _delayForThrottle = delayForThrottle ?? DelayForThrottleAsync;
         _onBlockedBucketRequeued = onBlockedBucketRequeued;
+        _onPipelinedResponseAcquired = onPipelinedResponseAcquired;
         _disposalDrainTimeout = disposalDrainTimeout ?? DisposalDrainTimeout;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
@@ -2978,6 +2981,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // array — catch blocks must NOT return them to ArrayPool, or they will be recycled
         // while PendingResponse still references them (causing cross-request batch contamination).
         var pendingResponseAdded = false;
+        var responseTask = default(PipelinedResponse<ProduceResponse>);
         try
         {
             // Assign sequences at send time (Java Kafka Sender pattern).
@@ -3161,10 +3165,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // Use the connection-owned timeout path for pipelined sends. The send loop can
                 // have multiple responses in flight on this connection; a reusable caller-owned
                 // CTS would let a later send reset or cancel an earlier response timeout.
-                var responseTask = await SendPipelinedAfterWriteAsync(
+                responseTask = await SendPipelinedAfterWriteAsync(
                     connection,
                     request,
                     (short)apiVersion).ConfigureAwait(false);
+                _onPipelinedResponseAcquired?.Invoke();
                 // Response RTT starts after the request is written. Including request
                 // construction and TCP write time biases admission-rate samples low.
                 var rttStartTime = Stopwatch.GetTimestamp();
@@ -3361,7 +3366,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // The generations snapshot transfers to PendingResponse along with the batches
             // array; ReturnBatchesArray returns both. On every other path it is owned here.
             if (!pendingResponseAdded)
+            {
+                responseTask.Abandon();
                 ArrayPool<int>.Shared.Return(generations);
+            }
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1750,6 +1750,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                     redeliver, disposedException,
                                     recoveredBatches, recoveredBatchSet);
                         }
+                        pr.ResponseTask.Abandon();
                         pr.ReturnBatchesArray();
                     }
                     Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
@@ -4333,6 +4334,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         }
                     }
 
+                    pr.ResponseTask.Abandon();
                     pr.ReturnBatchesArray();
                 }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -154,7 +154,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // HandleTimedOutRequests (Java pattern) checks request timeout centrally and fails all
     // pending responses on timeout, invalidating the connection.
     private readonly record struct PendingResponse(
-        Task<ProduceResponse> ResponseTask,
+        PipelinedResponse<ProduceResponse> ResponseTask,
         ReadyBatch[] Batches,
         int[] BatchGenerations,
         int Count,
@@ -170,7 +170,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// it is returned by <see cref="ReturnBatchesArray"/>.
         /// </summary>
         public static PendingResponse Create(
-            Task<ProduceResponse> responseTask, ReadyBatch[] batches, int[] generations,
+            PipelinedResponse<ProduceResponse> responseTask, ReadyBatch[] batches, int[] generations,
             int count, long encodedBytes, long requestStartTime, long rttStartTime)
             => new(responseTask, batches, generations, count, encodedBytes,
                 requestStartTime, rttStartTime);
@@ -2123,7 +2123,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             batches[i]?.ReleaseResourcePin();
     }
 
-    private ValueTask<Task<ProduceResponse>> SendPipelinedAfterWriteAsync(
+    private ValueTask<PipelinedResponse<ProduceResponse>> SendPipelinedAfterWriteAsync(
         IKafkaConnection connection,
         ProduceRequest request,
         short apiVersion)
@@ -2300,7 +2300,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 if (task.IsFaulted || task.IsCanceled)
                 {
-                    var ex = task.Exception?.InnerException ?? new OperationCanceledException();
+                    Exception ex;
+                    try
+                    {
+                        _ = task.GetResult();
+                        ex = new OperationCanceledException();
+                    }
+                    catch (Exception responseException)
+                    {
+                        ex = responseException;
+                    }
                     LogResponseFailed(ex, _brokerId);
                     _pinnedConnections[connIdx] = null; // Invalidate only the affected connection
 
@@ -2327,7 +2336,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     continue;
                 }
 
-                var response = task.Result;
+                var response = task.GetResult();
                 ObserveBrokerThrottle(response.ThrottleTimeMs);
                 var allPartitionsSucceeded = true;
                 // Reuse caller-provided dictionary to avoid per-response allocation.
@@ -2670,6 +2679,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                 }
 
+                pending.ResponseTask.Abandon();
                 pending.ReturnBatchesArray();
             }
 
@@ -3236,8 +3246,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // Unlike ContinueWith(ExecuteSynchronously), UnsafeOnCompleted schedules the
                     // callback on the ThreadPool rather than running inline on the completing thread.
                     // This is intentional — it keeps the I/O completion thread free.
-                    responseTask.ConfigureAwait(false).GetAwaiter()
-                        .UnsafeOnCompleted(_responseCompletionCallback);
+                    responseTask.UnsafeOnCompleted(_responseCompletionCallback);
                 }
 
                 // A request limit of one keeps its partition muted until the response.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2342,7 +2342,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     var requestWrittenCallback = afterRequestWrittenAsync;
                     afterRequestWrittenAsync = null;
                     await requestWrittenCallback().ConfigureAwait(false);
-                    response = await responseTask.ConfigureAwait(false);
+                    response = await responseTask.AsValueTask().ConfigureAwait(false);
                 }
             }
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2339,10 +2339,22 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
                             request, apiVersion, cancellationToken)
                         .ConfigureAwait(false);
-                    var requestWrittenCallback = afterRequestWrittenAsync;
-                    afterRequestWrittenAsync = null;
-                    await requestWrittenCallback().ConfigureAwait(false);
-                    response = await responseTask.AsValueTask().ConfigureAwait(false);
+                    var responseConsumptionStarted = false;
+                    try
+                    {
+                        var requestWrittenCallback = afterRequestWrittenAsync;
+                        afterRequestWrittenAsync = null;
+                        await requestWrittenCallback().ConfigureAwait(false);
+
+                        var responseValueTask = responseTask.AsValueTask();
+                        responseConsumptionStarted = true;
+                        response = await responseValueTask.ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        if (!responseConsumptionStarted)
+                            responseTask.Abandon();
+                    }
                 }
             }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Security;
@@ -215,6 +216,114 @@ public sealed class KafkaConnectionTests
 
             var act = async () => await sendTask;
             await Assert.That(act).Throws<TimeoutException>();
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [NotInParallel]
+    [Timeout(10_000)]
+    public async Task PipelinedResponse_AbandonRace_ReturnsOperationToPool(
+        bool abandonBeforeCompletion,
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            using var callerTimeout = new CancellationTokenSource();
+
+            var response = await ((IKafkaPipelinedWriteCompletionConnection)connection)
+                .SendPipelinedWithCallerTimeoutAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    callerTimeout.Token);
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+
+            if (abandonBeforeCompletion)
+                response.Abandon();
+
+            await callerTimeout.CancelAsync();
+            if (!abandonBeforeCompletion)
+            {
+                while (!response.IsCompleted)
+                    await Task.Yield();
+                response.Abandon();
+            }
+
+            while (KafkaConnection.GetPipelinedResponsePoolCount<
+                       ApiVersionsRequest,
+                       ApiVersionsResponse>() < expectedAfterReturn)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    [Timeout(10_000)]
+    public async Task PipelinedResponse_ParsesAndReturnsOperationToPool(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var response = await ((IKafkaPipelinedWriteCompletionConnection)connection)
+                .SendPipelinedAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    cancellationToken);
+            var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
+            await serverClient.GetStream().WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken);
+
+            while (!response.IsCompleted)
+                await Task.Yield();
+            var parsed = response.GetResult();
+
+            await Assert.That(parsed.ErrorCode).IsEqualTo(ErrorCode.None);
+            await Assert.That(parsed.ApiKeys).HasSingleItem();
+            await Assert.That(KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>()).IsEqualTo(expectedAfterReturn);
         }
         finally
         {
@@ -654,6 +763,26 @@ public sealed class KafkaConnectionTests
             validateServerCertificateHostName: false);
 
         await Assert.That(result).IsEqualTo(SslPolicyErrors.None);
+    }
+
+    private static byte[] BuildApiVersionsV3ResponseFrame(int correlationId)
+    {
+        var bodyBuffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(bodyBuffer);
+        writer.WriteInt16(0);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ApiKey.ApiVersions);
+        writer.WriteInt16(0);
+        writer.WriteInt16(3);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt32(0);
+        writer.WriteEmptyTaggedFields();
+
+        var frame = new byte[8 + bodyBuffer.WrittenCount];
+        BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - 4);
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(4), correlationId);
+        bodyBuffer.WrittenSpan.CopyTo(frame.AsSpan(8));
+        return frame;
     }
 
     private static async Task<byte[]> ReadRequestFrameAsync(NetworkStream stream, CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -286,6 +286,67 @@ public sealed class KafkaConnectionTests
     [Test]
     [NotInParallel]
     [Timeout(10_000)]
+    public async Task PipelinedResponse_AbandonDuringPublication_ReturnsOperationToPool(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var beforePublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePublish = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        KafkaConnection.PipelinedResponseBeforePublishTestHook = () =>
+        {
+            beforePublish.TrySetResult();
+            releasePublish.Task.GetAwaiter().GetResult();
+        };
+
+        try
+        {
+            var baseline = KafkaConnection.GetPipelinedResponsePoolCount<
+                ApiVersionsRequest,
+                ApiVersionsResponse>();
+            var expectedAfterReturn = Math.Max(1, baseline);
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            using var callerTimeout = new CancellationTokenSource();
+
+            var response = await ((IKafkaPipelinedWriteCompletionConnection)connection)
+                .SendPipelinedWithCallerTimeoutAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    callerTimeout.Token);
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+
+            var cancelTask = callerTimeout.CancelAsync();
+            await beforePublish.Task.WaitAsync(cancellationToken);
+            response.Abandon();
+            releasePublish.TrySetResult();
+            await cancelTask.WaitAsync(cancellationToken);
+
+            while (KafkaConnection.GetPipelinedResponsePoolCount<
+                       ApiVersionsRequest,
+                       ApiVersionsResponse>() < expectedAfterReturn)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+        finally
+        {
+            releasePublish.TrySetResult();
+            KafkaConnection.PipelinedResponseBeforePublishTestHook = null;
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [NotInParallel]
+    [Timeout(10_000)]
     public async Task PipelinedResponse_ParsesAndReturnsOperationToPool(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -46,6 +46,42 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [Timeout(120_000)]
+    public async Task SendFailure_AfterPipelinedResponseAcquired_IsAbandoned(
+        CancellationToken cancellationToken)
+    {
+        var responseSource = new TrackingPipelinedResponseSource();
+        var connection = new TestKafkaConnection { PipelinedResponseSource = responseSource };
+        var (pool, _) = CreateScaleTrackingPool(connection);
+        var options = CreateOptions(retryBackoffMs: 60_000, retryBackoffMaxMs: 60_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            onPipelinedResponseAcquired: () => throw new InvalidOperationException("test"));
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+
+            await WaitUntilAsync(
+                () => Volatile.Read(ref responseSource.AbandonCalls) == 1,
+                cancellationToken);
+
+            await Assert.That(Volatile.Read(ref responseSource.AbandonCalls)).IsEqualTo(1);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ShouldMicroLinger_TransactionalAwaitedBatch_ReturnsFalse()
     {
         var batch = new ReadyBatch();
@@ -321,6 +357,7 @@ public sealed class BrokerSenderSendLoopTests
         Func<long>? getTimestamp = null,
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
+        Action? onPipelinedResponseAcquired = null,
         BrokerUnackedByteBudget? unackedBudget = null,
         int produceApiVersion = 9,
         bool isTransactional = false,
@@ -345,7 +382,8 @@ public sealed class BrokerSenderSendLoopTests
             delayForThrottle: delayForThrottle,
             onBlockedBucketRequeued: onBlockedBucketRequeued,
             unackedBudget: unackedBudget,
-            usesTransactionV2: () => usesTransactionV2);
+            usesTransactionV2: () => usesTransactionV2,
+            onPipelinedResponseAcquired: onPipelinedResponseAcquired);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Metadata;
@@ -25,6 +26,25 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerSenderSendLoopTests
 {
+    private sealed class TrackingPipelinedResponseSource : IPipelinedResponseSource<ProduceResponse>
+    {
+        public int AbandonCalls;
+
+        public void Abandon(short token) => Interlocked.Increment(ref AbandonCalls);
+
+        public ProduceResponse GetResult(short token) => throw new InvalidOperationException();
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Pending;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags)
+        {
+        }
+    }
+
     [Test]
     public async Task ShouldMicroLinger_TransactionalAwaitedBatch_ReturnsFalse()
     {
@@ -398,6 +418,38 @@ public sealed class BrokerSenderSendLoopTests
         {
             retryResponse.TrySetResult(
                 CreateSuccessResponse("test-topic", partition: 0, baseOffset: 42));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task DisposeAsync_PendingPipelinedResponse_IsAbandoned(
+        CancellationToken cancellationToken)
+    {
+        var responseSource = new TrackingPipelinedResponseSource();
+        var connection = new TestKafkaConnection { PipelinedResponseSource = responseSource };
+        var (pool, _) = CreateScaleTrackingPool(connection);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+            await WaitUntilAsync(
+                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 1,
+                cancellationToken);
+
+            await sender.DisposeAsync();
+
+            await Assert.That(Volatile.Read(ref responseSource.AbandonCalls)).IsEqualTo(1);
+        }
+        finally
+        {
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Compression;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
@@ -163,7 +164,8 @@ public sealed class ReadyBatchIncarnationTests
         var capturedGeneration = batch.Generation;
         var batches = new[] { batch };
         var generations = new[] { capturedGeneration };
-        var responseTask = Task.FromResult(new ProduceResponse());
+        var responseTask = new PipelinedResponse<ProduceResponse>(
+            Task.FromResult(new ProduceResponse()));
         var create = PendingResponseType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
         var timestamp = Stopwatch.GetTimestamp();
         var pending = create.Invoke(

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -33,6 +33,7 @@ internal sealed class TestKafkaConnection :
         TaskCreationOptions.RunContinuationsAsynchronously);
 
     public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
+    public IPipelinedResponseSource<ProduceResponse>? PipelinedResponseSource { get; set; }
     public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
     public Func<Type, object>? SendResponse { get; set; }
 
@@ -143,6 +144,12 @@ internal sealed class TestKafkaConnection :
         where TResponse : IKafkaResponse
     {
         Interlocked.Increment(ref SendPipelinedAfterWriteCalls);
+
+        if (PipelinedResponseSource is not null)
+        {
+            var source = (IPipelinedResponseSource<TResponse>)(object)PipelinedResponseSource;
+            return new PipelinedResponse<TResponse>(source, token: 0);
+        }
 
         if (SendProducePipelinedAfterWrite is null)
             throw new NotSupportedException();

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -135,7 +135,7 @@ internal sealed class TestKafkaConnection :
         Volatile.Write(ref _retirementState, 2);
     }
 
-    public async ValueTask<Task<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+    public async ValueTask<PipelinedResponse<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken = default)
@@ -148,10 +148,10 @@ internal sealed class TestKafkaConnection :
             throw new NotSupportedException();
 
         var responseTask = await SendProducePipelinedAfterWrite().ConfigureAwait(false);
-        return CastResponseTask<TResponse>(responseTask);
+        return new PipelinedResponse<TResponse>(CastResponseTask<TResponse>(responseTask));
     }
 
-    public async ValueTask<Task<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+    public async ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
 using Dekaf.Internal;
 using Dekaf.Metadata;
@@ -544,6 +545,26 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task CommitAfterRequestWrittenAsync_CallbackFailure_AbandonsResponse()
+    {
+        var preparedState = new PreparedTransactionState(1001, 4);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+        var callbackFailure = new InvalidOperationException("callback failed");
+
+        var exception = await Assert.That(() => transaction.CommitAfterRequestWrittenAsync(
+                () => ValueTask.FromException(callbackFailure)).AsTask())
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception).IsSameReferenceAs(callbackFailure);
+        await Assert.That(harness.PipelinedResponseAbandonCalls).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ReinitializeProducerIdAsync_HoldsConnectionLeaseDuringRequest()
     {
         var preparedState = new PreparedTransactionState(1001, 4);
@@ -893,6 +914,7 @@ public sealed class TransactionTests
             ?? throw new InvalidOperationException("EndTxn request was not captured.");
         public int LeaseCountDuringRequest => connection.LeaseCountDuringRequest;
         public int LeaseCount => connection.LeaseCount;
+        public int PipelinedResponseAbandonCalls => connection.PipelinedResponseAbandonCalls;
 
         public async ValueTask DisposeAsync()
         {
@@ -905,8 +927,10 @@ public sealed class TransactionTests
         PreparedTransactionState preparedState,
         long producerId,
         short producerEpoch,
-        ErrorCode endTxnError) : IKafkaConnection, IRetirableKafkaConnection
+        ErrorCode endTxnError) : IKafkaConnection, IRetirableKafkaConnection,
+        IKafkaPipelinedWriteCompletionConnection
     {
+        private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
         private int _leaseCount;
         private int _leaseCountDuringRequest = -1;
 
@@ -918,6 +942,7 @@ public sealed class TransactionTests
         public int LeaseCount => Volatile.Read(ref _leaseCount);
         public int LeaseCountDuringRequest => Volatile.Read(ref _leaseCountDuringRequest);
         public int ActiveOperationCount => 0;
+        public int PipelinedResponseAbandonCalls => _pipelinedResponseSource.AbandonCalls;
 
         public bool TryAcquireLease()
         {
@@ -996,5 +1021,52 @@ public sealed class TransactionTests
             where TRequest : IKafkaRequest<TResponse>
             where TResponse : IKafkaResponse
             => throw new NotSupportedException();
+
+        public ValueTask<PipelinedResponse<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is not EndTxnRequest endTxnRequest)
+                throw new NotSupportedException();
+
+            Volatile.Write(ref _leaseCountDuringRequest, LeaseCount);
+            _pipelinedResponseSource.SetResult(CreateEndTxnResponse(endTxnRequest));
+            return ValueTask.FromResult(new PipelinedResponse<TResponse>(
+                (IPipelinedResponseSource<TResponse>)(object)_pipelinedResponseSource,
+                token: 0));
+        }
+
+        public ValueTask<PipelinedResponse<TResponse>>
+            SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
+                TRequest request,
+                short apiVersion,
+                CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+    }
+
+    private sealed class TrackingResponseSource<TResponse> : IPipelinedResponseSource<TResponse>
+    {
+        private TResponse? _response;
+
+        public int AbandonCalls { get; private set; }
+
+        public void SetResult(TResponse response) => _response = response;
+
+        public TResponse GetResult(short token) => _response!;
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Succeeded;
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) => continuation(state);
+
+        public void Abandon(short token) => AbandonCalls++;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
@@ -1,0 +1,128 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures one small pipelined request/response round trip. The public baseline retains
+/// its compatibility <see cref="Task{TResult}"/> adapter; the producer path consumes the
+/// pooled response source directly.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class PipelinedResponseAllocationBenchmarks
+{
+    private TcpListener _listener = null!;
+    private TcpClient _serverClient = null!;
+    private KafkaConnection _connection = null!;
+    private CancellationTokenSource _serverCancellation = null!;
+    private Task _serverTask = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        var acceptTask = _listener.AcceptTcpClientAsync();
+        _connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+        await _connection.ConnectAsync().ConfigureAwait(false);
+        _serverClient = await acceptTask.ConfigureAwait(false);
+        _serverCancellation = new CancellationTokenSource();
+        _serverTask = RunServerAsync(_serverClient.GetStream(), _serverCancellation.Token);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<ErrorCode> PublicTaskAdapter()
+    {
+        var response = await _connection.SendPipelinedAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            CreateRequest(),
+            apiVersion: 3).ConfigureAwait(false);
+        return response.ErrorCode;
+    }
+
+    [Benchmark]
+    public async ValueTask<ErrorCode> PooledProducerPath()
+    {
+        var response = await ((IKafkaPipelinedWriteCompletionConnection)_connection)
+            .SendPipelinedAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                CreateRequest(),
+                apiVersion: 3).ConfigureAwait(false);
+        var parsed = await response.AsValueTask().ConfigureAwait(false);
+        return parsed.ErrorCode;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _serverCancellation.CancelAsync().ConfigureAwait(false);
+        await _connection.DisposeAsync().ConfigureAwait(false);
+        try
+        {
+            await _serverTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        _serverClient.Dispose();
+        _listener.Stop();
+        _serverCancellation.Dispose();
+    }
+
+    private static ApiVersionsRequest CreateRequest() => new()
+    {
+        ClientSoftwareName = "benchmark",
+        ClientSoftwareVersion = "1.0"
+    };
+
+    private static async Task RunServerAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var lengthBuffer = new byte[4];
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+            var length = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
+            var request = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                await stream.ReadExactlyAsync(request.AsMemory(0, length), cancellationToken)
+                    .ConfigureAwait(false);
+                var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4, 4));
+                await stream.WriteAsync(BuildResponseFrame(correlationId), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(request);
+            }
+        }
+    }
+
+    private static byte[] BuildResponseFrame(int correlationId)
+    {
+        var bodyBuffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(bodyBuffer);
+        writer.WriteInt16(0);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ApiKey.ApiVersions);
+        writer.WriteInt16(0);
+        writer.WriteInt16(3);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt32(0);
+        writer.WriteEmptyTaggedFields();
+
+        var frame = new byte[8 + bodyBuffer.WrittenCount];
+        BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - 4);
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(4), correlationId);
+        bodyBuffer.WrittenSpan.CopyTo(frame.AsSpan(8));
+        return frame;
+    }
+}


### PR DESCRIPTION
Closes #1925

Replaces the per-request pipelined response parsing/cleanup Task state machine with a typed pooled IValueTaskSource operation. BrokerSender polls and consumes the pooled response directly; public Task APIs remain compatibility adapters. Explicit abandonment handles request-timeout removal without leaking pooled operations.

Validation:
- net10 unit suite: 5,232 passed
- net8 unit suite: 5,143 passed
- netstandard2.0 build passed
- multi-inflight integration: 7 passed
- multi-connection producer integration: 8 passed
- transaction integration: 5 passed
- BenchmarkDotNet: 959 B/request public Task adapter vs 776 B/request pooled producer path (19% reduction)