### PR TITLE
Corroborate stress regressions with Confluent control

### DIFF
--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -132,10 +132,13 @@ def _matching_control_ratios(runs, result, metric):
     ratios = []
 
     for run in runs:
+        if run.get("environmentShiftSuspected", False):
+            continue
         matching_results = [
             item
             for item in run.get("results", [])
             if _pair_identity(item) == pair_key
+            and not item.get("environmentShiftSuspected", False)
         ]
         candidate = next(
             (item for item in matching_results if _identity(item) == candidate_key),

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -92,6 +92,26 @@ def _identity(result):
     )
 
 
+def _is_confluent(result):
+    return str(result.get("client", "")).casefold().startswith("confluent")
+
+
+def _pair_identity(result):
+    """Match a Dekaf scenario to its same-run Confluent control.
+
+    Client and consumer connection count are intentionally excluded: each client uses its
+    own connection preset, while broker count and workload shape define the paired run.
+    """
+    return (
+        str(result.get("scenario", "unknown")).casefold(),
+        result.get("brokerCount", 1),
+        result.get("durationMinutes"),
+        result.get("messageSizeBytes"),
+        _consumer_seed_batch_size(result),
+        _roundtrip_messages(result),
+    )
+
+
 def _matching_observations(runs, result):
     key = _identity(result)
     matches = []
@@ -103,6 +123,41 @@ def _matching_observations(runs, result):
         if observation is not None:
             matches.append(observation)
     return matches
+
+
+def _matching_control_ratios(runs, result, metric):
+    pair_key = _pair_identity(result)
+    candidate_key = _identity(result)
+    trend_field = f"{metric}ControlRatioTrend"
+    ratios = []
+
+    for run in runs:
+        matching_results = [
+            item
+            for item in run.get("results", [])
+            if _pair_identity(item) == pair_key
+        ]
+        candidate = next(
+            (item for item in matching_results if _identity(item) == candidate_key),
+            None,
+        )
+        control = next((item for item in matching_results if _is_confluent(item)), None)
+        if candidate is None or control is None:
+            continue
+
+        candidate_value = candidate.get(metric)
+        control_value = control.get(metric)
+        if (
+            not _finite_number(candidate_value)
+            or not _finite_number(control_value)
+            or control_value == 0
+            or candidate.get(trend_field) == "regression"
+        ):
+            continue
+
+        ratios.append(candidate_value / control_value)
+
+    return ratios[-HISTORY_LIMIT:]
 
 
 def _limit_observations_per_identity(runs):
@@ -124,6 +179,7 @@ def _limit_observations_per_identity(runs):
                 if (
                     _finite_number(observation.get(metric))
                     and observation.get(f"{metric}Trend") != "regression"
+                    and not observation.get("environmentShiftSuspected", False)
                     and retained_baseline_counts.get(baseline_key, 0) < HISTORY_LIMIT
                 ):
                     baseline_keys.append(baseline_key)
@@ -179,6 +235,42 @@ def _metric_status(value, baseline, lower_is_regression):
     return status, baseline_median, mad, lower, upper
 
 
+def _control_ratio_evaluation(baseline_runs, result, metric, definition, value, control_value):
+    ratio = value / control_value
+    ratio_history = _matching_control_ratios(baseline_runs, result, metric)
+    evaluation = {
+        "scenario": _scenario_label(result),
+        "metric": f"{metric}ControlRatio",
+        "metricLabel": f"{definition['label']} / Confluent",
+        "current": ratio,
+        "baselineCount": len(ratio_history),
+        "median": None,
+        "mad": None,
+        "lower": None,
+        "upper": None,
+        "status": "insufficient-history",
+        "repeatedRegression": False,
+        "failureEligible": False,
+        "corroboratesBaselineRegression": False,
+    }
+    if len(ratio_history) < MIN_BASELINE_RUNS:
+        return evaluation
+
+    status, center, mad, lower, upper = _metric_status(
+        ratio,
+        ratio_history,
+        definition["lower_is_regression"],
+    )
+    evaluation.update({
+        "median": center,
+        "mad": mad,
+        "lower": lower,
+        "upper": upper,
+        "status": status,
+    })
+    return evaluation
+
+
 def evaluate_and_update(history, current_results, run_started_at):
     """Evaluate current results, append one compact run, and return failure state."""
     if history is not None and history.get("version") != HISTORY_VERSION:
