### PR TITLE
Fix unacked-budget rate/RTT estimation with BBR per-request delivery sampling

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -167,6 +167,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // request is sent and removed by ProcessCompletedResponses when the response task completes.
     // HandleTimedOutRequests (Java pattern) checks request timeout centrally and fails all
     // pending responses on timeout, invalidating the connection.
+    /// <summary>
+    /// Wraps a pipelined response with the batch-generation snapshot the send captured
+    /// at send start (before its first await) — the generations detect batch object
+    /// recycling between send and response processing. Ownership of the rented
+    /// <paramref name="BatchGenerations"/> and <paramref name="Batches"/> arrays transfers
+    /// to this PendingResponse; they are returned by <see cref="ReturnBatchesArray"/>.
+    /// </summary>
     private readonly record struct PendingResponse(
         PipelinedResponse<ProduceResponse> ResponseTask,
         ReadyBatch[] Batches,
@@ -174,21 +181,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         int Count,
         long EncodedBytes,
         long RequestStartTime,
-        long RttStartTime)
+        BrokerUnackedByteBudget.DeliverySnapshot DeliverySnapshotAtSend)
     {
-        /// <summary>
-        /// Wraps a pipelined response with the batch-generation snapshot the send captured
-        /// at send start (before its first await) — the generations detect batch object
-        /// recycling between send and response processing. Ownership of the rented
-        /// <paramref name="generations"/> array transfers to this PendingResponse;
-        /// it is returned by <see cref="ReturnBatchesArray"/>.
-        /// </summary>
-        public static PendingResponse Create(
-            PipelinedResponse<ProduceResponse> responseTask, ReadyBatch[] batches, int[] generations,
-            int count, long encodedBytes, long requestStartTime, long rttStartTime)
-            => new(responseTask, batches, generations, count, encodedBytes,
-                requestStartTime, rttStartTime);
-
         /// <summary>
         /// Returns true if the batch at index <paramref name="i"/> is the same incarnation
         /// that was present when this PendingResponse was created.
@@ -205,20 +199,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             ArrayPool<int>.Shared.Return(BatchGenerations);
             ArrayPool<ReadyBatch>.Shared.Return(Batches, clearArray: true);
-        }
-    }
-
-    internal struct AckedResponsePass
-    {
-        public long Bytes { get; private set; }
-        public long EarliestRequestStart { get; private set; }
-
-        public void Add(long bytes, long requestStart)
-        {
-            EarliestRequestStart = Bytes == 0
-                ? requestStart
-                : Math.Min(EarliestRequestStart, requestStart);
-            Bytes += bytes;
         }
     }
 
@@ -2595,10 +2575,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         CancellationToken cancellationToken,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? reusableResponseLookup = null)
     {
-        // Aggregate every successful request completed in this pass. Multiple connection
-        // lanes drain concurrently, so per-request samples understate broker-wide capacity.
-        var ackedPass = new AckedResponsePass();
-
         // CRITICAL: Process responses in FORWARD order (oldest request first).
         // With multi-inflight, R1 and R2 may both complete with errors for the same partition.
         // Forward iteration ensures R1's retry batches are added to carry-over before R2's,
@@ -2683,8 +2659,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
                 }
 
-                if (allPartitionsSucceeded)
-                    ackedPass.Add(pending.EncodedBytes, pending.RttStartTime);
+                if (allPartitionsSucceeded && _unackedBudget is { } unackedBudget)
+                {
+                    // Per-request BBR delivery-rate sample: the delivered-counter delta since
+                    // this request's send snapshot covers concurrent connection lanes. A fresh
+                    // timestamp per call keeps 'now' honest when a pass spends time in
+                    // acknowledgement callbacks between completions.
+                    unackedBudget.OnAcked(
+                        pending.EncodedBytes,
+                        pending.DeliverySnapshotAtSend,
+                        Stopwatch.GetTimestamp());
+                }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
                 if (_logger.IsEnabled(LogLevel.Debug))
@@ -2745,17 +2730,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
-        if (ackedPass.Bytes > 0 && _unackedBudget is { } unackedBudget)
-        {
-            // Oldest start spans the whole concurrent completion window. Dividing total
-            // bytes by that busy time captures aggregate broker drain without counting
-            // admission-blocked gaps between response passes.
-            var ackTimestamp = Stopwatch.GetTimestamp();
-            unackedBudget.OnAcked(
-                ackedPass.Bytes,
-                ackTimestamp - ackedPass.EarliestRequestStart,
-                ackTimestamp);
-        }
     }
 
     /// <summary>
@@ -3474,14 +3448,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // Use the connection-owned timeout path for pipelined sends. The send loop can
                 // have multiple responses in flight on this connection; a reusable caller-owned
                 // CTS would let a later send reset or cancel an earlier response timeout.
+                // The delivery token is minted post-serialization but pre-write: an RTT anchor
+                // stamped after the write-completion await can postdate the response's arrival
+                // (the continuation may run arbitrarily late), which manufactured microsecond
+                // RTT samples and disabled the budget's RTT safety floor. Including TCP write
+                // time biases individual RTT samples high, which the budget's minimum filter
+                // discards.
+                var deliverySnapshotAtSend = _unackedBudget?.SnapshotDelivery(
+                    Stopwatch.GetTimestamp(),
+                    appLimited: Volatile.Read(ref _totalPendingResponseCount) == 0) ?? default;
                 responseTask = await SendPipelinedAfterWriteAsync(
                     connection,
                     request,
                     (short)apiVersion).ConfigureAwait(false);
                 _onPipelinedResponseAcquired?.Invoke();
-                // Response RTT starts after the request is written. Including request
-                // construction and TCP write time biases admission-rate samples low.
-                var rttStartTime = Stopwatch.GetTimestamp();
 
                 // Clear batch references from scratch arrays (see ClearReferences() doc for exception-path semantics)
                 scratch.ClearReferences();
@@ -3512,14 +3492,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     encodedBytes += Math.Max(batch.EncodedSize, batch.DataSize);
                 }
 
