### PR TITLE
Enforce producer delivery latency feedback

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3468,9 +3468,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // RTT samples and disabled the budget's RTT safety floor. Including TCP write
                 // time biases individual RTT samples high, which the budget's minimum filter
                 // discards.
+                var oldestBatchTimestamp = batches[0].StopwatchCreatedTicks;
+                for (var i = 1; i < count; i++)
+                {
+                    oldestBatchTimestamp = Math.Min(
+                        oldestBatchTimestamp,
+                        batches[i].StopwatchCreatedTicks);
+                }
                 var deliverySnapshotAtSend = _unackedBudget?.SnapshotDelivery(
                     Stopwatch.GetTimestamp(),
-                    appLimited: Volatile.Read(ref _totalPendingResponseCount) == 0) ?? default;
+                    appLimited: Volatile.Read(ref _totalPendingResponseCount) == 0,
+                    oldestBatchTimestamp) ?? default;
                 responseTask = await SendPipelinedAfterWriteAsync(
                     connection,
                     request,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -12,14 +12,17 @@ namespace Dekaf.Producer;
 /// by the broker's drain rate; capping the standing bytes to
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
 /// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
+/// A two-second append-to-ack p95 feeds back queueing before the socket write; when it exceeds
+/// the target, the admission horizon contracts by <c>target / observed p95</c>.
 /// <para>
 /// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
 /// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
 /// delta over the larger of the request's own sojourn and the interval since the delivery
 /// clock at send (sojourn only for app-limited sends, where the pipe was empty and the
-/// preceding interval is idle time). The denominator is therefore never smaller than one
-/// real round trip, so response-pass timing (hot polling, clustered completions,
-/// processing stalls) cannot manufacture inflated samples.
+/// preceding interval is idle time). It also carries the oldest batch's append-start timestamp
+/// so the acknowledgement can measure queueing that happened before admission and send.
+/// The drain-rate denominator is never smaller than one real round trip, so response-pass
+/// timing cannot manufacture inflated samples.
 /// </para>
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
@@ -46,7 +49,8 @@ internal sealed class BrokerUnackedByteBudget
         long DeliveredBytes,
         long DeliveredTimestamp,
         long SendTimestamp,
-        bool AppLimited);
+        bool AppLimited,
+        long OldestBatchTimestamp);
 
     /// <summary>
     /// Budget ceiling in batches per connection. Sized so a ~1 GB/s drain with ~30 ms ack
@@ -78,6 +82,9 @@ internal sealed class BrokerUnackedByteBudget
     /// 32 ms and above).
     /// </summary>
     private const int HistogramBucketCount = 16;
+    private const int DeliveryLatencySubBucketsPerPowerOfTwo = 4;
+    private const int DeliveryLatencyHistogramBucketCount =
+        24 * DeliveryLatencySubBucketsPerPowerOfTwo;
     private const int RequestSizeHistogramShift = 8;
 
     /// <summary>
@@ -119,6 +126,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _admissionBlockEvents;
     private long _minimumRttMicros;
     private long _maxRateBytesPerSecond;
+    private long _deliveryLatencyP95Micros;
     private long _pendingWrittenUnackedPeakBytes;
     // BBR delivery clock: cumulative acked bytes ("delivered") and the timestamp of the most
     // recent delivery ("delivered_mstamp"). Written only by OnAcked (single writer); snapshot
@@ -132,6 +140,10 @@ internal sealed class BrokerUnackedByteBudget
     private long _capBytes;
     private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
     private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
+    private readonly long[] _deliveryLatencyBucketCounts =
+        new long[WindowBucketCount * DeliveryLatencyHistogramBucketCount];
+    private readonly long[] _deliveryLatencyWindowCounts =
+        new long[DeliveryLatencyHistogramBucketCount];
     // Per-request diagnostics: log2 histograms of acked request sizes and RTTs. Incremented
     // only by the owning send loop; snapshot copies use per-element volatile reads, so
     // readers may observe slightly stale counts (acceptable for diagnostics).
@@ -140,6 +152,8 @@ internal sealed class BrokerUnackedByteBudget
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
     private long _windowMaxOccupancyBytes;
+    private long _deliveryLatencySampleCount;
+    private double _deliveryLatencyP95Seconds;
     private double _minRttSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
@@ -186,6 +200,8 @@ internal sealed class BrokerUnackedByteBudget
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
 
