### PR TITLE
Eliminate consumer Gen2 churn

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -42,23 +42,31 @@ internal sealed class PendingFetchData : IDisposable
     // LockFreeStack avoids the ConcurrentStack node allocation on every return to the pool.
     private const int DefaultMaxPoolSize = 128;
     // Slabs outlive an individual PendingFetchData use, but not the pooled object itself.
-    // Bound retention per size bucket so deep prefetch cannot pin one large slab per item.
-    private const int MaxParsedRecordSlabsPerBucket = 16;
+    // Bound retention per size bucket so deep prefetch cannot pin one large slab per item;
+    // PoolSizing ratchets the depth for high-partition workloads.
+    private const int DefaultMaxParsedRecordSlabsPerBucket = 16;
     private static int s_maxPoolSize = DefaultMaxPoolSize;
     private static LockFreeStack<PendingFetchData> s_pool = new(DefaultMaxPoolSize);
-    private static readonly ArrayPool<Record> s_parsedRecordSlabPool = ArrayPool<Record>.Create(
+    private static int s_maxParsedRecordSlabsPerBucket = DefaultMaxParsedRecordSlabsPerBucket;
+    private static ArrayPool<Record> s_parsedRecordSlabPool = ArrayPool<Record>.Create(
         RecordBatch.MaxReasonableLazyRecordCount,
-        MaxParsedRecordSlabsPerBucket);
+        DefaultMaxParsedRecordSlabsPerBucket);
     private static readonly Lock s_resizeLock = new();
 
     internal static int MaxPoolSizeValue => Volatile.Read(ref s_maxPoolSize);
+    internal static int MaxParsedRecordSlabsPerBucketValue =>
+        Volatile.Read(ref s_maxParsedRecordSlabsPerBucket);
 
-    internal static void RatchetPoolSize(int newSize)
+    internal static void RatchetPoolSize(int newSize) =>
+        RatchetPoolSize(newSize, PoolSizing.ForConsumerParsedRecordSlabs(newSize));
+
+    internal static void RatchetPoolSize(int newSize, int desiredSlabDepth)
     {
         InterlockedHelper.RatchetUp(ref s_maxPoolSize, newSize);
 
         var currentPool = Volatile.Read(ref s_pool);
-        if (currentPool.Capacity < newSize)
+        if (currentPool.Capacity < newSize ||
+            Volatile.Read(ref s_maxParsedRecordSlabsPerBucket) < desiredSlabDepth)
         {
             lock (s_resizeLock)
             {
@@ -76,6 +84,15 @@ internal sealed class PendingFetchData : IDisposable
                         newPool.TryPush(item);
                     Volatile.Write(ref s_pool, newPool);
                 }
+
+                if (Volatile.Read(ref s_maxParsedRecordSlabsPerBucket) < desiredSlabDepth)
+                {
+                    var newSlabPool = ArrayPool<Record>.Create(
+                        RecordBatch.MaxReasonableLazyRecordCount,
+                        desiredSlabDepth);
+                    Volatile.Write(ref s_parsedRecordSlabPool, newSlabPool);
+                    Volatile.Write(ref s_maxParsedRecordSlabsPerBucket, desiredSlabDepth);
+                }
             }
         }
     }
@@ -84,6 +101,7 @@ internal sealed class PendingFetchData : IDisposable
     private Dictionary<long, Queue<long>>? _abortedProducers;
     private IPooledMemory? _memoryOwner;
     private Record[]? _parsedRecordSlab;
+    private ArrayPool<Record>? _parsedRecordSlabOwner;
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
@@ -197,8 +215,10 @@ internal sealed class PendingFetchData : IDisposable
         if (totalRecordCount == 0)
             return;
 
-        var slab = s_parsedRecordSlabPool.Rent(totalRecordCount);
+        var slabPool = Volatile.Read(ref s_parsedRecordSlabPool);
+        var slab = slabPool.Rent(totalRecordCount);
         _parsedRecordSlab = slab;
+        _parsedRecordSlabOwner = slabPool;
         slab.AsSpan(0, totalRecordCount).Clear();
         var offset = 0;
         for (var i = 0; i < batches.Count; i++)
@@ -528,9 +548,12 @@ internal sealed class PendingFetchData : IDisposable
         }
 
         var parsedRecordSlab = _parsedRecordSlab;
+        var parsedRecordSlabOwner = _parsedRecordSlabOwner;
         _parsedRecordSlab = null;
+        _parsedRecordSlabOwner = null;
         if (parsedRecordSlab is not null)
-            s_parsedRecordSlabPool.Return(parsedRecordSlab, clearArray: true);
+            (parsedRecordSlabOwner ?? Volatile.Read(ref s_parsedRecordSlabPool))
+                .Return(parsedRecordSlab, clearArray: true);
 
         // Return the batch list to the pool for reuse
         if (_batches is List<RecordBatch> batchList)
@@ -1089,7 +1112,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Use 64 as default partition count estimate — covers most workloads.
         // PendingFetchData uses a ratchet, so this only increases over time.
         var consumerSizes = PoolSizing.ForConsumer(maxPartitionCount: 64);
-        PendingFetchData.RatchetPoolSize(consumerSizes.FetchDataPool);
+        PendingFetchData.RatchetPoolSize(
+            consumerSizes.FetchDataPool,
+            consumerSizes.ParsedRecordSlabsPerBucket);
         RatchetRecordWrapperPools(partitionCount: 64);
         _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
         _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
