### PR TITLE
Avoid unused producer connections

### DIFF
--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -15,6 +15,7 @@ namespace Dekaf.Networking;
 public sealed partial class ConnectionPool : IConnectionPool
 {
     private const int MaxConnectionReapDiagnosticEvents = 256;
+    private static readonly TimeSpan DefaultIdleReapDrainTimeout = TimeSpan.FromSeconds(5);
     private readonly string? _clientId;
     private readonly ConnectionOptions _connectionOptions;
     private readonly ILoggerFactory? _loggerFactory;
@@ -22,6 +23,7 @@ public sealed partial class ConnectionPool : IConnectionPool
     private readonly int _connectionsPerBroker;
     private readonly ResponseBufferPool _responseBufferPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
+    private readonly TimeSpan _idleReapDrainTimeout;
     private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
     private CancellationTokenSource? _idleReaperCts;
     private Task? _idleReaperTask;
@@ -88,7 +90,8 @@ public sealed partial class ConnectionPool : IConnectionPool
         int connectionsPerBroker,
         ResponseBufferPool responseBufferPool,
         int? pipeMemoryBucketCapacity = null,
-        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null,
+        TimeSpan? idleReapDrainTimeout = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -100,6 +103,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
         _responseBufferPool = responseBufferPool;
         _telemetryMetricCollector = telemetryMetricCollector;
+        _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
         _sharedPipeMemoryPool = PipeMemoryPool.Create(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
@@ -114,7 +118,8 @@ public sealed partial class ConnectionPool : IConnectionPool
         string? clientId,
         ConnectionOptions? connectionOptions,
         int connectionsPerBroker,
-        Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>> connectionFactory)
+        Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>> connectionFactory,
+        TimeSpan? idleReapDrainTimeout = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -126,6 +131,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
         _responseBufferPool = ResponseBufferPool.Default;
         _connectionFactory = connectionFactory;
+        _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
         // No shared pool needed: factory-created connections manage their own pools.
         StartIdleConnectionReaper();
     }
@@ -290,7 +296,12 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
 
         // Need to create new connection group
-        var created = await CreateConnectionGroupAsync(brokerId, brokerInfo, cancellationToken).ConfigureAwait(false);
+        var created = await CreateConnectionGroupAsync(
+                brokerId,
+                brokerInfo,
+                _connectionsPerBroker,
+                cancellationToken)
+            .ConfigureAwait(false);
         return MarkConnectionAcquired(created);
     }
 
@@ -298,6 +309,9 @@ public sealed partial class ConnectionPool : IConnectionPool
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(ConnectionPool));
+
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfEqual(index, int.MaxValue);
 
         if (!_brokers.TryGetValue(brokerId, out var brokerInfo))
         {
@@ -312,38 +326,52 @@ public sealed partial class ConnectionPool : IConnectionPool
         // single connection — serializing all sends on one socket.
         if (!_connectionGroupsById.TryGetValue(brokerId, out var connections))
         {
-            if (_connectionsPerBroker <= 1)
+            if (_connectionsPerBroker <= 1 && index == 0)
             {
                 // Graceful degradation: single-connection configuration with no scaled
                 // group yet — fall back to the single-connection path.
                 return await GetConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
             }
 
-            // CreateConnectionGroupAsync populates _connectionGroupsById and returns
-            // the first connection. If it throws (timeout, broker unreachable), the
-            // exception propagates — no null-dereference risk below.
-            await CreateConnectionGroupAsync(brokerId, brokerInfo, cancellationToken).ConfigureAwait(false);
+            // Indexed routing creates only the slots it can currently use. Additional
+            // partition-affined slots are added lazily when their index is first requested.
+            await CreateConnectionGroupAsync(
+                    brokerId,
+                    brokerInfo,
+                    index + 1,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             if (!_connectionGroupsById.TryGetValue(brokerId, out connections))
                 throw new InvalidOperationException($"Connection group for broker {brokerId} was not created");
         }
 
-        var effectiveIndex = index % connections.Length;
-        var connection = connections[effectiveIndex];
+        if (connections.Length <= index)
+        {
+            await ScaleConnectionGroupAsync(brokerId, index + 1, cancellationToken).ConfigureAwait(false);
+            if (!_connectionGroupsById.TryGetValue(brokerId, out connections))
+                throw new InvalidOperationException($"Connection group for broker {brokerId} was not scaled");
+        }
+
+        var connection = connections[index];
 
         if (connection is not null && connection.IsConnected)
         {
             return MarkConnectionAcquired(connection);
         }
 
-        var replacement = await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, effectiveIndex, cancellationToken).ConfigureAwait(false);
+        var replacement = await ReplaceConnectionInGroupAsync(brokerId, brokerInfo, index, cancellationToken).ConfigureAwait(false);
         return MarkConnectionAcquired(replacement);
     }
 
