### PR TITLE
Coalesce partition-limit diagnostics

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -555,6 +555,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private long _lastSendLoopPressureSnapshot;
     private long _partitionLimitedPressureEvents;
     private long _lastPartitionLimitedPressureSnapshot;
+    private long _lastPartitionLimitedDiagnosticMs;
+    private long _partitionLimitedDiagnosticObservationCount;
+    private long _partitionLimitedDiagnosticMaxBufferPressureDelta;
+    private long _partitionLimitedDiagnosticMaxSendLoopPressureDelta;
+    private double _partitionLimitedDiagnosticMaxBufferUtilization;
     private long _lastScaleTimeTicks;
     private Task<int>? _pendingScaleTask; // Background connection creation, polled by send loop
     private double _pendingScaleBufferUtilization;
@@ -597,6 +602,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // so changing this value affects both trigger sensitivity and per-step magnitude.
     private const long ScalePressureDeltaThreshold = 100;
     private const long ScaleCooldownMs = 5_000;
+    private const long PartitionLimitedDiagnosticIntervalMs = 15_000;
     private const double ScaleUtilizationThreshold = 0.7;
 
     private const int MaxScaleStep = 3; // Cap per scale-up to avoid over-provisioning from a brief spike
@@ -4946,17 +4952,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 || (utilization >= ScaleUtilizationThreshold
                     && partitionLimitedBufferPressureDelta >= ScalePressureDeltaThreshold)))
         {
-            _accumulator.RecordConnectionScaleEvent(
-                _brokerId,
-                _connectionCount,
-                _connectionCount,
+            ObservePartitionLimitedPressure(
+                now,
                 utilization,
                 partitionLimitedBufferPressureDelta + partitionLimitedUnackedBlockDelta,
-                partitionLimitedPressureDelta,
-                partitionLimited: true);
+                partitionLimitedPressureDelta);
             _lastPartitionLimitedPressureSnapshot = _partitionLimitedPressureEvents;
             _lastPartitionLimitedBufferPressureSnapshot = _accumulator.BufferPressureEvents;
             _lastPartitionLimitedUnackedBlockSnapshot = unackedBlockEvents;
+        }
+        else if (!partitionLimitedScalePressure)
+        {
+            EndPartitionLimitedDiagnosticState(now);
         }
         var scalePressureDelta = ComputeScalePressureDelta(
             bufferPressureDelta + usefulUnackedBlockDelta, sendLoopPressureDelta);
@@ -5110,6 +5117,63 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _brokerId, targetShrinkCount, _cts.Token).AsTask();
 
         return 0;