@@ -6789,7 +6814,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void RatchetConsumerPoolSizes(int partitionCount)
     {
         var sizes = PoolSizing.ForConsumer(partitionCount);
-        PendingFetchData.RatchetPoolSize(sizes.FetchDataPool);
+        PendingFetchData.RatchetPoolSize(
+            sizes.FetchDataPool,
+            sizes.ParsedRecordSlabsPerBucket);
         RatchetRecordWrapperPools(partitionCount);
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -84,7 +84,6 @@ internal sealed class PendingFetchData : IDisposable
     private Dictionary<long, Queue<long>>? _abortedProducers;
     private IPooledMemory? _memoryOwner;
     private Record[]? _parsedRecordSlab;
-    private int _parsedRecordSlabCount;
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
@@ -198,18 +197,9 @@ internal sealed class PendingFetchData : IDisposable
         if (totalRecordCount == 0)
             return;
 
-        var slab = _parsedRecordSlab;
-        if (slab is null || slab.Length < totalRecordCount)
-        {
-            if (slab is not null)
-                s_parsedRecordSlabPool.Return(slab, clearArray: false);
-
-            slab = s_parsedRecordSlabPool.Rent(totalRecordCount);
-            _parsedRecordSlab = slab;
-        }
-
+        var slab = s_parsedRecordSlabPool.Rent(totalRecordCount);
+        _parsedRecordSlab = slab;
         slab.AsSpan(0, totalRecordCount).Clear();
-        _parsedRecordSlabCount = totalRecordCount;
         var offset = 0;
         for (var i = 0; i < batches.Count; i++)
         {
@@ -540,11 +530,7 @@ internal sealed class PendingFetchData : IDisposable
         var parsedRecordSlab = _parsedRecordSlab;
         _parsedRecordSlab = null;
         if (parsedRecordSlab is not null)
-        {
-            parsedRecordSlab.AsSpan(0, _parsedRecordSlabCount).Clear();
-            s_parsedRecordSlabPool.Return(parsedRecordSlab, clearArray: false);
-        }
-        _parsedRecordSlabCount = 0;
+            s_parsedRecordSlabPool.Return(parsedRecordSlab, clearArray: true);
 
         // Return the batch list to the pool for reuse
         if (_batches is List<RecordBatch> batchList)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -41,8 +41,14 @@ internal sealed class PendingFetchData : IDisposable
     // Pool for reusing PendingFetchData instances to eliminate per-partition-per-fetch allocation.
     // LockFreeStack avoids the ConcurrentStack node allocation on every return to the pool.
     private const int DefaultMaxPoolSize = 128;
+    // Slabs outlive an individual PendingFetchData use, but not the pooled object itself.
+    // Bound retention per size bucket so deep prefetch cannot pin one large slab per item.
+    private const int MaxParsedRecordSlabsPerBucket = 16;
     private static int s_maxPoolSize = DefaultMaxPoolSize;
     private static LockFreeStack<PendingFetchData> s_pool = new(DefaultMaxPoolSize);
+    private static readonly ArrayPool<Record> s_parsedRecordSlabPool = ArrayPool<Record>.Create(
+        RecordBatch.MaxReasonableLazyRecordCount,
+        MaxParsedRecordSlabsPerBucket);
     private static readonly Lock s_resizeLock = new();
 
     internal static int MaxPoolSizeValue => Volatile.Read(ref s_maxPoolSize);
@@ -196,9 +202,9 @@ internal sealed class PendingFetchData : IDisposable
         if (slab is null || slab.Length < totalRecordCount)
         {
             if (slab is not null)
-                ArrayPool<Record>.Shared.Return(slab, clearArray: false);
+                s_parsedRecordSlabPool.Return(slab, clearArray: false);
 
-            slab = ArrayPool<Record>.Shared.Rent(totalRecordCount);
+            slab = s_parsedRecordSlabPool.Rent(totalRecordCount);
             _parsedRecordSlab = slab;
         }
 
@@ -532,8 +538,12 @@ internal sealed class PendingFetchData : IDisposable
         }
 
         var parsedRecordSlab = _parsedRecordSlab;
+        _parsedRecordSlab = null;
         if (parsedRecordSlab is not null)
+        {
             parsedRecordSlab.AsSpan(0, _parsedRecordSlabCount).Clear();
+            s_parsedRecordSlabPool.Return(parsedRecordSlab, clearArray: false);
+        }
         _parsedRecordSlabCount = 0;
 
         // Return the batch list to the pool for reuse

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -25,6 +25,8 @@ internal static class PoolSizing
     private const int MaxConsumerPrefetchBufferCapacity = 1024;
     private const int MinConsumerResponseBuffersPerBucket = 16;
     private const int MaxConsumerResponseBuffersPerBucket = 256;
+    private const int MinConsumerParsedRecordSlabsPerBucket = 16;
+    private const int MaxConsumerParsedRecordSlabsPerBucket = 64;
 
     /// <summary>
     /// Approximate number of coalesced partitions per batch — used to scale
@@ -50,6 +52,7 @@ internal static class PoolSizing
     internal readonly record struct ConsumerPoolSizes
     {
         public required int FetchDataPool { get; init; }
+        public required int ParsedRecordSlabsPerBucket { get; init; }
         public required int CancellationTokenSources { get; init; }
     }
 
@@ -109,11 +112,25 @@ internal static class PoolSizing
 
     internal static ConsumerPoolSizes ForConsumer(int maxPartitionCount)
     {
+        var partitionCount = Math.Max((long)maxPartitionCount, 0L);
+        var fetchDataPool = (int)Math.Clamp(partitionCount * 2L, 32L, 512L);
         return new ConsumerPoolSizes
         {
-            FetchDataPool = Math.Clamp(maxPartitionCount * 2, 32, 512),
-            CancellationTokenSources = Math.Clamp(maxPartitionCount * 4, 64, 2048),
+            FetchDataPool = fetchDataPool,
+            ParsedRecordSlabsPerBucket = ForConsumerParsedRecordSlabs(fetchDataPool),
+            CancellationTokenSources = (int)Math.Clamp(partitionCount * 4L, 64L, 2048L),
         };
+    }
+
+    internal static int ForConsumerParsedRecordSlabs(int fetchDataPool)
+    {
+        // Only eagerly parsed fetches need slabs, so retaining one slab per eight pending
+        // fetch slots covers normal overlap without letting this process-wide LOH pool grow
+        // as deep as the lightweight PendingFetchData object pool.
+        return Math.Clamp(
+            fetchDataPool / 8,
+            MinConsumerParsedRecordSlabsPerBucket,
+            MaxConsumerParsedRecordSlabsPerBucket);
     }
 
     internal static int ForConsumerRecordWrappers(long prefetchMaxBytes)

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3459,6 +3459,10 @@ public sealed class ConnectionOptions
 /// </summary>
 internal sealed class ResponseBufferPool
 {
+    // Managed arrays at or above this size enter the LOH and force full collections while
+    // high-throughput consumers warm their response-buffer buckets.
+    internal const int NativeMemoryThresholdBytes = 85_000;
+
     /// <summary>
     /// Overhead bytes added to <c>FetchMaxBytes</c> to account for Kafka protocol framing
     /// (message size prefix, response headers, tagged fields, per-partition overhead).
@@ -3480,6 +3484,7 @@ internal sealed class ResponseBufferPool
     internal static readonly ResponseBufferPool Default = new(DefaultMaxArrayLength, DefaultMaxArraysPerBucket);
     private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), ResponseBufferPool>
         s_sharedPools = new();
+    private readonly ConcurrentDictionary<int, NativeBufferBucket> _nativeBuckets = new();
 
     internal ArrayPool<byte> Pool { get; }
     internal int MaxArrayLength { get; }
@@ -3530,28 +3535,169 @@ internal sealed class ResponseBufferPool
         var rounded = ((value + SizeTierBytes - 1) / SizeTierBytes) * SizeTierBytes;
         return rounded >= int.MaxValue ? int.MaxValue : (int)rounded;
     }
