### PR TITLE
Expose producer request-shape diagnostics

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3405,6 +3405,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
                 var request = scratch.Build(batches, generations, count);
+                _accumulator.RecordProduceRequest(count);
 
                 // Handle Acks.None (fire-and-forget)
                 if (_options.Acks == Acks.None)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -244,6 +244,11 @@ internal interface IProducerDiagnostics
     /// Captures batches still tracked inside the producer pipeline.
     /// </summary>
     ProducerDeliveryDiagnosticsSnapshot GetDeliveryDiagnosticsSnapshot();
+
+    /// <summary>
+    /// Starts a new produce-request diagnostics measurement window.
+    /// </summary>
+    void ResetProduceRequestDiagnostics();
 }
 
 /// <summary>
@@ -254,11 +259,22 @@ internal sealed class ProducerDeliveryDiagnosticsSnapshot
     public bool DiagnosticsEnabled { get; init; }
     public DateTimeOffset CapturedAtUtc { get; init; }
     public long InFlightBatchCount { get; init; }
+    public long ProduceRequestCount { get; init; }
+    public double ProduceRequestElapsedSeconds { get; init; }
+    public double ProduceRequestsPerSecond { get; init; }
+    public List<ProducerCoalesceWidthDiagnostic> CoalesceWidthHistogram { get; init; } = [];
     public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgets { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgetSamples { get; init; } = [];
     public List<ConnectionReapDiagnostic> ConnectionReapEvents { get; init; } = [];
     public List<ProducerConnectionScaleDiagnostic> ConnectionScaleEvents { get; init; } = [];
+}
+
+internal sealed class ProducerCoalesceWidthDiagnostic
+{
+    public required int MinimumWidth { get; init; }
+    public int? MaximumWidth { get; init; }
+    public required long RequestCount { get; init; }
 }
 
 internal sealed class ProducerBrokerBudgetDiagnostic

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2605,6 +2605,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return snapshot;
     }
 
+    void IProducerDiagnostics.ResetProduceRequestDiagnostics() =>
+        _accumulator.ResetProduceRequestDiagnostics();
+
     int IProducerDiagnostics.MaxObservedBrokerThrottleTimeMs =>
         Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4668,8 +4668,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var batches = new List<DiagnosticBatchReference>();
         InFlightBatchDiagnosticSnapshot(batches);
 
-        var produceRequestCount = Interlocked.Read(ref _produceRequestCount);
         var startedAt = Volatile.Read(ref _produceRequestDiagnosticsStartedAt);
+        var produceRequestCount = Interlocked.Read(ref _produceRequestCount);
         var produceRequestElapsedSeconds = Math.Max(
             0,
             (Stopwatch.GetTimestamp() - startedAt) / (double)Stopwatch.Frequency);
@@ -4744,10 +4744,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (widthCounts is null)
             return;
 
-        Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
         Interlocked.Exchange(ref _produceRequestCount, 0);
         for (var width = 1; width < widthCounts.Length; width++)
             Interlocked.Exchange(ref widthCounts[width], 0);
