### PR TITLE
Warm round-trip harness and report phase rates

### DIFF
--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -478,10 +478,103 @@ public class RoundTripMessageCodecTests
                 UnexpectedMessages = 0,
                 TimedOut = false
             },
+            RoundTripScenarioHelpers.CreatePhaseSnapshot(
+                producedMessages: 200,
+                produceElapsed: TimeSpan.FromSeconds(2),
+                consumedMessages: 200,
+                consumeElapsed: TimeSpan.FromSeconds(4)),
             snapshot);
 
         await Assert.That(result.ProducerDeliveryDiagnostics).IsSameReferenceAs(snapshot);
         await Assert.That(result.IsMessageBounded).IsTrue();
+        await Assert.That(result.RoundTripPhases!.ProduceMessagesPerSecond).IsEqualTo(100);
+        await Assert.That(result.RoundTripPhases.ConsumeMessagesPerSecond).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task RoundTripPhaseSnapshot_SerializesPhaseCountsDurationsAndRates()
+    {
+        var phases = RoundTripScenarioHelpers.CreatePhaseSnapshot(
+            producedMessages: 250_000,
+            produceElapsed: TimeSpan.FromSeconds(2),
+            consumedMessages: 250_000,
+            consumeElapsed: TimeSpan.FromSeconds(0.25));
+
+        var result = CreateRoundTripResult(phases);
+        var json = result.ToJson();
+        var restored = StressTestResult.FromJson(json);
+
+        await Assert.That(json).Contains("\"roundTripPhases\"");
+        await Assert.That(json).Contains("\"produceMessagesPerSecond\": 125000");
+        await Assert.That(json).Contains("\"consumeMessagesPerSecond\": 1000000");
+        await Assert.That(restored!.RoundTripPhases!.ProducedMessages).IsEqualTo(250_000);
+        await Assert.That(restored.RoundTripPhases.ProduceElapsedSeconds).IsEqualTo(2);
+        await Assert.That(restored.RoundTripPhases.ConsumedMessages).IsEqualTo(250_000);
+        await Assert.That(restored.RoundTripPhases.ConsumeElapsedSeconds).IsEqualTo(0.25);
+    }
+
+    [Test]
+    public async Task RoundTripPhaseSnapshot_ZeroDurationReportsZeroRate()
+    {
+        var phases = RoundTripScenarioHelpers.CreatePhaseSnapshot(
+            producedMessages: 1,
+            produceElapsed: TimeSpan.Zero,
+            consumedMessages: 1,
+            consumeElapsed: TimeSpan.Zero);
+
+        await Assert.That(phases.ProduceMessagesPerSecond).IsEqualTo(0);
+        await Assert.That(phases.ConsumeMessagesPerSecond).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RoundTripReport_ShowsProduceAndConsumePhaseRates()
+    {
+        var resultWithoutValidation = CreateRoundTripResult(RoundTripScenarioHelpers.CreatePhaseSnapshot(
+            producedMessages: 250_000,
+            produceElapsed: TimeSpan.FromSeconds(2),
+            consumedMessages: 250_000,
+            consumeElapsed: TimeSpan.FromSeconds(0.25)));
+        var result = WithValidation(resultWithoutValidation);
+        var now = DateTime.UtcNow;
+
+        var markdown = MarkdownReporter.Generate(new StressTestResults
+        {
+            RunStartedAtUtc = now,
+            RunCompletedAtUtc = now.AddSeconds(2.25),
+            MachineName = "test",
+            ProcessorCount = 1,
+            Results = [result]
+        });
+
+        await Assert.That(markdown).Contains("| Produce msg/s | Consume msg/s |");
+        await Assert.That(markdown).Contains("125,000");
+        await Assert.That(markdown).Contains("1,000,000");
+
+        static StressTestResult WithValidation(StressTestResult source) => new()
+        {
+            Scenario = source.Scenario,
+            Client = source.Client,
+            DurationMinutes = source.DurationMinutes,
+            MessageSizeBytes = source.MessageSizeBytes,
+            StartedAtUtc = source.StartedAtUtc,
+            CompletedAtUtc = source.CompletedAtUtc,
+            Throughput = source.Throughput,
+            GcStats = source.GcStats,
+            IsMessageBounded = true,
+            RoundTripPhases = source.RoundTripPhases,
+            RoundTripValidation = new RoundTripValidationSnapshot
+            {
+                ExpectedMessages = 250_000,
+                ConsumedMessages = 250_000,
+                MissingMessages = 0,
+                DuplicateMessages = 0,
+                CorruptMessages = 0,
+                OutOfOrderMessages = 0,
+                MispartitionedMessages = 0,
+                UnexpectedMessages = 0,
+                TimedOut = false
+            }
+        };
     }
 
     [Test]
@@ -518,5 +611,39 @@ public class RoundTripMessageCodecTests
         };
 
         await Assert.That(result.MedianIntervalMessagesPerSecond).IsNull();
