### PR TITLE
perf(producer): cut send-loop estimator and coalesce-spin CPU

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1070,6 +1070,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var waveCoalesceMaxTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.MaximumMicroseconds);
         var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.QuietMicroseconds);
         var waveCoalesceArmed = true;
+        var waveCoalesceGate = new WaveCoalesceGate();
 
         // Pre-allocate reusable response lookup dictionary to avoid per-response allocation.
         // Single-threaded: only accessed by the send loop, cleared after each use.
@@ -1346,6 +1347,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
+                    && waveCoalesceGate.ShouldSpin()
                     && ShouldMicroLinger(
                         coalescedBatches,
                         coalescedCount,
@@ -1353,6 +1355,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 {
                     waveCoalesceArmed = false;
                     _onWaveCoalesceStarted?.Invoke();
+                    var coalescedCountBeforeSpin = coalescedCount;
                     var started = Stopwatch.GetTimestamp();
                     var hardDeadline = started + waveCoalesceMaxTicks;
                     var quietDeadline = Math.Min(started + waveCoalesceQuietTicks, hardDeadline);
@@ -1394,6 +1397,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             break;
                         }
                     }
+
+                    waveCoalesceGate.OnSpinCompleted(coalescedCount > coalescedCountBeforeSpin);
                 }
 
                 // ── 6. Send or wait ──
@@ -1748,8 +1753,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                 // Keep forming request waves while the pipeline is busy. Without rearming here,
                 // only the first request after an idle period can coalesce adjacent partitions.
+                // The gate suppresses the spin itself once it proves fruitless on this workload.
                 if (sentThisIteration)
+                {
                     waveCoalesceArmed = true;
+                    waveCoalesceGate.OnSent();
+                }
 
                 // ── 7. Compute timeout and wait ──
                 if (transactionEnrollmentReady)
@@ -2608,6 +2617,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // preserving per-partition FIFO ordering during the next coalescing pass.
         // Reverse iteration (swap-with-last O(1) removal) would process R2 before R1,
         // causing the newer batch to be coalesced first and violating ordering.
+        var ackedRequestsThisPass = 0;
         for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
         {
             var pendingList = _pendingResponsesByConnection[connIdx];
@@ -2691,11 +2701,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // Per-request BBR delivery-rate sample: the delivered-counter delta since
                     // this request's send snapshot covers concurrent connection lanes. A fresh
                     // timestamp per call keeps 'now' honest when a pass spends time in
-                    // acknowledgement callbacks between completions.
+                    // acknowledgement callbacks between completions. The budget itself is
+                    // republished once per pass via CompleteAckedPass below.
                     unackedBudget.OnAcked(
                         pending.EncodedBytes,
                         pending.DeliverySnapshotAtSend,
                         Stopwatch.GetTimestamp());
+                    ackedRequestsThisPass++;
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
@@ -2757,6 +2769,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
+        if (ackedRequestsThisPass > 0 && _unackedBudget is { } budgetToPublish)
+            budgetToPublish.CompleteAckedPass(Stopwatch.GetTimestamp());
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2617,7 +2617,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // preserving per-partition FIFO ordering during the next coalescing pass.
         // Reverse iteration (swap-with-last O(1) removal) would process R2 before R1,
         // causing the newer batch to be coalesced first and violating ordering.
-        var ackedRequestsThisPass = 0;
+        var anyAckedThisPass = false;
+        long lastAckTimestamp = 0;
         for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
         {
             var pendingList = _pendingResponsesByConnection[connIdx];
@@ -2703,11 +2704,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // timestamp per call keeps 'now' honest when a pass spends time in
                     // acknowledgement callbacks between completions. The budget itself is
                     // republished once per pass via CompleteAckedPass below.
+                    lastAckTimestamp = Stopwatch.GetTimestamp();
                     unackedBudget.OnAcked(
                         pending.EncodedBytes,
                         pending.DeliverySnapshotAtSend,
-                        Stopwatch.GetTimestamp());
-                    ackedRequestsThisPass++;
+                        lastAckTimestamp);
+                    anyAckedThisPass = true;
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis
@@ -2769,8 +2771,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             }
         }
 
-        if (ackedRequestsThisPass > 0 && _unackedBudget is { } budgetToPublish)
-            budgetToPublish.CompleteAckedPass(Stopwatch.GetTimestamp());
+        if (anyAckedThisPass)
+            _unackedBudget!.CompleteAckedPass(lastAckTimestamp);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -28,9 +28,10 @@ namespace Dekaf.Producer;
 /// (producer appenders, terminal batch paths, and parallel connection sends).
 /// <see cref="OnAcked"/>, <see cref="CompleteAckedPass"/>, and <see cref="SetCap"/> are
 /// single-writer — only the owning broker's send loop calls them — so the remaining estimator
