### PR TITLE
Restore round-trip batching and phase diagnostics

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -111,6 +111,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // the hard cap prevents a continuously busy producer from postponing dispatch forever.
     private const int WaveCoalesceQuietMicroseconds = 75;
     private const int WaveCoalesceMaxMicroseconds = 500;
+    private static readonly long WaveCoalesceMaxTicks =
+        MicrosecondsToStopwatchTicks(WaveCoalesceMaxMicroseconds);
 
     /// <summary>
     /// Maximum batches coalesced into one send-loop pass. The in-flight limit can be very
@@ -1082,7 +1084,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
-        var waveCoalesceMaxTicks = GetWaveCoalesceMaxTicks(_options.LingerMs);
+        var waveCoalesceMaxTicks = WaveCoalesceMaxTicks;
         var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(WaveCoalesceQuietMicroseconds);
         var waveCoalesceArmed = true;
 
@@ -1357,7 +1359,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // the spin pure waste. This is especially important for single-partition topics
                 // where coalescedCount is always 1 and every MicroLinger iteration is wasted.
                 if (waveCoalesceArmed
-                    && waveCoalesceMaxTicks > 0
                     && coalescedCount > 0
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
@@ -2231,11 +2232,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var batch = coalescedBatches[0];
         return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
-
-    internal static long GetWaveCoalesceMaxTicks(int lingerMs) =>
-        lingerMs <= 0
-            ? 0
-            : MicrosecondsToStopwatchTicks(Math.Min(lingerMs * 1_000L, WaveCoalesceMaxMicroseconds));
 
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
         Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -106,20 +106,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private const int BlockedBucketPollIntervalMs = 1;
     private static readonly TimeSpan DisposalDrainTimeout = TimeSpan.FromSeconds(5);
 
-    /// <summary>
-    /// Micro-linger: when coalesced batch count is at or below this threshold,
-    /// briefly spin-wait for more batches before sending. Reduces per-request
-    /// overhead in multi-broker setups with few partitions per broker.
-    /// </summary>
-    private const int MicroLingerBatchThreshold = 3;
-
-    /// <summary>
-    /// Maximum SpinWait iterations for the micro-linger. Bounds the spin cost
-    /// regardless of channel activity. Higher values (20 vs 10) give the sender
-    /// loop more time to enqueue all batches for this broker, improving coalescing
-    /// in multi-broker setups where per-broker batch counts are low.
-    /// </summary>
-    private const int MicroLingerMaxSpins = 20;
+    // A request wave often reaches the sender over hundreds of microseconds. Waiting for one
+    // short quiet period coalesces that wave without paying the full configured linger, while
+    // the hard cap prevents a continuously busy producer from postponing dispatch forever.
+    private const int WaveCoalesceQuietMicroseconds = 75;
+    private const int WaveCoalesceMaxMicroseconds = 500;
 
     /// <summary>
     /// Maximum batches coalesced into one send-loop pass. The in-flight limit can be very
@@ -155,6 +146,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly Action<int>? _onBrokerThrottle;
     private readonly Action? _onBlockedBucketRequeued;
     private readonly Action? _onPipelinedResponseAcquired;
+    private readonly Action? _onWaveCoalesceStarted;
     private readonly Func<long> _getTimestamp;
     private readonly Func<int, CancellationToken, ValueTask> _delayForThrottle;
     private readonly TimeSpan _disposalDrainTimeout;
@@ -718,7 +710,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         BrokerUnackedByteBudget? unackedBudget = null,
         TimeSpan? disposalDrainTimeout = null,
         Func<bool>? usesTransactionV2 = null,
-        Action? onPipelinedResponseAcquired = null)
+        Action? onPipelinedResponseAcquired = null,
+        Action? onWaveCoalesceStarted = null)
     {
         _unackedBudget = unackedBudget;
         _brokerId = brokerId;
@@ -743,6 +736,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _delayForThrottle = delayForThrottle ?? DelayForThrottleAsync;
         _onBlockedBucketRequeued = onBlockedBucketRequeued;
         _onPipelinedResponseAcquired = onPipelinedResponseAcquired;
+        _onWaveCoalesceStarted = onWaveCoalesceStarted;
         _disposalDrainTimeout = disposalDrainTimeout ?? DisposalDrainTimeout;
 
         _eventChannel = Channel.CreateUnbounded<SendLoopEvent>(new UnboundedChannelOptions
@@ -1088,6 +1082,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
+        var waveCoalesceMaxTicks = GetWaveCoalesceMaxTicks(_options.LingerMs);
+        var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(WaveCoalesceQuietMicroseconds);
+        var waveCoalesceArmed = true;
 
         // Pre-allocate reusable response lookup dictionary to avoid per-response allocation.
         // Single-threaded: only accessed by the send loop, cleared after each use.
@@ -1350,43 +1347,54 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 if (carryOver.Count > 0 || coalescedCount == maxCoalesce)
                     RecordSendLoopPressureIfScaleUseful();
 
-                // ── 5b. Micro-linger for small coalesced batches ──
-                // When very few batches are coalesced (e.g., broker has only 2 partitions in a
-                // multi-broker setup), sending immediately produces many small ProduceRequests.
-                // A brief adaptive spin gives the sender coordinator time to post more batches,
-                // reducing per-request overhead. SpinWait adapts across core counts (spins on
-                // multi-core, yields on single-core) and avoids kernel transitions when possible.
-                // The iteration count caps total work (both spins and channel reads).
+                // ── 5b. Form a request wave across known partitions ──
+                // Sealed batches for one producer wave reach this broker over hundreds of
+                // microseconds. Wait for a short quiet interval, extending it whenever another
+                // distinct partition arrives, but never beyond the configured hard cap.
                 //
                 // Skip when all known partitions are already coalesced — any new batch from the
                 // channel would be for an already-coalesced partition and get carried over, making
                 // the spin pure waste. This is especially important for single-partition topics
                 // where coalescedCount is always 1 and every MicroLinger iteration is wasted.
-                if (coalescedCount > 0 && coalescedCount <= MicroLingerBatchThreshold
+                if (waveCoalesceArmed
+                    && waveCoalesceMaxTicks > 0
+                    && coalescedCount > 0
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
-                    && Volatile.Read(ref _totalPendingResponseCount) < _totalMaxInFlight
+                    && Volatile.Read(ref _totalPendingResponseCount) == 0
                     && ShouldMicroLinger(
                         coalescedBatches,
                         coalescedCount,
                         _options.TransactionalId is not null))
                 {
-                    var spinWait = new SpinWait();
-                    for (var spin = 0; spin < MicroLingerMaxSpins && coalescedCount < maxCoalesce; spin++)
+                    waveCoalesceArmed = false;
+                    _onWaveCoalesceStarted?.Invoke();
+                    var started = Stopwatch.GetTimestamp();
+                    var hardDeadline = started + waveCoalesceMaxTicks;
+                    var quietDeadline = Math.Min(started + waveCoalesceQuietTicks, hardDeadline);
+                    while (coalescedCount < maxCoalesce
+                           && coalescedPartitions.Count < _knownPartitions.Count
+                           && Stopwatch.GetTimestamp() < quietDeadline)
                     {
                         if (!eventReader.TryRead(out var evt))
                         {
-                            spinWait.SpinOnce();
+                            // Fixed CPU spin never escalates to Sleep(1), so the deadline
+                            // remains a real sub-millisecond hard cap.
+                            global::System.Threading.Thread.SpinWait(32);
                             continue;
                         }
 
                         if (evt.Type == SendLoopEventType.NewBatch)
                         {
+                            var countBefore = coalescedCount;
                             CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
                                 ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
-                            if (coalescedCount > MicroLingerBatchThreshold)
-                                break;
+                            if (coalescedCount > countBefore)
+                            {
+                                var now = Stopwatch.GetTimestamp();
+                                quietDeadline = Math.Min(now + waveCoalesceQuietTicks, hardDeadline);
+                            }
                         }
                         else if (evt.Type == SendLoopEventType.TransactionEnrollmentReady)
                         {
@@ -1798,6 +1806,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     {
                         break;
                     }
+
+                    waveCoalesceArmed = true;
                 }
                 else if (carryOver.Count > 0 && sentThisIteration)
                 {
@@ -2221,6 +2231,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var batch = coalescedBatches[0];
         return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
+
+    internal static long GetWaveCoalesceMaxTicks(int lingerMs) =>
+        lingerMs <= 0
+            ? 0
+            : MicrosecondsToStopwatchTicks(Math.Min(lingerMs * 1_000L, WaveCoalesceMaxMicroseconds));
+
+    private static long MicrosecondsToStopwatchTicks(long microseconds) =>
+        Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool CarryOverIfCoalescedLimitReached(
@@ -2936,7 +2954,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         PartitionCarryOver carryOver,
         CancellationToken cancellationToken)
     {
-        var now = Stopwatch.GetTimestamp();
+        var now = _getTimestamp();
         var requestTimeoutTicks = _options.RequestTimeoutTicks;
 
         // Check each connection's pending responses for timeout.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -225,7 +225,8 @@ public sealed class BrokerSenderMuteOrderingTests
         MetadataManager? metadataManager = null,
         Action<ReadyBatch, int>? rerouteBatch = null,
         ILogger? logger = null,
-        int brokerId = 1) =>
+        int brokerId = 1,
+        Func<long>? getTimestamp = null) =>
         new(
             brokerId, pool,
             metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
@@ -240,7 +241,8 @@ public sealed class BrokerSenderMuteOrderingTests
             getCurrentEpoch: null,
             rerouteBatch: rerouteBatch,
             onAcknowledgement: onAcknowledgement,
-            logger: logger);
+            logger: logger,
+            getTimestamp: getTimestamp);
 
     private static object CreateCarryOver()
     {
@@ -494,14 +496,16 @@ public sealed class BrokerSenderMuteOrderingTests
         var (pool, connection) = CreateMockConnection(responseQueue);
         pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(connection);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: false,
-            deliveryTimeoutMs: 1, requestTimeoutMs: 1, connectionsPerBroker: 2);
+            deliveryTimeoutMs: 1, requestTimeoutMs: 10_000, connectionsPerBroker: 2);
         var accumulator = new RecordAccumulator(options);
         await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
         metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 2));
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
         var sendLogger = new PipelinedSendLogger(expectedSends: 1);
+        var testTimestamp = Stopwatch.GetTimestamp();
         var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { }, metadataManager,
-            logger: sendLogger);
+            logger: sendLogger,
+            getTimestamp: () => Volatile.Read(ref testTimestamp));
         var getConnection = typeof(BrokerSender).GetMethod(
             "GetConnectionForPartition", BindingFlags.Instance | BindingFlags.NonPublic)!;
         var topicPartition = new TopicPartition("test-topic", 3);