-                var pendingResponse = PendingResponse.Create(
+                var pendingResponse = new PendingResponse(
                     responseTask,
                     batches,
                     generations,
                     count,
                     encodedBytes,
                     requestStartTime,
-                    rttStartTime);
+                    deliverySnapshotAtSend);
                 _pendingResponsesByConnection[connectionIndex].Add(pendingResponse);
                 pendingResponseAdded = true; // Array ownership transferred to PendingResponse
                 Interlocked.Increment(ref _totalPendingResponseCount);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4142,7 +4142,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             for (var j = 0; j < pr.Count; j++)
             {
                 // Entries within Count can legally be null: batches with stale generations
-                // are nulled out before PendingResponse.Create captures the array.
+                // are nulled out before PendingResponse captures the array.
                 if (pr.IsSameIncarnation(j)
                     && pr.Batches[j].TopicPartition == topicPartition)
                     return true;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
@@ -12,16 +13,41 @@ namespace Dekaf.Producer;
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
 /// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
 /// <para>
+/// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
+/// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
+/// delta over the larger of the request's own sojourn and the interval since the delivery
+/// clock at send (sojourn only for app-limited sends, where the pipe was empty and the
+/// preceding interval is idle time). The denominator is therefore never smaller than one
+/// real round trip, so response-pass timing (hot polling, clustered completions,
+/// processing stalls) cannot manufacture inflated samples.
+/// </para>
+/// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
 /// <see cref="IsOverBudgetAt"/>/<see cref="RecordAdmissionBlock"/>/
-/// <see cref="ObserveWrittenUnackedBytes"/> are cross-thread (producer appenders, terminal batch
-/// paths, and parallel connection sends). <see cref="OnAcked"/> and <see cref="SetCap"/> are
-/// single-writer — only the owning broker's send loop calls them — so the remaining estimator
-/// state needs no synchronization; the computed budget is published with a volatile write.
+/// <see cref="ObserveWrittenUnackedBytes"/>/<see cref="SnapshotDelivery"/> are cross-thread
+/// (producer appenders, terminal batch paths, and parallel connection sends).
+/// <see cref="OnAcked"/> and <see cref="SetCap"/> are single-writer — only the owning broker's
+/// send loop calls them — so the remaining estimator state needs no synchronization; the
+/// computed budget is published with a volatile write. <see cref="SnapshotDelivery"/> performs
+/// two independent volatile reads racing the single writer; both fields are monotonic, so a
+/// torn pair only skews one rate sample marginally and the windowed max filters it.
 /// </para>
 /// </summary>
 internal sealed class BrokerUnackedByteBudget
 {
+    /// <summary>
+    /// Per-send token minted by <see cref="SnapshotDelivery"/>: the delivery clock (cumulative
+    /// delivered bytes and the timestamp of the most recent delivery), the pre-write send
+    /// timestamp, and whether the broker pipe was empty at send. Carried opaquely on the
+    /// in-flight request and redeemed by <see cref="OnAcked"/> when the response arrives, so
+    /// the values that must be captured together cannot drift apart at call sites.
+    /// </summary>
+    internal readonly record struct DeliverySnapshot(
+        long DeliveredBytes,
+        long DeliveredTimestamp,
+        long SendTimestamp,
+        bool AppLimited);
+
     /// <summary>
     /// Budget ceiling in batches per connection. Sized so a ~1 GB/s drain with ~30 ms ack
     /// round-trips keeps the pipe full at the 1 MB default batch size (~32 MB BDP). Shared
@@ -34,6 +60,25 @@ internal sealed class BrokerUnackedByteBudget
     private const double WindowBucketSeconds = 0.100;
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
+
+    /// <summary>
+    /// Bounds the occupancy floor to this multiple of the rate-derived budget once a drain
+    /// estimate exists. Occupancy is itself admission-bounded by the budget, so an uncapped
+    /// <c>1.5 × occupancy</c> floor is a positive feedback loop that ratchets the budget to
+    /// its cap. With the bound, the iteration's fixed point is this multiple of the rate
+    /// budget (1.5 × target = 15 ms standing latency at the 10 ms default) instead of the cap.
+    /// Genuine wire demand beyond the estimate recovers via capacity probes within 8 RTTs.
+    /// </summary>
+    private const double OccupancyFloorHeadroom = 1.5;
+
+    /// <summary>
+    /// Log2 histogram buckets for per-request diagnostics. Request sizes shift by
+    /// <see cref="RequestSizeHistogramShift"/> (bucket 0 = under 512 B, bucket 15 = 8 MB and
+    /// above); RTT buckets are unshifted microseconds (bucket 0 = under 2 µs, bucket 15 =
+    /// 32 ms and above).
+    /// </summary>
+    private const int HistogramBucketCount = 16;
+    private const int RequestSizeHistogramShift = 8;
 
     /// <summary>
     /// Delivery-rate and written-occupancy maxima cover two seconds in 100ms buckets.
@@ -75,6 +120,11 @@ internal sealed class BrokerUnackedByteBudget
     private long _minimumRttMicros;
     private long _maxRateBytesPerSecond;
     private long _pendingWrittenUnackedPeakBytes;
+    // BBR delivery clock: cumulative acked bytes ("delivered") and the timestamp of the most
+    // recent delivery ("delivered_mstamp"). Written only by OnAcked (single writer); snapshot
+    // via volatile reads by parallel connection sends at send time.
+    private long _totalDeliveredBytes;
+    private long _lastDeliveredTimestamp;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
@@ -82,10 +132,14 @@ internal sealed class BrokerUnackedByteBudget
     private long _capBytes;
     private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
     private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
+    // Per-request diagnostics: log2 histograms of acked request sizes and RTTs. Incremented
+    // only by the owning send loop; snapshot copies use per-element volatile reads, so
+    // readers may observe slightly stale counts (acceptable for diagnostics).
+    private readonly long[] _requestSizeLog2Histogram = new long[HistogramBucketCount];
+    private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
     private long _windowMaxOccupancyBytes;
-    private long _lastAckTimestamp;
     private double _minRttSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
@@ -131,6 +185,38 @@ internal sealed class BrokerUnackedByteBudget
     internal long MinimumRttMicros => Volatile.Read(ref _minimumRttMicros);
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
+
+    /// <summary>
+    /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
+    /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
+    /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Two
+    /// independent volatile reads — tearing is benign because both fields are monotonic and a
+    /// skewed pair only shifts one rate sample marginally.
+    /// </summary>
+    /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
+    /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
+    internal DeliverySnapshot SnapshotDelivery(long sendTimestamp, bool appLimited)
+        => new(
+            Volatile.Read(ref _totalDeliveredBytes),
+            Volatile.Read(ref _lastDeliveredTimestamp),
+            sendTimestamp,
+            appLimited);
+
+    /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
+    /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
+    internal long[] CopyRequestSizeHistogram() => CopyHistogram(_requestSizeLog2Histogram);
+
+    /// <summary>Diagnostics: log2 histogram of acked request round-trip times in microseconds.</summary>
+    internal long[] CopyRequestRttMicrosHistogram() => CopyHistogram(_requestRttMicrosLog2Histogram);
+
+    private static long[] CopyHistogram(long[] source)
+    {
+        var copy = new long[source.Length];
+        for (var i = 0; i < source.Length; i++)
+            copy[i] = Volatile.Read(ref source[i]);
+
+        return copy;
+    }
 
     // Volatile.Read (a plain acquire load) rather than Interlocked.Read: this runs per
     // message from every appender thread, and a locked read would take the cache line
@@ -243,12 +329,19 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     /// <summary>
-    /// Feeds successfully acknowledged requests from one response pass into the drain
-    /// estimate, then republishes the budget. Called only from the owning send loop after
-    /// a response pass completes successfully-acked requests. O(1), allocation-free.
+    /// Feeds one successfully acknowledged request into the drain estimate, then republishes
+    /// the budget. Called only from the owning send loop, once per acked request. O(1),
+    /// allocation-free.
     /// </summary>
-    public void OnAcked(long ackedBytes, long rttTicks, long nowTicks)
+    /// <param name="ackedBytes">Encoded payload bytes of the acknowledged request.</param>
+    /// <param name="sendSnapshot">Token minted via <see cref="SnapshotDelivery"/> just before
+    /// the request's socket write, so <c>nowTicks - SendTimestamp</c> is never smaller than
+    /// the true round trip. For app-limited sends the interval since the last delivery is
+    /// idle time, not drain time, and the sample falls back to the request's own sojourn.</param>
+    /// <param name="nowTicks">Response observation timestamp.</param>
+    public void OnAcked(long ackedBytes, DeliverySnapshot sendSnapshot, long nowTicks)
     {
+        var rttTicks = nowTicks - sendSnapshot.SendTimestamp;
         if (ackedBytes <= 0 || rttTicks <= 0)
             return;
 
@@ -256,17 +349,24 @@ internal sealed class BrokerUnackedByteBudget
         UpdateMinRtt(rttSeconds, nowTicks);
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
 
-        var requestStartTimestamp = nowTicks - rttTicks;
-        var rateIntervalStartTimestamp = _lastAckTimestamp == 0
-            ? requestStartTimestamp
-            : Math.Max(_lastAckTimestamp, requestStartTimestamp);
-        _lastAckTimestamp = nowTicks;
+        RecordRequestHistograms(ackedBytes, rttSeconds);
+
+        // BBR delivery-rate sample: delivered-counter delta over the larger of the request's
+        // own sojourn and the ack-axis interval (time since the delivery clock at send). The
+        // sojourn bounds the denominator below by one real round trip, so clustered response
+        // passes cannot inflate the sample; the ack axis spreads a processing-stall backlog
+        // over the wall time the deliveries actually took.
+        var totalDelivered = _totalDeliveredBytes + ackedBytes;
+        Volatile.Write(ref _totalDeliveredBytes, totalDelivered);
+        var deliveredDelta = totalDelivered - sendSnapshot.DeliveredBytes;
+
+        var intervalTicks = rttTicks;
+        if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
+            intervalTicks = Math.Max(intervalTicks, nowTicks - sendSnapshot.DeliveredTimestamp);
+        Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
 
         AdvanceWindow(nowTicks);
-        var intervalTicks = nowTicks - rateIntervalStartTimestamp;
-        var bytesPerSecond = intervalTicks > 0
-            ? ackedBytes * (double)Stopwatch.Frequency / intervalTicks
-            : 0;
+        var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
         if (bytesPerSecond > 0)
         {
             AddRateSample(bytesPerSecond);
@@ -277,9 +377,23 @@ internal sealed class BrokerUnackedByteBudget
         if (writtenUnackedPeak > 0)
             AddOccupancySample(writtenUnackedPeak);
 
-        UpdateCapacityProbe(bytesPerSecond, requestStartTimestamp, rttTicks, nowTicks);
+        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
 
         RecomputeBudget();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void RecordRequestHistograms(long ackedBytes, double rttSeconds)
+    {
+        var sizeBucket = Math.Clamp(
+            BitOperations.Log2((ulong)ackedBytes | 1) - RequestSizeHistogramShift,
+            0,
+            HistogramBucketCount - 1);
+        _requestSizeLog2Histogram[sizeBucket]++;
+
+        var rttMicros = (ulong)(rttSeconds * 1_000_000);
+        var rttBucket = Math.Min(BitOperations.Log2(rttMicros | 1), HistogramBucketCount - 1);
+        _requestRttMicrosLog2Histogram[rttBucket]++;
     }
 
     private void UpdateMinRtt(double rttSeconds, long nowTicks)
@@ -404,7 +518,7 @@ internal sealed class BrokerUnackedByteBudget
 
     private void UpdateCapacityProbe(
         double bytesPerSecond,
-        long requestStartTimestamp,
+        long sendTimestamp,
         long rttTicks,
         long nowTicks)
     {
@@ -421,10 +535,10 @@ internal sealed class BrokerUnackedByteBudget
                 return;
             }
 
-            // A response can confirm the probe only when its oldest request was created
-            // after the larger budget was published. If observed rate grows, retain the
-            // probe and require another wholly-probed sample at the new level.
-            if (requestStartTimestamp < _capacityProbeStartTimestamp)
+            // A response can confirm the probe only when its request was sent after the
+            // larger budget was published. If observed rate grows, retain the probe and
+            // require another wholly-probed sample at the new level.
+            if (sendTimestamp < _capacityProbeStartTimestamp)
                 return;
 
             if (bytesPerSecond > _capacityProbeBaselineRate * ProbeGrowthThreshold)
@@ -521,6 +635,7 @@ internal sealed class BrokerUnackedByteBudget
         double minRttSeconds)
     {
         long budget;
+        double rateBudgetBytes = 0;
         if (_windowMaxRate == 0)
         {
             // Cold start: no drain estimate yet — keep today's semantics (cap) so short-lived
@@ -532,7 +647,8 @@ internal sealed class BrokerUnackedByteBudget
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
                 ? Math.Max(_targetSeconds, RttSafetyMultiplier * minRttSeconds)
                 : _targetSeconds;
-            var estimatedBytes = _windowMaxRate * horizonSeconds;
+            rateBudgetBytes = _windowMaxRate * horizonSeconds;
+            var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)
                 estimatedBytes *= ProbeBudgetMultiplier;
 
@@ -542,6 +658,17 @@ internal sealed class BrokerUnackedByteBudget
         if (!minRttProbeActive)
         {
             var occupancyFloor = (long)(_windowMaxOccupancyBytes * OccupancySafetyMultiplier);
+            if (rateBudgetBytes > 0)
+            {
+                // The floor exists so a lagging estimator cannot strangle a pipe that is
+                // demonstrably fuller (#1911). Once a drain estimate exists, genuine extra
+                // demand shows up in the delivered-rate samples within one round trip, so the
+                // occupancy proxy may exceed the rate budget by a bounded headroom only —
+                // otherwise occupancy (itself admission-bounded by the budget) ratchets the
+                // budget to its cap and the latency target is never enforced.
+                occupancyFloor = Math.Min(occupancyFloor, (long)(OccupancyFloorHeadroom * rateBudgetBytes));
+            }
+
             budget = Math.Max(budget, occupancyFloor);
         }
 

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -286,6 +286,20 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
     public required long AdmissionBlockCount { get; init; }
+
+    /// <summary>
+    /// Log2 histogram of acked produce-request payload sizes; bucket semantics are defined
+    /// by <see cref="BrokerUnackedByteBudget.CopyRequestSizeHistogram"/>. Populated only on
+    /// live snapshots, not periodic samples, to keep the sample ring compact.
+    /// </summary>
+    public long[]? RequestSizeLog2Histogram { get; init; }
+
+    /// <summary>
+    /// Log2 histogram of acked produce-request round trips in microseconds; bucket semantics
+    /// are defined by <see cref="BrokerUnackedByteBudget.CopyRequestRttMicrosHistogram"/>.
+    /// Populated only on live snapshots.
+    /// </summary>
+    public long[]? RequestRttMicrosLog2Histogram { get; init; }
 }
 
 internal sealed class ProducerConnectionScaleDiagnostic

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4731,7 +4731,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var capturedAtUtc = snapshot.CapturedAtUtc;
         foreach (var (brokerId, budget) in _brokerUnackedBudgets)
-            snapshot.BrokerBudgets.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc));
+            snapshot.BrokerBudgets.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc, includeHistograms: true));
 
         lock (_deliveryDiagnosticsLock)
         {
@@ -4833,7 +4833,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (_brokerBudgetSamples.Count >= MaxBrokerBudgetDiagnosticSamples)
                     _brokerBudgetSamples.RemoveAt(0);
 
-                _brokerBudgetSamples.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc));
+                _brokerBudgetSamples.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc, includeHistograms: false));
             }
         }
     }