-/// state needs no synchronization; the computed budget is published with a volatile write. <see cref="SnapshotDelivery"/> performs
-/// two independent volatile reads racing the single writer; both fields are monotonic, so a
-/// torn pair only skews one rate sample marginally and the windowed max filters it.
+/// state needs no synchronization; the computed budget is published with a volatile write.
+/// <see cref="SnapshotDelivery"/> performs two independent volatile reads racing the single
+/// writer; both fields are monotonic, so a torn pair only skews one rate sample marginally
+/// and the windowed max filters it.
 /// </para>
 /// </summary>
 internal sealed class BrokerUnackedByteBudget
@@ -353,10 +354,8 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Feeds one successfully acknowledged request into the drain estimate. Called only from
     /// the owning send loop, once per acked request. O(1), allocation-free. The budget itself
-    /// is republished by <see cref="CompleteAckedPass"/> once per response pass: a pass at the
-    /// in-flight ceiling drains many requests, and recomputing/publishing per request tripled
-    /// the estimator's share of send-loop CPU for no admission-precision gain — the admission
-    /// gate only reads the budget between passes.
+    /// is republished once per response pass by <see cref="CompleteAckedPass"/>, which owns
+    /// the per-pass-vs-per-request rationale.
     /// </summary>
     /// <param name="ackedBytes">Encoded payload bytes of the acknowledged request.</param>
     /// <param name="sendSnapshot">Token minted via <see cref="SnapshotDelivery"/> just before
@@ -405,9 +404,10 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Drains the cross-thread written-occupancy peak into the sample window and republishes
     /// the budget. Called by the owning send loop once per response pass, after every
-    /// <see cref="OnAcked"/> for that pass — the interlocked peak drain and the budget
-    /// recompute are the estimator's expensive steps, and per-pass granularity keeps their
-    /// cost independent of how many requests a pass drains.
+    /// <see cref="OnAcked"/> for that pass. The interlocked peak drain and the budget
+    /// recompute are the estimator's expensive steps; a pass at the in-flight ceiling drains
+    /// many requests, and the admission gate only reads the budget between passes, so
+    /// per-request publishing multiplied that cost for no admission-precision gain.
     /// </summary>
     public void CompleteAckedPass(long nowTicks)
     {

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -26,9 +26,9 @@ namespace Dekaf.Producer;
 /// <see cref="IsOverBudgetAt"/>/<see cref="RecordAdmissionBlock"/>/
 /// <see cref="ObserveWrittenUnackedBytes"/>/<see cref="SnapshotDelivery"/> are cross-thread
 /// (producer appenders, terminal batch paths, and parallel connection sends).
-/// <see cref="OnAcked"/> and <see cref="SetCap"/> are single-writer — only the owning broker's
-/// send loop calls them — so the remaining estimator state needs no synchronization; the
-/// computed budget is published with a volatile write. <see cref="SnapshotDelivery"/> performs
+/// <see cref="OnAcked"/>, <see cref="CompleteAckedPass"/>, and <see cref="SetCap"/> are
+/// single-writer — only the owning broker's send loop calls them — so the remaining estimator
+/// state needs no synchronization; the computed budget is published with a volatile write. <see cref="SnapshotDelivery"/> performs
 /// two independent volatile reads racing the single writer; both fields are monotonic, so a
 /// torn pair only skews one rate sample marginally and the windowed max filters it.
 /// </para>
@@ -351,9 +351,12 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     /// <summary>
-    /// Feeds one successfully acknowledged request into the drain estimate, then republishes
-    /// the budget. Called only from the owning send loop, once per acked request. O(1),
-    /// allocation-free.
+    /// Feeds one successfully acknowledged request into the drain estimate. Called only from
+    /// the owning send loop, once per acked request. O(1), allocation-free. The budget itself
+    /// is republished by <see cref="CompleteAckedPass"/> once per response pass: a pass at the
+    /// in-flight ceiling drains many requests, and recomputing/publishing per request tripled
+    /// the estimator's share of send-loop CPU for no admission-precision gain — the admission
+    /// gate only reads the budget between passes.
     /// </summary>
     /// <param name="ackedBytes">Encoded payload bytes of the acknowledged request.</param>
     /// <param name="sendSnapshot">Token minted via <see cref="SnapshotDelivery"/> just before
@@ -396,11 +399,22 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _maxRateBytesPerSecond, (long)_windowMaxRate);
         }
 