@@ -511,15 +515,29 @@ public sealed class BrokerSenderMuteOrderingTests
         {
             sender.Enqueue(batch);
             await sendLogger.SendSignals[0].Task.WaitAsync(ct);
+            await WaitForDiagAsync(batch, 'W', TimeSpan.FromSeconds(5), ct);
             metadataManager.Metadata.Update(CreateRoutingMetadata(partitionZeroLeader: 1));
             typeof(BrokerSender).GetMethod(
                     "RefreshPartitionRouting", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .Invoke(sender, null);
 
+            var migratingCount = (int)typeof(BrokerSender).GetMethod(
+                    "GetMigratingPartitionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, null)!;
+            await Assert.That(migratingCount).IsEqualTo(1);
+
             await Task.Delay(20, ct);
+            Volatile.Write(
+                ref testTimestamp,
+                Stopwatch.GetTimestamp() + (20 * Stopwatch.Frequency));
             typeof(BrokerSender).GetMethod(
                     "HandleTimedOutRequests", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .Invoke(sender, [CreateCarryOver(), ct]);
+
+            migratingCount = (int)typeof(BrokerSender).GetMethod(
+                    "GetMigratingPartitionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(sender, null)!;
+            await Assert.That(migratingCount).IsEqualTo(0);
 
             await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
                 .Because("timeout removal leaves no old request that can justify a migration fence");

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -126,13 +126,97 @@ public sealed class BrokerSenderSendLoopTests
             .IsTrue();
     }
 
+    [Test]
+    public async Task GetWaveCoalesceMaxTicks_UsesLingerBoundAndHardCap()
+    {
+        await Assert.That(BrokerSender.GetWaveCoalesceMaxTicks(0)).IsEqualTo(0);
+        await Assert.That(BrokerSender.GetWaveCoalesceMaxTicks(1)).IsEqualTo(
+            Math.Max(1, 500L * Stopwatch.Frequency / 1_000_000));
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWait(
+        CancellationToken cancellationToken)
+    {
+        var connection = new TestKafkaConnection
+        {
+            SendProduceFireAndForgetWithCallerTimeout = () => ValueTask.CompletedTask
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var options = CreateOptions(
+            acks: Acks.None,
+            enableIdempotence: false,
+            lingerMs: 1,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var injectSibling = 0;
+        BrokerSender? sender = null;
+        sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            onWaveCoalesceStarted: () =>
+            {
+                if (Volatile.Read(ref injectSibling) != 0)
+                    sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+            });
+
+        try
+        {
+            // Prime both known partitions in one request. The next single-partition event
+            // must enter the wave-coalesce path rather than being fully drained already.
+            sender.EnqueueBulk(
+            [
+                CreateTestBatch(valueTaskSourcePool, "test-topic", 0),
+                CreateTestBatch(valueTaskSourcePool, "test-topic", 1)
+            ]);
+            await WaitUntilAsync(
+                () => accumulator.GetDeliveryDiagnosticsSnapshot()
+                    .ProduceRequestCount == 1,
+                cancellationToken);
+
+            Volatile.Write(ref injectSibling, 1);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await WaitUntilAsync(
+                () => accumulator.GetDeliveryDiagnosticsSnapshot()
+                    .ProduceRequestCount == 2,
+                cancellationToken);
+
+            // The sender is fully idle again. Waiting for this event must re-arm the wave.
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await WaitUntilAsync(
+                () => accumulator.GetDeliveryDiagnosticsSnapshot()
+                    .ProduceRequestCount == 3,
+                cancellationToken);
+
+            var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot();
+            await Assert.That(connection.SendFireAndForgetWithCallerTimeoutCalls).IsEqualTo(3);
+            await Assert.That(diagnostic.CoalesceWidthHistogram
+                    .Single(bucket => bucket.MinimumWidth == 2).RequestCount)
+                .IsEqualTo(3);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,
         int connectionsPerBroker = 1, bool enableAdaptiveConnections = true,
         bool enableIdempotence = true, int batchSize = 1_048_576,
         long? unackedByteBudgetCapOverride = null, long? scaleCooldownMsOverride = null,
-        string? transactionalId = null) => new()
+        string? transactionalId = null, int lingerMs = 0,
+        bool enableDeliveryDiagnostics = false) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -145,7 +229,8 @@ public sealed class BrokerSenderSendLoopTests
             RetryBackoffMaxMs = retryBackoffMaxMs,
             RequestTimeoutMs = requestTimeoutMs,
             BatchSize = batchSize,
-            LingerMs = 0,
+            LingerMs = lingerMs,
+            EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
             UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride,
             ScaleCooldownMsOverride = scaleCooldownMsOverride,
             TransactionalId = transactionalId
@@ -358,6 +443,7 @@ public sealed class BrokerSenderSendLoopTests
         Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
         Action? onBlockedBucketRequeued = null,
         Action? onPipelinedResponseAcquired = null,
+        Action? onWaveCoalesceStarted = null,
         BrokerUnackedByteBudget? unackedBudget = null,
         int produceApiVersion = 9,
         bool isTransactional = false,
@@ -386,7 +472,8 @@ public sealed class BrokerSenderSendLoopTests
             onBlockedBucketRequeued: onBlockedBucketRequeued,
             unackedBudget: unackedBudget,
             usesTransactionV2: () => usesTransactionV2,
-            onPipelinedResponseAcquired: onPipelinedResponseAcquired);
+            onPipelinedResponseAcquired: onPipelinedResponseAcquired,
+            onWaveCoalesceStarted: onWaveCoalesceStarted);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -127,16 +127,8 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
-    public async Task GetWaveCoalesceMaxTicks_UsesLingerBoundAndHardCap()
-    {
-        await Assert.That(BrokerSender.GetWaveCoalesceMaxTicks(0)).IsEqualTo(0);
-        await Assert.That(BrokerSender.GetWaveCoalesceMaxTicks(1)).IsEqualTo(
-            Math.Max(1, 500L * Stopwatch.Frequency / 1_000_000));
-    }
-
-    [Test]
     [Timeout(120_000)]
-    public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWait(
+    public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWaitAtDefaultLinger(
         CancellationToken cancellationToken)
     {
         var connection = new TestKafkaConnection
@@ -150,7 +142,7 @@ public sealed class BrokerSenderSendLoopTests
         var options = CreateOptions(
             acks: Acks.None,
             enableIdempotence: false,
-            lingerMs: 1,
+            lingerMs: 0,
             enableDeliveryDiagnostics: true);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -43,7 +43,10 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
-            .WithConnectionsPerBroker(options.ConnectionsPerBroker);
+            .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Keep this comparison
+            // fixed too so adaptive scale events cannot change ordering or the test profile.
+            .WithoutAdaptiveConnections();
 
         _ = options.Compression switch
         {


### PR DESCRIPTION
## Summary

- form one bounded cross-partition request wave after producer idle without stalling an active pipeline
- warm both round-trip producers before timing and keep Dekaf on the requested fixed connection profile
- report separate produce and consume rates instead of hiding the regressed phase in one blended number
- expose per-broker request rate, average coalesce width, and coalesce-width histogram
- make request-timeout tests deterministic through the injected monotonic clock

## Root cause

After non-idempotent mute-on-send was removed, narrow partition batches could be dispatched before sibling partitions reached the sender. The old 20-iteration spin covered only a few microseconds. The stress harness also timed producer construction, blended produce and consume phases, and let Dekaf adapt beyond the fixed connection count used by Confluent, obscuring both the regression and ordering behavior.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore` — 0 warnings, 0 errors
- net10 unit suite — 5,296 passed
- Kafka 4.3.1 round-trip stress, 250,000 × 1000-byte messages, 16KB batches, 5ms linger, both clients:
  - Dekaf: 250,000 consumed, 0 missing/duplicate/corrupt/out-of-order, 70,522 produce msg/s
  - Confluent: 250,000 consumed, 0 missing/duplicate/corrupt/out-of-order, 70,622 produce msg/s
  - blended round-trip: Dekaf 53,507 msg/s vs Confluent 44,815 msg/s (1.19x)

Closes #1940