### PR TITLE
Enforce producer delivery latency target

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3468,9 +3468,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // RTT samples and disabled the budget's RTT safety floor. Including TCP write
                 // time biases individual RTT samples high, which the budget's minimum filter
                 // discards.
+                var oldestBatchTimestamp = long.MaxValue;
+                for (var i = 0; i < count; i++)
+                    oldestBatchTimestamp = Math.Min(oldestBatchTimestamp, batches[i].StopwatchCreatedTicks);
+                if (oldestBatchTimestamp == long.MaxValue)
+                    oldestBatchTimestamp = 0;
+
                 var deliverySnapshotAtSend = _unackedBudget?.SnapshotDelivery(
                     Stopwatch.GetTimestamp(),
-                    appLimited: Volatile.Read(ref _totalPendingResponseCount) == 0) ?? default;
+                    appLimited: Volatile.Read(ref _totalPendingResponseCount) == 0,
+                    oldestBatchTimestamp) ?? default;
                 responseTask = await SendPipelinedAfterWriteAsync(
                     connection,
                     request,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -46,7 +46,8 @@ internal sealed class BrokerUnackedByteBudget
         long DeliveredBytes,
         long DeliveredTimestamp,
         long SendTimestamp,
-        bool AppLimited);
+        bool AppLimited,
+        long OldestBatchTimestamp);
 
     /// <summary>
     /// Budget ceiling in batches per connection. Sized so a ~1 GB/s drain with ~30 ms ack
@@ -60,6 +61,10 @@ internal sealed class BrokerUnackedByteBudget
     private const double WindowBucketSeconds = 0.100;
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
+    private const double DeliveryLatencyEwmaWeight = 0.125;
+    private const double MinimumLatencyBudgetScale = 0.10;
+    private const double MinimumLatencyAdjustmentFactor = 0.75;
+    private const double MaximumLatencyAdjustmentFactor = 1.05;
 
     /// <summary>
     /// Bounds the occupancy floor to this multiple of the rate-derived budget once a drain
@@ -86,6 +91,7 @@ internal sealed class BrokerUnackedByteBudget
     /// enough history to ignore short scheduler and broker stalls.
     /// </summary>
     private static readonly long WindowBucketTicks = Math.Max(1, (long)(WindowBucketSeconds * Stopwatch.Frequency));
+    private static readonly long LatencyControlIntervalTicks = Math.Max(1, Stopwatch.Frequency / 10);
 
     /// <summary>How long an observed base RTT remains valid before it is refreshed.</summary>
     private static readonly long MinRttWindowTicks = 10 * Stopwatch.Frequency;
@@ -152,6 +158,9 @@ internal sealed class BrokerUnackedByteBudget
     private long _capacityProbeDeadlineTimestamp;
     private double _capacityProbeBaselineRate;
     private bool _capacityProbeActive;
+    private double _deliveryLatencyEwmaSeconds;
+    private double _latencyBudgetScale = 1.0;
+    private long _nextLatencyControlTimestamp;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
     {
@@ -186,6 +195,11 @@ internal sealed class BrokerUnackedByteBudget
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
 
+    internal long DeliveryLatencyEwmaMicros =>
+        (long)(Volatile.Read(ref _deliveryLatencyEwmaSeconds) * 1_000_000);
+
+    internal double LatencyBudgetScale => Volatile.Read(ref _latencyBudgetScale);
+
     /// <summary>
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
@@ -195,12 +209,18 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
-    internal DeliverySnapshot SnapshotDelivery(long sendTimestamp, bool appLimited)
+    /// <param name="oldestBatchTimestamp">Seal timestamp of the oldest batch in the request,
+    /// or zero when delivery-age feedback is unavailable.</param>
+    internal DeliverySnapshot SnapshotDelivery(
+        long sendTimestamp,
+        bool appLimited,
+        long oldestBatchTimestamp = 0)
         => new(
             Volatile.Read(ref _totalDeliveredBytes),
             Volatile.Read(ref _lastDeliveredTimestamp),
             sendTimestamp,
-            appLimited);
+            appLimited,
+            oldestBatchTimestamp);
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
     /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
@@ -348,6 +368,7 @@ internal sealed class BrokerUnackedByteBudget
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
         UpdateMinRtt(rttSeconds, nowTicks);
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
+        UpdateDeliveryLatency(sendSnapshot.OldestBatchTimestamp, nowTicks);
 
         RecordRequestHistograms(ackedBytes, rttSeconds);
 
@@ -380,6 +401,38 @@ internal sealed class BrokerUnackedByteBudget
         UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
 
         RecomputeBudget();
