### PR TITLE
Stabilize producer budget recovery

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -11,7 +11,8 @@ namespace Dekaf.Producer;
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
 /// by the broker's drain rate; capping the standing bytes to
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
-/// periodically refreshed minimum RTT so standing queue delay cannot inflate its horizon.
+/// periodically refreshed minimum RTT plus the loaded serving RTT, so standing queue delay
+/// cannot replace the base RTT while replicated service time still keeps the pipe full.
 /// <para>
 /// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
 /// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
@@ -60,12 +61,15 @@ internal sealed class BrokerUnackedByteBudget
 
     private const int WindowBucketCount = 20;
     private const double WindowBucketSeconds = 0.100;
+    private const double LoadedRateHalfLifeSeconds = 60.0;
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
     private const double DeliveryLatencyEwmaWeight = 0.125;
+    private const double ServingRttEwmaWeight = 0.125;
     private const double MinimumLatencyBudgetScale = 0.10;
     private const double MinimumLatencyAdjustmentFactor = 0.75;
     private const double MaximumLatencyAdjustmentFactor = 1.05;
+    private const double MaximumBudgetDecayPerSecond = 0.10;
 
     /// <summary>
     /// Log2 histogram buckets for per-request diagnostics. Request sizes shift by
@@ -82,6 +86,8 @@ internal sealed class BrokerUnackedByteBudget
     /// enough history to ignore short scheduler and broker stalls.
     /// </summary>
     private static readonly long WindowBucketTicks = Math.Max(1, (long)(WindowBucketSeconds * Stopwatch.Frequency));
+    private static readonly double LoadedRateDecayPerBucket =
+        Math.Pow(0.5, WindowBucketSeconds / LoadedRateHalfLifeSeconds);
     private static readonly long LatencyControlIntervalTicks = Math.Max(1, Stopwatch.Frequency / 10);
 
     /// <summary>How long an observed base RTT remains valid before it is refreshed.</summary>
@@ -104,9 +110,13 @@ internal sealed class BrokerUnackedByteBudget
     /// the budget below BDP, underfill the pipe, lower the measured rate, and ratchet the
     /// budget down to the floor — collapsing throughput on high-latency links.</summary>
     private const double RttSafetyMultiplier = 1.5;
+    private const double MinRttProbeSafetyMultiplier = 1.0;
 
     private const int ProbeIntervalRtts = 8;
+    private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
+    private const double RttFloorProbeBudgetMultiplier = 1.5;
+    private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
 
     // Cross-thread state.
     private long _unackedBytes;
@@ -136,8 +146,10 @@ internal sealed class BrokerUnackedByteBudget
     private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
+    private double _retainedLoadedMaxRate;
     private long _windowMaxOccupancyBytes;
     private double _minRttSeconds;
+    private double _servingRttEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
     private long _minRttTimestamp;
@@ -149,18 +161,23 @@ internal sealed class BrokerUnackedByteBudget
     private long _capacityProbeDeadlineTimestamp;
     private long _capacityProbeEvaluationDeadlineTimestamp;
     private double _capacityProbeBaselineRate;
-    private double _capacityProbePeakRate;
+    private double _capacityProbeRateSum;
+    private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
     private double _deliveryLatencyEwmaSeconds;
     private double _latencyBudgetScale = 1.0;
     private long _nextLatencyControlTimestamp;
     private long _lastLatencyControlAdmissionBlockEvents;
+    private long _lastNormalBudgetBytes;
+    private long _lastBudgetUpdateTimestamp;
+    private long _lastBudgetAdmissionBlockEvents;
 
     public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
     {
         _targetSeconds = targetSeconds;
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, initialCapBytes);
+        _lastNormalBudgetBytes = _capBytes;
         Volatile.Write(ref _budgetBytes, _capBytes);
         Volatile.Write(ref _budgetAfterMinRttProbeBytes, _capBytes);
         Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, _capBytes);
@@ -341,7 +358,7 @@ internal sealed class BrokerUnackedByteBudget
         CompleteExpiredMinRttProbe(nowTicks);
         if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
             DeactivateCapacityProbe();
-        RecomputeBudget();
+        RecomputeBudget(nowTicks);
     }
 
     /// <summary>
@@ -364,6 +381,13 @@ internal sealed class BrokerUnackedByteBudget
 
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
         UpdateMinRtt(rttSeconds, nowTicks);