+    internal long DeliveryLatencyP95Micros => Volatile.Read(ref _deliveryLatencyP95Micros);
+
     /// <summary>
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
@@ -195,12 +211,18 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
-    internal DeliverySnapshot SnapshotDelivery(long sendTimestamp, bool appLimited)
+    /// <param name="oldestBatchTimestamp">Oldest append-start timestamp represented by the
+    /// request, or zero when the caller has no batch-age signal.</param>
+    internal DeliverySnapshot SnapshotDelivery(
+        long sendTimestamp,
+        bool appLimited,
+        long oldestBatchTimestamp = 0)
         => new(
             Volatile.Read(ref _totalDeliveredBytes),
             Volatile.Read(ref _lastDeliveredTimestamp),
             sendTimestamp,
-            appLimited);
+            appLimited,
+            oldestBatchTimestamp);
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
     /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
@@ -366,6 +388,11 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
 
         AdvanceWindow(nowTicks);
+        if (sendSnapshot.OldestBatchTimestamp > 0
+            && sendSnapshot.OldestBatchTimestamp <= nowTicks)
+        {
+            AddDeliveryLatencySample(nowTicks - sendSnapshot.OldestBatchTimestamp);
+        }
         var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
         if (bytesPerSecond > 0)
         {
@@ -476,8 +503,12 @@ internal sealed class BrokerUnackedByteBudget
         {
             Array.Clear(_rateBucketMaxValues);
             Array.Clear(_occupancyBucketMaxValues);
+            Array.Clear(_deliveryLatencyBucketCounts);
+            Array.Clear(_deliveryLatencyWindowCounts);
             _windowMaxRate = 0;
             _windowMaxOccupancyBytes = 0;
+            _deliveryLatencySampleCount = 0;
+            PublishDeliveryLatencyP95(0);
         }
         else
         {
@@ -491,12 +522,14 @@ internal sealed class BrokerUnackedByteBudget
                     && _occupancyBucketMaxValues[slot] >= _windowMaxOccupancyBytes;
                 _rateBucketMaxValues[slot] = 0;
                 _occupancyBucketMaxValues[slot] = 0;
+                ClearDeliveryLatencyWindowSlot(slot);
             }
 
             if (recomputeRate)
                 _windowMaxRate = Max(_rateBucketMaxValues);
             if (recomputeOccupancy)
                 _windowMaxOccupancyBytes = Max(_occupancyBucketMaxValues);
+            RecomputeDeliveryLatencyP95();
         }
 
         _currentWindowBucket = bucket;
@@ -514,6 +547,78 @@ internal sealed class BrokerUnackedByteBudget
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _occupancyBucketMaxValues[slot] = Math.Max(_occupancyBucketMaxValues[slot], bytes);
         _windowMaxOccupancyBytes = Math.Max(_windowMaxOccupancyBytes, bytes);
