### PR TITLE
Reduce consumer LOH churn

### DIFF
--- a/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
+++ b/src/Dekaf/Consumer/AdaptiveFetchSizer.cs
@@ -192,24 +192,58 @@ internal sealed class AdaptiveFetchSizer
 
     private void Grow()
     {
-        _currentPartitionFetchBytes = Math.Min(
-            (int)Math.Min((long)(_currentPartitionFetchBytes * _growthFactor), int.MaxValue),
+        _currentPartitionFetchBytes = QuantizeGrowth(
+            _currentPartitionFetchBytes,
+            _growthFactor,
             _maxPartitionFetchBytes);
 
-        _currentFetchMaxBytes = Math.Min(
-            (int)Math.Min((long)(_currentFetchMaxBytes * _growthFactor), int.MaxValue),
+        _currentFetchMaxBytes = QuantizeGrowth(
+            _currentFetchMaxBytes,
+            _growthFactor,
             _maxFetchMaxBytes);
     }
 
     private void Shrink()
     {
-        _currentPartitionFetchBytes = Math.Max(
-            (int)(_currentPartitionFetchBytes * _shrinkFactor),
+        _currentPartitionFetchBytes = QuantizeShrink(
+            _currentPartitionFetchBytes,
+            _shrinkFactor,
             _minPartitionFetchBytes);
 
-        _currentFetchMaxBytes = Math.Max(
-            (int)(_currentFetchMaxBytes * _shrinkFactor),
+        _currentFetchMaxBytes = QuantizeShrink(
+            _currentFetchMaxBytes,
+            _shrinkFactor,
             _minFetchMaxBytes);
+    }
+
+    private static int QuantizeGrowth(int current, double factor, int maximum)
+    {
+        var candidate = Math.Min((long)(current * factor), maximum);
+        return Math.Min(RoundUpToPowerOfTwo(candidate), maximum);
+    }
+
+    private static int QuantizeShrink(int current, double factor, int minimum)
+    {
+        var candidate = Math.Max((long)(current * factor), minimum);
+        return Math.Max(RoundDownToPowerOfTwo(candidate), minimum);
+    }
+
+    private static int RoundUpToPowerOfTwo(long value)
+    {
+        var result = 1L;
+        while (result < value && result <= int.MaxValue)
+            result <<= 1;
+
+        return result > int.MaxValue ? int.MaxValue : (int)result;
+    }
+
+    private static int RoundDownToPowerOfTwo(long value)
+    {
+        var result = 1L;
+        while ((result << 1) <= value && result <= int.MaxValue / 2L)
+            result <<= 1;
+
+        return (int)result;
     }
 }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1028,7 +1028,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 PoolSizing.ForConsumerResponseBuffers(
                     options.BootstrapServers.Count,
                     options.PrefetchPipelineDepth,
-                    options.ConnectionsPerBroker)),
+                    options.MaxConnectionsPerBroker)),
             telemetryMetricCollector: telemetryMetricCollector);
 
         var metadataManager = new MetadataManager(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -78,6 +78,7 @@ internal sealed class PendingFetchData : IDisposable
     private Dictionary<long, Queue<long>>? _abortedProducers;
     private IPooledMemory? _memoryOwner;
     private Record[]? _parsedRecordSlab;
+    private int _parsedRecordSlabCount;
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
@@ -155,6 +156,9 @@ internal sealed class PendingFetchData : IDisposable
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
 
+        for (var i = 0; i < batches.Count; i++)
+            batches[i].AttachConsumerPoolOwner(instance, instance.HeaderGeneration);
+
         if (abortedTransactions is { Count: > 0 })
         {
             instance._abortedProducers ??= new Dictionary<long, Queue<long>>();
@@ -188,8 +192,18 @@ internal sealed class PendingFetchData : IDisposable
         if (totalRecordCount == 0)
             return;
 
-        var slab = ArrayPool<Record>.Shared.Rent(totalRecordCount);
-        slab.AsSpan().Clear();
+        var slab = _parsedRecordSlab;
+        if (slab is null || slab.Length < totalRecordCount)
+        {
+            if (slab is not null)
+                ArrayPool<Record>.Shared.Return(slab, clearArray: false);
+
+            slab = ArrayPool<Record>.Shared.Rent(totalRecordCount);
+            _parsedRecordSlab = slab;
+        }
+
+        slab.AsSpan(0, totalRecordCount).Clear();
+        _parsedRecordSlabCount = totalRecordCount;
         var offset = 0;
         for (var i = 0; i < batches.Count; i++)
         {
@@ -198,8 +212,6 @@ internal sealed class PendingFetchData : IDisposable
             batch.UseParsedRecordSlab(slab, offset);
             offset += recordCount;
         }
-
-        _parsedRecordSlab = slab;
     }
 
     public static PendingFetchData CreateError(string topic, int partitionIndex, ConsumeException error)
@@ -516,13 +528,13 @@ internal sealed class PendingFetchData : IDisposable
         var batches = _batches;
         for (var i = 0; i < batches.Count; i++)
         {
-            batches[i].Dispose();
+            batches[i].DisposeAndReturnConsumerBatch(this, HeaderGeneration);
         }
 
         var parsedRecordSlab = _parsedRecordSlab;
-        _parsedRecordSlab = null;
         if (parsedRecordSlab is not null)
-            ArrayPool<Record>.Shared.Return(parsedRecordSlab, clearArray: false);
+            parsedRecordSlab.AsSpan(0, _parsedRecordSlabCount).Clear();
+        _parsedRecordSlabCount = 0;
 
         // Return the batch list to the pool for reuse
         if (_batches is List<RecordBatch> batchList)
@@ -1011,7 +1023,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(CalculateMaximumFetchResponsePayloadBytes(options)),
+            ResponseBufferPool.Create(
+                CalculateMaximumFetchResponsePayloadBytes(options),
+                PoolSizing.ForConsumerResponseBuffers(
+                    options.BootstrapServers.Count,
+                    options.PrefetchPipelineDepth,
+                    options.ConnectionsPerBroker)),
             telemetryMetricCollector: telemetryMetricCollector);
 
         var metadataManager = new MetadataManager(

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -23,6 +23,8 @@ internal static class PoolSizing
     private const int MaxValueTaskSources = 65536;
     private const int MinConsumerPrefetchBufferCapacity = 16;
     private const int MaxConsumerPrefetchBufferCapacity = 1024;
+    private const int MinConsumerResponseBuffersPerBucket = 16;
+    private const int MaxConsumerResponseBuffersPerBucket = 256;
 
     /// <summary>
     /// Approximate number of coalesced partitions per batch — used to scale
@@ -147,6 +149,24 @@ internal static class PoolSizing
             capacity,
             MinConsumerPrefetchBufferCapacity,
             MaxConsumerPrefetchBufferCapacity);
