### PR TITLE
perf(producer): make latency target a cap

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1066,7 +1066,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
-        var waveCoalesceBounds = SelectWaveCoalesceBounds(_options.LingerMs);
+        var waveCoalesceBounds = SelectWaveCoalesceBounds(
+            _options.LingerMs,
+            _options.DeliveryLatencyTargetMs);
         var waveCoalesceMaxTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.MaximumMicroseconds);
         var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.QuietMicroseconds);
         var waveCoalesceArmed = true;
@@ -2231,9 +2233,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(
-        int lingerMs) => lingerMs == 0
+        int lingerMs,
+        int deliveryLatencyTargetMs)
+    {
+        (int QuietMicroseconds, int MaximumMicroseconds) bounds = lingerMs == 0
             ? (ZeroLingerWaveCoalesceQuietMicroseconds, ZeroLingerWaveCoalesceMaxMicroseconds)
             : (WaveCoalesceQuietMicroseconds, WaveCoalesceMaxMicroseconds);
+        if (deliveryLatencyTargetMs <= 0)
+            return bounds;
+
+        var targetMicroseconds = (long)deliveryLatencyTargetMs * 1_000;
+        var quietCap = Math.Max(1, targetMicroseconds / 20);
+        var maximumCap = Math.Max(quietCap, targetMicroseconds / 10);
+        return (
+            (int)Math.Min(bounds.QuietMicroseconds, quietCap),
+            (int)Math.Min(bounds.MaximumMicroseconds, maximumCap));
+    }
 
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
         Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2253,6 +2253,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
         Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);
 