+    }
+
+    private void AddDeliveryLatencySample(long latencyTicks)
+    {
+        var latencyMicros = Math.Max(
+            1UL,
+            (ulong)(latencyTicks * (1_000_000.0 / Stopwatch.Frequency)));
+        var log2 = BitOperations.Log2(latencyMicros);
+        var powerOfTwoFloor = 1UL << log2;
+        var subBucket = (int)Math.Min(
+            DeliveryLatencySubBucketsPerPowerOfTwo - 1,
+            (latencyMicros - powerOfTwoFloor)
+            * DeliveryLatencySubBucketsPerPowerOfTwo
+            / powerOfTwoFloor);
+        var histogramBucket = Math.Min(
+            log2 * DeliveryLatencySubBucketsPerPowerOfTwo + subBucket,
+            DeliveryLatencyHistogramBucketCount - 1);
+        var windowSlot = (int)(_currentWindowBucket % WindowBucketCount);
+        _deliveryLatencyBucketCounts[
+            windowSlot * DeliveryLatencyHistogramBucketCount + histogramBucket]++;
+        _deliveryLatencyWindowCounts[histogramBucket]++;
+        _deliveryLatencySampleCount++;
+        RecomputeDeliveryLatencyP95();
+    }
+
+    private void ClearDeliveryLatencyWindowSlot(int windowSlot)
+    {
+        var offset = windowSlot * DeliveryLatencyHistogramBucketCount;
+        for (var bucket = 0; bucket < DeliveryLatencyHistogramBucketCount; bucket++)
+        {
+            var expired = _deliveryLatencyBucketCounts[offset + bucket];
+            if (expired == 0)
+                continue;
+
+            _deliveryLatencyBucketCounts[offset + bucket] = 0;
+            _deliveryLatencyWindowCounts[bucket] -= expired;
+            _deliveryLatencySampleCount -= expired;
+        }
+    }
+
+    private void RecomputeDeliveryLatencyP95()
+    {
+        if (_deliveryLatencySampleCount == 0)
+        {
+            PublishDeliveryLatencyP95(0);
+            return;
+        }
+
+        var rank = (_deliveryLatencySampleCount * 95 + 99) / 100;
+        long cumulative = 0;
+        for (var bucket = 0; bucket < DeliveryLatencyHistogramBucketCount; bucket++)
+        {
+            cumulative += _deliveryLatencyWindowCounts[bucket];
+            if (cumulative < rank)
+                continue;
+
+            var log2 = bucket / DeliveryLatencySubBucketsPerPowerOfTwo;
+            var subBucket = bucket % DeliveryLatencySubBucketsPerPowerOfTwo;
+            var powerOfTwoFloor = 1L << log2;
+            var bucketUpperBound = powerOfTwoFloor
+                + (powerOfTwoFloor * (subBucket + 1)
+                    + DeliveryLatencySubBucketsPerPowerOfTwo - 1)
+                / DeliveryLatencySubBucketsPerPowerOfTwo;
+            PublishDeliveryLatencyP95(bucketUpperBound);
+            return;
+        }
+    }
+
+    private void PublishDeliveryLatencyP95(long latencyMicros)
+    {
+        _deliveryLatencyP95Seconds = latencyMicros / 1_000_000.0;
+        Volatile.Write(ref _deliveryLatencyP95Micros, latencyMicros);
     }
 
     private void UpdateCapacityProbe(
@@ -644,9 +749,13 @@ internal sealed class BrokerUnackedByteBudget
         }
         else
         {
+            var governedTargetSeconds = _targetSeconds;
+            if (_deliveryLatencyP95Seconds > _targetSeconds)
+                governedTargetSeconds *= _targetSeconds / _deliveryLatencyP95Seconds;
+
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
-                ? Math.Max(_targetSeconds, RttSafetyMultiplier * minRttSeconds)
-                : _targetSeconds;
+                ? Math.Max(governedTargetSeconds, RttSafetyMultiplier * minRttSeconds)
+                : governedTargetSeconds;
             rateBudgetBytes = _windowMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -13,7 +13,8 @@ namespace Dekaf.Producer;
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
 /// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
 /// A two-second append-to-ack p95 feeds back queueing before the socket write; when it exceeds
-/// the target, the admission horizon contracts by <c>target / observed p95</c>.
+/// the target, the admission horizon contracts by <c>target / observed p95</c>, bounded to
+/// half the configured horizon so transient scheduler stalls cannot collapse throughput.
 /// <para>
 /// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
 /// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
@@ -85,6 +86,7 @@ internal sealed class BrokerUnackedByteBudget
     private const int DeliveryLatencySubBucketsPerPowerOfTwo = 4;
     private const int DeliveryLatencyHistogramBucketCount =
         24 * DeliveryLatencySubBucketsPerPowerOfTwo;
+    private const double MinimumLatencyFeedbackFactor = 0.5;
     private const int RequestSizeHistogramShift = 8;
 
     /// <summary>
@@ -751,7 +753,11 @@ internal sealed class BrokerUnackedByteBudget
         {
             var governedTargetSeconds = _targetSeconds;
             if (_deliveryLatencyP95Seconds > _targetSeconds)
-                governedTargetSeconds *= _targetSeconds / _deliveryLatencyP95Seconds;
+            {
+                governedTargetSeconds *= Math.Max(
+                    MinimumLatencyFeedbackFactor,
+                    _targetSeconds / _deliveryLatencyP95Seconds);
+            }
 
             var horizonSeconds = _hasMinRttSample && !minRttProbeActive
                 ? Math.Max(governedTargetSeconds, RttSafetyMultiplier * minRttSeconds)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -285,6 +285,7 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long UnackedBytes { get; init; }
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
+    public required long DeliveryLatencyP95Micros { get; init; }
     public required long AdmissionBlockCount { get; init; }
 
     /// <summary>

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -54,6 +54,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     private CancellationTokenRegistration _cancellationRegistration;
     private CancellationToken _cancellationToken;
     private long _startTicks;
+    private long _admissionStartedStopwatchTicks;
     private long _deadlineTickCount;
     private long _admissionRecheckTickCount;
     private RecordAccumulator _accumulator = null!;
@@ -84,6 +85,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     internal PooledValueTaskSource<RecordMetadata>? CompletionSource => _completionSource;
     internal Action<RecordMetadata, Exception?>? Callback => _callback;
     internal int RecordSize => _recordSize;
+    internal long AdmissionStartedStopwatchTicks => _admissionStartedStopwatchTicks;
 
     public PendingAppend()
     {
@@ -118,7 +120,8 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         long deadlineTickCount,
         RecordAccumulator accumulator,
         PendingAppendPool pool,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        long admissionStartedStopwatchTicks = 0)
     {
         _topic = topic;
         _partition = partition;
@@ -132,6 +135,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _callback = callback;
         _recordSize = recordSize;
         _startTicks = startTicks;
+        _admissionStartedStopwatchTicks = admissionStartedStopwatchTicks;
         _deadlineTickCount = deadlineTickCount;
         _admissionRecheckTickCount = 0;
         _cancellationToken = cancellationToken;
@@ -330,6 +334,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
         _completionSource = null;
         _callback = null;
         _cancellationToken = default;
+        _admissionStartedStopwatchTicks = 0;
         _deadlineTickCount = 0;
         _admissionRecheckTickCount = 0;
         _accumulator = null!;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1881,7 +1881,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         var result = AppendAfterReservation(
                             op.Topic, op.Partition, op.Timestamp,
                             op.Key, op.Value, op.Headers, op.HeaderCount,
-                            op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount);
+                            op.CompletionSource, op.Callback, op.RecordSize, op.PartitionCount,
+                            op.AdmissionStartedStopwatchTicks);
 
                         op.ReleasePendingCountAfterClaim();
                         op.CompleteResult(result);
@@ -2458,10 +2459,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        int partitionCount)
+        int partitionCount,
+        long admissionStartedStopwatchTicks = 0)
     {
         return AppendPooledAfterReservationCore(topic, partition, timestamp, key, value, headers, headerCount,
-            completionSource, callback, recordSize, partitionCount);
+            completionSource, callback, recordSize, partitionCount, admissionStartedStopwatchTicks);
     }
 
     private bool AppendPooledAfterReservationCore(
@@ -2475,7 +2477,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PooledValueTaskSource<RecordMetadata>? completionSource,
         Action<RecordMetadata, Exception?>? callback,
         int recordSize,
-        int partitionCount)
+        int partitionCount,
+        long admissionStartedStopwatchTicks = 0)
     {
         var topicPartition = new TopicPartition(topic, partition);
         var pd = GetOrCreateDeque(topic, partition);
@@ -2553,6 +2556,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 completionSource, callback, recordSize, out var appendedBytes,
                                 out var firstAwaitedProduceInBatch))
                             {
+                                currentBatch.TrackOldestAppendStart(admissionStartedStopwatchTicks);
                                 actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
@@ -2593,6 +2597,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 completionSource, callback, recordSize, out var appendedBytes,
                                 out var firstAwaitedProduceInBatch))
                             {
+                                newBatch.TrackOldestAppendStart(admissionStartedStopwatchTicks);
                                 actualBytesAdded = appendedBytes;
                                 ownsReservation = false;
                                 ownsRecordResources = false;
@@ -2745,12 +2750,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return new ValueTask<bool>(Task.FromException<bool>(new OperationCanceledException(cancellationToken)));
         }
 