+        if (!sendSnapshot.AppLimited)
+        {
+            _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
+                ? rttSeconds
+                : _servingRttEwmaSeconds
+                    + ServingRttEwmaWeight * (rttSeconds - _servingRttEwmaSeconds);
+        }
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
         UpdateDeliveryLatency(
             sendSnapshot.OldestBatchTimestamp,
@@ -390,8 +414,8 @@ internal sealed class BrokerUnackedByteBudget
         var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
         if (bytesPerSecond > 0)
         {
-            AddRateSample(bytesPerSecond);
-            Volatile.Write(ref _maxRateBytesPerSecond, (long)_windowMaxRate);
+            AddRateSample(bytesPerSecond, sendSnapshot.AppLimited);
+            Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
         UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
@@ -412,7 +436,7 @@ internal sealed class BrokerUnackedByteBudget
         if (writtenUnackedPeak > 0)
             AddOccupancySample(writtenUnackedPeak);
 
-        RecomputeBudget();
+        RecomputeBudget(nowTicks);
     }
 
     private void UpdateDeliveryLatency(
@@ -580,15 +604,29 @@ internal sealed class BrokerUnackedByteBudget
                 _windowMaxOccupancyBytes = Max(_occupancyBucketMaxValues);
         }
 
+        if (_retainedLoadedMaxRate > _windowMaxRate)
+        {
+            var decay = elapsed == 1
+                ? LoadedRateDecayPerBucket
+                : Math.Pow(LoadedRateDecayPerBucket, elapsed);
+            _retainedLoadedMaxRate = _windowMaxRate
+                + (_retainedLoadedMaxRate - _windowMaxRate) * decay;
+        }
+
         _currentWindowBucket = bucket;
     }
 
-    private void AddRateSample(double bytesPerSecond)
+    private void AddRateSample(double bytesPerSecond, bool appLimited)
     {
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
         _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
+        _retainedLoadedMaxRate = appLimited
+            ? 0
+            : Math.Max(_retainedLoadedMaxRate, bytesPerSecond);
     }
+
+    private double GetEffectiveMaxRate() => Math.Max(_windowMaxRate, _retainedLoadedMaxRate);
 
     private void AddOccupancySample(long bytes)
     {
@@ -603,7 +641,10 @@ internal sealed class BrokerUnackedByteBudget
         long rttTicks,
         long nowTicks)
     {
-        var probeIntervalTicks = ProbeIntervalRtts * rttTicks;
+        var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
+        var probeDurationTicks = Math.Max(
+            probeIntervalTicks,
+            (ProbeEvaluationRtts + 1L) * rttTicks);
         if (_nextProbeTimestamp == 0)
             _nextProbeTimestamp = nowTicks + probeIntervalTicks;
 
@@ -623,23 +664,26 @@ internal sealed class BrokerUnackedByteBudget
             if (sendTimestamp < _capacityProbeStartTimestamp)
                 return;
 
-            _capacityProbePeakRate = Math.Max(_capacityProbePeakRate, bytesPerSecond);
+            _capacityProbeRateSum += bytesPerSecond;
+            _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
-                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + rttTicks;
+                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + ProbeEvaluationRtts * rttTicks;
                 return;
             }
 
             if (nowTicks < _capacityProbeEvaluationDeadlineTimestamp)
                 return;
 
-            if (_capacityProbePeakRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            var averageRate = _capacityProbeRateSum / _capacityProbeRateSampleCount;
+            if (averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
-                _capacityProbeBaselineRate = _capacityProbePeakRate;
+                _capacityProbeBaselineRate = averageRate;
                 _capacityProbeStartTimestamp = nowTicks;
-                _capacityProbePeakRate = 0;
+                _capacityProbeRateSum = 0;
+                _capacityProbeRateSampleCount = 0;
                 _capacityProbeEvaluationDeadlineTimestamp = 0;
-                Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
+                Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             }
             else
             {
@@ -656,10 +700,11 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
         {
             _capacityProbeStartTimestamp = nowTicks;
-            _capacityProbeBaselineRate = _windowMaxRate;
-            _capacityProbePeakRate = 0;
+            _capacityProbeBaselineRate = GetEffectiveMaxRate();
+            _capacityProbeRateSum = 0;
+            _capacityProbeRateSampleCount = 0;
             _capacityProbeEvaluationDeadlineTimestamp = 0;
-            Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeIntervalTicks);
+            Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             Volatile.Write(ref _capacityProbeActive, true);
         }
 
@@ -668,9 +713,15 @@ internal sealed class BrokerUnackedByteBudget
         _nextProbeTimestamp = nowTicks + probeIntervalTicks;
     }
 