+    }
+
+    internal static int ForConsumerResponseBuffers(
+        int brokerCount,
+        int prefetchPipelineDepth,
+        int connectionsPerBroker)
+    {
+        var brokers = Math.Max((long)brokerCount, 1L);
+        var pipelineSlots = Math.Max((long)prefetchPipelineDepth, 1L) + 2L;
+        var connections = Math.Max((long)connectionsPerBroker, 1L);
+        var liveResponseBuffers = SaturatingMultiply(
+            SaturatingMultiply(brokers, pipelineSlots),
+            connections);
+
+        return ClampPoolDepth(
+            liveResponseBuffers,
+            MinConsumerResponseBuffersPerBucket,
+            MaxConsumerResponseBuffersPerBucket);
     }
 
     private static long CeilingDivide(long value, long divisor) =>

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3475,19 +3475,20 @@ internal sealed class ResponseBufferPool
     /// Default shared instance used by producers, admin clients, and connections
     /// that don't have consumer-specific configuration.
     /// </summary>
-    internal static readonly ResponseBufferPool Default = new(DefaultMaxArrayLength);
-    private static readonly ConcurrentDictionary<int, ResponseBufferPool> s_sharedPools = new();
+    private const int DefaultMaxArraysPerBucket = 4;
+    internal static readonly ResponseBufferPool Default = new(DefaultMaxArrayLength, DefaultMaxArraysPerBucket);
+    private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), ResponseBufferPool>
+        s_sharedPools = new();
 
     internal ArrayPool<byte> Pool { get; }
     internal int MaxArrayLength { get; }