+        var admissionStartedStopwatchTicks = Stopwatch.GetTimestamp();
         var (startTicks, deadline) = BeginReservationWait(recordSize);
 
         var op = _pendingAppendPool.Rent();
         op.Initialize(topic, partition, partitionCount, timestamp, key, value, headers, headerCount,
             completionSource, callback, recordSize, startTicks, deadline,
-            this, _pendingAppendPool, cancellationToken);
+            this, _pendingAppendPool, cancellationToken, admissionStartedStopwatchTicks);
 
         lock (_pendingAppendQueueLock)
             _pendingAppends.Enqueue(op);
@@ -3561,23 +3567,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _serializeBatchesPerPartition,
             hasPipelineBatch,
             batch.EstimatedSize,
-            batch.EffectiveBatchSizeLimit);
+            batch.EffectiveBatchSizeLimit,
+            _options.DeliveryLatencyTargetMs > 0);
     }
 
-    // An earlier pipeline batch provides a short delivery clock under load. Keep the next
-    // partial batch open until it fills; if traffic becomes sparse, the predecessor exits,
-    // queued bytes reach zero, and the next linger pass seals normally. Size-full batches
-    // bypass this method in ShouldSealAppendedBatch and continue pipelining immediately.
+    // An earlier pipeline batch normally provides a short delivery clock under load. A
+    // configured latency bound cannot rely on that: an underfilled 1MiB batch may itself
+    // exceed the target at the broker's per-partition rate, so let linger seal it. Muted or
+    // serialized partitions still defer because their next batch cannot be sent yet.
     internal static bool ShouldDeferPartialBatchSeal(
         bool isMuted,
         bool serializeBatchesPerPartition,
         bool hasPipelineBatch,
         int currentBatchSize,
-        int maximumBatchSize) =>
+        int maximumBatchSize,
+        bool deliveryLatencyBoundEnabled) =>
         isMuted
         || (hasPipelineBatch
             && (serializeBatchesPerPartition
-                || currentBatchSize < maximumBatchSize));
+                || (!deliveryLatencyBoundEnabled && currentBatchSize < maximumBatchSize)));
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
@@ -4472,9 +4480,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var cap = _options.UnackedByteBudgetCapOverride
             ?? BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, _options.ConnectionsPerBroker);