+    private static long GetProbeIntervalTicks(long rttTicks)
+        => rttTicks >= MaxProbeIntervalTicks / ProbeIntervalRtts
+            ? MaxProbeIntervalTicks
+            : ProbeIntervalRtts * rttTicks;
+
     private void DeactivateCapacityProbe()
     {
-        _capacityProbePeakRate = 0;
+        _capacityProbeRateSum = 0;
+        _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
@@ -694,20 +745,22 @@ internal sealed class BrokerUnackedByteBudget
         return maximum;
     }
 
-    private void RecomputeBudget()
+    private void RecomputeBudget(long nowTicks)
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
         var postProbeMinRttSeconds = _minRttSeconds;
         if (minRttProbeActive && _minRttProbeMinimumSeconds != double.MaxValue)
             postProbeMinRttSeconds = _minRttProbeMinimumSeconds;
-        var normalBudget = ComputeBudget(
+        var computedNormalBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: false,
             postProbeMinRttSeconds);
+        var normalBudget = ApplyNormalBudgetDecayHysteresis(computedNormalBudget, nowTicks);
         var probeBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: true,
             postProbeMinRttSeconds);
+        probeBudget = Math.Max(normalBudget, probeBudget);
         Volatile.Write(ref _budgetAfterMinRttProbeBytes, normalBudget);
         Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, probeBudget);
 
@@ -727,6 +780,43 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _budgetBytes, budget);
     }
 