+    }
+
+    private static StressTestResult CreateRoundTripResult(RoundTripPhaseSnapshot phases)
+    {
+        var now = DateTime.UtcNow;
+        return new StressTestResult
+        {
+            Scenario = "producer-roundtrip",
+            Client = "Dekaf",
+            DurationMinutes = 1,
+            MessageSizeBytes = 128,
+            StartedAtUtc = now,
+            CompletedAtUtc = now.AddSeconds(2.25),
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 250_000,
+                TotalBytes = 32_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 2.25,
+                AverageMessagesPerSecond = 111_111.11,
+                AverageMegabytesPerSecond = 13.56,
+                MessagesPerSecondSamples = [],
+                ErrorSamples = []
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            IsMessageBounded = true,
+            RoundTripPhases = phases
+        };
     }
 }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -432,14 +432,17 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## {title}");
         sb.AppendLine();
-        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Expected | Consumed | Missing | Duplicates | Corrupt | Out of Order | Wrong Partition | Unexpected | Timed Out | Result |");
-        sb.AppendLine($"|{new string('-', clientWidth + 2)}|----------|----------|---------|------------|---------|--------------|-----------------|------------|-----------|--------|");
+        sb.AppendLine($"| {"Client".PadRight(clientWidth)} | Produce msg/s | Consume msg/s | Expected | Consumed | Missing | Duplicates | Corrupt | Out of Order | Wrong Partition | Unexpected | Timed Out | Result |");
+        sb.AppendLine($"|{new string('-', clientWidth + 2)}|--------------:|--------------:|----------|----------|---------|------------|---------|--------------|-----------------|------------|-----------|--------|");
 
         foreach (var result in results.OrderBy(r => r.Client))
         {
             var validation = result.RoundTripValidation!;
+            var produceRate = result.RoundTripPhases?.ProduceMessagesPerSecond;
+            var consumeRate = result.RoundTripPhases?.ConsumeMessagesPerSecond;
             sb.AppendLine(
-                $"| {result.Client.PadRight(clientWidth)} | {validation.ExpectedMessages,8:N0} | " +
+                $"| {result.Client.PadRight(clientWidth)} | {produceRate?.ToString("N0") ?? "-",13} | " +
+                $"{consumeRate?.ToString("N0") ?? "-",13} | {validation.ExpectedMessages,8:N0} | " +
                 $"{validation.ConsumedMessages,8:N0} | {validation.MissingMessages,7:N0} | " +
                 $"{validation.DuplicateMessages,10:N0} | {validation.CorruptMessages,7:N0} | " +
                 $"{validation.OutOfOrderMessages,12:N0} | {validation.MispartitionedMessages,15:N0} | " +

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -31,6 +31,7 @@ internal sealed class StressTestResult
     public int BrokerCount { get; init; } = 1;
     public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
     public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
+    public RoundTripPhaseSnapshot? RoundTripPhases { get; init; }
 
     /// <summary>
     /// Whether a fixed message count, rather than <see cref="DurationMinutes"/>, defines
@@ -243,6 +244,20 @@ internal sealed class StressTestResult
 
     public static StressTestResult? FromJson(string json) =>
         JsonSerializer.Deserialize<StressTestResult>(json, JsonOptions);
+}
+
+internal sealed class RoundTripPhaseSnapshot
+{
+    public required long ProducedMessages { get; init; }
+    public required double ProduceElapsedSeconds { get; init; }
+    public required long ConsumedMessages { get; init; }
+    public required double ConsumeElapsedSeconds { get; init; }
+
+    public double ProduceMessagesPerSecond =>
+        ProduceElapsedSeconds > 0 ? ProducedMessages / ProduceElapsedSeconds : 0;
+
+    public double ConsumeMessagesPerSecond =>
+        ConsumeElapsedSeconds > 0 ? ConsumedMessages / ConsumeElapsedSeconds : 0;
 }
 
 internal sealed class TransactionVerificationSnapshot

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -167,18 +167,37 @@ internal static class ConfluentStressTestHelpers
     /// drain wait, warmup messages landing after the snapshot inflate the run's delivered
     /// count and can mask real loss.
     /// </summary>
-    internal static async Task<long?> WarmUpProducerAndQueryStartOffsetAsync(
+    internal static Task<long?> WarmUpProducerAndQueryStartOffsetAsync(
         ConfluentKafka.IProducer<string, string> producer,
         StressTestOptions options,
         string producerName,
-        ThroughputTracker throughput)
+        ThroughputTracker throughput) =>
+        WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            producerName,
+            throughput,
+            "warmup",
+            "warmup");
+
+    internal static async Task<long?> WarmUpProducerAndQueryStartOffsetAsync<TKey, TValue>(
+        ConfluentKafka.IProducer<TKey, TValue> producer,
+        StressTestOptions options,
+        string producerName,
+        ThroughputTracker throughput,
+        TKey warmupKey,
+        TValue warmupValue)
     {
         var warmupStartOffset = QueryTotalEndOffset(options.BootstrapServers, options.Topic, options.Partitions);
 
         Console.WriteLine($"  Warming up {producerName}...");
         for (var i = 0; i < StressTestHelpers.ProducerWarmupMessageCount; i++)
         {
-            producer.Produce(options.Topic, new ConfluentKafka.Message<string, string> { Key = "warmup", Value = "warmup" });
+            producer.Produce(options.Topic, new ConfluentKafka.Message<TKey, TValue>
+            {
+                Key = warmupKey,
+                Value = warmupValue
+            });
         }
         FlushWithTimeout(producer, throughput);
 

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Dekaf.Compression.Lz4;
 using Dekaf.Compression.Snappy;
 using Dekaf.Compression.Zstd;
@@ -30,12 +31,6 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .BuildAsync(cancellationToken);
 
-        var startOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
-            consumer,
-            options.Topic,
-            options.Partitions,
-            cancellationToken);
-
         var builder = Kafka.CreateProducer<string, byte[]>()
             .WithLoggerFactory(StressClientLogging.LoggerFactory)
             .WithBootstrapServers(options.BootstrapServers)
