### PR TITLE
ci(stress): warn on Confluent regressions

### DIFF
--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -202,6 +202,7 @@ def evaluate_and_update(history, current_results, run_started_at):
         observation["consumerConnectionsPerBroker"] = _consumer_connections_per_broker(result)
         observation["brokerCount"] = result.get("brokerCount", 1)
         observation["roundTripMessages"] = _roundtrip_messages(result)
+        is_dekaf = str(result.get("client", "")).casefold().startswith("dekaf")
         throughput_regression = False
 
         for metric, definition in _METRICS.items():
@@ -234,6 +235,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                 "upper": None,
                 "status": "insufficient-history",
                 "repeatedRegression": False,
+                "failureEligible": False,
             }
 
             if len(history_values) >= MIN_BASELINE_RUNS:
@@ -243,6 +245,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                     definition["lower_is_regression"],
                 )
                 repeated = status == "regression" and previous_trend == "regression"
+                failure_eligible = repeated and is_dekaf
                 evaluation.update({
                     "median": center,
                     "mad": mad,
@@ -250,8 +253,9 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "upper": upper,
                     "status": status,
                     "repeatedRegression": repeated,
+                    "failureEligible": failure_eligible,
                 })
-                should_fail = should_fail or repeated
+                should_fail = should_fail or failure_eligible
 
             observation[metric] = value
             observation[f"{metric}Trend"] = evaluation["status"]
@@ -262,8 +266,6 @@ def evaluate_and_update(history, current_results, run_started_at):
         intra_run = intra_run_throughput(result)
         if intra_run is not None:
             slope_breached = intra_run["slopeThresholdBreached"]
-            client = str(result.get("client", "")).casefold()
-            is_confluent = client.startswith("confluent")
             threshold_metrics = (
                 (
                     "steadyStatePeakRatio",
@@ -301,7 +303,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                     else slope_breached or throughput_regression
                 )
                 failure_eligible = (
-                    breached and repeated and corroborated and not is_confluent
+                    breached and repeated and corroborated and is_dekaf
                 )
                 evaluations.append({
                     "scenario": _scenario_label(result),
@@ -350,12 +352,12 @@ def format_markdown(evaluations):
             f"Current metrics are compared with up to {HISTORY_LIMIT} matching runs. "
             f"The noise band is trailing median ± max({MAD_MULTIPLIER:g}×MAD, "
             f"{RELATIVE_NOISE_FLOOR:.0%} of median); "
-            "a second consecutive adverse excursion fails the job."
+            "a second consecutive adverse Dekaf excursion fails the job."
         ),
         (
             "Intra-run breaches warn first; repeated Dekaf breaches fail only when "
             "corroborated by negative slope or baseline throughput regression. "
-            "Confluent intra-run breaches remain warnings."
+            "Confluent regressions remain warnings."
         ),
         "",
         "| Scenario | Metric | Current | Baseline median | Band | Status |",
@@ -394,7 +396,11 @@ def format_markdown(evaluations):
             else:
                 status = "Threshold breach (warning)"
         elif item["repeatedRegression"]:
-            status = "Repeated regression (fail)"
+            status = (
+                "Repeated regression (fail)"
+                if item.get("failureEligible", True)
+                else "Repeated regression (warning)"
+            )
         elif item["status"] == "regression":
             status = "Regression (warning)"
 

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -272,6 +272,35 @@ class StressTrendTests(unittest.TestCase):
         repeated = {item["metric"] for item in evaluations if item["repeatedRegression"]}
         self.assertEqual({"messagesPerSecond", "cpuMicrosPerMessage"}, repeated)
 
+    def test_confluent_consecutive_regressions_warn_but_never_fail(self):
+        runs = [history_run(i, client="Confluent") for i in range(1, 4)]
+        runs.append(history_run(
+            4,
+            client="Confluent",
+            messages_per_second=700.0,
+            cpu_micros_per_message=3.0,
+            messagesPerSecondTrend="regression",
+            cpuMicrosPerMessageTrend="regression",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(
+                client="Confluent",
+                messages_per_second=650.0,
+                cpu_micros_per_message=3.2,
+            )],
+            "2026-07-01T02:00:00Z",
+        )
+
+        self.assertFalse(should_fail)
+        repeated = [item for item in evaluations if item["repeatedRegression"]]
+        self.assertEqual(2, len(repeated))
+        self.assertTrue(all(not item["failureEligible"] for item in repeated))
+        markdown = format_markdown(repeated)
+        self.assertIn("Repeated regression (warning)", markdown)
+        self.assertNotIn("Repeated regression (fail)", markdown)
+
     def test_warned_run_does_not_widen_next_baseline(self):
         runs = [
             history_run(1, messages_per_second=950.0),


### PR DESCRIPTION
## What changed

- make repeated historical throughput and CPU regressions failure-eligible only for Dekaf results
- keep Confluent regressions in trend history and report them as warnings
- align intra-run eligibility with same Dekaf-only policy
- add regression coverage for consecutive Confluent throughput and CPU regressions

## Why

Confluent.Kafka is comparison baseline. Its performance degradation should not fail Dekaf stress regression gate. Dekaf performance regressions and Dekaf-to-Confluent latency thresholds remain gating; correctness failures still invalidate stress run.

## Validation

- `python -m unittest discover -s .github/scripts -p 'test_stress_*.py' -v` (42 passed)
- `git diff --check`