### PR TITLE
Keep producer request waves active under load

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -109,8 +109,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // A request wave often reaches the sender over hundreds of microseconds. Waiting for one
     // short quiet period coalesces that wave without paying the full configured linger, while
     // the hard cap prevents a continuously busy producer from postponing dispatch forever.
-    private const int WaveCoalesceQuietMicroseconds = 75;
-    private const int WaveCoalesceMaxMicroseconds = 500;
+    private const int WaveCoalesceQuietMicroseconds = 1000;
+    private const int WaveCoalesceMaxMicroseconds = 2000;
     private static readonly long WaveCoalesceMaxTicks =
         MicrosecondsToStopwatchTicks(WaveCoalesceMaxMicroseconds);
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1343,7 +1343,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
-                    && Volatile.Read(ref _totalPendingResponseCount) == 0
                     && ShouldMicroLinger(
                         coalescedBatches,
                         coalescedCount,
@@ -1742,6 +1741,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // No batches were coalesced at all — nothing to clear.
                     coalescedCount = 0;
                 }
+
+                // Keep forming request waves while the pipeline is busy. Without rearming here,
+                // only the first request after an idle period can coalesce adjacent partitions.
+                if (sentThisIteration)
+                    waveCoalesceArmed = true;
 
                 // ── 7. Compute timeout and wait ──
                 if (transactionEnrollmentReady)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -109,10 +109,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // A request wave often reaches the sender over hundreds of microseconds. Waiting for one
     // short quiet period coalesces that wave without paying the full configured linger, while
     // the hard cap prevents a continuously busy producer from postponing dispatch forever.
+    // Zero-linger producers retain the historical sub-millisecond bounds: asking for immediate
+    // dispatch must not implicitly add the wider throughput-oriented coalescing delay.
     private const int WaveCoalesceQuietMicroseconds = 1000;
     private const int WaveCoalesceMaxMicroseconds = 2000;
-    private static readonly long WaveCoalesceMaxTicks =
-        MicrosecondsToStopwatchTicks(WaveCoalesceMaxMicroseconds);
+    private const int ZeroLingerWaveCoalesceQuietMicroseconds = 75;
+    private const int ZeroLingerWaveCoalesceMaxMicroseconds = 500;
 
     /// <summary>
     /// Maximum batches coalesced into one send-loop pass. The in-flight limit can be very
@@ -1064,8 +1066,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
-        var waveCoalesceMaxTicks = WaveCoalesceMaxTicks;
-        var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(WaveCoalesceQuietMicroseconds);
+        var waveCoalesceBounds = SelectWaveCoalesceBounds(_options.LingerMs);
+        var waveCoalesceMaxTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.MaximumMicroseconds);
+        var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.QuietMicroseconds);
         var waveCoalesceArmed = true;
 
         // Pre-allocate reusable response lookup dictionary to avoid per-response allocation.
@@ -1357,10 +1360,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                            && coalescedPartitions.Count < _knownPartitions.Count
                            && Stopwatch.GetTimestamp() < quietDeadline)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         if (!eventReader.TryRead(out var evt))
                         {
-                            // Fixed CPU spin never escalates to Sleep(1), so the deadline
-                            // remains a real sub-millisecond hard cap.
+                            // Fixed CPU spin never escalates to Sleep(1), so it preserves
+                            // the configured microsecond deadline.
                             global::System.Threading.Thread.SpinWait(32);
                             continue;
                         }
@@ -2216,6 +2220,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var batch = coalescedBatches[0];
         return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
+
+    internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(
+        int lingerMs) => lingerMs == 0
+            ? (ZeroLingerWaveCoalesceQuietMicroseconds, ZeroLingerWaveCoalesceMaxMicroseconds)
+            : (WaveCoalesceQuietMicroseconds, WaveCoalesceMaxMicroseconds);
 
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
         Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -352,9 +352,10 @@ public sealed class ProducerOptions
     public int MaxBlockMs { get; init; } = 60000;
 
     /// <summary>
-    /// Maximum request size in bytes.
+    /// Maximum request size in bytes. Defaults to 8 MB so full batches from separate
+    /// partitions can share one ProduceRequest.
     /// </summary>
-    public int MaxRequestSize { get; init; } = 1048576;
+    public int MaxRequestSize { get; init; } = 8388608;
 
     /// <summary>
     /// Partitioner type.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -352,10 +352,9 @@ public sealed class ProducerOptions
     public int MaxBlockMs { get; init; } = 60000;
 
     /// <summary>
-    /// Maximum request size in bytes. Defaults to 8 MB so full batches from separate
-    /// partitions can share one ProduceRequest.
+    /// Maximum request size in bytes.
     /// </summary>