+    internal static long GetOldestBatchSealTimestamp(ReadyBatch[] batches, int count)
+    {
+        var oldestBatchTimestamp = long.MaxValue;
+        for (var i = 0; i < count; i++)
+            oldestBatchTimestamp = Math.Min(oldestBatchTimestamp, batches[i].StopwatchSealedTicks);
+
+        return oldestBatchTimestamp == long.MaxValue ? 0 : oldestBatchTimestamp;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool CarryOverIfCoalescedLimitReached(
         BatchReference batchRef,
@@ -3512,11 +3521,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // RTT samples and disabled the budget's RTT safety floor. Including TCP write
                 // time biases individual RTT samples high, which the budget's minimum filter
                 // discards.
-                var oldestBatchTimestamp = long.MaxValue;
-                for (var i = 0; i < count; i++)
-                    oldestBatchTimestamp = Math.Min(oldestBatchTimestamp, batches[i].StopwatchCreatedTicks);
-                if (oldestBatchTimestamp == long.MaxValue)
-                    oldestBatchTimestamp = 0;
+                var oldestBatchTimestamp = GetOldestBatchSealTimestamp(batches, count);
 
                 var deliverySnapshotAtSend = _unackedBudget?.SnapshotDelivery(
                     Stopwatch.GetTimestamp(),

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -68,16 +68,6 @@ internal sealed class BrokerUnackedByteBudget
     private const double MaximumLatencyAdjustmentFactor = 1.05;
 
     /// <summary>
-    /// Bounds the occupancy floor to this multiple of the rate-derived budget once a drain
-    /// estimate exists. Occupancy is itself admission-bounded by the budget, so an uncapped
-    /// <c>1.5 × occupancy</c> floor is a positive feedback loop that ratchets the budget to
-    /// its cap. With the bound, the iteration's fixed point is this multiple of the rate
-    /// budget (1.5 × target = 15 ms standing latency at the 10 ms default) instead of the cap.
-    /// Genuine wire demand beyond the estimate recovers via capacity probes within 8 RTTs.
-    /// </summary>
-    private const double OccupancyFloorHeadroom = 1.5;
-
-    /// <summary>
     /// Log2 histogram buckets for per-request diagnostics. Request sizes shift by
     /// <see cref="RequestSizeHistogramShift"/> (bucket 0 = under 512 B, bucket 15 = 8 MB and
     /// above); RTT buckets are unshifted microseconds (bucket 0 = under 2 µs, bucket 15 =
@@ -164,6 +154,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _deliveryLatencyEwmaSeconds;
     private double _latencyBudgetScale = 1.0;
     private long _nextLatencyControlTimestamp;
+    private long _lastLatencyControlAdmissionBlockEvents;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
     {
@@ -198,6 +189,8 @@ internal sealed class BrokerUnackedByteBudget
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
 
+    /// <summary>EWMA of controllable seal-to-send queue latency. The diagnostic property
+    /// retains its original name for compatibility.</summary>
     internal long DeliveryLatencyEwmaMicros =>
         (long)(Volatile.Read(ref _deliveryLatencyEwmaSeconds) * 1_000_000);
 
@@ -372,7 +365,10 @@ internal sealed class BrokerUnackedByteBudget
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
         UpdateMinRtt(rttSeconds, nowTicks);
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
-        UpdateDeliveryLatency(sendSnapshot.OldestBatchTimestamp, nowTicks);
+        UpdateDeliveryLatency(
+            sendSnapshot.OldestBatchTimestamp,
+            sendSnapshot.SendTimestamp,
+            nowTicks);
 
         RecordRequestHistograms(ackedBytes, rttSeconds);
 
@@ -419,12 +415,18 @@ internal sealed class BrokerUnackedByteBudget
         RecomputeBudget();
     }
 
-    private void UpdateDeliveryLatency(long oldestBatchTimestamp, long nowTicks)
+    private void UpdateDeliveryLatency(
+        long oldestBatchTimestamp,
+        long sendTimestamp,
+        long nowTicks)
     {
-        if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= nowTicks)
+        if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= sendTimestamp)
             return;
 
-        var sampleSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
+        // Only producer-controlled queueing belongs in the controller. Broker RTT, linger
+        // before sealing, and response scheduling cannot be reduced by shrinking admission;
+        // including them made the target an equilibrium setpoint and suppressed fan-out.
+        var sampleSeconds = (double)(sendTimestamp - oldestBatchTimestamp) / Stopwatch.Frequency;
         var latencyEstimate = _deliveryLatencyEwmaSeconds == 0
             ? sampleSeconds
             : _deliveryLatencyEwmaSeconds
@@ -434,16 +436,26 @@ internal sealed class BrokerUnackedByteBudget
         if (_nextLatencyControlTimestamp == 0)
         {
             _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
+            _lastLatencyControlAdmissionBlockEvents = AdmissionBlockEvents;
             return;
         }
 
         if (nowTicks < _nextLatencyControlTimestamp)
             return;
 
+        var admissionBlockEvents = AdmissionBlockEvents;
+        var admissionWasBlocked = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
+        _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
+
         var targetRatio = _targetSeconds / latencyEstimate;
-        var adjustment = targetRatio < 1
-            ? Math.Max(MinimumLatencyAdjustmentFactor, targetRatio)
-            : Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
+        double adjustment;
+        if (targetRatio < 1)
+            adjustment = Math.Max(MinimumLatencyAdjustmentFactor, targetRatio);
+        else if (admissionWasBlocked)
+            adjustment = Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
+        else
+            adjustment = 1.0;
+
         Volatile.Write(ref _latencyBudgetScale, Math.Clamp(
             _latencyBudgetScale * adjustment,
             MinimumLatencyBudgetScale,
@@ -753,7 +765,7 @@ internal sealed class BrokerUnackedByteBudget
                 // occupancy proxy may exceed the rate budget by a bounded headroom only —
                 // otherwise occupancy (itself admission-bounded by the budget) ratchets the
                 // budget to its cap and the latency target is never enforced.
-                occupancyFloor = Math.Min(occupancyFloor, (long)(OccupancyFloorHeadroom * rateBudgetBytes));
+                occupancyFloor = Math.Min(occupancyFloor, (long)rateBudgetBytes);
             }
 
             budget = Math.Max(budget, occupancyFloor);

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -286,6 +286,8 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
     public required long AdmissionBlockCount { get; init; }
+    /// <summary>Controllable seal-to-send queue-latency EWMA. Name retained for diagnostic
+    /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }
     public required double LatencyBudgetScale { get; init; }
 

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -139,7 +139,8 @@ public sealed class ProducerOptions
     internal bool IsAutoTuned { get; init; }
 
     /// <summary>
-    /// Soft target, in milliseconds, for per-broker producer queueing latency (append to ack).
+    /// Soft target, in milliseconds, for controllable per-broker producer queueing latency
+    /// (batch seal to socket send). Configured linger and broker round-trip time are excluded.
     /// Bounds the bytes each broker may hold unacknowledged to
     /// <c>target × measured ack throughput</c>, with a measured round-trip lower guard so
     /// throughput is never window-limited. When a broker exceeds its budget, message admission

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -6365,7 +6365,8 @@ internal sealed class PartitionBatch
                 _callbacks,
                 _callbackCount,
                 _arrayReuseQueue,
-                _recordCount);
+                _recordCount,
+                _createdStopwatchTimestamp);
 
             _completedBatch = readyBatch;
 
