### PR TITLE
Use minute windows for long-run trend gates

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/IntraRunThroughputReportingTests.cs
@@ -54,6 +54,55 @@ public sealed class IntraRunThroughputReportingTests
     }
 
     [Test]
+    public async Task LongRunMetrics_AggregateMinuteWindowsBeforePeakGate()
+    {
+        var samples = Enumerable.Range(0, 15 * 60)
+            .Select(index => index % 2 == 0 ? 2_000.0 : 0.0)
+            .ToList();
+        var result = CreateResult(samples, elapsedSeconds: 900, sampledElapsedSeconds: 900);
+
+        await Assert.That(result.SteadyStatePeakRatio).IsEqualTo(1.0);
+        await Assert.That(result.SteadyStatePeakThresholdBreached).IsFalse();
+    }
+
+    [Test]
+    public async Task LongRunMetrics_SustainedMinuteScaleDropStillBreaches()
+    {
+        double[] minuteAverages =
+        [
+            1012, 1033, 1073, 1119, 1051,
+            836, 769, 719, 961, 796,
+            876, 930, 884, 930, 900
+        ];
+        var samples = minuteAverages
+            .SelectMany(average => Enumerable.Repeat(average, 60))
+            .ToList();
+        var result = CreateResult(samples, elapsedSeconds: 900, sampledElapsedSeconds: 900);
+
+        await Assert.That(result.SteadyStatePeakRatio!.Value).IsLessThan(0.85);
+        await Assert.That(result.SteadyStatePeakThresholdBreached).IsTrue();
+    }
+
+    [Test]
+    public async Task LongRunMetrics_RecoveredMinuteProfileDoesNotBreach()
+    {
+        double[] minuteAverages =
+        [
+            427_506, 463_841, 477_631, 499_414, 496_505,
+            406_229, 290_625, 358_655, 388_820, 412_635,
+            443_887, 488_668, 464_850, 471_754, 506_938
+        ];
+        var samples = minuteAverages
+            .SelectMany(average => Enumerable.Repeat(average, 60))
+            .ToList();
+        var result = CreateResult(samples, elapsedSeconds: 900, sampledElapsedSeconds: 900);
+
+        await Assert.That(result.SteadyStatePeakRatio!.Value).IsGreaterThan(0.85);
+        await Assert.That(result.SteadyStatePeakThresholdBreached).IsFalse();
+        await Assert.That(result.ThroughputSlopeThresholdBreached).IsFalse();
+    }
+
+    [Test]
     [Arguments("message-bounded")]
     [Arguments("zero-elapsed")]
     [Arguments("too-few-samples")]

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -144,7 +144,7 @@ internal static class MarkdownReporter
 
             if (sizeResults.Any(r => r.IntraRunDriftPercent is not null))
             {
-                sb.AppendLine($"*Drift compares last-third with first-third average throughput. Slope is the normalized least-squares trend; steady-state below {StressTestResult.SteadyStatePeakThreshold:P0} of peak or slope below {StressTestResult.SlopePercentPerMinuteThreshold:F0}%/min fails the regression gate.*");
+                sb.AppendLine($"*Drift compares last-third with first-third average throughput. Runs of at least three minutes use one-minute trend windows; shorter runs use raw intervals. Slope is the normalized least-squares trend; steady-state below {StressTestResult.SteadyStatePeakThreshold:P0} of peak or slope below {StressTestResult.SlopePercentPerMinuteThreshold:F0}%/min fails the regression gate.*");
                 sb.AppendLine();
             }
 

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -10,6 +10,7 @@ internal sealed class StressTestResult
 {
     internal const double SteadyStatePeakThreshold = 0.85;
     internal const double SlopePercentPerMinuteThreshold = -1.0;
+    private const double IntraRunTrendWindowSeconds = 60.0;
 
     public required string Scenario { get; init; }
     public required string Client { get; set; }
@@ -174,11 +175,16 @@ internal sealed class StressTestResult
         if (IsMessageBounded || Throughput.ElapsedSeconds <= 0)
             return false;
 
-        var samples = Throughput.MessagesPerSecondSamples
+        var rawSamples = Throughput.MessagesPerSecondSamples
             .Where(sample => double.IsFinite(sample) && sample >= 0)
             .ToArray();
-        if (samples.Length < 3)
+        if (rawSamples.Length < 3)
             return false;
+
+        var sampledElapsedSeconds = Throughput.SampledElapsedSeconds > 0
+            ? Throughput.SampledElapsedSeconds
+            : Throughput.ElapsedSeconds;
+        var samples = AggregateTrendWindows(rawSamples, sampledElapsedSeconds);
 
         var thirdCount = Math.Max(1, samples.Length / 3);
         var firstThirdTotal = 0.0;
@@ -207,9 +213,6 @@ internal sealed class StressTestResult
             denominator += centeredIndex * centeredIndex;
         }
 
-        var sampledElapsedSeconds = Throughput.SampledElapsedSeconds > 0
-            ? Throughput.SampledElapsedSeconds
-            : Throughput.ElapsedSeconds;
         var sampleMinutes = sampledElapsedSeconds / samples.Length / 60.0;
         var slopePerSample = numerator / denominator;
         metrics = new IntraRunThroughputMetrics(
@@ -217,6 +220,27 @@ internal sealed class StressTestResult
             (lastThirdAverage - firstThirdAverage) / firstThirdAverage * 100.0,
             slopePerSample / sampleMinutes / firstThirdAverage * 100.0);
         return true;
+    }
+
+    private static double[] AggregateTrendWindows(double[] samples, double sampledElapsedSeconds)
+    {
+        var windowCount = (int)Math.Floor(sampledElapsedSeconds / IntraRunTrendWindowSeconds);
+        if (windowCount < 3 || samples.Length < windowCount)
+            return samples;
+
+        var windows = new double[windowCount];
+        for (var window = 0; window < windowCount; window++)
+        {
+            var start = window * samples.Length / windowCount;
+            var end = (window + 1) * samples.Length / windowCount;
+            var total = 0.0;
+            for (var sample = start; sample < end; sample++)
+                total += samples[sample];
+
+            windows[window] = total / (end - start);
+        }
+
+        return windows;
     }
 
     private static double GetPercentile(double[] samples, double percentile)


### PR DESCRIPTION
## Summary
- aggregate throughput trends into one-minute windows for runs of at least three minutes
- retain raw-interval metrics for short runs
- document the reporting behavior and cover burst variance, sustained regression, and the observed recovery profile

## Investigation
A fresh 15-minute `acks=all` run reproduced the minute 6-8 dip but fully recovered:
- 438,670 effective msg/s; 439,554 median msg/s
- drift -0.27%; slope +0.29%/min
- 395,008,450 accepted and delivered; zero errors

The existing gate compared last-third average throughput with a raw one-second p95, producing a false failure at 0.748. One-minute windows produce 0.937 for the same recovered profile. The original sustained minute-scale dip profile remains below 0.85 and still fails.

## Validation
- focused reporting tests: 10/10
- net10 unit suite: 5303/5303
- full Release build (net8/net10/netstandard): 0 warnings, 0 errors

Closes #1944