@@ -59,59 +54,72 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         };
         StressTestHelpers.ConfigureProducerDeliveryDiagnostics(builder, options);
 
+        using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
+        await using var producer = await builder.BuildAsync(cancellationToken);
+        _ = await StressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Dekaf round-trip producer",
+            throughput,
+            "warmup",
+            new byte[options.MessageSizeBytes],
+            cancellationToken).ConfigureAwait(false);
+        var startOffsets = await StressTestHelpers.QueryEndOffsetsAsync(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            cancellationToken).ConfigureAwait(false);
+
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
         using var gcStats = new GcStats();
-        using var deliveryErrorListener = CreateDeliveryErrorListener(throughput);
         throughput.Start();
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
+        var produceTimer = Stopwatch.StartNew();
 
-        ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
-        await using (var producer = await builder.BuildAsync(cancellationToken))
+        using var watchdog = options.ProgressWatchdog.Track(
+            throughput,
+            Client,
+            Name,
+            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
+        using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
+        Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
+        for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
         {
-            using var watchdog = options.ProgressWatchdog.Track(
-                throughput,
-                Client,
-                Name,
-                () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
-            using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
-
-            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
-            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+            if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                    produceTimeout.IsCancellationRequested,
+                    throughput,
+                    client: "Dekaf",
+                    ordinal: ordinal,
+                    cancellationToken: cancellationToken))
             {
-                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
-                        produceTimeout.IsCancellationRequested,
-                        throughput,
-                        client: "Dekaf",
-                        ordinal: ordinal,
-                        cancellationToken: cancellationToken))
-                {
-                    break;
-                }
-
-                var message = factory.Create(ordinal % options.Partitions);
-                try
-                {
-                    await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
-                    throughput.RecordMessage(message.Value.Length);
-                }
-                catch (Exception ex)
-                {
-                    throughput.RecordError(ex, "Round-trip produce", ordinal);
-                }
-
-                if ((ordinal + 1) % 50_000 == 0)
-                {
-                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
-                }
+                break;
             }
 
-            await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
-            producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
+            var message = factory.Create(ordinal % options.Partitions);
+            try
+            {
+                await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
+                throughput.RecordMessage(message.Value.Length);
+            }
+            catch (Exception ex)
+            {
+                throughput.RecordError(ex, "Round-trip produce", ordinal);
+            }
+
+            if ((ordinal + 1) % 50_000 == 0)
+            {
+                Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+            }
         }