+    private long ApplyNormalBudgetDecayHysteresis(long computedBudget, long nowTicks)
+    {
+        var admissionBlockEvents = AdmissionBlockEvents;
+        var admissionWasBlocked = admissionBlockEvents > _lastBudgetAdmissionBlockEvents;
+        var elapsedSeconds = _lastBudgetUpdateTimestamp == 0
+            ? 0
+            : Math.Max(0, (double)(nowTicks - _lastBudgetUpdateTimestamp) / Stopwatch.Frequency);
+        var budget = BoundBudgetDecay(
+            _lastNormalBudgetBytes,
+            computedBudget,
+            elapsedSeconds,
+            admissionWasBlocked);
+        budget = Math.Min(budget, _capBytes);
+        _lastNormalBudgetBytes = budget;
+        _lastBudgetUpdateTimestamp = nowTicks;
+        _lastBudgetAdmissionBlockEvents = admissionBlockEvents;
+        return budget;
+    }
+
+    internal static long BoundBudgetDecay(
+        long previousBudget,
+        long computedBudget,
+        double elapsedSeconds,
+        bool admissionWasBlocked)
+    {
+        if (!admissionWasBlocked
+            || computedBudget >= previousBudget
+            || elapsedSeconds <= 0)
+        {
+            return computedBudget;
+        }
+
+        var decayFraction = Math.Min(1.0, MaximumBudgetDecayPerSecond * elapsedSeconds);
+        var minimumBudget = (long)Math.Ceiling(previousBudget * (1.0 - decayFraction));
+        return Math.Max(computedBudget, minimumBudget);
+    }
+
     private long ComputeBudget(
         bool minRttProbeActive,
         bool capacityProbeActive,
@@ -734,7 +824,8 @@ internal sealed class BrokerUnackedByteBudget
     {
         long budget;
         double rateBudgetBytes = 0;
-        if (_windowMaxRate == 0)
+        var effectiveMaxRate = GetEffectiveMaxRate();
+        if (effectiveMaxRate == 0)
         {
             // Cold start: no drain estimate yet — keep today's semantics (cap) so short-lived
             // producers and tests never see admission throttling.
@@ -743,13 +834,24 @@ internal sealed class BrokerUnackedByteBudget
         else
         {
             var latencyGovernedTargetSeconds = _targetSeconds * _latencyBudgetScale;
-            var horizonSeconds = _hasMinRttSample && !minRttProbeActive
-                ? Math.Max(latencyGovernedTargetSeconds, RttSafetyMultiplier * minRttSeconds)
+            var loadAwareRttSeconds = _retainedLoadedMaxRate > 0
+                ? Math.Max(minRttSeconds, _servingRttEwmaSeconds)
+                : minRttSeconds;
+            var rttFloorSeconds = minRttProbeActive
+                ? MinRttProbeSafetyMultiplier * minRttSeconds
+                : RttSafetyMultiplier * loadAwareRttSeconds;
+            var horizonSeconds = _hasMinRttSample
+                ? Math.Max(latencyGovernedTargetSeconds, rttFloorSeconds)
                 : latencyGovernedTargetSeconds;
-            rateBudgetBytes = _windowMaxRate * horizonSeconds;
+            rateBudgetBytes = effectiveMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)
-                estimatedBytes *= ProbeBudgetMultiplier;
+            {
+                var multiplier = rttFloorSeconds > latencyGovernedTargetSeconds
+                    ? RttFloorProbeBudgetMultiplier
+                    : ProbeBudgetMultiplier;
+                estimatedBytes *= multiplier;
+            }
 
             budget = (long)estimatedBytes;
         }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -113,6 +113,8 @@ internal sealed class BrokerUnackedByteBudget
     private const double MinRttProbeSafetyMultiplier = 1.0;
 
     private const int ProbeIntervalRtts = 8;
+    // A capacity probe needs one RTT for the enlarged budget to reach the wire,
+    // then three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
     private const double RttFloorProbeBudgetMultiplier = 1.5;
@@ -782,6 +784,9 @@ internal sealed class BrokerUnackedByteBudget
 
     private long ApplyNormalBudgetDecayHysteresis(long computedBudget, long nowTicks)
     {
+        // Smooth downward changes only while fresh admission blocks prove demand.
+        // Capping decay at 10%/s prevents the short estimator window from draining
+        // the budget faster than a loaded pipeline can demonstrate recovery.
         var admissionBlockEvents = AdmissionBlockEvents;
         var admissionWasBlocked = admissionBlockEvents > _lastBudgetAdmissionBlockEvents;
         var elapsedSeconds = _lastBudgetUpdateTimestamp == 0

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -11,7 +11,7 @@ namespace Dekaf.Producer;
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
 /// by the broker's drain rate; capping the standing bytes to
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
-/// periodically refreshed minimum RTT plus the loaded serving RTT, so standing queue delay
+/// periodically refreshed minimum RTT or the loaded serving RTT, so standing queue delay
 /// cannot replace the base RTT while replicated service time still keeps the pipe full.
 /// <para>
 /// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
@@ -86,6 +86,10 @@ internal sealed class BrokerUnackedByteBudget
     /// enough history to ignore short scheduler and broker stalls.
     /// </summary>
     private static readonly long WindowBucketTicks = Math.Max(1, (long)(WindowBucketSeconds * Stopwatch.Frequency));
+    // A momentarily empty pending-response count is normal between depth-one requests and
+    // concurrent send waves. Treat it as genuine application idle only after one full fast
+    // estimator window without a delivery.
+    private static readonly long WindowDurationTicks = WindowBucketCount * WindowBucketTicks;
     private static readonly double LoadedRateDecayPerBucket =
         Math.Pow(0.5, WindowBucketSeconds / LoadedRateHalfLifeSeconds);
     private static readonly long LatencyControlIntervalTicks = Math.Max(1, Stopwatch.Frequency / 10);
@@ -360,7 +364,7 @@ internal sealed class BrokerUnackedByteBudget
         CompleteExpiredMinRttProbe(nowTicks);
         if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
             DeactivateCapacityProbe();
-        RecomputeBudget(nowTicks);
+        RecomputeBudget(nowTicks, consumeAdmissionBlockEvents: false);
     }
 
     /// <summary>
@@ -382,8 +386,16 @@ internal sealed class BrokerUnackedByteBudget
             return;
 
         var rttSeconds = (double)rttTicks / Stopwatch.Frequency;
+        var deliveryIdleTicks = sendSnapshot.SendTimestamp - sendSnapshot.DeliveredTimestamp;
+        var sustainedIdle = sendSnapshot.AppLimited
+            && sendSnapshot.DeliveredTimestamp != 0
+            && deliveryIdleTicks >= WindowDurationTicks;
+        var loadedSample = !sendSnapshot.AppLimited
+            || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
+        var minRttProbeActive = _minRttProbeUntilTimestamp != 0
+            && nowTicks < _minRttProbeUntilTimestamp;
         UpdateMinRtt(rttSeconds, nowTicks);
-        if (!sendSnapshot.AppLimited)
+        if (loadedSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
                 ? rttSeconds
@@ -416,7 +428,7 @@ internal sealed class BrokerUnackedByteBudget
         var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
         if (bytesPerSecond > 0)
         {
-            AddRateSample(bytesPerSecond, sendSnapshot.AppLimited);
+            AddRateSample(bytesPerSecond, loadedSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
@@ -438,7 +450,7 @@ internal sealed class BrokerUnackedByteBudget
         if (writtenUnackedPeak > 0)
             AddOccupancySample(writtenUnackedPeak);
 
-        RecomputeBudget(nowTicks);
+        RecomputeBudget(nowTicks, consumeAdmissionBlockEvents: true);
     }
 
     private void UpdateDeliveryLatency(
@@ -618,14 +630,15 @@ internal sealed class BrokerUnackedByteBudget
         _currentWindowBucket = bucket;
     }
 
-    private void AddRateSample(double bytesPerSecond, bool appLimited)
+    private void AddRateSample(double bytesPerSecond, bool loadedSample, bool sustainedIdle)
     {
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
         _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
-        _retainedLoadedMaxRate = appLimited
-            ? 0
-            : Math.Max(_retainedLoadedMaxRate, bytesPerSecond);
+        if (sustainedIdle)
+            _retainedLoadedMaxRate = 0;
+        else if (loadedSample)
+            _retainedLoadedMaxRate = Math.Max(_retainedLoadedMaxRate, bytesPerSecond);
     }
 
     private double GetEffectiveMaxRate() => Math.Max(_windowMaxRate, _retainedLoadedMaxRate);
@@ -747,7 +760,7 @@ internal sealed class BrokerUnackedByteBudget
         return maximum;
     }
 
-    private void RecomputeBudget(long nowTicks)
+    private void RecomputeBudget(long nowTicks, bool consumeAdmissionBlockEvents)
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
         var postProbeMinRttSeconds = _minRttSeconds;
@@ -757,7 +770,10 @@ internal sealed class BrokerUnackedByteBudget
             minRttProbeActive: false,
             capacityProbeActive: false,
             postProbeMinRttSeconds);
-        var normalBudget = ApplyNormalBudgetDecayHysteresis(computedNormalBudget, nowTicks);
+        var normalBudget = ApplyNormalBudgetDecayHysteresis(
+            computedNormalBudget,
+            nowTicks,
+            consumeAdmissionBlockEvents);
         var probeBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: true,
@@ -782,7 +798,10 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _budgetBytes, budget);
     }
 