+
+    internal NativeResponseBuffer RentNative(int minimumLength)
+    {
+        var capacity = RoundUpToPowerOfTwo(minimumLength);
+        var bucket = _nativeBuckets.GetOrAdd(
+            capacity,
+            static (size, retention) => new NativeBufferBucket(size, retention),
+            MaxArraysPerBucket);
+        return NativeResponseBuffer.Rent(this, bucket.Rent(), capacity);
+    }
+
+    internal void ReturnNative(IntPtr pointer, int capacity)
+    {
+        var bucket = _nativeBuckets.GetOrAdd(
+            capacity,
+            static (size, retention) => new NativeBufferBucket(size, retention),
+            MaxArraysPerBucket);
+        bucket.Return(pointer);
+    }
+
+    private static int RoundUpToPowerOfTwo(int value)
+    {
+        var rounded = (uint)(value - 1);
+        rounded |= rounded >> 1;
+        rounded |= rounded >> 2;
+        rounded |= rounded >> 4;
+        rounded |= rounded >> 8;
+        rounded |= rounded >> 16;
+        rounded++;
+        return rounded <= int.MaxValue ? (int)rounded : value;
+    }
+
+    private sealed class NativeBufferBucket(int capacity, int maxRetained)
+    {
+        private readonly ConcurrentStack<IntPtr> _buffers = new();
+        private int _retained;
+
+        internal IntPtr Rent()
+        {
+            if (_buffers.TryPop(out var pointer))
+            {
+                Interlocked.Decrement(ref _retained);
+                return pointer;
+            }
+
+            return Marshal.AllocHGlobal(capacity);
+        }
+
+        internal void Return(IntPtr pointer)
+        {
+            if (Interlocked.Increment(ref _retained) <= maxRetained)
+            {
+                _buffers.Push(pointer);
+                return;
+            }
+
+            Interlocked.Decrement(ref _retained);
+            Marshal.FreeHGlobal(pointer);
+        }
+    }
+}
+
+/// <summary>
+/// Contiguous pooled response storage outside the managed large object heap. Ownership
+/// follows the same explicit transfer and disposal path as managed pooled responses.
+/// </summary>
+internal sealed unsafe class NativeResponseBuffer : MemoryManager<byte>
+{
+    private static readonly NativeResponseBufferPool s_pool = new();
+
+    private ResponseBufferPool? _pool;
+    private IntPtr _pointer;
+    private int _capacity;
+    private int _disposed = 1;
+
+    private NativeResponseBuffer() { }
+
+    internal IntPtr Address => _pointer;
+
+    internal static NativeResponseBuffer Rent(ResponseBufferPool pool, IntPtr pointer, int capacity)
+    {
+        var buffer = s_pool.Rent();
+        buffer._pool = pool;
+        buffer._pointer = pointer;
+        buffer._capacity = capacity;
+        Volatile.Write(ref buffer._disposed, 0);
+        return buffer;
+    }
+
+    public override Span<byte> GetSpan()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        return new Span<byte>((void*)_pointer, _capacity);
+    }
+
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)elementIndex, (uint)_capacity);
+        return new MemoryHandle((byte*)_pointer + elementIndex, default, this);
+    }
+
+    public override void Unpin() { }
+
+    internal void Return() => Dispose(disposing: true);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        var pool = _pool!;
+        var pointer = _pointer;
+        var capacity = _capacity;
+        _pool = null;
+        _pointer = IntPtr.Zero;
+        _capacity = 0;
+        pool.ReturnNative(pointer, capacity);
+        s_pool.Return(this);
+    }
+
+    private sealed class NativeResponseBufferPool() : ObjectPool<NativeResponseBuffer>(maxPoolSize: 256)
+    {
+        protected override NativeResponseBuffer Create() => new();
+        protected override void Reset(NativeResponseBuffer item) { }
+    }
 }
 
 internal readonly struct PooledResponseBuffer : IDisposable
 {
-    private readonly byte[] _buffer;
+    private readonly byte[]? _buffer;
+    private readonly NativeResponseBuffer? _nativeBuffer;
     private readonly int _offset;
     private readonly ResponseBufferPool? _pool;
 
     public PooledResponseBuffer(byte[] buffer, int length, bool isPooled, int offset = 0, ResponseBufferPool? pool = null)
     {
         _buffer = buffer;
+        _nativeBuffer = null;
         Length = length;
         IsPooled = isPooled;
         _offset = offset;
         _pool = pool;
     }
 
-    public byte[] Buffer => _buffer;
+    internal PooledResponseBuffer(NativeResponseBuffer buffer, int length, int offset = 0)
+    {
+        _buffer = null;
+        _nativeBuffer = buffer;
+        Length = length;
+        IsPooled = true;
+        _offset = offset;
+        _pool = null;
+    }
+
+    public byte[] Buffer => _buffer ?? throw new InvalidOperationException("Response uses native memory.");
     public int Length { get; }
     public bool IsPooled { get; }
+    internal bool UsesNativeMemory => _nativeBuffer is not null;
 
-    public ReadOnlyMemory<byte> Data => _buffer.AsMemory(_offset, Length);
+    public ReadOnlyMemory<byte> Data => _nativeBuffer is not null
+        ? _nativeBuffer.Memory.Slice(_offset, Length)
+        : _buffer.AsMemory(_offset, Length);
 
     /// <summary>
     /// Creates a new view of the buffer with an adjusted offset.
@@ -3559,7 +3705,9 @@ internal readonly struct PooledResponseBuffer : IDisposable
     /// </summary>
     public PooledResponseBuffer Slice(int additionalOffset)
     {
-        return new PooledResponseBuffer(_buffer, Length - additionalOffset, IsPooled, _offset + additionalOffset, _pool);
+        return _nativeBuffer is not null
+            ? new PooledResponseBuffer(_nativeBuffer, Length - additionalOffset, _offset + additionalOffset)
+            : new PooledResponseBuffer(_buffer!, Length - additionalOffset, IsPooled, _offset + additionalOffset, _pool);
     }
 
     /// <summary>
@@ -3568,12 +3716,18 @@ internal readonly struct PooledResponseBuffer : IDisposable
     /// </summary>
     public PooledResponseMemory TransferOwnership()
     {
-        return PooledResponseMemory.Create(_buffer, Length, IsPooled, _offset, _pool);
+        return _nativeBuffer is not null
+            ? PooledResponseMemory.Create(_nativeBuffer, Length, _offset)
+            : PooledResponseMemory.Create(_buffer!, Length, IsPooled, _offset, _pool);
     }
 
     public void Dispose()
     {
-        if (IsPooled && _buffer is not null)
+        if (_nativeBuffer is not null)
+        {
+            _nativeBuffer.Return();
+        }
+        else if (IsPooled && _buffer is not null)
         {
             Debug.Assert(_pool is not null, "Pooled buffer must have a non-null pool reference");
             _pool!.Pool.Return(_buffer);
@@ -3591,6 +3745,7 @@ internal sealed class PooledResponseMemory : IPooledMemory
     private static readonly PooledResponseMemoryPool s_pool = new();
 
     private byte[]? _buffer;
+    private NativeResponseBuffer? _nativeBuffer;
     private int _length;
     private bool _isPooled;
     private int _offset;
@@ -3607,9 +3762,24 @@ internal sealed class PooledResponseMemory : IPooledMemory
         return memory;
     }
 
+    internal static PooledResponseMemory Create(NativeResponseBuffer buffer, int length, int offset)
+    {
+        var memory = s_pool.Rent();
+        memory._buffer = null;
+        memory._nativeBuffer = buffer;
+        memory._length = length;
+        memory._isPooled = true;
+        memory._offset = offset;
+        memory._pool = null;
+        memory._pooled = 1;
+        Volatile.Write(ref memory._disposed, 0);
+        return memory;
+    }
+
     private void Initialize(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool, bool pooled)
     {
         _buffer = buffer;
+        _nativeBuffer = null;
         _length = length;
         _isPooled = isPooled;
         _offset = offset;
@@ -3618,9 +3788,11 @@ internal sealed class PooledResponseMemory : IPooledMemory
         Volatile.Write(ref _disposed, 0);
     }
 
-    public ReadOnlyMemory<byte> Memory => _buffer is not null
-        ? _buffer.AsMemory(_offset, _length)
-        : throw new ObjectDisposedException(nameof(PooledResponseMemory));
+    public ReadOnlyMemory<byte> Memory => _nativeBuffer is not null
+        ? _nativeBuffer.Memory.Slice(_offset, _length)
+        : _buffer is not null
+            ? _buffer.AsMemory(_offset, _length)
+            : throw new ObjectDisposedException(nameof(PooledResponseMemory));
 
     public void Dispose()
     {
@@ -3628,6 +3800,8 @@ internal sealed class PooledResponseMemory : IPooledMemory
             return;
 
         var buffer = Interlocked.Exchange(ref _buffer, null);
+        var nativeBuffer = Interlocked.Exchange(ref _nativeBuffer, null);
+        nativeBuffer?.Return();
         if (_isPooled && buffer is not null)
         {
             Debug.Assert(_pool is not null, "Pooled buffer must have a non-null pool reference");
@@ -3645,6 +3819,7 @@ internal sealed class PooledResponseMemory : IPooledMemory
         protected override void Reset(PooledResponseMemory item)
         {
             item._buffer = null;
+            item._nativeBuffer = null;
             item._length = 0;
             item._isPooled = false;
             item._offset = 0;

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3557,6 +3557,9 @@ internal sealed class ResponseBufferPool
 
     private static int RoundUpToPowerOfTwo(int value)
     {
+        if (value > 1 << 30)
+            return value;
+
         var rounded = (uint)(value - 1);
         rounded |= rounded >> 1;
         rounded |= rounded >> 2;
@@ -3564,7 +3567,7 @@ internal sealed class ResponseBufferPool
         rounded |= rounded >> 8;
         rounded |= rounded >> 16;
         rounded++;
-        return rounded <= int.MaxValue ? (int)rounded : value;
+        return (int)rounded;
     }
 
     private sealed class NativeBufferBucket(int capacity, int maxRetained)

--- a/src/Dekaf/Networking/ResponseFrameReader.cs
+++ b/src/Dekaf/Networking/ResponseFrameReader.cs
@@ -131,12 +131,24 @@ internal sealed class ResponseFrameReader : IDisposable
             }
         }
 
-        // Receive the remainder of the payload directly into the pooled array — no
-        // intermediate buffer, so large fetch payloads are copied exactly once.
+        // Modern targets receive the remainder directly into pooled storage. The
+        // netstandard2.0 native path uses the bounded receive buffer for compatibility.
         while (_frameFilled < _frameSize)
         {
+#if NETSTANDARD2_0
+            // The netstandard2.0 compatibility read path only supports array-backed
+            // Memory<byte>. Stage native destinations through the bounded receive buffer.
+            var remaining = _frameSize - _frameFilled;
+            var destination = _nativeFrame is not null
+                ? _buffer[..Math.Min(_buffer.Length, remaining)]
+                : FrameMemory.Slice(_frameFilled, remaining);
+            var read = await ReadSourceAsync(destination).ConfigureAwait(false);
+            if (_nativeFrame is not null && read > 0)
+                destination.Span[..read].CopyTo(FrameMemory.Span.Slice(_frameFilled));
+#else
             var read = await ReadSourceAsync(FrameMemory.Slice(_frameFilled, _frameSize - _frameFilled))
                 .ConfigureAwait(false);
+#endif
             if (read == 0)
             {
                 // EOF mid-frame: discard the partial frame; the caller fails pending requests.

--- a/src/Dekaf/Networking/ResponseFrameReader.cs
+++ b/src/Dekaf/Networking/ResponseFrameReader.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 
@@ -8,7 +9,7 @@ namespace Dekaf.Networking;
 /// <summary>
 /// Reads length-prefixed Kafka response frames directly from the connection's read source
 /// (the raw <see cref="Socket"/> for plain TCP, the <c>SslStream</c> for TLS) into pooled
-/// pooled response storage.
+/// response storage.
 /// <para/>
 /// <b>Why not a Pipe?</b> The previous receive path pumped socket bytes into a
 /// <c>System.IO.Pipelines.Pipe</c> and then copied every frame out of the pipe's segments
@@ -131,24 +132,12 @@ internal sealed class ResponseFrameReader : IDisposable
             }
         }
 
-        // Modern targets receive the remainder directly into pooled storage. The
-        // netstandard2.0 native path uses the bounded receive buffer for compatibility.
+        // Receive the remainder directly into pooled storage. ReadSourceAsync handles
+        // the netstandard2.0 TLS compatibility case without affecting plain sockets.
         while (_frameFilled < _frameSize)
         {
-#if NETSTANDARD2_0
-            // The netstandard2.0 compatibility read path only supports array-backed
-            // Memory<byte>. Stage native destinations through the bounded receive buffer.
-            var remaining = _frameSize - _frameFilled;
-            var destination = _nativeFrame is not null
-                ? _buffer[..Math.Min(_buffer.Length, remaining)]
-                : FrameMemory.Slice(_frameFilled, remaining);
-            var read = await ReadSourceAsync(destination).ConfigureAwait(false);
-            if (_nativeFrame is not null && read > 0)
-                destination.Span[..read].CopyTo(FrameMemory.Span.Slice(_frameFilled));
-#else
             var read = await ReadSourceAsync(FrameMemory.Slice(_frameFilled, _frameSize - _frameFilled))
                 .ConfigureAwait(false);
-#endif
             if (read == 0)
             {
                 // EOF mid-frame: discard the partial frame; the caller fails pending requests.
@@ -177,6 +166,20 @@ internal sealed class ResponseFrameReader : IDisposable
         Volatile.Write(ref _readInFlight, true);
         try
         {
+#if NETSTANDARD2_0
+            // Polyfill's Stream.ReadAsync(Memory<byte>) drops data when Memory is backed by
+            // a MemoryManager instead of an array. TLS on the netstandard asset therefore
+            // reads through the existing small receive buffer before copying into native
+            // frame storage. Plain sockets and modern target frameworks remain direct-fill.
+            if (_stream is not null && _nativeFrame is not null)
+            {
+                Debug.Assert(BufferedByteCount == 0);
+                var intermediate = _buffer[..Math.Min(_buffer.Length, destination.Length)];
+                read = await _stream.ReadAsync(intermediate).ConfigureAwait(false);
+                intermediate.Span[..read].CopyTo(destination.Span);
+            }
+            else
+#endif
             read = _stream is not null
                 ? await _stream.ReadAsync(destination).ConfigureAwait(false)
                 : await _socket!.ReceiveAsync(destination, SocketFlags.None).ConfigureAwait(false);

--- a/src/Dekaf/Networking/ResponseFrameReader.cs
+++ b/src/Dekaf/Networking/ResponseFrameReader.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Networking;
 /// <summary>
 /// Reads length-prefixed Kafka response frames directly from the connection's read source
 /// (the raw <see cref="Socket"/> for plain TCP, the <c>SslStream</c> for TLS) into pooled
-/// response arrays.
+/// pooled response storage.
 /// <para/>
 /// <b>Why not a Pipe?</b> The previous receive path pumped socket bytes into a
 /// <c>System.IO.Pipelines.Pipe</c> and then copied every frame out of the pipe's segments
@@ -41,8 +41,9 @@ internal sealed class ResponseFrameReader : IDisposable
     private int _end;
 
     // In-progress frame assembly state. Kept in fields (not locals) so that an EOF or a
-    // faulted read mid-frame can release the pooled array via AbandonInProgressFrame.
+    // faulted read mid-frame can release pooled storage via AbandonInProgressFrame.
     private byte[]? _frameArray;
+    private NativeResponseBuffer? _nativeFrame;
     private int _frameSize;
     private int _frameFilled;
 
@@ -87,7 +88,7 @@ internal sealed class ResponseFrameReader : IDisposable
 #endif
     public async ValueTask<ResponseFrame> ReadFrameAsync()
     {
-        if (_frameArray is null)
+        if (_frameArray is null && _nativeFrame is null)
         {
             // Accumulate the 4-byte size prefix through the internal buffer. Only ever
             // buffers ahead within the current receive; compaction moves at most 3 bytes.
@@ -111,12 +112,15 @@ internal sealed class ResponseFrameReader : IDisposable
             ConnectionHelper.ValidateResponseFrameSize(frameSize, _responseBufferPool.MaxArrayLength);
             _start += 4;
 
-            _frameArray = _responseBufferPool.Pool.Rent(frameSize);
+            if (frameSize >= ResponseBufferPool.NativeMemoryThresholdBytes)
+                _nativeFrame = _responseBufferPool.RentNative(frameSize);
+            else
+                _frameArray = _responseBufferPool.Pool.Rent(frameSize);
             _frameSize = frameSize;
 
             // Copy whatever part of the payload is already buffered.
             var buffered = Math.Min(frameSize, BufferedByteCount);
-            _buffer.Span.Slice(_start, buffered).CopyTo(_frameArray);
+            _buffer.Span.Slice(_start, buffered).CopyTo(FrameMemory.Span);
             _start += buffered;
             _frameFilled = buffered;
 
@@ -131,7 +135,7 @@ internal sealed class ResponseFrameReader : IDisposable
         // intermediate buffer, so large fetch payloads are copied exactly once.
         while (_frameFilled < _frameSize)
         {
-            var read = await ReadSourceAsync(_frameArray.AsMemory(_frameFilled, _frameSize - _frameFilled))
+            var read = await ReadSourceAsync(FrameMemory.Slice(_frameFilled, _frameSize - _frameFilled))
                 .ConfigureAwait(false);
             if (read == 0)
             {
@@ -143,8 +147,11 @@ internal sealed class ResponseFrameReader : IDisposable
             _frameFilled += read;
         }
 
-        var correlationId = BinaryPrimitives.ReadInt32BigEndian(_frameArray);
-        var response = new PooledResponseBuffer(_frameArray, _frameSize, isPooled: true, pool: _responseBufferPool);
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(FrameMemory.Span);
+        var response = _nativeFrame is not null
+            ? new PooledResponseBuffer(_nativeFrame, _frameSize)
+            : new PooledResponseBuffer(_frameArray!, _frameSize, isPooled: true, pool: _responseBufferPool);
+        _nativeFrame = null;
         _frameArray = null;
         return ResponseFrame.ForResponse(correlationId, response);
     }
@@ -223,10 +230,17 @@ internal sealed class ResponseFrameReader : IDisposable
     private void AbandonInProgressFrame()
     {
         var frameArray = _frameArray;
+        var nativeFrame = _nativeFrame;
         _frameArray = null;
+        _nativeFrame = null;
         if (frameArray is not null)
             _responseBufferPool.Pool.Return(frameArray);
+        nativeFrame?.Return();
     }
+
+    private Memory<byte> FrameMemory => _nativeFrame is not null
+        ? _nativeFrame.Memory
+        : _frameArray.AsMemory();
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -113,9 +113,13 @@ public class PendingFetchDataTests
     public async Task RatchetPoolSize_IncreasesMaxPoolSize()
     {
         var before = PendingFetchData.MaxPoolSizeValue;
+        var target = before + 100;
 
-        PendingFetchData.RatchetPoolSize(before + 100);
-        await Assert.That(PendingFetchData.MaxPoolSizeValue).IsGreaterThanOrEqualTo(before + 100);
+        PendingFetchData.RatchetPoolSize(target);
+
+        await Assert.That(PendingFetchData.MaxPoolSizeValue).IsGreaterThanOrEqualTo(target);
+        await Assert.That(PendingFetchData.MaxParsedRecordSlabsPerBucketValue)
+            .IsGreaterThanOrEqualTo(PoolSizing.ForConsumerParsedRecordSlabs(target));
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -206,6 +206,7 @@ public class PendingFetchDataTests
 
             var first = PendingFetchData.Create("topic-1", 0, Array.Empty<RecordBatch>());
             var slab = new Record[32];
+            slab[^1] = new Record { Value = new byte[] { 42 } };
             slabField.SetValue(first, slab);
             first.Dispose();
 
@@ -213,6 +214,7 @@ public class PendingFetchDataTests
 
             await Assert.That(second).IsSameReferenceAs(first);
             await Assert.That(slabField.GetValue(second)).IsNull();
+            await Assert.That(slab[^1]).IsEqualTo(default(Record));
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -191,7 +191,7 @@ public class PendingFetchDataTests
 
     [Test]
     [NotInParallel]
-    public async Task Dispose_RetainsParsedRecordSlabAcrossPooledReuse()
+    public async Task Dispose_ReleasesParsedRecordSlabBeforePooledReuse()
     {
         var originalMaxPoolSize = MaxPoolSizeField.GetValue(null);
         var originalPool = PoolField.GetValue(null);
@@ -212,7 +212,7 @@ public class PendingFetchDataTests
             second = PendingFetchData.Create("topic-2", 1, Array.Empty<RecordBatch>());
 
             await Assert.That(second).IsSameReferenceAs(first);
-            await Assert.That(slabField.GetValue(second)).IsSameReferenceAs(slab);
+            await Assert.That(slabField.GetValue(second)).IsNull();
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/PoolSizingTests.cs
@@ -195,7 +195,32 @@ public class PoolSizingTests
     {
         var sizes = PoolSizing.ForConsumer(maxPartitionCount: 10000);
 
-        await Assert.That(sizes.FetchDataPool).IsLessThanOrEqualTo(512);
+        await Assert.That(sizes.FetchDataPool).IsEqualTo(512);
+        await Assert.That(sizes.ParsedRecordSlabsPerBucket).IsEqualTo(64);
+        await Assert.That(sizes.CancellationTokenSources).IsEqualTo(2048);
+    }
+
+    [Test]
+    public async Task ForConsumer_PathologicalPartitionCount_ClampsWithoutOverflow()
+    {
+        var sizes = PoolSizing.ForConsumer(maxPartitionCount: int.MaxValue);
+
+        await Assert.That(sizes.FetchDataPool).IsEqualTo(512);
+        await Assert.That(sizes.ParsedRecordSlabsPerBucket).IsEqualTo(64);
+        await Assert.That(sizes.CancellationTokenSources).IsEqualTo(2048);
+    }
+
+    [Test]
+    [Arguments(32, 16)]
+    [Arguments(128, 16)]
+    [Arguments(400, 50)]
+    [Arguments(512, 64)]
+    public async Task ForConsumerParsedRecordSlabs_ScalesWithinRetentionBounds(
+        int fetchDataPool,
+        int expected)
+    {
+        await Assert.That(PoolSizing.ForConsumerParsedRecordSlabs(fetchDataPool))
+            .IsEqualTo(expected);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -154,6 +154,21 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
+    public async Task NativeBuffer_SlicedMemoryCopyPreservesOffset()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var native = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        native.GetSpan().Clear();
+        var source = new byte[] { 10, 20, 30, 40 };
+
+        source.AsMemory().CopyTo(native.Memory.Slice(4092, source.Length));
+
+        await Assert.That(native.GetSpan()[4091]).IsEqualTo((byte)0);
+        await Assert.That(native.GetSpan().Slice(4092, source.Length).ToArray()).IsEquivalentTo(source);
+        native.Return();
+    }
+
+    [Test]
     public async Task PooledResponseBuffer_ReturnsToCorrectPool()
     {
         var pool = ResponseBufferPool.Create(20 * 1024 * 1024);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -118,6 +118,42 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
+    public async Task NativePool_ReusesReturnedLargeBuffer()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var address = first.Address;
+        first.GetSpan()[0] = 42;
+
+        var response = new PooledResponseBuffer(first, ResponseBufferPool.NativeMemoryThresholdBytes);
+        await Assert.That(response.Data.Span[0]).IsEqualTo((byte)42);
+        response.Dispose();
+
+        var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        await Assert.That(second.Address).IsEqualTo(address);
+        second.Return();
+    }
+
+    [Test]
+    public async Task NativeBuffer_TransferOwnershipReturnsBufferOnce()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var native = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var address = native.Address;
+        native.GetSpan()[0] = 99;
+        var response = new PooledResponseBuffer(native, ResponseBufferPool.NativeMemoryThresholdBytes);
+
+        var memory = response.TransferOwnership();
+        await Assert.That(memory.Memory.Span[0]).IsEqualTo((byte)99);
+        memory.Dispose();
+        memory.Dispose();
+
+        var reused = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        await Assert.That(reused.Address).IsEqualTo(address);
+        reused.Return();
+    }
+
+    [Test]
     public async Task PooledResponseBuffer_ReturnsToCorrectPool()
     {
         var pool = ResponseBufferPool.Create(20 * 1024 * 1024);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -83,6 +83,18 @@ public sealed class ResponseFrameReaderTests
     }
 
     [Test]
+    public async Task ReadFrameAsync_LargeFrame_UsesNativePooledMemory()
+    {
+        var frame = BuildFrame(correlationId: 12, payloadSize: ResponseBufferPool.NativeMemoryThresholdBytes);
+        using var reader = CreateReader(out _, receiveBufferSize: 4096, chunks: [frame]);
+
+        var result = await reader.ReadFrameAsync();
+
+        await Assert.That(result.Buffer.UsesNativeMemory).IsTrue();
+        await AssertPayloadAsync(result, ResponseBufferPool.NativeMemoryThresholdBytes);
+    }
+
+    [Test]
     public async Task ReadFrameAsync_TrailingPartialFrame_CompletesOnNextChunk()
     {
         var first = BuildFrame(correlationId: 1, payloadSize: 20);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -1,4 +1,6 @@
 using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
 using Dekaf.Errors;
 using Dekaf.Networking;
 
@@ -92,6 +94,35 @@ public sealed class ResponseFrameReaderTests
 
         await Assert.That(result.Buffer.UsesNativeMemory).IsTrue();
         await Assert.That(result.CorrelationId).IsEqualTo(12);
+        await AssertPayloadAsync(result, ResponseBufferPool.NativeMemoryThresholdBytes);
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task ReadFrameAsync_LargeSocketFrame_UsesNativePooledMemory(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var endpoint = (IPEndPoint)listener.LocalEndpoint;
+        using var client = new TcpClient();
+        var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+        await client.ConnectAsync(endpoint.Address, endpoint.Port, cancellationToken);
+        using var server = await acceptTask;
+        using var memoryPool = new PipeMemoryPool();
+        using var reader = new ResponseFrameReader(
+            client.Client,
+            stream: null,
+            receiveBufferSize: 4096,
+            ResponseBufferPool.Default,
+            memoryPool);
+        var frame = BuildFrame(correlationId: 13, payloadSize: ResponseBufferPool.NativeMemoryThresholdBytes);
+
+        await server.GetStream().WriteAsync(frame, cancellationToken);
+        var result = await reader.ReadFrameAsync();
+
+        await Assert.That(result.Buffer.UsesNativeMemory).IsTrue();
+        await Assert.That(result.CorrelationId).IsEqualTo(13);
         await AssertPayloadAsync(result, ResponseBufferPool.NativeMemoryThresholdBytes);
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -1,6 +1,8 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.Versioning;
 using Dekaf.Errors;
 using Dekaf.Networking;
 
@@ -85,8 +87,15 @@ public sealed class ResponseFrameReaderTests
     }
 
     [Test]
-    public async Task ReadFrameAsync_LargeFrame_UsesNativePooledMemory()
+    public async Task ReadFrameAsync_LargeStreamFrame_UsesNativePooledMemory()
     {
+#if NET8_0
+        // The net8 test target consumes Dekaf's netstandard2.0 asset, so this test executes
+        // ReadSourceAsync's NETSTANDARD2_0 native-stream staging branch in CI.
+        var framework = typeof(ResponseFrameReader).Assembly
+            .GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+        await Assert.That(framework).IsEqualTo(".NETStandard,Version=v2.0");
+#endif
         var frame = BuildFrame(correlationId: 12, payloadSize: ResponseBufferPool.NativeMemoryThresholdBytes);
         using var reader = CreateReader(out _, receiveBufferSize: 4096, chunks: [frame]);
 

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -174,6 +174,25 @@ public sealed class ResponseFrameReaderTests
     }
 
     [Test]
+    public async Task ReadFrameAsync_EofMidNativeFrame_ReturnsBufferToPool()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var seeded = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var address = seeded.Address;
+        seeded.Return();
+        var frame = BuildFrame(correlationId: 5, payloadSize: ResponseBufferPool.NativeMemoryThresholdBytes);
+        using var stream = new ScriptedReadStream([frame[..200]]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream, responseBufferPool: pool);
+
+        var result = await reader.ReadFrameAsync();
+
+        await Assert.That(result.IsEndOfStream).IsTrue();
+        var reused = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        await Assert.That(reused.Address).IsEqualTo(address);
+        reused.Return();
+    }
+
+    [Test]
     public async Task ReadFrameAsync_NegativeFrameSize_ThrowsKafkaException()
     {
         var invalid = new byte[8];

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -91,6 +91,7 @@ public sealed class ResponseFrameReaderTests
         var result = await reader.ReadFrameAsync();
 
         await Assert.That(result.Buffer.UsesNativeMemory).IsTrue();
+        await Assert.That(result.CorrelationId).IsEqualTo(12);
         await AssertPayloadAsync(result, ResponseBufferPool.NativeMemoryThresholdBytes);
     }
 
@@ -258,8 +259,11 @@ public sealed class ResponseFrameReaderTests
         // (offset by the 4-byte size prefix that is not part of the payload).
         for (var i = 4; i < payloadSize; i++)
         {
-            if (payload.Span[i] != (byte)((i + 4) % 251))
-                throw new InvalidOperationException($"Payload mismatch at offset {i}");
+            var expected = (byte)((i + 4) % 251);
+            var actual = payload.Span[i];
+            if (actual != expected)
+                throw new InvalidOperationException(
+                    $"Payload mismatch at offset {i}: expected {expected}, actual {actual}");
         }
 
         result.Buffer.Dispose();


### PR DESCRIPTION
Closes #1967

## Root cause

Two independent cold-start retention paths forced full collections:

- Every pooled `PendingFetchData` retained its own 1–2 MB parsed `Record[]` slab. Deep prefetch touched roughly 100 instances before reuse, pinning about 186 MiB of slabs.
- High-throughput fetch responses warmed managed 32/64 MiB `byte[]` buckets. The initial LOH allocations accounted for about 388 MiB and dominated Gen2 churn.

## Fix

- Return parsed-record slabs to a dedicated, bounded `ArrayPool<Record>` when each `PendingFetchData` use ends. Clear every rented slab entry before return so record memory/header references are not retained.
- Store response frames at or above the 85,000-byte LOH threshold in bounded, power-of-two native-memory buckets. Small responses keep the existing managed `ArrayPool<byte>` path.
- Preserve contiguous zero-copy parsing, ownership transfer, slicing, direct socket reads, and the existing response-memory wrapper pool.

## Validation

- Full Windows net10 unit suite after review fixes: 5,352/5,352.
- Full Linux net8 unit suite against the netstandard2.0 asset: 5,255/5,255.
- Debug multi-target build (`netstandard2.0`, `net10.0`): 0 warnings, 0 errors.
- Release stress build: 0 warnings, 0 errors.
- Same-host 15-minute consumer stress, 500k seeded messages / 6 partitions:
  - Gen2: **1** (target ≤2; original issue reports 13–17).
  - Throughput: **668,340 msg/s** average, **679,059 msg/s** median.
  - Drift: **-0.8%**; slope: **-0.08%/min** (no minutes 9–13 collapse).
  - Allocated: **106.41 MB** over 601.5M messages.
- Original local 2-minute baseline: 587,556 msg/s, 9 Gen2, 983.39 MB allocated.
- Exact final code on isolated Testcontainers: 0 Gen2 and 13.23 MB allocated over two minutes.