@@ -6979,14 +6980,20 @@ internal sealed class ReadyBatch
     internal long RetryNotBefore { get; set; }
 
     /// <summary>
-    /// Stopwatch timestamp when this batch was initialized. Used for absolute delivery deadline
-    /// computation in ProcessCompletedResponses (prevents infinite retries with relative deadlines).
+    /// Stopwatch timestamp when the accumulator batch was created. Used for absolute delivery
+    /// deadline computation in ProcessCompletedResponses (prevents infinite retries with relative
+    /// deadlines and includes configured linger time).
     /// </summary>
     internal long StopwatchCreatedTicks { get; private set; }
 
     /// <summary>
-    /// Age of this batch in milliseconds since creation (or since last reenqueue).
-    /// Used by Ready() to determine if linger time has expired.
+    /// Stopwatch timestamp when the accumulator batch was sealed into this ready batch. Producer
+    /// queue-latency control starts here so configured linger is not mistaken for admission delay.
+    /// </summary>
+    internal long StopwatchSealedTicks { get; private set; }
+
+    /// <summary>
+    /// Age of this ready batch in milliseconds since sealing (or since last reenqueue).
     /// </summary>
     internal int AgeMs => (int)((Stopwatch.GetTimestamp() - _createdTimestamp) * 1000 / Stopwatch.Frequency);
     private long _createdTimestamp;
@@ -7127,7 +7134,8 @@ internal sealed class ReadyBatch
         Action<RecordMetadata, Exception?>?[]? callbacks = null,
         int callbackCount = 0,
         BatchArrayReuseQueue? arrayReuseQueue = null,
-        int recordCount = 0)
+        int recordCount = 0,
+        long createdStopwatchTimestamp = 0)
     {
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
@@ -7168,8 +7176,11 @@ internal sealed class ReadyBatch
         _callbacks = callbacks;
         _callbackCount = callbackCount;
         _arrayReuseQueue = arrayReuseQueue;
-        StopwatchCreatedTicks = Stopwatch.GetTimestamp();
-        _createdTimestamp = StopwatchCreatedTicks;
+        StopwatchSealedTicks = Stopwatch.GetTimestamp();
+        StopwatchCreatedTicks = createdStopwatchTimestamp > 0
+            ? createdStopwatchTimestamp
+            : StopwatchSealedTicks;
+        _createdTimestamp = StopwatchSealedTicks;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4472,10 +4472,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var cap = _options.UnackedByteBudgetCapOverride
             ?? BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, _options.ConnectionsPerBroker);
