### PR TITLE
Remove redundant producer response scheduler hop

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -803,10 +803,11 @@ public sealed partial class KafkaConnection :
         private static readonly ConcurrentStack<PooledPipelinedResponse<TRequest, TResponse>> Pool = new();
         private static int s_poolCount;
 
-        private ManualResetValueTaskSourceCore<TResponse> _core = new()
-        {
-            RunContinuationsAsynchronously = true
-        };
+        // The pending request already enters this completion from an asynchronous callback.
+        // Resume the internal response consumer inline to avoid a second ThreadPool hop;
+        // _returnReadiness prevents pooling until this completion frame exits. Producer
+        // delivery sources still dispatch application continuations asynchronously.
+        private ManualResetValueTaskSourceCore<TResponse> _core;
         private readonly Action _pendingContinuation;
         private KafkaConnection? _connection;
         private PooledPendingRequest? _pending;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3572,9 +3572,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 else
                 {
-                    // Unlike ContinueWith(ExecuteSynchronously), UnsafeOnCompleted schedules the
-                    // callback on the ThreadPool rather than running inline on the completing thread.
-                    // This is intentional — it keeps the I/O completion thread free.
+                    // KafkaConnection invokes this callback inline from its asynchronous
+                    // pending-request completion. The callback only publishes wake-up signals;
+                    // response processing remains in ProcessCompletedResponses.
                     responseTask.UnsafeOnCompleted(_responseCompletionCallback);
                 }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -340,6 +341,64 @@ public sealed class KafkaConnectionTests
         {
             releasePublish.TrySetResult();
             KafkaConnection.PipelinedResponseBeforePublishTestHook = null;
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task PipelinedResponse_ContinuationRunsInlineInCompletionFrame(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var response = await ((IKafkaPipelinedWriteCompletionConnection)connection)
+                .SendPipelinedAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    cancellationToken);
+            var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
+            var completion = new TaskCompletionSource<ApiVersionsResponse>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var ranInCompletionFrame = false;
+            response.UnsafeOnCompleted(() =>
+            {
+                ranInCompletionFrame = new StackTrace().GetFrames().Any(
+                    static frame => frame.GetMethod()?.Name == "CompletePendingResponse"
+                        && frame.GetMethod()?.DeclaringType?.Name.StartsWith(
+                            "PooledPipelinedResponse",
+                            StringComparison.Ordinal) == true);
+
+                try
+                {
+                    completion.TrySetResult(response.GetResult());
+                }
+                catch (Exception exception)
+                {
+                    completion.TrySetException(exception);
+                }
+            });
+
+            await serverClient.GetStream().WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken);
+            var parsed = await completion.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(ranInCompletionFrame).IsTrue();
+            await Assert.That(parsed.ErrorCode).IsEqualTo(ErrorCode.None);
+        }
+        finally
+        {
             listener.Stop();
         }
     }


### PR DESCRIPTION
Closes #1968

## Root cause

A producer response crossed two forced ThreadPool boundaries: the pending socket response already resumed `PooledPipelinedResponse` asynchronously, then that pooled response forced its internal consumer (the broker send loop) through another dispatch. Transactional serial-awaited traffic pays this fixed scheduler cost once per message/request, contributing to CPU per message and timer-quantized RTT tails.

## Fix

Resume only the internal pooled-response consumer inline from the already-asynchronous pending-response callback. The existing two-phase `_returnReadiness` handshake still prevents pool reuse until the completion frame and consumer have both exited. Producer delivery sources remain `RunContinuationsAsynchronously = true`, so application code cannot run on the networking or broker-sender continuation.

## Validation

- Release build: 0 warnings, 0 errors (`net8.0`, `net10.0`).
- Full net10 unit suite: 5,340/5,340.
- Focused Kafka connection / broker sender / transaction suites: 136/136.
- Existing pipelined-response abandon/publication race tests pass.
- `PipelinedResponseAllocationBenchmarks.PooledProducerPath`: 43.44 us candidate vs 46.68 us `main` (-6.9%); allocations unchanged (775 vs 776 B/op).
- Same-host noisy local Kafka pair: 670 vs 821 CPU us/msg (-18%); both runs entered a low-throughput Docker regime, so this is directional only.
- Remote paired stress pending: https://github.com/thomhurst/Dekaf/actions/runs/29230349831