-    private async ValueTask<IKafkaConnection> CreateConnectionGroupAsync(int brokerId, BrokerInfo brokerInfo, CancellationToken cancellationToken)
+    private async ValueTask<IKafkaConnection> CreateConnectionGroupAsync(
+        int brokerId,
+        BrokerInfo brokerInfo,
+        int initialCount,
+        CancellationToken cancellationToken)
     {
         // Use a per-broker semaphore to ensure only one caller creates the group.
-        // Without this, concurrent callers both create full connection groups, leaking TCP connections.
+        // Without this, concurrent callers can create duplicate groups and leak connections.
         var groupLock = _groupCreationLocks.GetOrAdd(brokerId, static _ => new SemaphoreSlim(1, 1));
 
         await groupLock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -357,7 +385,8 @@ public sealed partial class ConnectionPool : IConnectionPool
                 return existingGroup[0];
             }
 
-            return await CreateConnectionGroupCoreAsync(brokerId, brokerInfo, cancellationToken).ConfigureAwait(false);
+            return await CreateConnectionGroupCoreAsync(brokerId, brokerInfo, initialCount, cancellationToken)
+                .ConfigureAwait(false);
         }
         finally
         {
@@ -365,11 +394,16 @@ public sealed partial class ConnectionPool : IConnectionPool
         }
     }
 