@@ -4841,7 +4841,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private static ProducerBrokerBudgetDiagnostic CreateBrokerBudgetDiagnostic(
         int brokerId,
         BrokerUnackedByteBudget budget,
-        DateTimeOffset capturedAtUtc) => new()
+        DateTimeOffset capturedAtUtc,
+        bool includeHistograms) => new()
     {
         CapturedAtUtc = capturedAtUtc,
         BrokerId = brokerId,
@@ -4849,7 +4850,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         UnackedBytes = budget.UnackedBytes,
         MinRttMicros = budget.MinimumRttMicros,
         MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
-        AdmissionBlockCount = budget.AdmissionBlockEvents
+        AdmissionBlockCount = budget.AdmissionBlockEvents,
+        RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
+        RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null
     };
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -48,7 +48,10 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         SetPrivateField(budget, "_minRttSeconds", 0.050);
         SetPrivateField(budget, "_minRttTimestamp", nowTicks - 11 * Stopwatch.Frequency);
         SetPrivateField(budget, "_minRttProbeUntilTimestamp", 0L);
-        budget.OnAcked(1_000_000, Stopwatch.Frequency / 20, nowTicks);
+        budget.OnAcked(
+            1_000_000,
+            budget.SnapshotDelivery(nowTicks - Stopwatch.Frequency / 20, appLimited: true),
+            nowTicks);
         budget.Charge(1_200_000);
 
         try

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
 using Dekaf.Errors;
