### PR TITLE
Add consumer fetch diagnostics timeline

### DIFF
--- a/src/Dekaf/Consumer/ConsumerDiagnosticSnapshot.cs
+++ b/src/Dekaf/Consumer/ConsumerDiagnosticSnapshot.cs
@@ -1,5 +1,7 @@
 namespace Dekaf.Consumer;
 
+using Dekaf.Networking;
+
 internal sealed class ConsumerDiagnosticSnapshot
 {
     public required DateTimeOffset CapturedAtUtc { get; init; }
@@ -18,6 +20,7 @@ internal sealed class ConsumerDiagnosticSnapshot
     public required ConsumerPartitionEpochDiagnostic[] MinimumFetchBufferEpochsByPartition { get; init; }
     public required int? AdaptivePartitionFetchBytes { get; init; }
     public required int? AdaptiveFetchMaxBytes { get; init; }
+    public ConnectionReapDiagnostic[] ConnectionReapEvents { get; init; } = [];
 }
 
 internal sealed record ConsumerTopicPartitionDiagnostic(string Topic, int Partition);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1367,8 +1367,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             MinimumFetchBufferEpochsByPartition = minimumEpochs,
             AdaptivePartitionFetchBytes = _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
             AdaptiveFetchMaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes,
-            ConnectionReapEvents = _connectionPool is ConnectionPool connectionPool
-                ? [.. connectionPool.GetConnectionReapDiagnosticsSnapshot()]
+            ConnectionReapEvents = _connectionPool is IConnectionPoolDiagnostics diagnostics
+                ? [.. diagnostics.GetConnectionReapDiagnosticsSnapshot()]
                 : []
         };
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1366,7 +1366,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             MinimumFetchBufferEpoch = Volatile.Read(ref _minimumFetchBufferEpoch),
             MinimumFetchBufferEpochsByPartition = minimumEpochs,
             AdaptivePartitionFetchBytes = _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-            AdaptiveFetchMaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes
+            AdaptiveFetchMaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes,
+            ConnectionReapEvents = _connectionPool is ConnectionPool connectionPool
+                ? [.. connectionPool.GetConnectionReapDiagnosticsSnapshot()]
+                : []
         };
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -12,7 +12,7 @@ namespace Dekaf.Networking;
 /// Connection pool for managing connections to Kafka brokers.
 /// Supports multiple connections per broker for parallel request handling.
 /// </summary>
-public sealed partial class ConnectionPool : IConnectionPool
+public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDiagnostics
 {
     private const int MaxConnectionReapDiagnosticEvents = 256;
     private static readonly TimeSpan DefaultIdleReapDrainTimeout = TimeSpan.FromSeconds(5);
@@ -1291,6 +1291,9 @@ public sealed partial class ConnectionPool : IConnectionPool
         lock (_connectionReapDiagnosticsLock)
             return [.. _connectionReapEvents];
     }
+
+    IReadOnlyList<ConnectionReapDiagnostic> IConnectionPoolDiagnostics.GetConnectionReapDiagnosticsSnapshot() =>
+        GetConnectionReapDiagnosticsSnapshot();
 
     private void RecordConnectionReapDiagnostic(int brokerId, int connectionIndex, long idleDurationMs)
     {

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -63,3 +63,8 @@ public interface IConnectionPool : IAsyncDisposable
     /// </summary>
     ValueTask CloseAllAsync();
 }
+
+internal interface IConnectionPoolDiagnostics
+{
+    IReadOnlyList<ConnectionReapDiagnostic> GetConnectionReapDiagnosticsSnapshot();
+}

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2600,7 +2600,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         var snapshot = _accumulator.GetDeliveryDiagnosticsSnapshot();
         if (snapshot.DiagnosticsEnabled)
-            snapshot.ConnectionReapEvents.AddRange(_connectionPool.GetConnectionReapDiagnosticsSnapshot());
+            snapshot.ConnectionReapEvents.AddRange(
+                ((IConnectionPoolDiagnostics)_connectionPool).GetConnectionReapDiagnosticsSnapshot());
 
         return snapshot;
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDiagnosticSnapshotTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 
@@ -44,6 +45,7 @@ public sealed class ConsumerDiagnosticSnapshotTests
         SetField(consumer, "_minimumFetchBufferEpoch", 5);
         SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearMarkerPresent", 1);
         SetField(consumer, "_coordinatorRevokedPartitionsPendingFetchClearPending", 1);
+        RecordConnectionReap(consumer, brokerId: 2, connectionIndex: 1, idleDurationMs: 540_010);
         EnqueuePendingFetch(consumer, PendingFetchData.Create(
             partition.Topic,
             partition.Partition,
@@ -73,6 +75,10 @@ public sealed class ConsumerDiagnosticSnapshotTests
             item.EndOffset == 123 && item.Epoch == 8);
         await Assert.That(snapshot.AdaptivePartitionFetchBytes).IsEqualTo(2_000_000);
         await Assert.That(snapshot.AdaptiveFetchMaxBytes).IsEqualTo(20_000_000);
+        await Assert.That(snapshot.ConnectionReapEvents).HasSingleItem();
+        await Assert.That(snapshot.ConnectionReapEvents[0].BrokerId).IsEqualTo(2);
+        await Assert.That(snapshot.ConnectionReapEvents[0].ConnectionIndex).IsEqualTo(1);
+        await Assert.That(snapshot.ConnectionReapEvents[0].IdleDurationMs).IsEqualTo(540_010);
     }
 
     private static TField GetField<TField>(KafkaConsumer<string, string> consumer, string name) =>