-    private async ValueTask<IKafkaConnection> CreateConnectionGroupCoreAsync(int brokerId, BrokerInfo brokerInfo, CancellationToken cancellationToken)
+    private async ValueTask<IKafkaConnection> CreateConnectionGroupCoreAsync(
+        int brokerId,
+        BrokerInfo brokerInfo,
+        int initialCount,
+        CancellationToken cancellationToken)
     {
-        // Create all connections for this broker in parallel
-        var connections = new IKafkaConnection[_connectionsPerBroker];
-        var tasks = new Task<IKafkaConnection>[_connectionsPerBroker];
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(initialCount);
+
+        var connections = new IKafkaConnection[initialCount];
+        var tasks = new Task<IKafkaConnection>[initialCount];
 
         using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -381,7 +415,7 @@ public sealed partial class ConnectionPool : IConnectionPool
         var success = false;
         try
         {
-            for (var i = 0; i < _connectionsPerBroker; i++)
+            for (var i = 0; i < initialCount; i++)
             {
                 var index = i;
                 tasks[i] = CreateConnectionForGroupAsync(
@@ -397,7 +431,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             // Similar pattern to RecordAccumulator disposal fix (commit 8f26f05)
             await Task.WhenAll(tasks).WaitAsync(_connectionOptions.ConnectionTimeout, cancellationToken).ConfigureAwait(false);
 
-            for (var i = 0; i < _connectionsPerBroker; i++)
+            for (var i = 0; i < initialCount; i++)
             {
                 connections[i] = await tasks[i].ConfigureAwait(false);
             }
@@ -406,7 +440,7 @@ public sealed partial class ConnectionPool : IConnectionPool
             _connectionGroupsById[brokerId] = connections;
             ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
 
-            LogCreatedConnectionGroup(_connectionsPerBroker, brokerId);
+            LogCreatedConnectionGroup(initialCount, brokerId);
 
             success = true;
             return connections[0];
@@ -1122,10 +1156,10 @@ public sealed partial class ConnectionPool : IConnectionPool
         var removedByBrokerId = connection.BrokerId >= 0
             && TryRemoveExact(_connectionsById, connection.BrokerId, connection);
 
-        var disposed = await DisposeIdleConnectionAsync(connection, connectionIndex: 0, now).ConfigureAwait(false);
-        if (!disposed)
+        var result = await DisposeIdleConnectionAsync(connection, connectionIndex: 0, now).ConfigureAwait(false);
+        if (!result.Reaped)
         {
-            if (connection.IsConnected)
+            if (result.CanRestore && connection.IsConnected)
             {
                 _connectionsByEndpoint.TryAdd(endpoint, connection);
                 if (removedByBrokerId)
@@ -1163,11 +1197,11 @@ public sealed partial class ConnectionPool : IConnectionPool
             }
         }
 
-        var disposed = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
-        if (!disposed && connection.IsConnected)
+        var result = await DisposeIdleConnectionAsync(connection, index, now).ConfigureAwait(false);
+        if (!result.Reaped && result.CanRestore && connection.IsConnected)
             Interlocked.CompareExchange(ref group[index], connection, null!);
 
-        return disposed;
+        return result.Reaped;
     }
 
     private bool IsIdleReapable(IKafkaConnection connection, long now)
@@ -1181,33 +1215,74 @@ public sealed partial class ConnectionPool : IConnectionPool
         return now - idleState.LastUsedTimestampMs >= _connectionOptions.ConnectionsMaxIdleMs;
     }
 
-    private async ValueTask<bool> DisposeIdleConnectionAsync(
+    private async ValueTask<IdleConnectionDisposalResult> DisposeIdleConnectionAsync(
         IKafkaConnection connection,
         int connectionIndex,
         long now)
     {
         if (!IsIdleReapable(connection, now))
-            return false;
+            return new IdleConnectionDisposalResult(Reaped: false, CanRestore: true);
 
+        var retirementBegun = false;
         try
         {
-            await connection.DisposeAsync().ConfigureAwait(false);
-            if (connection is IIdleTrackedKafkaConnection idleState)
+            if (connection is IRetirableKafkaConnection retirableConnection)
             {
-                var idleDurationMs = now - idleState.LastUsedTimestampMs;
-                LogReapedIdleConnection(
-                    connection.BrokerId,
-                    connection.Host,
-                    connection.Port,
-                    idleDurationMs);
-                RecordConnectionReapDiagnostic(connection.BrokerId, connectionIndex, idleDurationMs);
+                retirableConnection.BeginRetirement();
+                retirementBegun = true;
             }
-            return true;
+
+            var drainTask = DrainAndRecordIdleConnectionAsync(connection, connectionIndex, now);
+            try
+            {
+                await drainTask.WaitAsync(_idleReapDrainTimeout).ConfigureAwait(false);
+            }
+            catch (TimeoutException) when (!drainTask.IsCompleted)
+            {
+                _ = ObserveDetachedIdleDrainAsync(drainTask, connection);
+            }
+
+            return new IdleConnectionDisposalResult(Reaped: true, CanRestore: false);
         }
         catch (Exception ex)
         {
             LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
-            return false;
+            return retirementBegun
+                ? new IdleConnectionDisposalResult(Reaped: true, CanRestore: false)
+                : new IdleConnectionDisposalResult(Reaped: false, CanRestore: true);
+        }
+    }
+
+    private async Task DrainAndRecordIdleConnectionAsync(
+        IKafkaConnection connection,
+        int connectionIndex,
+        long now)
+    {
+        await RetiredConnectionDisposer
+            .DrainAndDisposeAsync(connection, CancellationToken.None)
+            .ConfigureAwait(false);
+
+        if (connection is IIdleTrackedKafkaConnection idleState)
+        {
+            var idleDurationMs = now - idleState.LastUsedTimestampMs;
+            LogReapedIdleConnection(
+                connection.BrokerId,
+                connection.Host,
+                connection.Port,
+                idleDurationMs);
+            RecordConnectionReapDiagnostic(connection.BrokerId, connectionIndex, idleDurationMs);
+        }
+    }
+
+    private async Task ObserveDetachedIdleDrainAsync(Task drainTask, IKafkaConnection connection)
+    {
+        try
+        {
+            await drainTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
         }
     }
 
@@ -1229,7 +1304,8 @@ public sealed partial class ConnectionPool : IConnectionPool
                 OccurredAtUtc = DateTimeOffset.UtcNow,
                 BrokerId = brokerId,
                 ConnectionIndex = connectionIndex,
-                IdleDurationMs = idleDurationMs
+                IdleDurationMs = idleDurationMs,
+                IsBootstrapConnection = brokerId < 0
             });
         }
     }
@@ -1565,4 +1641,5 @@ public sealed partial class ConnectionPool : IConnectionPool
 
     private readonly record struct EndpointKey(string Host, int Port);
     private readonly record struct BrokerInfo(int BrokerId, string Host, int Port);
+    private readonly record struct IdleConnectionDisposalResult(bool Reaped, bool CanRestore);
 }