@@ -3014,6 +3015,74 @@ public sealed class BrokerSenderSendLoopTests
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();
         }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task DeliverySnapshot_SecondPipelinedRequest_IsNotAppLimited(
+        CancellationToken cancellationToken)
+    {
+        var responses = new[]
+        {
+            new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var (pool, _) = CreateMockConnection(
+            new Queue<TaskCompletionSource<ProduceResponse>>(responses));
+        var options = CreateOptions(maxInFlight: 2, unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            unackedBudget: budget);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: 5_000));
+            await WaitUntilAsync(() => GetPendingResponseCount(sender) == 1, cancellationToken);
+
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1, dataSize: 5_000));
+            await WaitUntilAsync(() => GetPendingResponseCount(sender) == 2, cancellationToken);
+
+            await Assert.That(GetDeliverySnapshot(sender, 0).AppLimited).IsTrue();
+            await Assert.That(GetDeliverySnapshot(sender, 1).AppLimited).IsFalse();
+
+            responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
+            responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 1));
+        }
+        finally
+        {
+            responses[0].TrySetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
+            responses[1].TrySetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 1));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    private static int GetPendingResponseCount(BrokerSender sender) =>
+        (int)typeof(BrokerSender).GetField(
+            "_totalPendingResponseCount",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+
+    private static BrokerUnackedByteBudget.DeliverySnapshot GetDeliverySnapshot(
+        BrokerSender sender,
+        int index)
+    {
+        var pendingByConnection = (Array)typeof(BrokerSender).GetField(
+            "_pendingResponsesByConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+        var pending = pendingByConnection.GetValue(0)!;
+        var item = pending.GetType().GetProperty("Item")!.GetValue(pending, [index])!;
+        return (BrokerUnackedByteBudget.DeliverySnapshot)item.GetType()
+            .GetProperty("DeliverySnapshotAtSend")!.GetValue(item)!;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -2972,16 +2972,48 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
-    public async Task AckedResponsePass_AggregatesBytesAndKeepsOldestRequestStart()
+    [Timeout(120_000)]
+    public async Task RttAnchor_PrecedesWrite_SynchronousResponseCannotYieldMicrosecondRtt(
+        CancellationToken cancellationToken)
     {
-        var pass = new BrokerSender.AckedResponsePass();
+        // The mock write takes ~20ms and hands back an already-completed response — the
+        // pathological localhost shape where the response arrives before the write await
+        // resumes. An RTT anchor stamped after that await measured poll-loop latency here
+        // (microseconds), disabling the budget's RTT safety floor (#1941). The pre-write
+        // anchor includes the write time, so the observed minimum cannot undercut it.
+        var (pool, connection) = CreateMockConnection(new Queue<TaskCompletionSource<ProduceResponse>>());
+        var responseSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendProducePipelinedAfterWrite = async () =>
+        {
+            await Task.Delay(20);
+            responseSent.TrySetResult();
+            return Task.FromResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
+        };
 
-        pass.Add(bytes: 5_000, requestStart: 200);
-        pass.Add(bytes: 7_000, requestStart: 100);
-        pass.Add(bytes: 3_000, requestStart: 300);
+        var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { },
+            unackedBudget: budget);
 
-        await Assert.That(pass.Bytes).IsEqualTo(15_000);
-        await Assert.That(pass.EarliestRequestStart).IsEqualTo(100);
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0, dataSize: 5_000));
+
+            await responseSent.Task.WaitAsync(cancellationToken);
+            await WaitUntilAsync(() => budget.MinimumRttMicros > 0, cancellationToken);
+
+            // Half the injected write delay keeps this robust on slow runners while still
+            // catching a post-write anchor, which reads single-digit microseconds.
+            await Assert.That(budget.MinimumRttMicros).IsGreaterThanOrEqualTo(10_000);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -198,7 +198,8 @@ public sealed class BrokerUnackedAdmissionTests
 
         budget.OnAcked(
             ackedBytes: 1_000_000,
-            rttTicks: System.Diagnostics.Stopwatch.Frequency / 100,
+            budget.SnapshotDelivery(
+                nowTicks - System.Diagnostics.Stopwatch.Frequency / 100, appLimited: true),
             nowTicks);
         budget.Charge(1_200_000);
 
@@ -226,7 +227,8 @@ public sealed class BrokerUnackedAdmissionTests
 
         budget.OnAcked(
             ackedBytes: 1_000_000,
-            rttTicks: System.Diagnostics.Stopwatch.Frequency,
+            budget.SnapshotDelivery(
+                nowTicks - System.Diagnostics.Stopwatch.Frequency, appLimited: true),
             nowTicks);
         budget.Charge(1_200_000);
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -25,11 +25,31 @@ public sealed class BrokerUnackedByteBudgetTests
             .SetValue(budget, value);
 
     /// <summary>
+    /// Acknowledges one request the way the send loop does: the send timestamp is derived
+    /// from the request's round trip, and the delivery snapshot defaults to the clock as of
+    /// the previous acknowledgement. <paramref name="appLimitedAtSend"/> defaults to true
+    /// because sequential test sequences model a request sent after the previous response
+    /// arrived — an empty pipe — so the sample uses the request's own sojourn. Pipelining
+    /// tests mint explicit earlier snapshots with <c>appLimited: false</c>.
+    /// </summary>
+    private static void Ack(
+        BrokerUnackedByteBudget budget,
+        long ackedBytes,
+        double rttSeconds,
+        long nowTicks,
+        BrokerUnackedByteBudget.DeliverySnapshot? snapshotAtSend = null,
+        bool appLimitedAtSend = true)
+        => budget.OnAcked(
+            ackedBytes,
+            snapshotAtSend ?? budget.SnapshotDelivery(nowTicks - Seconds(rttSeconds), appLimitedAtSend),
+            nowTicks);
+
+    /// <summary>
     /// Establishes a per-request drain-rate sample of <paramref name="bytesPerSecond"/>.
     /// </summary>
     private static void EstablishRate(BrokerUnackedByteBudget budget, long bytesPerSecond, double rttSeconds)
     {
-        budget.OnAcked((long)(bytesPerSecond * rttSeconds), Seconds(rttSeconds), T0);
+        Ack(budget, (long)(bytesPerSecond * rttSeconds), rttSeconds, T0);
     }
 
     [Test]
@@ -81,7 +101,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.100);
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
 
         // 100,000 B/s × max(0.010, 1.5 × 0.100) = 15,000 bytes (±tick-quantization of the RTT).
         await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(14_990);
