### PR TITLE
Fix sequential round-trip watchdog registration

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -140,6 +140,30 @@ public sealed class ProgressWatchdogTests
         }
     }
 
+    [Test]
+    public void Track_SequentialPhases_ReusesWatchdog()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            using var watchdog = new ProgressWatchdog(outputDirectory);
+            var produceProgress = new ThroughputTracker();
+            var consumeProgress = new ThroughputTracker();
+
+            using (watchdog.Track(produceProgress, "Dekaf", "producer-roundtrip"))
+            {
+            }
+
+            using (watchdog.Track(consumeProgress, "Dekaf", "producer-roundtrip-consume"))
+            {
+            }
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
     private static string CreateOutputDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"dekaf-watchdog-tests-{Guid.NewGuid():N}");

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -83,45 +83,48 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
         var produceTimer = Stopwatch.StartNew();
 
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
-        using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
-
-        Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
-        for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+        using (options.ProgressWatchdog.Track(
+                   throughput,
+                   Client,
+                   Name,
+                   () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options)))
+        using (var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
         {
-            if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
-                    produceTimeout.IsCancellationRequested,
-                    throughput,
-                    client: "Dekaf",
-                    ordinal: ordinal,
-                    cancellationToken: cancellationToken))
+            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
+            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
+            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
             {
-                break;
+                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                        produceTimeout.IsCancellationRequested,
+                        throughput,
+                        client: "Dekaf",
+                        ordinal: ordinal,
+                        cancellationToken: cancellationToken))
+                {
+                    break;
+                }
+
+                var message = factory.Create(ordinal % options.Partitions);
+                try
+                {
+                    await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
+                    throughput.RecordMessage(message.Value.Length);
+                }
+                catch (Exception ex)
+                {
+                    throughput.RecordError(ex, "Round-trip produce", ordinal);
+                }
+
+                if ((ordinal + 1) % 50_000 == 0)
+                {
+                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                }
             }
 
-            var message = factory.Create(ordinal % options.Partitions);
-            try
-            {
-                await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
-                throughput.RecordMessage(message.Value.Length);
-            }
-            catch (Exception ex)
-            {
-                throughput.RecordError(ex, "Round-trip produce", ordinal);
-            }
-
-            if ((ordinal + 1) % 50_000 == 0)
-            {
-                Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
-            }
+            await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
         }
 
-        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
         produceTimer.Stop();
         var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         await sampler.StopAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- dispose the Dekaf producer-phase watchdog before the sequential consume phase starts
- keep producer timeout and flush inside the producer phase lifetime
- cover reusing one `ProgressWatchdog` across sequential phases

## Root cause

The producer registration used method-level `using var` lifetime, so it remained active when the consumer phase registered against the same watchdog. `ProgressWatchdog.Track` correctly rejected the overlapping registration and aborted every Dekaf round-trip scenario.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- `Dekaf.Tests.Unit.exe --treenode-filter '/*/*/ProgressWatchdogTests/*'` (4 passed)
- full net10.0 unit suite (5,335 passed)

Closes #1963