-    private long ApplyNormalBudgetDecayHysteresis(long computedBudget, long nowTicks)
+    private long ApplyNormalBudgetDecayHysteresis(
+        long computedBudget,
+        long nowTicks,
+        bool consumeAdmissionBlockEvents)
     {
         // Smooth downward changes only while fresh admission blocks prove demand.
         // Capping decay at 10%/s prevents the short estimator window from draining
@@ -800,7 +819,10 @@ internal sealed class BrokerUnackedByteBudget
         budget = Math.Min(budget, _capBytes);
         _lastNormalBudgetBytes = budget;
         _lastBudgetUpdateTimestamp = nowTicks;
-        _lastBudgetAdmissionBlockEvents = admissionBlockEvents;
+        // SetCap may run immediately before the ack pass that owns this pressure signal.
+        // Only that pass consumes the cursor, so scaling cannot erase decay protection.
+        if (consumeAdmissionBlockEvents)
+            _lastBudgetAdmissionBlockEvents = admissionBlockEvents;
         return budget;
     }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -392,8 +392,11 @@ internal sealed class BrokerUnackedByteBudget
             && deliveryIdleTicks >= WindowDurationTicks;
         var loadedSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
+        // The deadline ack may establish the first loaded serving estimate (depth-one traffic),
+        // but must not drag an existing estimate toward the queue-drained probe RTT.
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0
-            && nowTicks < _minRttProbeUntilTimestamp;
+            && (nowTicks < _minRttProbeUntilTimestamp
+                || (nowTicks == _minRttProbeUntilTimestamp && _servingRttEwmaSeconds > 0));
         UpdateMinRtt(rttSeconds, nowTicks);
         if (loadedSample && !minRttProbeActive)
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -3167,11 +3167,12 @@ public sealed class BrokerSenderSendLoopTests
                 responses[i].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: i * 10));
             }
 
-            // The first ack establishes a rate and starts the target-only base-RTT probe.
-            // Its tiny target clamps to 200 bytes; recent occupancy is deliberately ignored
-            // until the standing queue drains and the minimum-RTT probe completes.
+            // The first ack establishes a rate and starts the base-RTT probe. The probe
+            // ignores recent occupancy but retains one BDP, exactly this one-request pipe,
+            // so sampling base RTT cannot empty the connection. Tick conversion may truncate
+            // the rate-times-RTT reconstruction by one byte.
             await WaitUntilAsync(() => budget.BudgetBytes != 1_000_000, cancellationToken);