+    internal int MaxArraysPerBucket { get; }
 
-    internal ResponseBufferPool(int maxArrayLength)
+    internal ResponseBufferPool(int maxArrayLength, int maxArraysPerBucket = DefaultMaxArraysPerBucket)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxArraysPerBucket);
         MaxArrayLength = maxArrayLength;
-        // Limit bucket count to cap worst-case memory retention.
-        // 4 arrays per bucket: default pool = 4 × 16 MB = ~64 MB, consumer pool = 4 × 51 MB = ~204 MB.
-        // Previous values (32/8) caused up to 512 MB retention for the default pool alone.
-        const int maxArraysPerBucket = 4;
+        MaxArraysPerBucket = maxArraysPerBucket;
         Pool = ArrayPool<byte>.Create(
             maxArrayLength: maxArrayLength,
             maxArraysPerBucket: maxArraysPerBucket);
@@ -3498,12 +3499,18 @@ internal sealed class ResponseBufferPool
     /// <c>FetchMaxBytes</c> configuration. The pool's max array length is rounded up to
     /// a MiB tier after adding protocol overhead, with a minimum of <see cref="DefaultMaxArrayLength"/>.
     /// </summary>
-    internal static ResponseBufferPool Create(int fetchMaxBytes)
+    internal static ResponseBufferPool Create(
+        int fetchMaxBytes,
+        int maxArraysPerBucket = DefaultMaxArraysPerBucket)
     {
         var maxArrayLength = ComputeMaxArrayLength(fetchMaxBytes);
-        return maxArrayLength == DefaultMaxArrayLength
+        return maxArrayLength == DefaultMaxArrayLength && maxArraysPerBucket == DefaultMaxArraysPerBucket
             ? Default
-            : s_sharedPools.GetOrAdd(maxArrayLength, static length => new ResponseBufferPool(length));
+            : s_sharedPools.GetOrAdd(
+                (maxArrayLength, maxArraysPerBucket),
+                static configuration => new ResponseBufferPool(
+                    configuration.MaxArrayLength,
+                    configuration.MaxArraysPerBucket));
     }
 
     internal static int ComputeMaxArrayLength(int fetchMaxBytes)

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -351,7 +351,7 @@ public sealed class FetchResponsePartition
 
         for (var i = 0; i < list.Count; i++)
         {
-            list[i].Dispose();
+            list[i].DisposeAndReturnUnownedConsumerBatch();
         }
 
         s_recordBatchListPool.Return(list);

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -544,9 +544,7 @@ public sealed class FetchResponsePartition
                         DekafMetrics.BatchParseErrors.Add(1);
                         recordParseError = new MalformedProtocolDataException(
                             $"Failed to parse record batch for partition {partitionIndex}", ex);
-                        foreach (var record in records)
-                            record.Dispose();
-                        ReturnRecordBatchList(records);
+                        ReturnRecordBatchListAfterFailedParse(records);
                         records = null;
                         break;
                     }

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -753,9 +753,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     }
 
     /// <summary>
-    /// Disposes any pooled memory associated with this batch's records.
-    /// Consumer-read batches are not object-pooled because callers own their disposable
-    /// lifetime. Producer-owned batches use <see cref="ReturnToPool"/> explicitly.
+    /// Disposes pooled memory associated with this batch's records without returning the
+    /// batch object to its pool. Consumer paths must use the owner-aware return helpers;
+    /// producer paths call <see cref="ReturnToPool"/> after their ownership ends.
     /// </summary>
     public void Dispose()
     {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -7,6 +7,7 @@ using System.Runtime.Intrinsics.X86;
 using ArmCrc32 = System.Runtime.Intrinsics.Arm.Crc32;
 #endif
 using Dekaf.Compression;
+using Dekaf.Consumer;
 using Dekaf.Internal;
 using Dekaf.Producer;
 using Dekaf.Serialization;
@@ -766,9 +767,36 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         DisposeRecordList();
     }
 