@@ -94,4 +100,18 @@ public sealed class ConsumerDiagnosticSnapshotTests
             .GetMethod("EnqueuePendingFetch", BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException("Could not find EnqueuePendingFetch."))
         .Invoke(consumer, [pending]);
+
+    private static void RecordConnectionReap(
+        KafkaConsumer<string, string> consumer,
+        int brokerId,
+        int connectionIndex,
+        long idleDurationMs)
+    {
+        var pool = GetField<IConnectionPool>(consumer, "_connectionPool");
+        (pool.GetType().GetMethod(
+            "RecordConnectionReapDiagnostic",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Could not find RecordConnectionReapDiagnostic."))
+        .Invoke(pool, [brokerId, connectionIndex, idleDurationMs]);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -1,0 +1,221 @@
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Networking;
+using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Reporting;
+
+namespace Dekaf.Tests.Unit.StressTests;
+
+public sealed class ConsumerFetchDiagnosticsTests
+{
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task Listener_CollectsFetchDurationAndTopicBytes()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic");
+        tracker.Start(CreateConsumerSnapshot(startedAt));
+
+        DekafMetrics.FetchDuration.Record(0.02);
+        DekafMetrics.BytesReceived.Add(
+            2_048,
+            new KeyValuePair<string, object?>(
+                DekafDiagnostics.MessagingDestinationName,
+                "consumer-topic"));
+        DekafMetrics.BytesReceived.Add(
+            8_192,
+            new KeyValuePair<string, object?>(
+                DekafDiagnostics.MessagingDestinationName,
+                "different-topic"));
+        tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddSeconds(1)));
+
+        var sample = tracker.GetSnapshot().Samples.Single();
+        await Assert.That(sample.FetchRequestCount).IsEqualTo(1);
+        await Assert.That(sample.BytesPerFetch).IsEqualTo(2_048);
+        await Assert.That(sample.AverageFetchRttMs).IsBetween(19.9, 20.1);
+    }
+
+    [Test]
+    public async Task TakeSample_ReportsIntervalFetchAndQueueMetrics()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic", listenToMetrics: false);
+        tracker.Start(CreateConsumerSnapshot(startedAt));
+
+        tracker.RecordFetchDuration(0.1);
+        tracker.RecordFetchDuration(0.3);
+        tracker.RecordBytesReceived(1_000);
+        tracker.TakeSample(CreateConsumerSnapshot(
+            startedAt.AddMinutes(1),
+            pendingFetchDepth: 2,
+            prefetchBufferDepth: 3,
+            prefetchedBytes: 4_096));
+
+        var sample = tracker.GetSnapshot().Samples.Single();
+        await Assert.That(sample.IntervalSeconds).IsEqualTo(60.0);
+        await Assert.That(sample.FetchRequestCount).IsEqualTo(2);
+        await Assert.That(sample.FetchRequestsPerSecond).IsBetween(0.0333, 0.0334);
+        await Assert.That(sample.BytesPerFetch).IsEqualTo(500.0);
+        await Assert.That(sample.AverageFetchRttMs).IsBetween(199.9, 200.1);
+        await Assert.That(sample.PendingFetchDepth).IsEqualTo(2);
+        await Assert.That(sample.PrefetchBufferDepth).IsEqualTo(3);
+        await Assert.That(sample.PrefetchDepth).IsEqualTo(5);
+        await Assert.That(sample.PrefetchedBytes).IsEqualTo(4_096);
+    }
+
+    [Test]
+    public async Task TakeSample_UsesPerIntervalDeltasAndKeepsConnectionReaps()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic", listenToMetrics: false);
+        tracker.Start(CreateConsumerSnapshot(startedAt));
+
+        tracker.RecordFetchDuration(0.1);
+        tracker.RecordBytesReceived(900);
+        tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddMinutes(1)));
+
+        tracker.RecordFetchDuration(0.25);
+        tracker.RecordBytesReceived(400);
+        var reap = new ConnectionReapDiagnostic
+        {
+            OccurredAtUtc = startedAt.AddMinutes(1.5),
+            BrokerId = 2,
+            ConnectionIndex = 1,
+            IdleDurationMs = 540_010,
+            IsBootstrapConnection = false
+        };
+        tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddMinutes(2), connectionReaps: [reap]));
+
+        var snapshot = tracker.GetSnapshot();
+        var second = snapshot.Samples[1];
+        await Assert.That(second.FetchRequestCount).IsEqualTo(1);
+        await Assert.That(second.BytesPerFetch).IsEqualTo(400.0);
+        await Assert.That(second.AverageFetchRttMs).IsBetween(249.9, 250.1);
+        await Assert.That(snapshot.ConnectionReapEvents).HasSingleItem();
+        await Assert.That(snapshot.ConnectionReapEvents[0].ConnectionIndex).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Result_SerializesAndReportsConsumerFetchTimeline()
+    {
+        var capturedAt = new DateTimeOffset(2026, 7, 13, 10, 1, 0, TimeSpan.Zero);
+        var result = CreateResult(new ConsumerFetchDiagnosticsSnapshot
+        {
+            Samples =
+            [
+                new ConsumerFetchDiagnosticSample
+                {
+                    CapturedAtUtc = capturedAt,
+                    IntervalSeconds = 60,
+                    FetchRequestCount = 120,
+                    FetchRequestsPerSecond = 2,
+                    BytesPerFetch = 524_288,
+                    AverageFetchRttMs = 7.5,
+                    PendingFetchDepth = 2,
+                    PrefetchBufferDepth = 3,
+                    PrefetchDepth = 5,
+                    PrefetchedBytes = 8_388_608
+                }
+            ],
+            ConnectionReapEvents =
+            [
+                new ConnectionReapDiagnostic
+                {
+                    OccurredAtUtc = capturedAt.AddSeconds(-5),
+                    BrokerId = 1,
+                    ConnectionIndex = 0,
+                    IdleDurationMs = 540_000,
+                    IsBootstrapConnection = false
+                }
+            ]
+        });
+
+        var json = result.ToJson();
+        var markdown = MarkdownReporter.Generate(new StressTestResults
+        {
+            RunStartedAtUtc = capturedAt.UtcDateTime.AddMinutes(-1),
+            RunCompletedAtUtc = capturedAt.UtcDateTime,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        });
+
+        await Assert.That(json).Contains("\"consumerFetchDiagnostics\"");
+        await Assert.That(json).Contains("\"fetchRequestsPerSecond\": 2");
+        await Assert.That(markdown).Contains("Consumer Fetch Timeline - Consumer");
+        await Assert.That(markdown).Contains("512.0 KiB");
+        await Assert.That(markdown).Contains("7.50ms");
+        await Assert.That(markdown).Contains("1 reap");
+        await Assert.That(markdown).Contains("2 / 3 / 5");
+    }
+
+    private static ConsumerDiagnosticSnapshot CreateConsumerSnapshot(
+        DateTimeOffset capturedAtUtc,
+        int pendingFetchDepth = 0,
+        int prefetchBufferDepth = 0,
+        long prefetchedBytes = 0,
+        ConnectionReapDiagnostic[]? connectionReaps = null) =>
+        new()
+        {
+            CapturedAtUtc = capturedAtUtc,
+            FetchPositions = [],
+            Assignment = [],
+            PrefetchedBytes = prefetchedBytes,
+            PendingFetchDepth = pendingFetchDepth,
+            PrefetchBufferDepth = prefetchBufferDepth,
+            PrefetchDepth = pendingFetchDepth + prefetchBufferDepth,
+            PendingRevocations = [],
+            PendingRevocationMarkerPresent = false,
+            PendingRevocationClearPending = false,
+            PendingDivergingEpochResets = [],
+            FetchBufferEpoch = 0,
+            MinimumFetchBufferEpoch = 0,
+            MinimumFetchBufferEpochsByPartition = [],
+            AdaptivePartitionFetchBytes = null,
+            AdaptiveFetchMaxBytes = null,
+            ConnectionReapEvents = connectionReaps ?? []
+        };
+
+    private static StressTestResult CreateResult(ConsumerFetchDiagnosticsSnapshot diagnostics)
+    {
+        var capturedAt = diagnostics.Samples[0].CapturedAtUtc;
+        return new StressTestResult
+        {
+            Scenario = "consumer",
+            Client = "Dekaf",
+            DurationMinutes = 15,
+            MessageSizeBytes = 1_000,
+            StartedAtUtc = capturedAt.UtcDateTime.AddMinutes(-1),
+            CompletedAtUtc = capturedAt.UtcDateTime,
+            Throughput = new ThroughputSnapshot
+            {
+                TotalMessages = 1_000,
+                TotalBytes = 1_000_000,
+                TotalErrors = 0,
+                ElapsedSeconds = 60,
+                AverageMessagesPerSecond = 1_000,
+                AverageMegabytesPerSecond = 0.95,
+                MessagesPerSecondSamples = [1_000, 1_000, 1_000],
+                IntervalSamples =
+                [
+                    new ThroughputIntervalSample
+                    {
+                        CapturedAtUtc = capturedAt,
+                        ElapsedSeconds = 60,
+                        MessagesPerSecond = 1_000
+                    }
+                ],
+                SampledElapsedSeconds = 60,
+                ErrorSamples = []
+            },
+            GcStats = new GcSnapshot
+            {
+                Gen0Collections = 0,
+                Gen1Collections = 0,
+                Gen2Collections = 0,
+                AllocatedBytes = 0
+            },
+            ConsumerFetchDiagnostics = diagnostics
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -149,6 +149,43 @@ public sealed class ConsumerFetchDiagnosticsTests
         await Assert.That(markdown).Contains("2 / 3 / 5");
     }
 
+    [Test]
+    public async Task Report_CapsConsumerFetchTimelineRows()
+    {
+        var capturedAt = new DateTimeOffset(2026, 7, 13, 10, 1, 0, TimeSpan.Zero);
+        var result = CreateResult(new ConsumerFetchDiagnosticsSnapshot
+        {
+            Samples =
+            [
+                .. Enumerable.Range(0, 150).Select(index => new ConsumerFetchDiagnosticSample
+                {
+                    CapturedAtUtc = capturedAt.AddMinutes(index),
+                    IntervalSeconds = 60,
+                    FetchRequestCount = 0,
+                    FetchRequestsPerSecond = 0,
+                    BytesPerFetch = 0,
+                    AverageFetchRttMs = 0,
+                    PendingFetchDepth = 0,
+                    PrefetchBufferDepth = 0,
+                    PrefetchDepth = 0,
+                    PrefetchedBytes = 0
+                })
+            ],
+            ConnectionReapEvents = []
+        });
+
+        var markdown = MarkdownReporter.Generate(new StressTestResults
+        {
+            RunStartedAtUtc = capturedAt.UtcDateTime,
+            RunCompletedAtUtc = capturedAt.UtcDateTime.AddMinutes(150),
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        });
+
+        await Assert.That(markdown).Contains("50 fetch sample(s) omitted");
+    }
+
     private static ConsumerDiagnosticSnapshot CreateConsumerSnapshot(
         DateTimeOffset capturedAtUtc,
         int pendingFetchDepth = 0,

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -36,6 +36,16 @@ public sealed class ConsumerFetchDiagnosticsTests
     }
 
     [Test]
+    [NotInParallel("MeterListener")]
+    public async Task Listener_RejectsConcurrentConsumerDiagnosticsTracker()
+    {
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic");
+
+        await Assert.That(() => new ConsumerFetchDiagnosticsTracker("other-topic"))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task TakeSample_ReportsIntervalFetchAndQueueMetrics()
     {
         var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
@@ -93,6 +103,16 @@ public sealed class ConsumerFetchDiagnosticsTests
         await Assert.That(second.AverageFetchRttMs).IsBetween(249.9, 250.1);
         await Assert.That(snapshot.ConnectionReapEvents).HasSingleItem();
         await Assert.That(snapshot.ConnectionReapEvents[0].ConnectionIndex).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TryTakeSample_DoesNotPropagateDiagnosticFailure()
+    {
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic", listenToMetrics: false);
+
+        tracker.TryTakeSample(() => throw new InvalidOperationException("diagnostic failure"));
+
+        await Assert.That(tracker.GetSnapshot().Samples).IsEmpty();
     }
 
     [Test]
@@ -186,6 +206,44 @@ public sealed class ConsumerFetchDiagnosticsTests
         await Assert.That(markdown).Contains("50 fetch sample(s) omitted");
     }
 
+    [Test]
+    public async Task Report_PreservesGcTableUnitConvention()
+    {
+        var capturedAt = new DateTimeOffset(2026, 7, 13, 10, 1, 0, TimeSpan.Zero);
+        var result = CreateResult(new ConsumerFetchDiagnosticsSnapshot
+        {
+            Samples =
+            [
+                new ConsumerFetchDiagnosticSample
+                {
+                    CapturedAtUtc = capturedAt,
+                    IntervalSeconds = 60,
+                    FetchRequestCount = 0,
+                    FetchRequestsPerSecond = 0,
+                    BytesPerFetch = 0,
+                    AverageFetchRttMs = 0,
+                    PendingFetchDepth = 0,
+                    PrefetchBufferDepth = 0,
+                    PrefetchDepth = 0,
+                    PrefetchedBytes = 0
+                }
+            ],
+            ConnectionReapEvents = []
+        }, allocatedBytes: 1_048_576);
+
+        var markdown = MarkdownReporter.Generate(new StressTestResults
+        {
+            RunStartedAtUtc = capturedAt.UtcDateTime.AddMinutes(-1),
+            RunCompletedAtUtc = capturedAt.UtcDateTime,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        });
+
+        await Assert.That(markdown).Contains("1.00 MB");
+        await Assert.That(markdown).Contains("1.02 KB");
+    }
+
     private static ConsumerDiagnosticSnapshot CreateConsumerSnapshot(
         DateTimeOffset capturedAtUtc,
         int pendingFetchDepth = 0,
@@ -213,7 +271,9 @@ public sealed class ConsumerFetchDiagnosticsTests
             ConnectionReapEvents = connectionReaps ?? []
         };
 
-    private static StressTestResult CreateResult(ConsumerFetchDiagnosticsSnapshot diagnostics)
+    private static StressTestResult CreateResult(
+        ConsumerFetchDiagnosticsSnapshot diagnostics,
+        long allocatedBytes = 0)
     {
         var capturedAt = diagnostics.Samples[0].CapturedAtUtc;
         return new StressTestResult
@@ -250,7 +310,7 @@ public sealed class ConsumerFetchDiagnosticsTests
                 Gen0Collections = 0,
                 Gen1Collections = 0,
                 Gen2Collections = 0,
-                AllocatedBytes = 0
+                AllocatedBytes = allocatedBytes
             },
             ConsumerFetchDiagnostics = diagnostics
         };

--- a/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Networking;
+
+namespace Dekaf.StressTests.Metrics;
+
+internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
+{
+    private static readonly TimeSpan SampleInterval = TimeSpan.FromMinutes(1);
+
+    private readonly string _topic;
+    private readonly MeterListener? _listener;
+    private readonly List<ConsumerFetchDiagnosticSample> _samples = [];
+    private DateTimeOffset? _lastSampleAtUtc;
+    private long _fetchRequestCount;
+    private long _fetchDurationTicks;
+    private long _receivedBytes;
+    private long _lastFetchRequestCount;
+    private long _lastFetchDurationTicks;
+    private long _lastReceivedBytes;
+    private ConnectionReapDiagnostic[] _connectionReapEvents = [];
+
+    internal ConsumerFetchDiagnosticsTracker(string topic, bool listenToMetrics = true)
+    {
+        _topic = topic;
+        if (!listenToMetrics)
+            return;
+
+        var fetchDurationName = DekafMetrics.FetchDuration.Name;
+        var bytesReceivedName = DekafMetrics.BytesReceived.Name;
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                    (instrument.Name == fetchDurationName || instrument.Name == bytesReceivedName))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == fetchDurationName)
+                RecordFetchDuration(measurement);
+        });
+        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            if (instrument.Name == bytesReceivedName && HasTopic(tags))
+                RecordBytesReceived(measurement);
+        });
+        _listener.Start();
+    }
+
+    internal void Start(ConsumerDiagnosticSnapshot snapshot)
+    {
+        _lastSampleAtUtc = snapshot.CapturedAtUtc;
+        _lastFetchRequestCount = Interlocked.Read(ref _fetchRequestCount);
+        _lastFetchDurationTicks = Interlocked.Read(ref _fetchDurationTicks);
+        _lastReceivedBytes = Interlocked.Read(ref _receivedBytes);
+        _connectionReapEvents = snapshot.ConnectionReapEvents;
+    }
+
+    internal void RecordFetchDuration(double durationSeconds)
+    {
+        Interlocked.Increment(ref _fetchRequestCount);
+        Interlocked.Add(
+            ref _fetchDurationTicks,
+            (long)Math.Round(durationSeconds * TimeSpan.TicksPerSecond));
+    }
+
+    internal void RecordBytesReceived(long bytes) => Interlocked.Add(ref _receivedBytes, bytes);
+
+    internal void TakeSample(ConsumerDiagnosticSnapshot snapshot)
+    {
+        if (_lastSampleAtUtc is not { } lastSampleAtUtc)
+        {
+            Start(snapshot);
+            return;
+        }
+
+        _connectionReapEvents = snapshot.ConnectionReapEvents;
+        var intervalSeconds = (snapshot.CapturedAtUtc - lastSampleAtUtc).TotalSeconds;
+        if (intervalSeconds <= 0)
+            return;
+
+        var fetchRequestCount = Interlocked.Read(ref _fetchRequestCount);
+        var fetchDurationTicks = Interlocked.Read(ref _fetchDurationTicks);
+        var receivedBytes = Interlocked.Read(ref _receivedBytes);
+        var intervalFetches = fetchRequestCount - _lastFetchRequestCount;
+        var intervalFetchDurationTicks = fetchDurationTicks - _lastFetchDurationTicks;
+        var intervalReceivedBytes = receivedBytes - _lastReceivedBytes;
+
+        _samples.Add(new ConsumerFetchDiagnosticSample
+        {
+            CapturedAtUtc = snapshot.CapturedAtUtc,
+            IntervalSeconds = intervalSeconds,
+            FetchRequestCount = intervalFetches,
+            FetchRequestsPerSecond = intervalFetches / intervalSeconds,
+            BytesPerFetch = intervalFetches > 0 ? (double)intervalReceivedBytes / intervalFetches : 0,
+            AverageFetchRttMs = intervalFetches > 0
+                ? intervalFetchDurationTicks * 1_000.0 / TimeSpan.TicksPerSecond / intervalFetches
+                : 0,
+            PendingFetchDepth = snapshot.PendingFetchDepth,
+            PrefetchBufferDepth = snapshot.PrefetchBufferDepth,
+            PrefetchDepth = snapshot.PrefetchDepth,
+            PrefetchedBytes = snapshot.PrefetchedBytes
+        });
+
+        _lastSampleAtUtc = snapshot.CapturedAtUtc;
+        _lastFetchRequestCount = fetchRequestCount;
+        _lastFetchDurationTicks = fetchDurationTicks;
+        _lastReceivedBytes = receivedBytes;
+    }
+
+    internal async Task RunSamplerAsync(
+        Func<ConsumerDiagnosticSnapshot?> captureSnapshot,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(SampleInterval, cancellationToken).ConfigureAwait(false);
+                if (captureSnapshot() is { } snapshot)
+                    TakeSample(snapshot);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    internal ConsumerFetchDiagnosticsSnapshot GetSnapshot() => new()
+    {
+        Samples = [.. _samples],
+        ConnectionReapEvents = [.. _connectionReapEvents]
+    };
+
+    private bool HasTopic(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == DekafDiagnostics.MessagingDestinationName &&
+                tag.Value is string topic &&
+                topic == _topic)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void Dispose() => _listener?.Dispose();
+}
+
+internal sealed class ConsumerFetchDiagnosticsSnapshot
+{
+    public List<ConsumerFetchDiagnosticSample> Samples { get; init; } = [];
+    public List<ConnectionReapDiagnostic> ConnectionReapEvents { get; init; } = [];
+}
+
+internal sealed class ConsumerFetchDiagnosticSample
+{
+    public required DateTimeOffset CapturedAtUtc { get; init; }
+    public required double IntervalSeconds { get; init; }
+    public required long FetchRequestCount { get; init; }
+    public required double FetchRequestsPerSecond { get; init; }
+    public required double BytesPerFetch { get; init; }
+    public required double AverageFetchRttMs { get; init; }
+    public required int PendingFetchDepth { get; init; }
+    public required int PrefetchBufferDepth { get; init; }
+    public required int PrefetchDepth { get; init; }
+    public required long PrefetchedBytes { get; init; }
+}