+    }
+
+    private void ObservePartitionLimitedPressure(
+        long now,
+        double bufferUtilization,
+        long bufferPressureDelta,
+        long sendLoopPressureDelta)
+    {
+        _partitionLimitedDiagnosticObservationCount++;
+        _partitionLimitedDiagnosticMaxBufferUtilization = Math.Max(
+            _partitionLimitedDiagnosticMaxBufferUtilization,
+            bufferUtilization);
+        _partitionLimitedDiagnosticMaxBufferPressureDelta = Math.Max(
+            _partitionLimitedDiagnosticMaxBufferPressureDelta,
+            bufferPressureDelta);
+        _partitionLimitedDiagnosticMaxSendLoopPressureDelta = Math.Max(
+            _partitionLimitedDiagnosticMaxSendLoopPressureDelta,
+            sendLoopPressureDelta);
+
+        if (_lastPartitionLimitedDiagnosticMs == 0
+            || now - _lastPartitionLimitedDiagnosticMs >= PartitionLimitedDiagnosticIntervalMs)
+        {
+            EmitPartitionLimitedDiagnostic(now);
+        }
+    }
+
+    private void EndPartitionLimitedDiagnosticState(long now)
+    {
+        EmitPartitionLimitedDiagnostic(now);
+        _lastPartitionLimitedDiagnosticMs = 0;
+    }
+
+    private void EmitPartitionLimitedDiagnostic(long now)
+    {
+        var observationCount = _partitionLimitedDiagnosticObservationCount;
+        if (observationCount == 0)
+            return;
+
+        var observedDurationMs = _lastPartitionLimitedDiagnosticMs == 0
+            ? 0
+            : Math.Max(0, now - _lastPartitionLimitedDiagnosticMs);
+        _accumulator.RecordConnectionScaleEvent(
+            _brokerId,
+            _connectionCount,
+            _connectionCount,
+            _partitionLimitedDiagnosticMaxBufferUtilization,
+            _partitionLimitedDiagnosticMaxBufferPressureDelta,
+            _partitionLimitedDiagnosticMaxSendLoopPressureDelta,
+            partitionLimited: true,
+            observationCount,
+            observedDurationMs);
+
+        _partitionLimitedDiagnosticObservationCount = 0;
+        _partitionLimitedDiagnosticMaxBufferUtilization = 0;
+        _partitionLimitedDiagnosticMaxBufferPressureDelta = 0;
+        _partitionLimitedDiagnosticMaxSendLoopPressureDelta = 0;
+        _lastPartitionLimitedDiagnosticMs = now;
     }
 
     private bool HasMutedPartitionLoad(PartitionCarryOver carryOver, bool hasUnreadEvent)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1883,6 +1883,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         finally
         {
+            EmitPartitionLimitedDiagnostic(Dekaf.MonotonicClock.GetMilliseconds());
+
             var redeliver = crashed
                 && Volatile.Read(ref _disposed) == 0
                 && _rerouteBatch is not null;
@@ -5158,6 +5160,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var observedDurationMs = _lastPartitionLimitedDiagnosticMs == 0
             ? 0
             : Math.Max(0, now - _lastPartitionLimitedDiagnosticMs);
+        // Partition-limited pressure means no additional connection can serve a distinct
+        // partition, so the connection count remains stable throughout this window.
         _accumulator.RecordConnectionScaleEvent(
             _brokerId,
             _connectionCount,

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -289,6 +289,8 @@ internal sealed class ProducerConnectionScaleDiagnostic
         }
     }
     public bool PartitionLimited { get; init; }
+    public long ObservationCount { get; init; } = 1;
+    public long ObservedDurationMs { get; init; }
     public required double BufferUtilization { get; init; }
     public required long BufferPressureDelta { get; init; }
     public required long SendLoopPressureDelta { get; init; }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4689,7 +4689,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         double bufferUtilization,
         long bufferPressureDelta,
         long sendLoopPressureDelta,
-        bool partitionLimited = false)
+        bool partitionLimited = false,
+        long observationCount = 1,
+        long observedDurationMs = 0)
     {
         if (!_options.EnableDeliveryDiagnostics)
             return;
@@ -4708,7 +4710,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 BufferUtilization = bufferUtilization,
                 BufferPressureDelta = bufferPressureDelta,
                 SendLoopPressureDelta = sendLoopPressureDelta,
-                PartitionLimited = partitionLimited
+                PartitionLimited = partitionLimited,
+                ObservationCount = observationCount,
+                ObservedDurationMs = observedDurationMs
             });
         }
     }

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -89,8 +89,56 @@ public sealed class AdaptiveScaleDownTests
                 .ConnectionScaleEvents.Single();
             await Assert.That(diagnostic.Direction).IsEqualTo("capped");
             await Assert.That(diagnostic.SendLoopPressureDelta).IsEqualTo(100);
+            await Assert.That(diagnostic.ObservationCount).IsEqualTo(1);
+            await Assert.That(diagnostic.ObservedDurationMs).IsEqualTo(0);
             await Assert.That(GetField<long>(sender, "_lastPartitionLimitedPressureSnapshot"))
                 .IsEqualTo(100);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task PartitionLimitedPressure_CoalescesUntilDiagnosticInterval()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+            GetField<HashSet<TopicPartition>>(sender, "_knownPartitions")
