### PR TITLE
Isolate global MeterListener tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-[NotInParallel]
+[NotInParallel("MeterListener")]
 public sealed class ConsumeOneFastPathTests
 {
     private const string Topic = "test-topic";

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -349,6 +349,7 @@ public sealed class ConsumeOneFastPathTests
     [Test]
     public async Task ConsumeOneAsync_EmitsFetchMetricsAsDeltas()
     {
+        var topic = $"metrics-test-{Guid.NewGuid():N}";
         var messagesReceived = new List<long>();
         var bytesReceived = new List<long>();
         using var listener = new MeterListener();
@@ -361,8 +362,11 @@ public sealed class ConsumeOneFastPathTests
                 meterListener.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
         {
+            if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                return;
+
             if (instrument.Name == "messaging.client.consumed.messages")
                 messagesReceived.Add(measurement);
             else if (instrument.Name == "messaging.client.consumed.bytes")
@@ -370,7 +374,7 @@ public sealed class ConsumeOneFastPathTests
         });
         listener.Start();
 
-        var fetch = PendingFetchData.Create(Topic, Partition,
+        var fetch = PendingFetchData.Create(topic, Partition,
         [
             CreateBatch(40,
                 CreateRecord(0, "a", "one"),
@@ -387,6 +391,17 @@ public sealed class ConsumeOneFastPathTests
 
         await Assert.That(messagesReceived).IsEquivalentTo([2L]);
         await Assert.That(bytesReceived.Sum()).IsEqualTo(8L);
+    }
+
+    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == key)
+                return tag.Value?.ToString();
+        }
+
+        return null;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-[NotInParallel("MeterListener")]
 public sealed class ConsumeOneFastPathTests
 {
     private const string Topic = "test-topic";
@@ -347,6 +346,7 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
+    [NotInParallel("MeterListener")]
     public async Task ConsumeOneAsync_EmitsFetchMetricsAsDeltas()
     {
         var topic = $"metrics-test-{Guid.NewGuid():N}";

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -7,6 +7,7 @@ using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
+using Dekaf.Tests.Unit.Producer;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -364,7 +365,7 @@ public sealed class ConsumeOneFastPathTests
         };
         listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
         {
-            if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+            if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
                 return;
 
             if (instrument.Name == "messaging.client.consumed.messages")
@@ -391,17 +392,6 @@ public sealed class ConsumeOneFastPathTests
 
         await Assert.That(messagesReceived).IsEquivalentTo([2L]);
         await Assert.That(bytesReceived.Sum()).IsEqualTo(8L);
-    }
-
-    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
-    {
-        foreach (var tag in tags)
-        {
-            if (tag.Key == key)
-                return tag.Value?.ToString();
-        }
-
-        return null;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
@@ -11,7 +11,7 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-[NotInParallel]
+[NotInParallel("MeterListener")]
 public sealed class KafkaConsumerFetchMetricsTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
@@ -11,10 +11,10 @@ using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Consumer;
 
-[NotInParallel("MeterListener")]
 public sealed class KafkaConsumerFetchMetricsTests
 {
     [Test]
+    [NotInParallel("MeterListener")]
     public async Task RecordFetchDuration_WhenDisabled_DoesNotCreateBrokerTags()
     {
         await using var consumer = CreateConsumer();
@@ -25,6 +25,7 @@ public sealed class KafkaConsumerFetchMetricsTests
     }
 
     [Test]
+    [NotInParallel("MeterListener")]
     public async Task RecordFetchDuration_WhenEnabled_ReusesBrokerTags()
     {
         var expectedBrokerId = BitConverter.ToInt32(Guid.NewGuid().ToByteArray());

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
@@ -27,8 +27,9 @@ public sealed class KafkaConsumerFetchMetricsTests
     [Test]
     public async Task RecordFetchDuration_WhenEnabled_ReusesBrokerTags()
     {
+        var expectedBrokerId = BitConverter.ToInt32(Guid.NewGuid().ToByteArray());
         double? duration = null;
-        string? brokerId = null;
+        int? brokerId = null;
 
         using var listener = new MeterListener();
         listener.InstrumentPublished = (instrument, meterListener) =>
@@ -41,10 +42,12 @@ public sealed class KafkaConsumerFetchMetricsTests
         };
         listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
         {
-            if (instrument.Name == "messaging.consumer.fetch.duration")
+            if (instrument.Name == "messaging.consumer.fetch.duration" &&
+                GetTag(tags, DekafDiagnostics.MessagingKafkaBrokerId) is int metricBrokerId &&
+                metricBrokerId == expectedBrokerId)
             {
                 duration = measurement;
-                brokerId = GetTag(tags, DekafDiagnostics.MessagingKafkaBrokerId);
+                brokerId = metricBrokerId;
             }
         });
         listener.Start();
@@ -53,11 +56,11 @@ public sealed class KafkaConsumerFetchMetricsTests
 
         await using var consumer = CreateConsumer();
 
-        InvokeRecordFetchDuration(consumer, brokerId: 7);
-        InvokeRecordFetchDuration(consumer, brokerId: 7);
+        InvokeRecordFetchDuration(consumer, expectedBrokerId);
+        InvokeRecordFetchDuration(consumer, expectedBrokerId);
 
         await Assert.That(duration).IsNotNull();
-        await Assert.That(brokerId).IsEqualTo("7");
+        await Assert.That(brokerId).IsEqualTo(expectedBrokerId);
         await Assert.That(GetFetchDurationMetricTagsCache(consumer).Count).IsEqualTo(1);
     }
 
@@ -100,12 +103,12 @@ public sealed class KafkaConsumerFetchMetricsTests
         return (ConcurrentDictionary<int, TagList>)field.GetValue(consumer)!;
     }
 
-    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
+    private static object? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
     {
         foreach (var tag in tags)
         {
             if (tag.Key == key)
-                return tag.Value?.ToString();
+                return tag.Value;
         }
 
         return null;

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafDiagnosticsTests.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using Dekaf.Diagnostics;
 
 namespace Dekaf.Tests.Unit.Diagnostics;
@@ -65,44 +64,6 @@ public sealed class DekafDiagnosticsTests
     {
         var meter = DekafDiagnostics.Meter;
         await Assert.That(meter.Name).IsEqualTo("Dekaf");
-    }
-
-    [Test]
-    public async Task MetricInstruments_HaveCorrectNames()
-    {
-        var instrumentNames = new List<string>();
-        using var listener = new MeterListener();
-        listener.InstrumentPublished = (instrument, meterListener) =>
-        {
-            if (instrument.Meter.Name == DekafDiagnostics.MeterName)
-            {
-                instrumentNames.Add(instrument.Name);
-            }
-        };
-        listener.Start();
-
-        // Force instrument creation by touching them
-        DekafMetrics.MessagesSent.Add(0);
-        DekafMetrics.BytesSent.Add(0);
-        DekafMetrics.OperationDuration.Record(0);
-        DekafMetrics.ProduceErrors.Add(0);
-        DekafMetrics.Retries.Add(0);
-        DekafMetrics.MessagesReceived.Add(0);
-        DekafMetrics.BytesReceived.Add(0);
-        DekafMetrics.RebalanceDuration.Record(0);
-        DekafMetrics.FetchDuration.Record(0);
-        // ConsumerLag is an observable gauge — auto-registered when the meter is listened to
-
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.messages");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.bytes");
-        await Assert.That(instrumentNames).Contains("messaging.client.operation.duration");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
-        await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
-        await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.fetch.duration");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.lag");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+
+namespace Dekaf.Tests.Unit.Diagnostics;
+
+[NotInParallel("MeterListener")]
+public sealed class DekafMetricInstrumentTests
+{
+    [Test]
+    public async Task MetricInstruments_HaveCorrectNames()
+    {
+        var instrumentNames = new List<string>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, _) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName)
+                instrumentNames.Add(instrument.Name);
+        };
+        listener.Start();
+
+        // Force instrument creation by touching them. ConsumerLag is an observable
+        // gauge, so listening to the meter publishes it without a measurement call.
+        DekafMetrics.MessagesSent.Add(0);
+        DekafMetrics.BytesSent.Add(0);
+        DekafMetrics.OperationDuration.Record(0);
+        DekafMetrics.ProduceErrors.Add(0);
+        DekafMetrics.Retries.Add(0);
+        DekafMetrics.MessagesReceived.Add(0);
+        DekafMetrics.BytesReceived.Add(0);
+        DekafMetrics.RebalanceDuration.Record(0);
+        DekafMetrics.FetchDuration.Record(0);
+
+        await Assert.That(instrumentNames).Contains("messaging.client.sent.messages");
+        await Assert.That(instrumentNames).Contains("messaging.client.sent.bytes");
+        await Assert.That(instrumentNames).Contains("messaging.client.operation.duration");
+        await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
+        await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
+        await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
+        await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
+        await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");
+        await Assert.That(instrumentNames).Contains("messaging.consumer.fetch.duration");
+        await Assert.That(instrumentNames).Contains("messaging.consumer.lag");
+    }
+}


### PR DESCRIPTION
## Summary
- isolate every global `MeterListener` test in one shared non-parallel group
- move instrument publication coverage out of the activity-listener-isolated class
- retain existing class-wide isolation for consumer fixture tests while allowing unrelated tests to run in parallel

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] three affected listener tests individually (all passed)
- [x] full unit suite twice consecutively (5294/5294 each)

Closes #1949