--- a/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
@@ -2,12 +2,14 @@ using System.Diagnostics.Metrics;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.Networking;
+using Dekaf.StressTests.Scenarios;
 
 namespace Dekaf.StressTests.Metrics;
 
 internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
 {
     private static readonly TimeSpan SampleInterval = TimeSpan.FromMinutes(1);
+    private static int s_activeMetricListener;
 
     private readonly string _topic;
     private readonly MeterListener? _listener;
@@ -26,31 +28,44 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         _topic = topic;
         if (!listenToMetrics)
             return;
+        if (Interlocked.CompareExchange(ref s_activeMetricListener, 1, 0) != 0)
+            throw new InvalidOperationException("Only one consumer diagnostics metric listener can be active at a time.");
 
         var fetchDurationName = DekafMetrics.FetchDuration.Name;
         var bytesReceivedName = DekafMetrics.BytesReceived.Name;
-        _listener = new MeterListener
+        try
         {
-            InstrumentPublished = (instrument, listener) =>
+            _listener = new MeterListener
             {
-                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                    (instrument.Name == fetchDurationName || instrument.Name == bytesReceivedName))
+                InstrumentPublished = (instrument, listener) =>
                 {
-                    listener.EnableMeasurementEvents(instrument);
+                    if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                        (instrument.Name == fetchDurationName || instrument.Name == bytesReceivedName))
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
                 }
-            }
-        };
-        _listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) =>
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) =>
+            {
+                // Fetch duration has no destination tag. Stress scenarios run one consumer and
+                // one diagnostics listener at a time, enforced above, so process-wide RTT is exact.
+                if (instrument.Name == fetchDurationName)
+                    RecordFetchDuration(measurement);
+            });
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                if (instrument.Name == bytesReceivedName && HasTopic(tags))
+                    RecordBytesReceived(measurement);
+            });
+            _listener.Start();
+        }
+        catch
         {
-            if (instrument.Name == fetchDurationName)
-                RecordFetchDuration(measurement);
-        });
-        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-        {
-            if (instrument.Name == bytesReceivedName && HasTopic(tags))
-                RecordBytesReceived(measurement);
-        });
-        _listener.Start();
+            _listener?.Dispose();
+            Interlocked.Exchange(ref s_activeMetricListener, 0);
+            throw;
+        }
     }
 
     internal void Start(ConsumerDiagnosticSnapshot snapshot)
