### PR TITLE
Retry Docker address-in-use port collisions

### DIFF
--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
@@ -45,7 +45,8 @@ internal static class ContainerStartupRetry
     internal static bool IsPortBindingCollision(Exception exception) =>
         Contains(exception, static candidate =>
             candidate is DockerApiException &&
-            candidate.Message.Contains("port is already allocated", StringComparison.OrdinalIgnoreCase));
+            (candidate.Message.Contains("port is already allocated", StringComparison.OrdinalIgnoreCase) ||
+             candidate.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase)));
 
     internal static bool IsKafkaStartupScriptBusy(Exception exception) =>
         Contains(exception, static candidate =>

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -8,7 +8,9 @@ namespace Dekaf.Tests.Integration;
 public sealed class ContainerStartupRetryTests
 {
     [Test]
-    public async Task RunAsync_PortBindingCollision_UsesFreshAttempt()
+    [Arguments("Bind for 0.0.0.0:32769 failed: port is already allocated")]
+    [Arguments("failed to bind host port 0.0.0.0:58162/tcp: address already in use")]
+    public async Task RunAsync_PortBindingCollision_UsesFreshAttempt(string message)
     {
         var attempts = 0;
         var cleanups = 0;
@@ -17,7 +19,7 @@ public sealed class ContainerStartupRetryTests
             () => ++attempts == 1
                 ? Task.FromException(new DockerApiException(
                     HttpStatusCode.InternalServerError,
-                    "Bind for 0.0.0.0:32769 failed: port is already allocated"))
+                    message))
                 : Task.CompletedTask,
             () =>
             {


### PR DESCRIPTION
Closes #1915.

Recognizes Docker Desktop's `address already in use` host-port collision wording while retaining `DockerApiException` gating and the existing `port is already allocated` behavior. Parameterized coverage exercises both variants.

Verification:
- `ContainerStartupRetryTests`: 9/9
- net8 / Kafka 4.2.1 Consumer release-matrix cell: 227/227 across Consumer, ConsumerLag, ConsumerGroup, Offsets, ShareConsumer, and ShareConsumerAdmin

#1916 is the duplicate and can close when this lands.