### PR TITLE
perf(producer): eliminate transactional continuation dispatch

### DIFF
--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -40,6 +40,12 @@ internal static class DekafMetrics
             unit: "{retry}",
             description: "Number of produce retries.");
 
+    internal static readonly Counter<long> InlineContinuationExceptions =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "dekaf.producer.inline_continuation.exceptions",
+            unit: "{exception}",
+            description: "Exceptions isolated from inline transactional produce continuations.");
+
     // Consumer metrics
     internal static readonly Counter<long> MessagesReceived =
         DekafDiagnostics.Meter.CreateCounter<long>(

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -190,6 +190,12 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Begins a transaction (if transactional).
     /// </summary>
+    /// <remarks>
+    /// Transactional produce continuations run inline on a broker sender thread shared by
+    /// other partitions using that broker connection. Code after each transactional
+    /// <see cref="ITransaction{TKey, TValue}.ProduceAsync"/> call must remain non-blocking
+    /// and avoid long-running synchronous work.
+    /// </remarks>
     ITransaction<TKey, TValue> BeginTransaction();
 
     /// <summary>
@@ -469,6 +475,12 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
     /// <summary>
     /// Produces a message within the transaction.
     /// </summary>
+    /// <remarks>
+    /// The continuation after awaiting this method runs inline on a broker sender thread
+    /// shared by other partitions using that broker connection. Keep code between this
+    /// call and the next transactional operation non-blocking and computationally cheap;
+    /// synchronous waits or long-running work delay broker-wide send and response processing.
+    /// </remarks>
     ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken = default);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -970,9 +970,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         // All checks passed - we can proceed synchronously
-        completion = _valueTaskSourcePool.Rent();
-        if (!runContinuationsAsynchronously)
-            completion.SetRunContinuationsAsynchronously(false);
+        completion = RentCompletion(runContinuationsAsynchronously);
         var result = SyncProduceResult.Success;
         try
         {
@@ -1027,9 +1025,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         // Topic cache miss — fetch topic metadata inline and produce
-        var completion = _valueTaskSourcePool.Rent();
-        if (!runContinuationsAsynchronously)
-            completion.SetRunContinuationsAsynchronously(false);
+        var completion = RentCompletion(runContinuationsAsynchronously);
         try
         {
             await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);
@@ -1056,6 +1052,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return await AwaitWithCancellation(completion, cancellationToken).ConfigureAwait(false);
         }
         return await completion.Task.ConfigureAwait(false);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private PooledValueTaskSource<RecordMetadata> RentCompletion(bool runContinuationsAsynchronously)
+    {
+        var completion = _valueTaskSourcePool.Rent();
+        if (!runContinuationsAsynchronously)
+            completion.SetRunContinuationsAsynchronously(false);
+        return completion;
     }
 
     /// <inheritdoc />

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -489,13 +489,24 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken = default)
     {
         if (_retryPolicy is not null)
-            return ProduceAsyncWithRetry(message, cancellationToken);
+            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: true, cancellationToken);
 
-        return ProduceAsyncCore(message, cancellationToken);
+        return ProduceAsyncCore(message, runContinuationsAsynchronously: true, cancellationToken);
+    }
+
+    internal ValueTask<RecordMetadata> ProduceTransactionAsync(
+        ProducerMessage<TKey, TValue> message,
+        CancellationToken cancellationToken)
+    {
+        if (_retryPolicy is not null)
+            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: false, cancellationToken);
+
+        return ProduceAsyncCore(message, runContinuationsAsynchronously: false, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(
         ProducerMessage<TKey, TValue> message,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         ThrowIfProduceCannotStart();
@@ -528,11 +539,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (!prepare.IsCompletedSuccessfully)
             {
-                return AwaitPrepareThenProduce(prepare, message, activity, cancellationToken);
+                return AwaitPrepareThenProduce(
+                    prepare,
+                    message,
+                    activity,
+                    runContinuationsAsynchronously,
+                    cancellationToken);
             }
         }
 
-        return ProduceAfterPrepare(message, activity, cancellationToken);
+        return ProduceAfterPrepare(message, activity, runContinuationsAsynchronously, cancellationToken);
     }
 
     // Stops and error-tags a started span when async serializer preparation fails before the
@@ -552,11 +568,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         // Fast path: Try synchronous produce if metadata is initialized and cached.
         // This bypasses channel overhead for 99%+ of calls after warmup.