@@ -114,22 +129,24 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         _lastReceivedBytes = receivedBytes;
     }
 
-    internal async Task RunSamplerAsync(
+    internal Task RunSamplerAsync(
         Func<ConsumerDiagnosticSnapshot?> captureSnapshot,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken) =>
+        StressTestHelpers.RunPeriodicAsync(
+            SampleInterval,
+            () => TryTakeSample(captureSnapshot),
+            cancellationToken);
+
+    internal void TryTakeSample(Func<ConsumerDiagnosticSnapshot?> captureSnapshot)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            try
-            {
-                await Task.Delay(SampleInterval, cancellationToken).ConfigureAwait(false);
-                if (captureSnapshot() is { } snapshot)
-                    TakeSample(snapshot);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
+            if (captureSnapshot() is { } snapshot)
+                TakeSample(snapshot);
+        }
+        catch
+        {
+            // Diagnostics are best-effort and must never abort a stress run.
         }
     }
 
@@ -154,7 +171,12 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         return false;
     }
 
-    public void Dispose() => _listener?.Dispose();
+    public void Dispose()
+    {
+        _listener?.Dispose();
+        if (_listener is not null)
+            Interlocked.Exchange(ref s_activeMetricListener, 0);
+    }
 }
 
 internal sealed class ConsumerFetchDiagnosticsSnapshot

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -30,6 +30,7 @@ internal static class MarkdownReporter
 
             GenerateThroughputTable(sb, title, groupResults);
             GenerateConnectionScaleTimeline(sb, groupResults, label);