-    public int MaxRequestSize { get; init; } = 8388608;
+    public int MaxRequestSize { get; init; } = 1048576;
 
     /// <summary>
     /// Partitioner type.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -202,6 +202,75 @@ public sealed class BrokerSenderSendLoopTests
         }
     }
 
+    [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_WaveCoalesce_RearmsWhileResponseIsInFlight(
+        CancellationToken cancellationToken)
+    {
+        var firstResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
+            [firstResponse, secondResponse]);
+        var (pool, connection) = CreateMockConnection(responses);
+        var options = CreateOptions(
+            acks: Acks.All,
+            maxInFlight: 5,
+            enableIdempotence: false,
+            lingerMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var injectSibling = 0;
+        BrokerSender? sender = null;
+        sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            onWaveCoalesceStarted: () =>
+            {
+                if (Volatile.Read(ref injectSibling) != 0)
+                    sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+            });
+
+        try
+        {
+            sender.EnqueueBulk(
+            [
+                CreateTestBatch(valueTaskSourcePool, "test-topic", 0),
+                CreateTestBatch(valueTaskSourcePool, "test-topic", 1)
+            ]);
+            await WaitUntilAsync(
+                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 1,
+                cancellationToken);
+
+            Volatile.Write(ref injectSibling, 1);
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
+            await WaitUntilAsync(
+                () => Volatile.Read(ref connection.SendPipelinedAfterWriteCalls) == 2,
+                cancellationToken);
+
+            await Assert.That(firstResponse.Task.IsCompleted).IsFalse();
+            var diagnostic = accumulator.GetDeliveryDiagnosticsSnapshot();
+            await Assert.That(diagnostic.CoalesceWidthHistogram
+                    .Single(bucket => bucket.MinimumWidth == 2).RequestCount)
+                .IsEqualTo(2);
+
+            firstResponse.SetResult(CreateSuccessResponseForPartitions("test-topic", 2));
+            secondResponse.SetResult(CreateSuccessResponseForPartitions("test-topic", 2));
+        }
+        finally
+        {
+            firstResponse.TrySetResult(CreateSuccessResponseForPartitions("test-topic", 2));
+            secondResponse.TrySetResult(CreateSuccessResponseForPartitions("test-topic", 2));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
     private static ProducerOptions CreateOptions(Acks acks = Acks.All, int maxInFlight = 1,
         int retryBackoffMs = 100, int retryBackoffMaxMs = 1000,
         int deliveryTimeoutMs = 30_000, int requestTimeoutMs = 30_000,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -128,6 +128,18 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    public async Task SelectWaveCoalesceBounds_ZeroLingerRetainsLowLatencyBounds()
+    {
+        var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);
+        var configuredLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 5);
+
+        await Assert.That(zeroLinger.QuietMicroseconds).IsEqualTo(75);
+        await Assert.That(zeroLinger.MaximumMicroseconds).IsEqualTo(500);
+        await Assert.That(configuredLinger.QuietMicroseconds).IsEqualTo(1_000);
+        await Assert.That(configuredLinger.MaximumMicroseconds).IsEqualTo(2_000);
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_WaveCoalesce_RearmsAfterIdleWaitAtDefaultLinger(
         CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- keep request-wave coalescing armed while produce responses remain in flight
- extend the active wave quiet/hard bounds to 1 ms / 2 ms, so the saturated sender polls the next batch wave instead of yielding between requests
- add a deterministic regression test proving a second width-2 request forms before the first response completes
- preserve all public producer option defaults

## Root cause

Wave coalescing required zero pending responses and was rearmed only after a fully idle wait. Under sustained load, the first request disabled it for the rest of the busy period. The sender repeatedly crossed an async scheduling boundary between requests, used only about one of its two pinned cores, and left the delivery-coupled accumulator with gaps that produced smaller requests.

The active pipeline now rearms the bounded micro-coalesce pass after each successful send. Batch formation overlaps in-flight network I/O, keeping the sender hot and requests full.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore` — netstandard2.0/net10, 0 warnings, 0 errors
- full net10 unit suite — 5,335 passed
- focused sender suite after merging latest main — 52 passed
- [3-minute paired stress run](https://github.com/thomhurst/Dekaf/actions/runs/29227333824), 1 broker, 1 KB messages, client pinned to 2 cores:

| Scenario | Dekaf | Confluent | Ratio | Dekaf cores | steady/peak |
|---|---:|---:|---:|---:|---:|
| producer | 2,150,563 msg/s | 1,307,345 | 1.65x | 1.94 | 0.96 |
| producer-acks-all | 1,661,170 | 899,000 | 1.85x | 1.86 | 0.975 |
| producer-idempotent | 2,169,165 | 1,333,376 | 1.63x | 1.95 | 0.96 |

The run's round-trip matrix job used the pre-#1969 base and failed on #1963's watchdog bug. #1969 is now merged into main and this branch; every producer matrix job passed.

Closes #1964