### PR TITLE
Fix round-trip progress watchdog lifetime

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ProgressWatchdogTests.cs
@@ -8,6 +8,30 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class ProgressWatchdogTests
 {
     [Test]
+    public void Track_SequentialRoundTripPhases_ReusesWatchdog()
+    {
+        var outputDirectory = CreateOutputDirectory();
+        try
+        {
+            var produceProgress = new ThroughputTracker();
+            var consumeProgress = new ThroughputTracker();
+            using var watchdog = new ProgressWatchdog(outputDirectory);
+
+            using (watchdog.Track(produceProgress, "Dekaf", "producer-roundtrip"))
+            {
+            }
+
+            using (watchdog.Track(consumeProgress, "Dekaf", "producer-roundtrip-consume"))
+            {
+            }
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task Track_Stall_CapturesStacksAndProducerDiagnosticsThenExits()
     {
         var outputDirectory = CreateOutputDirectory();

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -83,47 +83,51 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         await using var sampler = StressTestHelpers.StartSampler(throughput, cancellationToken);
         var produceTimer = Stopwatch.StartNew();
 
-        using var watchdog = options.ProgressWatchdog.Track(
-            throughput,
-            Client,
-            Name,
-            () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
-        using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
-
-        Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
-        for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+        ProducerDeliveryDiagnosticsSnapshot? producerDiagnostics;
         {
-            if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
-                    produceTimeout.IsCancellationRequested,
-                    throughput,
-                    client: "Dekaf",
-                    ordinal: ordinal,
-                    cancellationToken: cancellationToken))
+            using var produceWatchdog = options.ProgressWatchdog.Track(
+                throughput,
+                Client,
+                Name,
+                () => StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options));
+            using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
+
+            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
+            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
             {
-                break;
+                if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
+                        produceTimeout.IsCancellationRequested,
+                        throughput,
+                        client: "Dekaf",
+                        ordinal: ordinal,
+                        cancellationToken: cancellationToken))
+                {
+                    break;
+                }
+
+                var message = factory.Create(ordinal % options.Partitions);
+                try
+                {
+                    await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
+                    throughput.RecordMessage(message.Value.Length);
+                }
+                catch (Exception ex)
+                {
+                    throughput.RecordError(ex, "Round-trip produce", ordinal);
+                }
+
+                if ((ordinal + 1) % 50_000 == 0)
+                {
+                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                }
             }
 
-            var message = factory.Create(ordinal % options.Partitions);
-            try
-            {
-                await producer.FireAsync(options.Topic, message.Key, message.Value).ConfigureAwait(false);
-                throughput.RecordMessage(message.Value.Length);
-            }
-            catch (Exception ex)
-            {
-                throughput.RecordError(ex, "Round-trip produce", ordinal);
-            }
-
-            if ((ordinal + 1) % 50_000 == 0)
-            {
-                Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
-            }
+            await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
+            produceTimer.Stop();
+            producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         }
 
-        await StressTestHelpers.FlushWithTimeoutAsync(producer, throughput).ConfigureAwait(false);
-        produceTimer.Stop();
-        var producerDiagnostics = StressTestHelpers.CaptureProducerDeliveryDiagnostics(producer, options);
         await sampler.StopAsync().ConfigureAwait(false);
 
         var queriedEndOffsets = await RoundTripScenarioHelpers.TryQueryEndOffsetsAsync(


### PR DESCRIPTION
## Summary
- release the produce-phase progress watchdog before round-trip consumption starts
- cover sequential round-trip phase registrations on one watchdog

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- [x] focused `ProgressWatchdogTests` (4/4)
- [x] full net10 unit suite (5,335/5,335)
- [x] real Testcontainers round-trip: 1,000 produced and consumed; all validation counters clean; phase rates reported

Closes #1963