-            await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+            await Assert.That(budget.BudgetBytes).IsBetween(dataSize - 1, dataSize);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -282,7 +282,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task MinimumRtt_LoadedSamplesDoNotInflateBudget()
+    public async Task ServingRtt_LoadedSamplesRaiseSafetyFloorWithoutReplacingMinimum()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
@@ -290,9 +290,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 500, 0.005, T0 + Seconds(0.051));
         Ack(budget, 10_000, 0.100, T0 + Seconds(1.0));
 
-        // Both samples measure 100,000 B/s. The 5ms base RTT leaves the 10ms target
-        // in control; the later queue-loaded 100ms sample must not grow the horizon.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        // Both samples measure 100,000 B/s. The later back-to-back 100ms service sample
+        // raises the loaded horizon while the retained 5ms base RTT remains unchanged.
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_531);
     }
 
     [Test]
@@ -328,8 +329,9 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // The final 10,000-byte request measures its own 100ms sojourn (100,000 B/s);
         // pipelined delivery credit flows through the delivered-counter delta rather than
-        // a shrunken inter-ack interval.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        // a shrunken inter-ack interval. Normal operation restores the serving-RTT floor.
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(1_000);
     }
 
     [Test]
@@ -406,6 +408,8 @@ public sealed class BrokerUnackedByteBudgetTests
         // Refresh the old 100ms minimum, then observe 5ms while the drain probe is open.
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         Ack(budget, 500, 0.005, T0 + Seconds(10.25));
+        SetField(budget, "_retainedLoadedMaxRate", 0.0);
+        budget.SetCap(1_000_000, T0 + Seconds(10.25));
         budget.Charge(2_000);
 
         // Once the probe expires without another ack, admission must use the refreshed
@@ -424,9 +428,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.25));
 
-        // No ack landed inside the 100ms target-only drain. The late loaded sample must
-        // not replace the retained 5ms base RTT and inflate the horizon to 150ms.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        // No ack landed inside the 100ms drain. The late loaded sample must not replace
+        // the retained 5ms base RTT, but it does restore a serving-RTT safety horizon.
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_531);
     }
 
     [Test]
@@ -549,7 +554,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task AppLimitedSend_ResetsRetainedLoadedRate()
+    public async Task AppLimitedSend_AfterBriefDrainRetainsLoadedRate()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.5,
@@ -562,8 +567,84 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 100, 0.100, T0 + Seconds(3.0), appLimitedAtSend: true);
 
+        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsGreaterThan(0)
+            .Because("an instantaneous empty-pipe snapshot is common between loaded bursts");
+    }
+
+    [Test]
+    public async Task BackToBackAppLimitedSends_EstablishLoadedServiceEstimate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: true);
+        Ack(budget, 1_000, 0.100, T0 + Seconds(0.100), appLimitedAtSend: true);
+
+        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsGreaterThan(0)
+            .Because("recent delivery distinguishes a depth-one loaded pipe from real idle");
+        await Assert.That(GetField<double>(budget, "_servingRttEwmaSeconds")).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task AppLimitedSend_AfterSustainedIdleResetsRetainedLoadedRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
+        Ack(budget, 100, 0.100, T0 + Seconds(2.1), appLimitedAtSend: false);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000);
+
+        Ack(budget, 100, 0.100, T0 + Seconds(4.3), appLimitedAtSend: true);
+
         await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsEqualTo(0)
-            .Because("true application idle must clear the stale loaded-rate floor");
+            .Because("a full rate-window of true idle must clear stale loaded capacity");
+    }
+
+    [Test]
+    public async Task MinimumRttProbe_DoesNotLowerServingRttEwma()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.005);
+        SetField(budget, "_servingRttEwmaSeconds", 0.100);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_minRttProbeMinimumSeconds", double.MaxValue);
+
+        budget.OnAcked(
+            1_000,
+            budget.SnapshotDelivery(T0 - Seconds(0.005), appLimited: false),
+            T0);
+
+        await Assert.That(GetField<double>(budget, "_servingRttEwmaSeconds")).IsEqualTo(0.100)
+            .Because("queue-draining probe RTTs must not erase the loaded serving-RTT floor");
+    }
+
+    [Test]
+    public async Task SetCap_DoesNotConsumeAdmissionPressureBeforeAckPass()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_windowMaxRate", 1_000.0);
+        SetField(budget, "_lastNormalBudgetBytes", 100_000L);
+        SetField(budget, "_lastBudgetUpdateTimestamp", T0);
+        budget.RecordAdmissionBlock();
+
+        budget.SetCap(1_000_000, T0 + Seconds(1.0));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(90_000);
+
+        budget.CompleteAckedPass(T0 + Seconds(2.0));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(81_000)
+            .Because("the ack pass must still observe pressure seen just before SetCap");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -24,6 +24,11 @@ public sealed class BrokerUnackedByteBudgetTests
             .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(budget, value);
 