-        // Floor keeps the pipe full (≥ 2 batches, ≥ 1MiB BDP headroom) but must not exceed a
-        // deliberately tiny test cap, or the gate could never bind in unit tests.
-        var floor = Math.Min(Math.Max(2L * Math.Max(1, _options.BatchSize), 1L << 20), cap);
+        // Linger can seal partial batches, so a 1MiB BatchSize must not impose 1MiB of
+        // standing queue on a slower broker. Keep at most 64KiB of startup headroom; the
+        // measured rate and minimum-RTT safety horizon supply the real BDP. Oversized
+        // records may exceed the floor once, then the gate blocks subsequent appends.
+        var floor = Math.Min(Math.Min(Math.Max(1, _options.BatchSize), 64L << 10), cap);
         return new BrokerUnackedByteBudget(_options.DeliveryLatencyTargetMs / 1000.0, floor, cap);
     }
 
@@ -4850,6 +4860,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         UnackedBytes = budget.UnackedBytes,
         MinRttMicros = budget.MinimumRttMicros,
         MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
+        DeliveryLatencyP95Micros = budget.DeliveryLatencyP95Micros,
         AdmissionBlockCount = budget.AdmissionBlockEvents,
         RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
         RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null
@@ -5753,6 +5764,16 @@ internal sealed class PartitionBatch
     }
 
     /// <summary>
+    /// Extends the batch age to include time an append spent waiting for admission.
+    /// Called under the owning partition deque lock after the append succeeds.
+    /// </summary>
+    internal void TrackOldestAppendStart(long stopwatchTicks)
+    {
+        if (stopwatchTicks > 0 && stopwatchTicks < _createdStopwatchTimestamp)
+            _createdStopwatchTimestamp = stopwatchTicks;
+    }
+
+    /// <summary>
     /// Resets the batch for reuse with a new topic-partition.
     /// Called when renting from the pool.
     /// </summary>
@@ -6360,7 +6381,8 @@ internal sealed class PartitionBatch
                 _callbacks,
                 _callbackCount,
                 _arrayReuseQueue,
-                _recordCount);
+                _recordCount,
+                _createdStopwatchTimestamp);
 
             _completedBatch = readyBatch;
 
@@ -7122,7 +7144,8 @@ internal sealed class ReadyBatch
         Action<RecordMetadata, Exception?>?[]? callbacks = null,
         int callbackCount = 0,
         BatchArrayReuseQueue? arrayReuseQueue = null,
-        int recordCount = 0)
+        int recordCount = 0,
+        long stopwatchCreatedTicks = 0)
     {
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
@@ -7163,7 +7186,9 @@ internal sealed class ReadyBatch
         _callbacks = callbacks;
         _callbackCount = callbackCount;
         _arrayReuseQueue = arrayReuseQueue;
-        StopwatchCreatedTicks = Stopwatch.GetTimestamp();
+        StopwatchCreatedTicks = stopwatchCreatedTicks > 0
+            ? stopwatchCreatedTicks
+            : Stopwatch.GetTimestamp();
         _createdTimestamp = StopwatchCreatedTicks;
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3567,25 +3567,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _serializeBatchesPerPartition,
             hasPipelineBatch,
             batch.EstimatedSize,
-            batch.EffectiveBatchSizeLimit,
-            _options.DeliveryLatencyTargetMs > 0);
+            batch.EffectiveBatchSizeLimit);
     }
 