+                .Add(new TopicPartition(Topic, 0));
+
+            for (var observation = 0; observation < 3; observation++)
+            {
+                SetField(sender, "_partitionLimitedPressureEvents", (observation + 1L) * 100L);
+                if (observation == 2)
+                {
+                    SetField(
+                        sender,
+                        "_lastPartitionLimitedDiagnosticMs",
+                        Dekaf.MonotonicClock.GetMilliseconds() - 15_001L);
+                }
+
+                InvokeMaybeScaleConnections(sender);
+            }
+
+            var diagnostics = accumulator.GetDeliveryDiagnosticsSnapshot().ConnectionScaleEvents;
+            await Assert.That(diagnostics.Count).IsEqualTo(2);
+            await Assert.That(diagnostics[0].ObservationCount).IsEqualTo(1);
+            await Assert.That(diagnostics[1].ObservationCount).IsEqualTo(2);
+            await Assert.That(diagnostics[1].SendLoopPressureDelta).IsEqualTo(100);
+            await Assert.That(diagnostics[1].ObservedDurationMs).IsGreaterThanOrEqualTo(15_000);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -148,6 +148,41 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task PartitionLimitedPressure_DisposeFlushesPartialWindow()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+
+        try
+        {
+            var observe = typeof(BrokerSender).GetMethod(
+                "ObservePartitionLimitedPressure",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var now = Dekaf.MonotonicClock.GetMilliseconds();
+            observe.Invoke(sender, [now, 0.5, 10L, 20L]);
+            observe.Invoke(sender, [now + 1, 0.6, 30L, 40L]);
+
+            await sender.DisposeAsync();
+
+            var diagnostics = accumulator.GetDeliveryDiagnosticsSnapshot().ConnectionScaleEvents;
+            await Assert.That(diagnostics.Count).IsEqualTo(2);
+            await Assert.That(diagnostics[1].ObservationCount).IsEqualTo(1);
+            await Assert.That(diagnostics[1].BufferPressureDelta).IsEqualTo(30);
+            await Assert.That(diagnostics[1].SendLoopPressureDelta).IsEqualTo(40);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task PartitionLimitedBufferPressure_RecordsCappedEventOncePerDelta()
     {
         var options = CreateOptions(

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -7,6 +7,88 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class ConnectionScaleReportingTests
 {
     [Test]
+    public async Task Generate_LongScaleTimeline_SamplesWholeRunAndReportsOmissions()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 12, 2, 0, 0, TimeSpan.Zero);
+        var events = Enumerable.Range(0, 150)
+            .Select(index => new ProducerConnectionScaleDiagnostic
+            {
+                OccurredAtUtc = startedAt.AddSeconds(index * 6),
+                BrokerId = 1,
+                OldConnectionCount = 6,
+                NewConnectionCount = 6,
+                PartitionLimited = true,
+                BufferUtilization = 0,
+                BufferPressureDelta = 0,
+                SendLoopPressureDelta = 100,
+                ObservationCount = 10,
+                ObservedDurationMs = 6_000
+            })
+            .ToList();
+        var result = new StressTestResult
+        {
+            Scenario = "producer",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            BrokerCount = 1,
+            MessageSizeBytes = 1000,
+            StartedAtUtc = startedAt.UtcDateTime,
+            CompletedAtUtc = startedAt.AddMinutes(15).UtcDateTime,
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 1_000,
+                TotalBytes = 1_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 900,
+                AverageMessagesPerSecond = 1_000,
+                AverageMegabytesPerSecond = 1,
+                MessagesPerSecondSamples = [1_000, 900],
+                IntervalSamples =
+                [
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt,
+                        ElapsedSeconds = 0,
+                        MessagesPerSecond = 1_000
+                    },
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = startedAt.AddMinutes(15),
+                        ElapsedSeconds = 900,
+                        MessagesPerSecond = 900
+                    }
+                ]
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            ProducerDeliveryDiagnostics = new ProducerDeliveryDiagnosticsSnapshot
+            {
+                DiagnosticsEnabled = true,
+                CapturedAtUtc = startedAt.AddMinutes(15),
+                ConnectionScaleEvents = events
+            }
+        };
+
+        var markdown = MarkdownReporter.Generate(new StressTestResults
+        {
+            RunStartedAtUtc = result.StartedAtUtc,
+            RunCompletedAtUtc = result.CompletedAtUtc,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        });
+
+        await Assert.That(markdown).Contains("50 scale event(s) omitted");
+        await Assert.That(markdown).Contains("02:00:00.000");
+        await Assert.That(markdown).Contains("02:14:54.000");
+    }
+
+    [Test]
     public async Task Generate_ConnectionScaleEvent_CorrelatesNearestThroughputSample()
     {
         var startedAt = new DateTimeOffset(2026, 7, 12, 2, 0, 0, TimeSpan.Zero);

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -5,6 +5,8 @@ namespace Dekaf.StressTests.Reporting;
 
 internal static class MarkdownReporter
 {
+    private const int MaxConnectionScaleTimelineRows = 100;
+
     public static string Generate(StressTestResults results)
     {
         var sb = new StringBuilder();
@@ -177,11 +179,14 @@ internal static class MarkdownReporter
         if (rows.Count == 0)
             return;
 
+        var displayedRows = SampleEvenly(rows, MaxConnectionScaleTimelineRows);
+        var omittedRows = rows.Count - displayedRows.Count;
+
         sb.AppendLine($"## Connection Scale Timeline - {label}");
         sb.AppendLine();
-        sb.AppendLine("| Client | Event UTC | Broker | Connections | Buffer | Pressure (buffer/send) | Nearest throughput sample |");
-        sb.AppendLine("|--------|-----------|-------:|-------------|-------:|------------------------|---------------------------|");
-        foreach (var row in rows)
+        sb.AppendLine("| Client | Event UTC | Broker | Connections | Buffer | Pressure (buffer/send) | Observations / duration | Nearest throughput sample |");
+        sb.AppendLine("|--------|-----------|-------:|-------------|-------:|------------------------|-------------------------|---------------------------|");
+        foreach (var row in displayedRows)
         {
             var nearest = row.Result.Throughput.IntervalSamples
                 .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Event.OccurredAtUtc).TotalMilliseconds));
@@ -192,9 +197,27 @@ internal static class MarkdownReporter
                 $"| {row.Result.Client} | {row.Event.OccurredAtUtc:HH:mm:ss.fff} | " +
                 $"{row.Event.BrokerId} | {row.Event.OldConnectionCount}→{row.Event.NewConnectionCount} | " +
                 $"{row.Event.BufferUtilization * 100:F0}% | " +
-                $"{row.Event.BufferPressureDelta:N0}/{row.Event.SendLoopPressureDelta:N0} | {throughput} |");
+                $"{row.Event.BufferPressureDelta:N0}/{row.Event.SendLoopPressureDelta:N0} | " +
+                $"{row.Event.ObservationCount:N0} / {row.Event.ObservedDurationMs / 1000.0:F1}s | {throughput} |");
         }