@@ -93,9 +113,9 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.0));
+        Ack(budget, 500, 0.005, T0);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(1.0));
 
         // Both samples measure 100,000 B/s. The 5ms base RTT leaves the 10ms target
         // in control; the later queue-loaded 100ms sample must not grow the horizon.
@@ -107,21 +127,22 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+        Ack(budget, 500, 0.005, T0);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051));
 
         // Expiring the minimum with a loaded sample starts a brief target-only drain,
         // rather than immediately accepting the 100ms queueing delay as base RTT.
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 
-        budget.OnAcked(ackedBytes: 5_000, rttTicks: Seconds(0.050), nowTicks: T0 + Seconds(10.2));
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(10.31));
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.4));
+        Ack(budget, 5_000, 0.050, T0 + Seconds(10.2));
+        Ack(budget, 500, 0.005, T0 + Seconds(10.31));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.4));
 
-        // Final 10,000-byte pass lands 90ms after the preceding ack, measuring
-        // 111,111 B/s from inter-ack delivery time rather than 100ms request sojourn.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_111);
+        // The final 10,000-byte request measures its own 100ms sojourn (100,000 B/s);
+        // pipelined delivery credit flows through the delivered-counter delta rather than
+        // a shrunken inter-ack interval.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]
@@ -129,11 +150,11 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+        Ack(budget, 500, 0.005, T0);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051));
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
-        budget.OnAcked(ackedBytes: 5_000, rttTicks: Seconds(0.050), nowTicks: T0 + Seconds(10.16));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
+        Ack(budget, 5_000, 0.050, T0 + Seconds(10.16));
 
         // The 100ms sample that starts the refresh keeps the target-only drain active.
         // Sizing from the stale 5ms minimum would have ended after the 50ms floor and