-        if (TryProduceSyncForAsync(message, out var completion))
+        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var completion))
         {
             // POST-QUEUE: Message appended to batch, committed to being sent
             // Message WILL be delivered, but caller can stop waiting via cancellation token.
@@ -577,13 +594,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Slow path: Fall back to channel-based async processing.
         // This handles first-time metadata initialization or cache misses.
-        return ProduceAsyncSlow(message, activity, cancellationToken);
+        return ProduceAsyncSlow(message, activity, runContinuationsAsynchronously, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
         ValueTask prepare,
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         try
@@ -598,7 +616,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw;
         }
 
-        return await ProduceAfterPrepare(message, activity, cancellationToken).ConfigureAwait(false);
+        return await ProduceAfterPrepare(
+            message,
+            activity,
+            runContinuationsAsynchronously,
+            cancellationToken).ConfigureAwait(false);
     }
 
     // Ensures any serializer that implements IAsyncSerializerPreparer<T> has fetched its schema (or
@@ -707,7 +729,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         DateTimeOffset? timestamp,
         CancellationToken cancellationToken)
     {
-        if (TryProduceSyncForAsync(topic, key, value, headers, partition, timestamp, out var completion))
+        if (TryProduceSyncForAsync(
+            topic,
+            key,
+            value,
+            headers,
+            partition,
+            timestamp,
+            runContinuationsAsynchronously: true,
+            out var completion))
         {
             // POST-QUEUE: Message appended to batch, committed to being sent
             // Message WILL be delivered, but caller can stop waiting via cancellation token.
@@ -731,7 +761,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Headers = headers,
             Partition = partition,
             Timestamp = timestamp
-        }, activity: null, cancellationToken);
+        }, activity: null, runContinuationsAsynchronously: true, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
@@ -751,6 +781,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     [MethodImpl(MethodImplOptions.NoInlining)]
     private async ValueTask<RecordMetadata> ProduceAsyncWithRetry(
         ProducerMessage<TKey, TValue> message,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         var attempt = 0;
@@ -758,7 +789,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             try
             {
-                return await ProduceAsyncCore(message, cancellationToken).ConfigureAwait(false);
+                return await ProduceAsyncCore(
+                    message,
+                    runContinuationsAsynchronously,
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (KafkaException ex) when (ex.IsRetriable)
             {
@@ -880,8 +914,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// Uses thread-local metadata cache for maximum performance on hot path.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool TryProduceSyncForAsync(ProducerMessage<TKey, TValue> message, out PooledValueTaskSource<RecordMetadata>? completion)
-        => TryProduceSyncForAsync(message.Topic, message.Key, message.Value, message.Headers, message.Partition, message.Timestamp, out completion);
+    private bool TryProduceSyncForAsync(
+        ProducerMessage<TKey, TValue> message,
+        bool runContinuationsAsynchronously,
+        out PooledValueTaskSource<RecordMetadata>? completion)
+        => TryProduceSyncForAsync(
+            message.Topic,
+            message.Key,
+            message.Value,
+            message.Headers,
+            message.Partition,
+            message.Timestamp,
+            runContinuationsAsynchronously,
+            out completion);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool TryProduceSyncForAsync(
@@ -891,6 +936,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
+        bool runContinuationsAsynchronously,
         out PooledValueTaskSource<RecordMetadata>? completion)
     {
         completion = null;
@@ -925,6 +971,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // All checks passed - we can proceed synchronously
         completion = _valueTaskSourcePool.Rent();
+        completion.SetRunContinuationsAsynchronously(runContinuationsAsynchronously);
         var result = SyncProduceResult.Success;
         try
         {
@@ -957,10 +1004,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private async ValueTask<RecordMetadata> ProduceAsyncSlow(
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         // Retry fast path - metadata should already be initialized via InitializeAsync()
-        if (TryProduceSyncForAsync(message, out var fastCompletion))
+        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var fastCompletion))
         {
             if (activity is not null)
             {
@@ -979,6 +1027,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Topic cache miss — fetch topic metadata inline and produce
         var completion = _valueTaskSourcePool.Rent();
+        completion.SetRunContinuationsAsynchronously(runContinuationsAsynchronously);
         try
         {
             await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);
@@ -1296,6 +1345,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 // Clean up headers — the async slow path will re-serialize.
                 RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
+                completion.SetRunContinuationsAsynchronously(true);
                 _valueTaskSourcePool.Return(completion);
                 customPartitionerKey.Return();
                 customPartitionerValue.Return();
@@ -4377,7 +4427,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 
             // Partition registration with AddPartitionsToTxn is handled automatically
             // by BrokerSender before the ProduceRequest is sent to the broker.
-            return _producer.ProduceAsync(message, cancellationToken);
+            return _producer.ProduceTransactionAsync(message, cancellationToken);
         }
         catch (OperationCanceledException exception)
         {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -971,7 +971,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // All checks passed - we can proceed synchronously
         completion = _valueTaskSourcePool.Rent();
-        completion.SetRunContinuationsAsynchronously(runContinuationsAsynchronously);
+        if (!runContinuationsAsynchronously)
+            completion.SetRunContinuationsAsynchronously(false);
         var result = SyncProduceResult.Success;
         try
         {
@@ -1027,7 +1028,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Topic cache miss — fetch topic metadata inline and produce
         var completion = _valueTaskSourcePool.Rent();
-        completion.SetRunContinuationsAsynchronously(runContinuationsAsynchronously);
+        if (!runContinuationsAsynchronously)
+            completion.SetRunContinuationsAsynchronously(false);
         try
         {
             await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -42,6 +42,12 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         _pool = pool;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void SetRunContinuationsAsynchronously(bool value)
+    {
+        _core.RunContinuationsAsynchronously = value;
+    }
+
     /// <summary>
     /// Sets a delivery handler to be invoked when the operation completes.
     /// The handler receives the result (or default) and any exception that occurred.
@@ -180,6 +186,7 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
             // Reset completion flag and core for reuse
             Volatile.Write(ref _hasCompleted, 0);
             _core.Reset();
+            _core.RunContinuationsAsynchronously = true;
             pool?.Return(this);
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -7288,13 +7288,13 @@ internal sealed class ReadyBatch
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (source?.TrySetResult(new RecordMetadata
+                    if (TryCompleteSource(source, new RecordMetadata
                     {
                         Topic = _topicPartition.Topic,
                         Partition = _topicPartition.Partition,
                         Offset = baseOffset + i,
                         Timestamp = timestamp
-                    }) == true)
+                    }))
                     {
 #if DEBUG
                         completedCount++;
@@ -7437,7 +7437,7 @@ internal sealed class ReadyBatch
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (source?.TrySetException(exception) == true)
+                    if (TryFailSource(source, exception))
                     {
 #if DEBUG
                         failedCount++;
@@ -7478,6 +7478,44 @@ internal sealed class ReadyBatch
         finally
         {
             Cleanup();
+        }
+    }
+
+    private static bool TryCompleteSource(
+        PooledValueTaskSource<RecordMetadata>? source,
+        RecordMetadata metadata)
+    {
+        if (source is null)
+            return false;
+
+        try
+        {
+            return source.TrySetResult(metadata);
+        }
+        catch
+        {
+            // A raw inline continuation can throw after the source is complete.
+            // Keep resolving the rest of the batch.
+            return true;
+        }
+    }
+
+    private static bool TryFailSource(
+        PooledValueTaskSource<RecordMetadata>? source,
+        Exception exception)
+    {
+        if (source is null)
+            return false;
+
+        try
+        {
+            return source.TrySetException(exception);
+        }
+        catch
+        {
+            // A raw inline continuation can throw after the source is complete.
+            // Keep resolving the rest of the batch.
+            return true;
         }
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -130,6 +130,7 @@ internal static class ProducerDebugCounters
     private static int _batchesFailed;
     private static int _completionSourcesCompleted;
     private static int _completionSourcesFailed;
+    private static int _inlineContinuationExceptions;
 
     // ReadyBatch pool lifecycle. A return count above the rent count proves the same
     // object entered the pool more than once and can be handed to concurrent renters.
@@ -189,6 +190,10 @@ internal static class ProducerDebugCounters
         Interlocked.Add(ref _completionSourcesFailed, count);
 
     [Conditional("DEBUG")]
+    public static void RecordInlineContinuationException() =>
+        Interlocked.Increment(ref _inlineContinuationExceptions);
+
+    [Conditional("DEBUG")]
     public static void RecordReadyBatchRented() => Interlocked.Increment(ref _readyBatchesRented);
 
     [Conditional("DEBUG")]
@@ -220,6 +225,7 @@ internal static class ProducerDebugCounters
         _batchesFailed = 0;
         _completionSourcesCompleted = 0;
         _completionSourcesFailed = 0;
+        _inlineContinuationExceptions = 0;
         _readyBatchesRented = 0;
         _readyBatchesReturned = 0;
         _readyBatchDuplicateReturns = 0;
@@ -276,6 +282,7 @@ internal static class ProducerDebugCounters
               Batches failed: {_batchesFailed}
               Completion sources completed: {_completionSourcesCompleted}
               Completion sources failed: {_completionSourcesFailed}
+              Inline continuation exceptions: {_inlineContinuationExceptions}
             Stage 5 - Flush/Dispose:
               Flush calls: {_flushCalls}
               Batches flushed from dictionary: {_batchesFlushedFromDictionary}
@@ -423,6 +430,7 @@ internal static class PooledCompletionSource
         {
             // A raw inline continuation can throw after the source is complete.
             // Isolate it so sibling completions and producer cleanup can continue.
+            ProducerDebugCounters.RecordInlineContinuationException();
             return true;
         }
     }
@@ -442,6 +450,7 @@ internal static class PooledCompletionSource
         {
             // A raw inline continuation can throw after the source is complete.
             // Isolate it so sibling completions and producer cleanup can continue.
+            ProducerDebugCounters.RecordInlineContinuationException();
             return true;
         }
     }
@@ -461,6 +470,7 @@ internal static class PooledCompletionSource
         {
             // A raw inline continuation can throw after the source is complete.
             // Isolate it so sibling completions and producer cleanup can continue.
+            ProducerDebugCounters.RecordInlineContinuationException();
             return true;
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -430,7 +430,7 @@ internal static class PooledCompletionSource
         {
             // A raw inline continuation can throw after the source is complete.
             // Isolate it so sibling completions and producer cleanup can continue.
-            ProducerDebugCounters.RecordInlineContinuationException();
+            RecordInlineContinuationException();
             return true;
         }
     }
@@ -448,9 +448,7 @@ internal static class PooledCompletionSource
         }
         catch
         {
-            // A raw inline continuation can throw after the source is complete.
-            // Isolate it so sibling completions and producer cleanup can continue.
-            ProducerDebugCounters.RecordInlineContinuationException();
+            RecordInlineContinuationException();
             return true;
         }
     }
@@ -468,11 +466,17 @@ internal static class PooledCompletionSource
         }
         catch
         {
-            // A raw inline continuation can throw after the source is complete.
-            // Isolate it so sibling completions and producer cleanup can continue.
-            ProducerDebugCounters.RecordInlineContinuationException();
+            RecordInlineContinuationException();
             return true;
         }
+    }
+
+    private static void RecordInlineContinuationException()
+    {
+        // The source already completed. Preserve sibling progress while exposing the raw
+        // continuation failure through Release telemetry and richer DEBUG diagnostics.
+        ProducerDebugCounters.RecordInlineContinuationException();
+        Diagnostics.DekafMetrics.InlineContinuationExceptions.Add(1);
     }
 }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -406,6 +406,66 @@ internal static class ProducerContainerPools
             maxArrayLength: MaxRecordArrayLength, maxArraysPerBucket: 16);
 }
 
+internal static class PooledCompletionSource
+{
+    internal static bool TrySetResult(
+        PooledValueTaskSource<RecordMetadata>? source,
+        RecordMetadata metadata)
+    {
+        if (source is null)
+            return false;
+
+        try
+        {
+            return source.TrySetResult(metadata);
+        }
+        catch
+        {
+            // A raw inline continuation can throw after the source is complete.
+            // Isolate it so sibling completions and producer cleanup can continue.
+            return true;
+        }
+    }
+
+    internal static bool TrySetException(
+        PooledValueTaskSource<RecordMetadata>? source,
+        Exception exception)
+    {
+        if (source is null)
+            return false;
+
+        try
+        {
+            return source.TrySetException(exception);
+        }
+        catch
+        {
+            // A raw inline continuation can throw after the source is complete.
+            // Isolate it so sibling completions and producer cleanup can continue.
+            return true;
+        }
+    }
+
+    internal static bool TrySetCanceled(
+        PooledValueTaskSource<RecordMetadata>? source,
+        CancellationToken cancellationToken)
+    {
+        if (source is null)
+            return false;
+
+        try
+        {
+            return source.TrySetCanceled(cancellationToken);
+        }
+        catch
+        {
+            // A raw inline continuation can throw after the source is complete.
+            // Isolate it so sibling completions and producer cleanup can continue.
+            return true;
+        }
+    }
+}
+
 /// <summary>
 /// Represents memory rented from <see cref="ProducerDataPool.BytePool"/> that must be returned
 /// when no longer needed.
@@ -2224,18 +2284,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (!await appendTask.ConfigureAwait(false))
                 {
                     CleanupWorkItemResources(in workItem);
-                    workItem.Completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
+                    PooledCompletionSource.TrySetException(
+                        workItem.Completion,
+                        new ObjectDisposedException(nameof(RecordAccumulator)));
                 }
             }
             catch (OperationCanceledException) when (workItem.CancellationToken.IsCancellationRequested)
             {
                 if (!appendStarted)
                     CleanupWorkItemResources(in workItem);
-                workItem.Completion.TrySetCanceled(workItem.CancellationToken);
+                PooledCompletionSource.TrySetCanceled(workItem.Completion, workItem.CancellationToken);
             }
             catch (Exception ex)
             {
-                workItem.Completion.TrySetException(ex);
+                PooledCompletionSource.TrySetException(workItem.Completion, ex);
             }
             finally
             {
@@ -2290,7 +2352,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             DecrementSlowPathAppendCount(topic, partition);
             CleanupWorkItemResources(in workItem);
-            completion.TrySetException(new ObjectDisposedException(nameof(RecordAccumulator)));
+            PooledCompletionSource.TrySetException(
+                completion,
+                new ObjectDisposedException(nameof(RecordAccumulator)));
         }
     }
 