+    private static T GetField<T>(BrokerUnackedByteBudget budget, string fieldName)
+        => (T)typeof(BrokerUnackedByteBudget)
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(budget)!;
+
     /// <summary>
     /// Acknowledges one request the way the send loop does: the send timestamp is derived
     /// from the request's round trip, and the delivery snapshot defaults to the clock as of
@@ -237,6 +242,46 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task Budget_RttGuard_UsesServingRttEwmaUnderLoad()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.001);
+        SetField(budget, "_servingRttEwmaSeconds", 0.020);
+        SetField(budget, "_windowMaxRate", 1_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+
+        budget.SetCap(1_000_000, T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000)
+            .Because("replicated serving RTT, not base RTT, determines the loaded BDP");
+    }
+
+    [Test]
+    public async Task RttFloorCapacityProbe_UsesExtraHeadroom()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.001);
+        SetField(budget, "_servingRttEwmaSeconds", 0.020);
+        SetField(budget, "_windowMaxRate", 1_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_capacityProbeActive", true);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+
+        budget.SetCap(1_000_000, T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(45_000)
+            .Because("an RTT-floor-bound pipe needs a wider probe than the normal 1.25x step");
+    }
+
+    [Test]
     public async Task MinimumRtt_LoadedSamplesDoNotInflateBudget()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -248,6 +293,20 @@ public sealed class BrokerUnackedByteBudgetTests
         // Both samples measure 100,000 B/s. The 5ms base RTT leaves the 10ms target
         // in control; the later queue-loaded 100ms sample must not grow the horizon.
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+    }
+
+    [Test]
+    public async Task MinimumRttProbe_RetainsOneBdpWhileDrainingQueue()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 10_000, 0.100, T0, appLimitedAtSend: false);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000)
+            .Because("base-RTT sampling must drain queueing without emptying the serving pipe");
     }
 
     [Test]
@@ -298,7 +357,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0);
         Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
         Ack(budget, 200_000, 2.000, T0 + Seconds(10.2));
-        budget.Charge(2_000);
+        budget.Charge(11_000);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.451))).IsFalse();
@@ -314,7 +373,7 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
 
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
 
         budget.SetCap(1_000_000, T0 + Seconds(10.401));
 
@@ -329,7 +388,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0);
         Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
-        budget.Charge(2_000);
+        budget.Charge(11_000);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
         await Assert.That(budget.IsOverBudget()).IsTrue();
@@ -464,12 +523,47 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task WindowedMaximum_PeakExpires_AfterTwoSeconds()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
 
         Ack(budget, 1_000, 0.100, T0);
         for (var i = 1; i <= 20; i++)
             Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
+    }
+
+    [Test]
+    public async Task LoadedRatePeak_DecaysOverMinutes_NotTwoSeconds()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
+        for (var i = 1; i <= 21; i++)
+            Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100), appLimitedAtSend: false);
+
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000)
+            .Because("a two-second broker stall must not collapse the estimated pipe capacity");
+    }
+
+    [Test]
+    public async Task AppLimitedSend_ResetsRetainedLoadedRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
+        Ack(budget, 100, 0.100, T0 + Seconds(2.1), appLimitedAtSend: false);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000);
+
+        Ack(budget, 100, 0.100, T0 + Seconds(3.0), appLimitedAtSend: true);
+
+        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsEqualTo(0)
+            .Because("true application idle must clear the stale loaded-rate floor");
     }
 
     [Test]