-    // An earlier pipeline batch normally provides a short delivery clock under load. A
-    // configured latency bound cannot rely on that: an underfilled 1MiB batch may itself
-    // exceed the target at the broker's per-partition rate, so let linger seal it. Muted or
-    // serialized partitions still defer because their next batch cannot be sent yet.
+    // An earlier pipeline batch provides a short delivery clock under load. Keep the next
+    // partial batch open until it fills; if traffic becomes sparse, the predecessor exits,
+    // queued bytes reach zero, and the next linger pass seals normally. Size-full batches
+    // bypass this method in ShouldSealAppendedBatch and continue pipelining immediately.
     internal static bool ShouldDeferPartialBatchSeal(
         bool isMuted,
         bool serializeBatchesPerPartition,
         bool hasPipelineBatch,
         int currentBatchSize,
-        int maximumBatchSize,
-        bool deliveryLatencyBoundEnabled) =>
+        int maximumBatchSize) =>
         isMuted
         || (hasPipelineBatch
             && (serializeBatchesPerPartition
-                || (!deliveryLatencyBoundEnabled && currentBatchSize < maximumBatchSize)));
+                || currentBatchSize < maximumBatchSize));
 
     private ReadyBatch? CompleteDetachedBatchAndEnqueue(PartitionDeque pd, PartitionBatch batchToComplete)
     {
@@ -4480,11 +4478,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var cap = _options.UnackedByteBudgetCapOverride
             ?? BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, _options.ConnectionsPerBroker);
-        // Linger can seal partial batches, so a 1MiB BatchSize must not impose 1MiB of
-        // standing queue on a slower broker. Keep at most 64KiB of startup headroom; the
-        // measured rate and minimum-RTT safety horizon supply the real BDP. Oversized
-        // records may exceed the floor once, then the gate blocks subsequent appends.
-        var floor = Math.Min(Math.Min(Math.Max(1, _options.BatchSize), 64L << 10), cap);
+        // Floor keeps the pipe full (>= 2 batches, >= 1MiB BDP headroom) but must not exceed a
+        // deliberately tiny test cap, or the gate could never bind in unit tests.
+        var floor = Math.Min(Math.Max(2L * Math.Max(1, _options.BatchSize), 1L << 20), cap);
         return new BrokerUnackedByteBudget(_options.DeliveryLatencyTargetMs / 1000.0, floor, cap);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3130,8 +3130,16 @@ public sealed class BrokerSenderSendLoopTests
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1, dataSize: 5_000));
             await WaitUntilAsync(() => GetPendingResponseCount(sender) == 2, cancellationToken);
 
-            await Assert.That(GetDeliverySnapshot(sender, 0).AppLimited).IsTrue();
-            await Assert.That(GetDeliverySnapshot(sender, 1).AppLimited).IsFalse();
+            var firstSnapshot = GetDeliverySnapshot(sender, 0);
+            var secondSnapshot = GetDeliverySnapshot(sender, 1);
+            await Assert.That(firstSnapshot.AppLimited).IsTrue();
+            await Assert.That(secondSnapshot.AppLimited).IsFalse();
+            await Assert.That(firstSnapshot.OldestBatchTimestamp).IsGreaterThan(0);
+            await Assert.That(firstSnapshot.OldestBatchTimestamp)
+                .IsLessThanOrEqualTo(firstSnapshot.SendTimestamp);
+            await Assert.That(secondSnapshot.OldestBatchTimestamp).IsGreaterThan(0);
+            await Assert.That(secondSnapshot.OldestBatchTimestamp)
+                .IsLessThanOrEqualTo(secondSnapshot.SendTimestamp);
 
             responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
             responses[1].SetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 1));

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -90,22 +90,6 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
-    public async Task BudgetFloor_DoesNotForceOneFullDefaultBatch()
-    {
-        const int batchSize = 1 << 20;
-        await using var accumulator = new RecordAccumulator(
-            CreateOptions(capOverride: 100L << 20, batchSize: batchSize),
-            resolveLeaderId: (_, _) => LeaderNodeId);
-        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
-        var nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
-        var sendTicks = nowTicks - System.Diagnostics.Stopwatch.Frequency / 1_000;
-
-        budget.OnAcked(1, budget.SnapshotDelivery(sendTicks, appLimited: true), nowTicks);
-
-        await Assert.That(budget.BudgetBytes).IsEqualTo(64 << 10);
-    }
-
-    [Test]
     public async Task Seal_ChargesLeaderBudget_AndBatchExitReleases()
     {
         var options = CreateOptions(capOverride: null);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -90,6 +90,22 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    public async Task BudgetFloor_DoesNotForceOneFullDefaultBatch()
+    {
+        const int batchSize = 1 << 20;
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(capOverride: 100L << 20, batchSize: batchSize),
+            resolveLeaderId: (_, _) => LeaderNodeId);
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+        var nowTicks = System.Diagnostics.Stopwatch.GetTimestamp();
+        var sendTicks = nowTicks - System.Diagnostics.Stopwatch.Frequency / 1_000;
+
+        budget.OnAcked(1, budget.SnapshotDelivery(sendTicks, appLimited: true), nowTicks);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(64 << 10);
+    }
+
+    [Test]
     public async Task Seal_ChargesLeaderBudget_AndBatchExitReleases()
     {
         var options = CreateOptions(capOverride: null);
@@ -170,6 +186,7 @@ public sealed class BrokerUnackedAdmissionTests
                 "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 PooledMemory.Null, PooledMemory.Null, null, 0, null, null, cancellationToken);
             await Assert.That(gatedAppend.IsCompleted).IsFalse();
+            await Task.Delay(25, cancellationToken);
 
             // Acking (exiting) the charged batches reopens the gate and serves the queue.
             foreach (var batch in DrainSealedBatches(accumulator, metadataManager))
@@ -177,6 +194,15 @@ public sealed class BrokerUnackedAdmissionTests
 
             var appended = await gatedAppend;
             await Assert.That(appended).IsTrue();
+
+            await SealAllAsync(accumulator);
+            var admittedBatches = DrainSealedBatches(accumulator, metadataManager);
+            var admittedBatch = admittedBatches.MaxBy(static batch => batch.StopwatchCreatedTicks)!;
+            await Assert.That(System.Diagnostics.Stopwatch.GetElapsedTime(
+                    admittedBatch.StopwatchCreatedTicks).TotalMilliseconds)
+                .IsGreaterThanOrEqualTo(20);
+            foreach (var batch in admittedBatches)
+                ExitAndReturn(accumulator, batch);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -72,7 +72,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task Budget_DeliveryLatencyAboveTarget_ShrinksAdmissionHorizon()
+    public async Task Budget_DeliveryLatencyAboveTarget_BoundsAdmissionCorrection()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -89,7 +89,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.DeliveryLatencyP95Micros)
             .IsGreaterThanOrEqualTo(32_000);