@@ -146,9 +167,9 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
-        budget.OnAcked(ackedBytes: 200_000, rttTicks: Seconds(2.000), nowTicks: T0 + Seconds(10.2));
+        Ack(budget, 10_000, 0.100, T0);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
+        Ack(budget, 200_000, 2.000, T0 + Seconds(10.2));
         budget.Charge(2_000);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
@@ -160,11 +181,11 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        Ack(budget, 10_000, 0.100, T0);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
         await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
 
-        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
+        Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 
         budget.SetCap(1_000_000, T0 + Seconds(10.401));
@@ -177,9 +198,9 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
-        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
+        Ack(budget, 10_000, 0.100, T0);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
+        Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         budget.Charge(2_000);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
@@ -192,12 +213,12 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        Ack(budget, 10_000, 0.100, T0);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
 
         // Refresh the old 100ms minimum, then observe 5ms while the drain probe is open.
-        budget.OnAcked(ackedBytes: 20_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(10.2));
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(10.25));
+        Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
+        Ack(budget, 500, 0.005, T0 + Seconds(10.25));
         budget.Charge(2_000);
 
         // Once the probe expires without another ack, admission must use the refreshed
@@ -210,11 +231,11 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 500, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.051));
+        Ack(budget, 500, 0.005, T0);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051));
 
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.1));
-        budget.OnAcked(ackedBytes: 10_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(10.25));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.25));
 
         // No ack landed inside the 100ms target-only drain. The late loaded sample must
         // not replace the retained 5ms base RTT and inflate the horizon to 150ms.
@@ -229,7 +250,7 @@ public sealed class BrokerUnackedByteBudgetTests
         EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
 
-        budget.OnAcked(ackedBytes: 1, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+        Ack(budget, 1, 0.001, T0 + Seconds(11.0));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
@@ -242,7 +263,7 @@ public sealed class BrokerUnackedByteBudgetTests
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
 
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(11.0));
+        Ack(budget, 100, 0.001, T0 + Seconds(11.0));
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
 
@@ -251,7 +272,7 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.0001), nowTicks: T0);
+        Ack(budget, 10, 0.0001, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }
@@ -265,7 +286,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var shrunken = budget.BudgetBytes;
 
         // Faster drain in the next window must grow the budget back (no ratchet-down).
-        budget.OnAcked(ackedBytes: 12_000, rttTicks: Seconds(0.001), nowTicks: T0 + Seconds(2.0));
+        Ack(budget, 12_000, 0.001, T0 + Seconds(2.0));
 
         await Assert.That(budget.BudgetBytes).IsGreaterThan(shrunken);
     }
@@ -275,7 +296,7 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        Ack(budget, 1_000, 0.100, T0);
 
         // 1,000 bytes / 100ms request RTT = 10,000 B/s. The first request is enough to
         // establish rate; no preceding wall-clock ack timestamp is required.
@@ -283,16 +304,20 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task RateSample_UsesInterAckDeliveryTime_ForPipelinedRequests()
+    public async Task RateSample_UsesDeliveredDelta_ForPipelinedRequests()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.005), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.005), nowTicks: T0 + Seconds(0.001));
+        // Both requests were sent before either delivery.
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.005), appLimited: false);
+        var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.001) - Seconds(0.005), appLimited: false);
+        budget.OnAcked(1_000, firstSend, T0);
+        budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
 
-        // Both requests overlapped on the wire. The second 1,000-byte delivery took 1ms
-        // since the preceding acknowledgement, independent of its 5ms request sojourn.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+        // The second sample's delivered-counter delta covers both deliveries: 2,000 bytes
+        // over its own 5ms sojourn = 400,000 B/s aggregate drain, independent of the 1ms
+        // gap between the two acknowledgements.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(4_000);
     }
 
     [Test]
@@ -300,8 +325,8 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.100));
+        Ack(budget, 1_000, 0.100, T0);
+        Ack(budget, 100, 0.100, T0 + Seconds(0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
@@ -311,9 +336,9 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        Ack(budget, 1_000, 0.100, T0);
         for (var i = 1; i <= 20; i++)
-            budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
@@ -323,15 +348,15 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0);
+        Ack(budget, 1_000, 0.100, T0);
         for (var i = 1; i <= 20; i++)
-            budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.025), nowTicks: T0 + Seconds(i * 0.025));
+            Ack(budget, 10, 0.025, T0 + Seconds(i * 0.025));
 
-        // Twenty fast response passes cover only 500ms, so the 2-second maximum window
+        // Twenty fast acknowledgements cover only 500ms, so the 2-second maximum window
         // must retain the original 10,000 B/s observation.
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
 
-        budget.OnAcked(ackedBytes: 10, rttTicks: Seconds(0.025), nowTicks: T0 + Seconds(2.1));
+        Ack(budget, 10, 0.025, T0 + Seconds(2.1));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
@@ -342,11 +367,11 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         for (var i = 0; i <= 8; i++)
-            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.900));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(0.900));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
@@ -360,7 +385,7 @@ public sealed class BrokerUnackedByteBudgetTests
             initialCapBytes: 1_000_000);
 
         for (var i = 0; i <= 8; i++)
-            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
         budget.Charge(5_500);
@@ -397,17 +422,17 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         for (var i = 0; i <= 8; i++)
-            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         // This request began before the probe opened at 800ms, so it cannot confirm
         // capacity under the larger admission budget even though it completes later.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.200), nowTicks: T0 + Seconds(0.900));
+        Ack(budget, 1_000, 0.200, T0 + Seconds(0.900));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         // First request wholly admitted under the probe confirms no rate gain and ends it.
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.000));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
 
@@ -417,17 +442,17 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         for (var i = 0; i <= 8; i++)
-            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
-        budget.OnAcked(ackedBytes: 1_250, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.900));
+        Ack(budget, 1_250, 0.100, T0 + Seconds(0.900));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
 