+
+        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
+        produceTimer.Stop();
+        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         await sampler.StopAsync().ConfigureAwait(false);
 
         var queriedEndOffsets = await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(
@@ -130,6 +138,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
         var consumeProgress = new ThroughputTracker();
         consumeProgress.Start();
+        var consumeTimer = Stopwatch.StartNew();
         using var consumeWatchdog = options.ProgressWatchdog.Track(
             consumeProgress,
             Client,
@@ -151,6 +160,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         }
         finally
         {
+            consumeTimer.Stop();
             consumeProgress.Stop();
         }
 
@@ -169,6 +179,11 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             gcStats,
             delivered,
             validation,
+            RoundTripScenarioHelpers.CreatePhaseSnapshot(
+                throughput.MessageCount,
+                produceTimer.Elapsed,
+                validation.ConsumedMessages,
+                consumeTimer.Elapsed),
             producerDiagnostics);
     }
 
@@ -260,12 +275,6 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         };
 
         using var consumer = new ConfluentKafka.ConsumerBuilder<string, byte[]>(consumerConfig).Build();
-        var startOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
-            consumer,
-            options.Topic,
-            options.Partitions,
-            TimeSpan.FromSeconds(30));
-
         var producerConfig = new ConfluentKafka.ProducerConfig
         {
             BootstrapServers = options.BootstrapServers,
@@ -287,6 +296,20 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             }
         };
 
+        using var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build();
+        _ = await ConfluentStressTestHelpers.WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            "Confluent round-trip producer",
+            throughput,
+            "warmup",
+            new byte[options.MessageSizeBytes]).ConfigureAwait(false);
+        var startOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
+            consumer,
+            options.Topic,
+            options.Partitions,
+            TimeSpan.FromSeconds(30));
+
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -294,68 +317,67 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         throughput.Start();
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
+        var produceTimer = Stopwatch.StartNew();
 
-        using (var producer = new ConfluentKafka.ProducerBuilder<string, byte[]>(producerConfig).Build())
+        using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
+        using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
+        Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
+            RecordDeliveryReportError(throughput, report.Error);
+
+        Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
+        for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
         {
-            using var watchdog = options.ProgressWatchdog.Track(throughput, Client, Name);
-            using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
-
-            Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
-                RecordDeliveryReportError(throughput, report.Error);
-
-            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
-            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+            if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                    produceTimeout.IsCancellationRequested,
+                    throughput,
+                    client: "Confluent",
+                    ordinal: ordinal,
+                    cancellationToken: cancellationToken))
             {
-                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
-                        produceTimeout.IsCancellationRequested,
-                        throughput,
-                        client: "Confluent",
-                        ordinal: ordinal,
-                        cancellationToken: cancellationToken))
-                {
-                    break;
-                }
-
-                var message = factory.Create(ordinal % options.Partitions);
-                try
-                {
-                    ConfluentStressTestHelpers.ProduceWithBackpressure(
-                        producer,
-                        options.Topic,
-                        new ConfluentKafka.Message<string, byte[]>
-                        {
-                            Key = message.Key,
-                            Value = message.Value
-                        },
-                        deliveryHandler,
-                        produceTimeout.Token);
-                    throughput.RecordMessage(message.Value.Length);
-                }
-                catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)
-                {
-                    _ = RoundTripScenarioHelpers.TryRecordProduceTimeout(
-                        produceTimeout.IsCancellationRequested,
-                        throughput,
-                        client: "Confluent",
-                        ordinal: ordinal,
-                        cancellationToken: cancellationToken);
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    throughput.RecordError(ex, "Round-trip produce", ordinal);
-                }
-
-                if ((ordinal + 1) % 50_000 == 0)
-                {
-                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
-                    await Task.Yield();
-                }
+                break;
             }
 
-            ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
+            var message = factory.Create(ordinal % options.Partitions);
+            try
+            {
+                ConfluentStressTestHelpers.ProduceWithBackpressure(
+                    producer,
+                    options.Topic,
+                    new ConfluentKafka.Message<string, byte[]>
+                    {
+                        Key = message.Key,
+                        Value = message.Value
+                    },
+                    deliveryHandler,
+                    produceTimeout.Token);
+                throughput.RecordMessage(message.Value.Length);
+            }
+            catch (OperationCanceledException) when (produceTimeout.IsCancellationRequested)
+            {
+                _ = RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                    produceTimeout.IsCancellationRequested,
+                    throughput,
+                    client: "Confluent",
+                    ordinal: ordinal,
+                    cancellationToken: cancellationToken);
+                break;
+            }
+            catch (Exception ex)
+            {
+                throughput.RecordError(ex, "Round-trip produce", ordinal);
+            }
+
+            if ((ordinal + 1) % 50_000 == 0)
+            {
+                Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                await Task.Yield();
+            }
         }