-        await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
 
     [Test]
@@ -104,7 +104,7 @@ public sealed class BrokerUnackedByteBudgetTests
             appLimited: true,
             oldestBatchTimestamp: T0 - Seconds(0.040));
         budget.OnAcked(1_000, highLatencySnapshot, T0);
-        await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
 
         var recoveredAt = T0 + Seconds(2.1);
         var recoveredSnapshot = budget.SnapshotDelivery(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -72,6 +72,75 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task Budget_DeliveryLatencyAboveTarget_ShrinksAdmissionHorizon()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var sendTimestamp = T0 - Seconds(0.001);
+        var oldestBatchTimestamp = T0 - Seconds(0.040);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp,
+            appLimited: true,
+            oldestBatchTimestamp);
+
+        budget.OnAcked(1_000, snapshot, T0);
+
+        await Assert.That(budget.DeliveryLatencyP95Micros)
+            .IsGreaterThanOrEqualTo(32_000);
+        await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
+    }
+
+    [Test]
+    public async Task Budget_HighDeliveryLatencyExpires_AndTargetHorizonRecovers()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var highLatencySnapshot = budget.SnapshotDelivery(
+            T0 - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: T0 - Seconds(0.040));
+        budget.OnAcked(1_000, highLatencySnapshot, T0);
+        await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
+
+        var recoveredAt = T0 + Seconds(2.1);
+        var recoveredSnapshot = budget.SnapshotDelivery(
+            recoveredAt - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: recoveredAt - Seconds(0.005));
+        budget.OnAcked(1_000, recoveredSnapshot, recoveredAt);
+
+        await Assert.That(budget.DeliveryLatencyP95Micros).IsLessThan(10_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+    }
+
+    [Test]
+    public async Task Budget_SingleTailOutlier_DoesNotThrottleP95Governor()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        for (var i = 0; i < 20; i++)
+        {
+            var acknowledgedAt = T0 + Seconds(i * 0.001);
+            var deliveryLatency = i == 19 ? 0.100 : 0.005;
+            var snapshot = budget.SnapshotDelivery(
+                acknowledgedAt - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: acknowledgedAt - Seconds(deliveryLatency));
+            budget.OnAcked(1_000, snapshot, acknowledgedAt);
+        }
+
+        await Assert.That(budget.DeliveryLatencyP95Micros).IsLessThan(10_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+    }
+
+    [Test]
     public async Task Budget_ClampsToFloor_WhenRateCollapses()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 3_200);

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -160,7 +160,10 @@ public sealed class ProducerDeliveryDiagnosticsTests
         var ackTimestamp = Stopwatch.GetTimestamp();
         budget.OnAcked(
             1_000,
-            budget.SnapshotDelivery(ackTimestamp - Stopwatch.Frequency / 1_000, appLimited: true),
+            budget.SnapshotDelivery(
+                ackTimestamp - Stopwatch.Frequency / 1_000,
+                appLimited: true,
+                oldestBatchTimestamp: ackTimestamp - Stopwatch.Frequency / 200),
             ackTimestamp);
 
         await accumulator.ExpireLingerAsync(CancellationToken.None);