-        budget.OnAcked(ackedBytes: 1_562, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.000));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
         // A second wholly-probed sample at the same rate confirms capacity and publishes
         // the newly discovered base budget without the temporary 1.25x multiplier.
-        budget.OnAcked(ackedBytes: 1_562, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(1.100));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
     }
 
@@ -437,10 +462,14 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         budget.ObserveWrittenUnackedBytes(20_000);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        Ack(budget, 100, 0.100, T0);
+        Ack(budget, 100, 0.100, T0 + Seconds(0.101));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000);
+        // Rate budget = 1,000 B/s × max(10ms, 1.5 × 100ms) = 150 bytes. The demonstrated
+        // 20,000-byte occupancy grants headroom above that, but only up to 1.5 × the rate
+        // budget — occupancy is admission-bounded by the budget itself, so an uncapped
+        // floor would ratchet the budget to its cap (#1941).
+        await Assert.That(budget.BudgetBytes).IsEqualTo(225);
     }
 
     [Test]
@@ -449,15 +478,15 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         budget.ObserveWrittenUnackedBytes(20_000);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
+        Ack(budget, 100, 0.100, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(200)
             .Because("minimum-RTT probes must publish a target-only budget that drains standing queueing");
 
         budget.ObserveWrittenUnackedBytes(20_000);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(0.101));
+        Ack(budget, 100, 0.100, T0 + Seconds(0.101));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(225);
     }
 
     [Test]
@@ -466,10 +495,100 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         budget.ObserveWrittenUnackedBytes(20_000);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 100, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(2.1));
+        Ack(budget, 100, 0.100, T0);
+        Ack(budget, 100, 0.100, T0 + Seconds(2.1));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task OccupancyFloor_IsBoundedByRateBudget_NoFeedbackRatchet()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        // 100,000 B/s drain at negligible RTT => rate budget 1,000 bytes. Feed the
+        // published budget back as observed occupancy each round — the exact feedback
+        // shape that previously ratcheted the budget to its cap.
+        Ack(budget, 100, 0.001, T0);
+        for (var i = 1; i <= 5; i++)
+        {
+            budget.ObserveWrittenUnackedBytes(budget.BudgetBytes);
+            Ack(budget, 100, 0.001, T0 + Seconds(i * 0.100));
+        }
+
+        // Fixed point is 1.5 × the rate budget, not the 1,000,000-byte cap.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+    }
+
+    [Test]
+    public async Task HotPollPasses_BackToBackAcks_MeasureAggregateRate_NotInterPassGap()
+    {
+        // The stress-run failure shape (#1941): five pipelined 1 MB requests all sent
+        // before any delivery, whose responses drain in back-to-back hot-poll passes
+        // microseconds apart. Interval math based on inter-pass gaps read TB/s here.
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 200_000_000);
+
+        var sendSnapshots = new BrokerUnackedByteBudget.DeliverySnapshot[5];
+        for (var i = 0; i < 5; i++)
+            sendSnapshots[i] = budget.SnapshotDelivery(T0 + Seconds(i * 0.00001), appLimited: false);
+        for (var i = 0; i < 5; i++)
+            budget.OnAcked(1_000_000, sendSnapshots[i], T0 + Seconds(0.100 + i * 0.00001));
+
+        // Each sample measures the cumulative delivered delta over its own ~100ms sojourn;
+        // the last one reads the true aggregate drain of ~50 MB/s.
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(49_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(51_000_000);
+
+        // Budget ≈ target × rate — three orders of magnitude below the cap the broken
+        // estimator pegged.
+        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(600_000);
+    }
+
+    [Test]
+    public async Task AckAxis_LoadedGapSpreadsDeliveryOverArrivalTime()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        Ack(budget, 10, 0.005, T0);
+
+        // The pipe was loaded at send (not app-limited) but nothing was delivered for
+        // 500ms; the 100,000-byte delivery must average over the wall time it actually
+        // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
+        Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
+    }
+
+    [Test]
+    public async Task AppLimitedSend_AfterIdle_UsesSojournAxis_NotIdleGap()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        Ack(budget, 10, 0.005, T0);
+
+        // The pipe was empty at send: the 5-second idle gap is not drain time, so the
+        // sample uses the request's own 5ms sojourn (20 MB/s, budget clamps to cap).
+        Ack(budget, 100_000, 0.005, T0 + Seconds(5.0));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+    }
+
+    [Test]
+    public async Task RequestHistograms_RecordSizeAndRttBuckets()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        // 100,000 bytes => log2 = 16, shifted by 8 => size bucket 8.
+        // 1ms RTT = 1,000 µs => log2 = 9 => RTT bucket 9.
+        Ack(budget, 100_000, 0.001, T0);
+
+        var sizeHistogram = budget.CopyRequestSizeHistogram();
+        var rttHistogram = budget.CopyRequestRttMicrosHistogram();
+
+        await Assert.That(sizeHistogram[8]).IsEqualTo(1);
+        await Assert.That(sizeHistogram.Sum()).IsEqualTo(1);
+        await Assert.That(rttHistogram[9]).IsEqualTo(1);
+        await Assert.That(rttHistogram.Sum()).IsEqualTo(1);
     }
 
     [Test]
@@ -478,7 +597,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         for (var i = 0; i <= 8; i++)
-            budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.100), nowTicks: T0 + Seconds(i * 0.100));
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         budget.Charge(5_500);
 
@@ -495,8 +614,8 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.010), nowTicks: T0);
-        budget.OnAcked(ackedBytes: 1_000, rttTicks: Seconds(0.010), nowTicks: T0 + Seconds(1.0));
+        Ack(budget, 1_000, 0.010, T0);
+        Ack(budget, 1_000, 0.010, T0 + Seconds(1.0));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -157,7 +157,11 @@ public sealed class ProducerDeliveryDiagnosticsTests
         var budget = accumulator.GetBrokerUnackedBudget(7)!;
         budget.Charge(600);
         budget.RecordAdmissionBlock();
-        budget.OnAcked(1_000, Stopwatch.Frequency / 1_000, Stopwatch.GetTimestamp());
+        var ackTimestamp = Stopwatch.GetTimestamp();
+        budget.OnAcked(
+            1_000,
+            budget.SnapshotDelivery(ackTimestamp - Stopwatch.Frequency / 1_000, appLimited: true),
+            ackTimestamp);
 
         await accumulator.ExpireLingerAsync(CancellationToken.None);
         var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