-    // ── Pool for producer-path RecordBatch reuse ──
+    private PendingFetchData? _consumerPoolOwner;
+    private int _consumerPoolOwnerGeneration;
+
+    internal void AttachConsumerPoolOwner(PendingFetchData owner, int generation)
+    {
+        _consumerPoolOwner = owner;
+        _consumerPoolOwnerGeneration = generation;
+    }
+
+    internal void DisposeAndReturnConsumerBatch(PendingFetchData owner, int generation)
+    {
+        if (!ReferenceEquals(_consumerPoolOwner, owner) || _consumerPoolOwnerGeneration != generation)
+            return;
+
+        Dispose();
+        ReturnToPool();
+    }
+
+    internal void DisposeAndReturnUnownedConsumerBatch()
+    {
+        if (_consumerPoolOwner is not null)
+            return;
+
+        Dispose();
+        ReturnToPool();
+    }
+
+    // ── Pool for producer and consumer RecordBatch reuse ──
     // Eliminates per-batch class allocation (~120 bytes) that survives Gen0 due to
-    // its lifetime spanning the send pipeline (1-10ms), contributing to high Gen1/Gen0 ratio.
+    // its lifetime spanning producer and consumer pipelines, contributing to Gen1 pressure.
     // Reuses ObjectPool<T> for zero-alloc CAS-based pooling with miss tracking and exception safety.
     private static readonly RecordBatchPool s_pool = new();
 
@@ -799,6 +827,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             item._preEncodedRecords = default;
             item._hasPreEncodedRecords = false;
             item._preEncodedRecordsCrc = 0;
+            item._consumerPoolOwner = null;
+            item._consumerPoolOwnerGeneration = 0;
 
             // Reset mutable state to defaults
             item.BaseOffset = 0;
@@ -819,6 +849,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     /// <summary>
     /// Rents a RecordBatch from the pool or creates a new one.
     /// Caller must call <see cref="ReturnToPool"/> after the batch is fully processed.
+    /// Consumer-read batches are returned by their owning <c>PendingFetchData</c>.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static RecordBatch RentFromPool()
@@ -831,8 +862,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     /// <summary>
     /// Returns this RecordBatch to the pool for reuse. Clears all references to avoid
-    /// holding onto Records data. Caller must call <see cref="ReturnPreCompressedBuffer"/>
-    /// before this method to return any pooled compression buffers.
+    /// holding onto Records data. Producer callers must call
+    /// <see cref="ReturnPreCompressedBuffer"/> first when applicable.
     /// </summary>
     internal void ReturnToPool()
     {
@@ -1293,11 +1324,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             pooledRecordData = pooledArray;
         }
 
-        // A RecordBatch returned by Read is directly disposable by its caller. Pooling that
-        // instance cannot make a stale second Dispose distinguish its old lease from a later
-        // renter, so consumer-read batches remain unpooled while producer-owned batches use
-        // RentFromPool explicitly.
-        var batch = new RecordBatch();
+        var batch = RentFromPool();
         batch.BaseOffset = baseOffset;
         batch.BatchLength = batchLength;
         batch.PartitionLeaderEpoch = partitionLeaderEpoch;

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -738,52 +738,57 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 break; // Partial batch
             }
 
