### PR TITLE
Make BrokerSender response wakeup test deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -651,16 +651,16 @@ public sealed class BrokerSenderMuteOrderingTests
     }
 
     [Test]
-    // Mock response continuations intentionally run on the ThreadPool. Isolate this timing-sensitive
-    // integration of the sender state machine so unrelated concurrency tests cannot starve its wakeups.
+    // Complete mock responses inline so this ordering test does not depend on ThreadPool
+    // availability to publish the sender wakeup. The acknowledgement source remains
+    // asynchronous below, preventing test continuation reentrancy on the sender thread.
     [NotInParallel]
     [Timeout(30_000)]
     public async Task NonIdempotentProducer_MultipleInFlight_PipelinesSamePartitionBatches(
         CancellationToken ct)
     {
         var responses = Enumerable.Range(0, 2)
-            .Select(_ => new TaskCompletionSource<ProduceResponse>(
-                TaskCreationOptions.RunContinuationsAsynchronously))
+            .Select(_ => new TaskCompletionSource<ProduceResponse>())
             .ToArray();
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
         var (pool, _) = CreateMockConnection(responseQueue);


### PR DESCRIPTION
Closes #1973

## Summary
- complete the two mock broker responses inline in the multi-inflight ordering test
- remove the test's dependency on ThreadPool availability for publishing sender wakeups
- keep acknowledgement continuation asynchronous, avoiding reentrancy onto the sender thread

## Validation
- Release build: 0 warnings, 0 errors
- exact flaky test: 50/50 repeated passes
- `BrokerSenderMuteOrderingTests`: 22/22 after rebasing onto #1976
- full net10 suite: 5,338/5,338 in three complete runs
- one unrelated `ShareConsumerRecordPoolingTests` pool-identity assertion failed once between runs, passed immediately in isolation, and passed in both subsequent full runs