### PR TITLE
test(stress): use Kafka 4.3.1

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -187,7 +187,7 @@ jobs:
             -e KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=1000 \
             -e KAFKA_LOG_INITIAL_TASK_DELAY_MS=1000 \
             -e KAFKA_LOG_CLEANUP_POLICY=delete \
-            apache/kafka:latest
+            apache/kafka:4.3.1
 
           echo "Waiting for Kafka to be ready..."
           for i in {1..60}; do

--- a/tests/Dekaf.Tests.Unit/StressTests/KafkaEnvironmentTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/KafkaEnvironmentTests.cs
@@ -6,15 +6,11 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class KafkaEnvironmentTests
 {
     [Test]
-    public async Task SingleBrokerConfiguration_EnablesKip848ConsumerProtocol()
+    public async Task StressBrokerConfiguration_UsesLatestKafka()
     {
-        await Assert.That(KafkaEnvironment.SingleBrokerImage)
-            .IsEqualTo("confluentinc/cp-kafka:7.8.0");
+        await Assert.That(KafkaEnvironment.KafkaImage)
+            .IsEqualTo("apache/kafka:4.3.1");
         await Assert.That(KafkaEnvironment.SingleBrokerConsensusProtocol)
             .IsEqualTo(ConsensusProtocol.KRaft);
-        await Assert.That(KafkaEnvironment.SingleBrokerEnvironment)
-            .ContainsKey("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS");
-        await Assert.That(KafkaEnvironment.SingleBrokerEnvironment["KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS"])
-            .IsEqualTo("classic,consumer");
     }
 }

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -1,5 +1,6 @@
 using Confluent.Kafka;
 using Dekaf.Admin;
+using Dekaf.StressTests.Infrastructure;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using DotNet.Testcontainers.Builders;
@@ -19,7 +20,6 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
     private const ushort InternalBrokerPort = 9092;
     private const ushort ControllerPort = 9093;
     private const ushort ExternalBrokerPort = 29092;
-    private const string KafkaImage = "apache/kafka:4.1.2";
     private const string ToxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0";
     private const string ClusterId = "MkU3OEVBNTcwNTJENDM2Qg";
 
@@ -120,7 +120,7 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
                 var proxyPort = checked((ushort)(ToxiproxyBuilder.FirstProxiedPort + nodeId - 1));
                 var mappedProxyPort = toxiproxyContainer.GetMappedPublicPort(proxyPort);
 
-                var broker = new ContainerBuilder(KafkaImage)
+                var broker = new ContainerBuilder(KafkaEnvironment.KafkaImage)
                     .WithName($"{hostname}-fault-{Guid.NewGuid():N}")
                     .WithHostname(hostname)
                     .WithNetwork(network)

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -1,6 +1,8 @@
-using Docker.DotNet.Models;
+using System.Text;
 using Dekaf.Admin;
+using Docker.DotNet.Models;
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Testcontainers.Kafka;
@@ -14,16 +16,16 @@ namespace Dekaf.StressTests.Infrastructure;
 /// </summary>
 internal sealed class KafkaEnvironment : IAsyncDisposable
 {
-    internal const string SingleBrokerImage = "confluentinc/cp-kafka:7.8.0";
+    internal const string KafkaImage = "apache/kafka:4.3.1";
     internal static ConsensusProtocol SingleBrokerConsensusProtocol { get; } = ConsensusProtocol.KRaft;
 
-    internal static IReadOnlyDictionary<string, string> SingleBrokerEnvironment { get; } =
-        new Dictionary<string, string>
-        {
-            // Kafka 3.8 ships KIP-848 disabled by default. Dekaf defaults to the
-            // consumer protocol, so local consumer stress runs must enable it.
-            ["KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS"] = "classic,consumer",
-        };
+    // Testcontainers.Kafka emits a trailing comma in KAFKA_ADVERTISED_LISTENERS
+    // when no extra listener is configured. Kafka 4.2+ rejects that empty value.
+    private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
+        "#!/bin/bash\n" +
+        "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
+        "/etc/kafka/docker/configure\n" +
+        "exec /etc/kafka/docker/launch\n");
 
     // Retention tuned to balance two constraints:
     // 1. Original 5s retention was too aggressive — caused constant "offset out of range" resets
@@ -153,9 +155,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     private static async Task<KafkaEnvironment> CreateSingleBrokerAsync()
     {
         Console.WriteLine("Starting Kafka container via Testcontainers...");
-        // 7.8.x = Kafka 3.8, the first release with log.initial.task.delay.ms — see
-        // RetentionConfig; older images silently ignore it and die on tmpfs fill.
-        var builder = new KafkaBuilder(SingleBrokerImage);
+        var builder = new KafkaBuilder(KafkaImage);
         builder = SingleBrokerConsensusProtocol switch
         {
             ConsensusProtocol.KRaft => builder.WithKRaft(),
@@ -165,14 +165,13 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
 
         builder = builder
             .WithPortBinding(9092, true)
+            .WithResourceMapping(RunWrapperScript, "/etc/kafka/docker/run", 0, 0,
+                UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
+                UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
+                UnixFileModes.OtherRead | UnixFileModes.OtherExecute)
             // Explicit log dir so the optional tmpfs mount target always matches
             .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
             .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
-
-        foreach (var (key, value) in SingleBrokerEnvironment)
-        {
-            builder = builder.WithEnvironment(key, value);
-        }
 
         foreach (var (key, value) in RetentionConfig)
         {
@@ -224,7 +223,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
             var hostname = $"kafka-{nodeId}";
             var externalPort = 29091 + nodeId; // 29092, 29093, 29094
 
-            var containerBuilder = new ContainerBuilder("apache/kafka:4.1.2")
+            var containerBuilder = new ContainerBuilder(KafkaImage)
                 .WithName($"{hostname}-{Guid.NewGuid():N}")
                 .WithHostname(hostname)
                 .WithNetwork(network)

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -23,9 +23,11 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     // when no extra listener is configured. Kafka 4.2+ rejects that empty value.
     private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
         "#!/bin/bash\n" +
+        ". /etc/kafka/docker/bash-config\n" +
         "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
-        "/etc/kafka/docker/configure\n" +
-        "exec /etc/kafka/docker/launch\n");
+        ". /etc/kafka/docker/configureDefaults\n" +
+        ". /etc/kafka/docker/configure\n" +
+        ". /etc/kafka/docker/launch\n");
 
     // Retention tuned to balance two constraints:
     // 1. Original 5s retention was too aggressive — caused constant "offset out of range" resets


### PR DESCRIPTION
## Summary
- pin all stress-test brokers to Apache Kafka 4.3.1
- share one image constant across single- and multi-broker local harnesses
- remove obsolete Kafka 3.8 consumer-protocol override
- work around the Testcontainers trailing advertised-listener entry rejected by Kafka 4.2+

## Why
Transactional CI already used Kafka 4.x, but local single-broker stress runs still used Kafka 3.8 and therefore exercised TV1. Aligning every path on Kafka 4.3.1 makes local and CI stress coverage exercise the current broker and TV2 behavior.

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net10.0 --no-restore`
- `Dekaf.Tests.Unit.exe --treenode-filter /*/*/KafkaEnvironmentTests/*` (1 passed)
- zero-duration `producer-transactional` smoke against local Kafka 4.3.1: broker ready, topic creation succeeded, `InitTransactionsAsync` and warm-up commit succeeded