-            foreach (var record in batch.Records)
+            try
             {
-                if (results.Count >= maxRecords)
-                    break;
-
-                var offset = batch.BaseOffset + record.OffsetDelta;
-
-                var deliveryCount = FindDeliveryCount(
-                    partition.AcquiredRecords,
-                    offset,
-                    ref acquiredRecordIndex);
-                if (deliveryCount < 0)
-                    continue;
-
-                t_serializationContext.Topic = topicInfo.Name;
-                t_serializationContext.Component = SerializationComponent.Key;
-                var key = record.IsKeyNull
-                    ? default
-                    : _keyDeserializer.Deserialize(record.Key, t_serializationContext);
-
-                t_serializationContext.Component = SerializationComponent.Value;
-                var value = record.IsValueNull
-                    ? default!
-                    : _valueDeserializer.Deserialize(record.Value, t_serializationContext);
-
-                Header[]? headers = null;
-                if (record.Headers is not null && record.HeaderCount > 0)
+                foreach (var record in batch.Records)
                 {
-                    headers = new Header[record.HeaderCount];
-                    Array.Copy(record.Headers, headers, record.HeaderCount);
+                    if (results.Count >= maxRecords)
+                        break;
+
+                    var offset = batch.BaseOffset + record.OffsetDelta;
+
+                    var deliveryCount = FindDeliveryCount(
+                        partition.AcquiredRecords,
+                        offset,
+                        ref acquiredRecordIndex);
+                    if (deliveryCount < 0)
+                        continue;
+
+                    t_serializationContext.Topic = topicInfo.Name;
+                    t_serializationContext.Component = SerializationComponent.Key;
+                    var key = record.IsKeyNull
+                        ? default
+                        : _keyDeserializer.Deserialize(record.Key, t_serializationContext);
+
+                    t_serializationContext.Component = SerializationComponent.Value;
+                    var value = record.IsValueNull
+                        ? default!
+                        : _valueDeserializer.Deserialize(record.Value, t_serializationContext);
+
+                    Header[]? headers = null;
+                    if (record.Headers is not null && record.HeaderCount > 0)
+                    {
+                        headers = new Header[record.HeaderCount];
+                        Array.Copy(record.Headers, headers, record.HeaderCount);
+                    }
+
+                    results.Add(new ShareConsumeResult<TKey, TValue>
+                    {
+                        Topic = topicInfo.Name,
+                        Partition = partition.PartitionIndex,
+                        Offset = offset,
+                        Key = key,
+                        Value = value,
+                        Headers = headers,
+                        TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
+                        DeliveryCount = deliveryCount
+                    });
                 }
-
-                results.Add(new ShareConsumeResult<TKey, TValue>
-                {
-                    Topic = topicInfo.Name,
-                    Partition = partition.PartitionIndex,
-                    Offset = offset,
-                    Key = key,
-                    Value = value,
-                    Headers = headers,
-                    TimestampMs = batch.BaseTimestamp + record.TimestampDelta,
-                    DeliveryCount = deliveryCount
-                });
             }
-
-            batch.Dispose();
+            finally
+            {
+                batch.DisposeAndReturnUnownedConsumerBatch();
+            }
         }
 
         return results;

--- a/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AdaptiveFetchSizerTests.cs
@@ -55,8 +55,8 @@ public class AdaptiveFetchSizerTests
 
         sizer.EvaluateAndAdjust(0.3);
 
-        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2_000_000);
-        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(100_000_000);
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2 * 1024 * 1024);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(100 * 1024 * 1024);
     }
 
     [Test]
@@ -75,13 +75,13 @@ public class AdaptiveFetchSizerTests
         };
         var sizer = new AdaptiveFetchSizer(options);
 
-        // Step 1: 1M -> 1.5M
+        // Adaptive sizes stay on ArrayPool power-of-two bucket boundaries.
         sizer.EvaluateAndAdjust(0.3);
-        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(1_500_000);
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2 * 1024 * 1024);
 
-        // Step 2: 1.5M -> 2.25M
+        // Next growth moves to the next bucket instead of stranding the 2 MiB tier.
         sizer.EvaluateAndAdjust(0.3);
-        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2_250_000);
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(4 * 1024 * 1024);
     }
 
     #endregion
@@ -138,8 +138,8 @@ public class AdaptiveFetchSizerTests
 
         sizer.ReportMemoryPressure();
 
-        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2_000_000);
-        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(50_000_000);
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(1 * 1024 * 1024);
+        await Assert.That(sizer.CurrentFetchMaxBytes).IsEqualTo(32 * 1024 * 1024);
     }
 
     #endregion
@@ -366,7 +366,7 @@ public class AdaptiveFetchSizerTests
 
         // 5th signal triggers growth
         sizer.EvaluateAndAdjust(0.3);
-        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(1_500_000);
+        await Assert.That(sizer.CurrentPartitionFetchBytes).IsEqualTo(2 * 1024 * 1024);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
@@ -1,5 +1,8 @@
+using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Internal;
 using Dekaf.Networking;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