+        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
+    }
+
+    /// <summary>
+    /// Drains the cross-thread written-occupancy peak into the sample window and republishes
+    /// the budget. Called by the owning send loop once per response pass, after every
+    /// <see cref="OnAcked"/> for that pass — the interlocked peak drain and the budget
+    /// recompute are the estimator's expensive steps, and per-pass granularity keeps their
+    /// cost independent of how many requests a pass drains.
+    /// </summary>
+    public void CompleteAckedPass(long nowTicks)
+    {
+        AdvanceWindow(nowTicks);
         var writtenUnackedPeak = Interlocked.Exchange(ref _pendingWrittenUnackedPeakBytes, 0);
         if (writtenUnackedPeak > 0)
             AddOccupancySample(writtenUnackedPeak);
-
-        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
 
         RecomputeBudget();
     }

--- a/src/Dekaf/Producer/WaveCoalesceGate.cs
+++ b/src/Dekaf/Producer/WaveCoalesceGate.cs
@@ -1,0 +1,61 @@
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Suppresses the send loop's wave-coalesce spin for workloads where it never pays off.
+/// The spin waits up to a full quiet window per wave hoping a batch for another partition
+/// arrives; on workloads whose requests are effectively single-partition (large batches,
+/// few partitions per broker) that wait is pure CPU burn on every wave. After
+/// <see cref="FruitlessSpinSuppressThreshold"/> consecutive spins that coalesced nothing,
+/// the gate closes and only re-opens for a single probe spin every
+/// <see cref="SuppressedReprobeSendInterval"/> sends, so a workload shift back toward
+/// coalescible waves is still detected quickly.
+/// </summary>
+internal struct WaveCoalesceGate
+{
+    /// <summary>
+    /// Consecutive fruitless spins tolerated before suppression. Bounds the worst-case
+    /// wasted spin time per suppression cycle to this many quiet windows.
+    /// </summary>
+    internal const int FruitlessSpinSuppressThreshold = 8;
+
+    /// <summary>
+    /// Sends between probe spins while suppressed. Keeps steady-state waste to one quiet
+    /// window per this many waves (&lt;0.1% of a core at millisecond wave cadence) while
+    /// re-detecting coalescible workloads within one interval.
+    /// </summary>
+    internal const int SuppressedReprobeSendInterval = 64;
+
+    private int _consecutiveFruitlessSpins;
+    private int _sendsSinceSuppressed;
+
+    private readonly bool IsSuppressed => _consecutiveFruitlessSpins >= FruitlessSpinSuppressThreshold;
+
+    /// <summary>Whether the next wave may enter the coalesce spin.</summary>
+    public readonly bool ShouldSpin()
+        => !IsSuppressed || _sendsSinceSuppressed >= SuppressedReprobeSendInterval;
+
+    /// <summary>
+    /// Records the outcome of a spin permitted by <see cref="ShouldSpin"/>.
+    /// A spin that coalesced at least one additional batch re-opens the gate.
+    /// </summary>
+    public void OnSpinCompleted(bool coalescedAdditionalBatch)
+    {
+        if (coalescedAdditionalBatch)
+        {
+            _consecutiveFruitlessSpins = 0;
+        }
+        else if (!IsSuppressed)
+        {
+            _consecutiveFruitlessSpins++;
+        }
+
+        _sendsSinceSuppressed = 0;
+    }
+
+    /// <summary>Advances the probe schedule while suppressed. Call once per completed send pass.</summary>
+    public void OnSent()
+    {
+        if (IsSuppressed)
+            _sendsSinceSuppressed++;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -52,6 +52,7 @@ public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
             1_000_000,
             budget.SnapshotDelivery(nowTicks - Stopwatch.Frequency / 20, appLimited: true),
             nowTicks);
+        budget.CompleteAckedPass(nowTicks);
         budget.Charge(1_200_000);
 
         try

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -201,6 +201,7 @@ public sealed class BrokerUnackedAdmissionTests
             budget.SnapshotDelivery(
                 nowTicks - System.Diagnostics.Stopwatch.Frequency / 100, appLimited: true),
             nowTicks);
+        budget.CompleteAckedPass(nowTicks);
         budget.Charge(1_200_000);
 
         var gatedAppend = accumulator.AppendAsync(
@@ -230,6 +231,7 @@ public sealed class BrokerUnackedAdmissionTests
             budget.SnapshotDelivery(
                 nowTicks - System.Diagnostics.Stopwatch.Frequency, appLimited: true),
             nowTicks);