@@ -5403,7 +5467,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             while (channel.Reader.TryRead(out var workItem))
             {
                 CleanupWorkItemResources(in workItem);
-                workItem.Completion?.TrySetException(disposedException);
+                PooledCompletionSource.TrySetException(workItem.Completion, disposedException);
             }
         }
 
@@ -6403,7 +6467,7 @@ internal sealed class PartitionBatch
         if (_completionSourceCount > 0 && _completionSources is not null)
         {
             for (var i = 0; i < _completionSourceCount; i++)
-                _completionSources[i]?.TrySetException(exception);
+                PooledCompletionSource.TrySetException(_completionSources[i], exception);
         }
 
         if (_callbackCount > 0 && _callbacks is not null)
@@ -7205,7 +7269,8 @@ internal sealed class ReadyBatch
                     $"completed={Volatile.Read(ref _completed)}, trace={DiagTrace})");
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
-                    if (_completionSourcesArray[i]?.TrySetException(orphanedException) == true)
+                    if (PooledCompletionSource.TrySetException(
+                        _completionSourcesArray[i], orphanedException))
                         failedCount++;
                 }
             }
@@ -7288,7 +7353,7 @@ internal sealed class ReadyBatch
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (TryCompleteSource(source, new RecordMetadata
+                    if (PooledCompletionSource.TrySetResult(source, new RecordMetadata
                     {
                         Topic = _topicPartition.Topic,
                         Partition = _topicPartition.Partition,
@@ -7437,7 +7502,7 @@ internal sealed class ReadyBatch
                 for (var i = 0; i < _completionSourcesCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (TryFailSource(source, exception))
+                    if (PooledCompletionSource.TrySetException(source, exception))
                     {
 #if DEBUG
                         failedCount++;
@@ -7478,44 +7543,6 @@ internal sealed class ReadyBatch
         finally
         {
             Cleanup();
-        }
-    }
-
-    private static bool TryCompleteSource(
-        PooledValueTaskSource<RecordMetadata>? source,
-        RecordMetadata metadata)
-    {
-        if (source is null)
-            return false;
-
-        try
-        {
-            return source.TrySetResult(metadata);
-        }
-        catch
-        {
-            // A raw inline continuation can throw after the source is complete.
-            // Keep resolving the rest of the batch.
-            return true;
-        }
-    }
-
-    private static bool TryFailSource(
-        PooledValueTaskSource<RecordMetadata>? source,
-        Exception exception)
-    {
-        if (source is null)
-            return false;
-
-        try
-        {
-            return source.TrySetException(exception);
-        }
-        catch
-        {
-            // A raw inline continuation can throw after the source is complete.
-            // Keep resolving the rest of the batch.
-            return true;
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionTests.cs
@@ -23,7 +23,9 @@ public class TransactionTests(KafkaTestContainer kafka) : TransactionalKafkaInte
     }
 
     [Test]
-    public async Task Transaction_Commit_MessagesVisible()
+    [Timeout(60_000)]
+    public async Task Transaction_ProduceThenCommit_InlineContinuationDoesNotDeadlock(
+        CancellationToken cancellationToken)
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();
         var txnId = $"txn-commit-{Guid.NewGuid():N}";
@@ -33,20 +35,22 @@ public class TransactionTests(KafkaTestContainer kafka) : TransactionalKafkaInte
             .WithTransactionalId(txnId)
             .WithAcks(Acks.All)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
-            .BuildAsync();
+            .BuildAsync(cancellationToken);
 
-        await producer.InitTransactionsAsync();
+        await producer.InitTransactionsAsync(cancellationToken);
 
         await using (var txn = producer.BeginTransaction())
         {
+            // Produce resumes inline on the sender thread. Commit must yield at the
+            // asynchronous flush boundary so the sender can finish batch cleanup.
             await txn.ProduceAsync(new ProducerMessage<string, string>
             {
                 Topic = topic,
                 Key = "txn-key",
                 Value = "txn-value"
-            }, CancellationToken.None);
+            }, cancellationToken);
 
-            await txn.CommitAsync();
+            await txn.CommitAsync(cancellationToken);
         }
 
         // Consume the message - it should be visible after commit
@@ -55,7 +59,7 @@ public class TransactionTests(KafkaTestContainer kafka) : TransactionalKafkaInte
             .WithGroupId($"txn-consumer-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(Consumer.AutoOffsetReset.Earliest)
             .WithIsolationLevel(IsolationLevel.ReadCommitted)
-            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync(cancellationToken);
 
         consumer.Subscribe(topic);
 

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -25,6 +25,7 @@ public sealed class DekafMetricInstrumentTests
         DekafMetrics.OperationDuration.Record(0);
         DekafMetrics.ProduceErrors.Add(0);
         DekafMetrics.Retries.Add(0);
+        DekafMetrics.InlineContinuationExceptions.Add(0);
         DekafMetrics.MessagesReceived.Add(0);
         DekafMetrics.BytesReceived.Add(0);
         DekafMetrics.RebalanceDuration.Record(0);
@@ -35,6 +36,7 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.client.operation.duration");
         await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
         await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.inline_continuation.exceptions");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
         await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -303,6 +303,70 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
+    public async Task TransactionFastPath_BufferFull_RestoresAsyncModeBeforePoolReturn()
+    {
+        await using var producer = await CreateBufferBoundaryProducerAsync(maxBlockMs: 30_000);
+        var accumulator = producer.RecordAccumulator;
+        var pool = GetInstanceField<ValueTaskSourcePool<RecordMetadata>>(producer, "_valueTaskSourcePool");
+        await Assert.That(accumulator.TryReserveMemoryForTest(BufferMemoryLimit)).IsTrue();
+
+        try
+        {
+            var pooledBefore = pool.ApproximateCount;
+            var usedFastPath = InvokeTryProduceSyncForAsync(
+                producer,
+                new ProducerMessage<string, string> { Topic = Topic, Key = "key", Value = "value" },
+                runContinuationsAsynchronously: false,
+                out var completion);
+
+            await Assert.That(usedFastPath).IsFalse();
+            await Assert.That(completion).IsNull();
+            await Assert.That(pool.ApproximateCount).IsEqualTo(pooledBefore + 1);
+
+            var reused = pool.Rent();
+            var awaiter = reused.Task.GetAwaiter();
+            var continuationThreadId = 0;
+            var continuation = new TaskCompletionSource<RecordMetadata>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                continuationThreadId = Environment.CurrentManagedThreadId;
+                try
+                {
+                    continuation.SetResult(awaiter.GetResult());
+                }
+                catch (Exception ex)
+                {
+                    continuation.SetException(ex);
+                }
+            });
+            var completionThreadId = 0;
+            var completionThread = new Thread(() =>
+            {
+                completionThreadId = Environment.CurrentManagedThreadId;
+                reused.SetResult(new RecordMetadata
+                {
+                    Topic = Topic,
+                    Partition = 0,
+                    Offset = 0,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+            }) { IsBackground = true };
+
+            completionThread.Start();
+            completionThread.Join();
+            var metadata = await continuation.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            await Assert.That(metadata.Topic).IsEqualTo(Topic);
+            await Assert.That(continuationThreadId).IsNotEqualTo(completionThreadId);
+        }
+        finally
+        {
+            accumulator.ReleaseMemory(BufferMemoryLimit);
+        }
+    }
+
+    [Test]
     public async Task FireAsync_BufferMemoryFull_MaxBlockExpiryThrowsKafkaTimeoutException()
     {
         const int maxBlockMs = 100;
@@ -466,6 +530,37 @@ public class KafkaProducerFastPathTests
         try
         {
             return method!.Invoke(producer, [message, topicInfo, completion])!;
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static bool InvokeTryProduceSyncForAsync(
+        KafkaProducer<string, string> producer,
+        ProducerMessage<string, string> message,
+        bool runContinuationsAsynchronously,
+        out PooledValueTaskSource<RecordMetadata>? completion)
+    {
+        var method = typeof(KafkaProducer<string, string>).GetMethod(
+            "TryProduceSyncForAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            [
+                typeof(ProducerMessage<string, string>),
+                typeof(bool),
+                typeof(PooledValueTaskSource<RecordMetadata>).MakeByRefType()
+            ],
+            modifiers: null);
+        object?[] arguments = [message, runContinuationsAsynchronously, null];
+
+        try
+        {
+            var result = (bool)method!.Invoke(producer, arguments)!;
+            completion = (PooledValueTaskSource<RecordMetadata>?)arguments[2];
+            return result;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -115,6 +115,104 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
+    public async Task TransactionProduceAsync_CompletesContinuationInlineOnSenderThread()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-transaction-producer",
+            TransactionalId = "test-transaction-id",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        producer._transactionState = TransactionState.Ready;
+        var transaction = producer.BeginTransaction();
+        var produceTask = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = "key",
+            Value = "value"
+        });
+        var awaiter = produceTask.GetAwaiter();
+        var continuationThreadId = 0;
+        awaiter.UnsafeOnCompleted(() => continuationThreadId = Environment.CurrentManagedThreadId);
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        var senderThreadId = Environment.CurrentManagedThreadId;
+
+        readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+
+        await Assert.That(continuationThreadId).IsEqualTo(senderThreadId);
+        await Assert.That(awaiter.GetResult().Offset).IsEqualTo(7);
+        producer._transactionState = TransactionState.Ready;
+    }
+
+    [Test]
+    public async Task TransactionProduceAsync_SequentialAwaitCanReenterProducerOnSenderThread()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-sequential-transaction-producer",
+            TransactionalId = "test-transaction-id",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        producer._transactionState = TransactionState.Ready;
+        var transaction = producer.BeginTransaction();
+        var produceTask = ProduceSequentiallyAsync(transaction);
+        var firstBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+
+        firstBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+
+        var secondBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+        secondBatch.CompleteSend(baseOffset: 8, DateTimeOffset.UtcNow);
+        var offsets = await produceTask.ConfigureAwait(false);
+        await Assert.That(offsets).IsEquivalentTo([7L, 8L]);
+        producer._transactionState = TransactionState.Ready;
+
+        static async ValueTask<long[]> ProduceSequentiallyAsync(ITransaction<string, string> transaction)
+        {
+            var first = await transaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key-1",
+                Value = "value-1"
+            }).ConfigureAwait(false);
+            var second = await transaction.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = Topic,
+                Key = "key-2",
+                Value = "value-2"
+            }).ConfigureAwait(false);
+            return [first.Offset, second.Offset];
+        }
+    }
+
+    [Test]
     public async Task FireAsync_KeyedMessageOnStickyPartition_DoesNotAdvanceUniformStickyCounter()
     {
         const int partitionCount = 3;

--- a/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+[NotInParallel("MeterListener")]
+public sealed class PooledCompletionSourceMetricsTests
+{
+    [Test]
+    public async Task ThrowingInlineContinuation_RecordsReleaseMetric()
+    {
+        long recordedExceptions = 0;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName
+                && instrument.Name == "dekaf.producer.inline_continuation.exceptions")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == "dekaf.producer.inline_continuation.exceptions")
+                Interlocked.Add(ref recordedExceptions, measurement);
+        });
+        listener.Start();
+
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 1);
+        var source = pool.Rent();
+        source.SetRunContinuationsAsynchronously(false);
+        var awaiter = source.Task.GetAwaiter();
+        awaiter.UnsafeOnCompleted(static () => throw new InvalidOperationException("expected"));
+
+        var completed = PooledCompletionSource.TrySetResult(source, new RecordMetadata
+        {
+            Topic = "test-topic",
+            Partition = 0,
+            Offset = 0,
+            Timestamp = DateTimeOffset.UnixEpoch
+        });
+
+        await Assert.That(completed).IsTrue();
+        await Assert.That(Volatile.Read(ref recordedExceptions)).IsEqualTo(1);
+        _ = awaiter.GetResult();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -773,6 +773,36 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
+    public async Task ReadyBatch_ThrowingInlineContinuation_DoesNotStrandLaterCompletions()
+    {
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 2);
+        var first = pool.Rent();
+        var second = pool.Rent();
+        first.SetRunContinuationsAsynchronously(false);
+        second.SetRunContinuationsAsynchronously(false);
+        var firstAwaiter = first.Task.GetAwaiter();
+        var secondTask = second.Task;
+        firstAwaiter.UnsafeOnCompleted(static () => throw new InvalidOperationException("expected"));
+        var sources = ProducerContainerPools.CompletionSources.Rent(2);
+        sources[0] = first;
+        sources[1] = second;
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("test-topic", 0),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 2,
+            dataSize: 0);
+        var doneTask = batch.DoneTask;
+
+        batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+
+        await Assert.That(firstAwaiter.GetResult().Offset).IsEqualTo(7);
+        await Assert.That((await secondTask.ConfigureAwait(false)).Offset).IsEqualTo(8);
+        await Assert.That(await doneTask.ConfigureAwait(false)).IsTrue();
+    }
+
+    [Test]
     public async Task ReadyBatchDoneTask_RunContinuationsAsynchronously_SurvivesResetAndReuse()
     {
         var batch = new ReadyBatch();

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -749,6 +749,30 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
+    public async Task InlineContinuationMode_ResetsToAsynchronousWhenReused()
+    {
+        var pool = new ValueTaskSourcePool<int>(maxPoolSize: 1);
+        var source = pool.Rent();
+        source.SetRunContinuationsAsynchronously(false);
+        var awaiter = source.Task.GetAwaiter();
+        var continuationRan = false;
+        awaiter.UnsafeOnCompleted(() => continuationRan = true);
+
+        source.SetResult(1);
+
+        await Assert.That(continuationRan).IsTrue();
+        await Assert.That(awaiter.GetResult()).IsEqualTo(1);
+
+        var reused = pool.Rent();
+        await Assert.That(reused).IsSameReferenceAs(source);
+        var result = await CompleteWithoutRunningContinuationInlineAsync(
+            reused.Task,
+            () => reused.SetResult(2)).ConfigureAwait(false);
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ReadyBatchDoneTask_RunContinuationsAsynchronously_SurvivesResetAndReuse()
     {
         var batch = new ReadyBatch();

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -773,7 +773,9 @@ public class PooledValueTaskSourceTests
     }
 
     [Test]
-    public async Task ReadyBatch_ThrowingInlineContinuation_DoesNotStrandLaterCompletions()
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ReadyBatch_ThrowingInlineContinuation_DoesNotStrandLaterCompletions(bool succeeds)
     {
         await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 2);
         var first = pool.Rent();
@@ -795,11 +797,25 @@ public class PooledValueTaskSourceTests
             dataSize: 0);
         var doneTask = batch.DoneTask;
 
-        batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+        if (succeeds)
+        {
+            batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+            await Assert.That(firstAwaiter.GetResult().Offset).IsEqualTo(7);
+            await Assert.That((await secondTask.ConfigureAwait(false)).Offset).IsEqualTo(8);
+        }
+        else
+        {
+            batch.Fail(new InvalidOperationException("delivery failed"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                _ = firstAwaiter.GetResult();
+                await Task.CompletedTask;
+            });
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await secondTask.ConfigureAwait(false));
+        }
 