@@ -63,4 +66,34 @@ public sealed class ConsumerResponseBufferSizingTests
 
         await Assert.That(maximumPayload).IsEqualTo(int.MaxValue);
     }
+
+    [Test]
+    public async Task ConsumerInfrastructure_SizesResponsePoolForAdaptiveConnectionCeiling()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092", "localhost:9093"],
+            ConnectionsPerBroker = 1,
+            MaxConnectionsPerBroker = 4,
+            EnableAdaptiveConnections = true,
+            PrefetchPipelineDepth = 3
+        };
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var connectionPool = GetField<ConnectionPool>(consumer, "_connectionPool");
+        var responsePool = GetField<ResponseBufferPool>(connectionPool, "_responseBufferPool");
+
+        await Assert.That(responsePool.MaxArraysPerBucket).IsEqualTo(
+            PoolSizing.ForConsumerResponseBuffers(
+                options.BootstrapServers.Count,
+                options.PrefetchPipelineDepth,
+                options.MaxConnectionsPerBroker));
+    }
+
+    private static T GetField<T>(object target, string name) =>
+        (T)(target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(target)!);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -188,4 +188,37 @@ public class PendingFetchDataTests
         await Assert.That(second.Topic).IsEqualTo("topic");
         await Assert.That(second.LastYieldedOffset).IsEqualTo(-1L);
     }