-        // Floor keeps the pipe full (≥ 2 batches, ≥ 1MiB BDP headroom) but must not exceed a
-        // deliberately tiny test cap, or the gate could never bind in unit tests.
-        var floor = Math.Min(Math.Max(2L * Math.Max(1, _options.BatchSize), 1L << 20), cap);
-        return new BrokerUnackedByteBudget(_options.DeliveryLatencyTargetMs / 1000.0, floor, cap);
+        // Cold start uses the cap. After the first drain sample, target × rate and the
+        // minimum-RTT BDP guard provide time-derived floors; a fixed batch-byte floor makes
+        // standing latency grow as per-broker drain rate falls under fan-out.
+        return new BrokerUnackedByteBudget(
+            _options.DeliveryLatencyTargetMs / 1000.0,
+            floorBytes: 1,
+            initialCapBytes: cap);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -27,6 +27,50 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerSenderSendLoopTests
 {
+    [Test]
+    public async Task DeliveryLatencyTimestamp_HighThroughputLinger_UsesSealNotCreation()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            LingerMs = 100,
+            DeliveryLatencyTargetMs = 10
+        };
+        var partitionBatch = new PartitionBatch(new TopicPartition("test-topic", 0), options);
+        var simulatedCreationTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency / 10;
+        typeof(PartitionBatch)
+            .GetField("_createdStopwatchTimestamp", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(partitionBatch, simulatedCreationTimestamp);
+        var appendResult = partitionBatch.TryAppendFromSpans(
+            timestamp: 0,
+            keyData: ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            valueData: [1],
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            estimatedSize: 1);
+        var readyBatch = partitionBatch.Complete()!;
+
+        try
+        {
+            var deliveryTimestamp = BrokerSender.GetOldestBatchSealTimestamp([readyBatch], 1);
+
+            await Assert.That(appendResult.Success).IsTrue();
+            await Assert.That(readyBatch.StopwatchCreatedTicks).IsEqualTo(simulatedCreationTimestamp);
+            await Assert.That(deliveryTimestamp).IsEqualTo(readyBatch.StopwatchSealedTicks);
+            await Assert.That(deliveryTimestamp - readyBatch.StopwatchCreatedTicks)
+                .IsGreaterThanOrEqualTo(Stopwatch.Frequency / 20);
+        }
+        finally
+        {
+            readyBatch.TrySetMemoryReleased();
+            readyBatch.Fail(new InvalidOperationException("test cleanup"));
+        }
+    }
+
     private sealed class TrackingPipelinedResponseSource : IPipelinedResponseSource<ProduceResponse>
     {
         public int AbandonCalls;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -130,13 +130,18 @@ public sealed class BrokerSenderSendLoopTests
     [Test]
     public async Task SelectWaveCoalesceBounds_ZeroLingerRetainsLowLatencyBounds()
     {
-        var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);
-        var configuredLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 5);
+        var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0, deliveryLatencyTargetMs: 10);
+        var configuredLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 5, deliveryLatencyTargetMs: 10);
+        var oneMillisecondTarget = BrokerSender.SelectWaveCoalesceBounds(
+            lingerMs: 5,
+            deliveryLatencyTargetMs: 1);
 
         await Assert.That(zeroLinger.QuietMicroseconds).IsEqualTo(75);
         await Assert.That(zeroLinger.MaximumMicroseconds).IsEqualTo(500);
-        await Assert.That(configuredLinger.QuietMicroseconds).IsEqualTo(1_000);
-        await Assert.That(configuredLinger.MaximumMicroseconds).IsEqualTo(2_000);
+        await Assert.That(configuredLinger.QuietMicroseconds).IsEqualTo(500);
+        await Assert.That(configuredLinger.MaximumMicroseconds).IsEqualTo(1_000);
+        await Assert.That(oneMillisecondTarget.QuietMicroseconds).IsEqualTo(50);
+        await Assert.That(oneMillisecondTarget.MaximumMicroseconds).IsEqualTo(100);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -94,13 +94,58 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
 
-        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(20_000).Within(10);
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(19_000).Within(10);
         await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.25);
         await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
     }
 
     [Test]
-    public async Task DeliveryLatencyBelowTarget_RecoversReducedBudget()
+    public async Task DeliveryLatencyBelowTarget_DoesNotGrowBudgetWithoutAdmissionPressure()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.020));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+        for (var i = 0; i < 30; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.005));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+        var scaleAfterLatencySettledBelowTarget = budget.LatencyBudgetScale;
+
+        for (var i = 0; i < 20; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.005));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
+        await Assert.That(budget.LatencyBudgetScale)
+            .IsEqualTo(scaleAfterLatencySettledBelowTarget).Within(0.000_001);
+    }
+
+    [Test]
+    public async Task DeliveryLatencyBelowTarget_RecoversReducedBudgetWhenAdmissionBlocked()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -123,6 +168,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i < 30; i++)
         {
             now += Seconds(0.110);
+            budget.RecordAdmissionBlock();
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
@@ -133,6 +179,24 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
         await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(reducedScale);
         await Assert.That(budget.BudgetBytes).IsGreaterThan(2_500);
+    }
+
+    [Test]
+    public async Task DeliveryLatencySample_UsesSealToSendQueueDelay_NotBrokerRoundTrip()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var now = T0;
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.015),
+            appLimited: true,
+            oldestBatchTimestamp: now - Seconds(0.020));
+
+        Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(5_000).Within(10);
     }
 
     [Test]
@@ -559,10 +623,9 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 100, 0.100, T0 + Seconds(0.101));
 
         // Rate budget = 1,000 B/s × max(10ms, 1.5 × 100ms) = 150 bytes. The demonstrated