+            GenerateConsumerFetchTimeline(sb, groupResults, label);
             GenerateLatencyOutlierTimeline(sb, groupResults, label);
 
             var transactionalResults = groupResults
@@ -218,6 +219,48 @@ internal static class MarkdownReporter
         }
 
         return sampled;
+    }
+
+    private static void GenerateConsumerFetchTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ConsumerFetchDiagnostics?.Samples ?? [])
+                .Select(sample => (Result: result, Sample: sample)))
+            .OrderBy(row => row.Sample.CapturedAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        sb.AppendLine($"## Consumer Fetch Timeline - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Interval end UTC | Fetch req/s | Bytes/fetch | Avg fetch RTT | Queues (pending / buffer / total) | Prefetched | Connection reaps | Nearest throughput |");
+        sb.AppendLine("|--------|------------------|------------:|------------:|--------------:|----------------------------------:|-----------:|-----------------:|-------------------:|");
+        foreach (var row in rows)
+        {
+            var nearest = row.Result.Throughput.IntervalSamples
+                .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CapturedAtUtc).TotalMilliseconds));
+            var throughput = nearest is null
+                ? "-"
+                : $"{nearest.ElapsedSeconds:F0}s / {nearest.MessagesPerSecond:N0} msg/s";
+            var intervalStart = row.Sample.CapturedAtUtc.AddSeconds(-row.Sample.IntervalSeconds);
+            var reaps = row.Result.ConsumerFetchDiagnostics!.ConnectionReapEvents.Count(reap =>
+                reap.OccurredAtUtc > intervalStart && reap.OccurredAtUtc <= row.Sample.CapturedAtUtc);
+            var reapSummary = reaps == 0 ? "-" : $"{reaps} reap{(reaps == 1 ? "" : "s")}";
+
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss} | " +
+                $"{row.Sample.FetchRequestsPerSecond:F2} | {FormatDiagnosticBytes(row.Sample.BytesPerFetch)} | " +
+                $"{row.Sample.AverageFetchRttMs:F2}ms | " +
+                $"{row.Sample.PendingFetchDepth} / {row.Sample.PrefetchBufferDepth} / {row.Sample.PrefetchDepth} | " +
+                $"{FormatDiagnosticBytes(row.Sample.PrefetchedBytes)} | {reapSummary} | {throughput} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("*Bytes/fetch is consumed message payload bytes divided by completed fetch requests for the interval; queue depths are point-in-time samples.*");
+        sb.AppendLine();
     }
 
     private static double ComparisonMessagesPerSecond(StressTestResult result) =>