+        Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
     }
 
     internal void RecordConnectionScaleEvent(

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -868,6 +868,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private const int MaxConnectionScaleDiagnosticEvents = 256;
     private const int MaxBrokerBudgetDiagnosticSamples = 4096;
     private const int BrokerBudgetDiagnosticIntervalMs = 1_000;
+    private const int MaxTrackedCoalesceWidth = 64;
     // ReadyBatch lifecycle (seal→send→response→cleanup) is longer than PartitionBatch
     // (create→fill→seal), so its pool needs proportionally more capacity.
     private const int ReadyBatchPoolSizeRatio = 2;
@@ -968,6 +969,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly object _deliveryDiagnosticsLock = new();
     private readonly List<ProducerConnectionScaleDiagnostic> _connectionScaleEvents = [];
     private readonly List<ProducerBrokerBudgetDiagnostic> _brokerBudgetSamples = [];
+    private readonly long[]? _coalesceWidthCounts;
+    private long _produceRequestCount;
+    private long _produceRequestDiagnosticsStartedAt;
     private long _nextBrokerBudgetDiagnosticTimestampMs;
 
     // Optimization: Track the oldest batch creation time to skip unnecessary enumeration.
@@ -1989,6 +1993,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _onRecordAppended = onRecordAppended;
         _resolveLeaderId = resolveLeaderId;
         _unackedBudgetEnabled = options.DeliveryLatencyTargetMs > 0 && resolveLeaderId is not null;
+        if (options.EnableDeliveryDiagnostics)
+        {
+            _coalesceWidthCounts = new long[MaxTrackedCoalesceWidth + 2];
+            _produceRequestDiagnosticsStartedAt = Stopwatch.GetTimestamp();
+        }
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
 
@@ -4659,12 +4668,48 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var batches = new List<DiagnosticBatchReference>();
         InFlightBatchDiagnosticSnapshot(batches);
 
+        var produceRequestCount = Interlocked.Read(ref _produceRequestCount);
+        var startedAt = Volatile.Read(ref _produceRequestDiagnosticsStartedAt);
+        var produceRequestElapsedSeconds = Math.Max(
+            0,
+            (Stopwatch.GetTimestamp() - startedAt) / (double)Stopwatch.Frequency);
         var snapshot = new ProducerDeliveryDiagnosticsSnapshot
         {
             DiagnosticsEnabled = true,
             CapturedAtUtc = DateTimeOffset.UtcNow,
-            InFlightBatchCount = Volatile.Read(ref _inFlightBatchCount)
+            InFlightBatchCount = Volatile.Read(ref _inFlightBatchCount),
+            ProduceRequestCount = produceRequestCount,
+            ProduceRequestElapsedSeconds = produceRequestElapsedSeconds,
+            ProduceRequestsPerSecond = produceRequestElapsedSeconds > 0
+                ? produceRequestCount / produceRequestElapsedSeconds
+                : 0
         };
+
+        var widthCounts = _coalesceWidthCounts!;
+        for (var width = 1; width <= MaxTrackedCoalesceWidth; width++)
+        {
+            var requestCount = Interlocked.Read(ref widthCounts[width]);
+            if (requestCount > 0)
+            {
+                snapshot.CoalesceWidthHistogram.Add(new ProducerCoalesceWidthDiagnostic
+                {
+                    MinimumWidth = width,
+                    MaximumWidth = width,
+                    RequestCount = requestCount
+                });
+            }
+        }
+
+        var overflowCount = Interlocked.Read(ref widthCounts[MaxTrackedCoalesceWidth + 1]);
+        if (overflowCount > 0)
+        {
+            snapshot.CoalesceWidthHistogram.Add(new ProducerCoalesceWidthDiagnostic
+            {
+                MinimumWidth = MaxTrackedCoalesceWidth + 1,
+                MaximumWidth = null,
+                RequestCount = overflowCount
+            });
+        }
 
         var capturedAtUtc = snapshot.CapturedAtUtc;
         foreach (var (brokerId, budget) in _brokerUnackedBudgets)
@@ -4680,6 +4725,29 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             snapshot.Batches.Add(batch.Batch.CreateDeliveryDiagnostic(batch.Generation, batch.TopicPartition));
 
         return snapshot;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void RecordProduceRequest(int coalesceWidth)
+    {
+        var widthCounts = _coalesceWidthCounts;
+        if (widthCounts is null)
+            return;
+
+        Interlocked.Increment(ref _produceRequestCount);
+        Interlocked.Increment(ref widthCounts[Math.Min(coalesceWidth, MaxTrackedCoalesceWidth + 1)]);
+    }
+
+    internal void ResetProduceRequestDiagnostics()
+    {
+        var widthCounts = _coalesceWidthCounts;
+        if (widthCounts is null)
+            return;
+
+        Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
+        Interlocked.Exchange(ref _produceRequestCount, 0);
+        for (var width = 1; width < widthCounts.Length; width++)
+            Interlocked.Exchange(ref widthCounts[width], 0);
     }
 
     internal void RecordConnectionScaleEvent(

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -90,6 +90,62 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
+    public async Task ProduceRequestDiagnostics_CapturesCountRateAndCoalesceWidths()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(enableDeliveryDiagnostics: true));
+
+        accumulator.RecordProduceRequest(coalesceWidth: 1);
+        accumulator.RecordProduceRequest(coalesceWidth: 2);
+        accumulator.RecordProduceRequest(coalesceWidth: 2);
+        accumulator.RecordProduceRequest(coalesceWidth: 65);
+        accumulator.RecordProduceRequest(coalesceWidth: 100);
+
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(5);
+        await Assert.That(snapshot.ProduceRequestElapsedSeconds).IsGreaterThanOrEqualTo(0);
+        await Assert.That(snapshot.ProduceRequestsPerSecond).IsGreaterThanOrEqualTo(0);
+        await Assert.That(snapshot.CoalesceWidthHistogram.Single(bucket => bucket.MinimumWidth == 1).RequestCount)
+            .IsEqualTo(1);
+        await Assert.That(snapshot.CoalesceWidthHistogram.Single(bucket => bucket.MinimumWidth == 2).RequestCount)
+            .IsEqualTo(2);
+        var overflow = snapshot.CoalesceWidthHistogram.Single(bucket => bucket.MinimumWidth == 65);
+        await Assert.That(overflow.MaximumWidth).IsNull();
+        await Assert.That(overflow.RequestCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ProduceRequestDiagnostics_ResetStartsEmptyWindow()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(enableDeliveryDiagnostics: true));
+        accumulator.RecordProduceRequest(coalesceWidth: 4);
+
+        accumulator.ResetProduceRequestDiagnostics();
+        var reset = accumulator.GetDeliveryDiagnosticsSnapshot();
+        accumulator.RecordProduceRequest(coalesceWidth: 3);
+        var afterRequest = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(reset.ProduceRequestCount).IsEqualTo(0);
+        await Assert.That(reset.CoalesceWidthHistogram).IsEmpty();
+        await Assert.That(afterRequest.ProduceRequestCount).IsEqualTo(1);
+        await Assert.That(afterRequest.CoalesceWidthHistogram.Single().MinimumWidth).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ProduceRequestDiagnostics_Disabled_DoesNotRecord()
+    {
+        await using var accumulator = new RecordAccumulator(CreateOptions());
+
+        accumulator.RecordProduceRequest(coalesceWidth: 2);
+        var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
+
+        await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(0);
+        await Assert.That(snapshot.CoalesceWidthHistogram).IsEmpty();
+    }
+
+    [Test]
     public async Task BrokerBudgetDiagnostics_CapturesCurrentStateAndPeriodicSample()
     {
         var options = CreateOptions(

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -125,6 +125,24 @@ public sealed class ConnectionScaleReportingTests
             {
                 DiagnosticsEnabled = true,
                 CapturedAtUtc = startedAt.AddMinutes(15),
+                ProduceRequestCount = 2_500,
+                ProduceRequestElapsedSeconds = 5,
+                ProduceRequestsPerSecond = 500,
+                CoalesceWidthHistogram =
+                [
+                    new ProducerCoalesceWidthDiagnostic
+                    {
+                        MinimumWidth = 1,
+                        MaximumWidth = 1,
+                        RequestCount = 2_000
+                    },
+                    new ProducerCoalesceWidthDiagnostic
+                    {
+                        MinimumWidth = 2,
+                        MaximumWidth = 2,
+                        RequestCount = 500
+                    }
+                ],
                 ConnectionScaleEvents =
                 [
                     new ProducerConnectionScaleDiagnostic
@@ -150,6 +168,7 @@ public sealed class ConnectionScaleReportingTests
         };
 
         var markdown = MarkdownReporter.Generate(results);
+        var json = result.ToJson();
 
         await Assert.That(markdown).Contains("Connection Scale Timeline - Fire-and-Forget");
         await Assert.That(markdown).Contains("1→3");
@@ -166,5 +185,9 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("Gen2 +2 / pause +25.0ms");
         await Assert.That(markdown).Contains("| Dekaf | 45 | 02:00:15.000 | 3.0s | throughput collapse |");
         await Assert.That(markdown).Contains("3 additional latency outlier sample(s) exceeded the bounded diagnostic capacity");
+        await Assert.That(json).Contains("\"produceRequestCount\": 2500");
+        await Assert.That(json).Contains("\"produceRequestsPerSecond\": 500");
+        await Assert.That(json).Contains("\"coalesceWidthHistogram\"");
+        await Assert.That(json).Contains("\"requestCount\": 2000");
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -69,6 +69,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             options.Topic,
             options.Partitions,
             cancellationToken).ConfigureAwait(false);
+        StressTestHelpers.ResetProducerDeliveryDiagnostics(producer, options);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -175,7 +175,7 @@ internal static class StressTestHelpers
         // A stale start snapshot is a correctness hazard, not just noise: warmup messages
         // landing after the snapshot would inflate the run's delivered count and mask real
         // loss, so a catch-up timeout here is recorded as an error via the tracker.
-        return await QueryTotalEndOffsetAfterProducerDrainAsync(
+        var startOffset = await QueryTotalEndOffsetAfterProducerDrainAsync(
             options.BootstrapServers,
             options.Topic,
             options.Partitions,
@@ -183,6 +183,8 @@ internal static class StressTestHelpers
             ProducerWarmupMessageCount,
             throughput,
             "Warmup drain").ConfigureAwait(false);
+        ResetProducerDeliveryDiagnostics(producer, options);
+        return startOffset;
     }
 
     /// <summary>
@@ -367,6 +369,14 @@ internal static class StressTestHelpers
         }
 
         return snapshot;
+    }
+
+    internal static void ResetProducerDeliveryDiagnostics<TKey, TValue>(
+        IKafkaProducer<TKey, TValue> producer,
+        StressTestOptions options)
+    {
+        if (options.EnableProducerDeliveryDiagnostics && producer is IProducerDiagnostics diagnostics)
+            diagnostics.ResetProduceRequestDiagnostics();
     }
 
     internal static ConsumerDiagnosticSnapshot? CaptureConsumerDiagnostics<TKey, TValue>(


### PR DESCRIPTION
## Summary
- count ProduceRequest attempts and requests per second in delivery diagnostics
- capture allocation-conscious exact coalesce-width histogram through width 64 plus overflow
- reset request metrics after producer warm-up and serialize them in stress JSON

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/ProducerDeliveryDiagnosticsTests/*'` (16 passed)
- [x] `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/ConnectionScaleReportingTests/*'` (1 passed)
- [ ] `Dekaf.Tests.Unit.exe` (5296 passed, 1 unrelated MeterListener isolation failure tracked in #1949; isolated failing test passes)

Closes #1947