+        if (omittedRows > 0)
+            sb.AppendLine($"*{omittedRows:N0} scale event(s) omitted; rows sampled across the full timeline.*");
         sb.AppendLine();
+    }
+
+    private static List<T> SampleEvenly<T>(IReadOnlyList<T> rows, int maximumRows)
+    {
+        if (rows.Count <= maximumRows)
+            return [.. rows];
+
+        var sampled = new List<T>(maximumRows);
+        for (var i = 0; i < maximumRows; i++)
+        {
+            var index = (int)Math.Round(i * (rows.Count - 1d) / (maximumRows - 1d));
+            sampled.Add(rows[index]);
+        }
+
+        return sampled;
     }
 
     private static double ComparisonMessagesPerSecond(StressTestResult result) =>


### PR DESCRIPTION
## Summary
- coalesce partition-limited pressure into bounded 15-second summaries
- record observation count, duration, and maximum pressure per summary
- evenly sample long scale timelines across first/middle/last rows
- report omitted event counts instead of silently hiding late-run behavior

## Test plan
- [x] `dotnet build Dekaf.sln --configuration Release --no-restore`
- [x] `Dekaf.Tests.Unit.exe` (5,299 passed)
- [x] focused adaptive-scale/reporting diagnostics tests (52 passed)

Closes #1943