@@ -194,8 +286,15 @@ def evaluate_and_update(history, current_results, run_started_at):
     evaluations = []
     observations = []
     should_fail = False
+    environment_shift_suspected = False
+    controls = {
+        _pair_identity(result): result
+        for result in current_results
+        if _is_confluent(result)
+    }
 
     for result in current_results:
+        is_confluent = _is_confluent(result)
         prior = _matching_observations(baseline_runs, result)
         observation = {field: result.get(field) for field in _IDENTITY_FIELDS}
         observation["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
@@ -217,6 +316,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                 item.get(metric)
                 for item in prior
                 if item.get(trend_field) != "regression"
+                and not item.get("environmentShiftSuspected", False)
             ]
             history_values = [
                 item for item in history_values if _finite_number(item)
@@ -234,6 +334,8 @@ def evaluate_and_update(history, current_results, run_started_at):
                 "upper": None,
                 "status": "insufficient-history",
                 "repeatedRegression": False,
+                "failureEligible": False,
+                "corroborated": None,
             }
 
             if len(history_values) >= MIN_BASELINE_RUNS:
@@ -251,19 +353,49 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "status": status,
                     "repeatedRegression": repeated,
                 })
-                should_fail = should_fail or repeated
 
             observation[metric] = value
             observation[f"{metric}Trend"] = evaluation["status"]
+
+            ratio_evaluation = None
+            control = controls.get(_pair_identity(result)) if not is_confluent else None
+            control_value = definition["extract"](control) if control is not None else None
+            if _finite_number(control_value) and control_value != 0:
+                ratio_evaluation = _control_ratio_evaluation(
+                    baseline_runs,
+                    result,
+                    metric,
+                    definition,
+                    value,
+                    control_value,
+                )
+                ratio_metric = ratio_evaluation["metric"]
+                observation[ratio_metric] = ratio_evaluation["current"]
+                observation[f"{ratio_metric}Trend"] = ratio_evaluation["status"]
+                evaluation["corroborated"] = ratio_evaluation["status"] == "regression"
+                evaluation["failureEligible"] = (
+                    evaluation["repeatedRegression"] and evaluation["corroborated"]
+                )
+                ratio_evaluation["corroboratesBaselineRegression"] = evaluation[
+                    "failureEligible"
+                ]
+            elif not is_confluent:
+                evaluation["failureEligible"] = evaluation["repeatedRegression"]
+
+            if is_confluent and evaluation["status"] == "regression":
+                environment_shift_suspected = True
+                evaluation["environmentShiftSuspected"] = True
+
             evaluations.append(evaluation)
+            if ratio_evaluation is not None:
+                evaluations.append(ratio_evaluation)
+            should_fail = should_fail or evaluation["failureEligible"]
             if metric == "messagesPerSecond":
                 throughput_regression = evaluation["status"] == "regression"
 
         intra_run = intra_run_throughput(result)
         if intra_run is not None:
             slope_breached = intra_run["slopeThresholdBreached"]