@@ -516,6 +559,14 @@ internal static class MarkdownReporter
         < 1024 * 1024 => $"{numBytes / 1024.0:F2} KB",
         < 1024 * 1024 * 1024 => $"{numBytes / (1024.0 * 1024):F2} MB",
         _ => $"{numBytes / (1024.0 * 1024 * 1024):F2} GB"
+    };
+
+    private static string FormatDiagnosticBytes(double bytes) => bytes switch
+    {
+        < 1024 => $"{bytes:F0} B",
+        < 1024 * 1024 => $"{bytes / 1024:F1} KiB",
+        < 1024 * 1024 * 1024 => $"{bytes / (1024 * 1024):F1} MiB",
+        _ => $"{bytes / (1024 * 1024 * 1024):F1} GiB"
     };
 
     private static string EscapeTableCell(string value) =>

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -559,20 +559,21 @@ internal static class MarkdownReporter
         _ => scenario
     };
 
-    private static string FormatBytes(long numBytes) => FormatBytes(numBytes, 2);
+    private static string FormatBytes(long numBytes) => FormatBytes(numBytes, 2, useBinaryPrefixes: false);
 
-    private static string FormatDiagnosticBytes(double bytes) => FormatBytes(bytes, 1);
+    private static string FormatDiagnosticBytes(double bytes) => FormatBytes(bytes, 1, useBinaryPrefixes: true);
 