@@ -173,6 +176,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.UnackedBytes).IsEqualTo(600);
         await Assert.That(current.MinRttMicros).IsGreaterThan(0);
         await Assert.That(current.MaxRateBytesPerSec).IsGreaterThan(0);
+        await Assert.That(current.DeliveryLatencyP95Micros).IsEqualTo(5_120);
         await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
         await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
@@ -241,17 +241,19 @@ public class ShouldFlushTests
     }
 
     [Test]
-    [Arguments(true, false, false, 0, true)]
-    [Arguments(false, true, true, 100, true)]
-    [Arguments(false, true, false, 100, false)]
-    [Arguments(false, false, true, 100, true)]
-    [Arguments(false, false, true, 999, true)]
-    [Arguments(false, false, true, 1_000, false)]
+    [Arguments(true, false, false, 0, false, true)]
+    [Arguments(false, true, true, 100, false, true)]
+    [Arguments(false, true, false, 100, false, false)]
+    [Arguments(false, false, true, 100, false, true)]
+    [Arguments(false, false, true, 999, false, true)]
+    [Arguments(false, false, true, 999, true, false)]
+    [Arguments(false, false, true, 1_000, false, false)]
     public async Task DeliveryCoupledLinger_DefersOnlyBusyUnderfilledBatches(
         bool isMuted,
         bool serializeBatchesPerPartition,
         bool hasPipelineBatch,
         int currentBatchSize,
+        bool deliveryLatencyBoundEnabled,
         bool expected)
     {
         var result = RecordAccumulator.ShouldDeferPartialBatchSeal(
@@ -259,7 +261,8 @@ public class ShouldFlushTests
             serializeBatchesPerPartition,
             hasPipelineBatch,
             currentBatchSize,
-            maximumBatchSize: 1_000);
+            maximumBatchSize: 1_000,
+            deliveryLatencyBoundEnabled);
 
         await Assert.That(result).IsEqualTo(expected);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
@@ -241,19 +241,17 @@ public class ShouldFlushTests
     }
 
     [Test]
-    [Arguments(true, false, false, 0, false, true)]
-    [Arguments(false, true, true, 100, false, true)]
-    [Arguments(false, true, false, 100, false, false)]
-    [Arguments(false, false, true, 100, false, true)]
-    [Arguments(false, false, true, 999, false, true)]
-    [Arguments(false, false, true, 999, true, false)]
-    [Arguments(false, false, true, 1_000, false, false)]
+    [Arguments(true, false, false, 0, true)]
+    [Arguments(false, true, true, 100, true)]
+    [Arguments(false, true, false, 100, false)]
+    [Arguments(false, false, true, 100, true)]
+    [Arguments(false, false, true, 999, true)]
+    [Arguments(false, false, true, 1_000, false)]
     public async Task DeliveryCoupledLinger_DefersOnlyBusyUnderfilledBatches(
         bool isMuted,
         bool serializeBatchesPerPartition,
         bool hasPipelineBatch,
         int currentBatchSize,
-        bool deliveryLatencyBoundEnabled,
         bool expected)
     {
         var result = RecordAccumulator.ShouldDeferPartialBatchSeal(
@@ -261,8 +259,7 @@ public class ShouldFlushTests
             serializeBatchesPerPartition,
             hasPipelineBatch,
             currentBatchSize,
-            maximumBatchSize: 1_000,
-            deliveryLatencyBoundEnabled);
+            maximumBatchSize: 1_000);
 
         await Assert.That(result).IsEqualTo(expected);
     }


### PR DESCRIPTION
Closes #1965

## Summary
- measure a fixed-memory, two-second append-to-ack p95 per broker and feed it into the unacked-byte horizon
- preserve oldest admission-start time through `PendingAppend`, `PartitionBatch`, and `ReadyBatch`, so gate wait is no longer invisible
- bound latency correction to a 2x contraction, retain RTT/occupancy safety floors, and expose p95 in producer diagnostics

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore` (0 warnings)
- full unit suite: 5,338 passed
- stress-report suite: 26 passed
- focused producer regression classes: 228 passed
- paired 3-broker stress preserved 100% broker-confirmed delivery; the local 2-client-core profile was not used as an acceptance measurement because Confluent p50 degraded to 2.5s versus the issue baseline's 6.3ms

## Controller safety
- delivery latency uses a fixed 20 x 100ms histogram with quarter-log2 buckets and no per-ack allocation
- a single tail outlier below p95 does not throttle admission
- stale latency samples expire after two seconds
- feedback cannot contract below half the configured target horizon