### PR TITLE
Stabilize adaptive scale-down reap test

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -352,6 +352,8 @@ public sealed class AdaptiveScaleDownTests
                 await pool.GetConnectionAsync(1);
 
                 var senderType = typeof(BrokerSender);
+                GetField<MetadataManager>(sender, "_metadataManager")
+                    .Metadata.Update(CreateMetadata(leaderId: 1));
                 var getConnection = senderType.GetMethod(
                     "GetConnectionForPartition",
                     BindingFlags.Instance | BindingFlags.NonPublic)!;


### PR DESCRIPTION
## Summary
- publish broker leader metadata before testing routed-slot retention
- prevent the background idle sender from legitimately releasing the slot before manual reap
- preserve the exact one-connection reap invariant

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] affected test repeated 5 times
- [x] full unit suite twice consecutively (5297/5297 each)

Closes #1952