--- a/src/Dekaf/Networking/ConnectionReapDiagnostic.cs
+++ b/src/Dekaf/Networking/ConnectionReapDiagnostic.cs
@@ -6,4 +6,5 @@ internal sealed class ConnectionReapDiagnostic
     public required int BrokerId { get; init; }
     public required int ConnectionIndex { get; init; }
     public required long IdleDurationMs { get; init; }
+    public required bool IsBootstrapConnection { get; init; }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolConcurrencyTests.cs
@@ -13,6 +13,41 @@ namespace Dekaf.Tests.Unit.Networking;
 /// </summary>
 public sealed class ConnectionPoolConcurrencyTests
 {
+    [Test]
+    public async Task GetConnectionByIndex_CreatesOnlyRequestedRoutingWidth()
+    {
+        const int connectionsPerBroker = 3;
+        var createdIndices = new ConcurrentQueue<int>();
+        var pool = new ConnectionPool(
+            clientId: "test",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: connectionsPerBroker,
+            connectionFactory: (brokerId, host, port, index, _) =>
+            {
+                createdIndices.Enqueue(index);
+                var connection = Substitute.For<IKafkaConnection>();
+                connection.IsConnected.Returns(true);
+                connection.BrokerId.Returns(brokerId);
+                connection.Host.Returns(host);
+                connection.Port.Returns(port);
+                return ValueTask.FromResult(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionByIndexAsync(1, 0);
+            await Assert.That(createdIndices).IsEquivalentTo([0]);
+
+            await pool.GetConnectionByIndexAsync(1, 1);
+            await Assert.That(createdIndices).IsEquivalentTo([0, 1]);
+
+            await pool.GetConnectionByIndexAsync(1, 0);
+            await Assert.That(createdIndices).IsEquivalentTo([0, 1]);
+        }
+    }
+
     /// <summary>
     /// H4: When N concurrent callers trigger group creation for the same broker,
     /// only one group should be created — exactly connectionsPerBroker connections,

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -458,8 +458,122 @@ public sealed class ConnectionPoolTests
             var diagnostic = pool.GetConnectionReapDiagnosticsSnapshot().Single();
             await Assert.That(diagnostic.BrokerId).IsEqualTo(1);
             await Assert.That(diagnostic.ConnectionIndex).IsEqualTo(0);
+            await Assert.That(diagnostic.IsBootstrapConnection).IsFalse();
             await Assert.That(diagnostic.IdleDurationMs).IsGreaterThanOrEqualTo(IdleThresholdMs);
         }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_BootstrapDiagnostic_IsExplicitlyIdentified()
+    {
+        var connection = new TestIdleConnection(-1, "bootstrap", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+
+        await using (pool)
+        {
+            await pool.GetConnectionAsync("bootstrap", 9092);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+
+            var reaped = await pool.ReapIdleConnectionsAsync();
+
+            await Assert.That(reaped).IsEqualTo(1);
+            var diagnostic = pool.GetConnectionReapDiagnosticsSnapshot().Single();
+            await Assert.That(diagnostic.BrokerId).IsEqualTo(-1);
+            await Assert.That(diagnostic.IsBootstrapConnection).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_ActiveLease_DrainsBeforeDisposal()
+    {
+        var connection = new TestIdleConnection(1, "localhost", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+            await pool.GetConnectionAsync(1);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+            await Assert.That(KafkaConnectionLease.TryAcquire(connection, out var lease)).IsTrue();
+
+            var reapTask = pool.ReapIdleConnectionsAsync().AsTask();
+            await Assert.That(SpinWait.SpinUntil(
+                () => connection.RetirementState == 1,
+                TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(connection.DisposeCount).IsEqualTo(0);
+
+            lease.Dispose();
+            var reaped = await reapTask;
+
+            await Assert.That(reaped).IsEqualTo(1);
+            await Assert.That(connection.DisposeCount).IsEqualTo(1);
+            await Assert.That(connection.RetirementState).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_RequestWinsRecheck_RestoresConnection()
+    {
+        var connection = new TestIdleConnection(1, "localhost", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection));
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+            var first = await pool.GetConnectionAsync(1);
+            connection.LastUsedTimestampMs = StaleIdleTimestamp();
+            var pendingReads = 0;
+            connection.PendingRequestCountProvider = () =>
+                Interlocked.Increment(ref pendingReads) == 1 ? 0 : 1;
+
+            var reaped = await pool.ReapIdleConnectionsAsync();
+            var second = await pool.GetConnectionAsync(1);
+
+            await Assert.That(reaped).IsEqualTo(0);
+            await Assert.That(second).IsSameReferenceAs(first);
+            await Assert.That(connection.DisposeCount).IsEqualTo(0);
+            await Assert.That(connection.RetirementState).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task ReapIdleConnectionsAsync_DrainTimeout_DoesNotBlockPoolDisposal()
+    {
+        var connection = new TestIdleConnection(1, "localhost", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleThresholdMs },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => new ValueTask<IKafkaConnection>(connection),
+            idleReapDrainTimeout: TimeSpan.FromMilliseconds(20));
+
+        pool.RegisterBroker(1, "localhost", 9092);
+        await pool.GetConnectionAsync(1);
+        connection.LastUsedTimestampMs = StaleIdleTimestamp();
+        await Assert.That(KafkaConnectionLease.TryAcquire(connection, out var lease)).IsTrue();
+
+        var reaped = await pool.ReapIdleConnectionsAsync();
+        await pool.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(reaped).IsEqualTo(1);
+        await Assert.That(connection.DisposeCount).IsEqualTo(0);
+
+        lease.Dispose();
+        await Assert.That(SpinWait.SpinUntil(
+            () => connection.DisposeCount == 1,
+            TimeSpan.FromSeconds(5))).IsTrue();
     }
 
     [Test]
@@ -853,18 +967,24 @@ public sealed class ConnectionPoolTests
         return connection;
     }
 
-    internal sealed class TestIdleConnection(int brokerId, string host, int port) : IKafkaConnection, IIdleTrackedKafkaConnection
+    internal sealed class TestIdleConnection(int brokerId, string host, int port) :
+        IKafkaConnection,
+        IIdleTrackedKafkaConnection,
+        IRetirableKafkaConnection
     {
         private int _connected = 1;
         private long _lastUsedTimestampMs = Environment.TickCount64;
         private int _pendingRequestCount;
         private int _disposeCount;
+        private int _leaseCount;
+        private int _retirementState;
 
         public int BrokerId { get; } = brokerId;
         public string Host { get; } = host;
         public int Port { get; } = port;
         public bool IsConnected => Volatile.Read(ref _connected) != 0;
         public int DisposeCount => Volatile.Read(ref _disposeCount);
+        public int RetirementState => Volatile.Read(ref _retirementState);
 
         public long LastUsedTimestampMs
         {
@@ -878,11 +998,37 @@ public sealed class ConnectionPoolTests
             set => Volatile.Write(ref _pendingRequestCount, value);
         }
 
+        public Func<int>? PendingRequestCountProvider { get; set; }
+
         long IIdleTrackedKafkaConnection.LastUsedTimestampMs => LastUsedTimestampMs;
 
-        int IIdleTrackedKafkaConnection.PendingRequestCount => PendingRequestCount;
+        int IIdleTrackedKafkaConnection.PendingRequestCount =>
+            PendingRequestCountProvider?.Invoke() ?? PendingRequestCount;
 
         void IIdleTrackedKafkaConnection.Touch() => LastUsedTimestampMs = Environment.TickCount64;
+
+        int IRetirableKafkaConnection.LeaseCount => Volatile.Read(ref _leaseCount);
+
+        int IRetirableKafkaConnection.ActiveOperationCount => 0;
+
+        bool IRetirableKafkaConnection.TryAcquireLease()
+        {
+            if (Volatile.Read(ref _retirementState) != 0)
+                return false;
+
+            Interlocked.Increment(ref _leaseCount);
+            if (Volatile.Read(ref _retirementState) == 0)
+                return true;
+
+            Interlocked.Decrement(ref _leaseCount);
+            return false;
+        }
+
+        void IRetirableKafkaConnection.ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+
+        void IRetirableKafkaConnection.BeginRetirement() => Volatile.Write(ref _retirementState, 1);
+
+        void IRetirableKafkaConnection.CompleteRetirement() => Volatile.Write(ref _retirementState, 2);
 
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 


### PR DESCRIPTION
## Summary
- create indexed broker connections lazily as partition-affinity routes request each slot
- mark bootstrap connection reap diagnostics explicitly
- retire and drain active leases/operations before idle disposal

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe` (5,297 passed)
- [x] focused connection/reaper tests (86 passed post-rebase)
- [x] `MultiConnectionProducerTests` integration (8 passed)

Closes #1945