-        await Assert.That(firstAwaiter.GetResult().Offset).IsEqualTo(7);
-        await Assert.That((await secondTask.ConfigureAwait(false)).Offset).IsEqualTo(8);
-        await Assert.That(await doneTask.ConfigureAwait(false)).IsTrue();
+        await Assert.That(await doneTask.ConfigureAwait(false)).IsEqualTo(succeeds);
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ValueTaskContinuationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ValueTaskContinuationBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class ValueTaskContinuationBenchmarks
+{
+    private readonly ValueTaskSourcePool<int> _pool = new(maxPoolSize: 1);
+
+    [Benchmark(Baseline = true)]
+    public ValueTask<int> AsynchronousContinuation() => Complete(runContinuationsAsynchronously: true);
+
+    [Benchmark]
+    public ValueTask<int> InlineContinuation() => Complete(runContinuationsAsynchronously: false);
+
+    private ValueTask<int> Complete(bool runContinuationsAsynchronously)
+    {
+        var source = _pool.Rent();
+        source.SetRunContinuationsAsynchronously(runContinuationsAsynchronously);
+        var continuation = AwaitCompletion(source.Task);
+        source.SetResult(42);
+        return continuation;
+    }
+
+    private static async ValueTask<int> AwaitCompletion(ValueTask<int> task) =>
+        await task.ConfigureAwait(false);
+}


### PR DESCRIPTION
## Summary
- resume sequential transactional `ProduceAsync` continuations inline on the broker sender thread
- restore pooled completion sources to asynchronous continuation mode before reuse
- cover inline completion, pooled reuse, and sequential producer reentrancy
- add a focused continuation scheduling benchmark

## Performance
- paired 3-broker transactional stress: 842.93 us/msg Dekaf vs 889.42 us/msg Confluent (0.95x)
- median throughput: 63 vs 20 msg/s (3.18x)
- microbenchmark: 915.5 ns async vs 102.3 ns inline (0.11x), both 128 B
- transactional verification: zero loss, duplicates, aborted leaks, or unexpected records

## Validation
- `dotnet run --project tests/Dekaf.Tests.Unit -c Release -f net10.0 --no-build` (5,362 passed)
- `TransactionTests` integration filter (5 passed)
- `TransactionV2Tests` integration filter (3 passed)
- paired 1-minute `producer-transactional`, all clients, 3 brokers

Closes #1993