+        budget.CompleteAckedPass(nowTicks);
         budget.Charge(1_200_000);
 
         var firstAppend = accumulator.AppendAsync(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -39,10 +39,13 @@ public sealed class BrokerUnackedByteBudgetTests
         long nowTicks,
         BrokerUnackedByteBudget.DeliverySnapshot? snapshotAtSend = null,
         bool appLimitedAtSend = true)
-        => budget.OnAcked(
+    {
+        budget.OnAcked(
             ackedBytes,
             snapshotAtSend ?? budget.SnapshotDelivery(nowTicks - Seconds(rttSeconds), appLimitedAtSend),
             nowTicks);
+        budget.CompleteAckedPass(nowTicks);
+    }
 
     /// <summary>
     /// Establishes a per-request drain-rate sample of <paramref name="bytesPerSecond"/>.
@@ -89,6 +92,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.020));
             budget.OnAcked(1_000, snapshot, now);
+            budget.CompleteAckedPass(now);
         }
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(20_000).Within(10);
@@ -114,6 +118,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.020));
             budget.OnAcked(1_000, snapshot, now);
+            budget.CompleteAckedPass(now);
         }
         var reducedScale = budget.LatencyBudgetScale;
 
@@ -125,6 +130,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.005));
             budget.OnAcked(1_000, snapshot, now);
+            budget.CompleteAckedPass(now);
         }
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
@@ -374,6 +380,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.001) - Seconds(0.005), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
+        budget.CompleteAckedPass(T0 + Seconds(0.001));
 
         // The second sample's delivered-counter delta covers both deliveries: 2,000 bytes
         // over its own 5ms sojourn = 400,000 B/s aggregate drain, independent of the 1ms
@@ -622,6 +629,7 @@ public sealed class BrokerUnackedByteBudgetTests
             sendSnapshots[i] = budget.SnapshotDelivery(T0 + Seconds(i * 0.00001), appLimited: false);
         for (var i = 0; i < 5; i++)
             budget.OnAcked(1_000_000, sendSnapshots[i], T0 + Seconds(0.100 + i * 0.00001));
+        budget.CompleteAckedPass(T0 + Seconds(0.100 + 4 * 0.00001));
 
         // Each sample measures the cumulative delivered delta over its own ~100ms sojourn;
         // the last one reads the true aggregate drain of ~50 MB/s.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -91,8 +91,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 now - Seconds(0.001),
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.020));
-            budget.OnAcked(1_000, snapshot, now);
-            budget.CompleteAckedPass(now);
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(20_000).Within(10);
@@ -117,8 +116,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 now - Seconds(0.001),
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.020));
-            budget.OnAcked(1_000, snapshot, now);
-            budget.CompleteAckedPass(now);
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
         var reducedScale = budget.LatencyBudgetScale;
 
@@ -129,8 +127,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 now - Seconds(0.001),
                 appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.005));
-            budget.OnAcked(1_000, snapshot, now);
-            budget.CompleteAckedPass(now);
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -162,6 +162,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
             1_000,
             budget.SnapshotDelivery(ackTimestamp - Stopwatch.Frequency / 1_000, appLimited: true),
             ackTimestamp);
+        budget.CompleteAckedPass(ackTimestamp);
 
         await accumulator.ExpireLingerAsync(CancellationToken.None);
         var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();

