### PR TITLE
Restore delivery-coupled producer batching

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3552,7 +3552,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _serializeBatchesPerPartition,
             hasPipelineBatch,
             batch.EstimatedSize,
-            _options.BatchSize);
+            batch.EffectiveBatchSizeLimit);
     }
 
     // An earlier pipeline batch provides a short delivery clock under load. Keep the next
@@ -5772,7 +5772,7 @@ internal sealed class PartitionBatch
     public bool IsExactlyAtSizeLimit =>
         (long)RecordBatch.TotalBatchHeaderSize + _encodedRecordsLength == EffectiveBatchSizeLimit;
 
-    private int EffectiveBatchSizeLimit => _effectiveBatchSizeLimit;
+    internal int EffectiveBatchSizeLimit => _effectiveBatchSizeLimit;
 
     private static int GetEffectiveBatchSizeLimit(
         TopicPartition topicPartition,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3538,19 +3538,37 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private bool ShouldSealAppendedBatch(PartitionBatch batch)
         => batch.IsExactlyAtSizeLimit
             || (_options.LingerMs == 0
-                && !ShouldDeferPartialBatchSeal(batch.TopicPartition)
+                && !ShouldDeferPartialBatchSeal(batch)
                 && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldDeferPartialBatchSeal(TopicPartition topicPartition)
+    private bool ShouldDeferPartialBatchSeal(PartitionBatch batch)
     {
-        if (_mutedPartitions.ContainsKey(topicPartition))
-            return true;
-
-        return _serializeBatchesPerPartition
-            && _partitionQueueBytes.TryGetValue(topicPartition, out var queuedBytes)
+        var topicPartition = batch.TopicPartition;
+        var hasPipelineBatch = _partitionQueueBytes.TryGetValue(topicPartition, out var queuedBytes)
             && queuedBytes > 0;
+        return ShouldDeferPartialBatchSeal(
+            _mutedPartitions.ContainsKey(topicPartition),
+            _serializeBatchesPerPartition,
+            hasPipelineBatch,
+            batch.EstimatedSize,
+            _options.BatchSize);
     }
+
+    // An earlier pipeline batch provides a short delivery clock under load. Keep the next
+    // partial batch open until it fills; if traffic becomes sparse, the predecessor exits,
+    // queued bytes reach zero, and the next linger pass seals normally. Size-full batches
+    // bypass this method in ShouldSealAppendedBatch and continue pipelining immediately.
+    internal static bool ShouldDeferPartialBatchSeal(
+        bool isMuted,
+        bool serializeBatchesPerPartition,
+        bool hasPipelineBatch,
+        int currentBatchSize,
+        int maximumBatchSize) =>
+        isMuted
+        || (hasPipelineBatch
+            && (serializeBatchesPerPartition
+                || currentBatchSize < maximumBatchSize));
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
@@ -4259,7 +4277,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // allocating one BatchSize arena per record while they wait. Size-full batches
                 // still seal in the append path, and FlushAsync must always seal.
                 else if (sealAll
-                    || (!ShouldDeferPartialBatchSeal(topicPartition)
+                    || (!ShouldDeferPartialBatchSeal(pd.CurrentBatch)
                         && pd.CurrentBatch.ShouldFlush(now, _options.LingerMs)))
                 {
                     ProducerDebugCounters.RecordBatchFlushedFromDictionary();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -989,7 +989,7 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
-    public async Task ZeroLinger_NonIdempotentPipeline_SealsWhilePreviousBatchQueued()
+    public async Task ZeroLinger_NonIdempotentPipeline_FillsWhilePreviousBatchQueued()
     {
         var options = CreateTestOptions(
             batchSize: 100_000,
@@ -998,26 +998,52 @@ public class RecordAccumulatorReadyTests
             maxInFlight: 2);
         await using var accumulator = new RecordAccumulator(options);
 
-        foreach (var value in new[] { "first"u8.ToArray(), "second"u8.ToArray() })
-        {
-            var appended = await accumulator.AppendFromSpansAsync(
-                "test-topic",
-                partition: 0,
-                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                ReadOnlySpan<byte>.Empty,
-                keyIsNull: true,
-                value,
-                valueIsNull: false,
-                headers: null,
-                headerCount: 0,
-                callback: null,
-                CancellationToken.None,
-                partitionCount: 1);
+        var firstAppended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "first"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
 
-            await Assert.That(appended).IsTrue();
-            await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsFalse()
-                .Because("max-in-flight greater than one must expose another sealed batch to the sender");
-        }
+        await Assert.That(firstAppended).IsTrue();
+        await Assert.That(accumulator.TryDrainBatch(out var firstBatch)).IsTrue();
+
+        var secondAppended = await accumulator.AppendFromSpansAsync(
+            "test-topic",
+            partition: 0,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "second"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            callback: null,
+            CancellationToken.None,
+            partitionCount: 1);
+
+        await Assert.That(secondAppended).IsTrue();
+        await Assert.That(accumulator.TryGetBatch("test-topic", 0, out _)).IsTrue()
+            .Because("an in-flight predecessor should keep the next partial batch open");
+
+        firstBatch!.CompleteSend(baseOffset: 0, timestamp: DateTimeOffset.UtcNow);
+        accumulator.OnBatchExitsPipeline(firstBatch);
+        accumulator.ReturnReadyBatch(firstBatch);
+
+        await accumulator.ExpireLingerAsync(CancellationToken.None);
+        await Assert.That(accumulator.TryDrainBatch(out var secondBatch)).IsTrue()
+            .Because("the partial batch should seal after its predecessor exits");
+
+        secondBatch!.CompleteSend(baseOffset: 1, timestamp: DateTimeOffset.UtcNow);
+        accumulator.OnBatchExitsPipeline(secondBatch);
+        accumulator.ReturnReadyBatch(secondBatch);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -714,6 +714,7 @@ public class RecordAccumulatorTests
 
             var purged = accumulator.Purge(PurgeOptions.InFlight, CreatePurgedException());
             await Assert.That(purged).IsEqualTo(1);
+            await accumulator.ExpireLingerAsync(CancellationToken.None);
             await Assert.That(accumulator.TryDrainBatch(out nextBatch)).IsTrue();
 
             var nextSequence = accumulator.GetAndIncrementSequence(

--- a/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
@@ -239,4 +239,28 @@ public class ShouldFlushTests
         var result = InvokeShouldFlush(batch, now, lingerMs: 100);
         await Assert.That(result).IsTrue();
     }
+
+    [Test]
+    [Arguments(true, false, false, 0, true)]
+    [Arguments(false, true, true, 100, true)]
+    [Arguments(false, true, false, 100, false)]
+    [Arguments(false, false, true, 100, true)]
+    [Arguments(false, false, true, 999, true)]
+    [Arguments(false, false, true, 1_000, false)]
+    public async Task DeliveryCoupledLinger_DefersOnlyBusyUnderfilledBatches(
+        bool isMuted,
+        bool serializeBatchesPerPartition,
+        bool hasPipelineBatch,
+        int currentBatchSize,
+        bool expected)
+    {
+        var result = RecordAccumulator.ShouldDeferPartialBatchSeal(
+            isMuted,
+            serializeBatchesPerPartition,
+            hasPipelineBatch,
+            currentBatchSize,
+            maximumBatchSize: 1_000);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
 }


### PR DESCRIPTION
## Summary

- defer partial linger sealing while the same partition has an earlier batch in the delivery pipeline
- continue sealing size-full batches immediately, preserving non-idempotent and idempotent pipelining
- resume normal linger as soon as the predecessor exits, so sparse traffic does not wait for a full batch
- update zero-linger and purge coverage for delivery-coupled batching and contiguous idempotent sequences

## Root cause

Removing non-idempotent mute-on-send also removed the delivery clock that kept partial batches open during an in-flight request. Linger then sealed small batches even under sustained load. With partition-affined connections, each small batch became its own ProduceRequest and throughput hit the request-count ceiling.

The fix uses the existing per-partition pipeline-byte tracker as the delivery signal. A partial batch remains open while a predecessor exists; a full batch still seals and pipelines immediately. When traffic becomes sparse, the predecessor acknowledgement clears the signal and the next linger pass flushes normally.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore` — net8/net10, 0 warnings, 0 errors
- net10 unit suite — 5,303 passed
- focused accumulator/linger suite — 131 passed
- Kafka 4.3.1, 1-minute idempotent producer A/B:
  - no delivery coupling: 159,013 msg/s
  - full-batch delivery coupling: 570,825 msg/s (+259%)
  - paired Confluent result: 253,911 msg/s (Dekaf 2.25x)
  - 100% broker-confirmed delivery, 0 errors

Closes #1938