-    private static string FormatBytes(double bytes, int decimalPlaces)
+    private static string FormatBytes(double bytes, int decimalPlaces, bool useBinaryPrefixes)
     {
         var format = $"F{decimalPlaces}";
-        return bytes switch
+        var (value, unit) = bytes switch
         {
-            < 1024 => $"{bytes:F0} B",
-            < 1024 * 1024 => $"{(bytes / 1024.0).ToString(format)} KiB",
-            < 1024 * 1024 * 1024 => $"{(bytes / (1024.0 * 1024)).ToString(format)} MiB",
-            _ => $"{(bytes / (1024.0 * 1024 * 1024)).ToString(format)} GiB"
+            < 1024 => (bytes, "B"),
+            < 1024 * 1024 => (bytes / 1024.0, useBinaryPrefixes ? "KiB" : "KB"),
+            < 1024 * 1024 * 1024 => (bytes / (1024.0 * 1024), useBinaryPrefixes ? "MiB" : "MB"),
+            _ => (bytes / (1024.0 * 1024 * 1024), useBinaryPrefixes ? "GiB" : "GB")
         };
+        return unit == "B" ? $"{value:F0} {unit}" : $"{value.ToString(format)} {unit}";
     }
 
     private static string EscapeTableCell(string value) =>

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -5,7 +5,7 @@ namespace Dekaf.StressTests.Reporting;
 
 internal static class MarkdownReporter
 {
-    private const int MaxConnectionScaleTimelineRows = 100;
+    private const int MaxTimelineRows = 100;
 
     public static string Generate(StressTestResults results)
     {
@@ -180,7 +180,7 @@ internal static class MarkdownReporter
         if (rows.Count == 0)
             return;
 
-        var displayedRows = SampleEvenly(rows, MaxConnectionScaleTimelineRows);
+        var displayedRows = SampleEvenly(rows, MaxTimelineRows);
         var omittedRows = rows.Count - displayedRows.Count;
 
         sb.AppendLine($"## Connection Scale Timeline - {label}");
@@ -234,11 +234,14 @@ internal static class MarkdownReporter
         if (rows.Count == 0)
             return;
 
+        var displayedRows = SampleEvenly(rows, MaxTimelineRows);
+        var omittedRows = rows.Count - displayedRows.Count;
+
         sb.AppendLine($"## Consumer Fetch Timeline - {label}");
         sb.AppendLine();
         sb.AppendLine("| Client | Interval end UTC | Fetch req/s | Bytes/fetch | Avg fetch RTT | Queues (pending / buffer / total) | Prefetched | Connection reaps | Nearest throughput |");
         sb.AppendLine("|--------|------------------|------------:|------------:|--------------:|----------------------------------:|-----------:|-----------------:|-------------------:|");
-        foreach (var row in rows)
+        foreach (var row in displayedRows)
         {
             var nearest = row.Result.Throughput.IntervalSamples
                 .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CapturedAtUtc).TotalMilliseconds));
@@ -257,6 +260,9 @@ internal static class MarkdownReporter
                 $"{row.Sample.PendingFetchDepth} / {row.Sample.PrefetchBufferDepth} / {row.Sample.PrefetchDepth} | " +
                 $"{FormatDiagnosticBytes(row.Sample.PrefetchedBytes)} | {reapSummary} | {throughput} |");
         }
+
+        if (omittedRows > 0)
+            sb.AppendLine($"*{omittedRows:N0} fetch sample(s) omitted; rows sampled across the full timeline.*");
 
         sb.AppendLine();
         sb.AppendLine("*Bytes/fetch is consumed message payload bytes divided by completed fetch requests for the interval; queue depths are point-in-time samples.*");
@@ -553,21 +559,21 @@ internal static class MarkdownReporter
         _ => scenario
     };
 
-    private static string FormatBytes(long numBytes) => numBytes switch
-    {
-        < 1024 => $"{numBytes} B",
-        < 1024 * 1024 => $"{numBytes / 1024.0:F2} KB",
-        < 1024 * 1024 * 1024 => $"{numBytes / (1024.0 * 1024):F2} MB",
-        _ => $"{numBytes / (1024.0 * 1024 * 1024):F2} GB"
-    };
+    private static string FormatBytes(long numBytes) => FormatBytes(numBytes, 2);
 