--- a/tests/Dekaf.Tests.Unit/Producer/WaveCoalesceGateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/WaveCoalesceGateTests.cs
@@ -1,0 +1,100 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class WaveCoalesceGateTests
+{
+    [Test]
+    public async Task NewGate_AllowsSpinning()
+    {
+        var gate = new WaveCoalesceGate();
+
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+
+    [Test]
+    public async Task FruitlessSpins_BelowThreshold_KeepGateOpen()
+    {
+        var gate = new WaveCoalesceGate();
+
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold - 1; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+
+    [Test]
+    public async Task FruitlessSpins_AtThreshold_SuppressSpinning()
+    {
+        var gate = new WaveCoalesceGate();
+
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        await Assert.That(gate.ShouldSpin()).IsFalse();
+    }
+
+    [Test]
+    public async Task SuccessfulSpin_ResetsFruitlessCount()
+    {
+        var gate = new WaveCoalesceGate();
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold - 1; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        gate.OnSpinCompleted(coalescedAdditionalBatch: true);
+        gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+
+    [Test]
+    public async Task SuppressedGate_ReopensForProbe_AfterReprobeSendInterval()
+    {
+        var gate = new WaveCoalesceGate();
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval - 1; i++)
+            gate.OnSent();
+        await Assert.That(gate.ShouldSpin()).IsFalse();
+
+        gate.OnSent();
+
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+
+    [Test]
+    public async Task FruitlessProbe_ResuppressesForAnotherFullInterval()
+    {
+        var gate = new WaveCoalesceGate();
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval; i++)
+            gate.OnSent();
+
+        gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+
+        await Assert.That(gate.ShouldSpin()).IsFalse();
+        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval - 1; i++)
+            gate.OnSent();
+        await Assert.That(gate.ShouldSpin()).IsFalse();
+        gate.OnSent();
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+
+    [Test]
+    public async Task SuccessfulProbe_ReopensGateFully()
+    {
+        var gate = new WaveCoalesceGate();
+        for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval; i++)
+            gate.OnSent();
+
+        gate.OnSpinCompleted(coalescedAdditionalBatch: true);
+
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+        gate.OnSent();
+        await Assert.That(gate.ShouldSpin()).IsTrue();
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
@@ -35,6 +35,30 @@ public class BrokerUnackedByteBudgetBenchmarks
             _budget.OnAcked(ackedBytes: 1024 * 1024, snapshotAtSend, _timestamp);
         }
 
+        _budget.CompleteAckedPass(_timestamp);
+        return _budget.BudgetBytes;
+    }
+
+    /// <summary>
+    /// Models the production response-pass shape: a handful of acks drained per pass followed
+    /// by one budget publish, so the per-message cost of the publish shows up amortized.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public long RecordAcknowledgementPasses()
+    {
+        const int acksPerPass = 5;
+        for (var i = 0; i < Operations / acksPerPass; i++)
+        {
+            for (var j = 0; j < acksPerPass; j++)
+            {
+                var snapshotAtSend = _budget.SnapshotDelivery(_timestamp, appLimited: false);
+                _timestamp += RttTicks;
+                _budget.OnAcked(ackedBytes: 1024 * 1024, snapshotAtSend, _timestamp);
+            }
+
+            _budget.CompleteAckedPass(_timestamp);
+        }
+
         return _budget.BudgetBytes;
     }
 }


### PR DESCRIPTION
Fixes #1990.

## Problem

Two hot-path costs from the 07-13 pipeline work eroded Dekaf's CPU-per-message lead over Confluent (3-broker paired ratio 0.55-0.65x → 0.85-1.05x; fire-and-forget 3b now 2.21 vs 2.10 μs/msg in run 29237954294):

1. **Wave-coalesce spin re-armed after every send** (ae996d6f): on workloads whose requests are effectively single-partition — 99.99% of stress-run requests coalesce at width 1 — every wave burns up to a full 1ms quiet window in `Thread.SpinWait` + `Stopwatch.GetTimestamp()` polling, per broker send loop (~0.3 cores/broker at stress request rates).
2. **Per-acked-request budget recompute** (888b4ef1): `OnAcked` ran the full `RecomputeBudget` (2-3x `ComputeBudget`), the interlocked occupancy-peak drain, and every derived-field publish once per acked request; a hot-poll pass at the in-flight ceiling drains many requests, multiplying that cost by pass depth × broker count.

## Fix

1. **`WaveCoalesceGate`** (new struct): after 8 consecutive fruitless spins the spin is suppressed, with a probe spin every 64 sends so coalescible workloads re-open the gate within one interval. Fruitful spins keep the gate open, preserving the #1972 coalescing wins — the gate keys on the actual coalesce outcome, which static partition-count conditions cannot capture (many partitions + serial batch arrival should not spin; many partitions + co-temporal arrival should).
2. **`OnAcked` / `CompleteAckedPass` split**: `OnAcked` keeps the cheap per-request BBR rate/RTT/latency sampling; the new `CompleteAckedPass`, called once per response pass from `ProcessCompletedResponses` with the last acknowledgement's timestamp, drains the occupancy peak and republishes the budget. The admission gate only reads the budget between passes, so per-request publishing bought no precision.

## Numbers

`BrokerUnackedByteBudgetBenchmarks` (same machine, 0 B allocated):

| | main | this PR |
|---|---|---|
| per acked request | 15.5 ns | 7.9 ns (estimator feed) |
| amortized incl. per-pass publish (5-ack passes) | — | 9.6 ns |

Unit suite: 5359/5359 pass. New `WaveCoalesceGateTests` cover suppress/reprobe/reopen transitions.

## Validation gate (from #1990)

Paired stress run with CPU/msg ratio back ≤ 0.7x Confluent in 1b and 3b FnF/idempotent without losing the #1972 throughput gains — please eyeball the next scheduled stress run's CPU columns and the `coalesceWidthHistogram` before/after.