-        // 20,000-byte occupancy grants headroom above that, but only up to 1.5 × the rate
-        // budget — occupancy is admission-bounded by the budget itself, so an uncapped
-        // floor would ratchet the budget to its cap (#1941).
-        await Assert.That(budget.BudgetBytes).IsEqualTo(225);
+        // Occupancy is admission-bounded by the budget itself. It must never inflate the
+        // latency-governed rate budget; the configured 200-byte minimum wins here.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
 
     [Test]
@@ -579,7 +642,7 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.ObserveWrittenUnackedBytes(20_000);
         Ack(budget, 100, 0.100, T0 + Seconds(0.101));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(225);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
 
     [Test]
@@ -609,8 +672,8 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 100, 0.001, T0 + Seconds(i * 0.100));
         }
 
-        // Fixed point is 1.5 × the rate budget, not the 1,000,000-byte cap.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        // Fixed point is the rate budget, not a multiple of it or the 1,000,000-byte cap.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -186,6 +186,25 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
+    public async Task BrokerBudgetFloor_UsesMeasuredTimeBudget_NotFixedBatchBytes()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(deliveryLatencyTargetMs: 10),
+            resolveLeaderId: static (_, _) => 7);
+        var budget = accumulator.GetBrokerUnackedBudget(7)!;
+        var now = Stopwatch.GetTimestamp();
+
+        budget.OnAcked(
+            100,
+            budget.SnapshotDelivery(now - Stopwatch.Frequency / 1_000, appLimited: true),
+            now);
+        budget.CompleteAckedPass(now);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000)
+            .Because("100 kB/s at a 10 ms target needs a 1 kB time-derived budget");
+    }
+
+    [Test]
     public async Task BrokerBudgetDiagnostics_RollingWindowKeepsNewest4096Samples()
     {
         var options = CreateOptions(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerUnackedByteBudgetBenchmarks.cs
@@ -20,7 +20,7 @@ public class BrokerUnackedByteBudgetBenchmarks
     {
         _budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
-            floorBytes: 2 * 1024 * 1024,
+            floorBytes: 1,
             initialCapBytes: 32 * 1024 * 1024);
         _timestamp = Stopwatch.GetTimestamp();
     }
@@ -30,7 +30,10 @@ public class BrokerUnackedByteBudgetBenchmarks
     {
         for (var i = 0; i < Operations; i++)
         {
-            var snapshotAtSend = _budget.SnapshotDelivery(_timestamp, appLimited: false);
+            var snapshotAtSend = _budget.SnapshotDelivery(
+                _timestamp,
+                appLimited: false,
+                oldestBatchTimestamp: _timestamp - RttTicks);
             _timestamp += RttTicks;
             _budget.OnAcked(ackedBytes: 1024 * 1024, snapshotAtSend, _timestamp);
         }
@@ -51,7 +54,10 @@ public class BrokerUnackedByteBudgetBenchmarks
         {
             for (var j = 0; j < acksPerPass; j++)
             {
-                var snapshotAtSend = _budget.SnapshotDelivery(_timestamp, appLimited: false);
+                var snapshotAtSend = _budget.SnapshotDelivery(
+                    _timestamp,
+                    appLimited: false,
+                    oldestBatchTimestamp: _timestamp - RttTicks);
                 _timestamp += RttTicks;
                 _budget.OnAcked(ackedBytes: 1024 * 1024, snapshotAtSend, _timestamp);
             }


### PR DESCRIPTION
## Summary
- make latency-budget growth one-sided and require observed admission pressure
- control seal-to-send queue latency instead of broker RTT, using rate/RTT-derived floors
- cap wave-coalesce quiet/max waits to 5%/10% of the delivery-latency target
- cover controller, floor, coalescing, and diagnostic behavior; update hot-path benchmark inputs

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe` (5,362 passed)
- [x] `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- [x] `tests/Dekaf.Tests.Integration/bin/Release/net10.0/Dekaf.Tests.Integration.exe --treenode-filter /*/*/ProducerTests/*` (27 passed)
- [x] `dotnet run --project tools/Dekaf.Benchmarks --configuration Release -- --filter *BrokerUnackedByteBudgetBenchmarks*` (9.39 ns ack, 10.65 ns/pass, zero allocations)

Closes #1988