+    }
+
+    private void UpdateDeliveryLatency(long oldestBatchTimestamp, long nowTicks)
+    {
+        if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= nowTicks)
+            return;
+
+        var sampleSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
+        var latencyEstimate = _deliveryLatencyEwmaSeconds == 0
+            ? sampleSeconds
+            : _deliveryLatencyEwmaSeconds
+                + DeliveryLatencyEwmaWeight * (sampleSeconds - _deliveryLatencyEwmaSeconds);
+        Volatile.Write(ref _deliveryLatencyEwmaSeconds, latencyEstimate);
+
+        if (_nextLatencyControlTimestamp == 0)
+        {
+            _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
+            return;
+        }
+
+        if (nowTicks < _nextLatencyControlTimestamp)
+            return;
+
+        var targetRatio = _targetSeconds / latencyEstimate;
+        var adjustment = targetRatio < 1
+            ? Math.Max(MinimumLatencyAdjustmentFactor, targetRatio)
+            : Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
+        Volatile.Write(ref _latencyBudgetScale, Math.Clamp(
+            _latencyBudgetScale * adjustment,
+            MinimumLatencyBudgetScale,
+            1.0));
+        _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -644,9 +697,10 @@ internal sealed class BrokerUnackedByteBudget
         }
         else
         {
+            var latencyGovernedTargetSeconds = _targetSeconds * _latencyBudgetScale;
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
-                ? Math.Max(_targetSeconds, RttSafetyMultiplier * minRttSeconds)
-                : _targetSeconds;
+                ? Math.Max(latencyGovernedTargetSeconds, RttSafetyMultiplier * minRttSeconds)
+                : latencyGovernedTargetSeconds;
             rateBudgetBytes = _windowMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -286,6 +286,8 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
     public required long AdmissionBlockCount { get; init; }
+    public required long DeliveryLatencyEwmaMicros { get; init; }
+    public required double LatencyBudgetScale { get; init; }
 
     /// <summary>
     /// Log2 histogram of acked produce-request payload sizes; bucket semantics are defined

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4851,6 +4851,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         MinRttMicros = budget.MinimumRttMicros,
         MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
         AdmissionBlockCount = budget.AdmissionBlockEvents,
+        DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
+        LatencyBudgetScale = budget.LatencyBudgetScale,
         RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
         RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null
     };

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3132,6 +3132,8 @@ public sealed class BrokerSenderSendLoopTests
 
             await Assert.That(GetDeliverySnapshot(sender, 0).AppLimited).IsTrue();
             await Assert.That(GetDeliverySnapshot(sender, 1).AppLimited).IsFalse();
+            await Assert.That(GetDeliverySnapshot(sender, 0).OldestBatchTimestamp).IsGreaterThan(0);
+            await Assert.That(GetDeliverySnapshot(sender, 1).OldestBatchTimestamp).IsGreaterThan(0);
 
             responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
             responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 1));

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -72,6 +72,67 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task DeliveryLatencyAboveTarget_ReducesRateBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.020));
+            budget.OnAcked(1_000, snapshot, now);
+        }
+
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(20_000).Within(10);
+        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.25);
+        await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
+    }
+
+    [Test]
+    public async Task DeliveryLatencyBelowTarget_RecoversReducedBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.020));
+            budget.OnAcked(1_000, snapshot, now);
+        }
+        var reducedScale = budget.LatencyBudgetScale;
+
+        for (var i = 0; i < 30; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.005));
+            budget.OnAcked(1_000, snapshot, now);
+        }
+
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
+        await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(reducedScale);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(2_500);
+    }
+
+    [Test]
     public async Task Budget_ClampsToFloor_WhenRateCollapses()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);


### PR DESCRIPTION
Closes #1965

## Root cause

The per-broker admission budget used measured drain rate and minimum RTT, but never observed the age of delivered batches. Sealed batches could therefore wait behind the admission gate without that queueing delay reducing the budget, leaving `DeliveryLatencyTargetMs` unenforced.

## Fix

- Carry the oldest batch seal timestamp in each per-request delivery snapshot.
- Feed seal-to-ack age into a bounded EWMA controller every 100 ms.
- Scale the rate-derived budget toward the configured delivery target while preserving the existing RTT safety floor, capacity probes, and hard cap.
- Expose delivery-age EWMA and budget scale in producer stress diagnostics.
- Cover budget reduction, recovery, and sender timestamp propagation.

## Validation

- Release unit build: 0 warnings, 0 errors (`net8.0`, `net10.0`).
- Full net10 unit suite: 5,337 passed.
- Focused sender suite: 51 passed.
- Focused budget suite: 43 passed.
- 1-minute paired stress: https://github.com/thomhurst/Dekaf/actions/runs/29228325693
  - acks-all 3b: 947k msg/s; p50 8.65 ms, p95 24.55 ms, p99 44.95 ms (old: 1.078M; 20.6/59.6/81.4 ms).
  - idempotent 3b: 797k msg/s; p50 10.65 ms, p95 23.45 ms, p99 34.65 ms (old: 983k; 19.1/56.2/77.0 ms).
  - idempotent 3conn 3b: 835k msg/s; p50 9.95 ms, p95 22.45 ms, p99 37.85 ms.
  - all 12 jobs passed; round-trip watchdog path passed.
- 3-minute confirmation: https://github.com/thomhurst/Dekaf/actions/runs/29228593260
  - acks-all 3b: 868k msg/s; p50 8.25 ms, p95 24.75 ms, p99 39.55 ms.
  - idempotent 3b: 953k msg/s; p50 9.05 ms, p95 23.15 ms, p99 40.05 ms.
  - idempotent 3conn 3b: 973k msg/s; p50 9.05 ms, p95 23.45 ms, p99 39.25 ms.
  - all workload jobs passed; round-trip watchdog path passed.