+
+        ConfluentStressTestHelpers.FlushWithTimeout(producer, throughput);
+        produceTimer.Stop();
         await sampler.StopAsync().ConfigureAwait(false);
 
         var endOffsets = ConfluentStressTestHelpers.QueryEndOffsets(
@@ -365,6 +387,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             TimeSpan.FromSeconds(30));
         var delivered = RoundTripScenarioHelpers.CountRecords(startOffsets, endOffsets);
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var consumeTimer = Stopwatch.StartNew();
         var timedOut = ConsumeAndValidate(
             consumer,
             options,
@@ -373,6 +396,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             validator,
             throughput,
             cancellationToken);
+        consumeTimer.Stop();
 
         throughput.Stop();
 
@@ -389,6 +413,11 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
             gcStats,
             delivered,
             validation,
+            RoundTripScenarioHelpers.CreatePhaseSnapshot(
+                throughput.MessageCount,
+                produceTimer.Elapsed,
+                validation.ConsumedMessages,
+                consumeTimer.Elapsed),
             producerDeliveryDiagnostics: null);
     }
 
@@ -570,6 +599,7 @@ internal static class RoundTripScenarioHelpers
         GcStats gcStats,
         long delivered,
         RoundTripValidationSnapshot validation,
+        RoundTripPhaseSnapshot phases,
         ProducerDeliveryDiagnosticsSnapshot? producerDeliveryDiagnostics) =>
         new()
         {
@@ -587,6 +617,20 @@ internal static class RoundTripScenarioHelpers
             CpuTimeSeconds = throughput.CpuTimeSeconds,
             IsMessageBounded = true,
             RoundTripValidation = validation,
+            RoundTripPhases = phases,
             ProducerDeliveryDiagnostics = producerDeliveryDiagnostics
+        };
+
+    public static RoundTripPhaseSnapshot CreatePhaseSnapshot(
+        long producedMessages,
+        TimeSpan produceElapsed,
+        long consumedMessages,
+        TimeSpan consumeElapsed) =>
+        new()
+        {
+            ProducedMessages = producedMessages,
+            ProduceElapsedSeconds = produceElapsed.TotalSeconds,
+            ConsumedMessages = consumedMessages,
+            ConsumeElapsedSeconds = consumeElapsed.TotalSeconds
         };
 }

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -132,11 +132,28 @@ internal static class StressTestHelpers
         }
     }
 
-    internal static async Task<long?> WarmUpProducerAndQueryStartOffsetAsync(
+    internal static Task<long?> WarmUpProducerAndQueryStartOffsetAsync(
         IKafkaProducer<string, string> producer,
         StressTestOptions options,
         string producerName,
         ThroughputTracker throughput,
+        CancellationToken cancellationToken) =>
+        WarmUpProducerAndQueryStartOffsetAsync(
+            producer,
+            options,
+            producerName,
+            throughput,
+            "warmup",
+            "warmup",
+            cancellationToken);
+
+    internal static async Task<long?> WarmUpProducerAndQueryStartOffsetAsync<TKey, TValue>(
+        IKafkaProducer<TKey, TValue> producer,
+        StressTestOptions options,
+        string producerName,
+        ThroughputTracker throughput,
+        TKey warmupKey,
+        TValue warmupValue,
         CancellationToken cancellationToken)
     {
         var warmupStartOffset = await QueryTotalEndOffsetAsync(
@@ -148,10 +165,10 @@ internal static class StressTestHelpers
         // First produce uses ProduceAsync to prime the topic metadata cache asynchronously.
         // Send() would block the thread via FetchTopicMetadataSync (.GetAwaiter().GetResult())
         // which hangs if the broker is slow to respond to new topic metadata requests.
-        await producer.ProduceAsync(options.Topic, "warmup", "warmup", cancellationToken).ConfigureAwait(false);
+        await producer.ProduceAsync(options.Topic, warmupKey, warmupValue, cancellationToken).ConfigureAwait(false);
         for (var i = 1; i < ProducerWarmupMessageCount; i++)
         {
-            await producer.FireAsync(options.Topic, "warmup", "warmup").ConfigureAwait(false);
+            await producer.FireAsync(options.Topic, warmupKey, warmupValue).ConfigureAwait(false);
         }
 
         await producer.FlushAsync(CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- warm Dekaf and Confluent round-trip producers before measurement
- exclude warm-up records with post-drain offset snapshots
- serialize and report separate produce/consume phase throughput

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/RoundTripMessageCodecTests/*'` (24 passed)
- [x] `Dekaf.Tests.Unit.exe` (5297 passed)

Closes #1946