@@ -170,8 +174,14 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.MinRttMicros).IsGreaterThan(0);
         await Assert.That(current.MaxRateBytesPerSec).IsGreaterThan(0);
         await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
+        await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
+        await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
+        await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
+        await Assert.That(current.RequestRttMicrosLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(sample.BrokerId).IsEqualTo(7);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
+        await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
+            .Because("periodic samples omit histograms to keep the 4096-entry ring compact");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -166,11 +166,11 @@ public sealed class ReadyBatchIncarnationTests
         var generations = new[] { capturedGeneration };
         var responseTask = new PipelinedResponse<ProduceResponse>(
             Task.FromResult(new ProduceResponse()));
-        var create = PendingResponseType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
         var timestamp = Stopwatch.GetTimestamp();
-        var pending = create.Invoke(
-            null,
-            [responseTask, batches, generations, 1, (long)batch.EncodedSize, timestamp, timestamp])!;
+        var pending = Activator.CreateInstance(
+            PendingResponseType,
+            responseTask, batches, generations, 1, (long)batch.EncodedSize, timestamp,
+            default(BrokerUnackedByteBudget.DeliverySnapshot))!;
         var isSameIncarnation = PendingResponseType.GetMethod("IsSameIncarnation")!;
 
         Interlocked.Exchange(ref batch._returnedToPool, 1);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
@@ -30,8 +30,9 @@ public class BrokerUnackedByteBudgetBenchmarks
     {
         for (var i = 0; i < Operations; i++)
         {
+            var snapshotAtSend = _budget.SnapshotDelivery(_timestamp, appLimited: false);
             _timestamp += RttTicks;
-            _budget.OnAcked(ackedBytes: 1024 * 1024, RttTicks, _timestamp);
+            _budget.OnAcked(ackedBytes: 1024 * 1024, snapshotAtSend, _timestamp);
         }
 
         return _budget.BudgetBytes;


### PR DESCRIPTION
Fixes #1941. Refs #1938.

## Problem

The per-broker unacked-byte admission budget never enforced `DeliveryLatencyTargetMs` (10ms) because both estimator inputs were garbage (stress run [29213011704](https://github.com/thomhurst/Dekaf/actions/runs/29213011704)):

- **Rate samples of 806 GB/s median / 1.6 TB/s peak**: `OnAcked` divided pass-aggregated bytes by `now - max(lastAck, earliestRequestStart)`. The send loop hot-polls `ProcessCompletedResponses` while at the in-flight ceiling, so consecutive passes run microseconds apart and the interval collapses to the inter-pass gap. The 2s windowed MAX filter then retained the explosion permanently — budget pinned at cap (67–192MB), 3-broker idempotent p99 **281ms vs Confluent 20ms**, every 3b latency gate red.
- **minRtt samples of 2–4µs**: the RTT anchor was stamped *after* `await SendPipelinedAfterWriteAsync(...)` returned; on localhost the response can already be in, so the anchor measured poll-loop latency and disabled the 1.5×BDP RTT safety floor.
- **Occupancy-floor feedback**: `budget >= 1.5 × occupancy` where occupancy is itself admission-bounded by the budget — a positive feedback loop ratcheting toward cap.

This is the third estimator generation to fail by measuring through response-pass timing (#1856/#1857 → #1863/#1888 → #1920).

## Fix: BBR-style per-request delivery sampling

- Each request mints a `DeliverySnapshot` token (cumulative delivered bytes, delivery timestamp, **pre-write** send timestamp, app-limited flag) just before its socket write and redeems it on ack. The rate sample is the delivered-counter delta over `max(request sojourn, ack-axis interval)` — the denominator is never smaller than one real round trip, regardless of pass clustering or processing stalls. App-limited sends (pipe empty at send) fall back to the sojourn so idle gaps never deflate the estimate.
- The pre-write anchor makes 2–4µs RTT artifacts impossible by construction; its write-time inflation only biases individual samples high, which the min filter discards.
- The occupancy floor is bounded at `1.5 × rate budget`: fixed point becomes 1.5× the latency target instead of the cap, while #1911's headroom-above-demonstrated-demand protection survives (recovery beyond it is the capacity probes' job, which the sane rate samples make functional again).
- Min-RTT probe and capacity-probe mechanisms are unchanged; only their inputs are re-based.
- `AckedResponsePass` deleted; `OnAcked` is now called once per acked request.

## Diagnostics (for stress validation + #1938)

Per-request size and RTT log2 histograms on the budget, exposed via `ProducerBrokerBudgetDiagnostic` on live snapshots only (periodic 1s samples omit them to keep the 4096-entry ring compact). These directly answer #1938's discriminating question (request-size distribution) on the next stress run.

## Tests

- All 33 existing estimator tests re-pinned by hand-derivation (29 keep exact values; the pipelined-rate test re-derives under delta semantics; two occupancy tests re-pin to the damped bound; the expired-window test's final value changes 1,111→1,000 because pipelined credit now flows through the delivered counter, not a shrunken inter-ack interval).
- New regression tests: hot-poll back-to-back acks (the stress failure shape — would have read TB/s before), ack-axis stall spreading, app-limited idle non-deflation, occupancy-floor feedback convergence, histogram bucketing, and a sender-level test proving a synchronous response behind a ~20ms write can no longer produce microsecond min-RTT samples.
- Full unit sweep: **5302/5302 green**. Benchmark: **~20ns/op, 0 B allocated** per acked request (was 12.3ns/op per pass; per-batch scale).

## Expected stress outcome (validation gates)

- `maxRateBytesPerSec` ≈ 1e9, not 1e12; `minRttMicros` in [100, 1000]
- Budget ≈ 10–15MB at 1GB/s (1-broker) / 3–5MB per broker (3-broker) instead of cap
- `unackedBytes` p95 ≈ rate × 10ms; 3b idempotent p95/target ≤ 3, p99/Confluent ≤ 2, no 3b throughput loss
- 1b `admissionBlockCount` becomes non-trivial — the gate binding again restores append backpressure, which should partially restore batch size-sealing (#1938 interplay)

If 1b idempotent throughput dips post-merge, the escape knob is `OccupancyFloorHeadroom` 1.5 → 2.0 before any design revisit.
