### PR TITLE
Stabilize producer capacity probes across RTTs

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -150,7 +150,9 @@ internal sealed class BrokerUnackedByteBudget
     private long _nextProbeTimestamp;
     private long _capacityProbeStartTimestamp;
     private long _capacityProbeDeadlineTimestamp;
+    private long _capacityProbeEvaluationDeadlineTimestamp;
     private double _capacityProbeBaselineRate;
+    private double _capacityProbePeakRate;
     private bool _capacityProbeActive;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
@@ -535,16 +537,29 @@ internal sealed class BrokerUnackedByteBudget
                 return;
             }
 
-            // A response can confirm the probe only when its request was sent after the
-            // larger budget was published. If observed rate grows, retain the probe and
-            // require another wholly-probed sample at the new level.
+            // A response can contribute only when its request was sent after the larger
+            // budget was published. Collect a full RTT of wholly-probed responses before
+            // judging growth: response ordering across connection lanes can otherwise let
+            // one small request cancel the probe before the added budget reaches the wire.
             if (sendTimestamp < _capacityProbeStartTimestamp)
                 return;
 
-            if (bytesPerSecond > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            _capacityProbePeakRate = Math.Max(_capacityProbePeakRate, bytesPerSecond);
+            if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
-                _capacityProbeBaselineRate = bytesPerSecond;
+                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + rttTicks;
+                return;
+            }
+
+            if (nowTicks < _capacityProbeEvaluationDeadlineTimestamp)
+                return;
+
+            if (_capacityProbePeakRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            {
+                _capacityProbeBaselineRate = _capacityProbePeakRate;
                 _capacityProbeStartTimestamp = nowTicks;
+                _capacityProbePeakRate = 0;
+                _capacityProbeEvaluationDeadlineTimestamp = 0;
                 Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
             }
             else
@@ -563,6 +578,8 @@ internal sealed class BrokerUnackedByteBudget
         {
             _capacityProbeStartTimestamp = nowTicks;
             _capacityProbeBaselineRate = _windowMaxRate;
+            _capacityProbePeakRate = 0;
+            _capacityProbeEvaluationDeadlineTimestamp = 0;
             Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
             Volatile.Write(ref _capacityProbeActive, true);
         }
@@ -574,6 +591,8 @@ internal sealed class BrokerUnackedByteBudget
 
     private void DeactivateCapacityProbe()
     {
+        _capacityProbePeakRate = 0;
+        _capacityProbeEvaluationDeadlineTimestamp = 0;
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -362,7 +362,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RaisesBudgetForOneRtt_ThenRevertsWithoutRateGain()
+    public async Task PeriodicProbe_CollectsOneRtt_ThenRevertsWithoutRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
@@ -372,8 +372,28 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(0.900));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_CollectsFullRttBeforeJudgingRateGain()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+
+        for (var i = 0; i <= 8; i++)
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        // One small response can arrive first after the larger budget is published.
+        // It must not cancel the probe before other requests from the same RTT land.
+        Ack(budget, 500, 0.100, T0 + Seconds(0.900));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_250, 0.100, T0 + Seconds(0.950));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
     }
 
     [Test]
@@ -431,8 +451,12 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.200, T0 + Seconds(0.900));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        // First request wholly admitted under the probe confirms no rate gain and ends it.
+        // First request wholly admitted under the probe starts one RTT of measurement.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        // A full RTT of wholly-probed responses confirms no gain and ends the probe.
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
 
@@ -450,9 +474,13 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
-        // A second wholly-probed sample at the same rate confirms capacity and publishes
-        // the newly discovered base budget without the temporary 1.25x multiplier.
+        // The first sample under the higher level starts another full-RTT measurement.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+
+        // One RTT without further growth publishes the newly discovered base budget
+        // without the temporary 1.25x multiplier.
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
     }
 


### PR DESCRIPTION
## Summary
- collect all wholly-probed delivery-rate samples for one RTT before judging capacity growth
- prevent one low response from another connection lane from cancelling a bandwidth probe early
- retain the existing 8-RTT hard timeout and zero-allocation hot path

## Validation
- [x] Release build: 0 warnings, 0 errors
- [x] `BrokerUnackedByteBudgetTests`: 42/42
- [x] full net10 unit suite: 5,335/5,335 before final naming-only cleanup
- [x] post-cleanup suite: 5,334 passed plus unrelated timing timeout filed as #1973; timed-out test passed isolated in 399ms
- [x] BenchmarkDotNet: 16.19 ns/ack, 0 B allocated (prior reference: 19.6 ns)
- [x] 15m, 3-broker, idempotent 3conn: slope +6.370%/min (was -1.63), steady/peak 0.926, zero trend breaches/errors
- [x] 15m, 3-broker, acks-all: slope +2.944%/min (was -1.05), steady/peak 0.990, zero trend breaches/errors
- [x] 15m, 3-broker, idempotent 1conn: slope -0.873%/min (was -1.04), no configured slope breach; local Docker Desktop run had large alternating host-noise waves

Closes #1966