@@ -491,7 +585,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_CollectsOneRtt_ThenRevertsWithoutRateGain()
+    public async Task PeriodicProbe_CollectsThreeRtts_ThenRevertsWithoutRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
@@ -504,8 +598,68 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_CapsHighRttWallClockInterval()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 1.0, T0);
+
+        var nextProbeTimestamp = GetField<long>(budget, "_nextProbeTimestamp");
+        await Assert.That(nextProbeTimestamp - T0).IsLessThanOrEqualTo(Seconds(1.0));
+    }
+
+    [Test]
+    public async Task PeriodicProbe_UsesMultiRttAverage_NotSinglePeak()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_windowMaxRate", 10_000.0);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 2_000, 0.100, T0 + Seconds(0.100), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.200), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.400), appLimitedAtSend: false);
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("one noisy high sample must not ratchet a three-RTT low-rate probe");
+    }
+
+    [Test]
+    public async Task BudgetDecay_IsRateLimitedOnlyWhileAdmissionBlocks()
+    {
+        var blocked = BrokerUnackedByteBudget.BoundBudgetDecay(
+            previousBudget: 100_000,
+            computedBudget: 10_000,
+            elapsedSeconds: 1.0,
+            admissionWasBlocked: true);
+        var unblocked = BrokerUnackedByteBudget.BoundBudgetDecay(
+            previousBudget: 100_000,
+            computedBudget: 10_000,
+            elapsedSeconds: 1.0,
+            admissionWasBlocked: false);
+
+        await Assert.That(blocked).IsEqualTo(90_000);
+        await Assert.That(unblocked).IsEqualTo(10_000);
     }
 
     [Test]
@@ -580,12 +734,16 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.200, T0 + Seconds(0.900));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        // First request wholly admitted under the probe starts one RTT of measurement.
+        // First request wholly admitted under the probe starts three RTTs of measurement.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        // A full RTT of wholly-probed responses confirms no gain and ends the probe.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        // Three RTTs of wholly-probed responses confirm no gain and end the probe.
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
     }
 
@@ -603,13 +761,23 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
-        // The first sample under the higher level starts another full-RTT measurement.
+        // The probe averages three RTTs before ratcheting to the higher level.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
-        // One RTT without further growth publishes the newly discovered base budget
-        // without the temporary 1.25x multiplier.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+
+        // The ratcheted level gets another three-RTT average. No further growth publishes
+        // the discovered base budget without the temporary 1.25x multiplier.
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.300));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.400));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.500));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.600));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.700));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.800));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
+        Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
     }
 
@@ -696,9 +864,9 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(49_000_000);
         await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(51_000_000);
 
-        // Budget ≈ target × rate — three orders of magnitude below the cap the broken
-        // estimator pegged.
-        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(600_000);
+        // The initial minimum-RTT probe now retains one BDP instead of draining the pipe;
+        // this remains far below the cap the broken estimator pegged.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -628,6 +628,29 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRttProbe_CompletionAck_DoesNotLowerServingRttEwma()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.005);
+        SetField(budget, "_servingRttEwmaSeconds", 0.100);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0);
+        SetField(budget, "_minRttProbeMinimumSeconds", 0.005);
+
+        budget.OnAcked(
+            1_000,
+            budget.SnapshotDelivery(T0 - Seconds(0.005), appLimited: false),
+            T0);
+
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp")).IsEqualTo(0);
+        await Assert.That(GetField<double>(budget, "_servingRttEwmaSeconds")).IsEqualTo(0.100)
+            .Because("the ack that completes a queue-draining probe is still a probe RTT sample");
+    }
+
+    [Test]
     public async Task SetCap_DoesNotConsumeAdmissionPressureBeforeAckPass()
     {
         var budget = new BrokerUnackedByteBudget(


### PR DESCRIPTION
Closes #1989

## Summary

- floor loaded budgets on a serving-RTT EWMA instead of base RTT alone
- retain loaded delivery-rate peaks with a 60-second half-life, while clearing the retained floor after true application idle
- cap capacity-probe cadence at one second, evaluate three-RTT averages, and use stronger headroom when RTT-floor-bound
- retain one BDP during minimum-RTT probes instead of emptying the pipe
- rate-limit budget decay to 10%/second while new admission blocks show active gate pressure

Dense-affinity connection widening is intentionally excluded: each partition is deterministically assigned to one connection and width is capped by known partitions, so extra lanes would be idle or risk ordering changes. Recovery stays in the budget controller.

#1997 changes the same controller's latency-governor policy. This PR keeps that independent scope separate and may require a mechanical rebase after #1997 lands.

## Validation

- net10 unit suite: 5,367 passed
- net8 unit suite: 5,269 passed; one unrelated 30-second scheduling timeout passed alone in 302 ms
- focused budget suite: 52 passed
- BenchmarkDotNet: 10.29 ns acknowledgement, 13.00 ns acknowledgement pass, zero allocations