-    private static string FormatDiagnosticBytes(double bytes) => bytes switch
+    private static string FormatDiagnosticBytes(double bytes) => FormatBytes(bytes, 1);
+
+    private static string FormatBytes(double bytes, int decimalPlaces)
     {
-        < 1024 => $"{bytes:F0} B",
-        < 1024 * 1024 => $"{bytes / 1024:F1} KiB",
-        < 1024 * 1024 * 1024 => $"{bytes / (1024 * 1024):F1} MiB",
-        _ => $"{bytes / (1024 * 1024 * 1024):F1} GiB"
-    };
+        var format = $"F{decimalPlaces}";
+        return bytes switch
+        {
+            < 1024 => $"{bytes:F0} B",
+            < 1024 * 1024 => $"{(bytes / 1024.0).ToString(format)} KiB",
+            < 1024 * 1024 * 1024 => $"{(bytes / (1024.0 * 1024)).ToString(format)} MiB",
+            _ => $"{(bytes / (1024.0 * 1024 * 1024)).ToString(format)} GiB"
+        };
+    }
 
     private static string EscapeTableCell(string value) =>
         value

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -31,6 +31,7 @@ internal sealed class StressTestResult
     public required GcSnapshot GcStats { get; init; }
     public int BrokerCount { get; init; } = 1;
     public ProducerDeliveryDiagnosticsSnapshot? ProducerDeliveryDiagnostics { get; init; }
+    public ConsumerFetchDiagnosticsSnapshot? ConsumerFetchDiagnostics { get; init; }
     public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
     public RoundTripPhaseSnapshot? RoundTripPhases { get; init; }
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -108,7 +108,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
         try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
+        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -52,6 +52,8 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-batch stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
@@ -67,6 +69,9 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
+        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
+            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
+            cts.Token);
 
         try
         {
@@ -102,6 +107,8 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
+        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
@@ -121,7 +128,8 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             Throughput = throughput.GetSnapshot(),
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -52,6 +52,8 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-raw-batch stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
@@ -67,6 +69,9 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
+        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
+            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
+            cts.Token);
 
         try
         {
@@ -102,6 +107,8 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
+        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
@@ -121,7 +128,8 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
             Throughput = throughput.GetSnapshot(),
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -108,7 +108,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
         try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
+        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -54,6 +54,8 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-raw stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
@@ -69,6 +71,9 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
+        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
+            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
+            cts.Token);
 
         try
         {
@@ -98,6 +103,8 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
+        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
@@ -117,7 +124,8 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
             Throughput = throughput.GetSnapshot(),
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -104,7 +104,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
         try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
+        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -47,6 +47,8 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer stress test for {options.DurationMinutes} minutes...");
         Console.WriteLine($"  Start time: {DateTime.UtcNow:HH:mm:ss.fff} UTC");
@@ -62,6 +64,9 @@ internal sealed class ConsumerStressTest : IStressTestScenario
 
         var samplerTask = StressTestHelpers.RunSamplerAsync(throughput, cts.Token);
         var resourceMonitorTask = StressTestHelpers.RunResourceMonitorAsync(cts.Token);
+        var consumerDiagnosticsTask = consumerDiagnostics.RunSamplerAsync(
+            () => StressTestHelpers.CaptureConsumerDiagnostics(consumer),
+            cts.Token);
 
         try
         {
@@ -91,6 +96,8 @@ internal sealed class ConsumerStressTest : IStressTestScenario
 
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
+        try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
+        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");
@@ -110,7 +117,8 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             Throughput = throughput.GetSnapshot(),
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
-            CpuTimeSeconds = throughput.CpuTimeSeconds
+            CpuTimeSeconds = throughput.CpuTimeSeconds,
+            ConsumerFetchDiagnostics = consumerDiagnostics.GetSnapshot()
         };
     }
 }

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -97,7 +97,7 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         try { await samplerTask.ConfigureAwait(false); } catch { }
         try { await resourceMonitorTask.ConfigureAwait(false); } catch { }
         try { await consumerDiagnosticsTask.ConfigureAwait(false); } catch { }
-        consumerDiagnostics.TakeSample(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
+        consumerDiagnostics.TryTakeSample(() => StressTestHelpers.CaptureConsumerDiagnostics(consumer));
 
         var completedAt = DateTime.UtcNow;
         Console.WriteLine($"  Completed: {throughput.MessageCount:N0} messages, {throughput.GetAverageMessagesPerSecond():N0} msg/sec");

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -454,31 +454,32 @@ internal static class StressTestHelpers
         }
     }
 
-    internal static async Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(TimeSpan.FromSeconds(SamplerIntervalSeconds), cancellationToken).ConfigureAwait(false);
-                throughput.TakeSample();
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-    }
+    internal static Task RunSamplerAsync(ThroughputTracker throughput, CancellationToken cancellationToken) =>
+        RunPeriodicAsync(
+            TimeSpan.FromSeconds(SamplerIntervalSeconds),
+            throughput.TakeSample,
+            cancellationToken);
 
-    internal static async Task RunResourceMonitorAsync(CancellationToken cancellationToken)
+    internal static Task RunResourceMonitorAsync(CancellationToken cancellationToken)
     {
         var process = Process.GetCurrentProcess();
+        return RunPeriodicAsync(
+            TimeSpan.FromSeconds(5),
+            () => LogResourceUsage("Monitor", process),
+            cancellationToken);
+    }
+
+    internal static async Task RunPeriodicAsync(
+        TimeSpan interval,
+        Action action,
+        CancellationToken cancellationToken)
+    {
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(5000, cancellationToken).ConfigureAwait(false);
-                LogResourceUsage("Monitor", process);
+                await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+                action();
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- capture minute-scale consumer fetch request rate, payload bytes per fetch, average RTT, and queue depths
- persist connection-reap events in consumer diagnostics and correlate samples with throughput
- render the timeline in stress JSON and Markdown for every Dekaf consumer scenario

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --framework net10.0`
- [x] `Dekaf.Tests.Unit.exe` (5,363 passed)
- [x] `dotnet build src/Dekaf/Dekaf.csproj --configuration Release --framework netstandard2.0`
- [x] `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj --configuration Release`
- [x] 1-minute real-Kafka consumer stress smoke (10.2M messages; populated fetch timeline; zero errors)

Closes #1992