+
+    [Test]
+    [NotInParallel]
+    public async Task Dispose_RetainsParsedRecordSlabAcrossPooledReuse()
+    {
+        var originalMaxPoolSize = MaxPoolSizeField.GetValue(null);
+        var originalPool = PoolField.GetValue(null);
+        var slabField = typeof(PendingFetchData)
+            .GetField("_parsedRecordSlab", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        PendingFetchData? second = null;
+
+        try
+        {
+            MaxPoolSizeField.SetValue(null, 1);
+            PoolField.SetValue(null, new LockFreeStack<PendingFetchData>(1));
+
+            var first = PendingFetchData.Create("topic-1", 0, Array.Empty<RecordBatch>());
+            var slab = new Record[32];
+            slabField.SetValue(first, slab);
+            first.Dispose();
+
+            second = PendingFetchData.Create("topic-2", 1, Array.Empty<RecordBatch>());
+
+            await Assert.That(second).IsSameReferenceAs(first);
+            await Assert.That(slabField.GetValue(second)).IsSameReferenceAs(slab);
+        }
+        finally
+        {
+            second?.Dispose();
+            MaxPoolSizeField.SetValue(null, originalMaxPoolSize);
+            PoolField.SetValue(null, originalPool);
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -220,6 +220,26 @@ public class PoolSizingTests
         await Assert.That(capacity).IsEqualTo(1024);
     }
 
+    [Test]
+    [Arguments(1, 3, 1, 16)]
+    [Arguments(3, 3, 1, 16)]
+    [Arguments(3, 5, 2, 42)]
+    [Arguments(100, 100, 100, 256)]
+    [Arguments(int.MaxValue, int.MaxValue, int.MaxValue, 256)]
+    public async Task ForConsumerResponseBuffers_CoversPipelineWorkingSet(
+        int brokerCount,
+        int prefetchPipelineDepth,
+        int connectionsPerBroker,
+        int expected)
+    {
+        var capacity = PoolSizing.ForConsumerResponseBuffers(
+            brokerCount,
+            prefetchPipelineDepth,
+            connectionsPerBroker);
+
+        await Assert.That(capacity).IsEqualTo(expected);
+    }
+
     // --- ForSharedPools tests ---
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -230,4 +230,17 @@ public class ResponseBufferPoolTests
 
         await Assert.That(default1).IsSameReferenceAs(default2);
     }
+
+    [Test]
+    public async Task Create_DifferentRetentionDepths_UseDifferentSharedPools()
+    {
+        var shallow = ResponseBufferPool.Create(20 * 1024 * 1024, maxArraysPerBucket: 4);
+        var consumer = ResponseBufferPool.Create(20 * 1024 * 1024, maxArraysPerBucket: 16);
+
+        await Assert.That(shallow).IsNotSameReferenceAs(consumer);
+        await Assert.That(shallow.MaxArraysPerBucket).IsEqualTo(4);
+        await Assert.That(consumer.MaxArraysPerBucket).IsEqualTo(16);
+        await Assert.That(ResponseBufferPool.Create(20 * 1024 * 1024, 16))
+            .IsSameReferenceAs(consumer);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1234,6 +1234,35 @@ public class RecordBatchTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task RecordBatch_Read_IsReusedAfterPendingFetchDisposal()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        new RecordBatch
+        {
+            BaseOffset = 17,
+            Records = [new Record { IsKeyNull = true, Value = "pooled"u8.ToArray() }]
+        }.Write(buffer);
+
+        var firstReader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var first = RecordBatch.Read(ref firstReader);
+        var pending = PendingFetchData.Create("topic", 0, [first]);
+        pending.Dispose();
+
+        var secondReader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var second = RecordBatch.Read(ref secondReader);
+
+        await Assert.That(second).IsSameReferenceAs(first);
+        await Assert.That(second.BaseOffset).IsEqualTo(17L);
+
+        // Stale owner disposal remains harmless after the batch gets a new lease.
+        pending.Dispose();
+        await Assert.That(second.Records.Count).IsEqualTo(1);
+
+        using var secondOwner = PendingFetchData.Create("topic", 0, [second]);
+    }
+
+    [Test]
     public async Task RecordBatch_RatchetPoolSize_GrowsAndDoesNotShrink()
     {
         var target = RecordBatch.MaxPoolSizeValue + 1;

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRecordPoolingTests.cs
@@ -1,0 +1,87 @@
+using System.Buffers;
+using System.Reflection;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerRecordPoolingTests
+{
+    [Test]
+    [NotInParallel]
+    public async Task ParsePartitionRecords_DeserializerThrows_ReturnsBatchToPool()
+    {
+        var expectedBatch = RecordBatch.RentFromPool();
+        expectedBatch.ReturnToPool();
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using var source = new RecordBatch
+        {
+            BaseOffset = 17,
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        source.Write(buffer);
+
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-pooling-test"
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        var valueDeserializer = Substitute.For<IDeserializer<string>>();
+        valueDeserializer.Deserialize(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<SerializationContext>())
+            .Returns(_ => throw new InvalidOperationException("Deserializer failure"));
+        await using var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Serializers.String,
+            valueDeserializer,
+            pool,
+            metadataManager);
+
+        var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
+            "ParsePartitionRecords",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        TargetInvocationException? thrown = null;
+        try
+        {
+            method.Invoke(consumer,
+            [
+                new TopicInfo { Name = "topic", Partitions = [] },
+                new ShareFetchResponsePartition
+                {
+                    PartitionIndex = 0,
+                    CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                    RecordBytes = buffer.WrittenMemory,
+                    AcquiredRecords =
+                    [
+                        new ShareFetchAcquiredRecords
+                        {
+                            FirstOffset = 17,
+                            LastOffset = 17,
+                            DeliveryCount = 1
+                        }
+                    ]
+                },
+                1
+            ]);
+        }
+        catch (TargetInvocationException exception)
+        {
+            thrown = exception;
+        }
+
+        await Assert.That(thrown?.InnerException).IsTypeOf<InvalidOperationException>();
+
+        var returnedBatch = RecordBatch.RentFromPool();
+        await Assert.That(returnedBatch).IsSameReferenceAs(expectedBatch);
+        returnedBatch.ReturnToPool();
+    }
+}


### PR DESCRIPTION
## Summary
- size consumer response-buffer pools for the prefetch pipeline working set
- quantize adaptive fetch sizes to ArrayPool power-of-two tiers
- reuse consumer RecordBatch objects and retain parsed-record slabs across fetches
- preserve generation-safe ownership and failed-parse cleanup

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe` (5,302 passed)
- [x] `Dekaf.Tests.Integration.exe --treenode-filter '/*/*/ConsumerTests/*'` (30 passed)

Closes #1942