-            client = str(result.get("client", "")).casefold()
-            is_confluent = client.startswith("confluent")
             threshold_metrics = (
                 (
                     "steadyStatePeakRatio",
@@ -325,16 +457,23 @@ def evaluate_and_update(history, current_results, run_started_at):
 
         observations.append(observation)
 
+    if environment_shift_suspected:
+        for observation in observations:
+            observation["environmentShiftSuspected"] = True
+
     latency_evaluations = paired_latency_thresholds(current_results)
     evaluations.extend(latency_evaluations)
     should_fail = should_fail or any(
         item['thresholdBreach'] for item in latency_evaluations
     )
 
-    updated_runs = baseline_runs + [{
+    current_run = {
         "runStartedAtUtc": run_started_at,
         "results": observations,
-    }]
+    }
+    if environment_shift_suspected:
+        current_run["environmentShiftSuspected"] = True
+    updated_runs = baseline_runs + [current_run]
     updated = {
         "version": HISTORY_VERSION,
         "runs": _limit_observations_per_identity(updated_runs),
@@ -347,20 +486,31 @@ def format_markdown(evaluations):
         "## Stress Trend Analysis",
         "",
         (
-            f"Current metrics are compared with up to {HISTORY_LIMIT} matching runs. "
+            f"Current metrics and paired Dekaf/Confluent ratios are compared with up to "
+            f"{HISTORY_LIMIT} matching runs. "
             f"The noise band is trailing median ± max({MAD_MULTIPLIER:g}×MAD, "
             f"{RELATIVE_NOISE_FLOOR:.0%} of median); "
-            "a second consecutive adverse excursion fails the job."
+            "a second consecutive adverse excursion becomes a failure candidate."
         ),
         (
-            "Intra-run breaches warn first; repeated Dekaf breaches fail only when "
-            "corroborated by negative slope or baseline throughput regression. "
-            "Confluent intra-run breaches remain warnings."
+            "Paired Dekaf baseline regressions fail only when the same-run ratio also "
+            "regresses; unpaired scenarios retain the consecutive-regression gate. "
+            "Confluent regressions remain environment warnings."
         ),
+    ]
+
+    if any(item.get("environmentShiftSuspected") for item in evaluations):
+        lines.extend([
+            "",
+            "> Environment shift suspected: Confluent control regressed beyond its trailing band; "
+            "this run is excluded from absolute baselines.",
+        ])
+
+    lines.extend([
         "",
         "| Scenario | Metric | Current | Baseline median | Band | Status |",
         "|----------|--------|--------:|----------------:|------|--------|",
-    ]
+    ])
 
     labels = {
         "insufficient-history": "Collecting baseline",
@@ -393,8 +543,17 @@ def format_markdown(evaluations):
                 status = "Threshold breach (uncorroborated warning)"
             else:
                 status = "Threshold breach (warning)"
+        elif item.get("environmentShiftSuspected"):
+            status = "Environment shift suspected (warning)"
         elif item["repeatedRegression"]:
-            status = "Repeated regression (fail)"
+            if item.get("failureEligible"):
+                status = "Repeated regression (fail)"
+            elif item.get("corroborated") is False:
+                status = "Repeated regression (control-normalized warning)"
+            else:
+                status = "Repeated regression (warning)"
+        elif item.get("corroboratesBaselineRegression"):
+            status = "Regression (corroborates fail)"
         elif item["status"] == "regression":
             status = "Regression (warning)"
 
@@ -423,9 +582,19 @@ def emit_annotations(evaluations):
                 if item.get("latencyThreshold")
                 else "Intra-run threshold breach"
             )
+        elif item.get("environmentShiftSuspected"):
+            level = "warning"
+            prefix = "Environment shift suspected"
         elif item["repeatedRegression"]:
+            level = "error" if item.get("failureEligible") else "warning"
+            prefix = (
+                "Repeated regression"
+                if item.get("failureEligible")
+                else "Control-normalized regression warning"
+            )
+        elif item.get("corroboratesBaselineRegression"):
             level = "error"
-            prefix = "Repeated regression"
+            prefix = "Control ratio regression"
         elif item["status"] == "regression":
             level = "warning"
             prefix = "Regression"

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -457,6 +457,8 @@ def evaluate_and_update(history, current_results, run_started_at):
 
         observations.append(observation)
 
+    # Environment shifts model runner-wide noise: one regressed Confluent control makes
+    # every observation from the same run unsafe for future absolute baselines.
     if environment_shift_suspected:
         for observation in observations:
             observation["environmentShiftSuspected"] = True

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -413,6 +413,30 @@ class StressTrendTests(unittest.TestCase):
         self.assertEqual(3, throughput["baselineCount"])
         self.assertEqual(1000.0, throughput["median"])
 
+    def test_environment_shift_observations_do_not_enter_ratio_baseline(self):
+        runs = [paired_history_run(i) for i in range(1, 4)]
+        environment_shift = paired_history_run(
+            4,
+            dekaf_messages_per_second=5000.0,
+            confluent_messages_per_second=1000.0,
+        )
+        for observation in environment_shift["results"]:
+            observation["environmentShiftSuspected"] = True
+        runs.append(environment_shift)
+
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(), result(client="Confluent", messages_per_second=500.0)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertEqual(3, ratio["baselineCount"])
+        self.assertEqual(2.0, ratio["median"])
+
     def test_control_ratio_history_keeps_dekaf_connection_profiles_separate(self):
         runs = [
             paired_history_run(

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -288,6 +288,46 @@ class StressTrendTests(unittest.TestCase):
         self.assertIn("Environment shift suspected", annotations.getvalue())
         self.assertFalse(should_fail)
 
+    def test_environment_shift_excludes_every_observation_in_same_run(self):
+        runs = []
+        for index in range(1, 4):
+            run = history_run(index, client="Confluent")
+            run["results"].append({
+                **run["results"][0],
+                "scenario": "consumer",
+                "client": "Dekaf",
+            })
+            runs.append(run)
+        previous = history_run(
+            4,
+            messages_per_second=700.0,
+            client="Confluent",
+            messagesPerSecondTrend="regression",
+        )
+        previous["results"].append({
+            **previous["results"][0],
+            "scenario": "consumer",
+            "client": "Dekaf",
+        })
+        runs.append(previous)
+
+        _, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(client="Confluent", messages_per_second=650.0),
+                result(scenario="consumer", messages_per_second=1_000.0),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        current = updated["runs"][-1]
+        self.assertTrue(current["environmentShiftSuspected"])
+        self.assertTrue(all(
+            observation["environmentShiftSuspected"]
+            for observation in current["results"]
+        ))
+        self.assertFalse(should_fail)
+
     def test_paired_proportional_regressions_do_not_fail_when_control_ratio_is_stable(self):
         runs = [paired_history_run(i) for i in range(1, 4)]
         runs.append(paired_history_run(

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -5,7 +5,13 @@ from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
 
-from stress_trend import HISTORY_LIMIT, evaluate_and_update, format_markdown, main
+from stress_trend import (
+    HISTORY_LIMIT,
+    emit_annotations,
+    evaluate_and_update,
+    format_markdown,
+    main,
+)
 
 
 def result(messages_per_second=1000.0, cpu_micros_per_message=2.0, **overrides):
@@ -38,6 +44,22 @@ def history_run(index, messages_per_second=1000.0, cpu_micros_per_message=2.0, *
         "runStartedAtUtc": f"2026-06-{index:02d}T02:00:00Z",
         "results": [observation],
     }
+
+
+def paired_history_run(
+    index,
+    dekaf_messages_per_second=1000.0,
+    confluent_messages_per_second=500.0,
+    **trends,
+):
+    run = history_run(index, dekaf_messages_per_second, **trends)
+    confluent = {
+        **run["results"][0],
+        "client": "Confluent",
+        "messagesPerSecond": confluent_messages_per_second,
+    }
+    run["results"].append(confluent)
+    return run
 
 
 def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
@@ -229,6 +251,160 @@ class StressTrendTests(unittest.TestCase):
         self.assertTrue(all(item["repeatedRegression"] for item in intra_run))
         self.assertTrue(all(not item["failureEligible"] for item in intra_run))
         self.assertNotIn("(fail)", format_markdown(intra_run))
+        self.assertFalse(should_fail)
+
+    def test_confluent_baseline_regressions_mark_environment_shift_but_never_fail(self):
+        runs = [
+            history_run(i, client="Confluent")
+            for i in range(1, 4)
+        ]
+        runs.append(history_run(
+            4,
+            messages_per_second=700.0,
+            client="Confluent",
+            messagesPerSecondTrend="regression",
+        ))
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(client="Confluent", messages_per_second=650.0)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertTrue(throughput["repeatedRegression"])
+        self.assertFalse(throughput["failureEligible"])
+        self.assertTrue(throughput["environmentShiftSuspected"])
+        self.assertTrue(updated["runs"][-1]["environmentShiftSuspected"])
+        self.assertTrue(
+            updated["runs"][-1]["results"][0]["environmentShiftSuspected"]
+        )
+        self.assertIn("Environment shift suspected", format_markdown(evaluations))
+        with redirect_stdout(StringIO()) as annotations:
+            emit_annotations(evaluations)
+        self.assertIn("::warning", annotations.getvalue())
+        self.assertIn("Environment shift suspected", annotations.getvalue())
+        self.assertFalse(should_fail)
+
+    def test_paired_proportional_regressions_do_not_fail_when_control_ratio_is_stable(self):
+        runs = [paired_history_run(i) for i in range(1, 4)]
+        runs.append(paired_history_run(
+            4,
+            dekaf_messages_per_second=700.0,
+            confluent_messages_per_second=350.0,
+            messagesPerSecondTrend="regression",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(messages_per_second=650.0),
+                result(client="Confluent", messages_per_second=325.0),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        dekaf_throughput = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and item["scenario"].split(" / ")[1] == "Dekaf"
+        )
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertTrue(dekaf_throughput["repeatedRegression"])
+        self.assertFalse(dekaf_throughput["corroborated"])
+        self.assertFalse(dekaf_throughput["failureEligible"])
+        self.assertEqual("stable", ratio["status"])
+        self.assertFalse(should_fail)
+
+    def test_paired_dekaf_regression_fails_when_control_ratio_also_regresses(self):
+        runs = [paired_history_run(i) for i in range(1, 4)]
+        runs.append(paired_history_run(
+            4,
+            dekaf_messages_per_second=700.0,
+            confluent_messages_per_second=350.0,
+            messagesPerSecondTrend="regression",
+        ))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(messages_per_second=550.0),
+                result(client="Confluent", messages_per_second=325.0),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        dekaf_throughput = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and item["scenario"].split(" / ")[1] == "Dekaf"
+        )
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertTrue(dekaf_throughput["corroborated"])
+        self.assertTrue(dekaf_throughput["failureEligible"])
+        self.assertEqual("regression", ratio["status"])
+        self.assertTrue(should_fail)
+
+    def test_environment_shift_observations_do_not_enter_absolute_baseline(self):
+        runs = [history_run(i) for i in range(1, 4)]
+        runs.append({
+            **history_run(4, messages_per_second=5000.0),
+            "environmentShiftSuspected": True,
+        })
+        runs[-1]["results"][0]["environmentShiftSuspected"] = True
+
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(messages_per_second=1000.0)],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(3, throughput["baselineCount"])
+        self.assertEqual(1000.0, throughput["median"])
+
+    def test_control_ratio_history_keeps_dekaf_connection_profiles_separate(self):
+        runs = [
+            paired_history_run(
+                i,
+                scenario="consumer",
+                consumerConnectionsPerBroker=2,
+            )
+            for i in range(1, 4)
+        ]
+        for run in runs:
+            run["results"][1]["consumerConnectionsPerBroker"] = 1
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(scenario="consumer", consumerConnectionsPerBroker=3),
+                result(
+                    scenario="consumer",
+                    client="Confluent",
+                    consumerConnectionsPerBroker=1,
+                    messages_per_second=500.0,
+                ),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertEqual(0, ratio["baselineCount"])
+        self.assertEqual("insufficient-history", ratio["status"])
         self.assertFalse(should_fail)
 
     def test_empty_history_is_rejected(self):


### PR DESCRIPTION
## Summary
- treat Confluent baseline regressions as environment warnings, never gate failures
- require paired Dekaf regressions to be corroborated by a trailing Dekaf/Confluent ratio band
- mark suspected environment-shift runs and exclude them from absolute baselines
- preserve existing consecutive-regression behavior for unpaired scenarios

## Test plan
- [x] `python -m unittest test_stress_trend.py`
- [x] `python -m unittest discover -s .github/scripts -p 'test_stress_*.py'`
- [x] `python -m compileall -q .github/scripts`
- [x] replay stress run 29237954294 against committed history

Closes #1991