### PR TITLE
fix(producer): stabilize unacked-budget control

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -613,6 +613,66 @@ def format_consumer_fetch_timeline(results, title):
     return lines
 
 
+def format_producer_budget_timeline(results, title):
+    """Correlate producer budget/rate/probe state with throughput intervals."""
+    rows = []
+    for result in results:
+        diagnostics = result.get('producerDeliveryDiagnostics') or {}
+        for sample in diagnostics.get('brokerBudgetSamples') or []:
+            rows.append((result, sample))
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('capturedAtUtc', ''))
+    displayed_rows = _sample_evenly(rows, MAX_TIMELINE_ROWS)
+    omitted_rows = len(rows) - len(displayed_rows)
+    lines = [
+        f"## Producer Budget Timeline - {title}",
+        "",
+        "| Client | Sample UTC | Broker | Budget / unacked | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |",
+        "|--------|------------|-------:|------------------|---------:|----------------------:|-----------------:|---------------------------|",
+    ]
+    for result, sample in displayed_rows:
+        sample_time = _parse_timestamp(sample.get('capturedAtUtc'))
+        intervals = result.get('throughput', {}).get('intervalSamples') or []
+        timestamped_intervals = [
+            (interval, _parse_timestamp(interval.get('capturedAtUtc')))
+            for interval in intervals
+        ]
+        timestamped_intervals = [
+            (interval, captured_at)
+            for interval, captured_at in timestamped_intervals
+            if captured_at is not None
+        ]
+        nearest = min(
+            timestamped_intervals,
+            key=lambda item: abs((item[1] - sample_time).total_seconds()),
+            default=(None, None),
+        )[0] if sample_time is not None else None
+        throughput = '-'
+        if nearest is not None:
+            throughput = (
+                f"{nearest.get('elapsedSeconds', 0):.1f}s / "
+                f"{nearest.get('messagesPerSecond', 0):,.0f} msg/s"
+            )
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {sample.get('capturedAtUtc', '-')} | "
+            f"{sample.get('brokerId', '-')} | "
+            f"{sample.get('budgetBytes', 0) / 1_048_576:.1f} MiB / "
+            f"{sample.get('unackedBytes', 0) / 1_048_576:.1f} MiB | "
+            f"{sample.get('maxRateBytesPerSec', 0) / 1_000_000:.1f} MB/s | "
+            f"{sample.get('capacityProbeSuccessCount', 0):,}/"
+            f"{sample.get('capacityProbeFailureCount', 0):,} | "
+            f"{sample.get('admissionBlockCount', 0):,} | {throughput} |"
+        )
+    if omitted_rows > 0:
+        lines.append(
+            f"*{omitted_rows:,} budget sample(s) omitted; rows sampled across the full timeline.*"
+        )
+    lines.append("")
+    return lines
+
+
 def format_latency_outlier_timeline(results, title):
     """Correlate sampled delivery stalls with scaling, throughput, and GC."""
     rows = [
@@ -902,6 +962,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             output.extend(format_connection_scale_timeline(scenario_results, title))
             output.extend(format_producer_request_diagnostics(scenario_results, title))
             output.extend(format_consumer_fetch_timeline(scenario_results, title))
+            output.extend(format_producer_budget_timeline(scenario_results, title))
             output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -5,6 +5,7 @@ from stress_report import (
     format_roundtrip_validation_table,
     format_connection_scale_timeline,
     format_producer_request_diagnostics,
+    format_producer_budget_timeline,
     format_throughput_table,
     generate_scenario_tables,
     intra_run_throughput,
@@ -120,6 +121,33 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("1→2", report)
         self.assertIn("20.0s / 2,000 msg/s", report)
         self.assertIn("120/150", report)
+
+    def test_producer_budget_timeline_surfaces_probe_outcomes(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"]["intervalSamples"] = [{
+            "capturedAtUtc": "2026-07-12T02:20:50+00:00",
+            "elapsedSeconds": 20.0,
+            "messagesPerSecond": 2000.0,
+        }]
+        value["producerDeliveryDiagnostics"] = {
+            "brokerBudgetSamples": [{
+                "capturedAtUtc": "2026-07-12T02:20:49+00:00",
+                "brokerId": 1,
+                "budgetBytes": 8 * 1024 * 1024,
+                "unackedBytes": 6 * 1024 * 1024,
+                "maxRateBytesPerSec": 750_000_000,
+                "capacityProbeSuccessCount": 3,
+                "capacityProbeFailureCount": 2,
+                "admissionBlockCount": 12,
+            }]
+        }
+
+        report = "\n".join(format_producer_budget_timeline([value], "Producer"))
+
+        self.assertIn("8.0 MiB", report)
+        self.assertIn("750.0 MB/s", report)
+        self.assertIn("3/2", report)
+        self.assertIn("20.0s / 2,000 msg/s", report)
 
     def test_scenario_tables_surface_latency_outlier_diagnostics(self):
         value = stress_result("Dekaf", effective_rate=1400)

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -88,7 +88,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
-    private int _maxConnectionsPerBroker = 10;
+    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private bool _isMaxConnectionsPerBrokerConfigured;
     private bool _enableDeliveryDiagnostics;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
@@ -103,6 +104,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
         _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+        _isMaxConnectionsPerBrokerConfigured = true;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -279,13 +281,15 @@ public sealed class ProducerBuilder<TKey, TValue>
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
+        if (!_isMaxConnectionsPerBrokerConfigured)
+            _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
         return this;
     }
 
     /// <summary>
     /// Configures the maximum connections for adaptive connection scaling.
     /// Adaptive scaling is enabled by default — this method only needs to be called
-    /// to change the maximum from the default of 10.
+    /// to change the maximum from the default of 3.
     /// <para>
     /// When sustained backpressure is detected, the producer will automatically add connections
     /// per broker (up to <paramref name="maxConnections"/>) to increase drain throughput.
@@ -297,13 +301,15 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// are removed after sustained low utilization.
     /// </para>
     /// </summary>
-    /// <param name="maxConnections">Maximum connections per broker. Default: 10.</param>
-    public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 10)
+    /// <param name="maxConnections">Maximum connections per broker. Default: 3.</param>
+    public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(
+        int maxConnections = ProducerOptions.DefaultMaxConnectionsPerBroker)
     {
         ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
+        _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -103,7 +103,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _bootstrapServers = clientInfrastructure.BootstrapServers;
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
-        _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+        _maxConnectionsPerBroker = clientInfrastructure.ProducerMaxConnectionsPerBroker;
         _isMaxConnectionsPerBrokerConfigured = true;
     }
 
@@ -1424,7 +1424,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _prefetchPipelineDepth = 3;
     private int _connectionsPerBroker = 2;
     private bool _enableAdaptiveConnections = true;
-    private int _maxConnectionsPerBroker = 4;
+    private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -33,6 +33,8 @@ public enum OffsetCommitMode
 /// </summary>
 public sealed class ConsumerOptions
 {
+    internal const int DefaultMaxConnectionsPerBroker = 4;
+
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
     /// </summary>
@@ -419,7 +421,7 @@ public sealed class ConsumerOptions
         }
     }
 
-    private readonly int _maxConnectionsPerBroker = 4;
+    private readonly int _maxConnectionsPerBroker = DefaultMaxConnectionsPerBroker;
 
     /// <summary>
     /// Whether to enable adaptive fetch sizing based on consumer throughput.

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -96,6 +96,7 @@ public sealed class KafkaClientBuilder
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
     private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -369,6 +370,8 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
+        if (!_isMaxConnectionsPerBrokerConfigured)
+            _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
         return this;
     }
 
@@ -384,6 +387,7 @@ public sealed class KafkaClientBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
         _maxConnectionsPerBroker = maxConnectionsPerBroker;
+        _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
 

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -5,6 +5,7 @@ using Admin;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
+using Dekaf.Producer;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public sealed class KafkaClientBuilder
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
-    private int _maxConnectionsPerBroker = 10;
+    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -2,6 +2,7 @@ namespace Dekaf;
 
 using System.Net.Security;
 using Admin;
+using Dekaf.Consumer;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -95,7 +96,8 @@ public sealed class KafkaClientBuilder
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
-    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
+    private int _producerMaxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
     private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
@@ -371,7 +373,10 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
         if (!_isMaxConnectionsPerBrokerConfigured)
+        {
             _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
+            _producerMaxConnectionsPerBroker = Math.Max(_producerMaxConnectionsPerBroker, connectionsPerBroker);
+        }
         return this;
     }
 
@@ -387,6 +392,7 @@ public sealed class KafkaClientBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
         _maxConnectionsPerBroker = maxConnectionsPerBroker;
+        _producerMaxConnectionsPerBroker = maxConnectionsPerBroker;
         _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
@@ -485,6 +491,7 @@ public sealed class KafkaClientBuilder
             ConnectionsPerBroker = _connectionsPerBroker,
             MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
             MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            ProducerMaxConnectionsPerBroker = _producerMaxConnectionsPerBroker,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             MetadataMaxAge = _metadataMaxAge,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
@@ -525,6 +532,7 @@ internal sealed class KafkaClientOptions
     public int ConnectionsPerBroker { get; init; }
     public int MaxInFlightRequestsPerConnection { get; init; }
     public int MaxConnectionsPerBroker { get; init; }
+    public int ProducerMaxConnectionsPerBroker { get; init; }
     public int ConnectionsMaxIdleMs { get; init; }
     public TimeSpan? MetadataMaxAge { get; init; }
     public MetadataRecoveryStrategy MetadataRecoveryStrategy { get; init; }
@@ -547,7 +555,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory,
         int connectionsPerBroker,
-        int maxConnectionsPerBroker)
+        int maxConnectionsPerBroker,
+        int producerMaxConnectionsPerBroker)
     {
         BootstrapServers = bootstrapServers;
         ConnectionPool = connectionPool;
@@ -556,6 +565,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         LoggerFactory = loggerFactory;
         ConnectionsPerBroker = connectionsPerBroker;
         MaxConnectionsPerBroker = maxConnectionsPerBroker;
+        ProducerMaxConnectionsPerBroker = producerMaxConnectionsPerBroker;
     }
 
     public IReadOnlyList<string> BootstrapServers { get; }
@@ -565,6 +575,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     public ILoggerFactory? LoggerFactory { get; }
     public int ConnectionsPerBroker { get; }
     public int MaxConnectionsPerBroker { get; }
+    public int ProducerMaxConnectionsPerBroker { get; }
 
     public static KafkaClientInfrastructure Create(KafkaClientOptions options)
     {
@@ -630,7 +641,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             new ClientMemoryBudget(options.MemoryBudgetBytes),
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            options.MaxConnectionsPerBroker);
+            options.MaxConnectionsPerBroker,
+            options.ProducerMaxConnectionsPerBroker);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -16,6 +16,7 @@ using Dekaf.Internal;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
@@ -134,6 +135,8 @@ public sealed partial class KafkaConnection :
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly SemaphoreSlim _scatterGatherSenderLock = new(1, 1);
+    private SocketScatterGatherSender? _scatterGatherSender;
 
     private Task? _receiveTask;
     private CancellationTokenSource? _receiveCts;
@@ -1319,6 +1322,49 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        if (!_isTls
+            && _socket is not null
+            && request is ProduceRequest produceRequest
+            && TryPreSerializeSingleBatchProduceRequest(
+                produceRequest,
+                correlationId,
+                apiVersion,
+                headerVersion,
+                out var metadataArray,
+                out var prefixLength,
+                out var encodedRecords,
+                out var suffixOffset,
+                out var suffixLength))
+        {
+            try
+            {
+                await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                        _writeLock,
+                        nameof(KafkaConnection),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+                throw;
+            }
+
+            var segmentedWriteTask = WriteSegmentedFrameHoldingLockAsync(
+                metadataArray,
+                prefixLength,
+                encodedRecords,
+                suffixOffset,
+                suffixLength);
+            await AwaitBorrowedFrameWriteAsync(
+                    segmentedWriteTask,
+                    correlationId,
+                    callerOwnsTimeout,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
         var clearSerializedArray = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         try
@@ -1338,6 +1384,171 @@ public sealed partial class KafkaConnection :
         // socket write mid-frame (see AwaitFrameWriteAsync).
         var writeTask = WriteFrameHoldingLockAsync(serializedArray, serializedLength, clearSerializedArray);
         await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal bool TryPreSerializeSingleBatchProduceRequest(
+        ProduceRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion,
+        out byte[] metadataArray,
+        out int prefixLength,
+        out ArraySegment<byte> encodedRecords,
+        out int suffixOffset,
+        out int suffixLength)
+    {
+        metadataArray = null!;
+        prefixLength = 0;
+        encodedRecords = default;
+        suffixOffset = 0;
+        suffixLength = 0;
+
+        if (!request.TryGetSingleBatch(out var topic, out var partition, out var batch))
+            return false;
+
+        if (!batch.CanWriteSegmented(partition.Compression))
+            return false;
+
+        using var metadataWriter = new RentedBufferWriter(
+            DefaultPreSerializeInitialCapacity,
+            MessageSizePrefixLength);
+        var writer = new KafkaProtocolWriter(metadataWriter);
+        var header = new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = _clientId,
+            HeaderVersion = headerVersion
+        };
+
+        header.Write(ref writer);
+        var headerLength = writer.BytesWritten;
+
+        writer.WriteCompactNullableString(request.TransactionalId);
+        writer.WriteInt16(request.Acks);
+        writer.WriteInt32(request.TimeoutMs);
+        writer.WriteUnsignedVarInt(2); // one topic, compact count is item count + 1
+        writer.WriteCompactString(topic.Name);
+        writer.WriteUnsignedVarInt(2); // one partition
+        writer.WriteInt32(partition.Index);
+
+        var encodedBatchSize = batch.GetEncodedSize(partition.Compression);
+        writer.WriteUnsignedVarInt(checked(encodedBatchSize + 1));
+        if (!batch.TryWriteSegmentedHeader(
+                metadataWriter,
+                partition.Compression,
+                out var encodedRecordsMemory)
+            || !MemoryMarshal.TryGetArray(encodedRecordsMemory, out encodedRecords))
+        {
+            encodedRecords = default;
+            return false;
+        }
+
+        var segmentedBatchSize = RecordBatch.TotalBatchHeaderSize + encodedRecords.Count;
+        if (encodedBatchSize != segmentedBatchSize)
+        {
+            throw new KafkaException(
+                ErrorCode.CorruptMessage,
+                $"PRODUCE segmented framing mismatch for partition {partition.Index}: " +
+                $"declared batch length {encodedBatchSize} but segmented header and records total " +
+                $"{segmentedBatchSize} bytes.");
+        }
+
+        writer.AddBytesWritten(encodedBatchSize);
+        prefixLength = metadataWriter.WrittenCount;
+        writer.WriteEmptyTaggedFields(); // partition
+        writer.WriteEmptyTaggedFields(); // topic
+        writer.WriteEmptyTaggedFields(); // request
+        suffixOffset = prefixLength;
+        suffixLength = metadataWriter.WrittenCount - prefixLength;
+
+        var bodyLength = writer.BytesWritten - headerLength;
+        if (request.RequestBodySizeHint > 0 && bodyLength != request.RequestBodySizeHint)
+        {
+            throw new KafkaException(
+                ErrorCode.CorruptMessage,
+                $"PRODUCE segmented body mismatch: size hint {request.RequestBodySizeHint} but serialized {bodyLength} bytes.");
+        }
+
+        var totalLength = checked(metadataWriter.WrittenCount + encodedRecords.Count);
+        (metadataArray, _) = metadataWriter.DetachBuffer();
+        BinaryPrimitives.WriteInt32BigEndian(metadataArray, totalLength - MessageSizePrefixLength);
+        return true;
+    }
+
+    private async Task WriteSegmentedFrameHoldingLockAsync(
+        byte[] metadataArray,
+        int prefixLength,
+        ArraySegment<byte> encodedRecords,
+        int suffixOffset,
+        int suffixLength)
+    {
+        var scatterGatherSenderLockHeld = false;
+        try
+        {
+            await _scatterGatherSenderLock.WaitAsync().ConfigureAwait(false);
+            scatterGatherSenderLockHeld = true;
+
+            var socket = _socket ?? throw new InvalidOperationException("Not connected");
+            if (_stream is null)
+                throw new InvalidOperationException("Not connected");
+
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(KafkaConnection));
+
+            var sender = _scatterGatherSender ??= new SocketScatterGatherSender();
+            var sendSegments = sender.Segments;
+            sendSegments.Add(new ArraySegment<byte>(metadataArray, 0, prefixLength));
+            if (encodedRecords.Count > 0)
+                sendSegments.Add(encodedRecords);
+            if (suffixLength > 0)
+                sendSegments.Add(new ArraySegment<byte>(metadataArray, suffixOffset, suffixLength));
+
+            while (sendSegments.Count > 0)
+            {
+                var bytesSent = await sender.SendAsync(socket).ConfigureAwait(false);
+                if (bytesSent <= 0)
+                    throw new IOException("Socket closed while writing a Kafka request frame.");
+
+                ConsumeSentSegments(sendSegments, bytesSent);
+            }
+        }
+        catch
+        {
+            AbortAfterWriteFailure();
+            throw;
+        }
+        finally
+        {
+            if (scatterGatherSenderLockHeld)
+            {
+                _scatterGatherSender?.Segments.Clear();
+                SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
+            }
+
+            DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+            SemaphoreHelper.ReleaseSafely(_writeLock);
+        }
+    }
+
+    internal static void ConsumeSentSegments(List<ArraySegment<byte>> segments, int bytesSent)
+    {
+        while (bytesSent > 0)
+        {
+            var segment = segments[0];
+            if (bytesSent < segment.Count)
+            {
+                segments[0] = new ArraySegment<byte>(
+                    segment.Array!,
+                    segment.Offset + bytesSent,
+                    segment.Count - bytesSent);
+                return;
+            }
+
+            bytesSent -= segment.Count;
+            segments.RemoveAt(0);
+        }
     }
 
     /// <summary>
@@ -1386,10 +1597,35 @@ public sealed partial class KafkaConnection :
     /// write one further request timeout to finish before forcibly aborting the connection to
     /// unblock a socket write stuck on a dead broker.
     /// </summary>
-    private async ValueTask AwaitFrameWriteAsync(
+    private ValueTask AwaitFrameWriteAsync(
         Task writeTask,
         int correlationId,
         bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+        => AwaitFrameWriteCoreAsync(
+            writeTask,
+            correlationId,
+            callerOwnsTimeout,
+            payloadIsBorrowed: false,
+            cancellationToken);
+
+    private ValueTask AwaitBorrowedFrameWriteAsync(
+        Task writeTask,
+        int correlationId,
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+        => AwaitFrameWriteCoreAsync(
+            writeTask,
+            correlationId,
+            callerOwnsTimeout,
+            payloadIsBorrowed: true,
+            cancellationToken);
+
+    private async ValueTask AwaitFrameWriteCoreAsync(
+        Task writeTask,
+        int correlationId,
+        bool callerOwnsTimeout,
+        bool payloadIsBorrowed,
         CancellationToken cancellationToken)
     {
 #if DEBUG
@@ -1410,7 +1646,11 @@ public sealed partial class KafkaConnection :
             // Any OperationCanceledException here means the caller's timeout elapsed.
             catch (OperationCanceledException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
@@ -1426,18 +1666,45 @@ public sealed partial class KafkaConnection :
             }
             catch (OperationCanceledException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 throw new OperationCanceledException(cancellationToken);
             }
             catch (TimeoutException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     ErrorCode.RequestTimedOut,
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
+        }
+    }
+
+    /// <summary>
+    /// Borrowed producer buffers cannot outlive their caller. Abort a stalled socket write and
+    /// observe its completion before the caller can release or recycle the batch resources.
+    /// </summary>
+    private async Task AbortAndObserveFrameWriteAsync(Task writeTask)
+    {
+        if (!writeTask.IsCompleted)
+            AbortAfterWriteFailure();
+
+        try
+        {
+            await writeTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The timeout/cancellation remains the caller-visible failure.
         }
     }
 
@@ -3021,6 +3288,79 @@ public sealed partial class KafkaConnection :
         }
     }
 
+    private sealed class SocketScatterGatherSender : IValueTaskSource<int>, IDisposable
+    {
+        private readonly SocketAsyncEventArgs _eventArgs = new();
+        private ManualResetValueTaskSourceCore<int> _core = new()
+        {
+            RunContinuationsAsynchronously = true
+        };
+
+        public SocketScatterGatherSender()
+        {
+            _eventArgs.Completed += CompleteSend;
+        }
+
+        public List<ArraySegment<byte>> Segments { get; } = new(3);
+
+        public ValueTask<int> SendAsync(Socket socket)
+        {
+            Debug.Assert(_eventArgs.BufferList is null, "Scatter/gather sender reused before completion");
+            _core.Reset();
+            _eventArgs.BufferList = Segments;
+            _eventArgs.SocketFlags = SocketFlags.None;
+
+            try
+            {
+                if (socket.SendAsync(_eventArgs))
+                    return new ValueTask<int>(this, _core.Version);
+
+                var bytesTransferred = GetSynchronousResult();
+                _eventArgs.BufferList = null;
+                return new ValueTask<int>(bytesTransferred);
+            }
+            catch
+            {
+                _eventArgs.BufferList = null;
+                throw;
+            }
+        }
+
+        private int GetSynchronousResult()
+        {
+            if (_eventArgs.SocketError != SocketError.Success)
+                throw new SocketException((int)_eventArgs.SocketError);
+
+            return _eventArgs.BytesTransferred;
+        }
+
+        private void CompleteSend(object? sender, SocketAsyncEventArgs eventArgs)
+        {
+            eventArgs.BufferList = null;
+            if (eventArgs.SocketError == SocketError.Success)
+                _core.SetResult(eventArgs.BytesTransferred);
+            else
+                _core.SetException(new SocketException((int)eventArgs.SocketError));
+        }
+
+        public int GetResult(short token) => _core.GetResult(token);
+
+        public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
+
+        public void Dispose()
+        {
+            _eventArgs.Completed -= CompleteSend;
+            _eventArgs.Dispose();
+        }
+    }
+
     public ValueTask DisposeAsync()
         => new(EnsureDisposeStarted());
 
@@ -3114,8 +3454,21 @@ public sealed partial class KafkaConnection :
         _reauthTimer?.Dispose();
         _reauthLock.Dispose();
         _connectLock.Dispose();
-        // Do not dispose _writeLock here. A frame write may still be unwinding after
-        // stream/socket disposal unblocks it; its finally block must release the lock.
+        // The sender is shared by segmented writes. Use its dedicated lifetime lock so
+        // background write-failure disposal cannot transiently reacquire _writeLock after the
+        // faulted writer releases it. This still waits for an active socket send to unwind.
+        await _scatterGatherSenderLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _scatterGatherSender?.Dispose();
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
+        }
+
+        // Do not dispose either write semaphore here. Writers queued before disposal must still
+        // acquire them, observe the disposed connection, and release them from finally blocks.
         _timeoutCtsPool.Clear();
         _ownedTokenProvider?.Dispose();
 

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -30,6 +30,8 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
         _buffer = DekafPools.SerializationBuffers.Rent(initialCapacity + offset);
     }
 
+    internal int WrittenCount => _written;
+
     /// <summary>
     /// Detaches the underlying rented array. The caller owns the array and must return it
     /// to <see cref="DekafPools.SerializationBuffers"/>. After this call, the writer must not be used.

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -370,22 +370,31 @@ internal sealed class BrokerUnackedByteBudget
         {
             deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
             var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
-            if (epochDeliveredBytes == deliveredBytes)
-            {
-                deliveryEpochDeliveredBytes = epochDeliveredBytes;
-                return Volatile.Read(ref _sendEpochFirstTimestamp);
-            }
-
             if (epochDeliveredBytes == DeliveryEpochUpdating)
             {
                 spinner.SpinOnce();
                 continue;
             }
 
+            // The timestamp and delivered marker form one publication. Re-read the marker
+            // after the timestamp so a reader spanning another publisher's two writes retries
+            // instead of pairing an old byte anchor with a new time anchor.
+            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
+            if (Volatile.Read(ref _sendEpochDeliveredBytes) != epochDeliveredBytes)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            if (epochDeliveredBytes == deliveredBytes)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
+                return epochFirstSendTimestamp;
+            }
+
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
             // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
-            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
             if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
                 && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -548,7 +548,11 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds,
             sendSnapshot.UnackedBytesAtSend,
             ackedBytes);
-        UpdateMinRtt(serviceRttSeconds, rttSeconds, nowTicks);
+        UpdateMinRtt(
+            serviceRttSeconds,
+            rttSeconds,
+            nowTicks,
+            naturalMinRttSample: sendSnapshot.AppLimited && !sustainedIdle);
         if (loadedSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
@@ -750,7 +754,11 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds - queueAheadBytes / effectiveMaxRate);
     }
 
-    private void UpdateMinRtt(double serviceRttSeconds, double rawRttSeconds, long nowTicks)
+    private void UpdateMinRtt(
+        double serviceRttSeconds,
+        double rawRttSeconds,
+        long nowTicks,
+        bool naturalMinRttSample)
     {
         if (!_hasMinRttSample)
         {
@@ -758,6 +766,24 @@ internal sealed class BrokerUnackedByteBudget
             _minRttTimestamp = nowTicks;
             _hasMinRttSample = true;
             StartMinRttProbe(nowTicks, rawRttSeconds);
+            return;
+        }
+
+        if (naturalMinRttSample
+            && serviceRttSeconds <= _minRttSeconds * ProbeRttGrowthTolerance)
+        {
+            if (_minRttProbeUntilTimestamp != 0)
+            {
+                _minRttProbeMinimumSeconds = Math.Min(
+                    _minRttProbeMinimumSeconds,
+                    serviceRttSeconds);
+                CompleteMinRttProbe(nowTicks);
+            }
+            else
+            {
+                _minRttSeconds = Math.Min(_minRttSeconds, serviceRttSeconds);
+                _minRttTimestamp = nowTicks;
+            }
             return;
         }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -20,13 +20,14 @@ namespace Dekaf.Producer;
 /// each budget raise lengthens the RTT that justifies the next raise until the budget rides
 /// its cap (the 3-broker acks=all latency ratchet, #2009).
 /// <para>
-/// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
-/// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
-/// delta over the larger of the request's own sojourn and the interval since the delivery
-/// clock at send (sojourn only for app-limited sends, where the pipe was empty and the
-/// preceding interval is idle time). The denominator is therefore never smaller than one
-/// real round trip, so response-pass timing (hot polling, clustered completions,
-/// processing stalls) cannot manufacture inflated samples.
+/// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
+/// epoch; loaded sends retain its delivered-byte and first-send anchors even as acknowledgements
+/// advance the current delivery clock. The sample is cumulative delivered bytes over the full
+/// epoch elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples
+/// shorter than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// per-request rate remains available to the capacity probe, which needs each probe admission's
+/// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
+/// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
 /// </para>
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
@@ -44,8 +45,8 @@ namespace Dekaf.Producer;
 internal sealed class BrokerUnackedByteBudget
 {
     /// <summary>
-    /// Per-send token minted by <see cref="SnapshotDelivery"/>: the delivery clock (cumulative
-    /// delivered bytes and the timestamp of the most recent delivery), the pre-write send
+    /// Per-send token minted by <see cref="SnapshotDelivery"/>: the current delivery clock,
+    /// the loaded delivery epoch's delivered-byte and first-send anchors, the pre-write send
     /// timestamp, and whether the broker pipe was empty at send. Carried opaquely on the
     /// in-flight request and redeemed by <see cref="OnAcked"/> when the response arrives, so
     /// the values that must be captured together cannot drift apart at call sites.
@@ -53,6 +54,7 @@ internal sealed class BrokerUnackedByteBudget
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
         long DeliveredTimestamp,
+        long DeliveryEpochDeliveredBytes,
         long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
@@ -185,6 +187,8 @@ internal sealed class BrokerUnackedByteBudget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
+    // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
+    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -228,6 +232,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
+    private bool _hasLoadedServingSample;
     private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
@@ -310,8 +315,9 @@ internal sealed class BrokerUnackedByteBudget
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
     /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
-    /// epoch changes are CAS-published so parallel sends cannot regress the delivered-byte
-    /// marker; the independent last-delivery timestamp may only conservatively widen a sample.
+    /// epoch changes at app-limited boundaries are CAS-published so parallel sends cannot
+    /// regress the delivered-byte marker; loaded sends reuse the published epoch. The
+    /// independent last-delivery timestamp may only conservatively widen a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -324,10 +330,13 @@ internal sealed class BrokerUnackedByteBudget
     {
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,
+            appLimited,
+            out var deliveryEpochDeliveredBytes,
             out var deliveredBytes);
         return new DeliverySnapshot(
             deliveredBytes,
             Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveryEpochDeliveredBytes,
             deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
@@ -335,7 +344,11 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Read(ref _unackedBytes));
     }
 
-    private long CaptureDeliveryEpoch(long sendTimestamp, out long deliveredBytes)
+    private long CaptureDeliveryEpoch(
+        long sendTimestamp,
+        bool appLimited,
+        out long deliveryEpochDeliveredBytes,
+        out long deliveredBytes)
     {
         var spinner = new SpinWait();
         while (true)
@@ -343,12 +356,24 @@ internal sealed class BrokerUnackedByteBudget
             deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
             var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
             if (epochDeliveredBytes == deliveredBytes)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
                 return Volatile.Read(ref _sendEpochFirstTimestamp);
+            }
 
             if (epochDeliveredBytes == DeliveryEpochUpdating)
             {
                 spinner.SpinOnce();
                 continue;
+            }
+
+            // A loaded pipe belongs to the existing send epoch even after acknowledgements
+            // advance the delivery counter. Reset only when a send observes an empty pipe;
+            // otherwise serialized send/ack cycles collapse back to requestBytes / ownRTT.
+            if (!appLimited && epochDeliveredBytes != NoDeliveryEpoch)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
+                return Volatile.Read(ref _sendEpochFirstTimestamp);
             }
 
             if (Interlocked.CompareExchange(
@@ -360,7 +385,11 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
-            return PublishDeliveryEpoch(sendTimestamp, epochDeliveredBytes, out deliveredBytes);
+            return PublishDeliveryEpoch(
+                sendTimestamp,
+                epochDeliveredBytes,
+                out deliveryEpochDeliveredBytes,
+                out deliveredBytes);
         }
     }
 
@@ -368,6 +397,7 @@ internal sealed class BrokerUnackedByteBudget
     private long PublishDeliveryEpoch(
         long sendTimestamp,
         long previousEpochDeliveredBytes,
+        out long deliveryEpochDeliveredBytes,
         out long deliveredBytes)
     {
         // The loop-top delivery read can predate a newer epoch value observed by the
@@ -379,6 +409,7 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
 
         Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
+        deliveryEpochDeliveredBytes = deliveredBytes;
         return Volatile.Read(ref _sendEpochFirstTimestamp);
     }
 
@@ -531,8 +562,13 @@ internal sealed class BrokerUnackedByteBudget
         var sustainedIdle = sendSnapshot.AppLimited
             && sendSnapshot.DeliveredTimestamp != 0
             && deliveryIdleTicks >= WindowDurationTicks;
-        var loadedSample = !sendSnapshot.AppLimited
+        var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
+        var loadedRateSample = !sendSnapshot.AppLimited;
+        if (sustainedIdle)
+            _hasLoadedServingSample = false;
+        else if (loadedServingSample)
+            _hasLoadedServingSample = true;
         // The deadline ack may establish the first loaded serving estimate (depth-one traffic),
         // but must not drag an existing estimate toward the queue-drained probe RTT.
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0
@@ -553,7 +589,7 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds,
             nowTicks,
             naturalMinRttSample: sendSnapshot.AppLimited && !sustainedIdle);
-        if (loadedSample && !minRttProbeActive)
+        if (loadedServingSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
                 ? serviceRttSeconds
@@ -575,36 +611,46 @@ internal sealed class BrokerUnackedByteBudget
 
         RecordRequestHistograms(ackedBytes, rttSeconds);
 
-        // BBR delivery-rate sample: delivered-counter delta over the larger of the request's
-        // own sojourn and the ack-axis interval (time since the delivery clock at send). The
-        // sojourn bounds the denominator below by one real round trip, so clustered response
-        // passes cannot inflate the sample; the ack axis spreads a processing-stall backlog
-        // over the wall time the deliveries actually took.
+        // Keep two delivery-rate axes. The request axis attributes immediate delivery credit
+        // to one capacity probe. The epoch axis estimates sustainable rate from all delivery
+        // since the pipe last became loaded, including the first send's RTT; loaded sends keep
+        // that anchor across intervening acknowledgements. Thus a serialized request cannot
+        // claim requestBytes / ownRTT as broker capacity on every fast response.
         var totalDelivered = _totalDeliveredBytes + ackedBytes;
         Volatile.Write(ref _totalDeliveredBytes, totalDelivered);
         var deliveredDelta = totalDelivered - sendSnapshot.DeliveredBytes;
+        var deliveryEpochDelta = totalDelivered - sendSnapshot.DeliveryEpochDeliveredBytes;
 
-        var intervalTicks = rttTicks;
+        var requestIntervalTicks = rttTicks;
+        if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
+        {
+            requestIntervalTicks = Math.Max(
+                requestIntervalTicks,
+                nowTicks - sendSnapshot.DeliveredTimestamp);
+        }
+
+        var deliveryEpochIntervalTicks = requestIntervalTicks;
         if (sendSnapshot.DeliveryEpochFirstSendTimestamp > 0)
         {
-            intervalTicks = Math.Max(
-                intervalTicks,
-                sendSnapshot.SendTimestamp - sendSnapshot.DeliveryEpochFirstSendTimestamp);
+            deliveryEpochIntervalTicks = Math.Max(
+                deliveryEpochIntervalTicks,
+                nowTicks - sendSnapshot.DeliveryEpochFirstSendTimestamp);
         }
-        if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
-            intervalTicks = Math.Max(intervalTicks, nowTicks - sendSnapshot.DeliveredTimestamp);
         Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
 
         AdvanceWindow(nowTicks);
-        var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
-        if (bytesPerSecond > 0)
+        var requestBytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / requestIntervalTicks;
+        var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
+            / deliveryEpochIntervalTicks;
+        if (deliveryEpochBytesPerSecond > 0
+            && (!loadedRateSample || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
         {
-            AddRateSample(bytesPerSecond, loadedSample, sustainedIdle);
+            AddRateSample(deliveryEpochBytesPerSecond, loadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
         UpdateCapacityProbe(
-            bytesPerSecond,
+            requestBytesPerSecond,
             sendSnapshot.OldestBatchTimestamp != 0
                 ? sendSnapshot.OldestBatchTimestamp
                 : sendSnapshot.SendTimestamp,
@@ -1181,7 +1227,7 @@ internal sealed class BrokerUnackedByteBudget
             // The serving EWMA and the minimum RTT are queue-corrected at sample intake
             // (see OnAcked), so neither re-inflates from queueing this budget admitted;
             // the clamp below is a residual guard for correction error.
-            var loadAwareRttSeconds = _retainedLoadedMaxRate > 0
+            var loadAwareRttSeconds = _hasLoadedServingSample
                 ? Math.Max(
                     minRttSeconds,
                     Math.Min(_servingRttEwmaSeconds, ServingRttClampMultiplier * minRttSeconds))

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -47,9 +47,9 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Per-send token minted by <see cref="SnapshotDelivery"/>: the current delivery clock,
     /// the loaded delivery epoch's delivered-byte and first-send anchors, the pre-write send
-    /// timestamp, and whether the broker pipe was empty at send. Carried opaquely on the
-    /// in-flight request and redeemed by <see cref="OnAcked"/> when the response arrives, so
-    /// the values that must be captured together cannot drift apart at call sites.
+    /// timestamp, whether the broker pipe was empty, and whether the rate epoch was app-limited
+    /// at send. Carried opaquely on the in-flight request and redeemed by <see cref="OnAcked"/>
+    /// when the response arrives, so values captured together cannot drift apart at call sites.
     /// </summary>
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
@@ -58,6 +58,7 @@ internal sealed class BrokerUnackedByteBudget
         long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
+        bool RateAppLimited,
         long OldestBatchTimestamp,
         long UnackedBytesAtSend);
 
@@ -317,9 +318,10 @@ internal sealed class BrokerUnackedByteBudget
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
     /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
-    /// epoch changes at app-limited boundaries are CAS-published so parallel sends cannot
-    /// regress the delivered-byte marker; loaded sends reuse the published epoch. The
-    /// independent last-delivery timestamp may only conservatively widen a sample.
+    /// epoch changes at rate-app-limited boundaries are CAS-published so parallel sends cannot
+    /// regress the delivered-byte marker; loaded and immediately post-delivery sends reuse the
+    /// published epoch. The independent last-delivery timestamp may only conservatively widen
+    /// a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -330,25 +332,36 @@ internal sealed class BrokerUnackedByteBudget
         bool appLimited,
         long oldestBatchTimestamp = 0)
     {
+        var deliveredTimestamp = Volatile.Read(ref _lastDeliveredTimestamp);
+        var deliveryGapTicks = sendTimestamp - deliveredTimestamp;
+        // An empty pipe sent immediately after an ack is a serialized loaded rate cycle, not
+        // idle application time. Negative gaps can arise from concurrent delivery publication
+        // and cannot prove that ordering, so they remain rate-app-limited.
+        var continuesSerializedRateCycle = appLimited
+            && deliveredTimestamp != 0
+            && deliveryGapTicks >= 0
+            && deliveryGapTicks < MinimumLoadedRateSampleTicks;
+        var rateAppLimited = appLimited && !continuesSerializedRateCycle;
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,
-            appLimited,
+            rateAppLimited,
             out var deliveryEpochDeliveredBytes,
             out var deliveredBytes);
         return new DeliverySnapshot(
             deliveredBytes,
-            Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveredTimestamp,
             deliveryEpochDeliveredBytes,
             deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
+            rateAppLimited,
             oldestBatchTimestamp,
             Volatile.Read(ref _unackedBytes));
     }
 
     private long CaptureDeliveryEpoch(
         long sendTimestamp,
-        bool appLimited,
+        bool rateAppLimited,
         out long deliveryEpochDeliveredBytes,
         out long deliveredBytes)
     {
@@ -370,10 +383,10 @@ internal sealed class BrokerUnackedByteBudget
             }
 
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
-            // app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
             var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
-            if (!appLimited
+            if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
                 && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)
             {
@@ -569,7 +582,8 @@ internal sealed class BrokerUnackedByteBudget
             && deliveryIdleTicks >= WindowDurationTicks;
         var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
-        var loadedRateSample = !sendSnapshot.AppLimited;
+        var loadedRateEpoch = !sendSnapshot.RateAppLimited;
+        var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
             _hasLoadedServingSample = false;
         else if (loadedServingSample)
@@ -648,9 +662,9 @@ internal sealed class BrokerUnackedByteBudget
         var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
             / deliveryEpochIntervalTicks;
         if (deliveryEpochBytesPerSecond > 0
-            && (!loadedRateSample || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
+            && (!loadedRateEpoch || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
         {
-            AddRateSample(deliveryEpochBytesPerSecond, loadedRateSample, sustainedIdle);
+            AddRateSample(deliveryEpochBytesPerSecond, retainLoadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -165,6 +165,12 @@ internal sealed class BrokerUnackedByteBudget
     /// (and with it the RTT floor) toward zero.</summary>
     private const double MinCorrectedRttFraction = 0.25;
 
+    /// <summary>Maximum upward movement accepted from one minimum-RTT refresh. A drain
+    /// probe can remain partially queued across parallel connections; bounding one window
+    /// prevents that transient from multiplying the BDP floor, while repeated refreshes
+    /// still converge when the path's base RTT has genuinely increased.</summary>
+    private const double MinRttRefreshGrowthFactor = 1.25;
+
     private const int ProbeIntervalRtts = 8;
     // A capacity probe needs one RTT for the enlarged budget to reach the wire,
     // then three wholly-probed RTTs to average before accepting or rejecting growth.
@@ -790,7 +796,11 @@ internal sealed class BrokerUnackedByteBudget
     private void CompleteMinRttProbe(long nowTicks)
     {
         if (_minRttProbeMinimumSeconds != double.MaxValue)
-            _minRttSeconds = _minRttProbeMinimumSeconds;
+        {
+            _minRttSeconds = Math.Min(
+                _minRttProbeMinimumSeconds,
+                _minRttSeconds * MinRttRefreshGrowthFactor);
+        }
 
         // If the probe expired without an ack, retain the prior minimum and re-arm its
         // freshness window. An idle gap is not a base-RTT measurement.

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -74,9 +74,31 @@ internal sealed class BrokerUnackedByteBudget
     private const double DeliveryLatencyEwmaWeight = 0.125;
     private const double ServingRttEwmaWeight = 0.125;
     private const double MinimumLatencyBudgetScale = 0.10;
+
+    /// <summary>
+    /// Upper bound on the latency budget scale. Above 1.0 the scale is the budget's only
+    /// unconditional upward force (#2008): the drain-rate estimate is measured from traffic
+    /// the admission gate itself admitted, so <c>rate × target</c> is self-confirming at any
+    /// throughput level — without headroom above parity the budget can never discover broker
+    /// or sender capacity beyond whatever it happens to be admitting. The controller grows
+    /// the scale only while admission is blocking (proof of demand) and measured delivery
+    /// latency sits below target, and growth decelerates as latency approaches target. The
+    /// bound keeps a stale-high scale's overshoot window short: shrinking back to parity
+    /// from here takes ~8 control intervals (~0.8 s).
+    /// </summary>
+    private const double MaximumLatencyBudgetScale = 10.0;
     private const double MinimumLatencyAdjustmentFactor = 0.75;
     private const double MaximumLatencyAdjustmentFactor = 1.05;
     private const double MaximumBudgetDecayPerSecond = 0.10;
+
+    /// <summary>
+    /// The scale shrinks only while written-unacked occupancy demonstrates at least this
+    /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
+    /// means the send loop, not broker admission, is the bottleneck — shrinking admission
+    /// there cannot reduce the latency, it only starves the sender below its capacity
+    /// (the 1-broker collapse mode of #2008).
+    /// </summary>
+    private const double ShrinkOccupancyFraction = 0.5;
 
     /// <summary>
     /// Log2 histogram buckets for per-request diagnostics. Request sizes shift by
@@ -184,7 +206,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
-    private double _lastNormalRttFloorSeconds;
+    private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
     private long _minRttTimestamp;
@@ -513,15 +535,24 @@ internal sealed class BrokerUnackedByteBudget
         if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= sendTimestamp)
             return;
 
-        // Only producer-controlled queueing belongs in the controller. Broker RTT, linger
-        // before sealing, and response scheduling cannot be reduced by shrinking admission;
-        // including them made the target an equilibrium setpoint and suppressed fan-out.
         var sampleSeconds = (double)(sendTimestamp - oldestBatchTimestamp) / Stopwatch.Frequency;
         var latencyEstimate = _deliveryLatencyEwmaSeconds == 0
             ? sampleSeconds
             : _deliveryLatencyEwmaSeconds
                 + DeliveryLatencyEwmaWeight * (sampleSeconds - _deliveryLatencyEwmaSeconds);
         Volatile.Write(ref _deliveryLatencyEwmaSeconds, latencyEstimate);
+
+        // Measured seal-to-ack is the delivery latency users experience from the moment a
+        // batch is eligible to send. The queue-drained base RTT is subtracted before the
+        // control decision: broker round-trip time cannot be reduced by shrinking admission,
+        // and charging it to the controller is what turned the target into an equilibrium
+        // setpoint that suppressed fan-out (#1988). What remains — sender backlog plus
+        // broker-side queueing — is exactly the delay the budget controls (#2008, #2009).
+        var sealToAckSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
+        _sealToAckEwmaSeconds = _sealToAckEwmaSeconds == 0
+            ? sealToAckSeconds
+            : _sealToAckEwmaSeconds
+                + DeliveryLatencyEwmaWeight * (sealToAckSeconds - _sealToAckEwmaSeconds);
 
         if (_nextLatencyControlTimestamp == 0)
         {
@@ -537,44 +568,45 @@ internal sealed class BrokerUnackedByteBudget
         var admissionWasBlocked = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
         _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
 
-        // Seal-to-send alone is blind to bytes already written and queued at the broker —
-        // the delay the budget most directly controls. Standing queue delay beyond the
-        // floor-sanctioned occupancy is that signal; controlling on the larger of the two
-        // lets the governor see broker-side queueing that never shows up between seal and
-        // socket write (#2009).
-        var controlLatencySeconds = Math.Max(latencyEstimate, GetStandingQueueDelaySeconds());
+        var baseRttSeconds = _hasMinRttSample ? _minRttSeconds : 0;
+        var brokerQueueSeconds = _sealToAckEwmaSeconds - baseRttSeconds;
+        var controlLatencySeconds = Math.Max(latencyEstimate, brokerQueueSeconds);
         var targetRatio = _targetSeconds / controlLatencySeconds;
         double adjustment;
         if (targetRatio < 1)
-            adjustment = Math.Max(MinimumLatencyAdjustmentFactor, targetRatio);
+        {
+            // Broker-side queueing always responds to admission — shrink acts on it
+            // unconditionally. When the seal-to-send backlog dominates instead, shrink only
+            // if the wire is demonstrably carrying the budget: backlog with an underfilled
+            // wire means the send loop, not admission, is the bottleneck, and shrinking
+            // there starves the sender below its capacity without reducing the backlog
+            // (the 1-broker collapse mode of #2008).
+            var senderBacklogDominates = latencyEstimate >= brokerQueueSeconds;
+            var shrinkActionable = !senderBacklogDominates
+                || _windowMaxOccupancyBytes
+                    >= ShrinkOccupancyFraction * _lastNormalBudgetBytes;
+            adjustment = shrinkActionable
+                ? Math.Max(MinimumLatencyAdjustmentFactor, targetRatio)
+                : 1.0;
+        }
         else if (admissionWasBlocked)
+        {
+            // The budget's only unconditional upward force: blocked demand with measured
+            // latency below target grows the scale past rate parity, breaking the
+            // self-confirming rate x target equilibrium (#2008). Growth decelerates as
+            // latency approaches target (adjustment -> 1 as targetRatio -> 1).
             adjustment = Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
+        }
         else
+        {
             adjustment = 1.0;
+        }
 
         Volatile.Write(ref _latencyBudgetScale, Math.Clamp(
             _latencyBudgetScale * adjustment,
             MinimumLatencyBudgetScale,
-            1.0));
+            MaximumLatencyBudgetScale));
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
-    }
-
-    /// <summary>Producer-controlled standing queue delay: unacked bytes over the drain rate,
-    /// less the occupancy the budget's own RTT floor sanctions to keep the pipe full. Delay
-    /// inside the sanctioned floor is not actionable — shrinking the scale cannot reduce a
-    /// budget the floor holds up — so charging it to the governor would only wind the scale
-    /// down against a wall.</summary>
-    private double GetStandingQueueDelaySeconds()
-    {
-        var effectiveMaxRate = GetEffectiveMaxRate();
-        if (effectiveMaxRate <= 0)
-            return 0;
-
-        var sanctionedSeconds = Math.Max(
-            _lastNormalRttFloorSeconds,
-            _hasMinRttSample ? _minRttSeconds : 0);
-        var standingSeconds = UnackedBytes / effectiveMaxRate;
-        return Math.Max(0, standingSeconds - sanctionedSeconds);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -996,8 +1028,6 @@ internal sealed class BrokerUnackedByteBudget
             var rttFloorSeconds = minRttProbeActive
                 ? MinRttProbeSafetyMultiplier * minRttSeconds
                 : RttSafetyMultiplier * loadAwareRttSeconds;
-            if (!minRttProbeActive)
-                _lastNormalRttFloorSeconds = rttFloorSeconds;
             var horizonSeconds = _hasMinRttSample
                 ? Math.Max(latencyGovernedTargetSeconds, rttFloorSeconds)
                 : latencyGovernedTargetSeconds;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -159,10 +159,6 @@ internal sealed class BrokerUnackedByteBudget
     /// enough slack for replication service-time variance without the ratchet.</summary>
     private const double ServingRttClampMultiplier = 2.0;
 
-    /// <summary>Standing unacked bytes at this multiple of the freshly computed budget prove
-    /// the previous budget over-admitted; decay smoothing then yields to the recompute.</summary>
-    private const long StandingQueueDecayBypassMultiplier = 2;
-
     /// <summary>Lower bound on queue-corrected RTT samples as a fraction of the raw round
     /// trip, so an overestimated drain rate cannot collapse the corrected service estimate
     /// (and with it the RTT floor) toward zero.</summary>
@@ -596,7 +592,11 @@ internal sealed class BrokerUnackedByteBudget
         var loadedRateEpoch = !sendSnapshot.RateAppLimited;
         var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
+        {
             _hasLoadedServingSample = false;
+            _lastNormalBudgetBytes = _capBytes;
+            _lastBudgetUpdateTimestamp = nowTicks;
+        }
         else if (loadedServingSample)
             _hasLoadedServingSample = true;
         // The deadline ack may establish the first loaded serving estimate (depth-one traffic),
@@ -1202,14 +1202,10 @@ internal sealed class BrokerUnackedByteBudget
         var elapsedSeconds = _lastBudgetUpdateTimestamp == 0
             ? 0
             : Math.Max(0, (double)(nowTicks - _lastBudgetUpdateTimestamp) / Stopwatch.Frequency);
-        // _unackedBytes shares a contended cache line with every appender's Interlocked.Add;
-        // only pay for the read when a downward move can consult the queue bypass.
-        var unackedBytes = computedBudget < _lastNormalBudgetBytes ? UnackedBytes : 0;
         var budget = BoundBudgetDecay(
             _lastNormalBudgetBytes,
             computedBudget,
-            elapsedSeconds,
-            unackedBytes);
+            elapsedSeconds);
         budget = Math.Min(budget, _capBytes);
         _lastNormalBudgetBytes = budget;
         _lastBudgetUpdateTimestamp = nowTicks;
@@ -1219,15 +1215,9 @@ internal sealed class BrokerUnackedByteBudget
     internal static long BoundBudgetDecay(
         long previousBudget,
         long computedBudget,
-        double elapsedSeconds,
-        long unackedBytes)
+        double elapsedSeconds)
     {
         if (computedBudget >= previousBudget)
-            return computedBudget;
-
-        // Bytes at a multiple of the fresh budget prove the old budget over-admitted;
-        // smoothing would otherwise preserve the standing queue for minutes at 10%/s.
-        if (unackedBytes >= StandingQueueDecayBypassMultiplier * computedBudget)
             return computedBudget;
 
         var decayFraction = Math.Min(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -36,9 +36,9 @@ namespace Dekaf.Producer;
 /// <see cref="OnAcked"/>, <see cref="CompleteAckedPass"/>, and <see cref="SetCap"/> are
 /// single-writer — only the owning broker's send loop calls them — so the remaining estimator
 /// state needs no synchronization; the computed budget is published with a volatile write.
-/// <see cref="SnapshotDelivery"/> performs two independent volatile reads racing the single
-/// writer; both fields are monotonic, so a torn pair only skews one rate sample marginally
-/// and the windowed max filters it.
+/// <see cref="SnapshotDelivery"/> serializes delivery-epoch publication with a CAS while the
+/// most-recent-delivery timestamp remains an independent monotonic read. Skew between those
+/// clocks only widens one sample marginally.
 /// </para>
 /// </summary>
 internal sealed class BrokerUnackedByteBudget
@@ -53,6 +53,7 @@ internal sealed class BrokerUnackedByteBudget
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
         long DeliveredTimestamp,
+        long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
         long OldestBatchTimestamp,
@@ -169,12 +170,17 @@ internal sealed class BrokerUnackedByteBudget
     // then three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
+    /// <summary>Only probe when standing demand fills at least this fraction of the gate;
+    /// enlarging a more-open gate cannot reveal additional delivery capacity.</summary>
+    private const double CapacityProbeDemandFraction = 0.5;
     /// <summary>A probe confirms capacity only when rate rises without the round trip
     /// inflating past this tolerance. Through a saturated broker, delivered rate never drops
     /// when queue is added, so a rate-only acceptance test converts every probe into budget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
+    private const long NoDeliveryEpoch = -1;
+    private const long DeliveryEpochUpdating = -2;
 
     // Cross-thread state.
     private long _unackedBytes;
@@ -190,6 +196,8 @@ internal sealed class BrokerUnackedByteBudget
     // via volatile reads by parallel connection sends at send time.
     private long _totalDeliveredBytes;
     private long _lastDeliveredTimestamp;
+    private long _sendEpochDeliveredBytes = NoDeliveryEpoch;
+    private long _sendEpochFirstTimestamp;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
@@ -229,7 +237,6 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbeRateSum;
     private double _capacityProbeRttSumSeconds;
     private double _capacityProbePreProbeRttSeconds;
-    private double _capacityProbeMaxRate;
     private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
     private long _capacityProbeSuccessCount;
@@ -296,9 +303,9 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
-    /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Two
-    /// independent volatile reads — tearing is benign because both fields are monotonic and a
-    /// skewed pair only shifts one rate sample marginally.
+    /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
+    /// epoch changes are CAS-published so parallel sends cannot regress the delivered-byte
+    /// marker; the independent last-delivery timestamp may only conservatively widen a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -308,13 +315,66 @@ internal sealed class BrokerUnackedByteBudget
         long sendTimestamp,
         bool appLimited,
         long oldestBatchTimestamp = 0)
-        => new(
-            Volatile.Read(ref _totalDeliveredBytes),
+    {
+        var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
+            sendTimestamp,
+            out var deliveredBytes);
+        return new DeliverySnapshot(
+            deliveredBytes,
             Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
             oldestBatchTimestamp,
             Volatile.Read(ref _unackedBytes));
+    }
+
+    private long CaptureDeliveryEpoch(long sendTimestamp, out long deliveredBytes)
+    {
+        var spinner = new SpinWait();
+        while (true)
+        {
+            deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
+            var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
+            if (epochDeliveredBytes == deliveredBytes)
+                return Volatile.Read(ref _sendEpochFirstTimestamp);
+
+            if (epochDeliveredBytes == DeliveryEpochUpdating)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            if (Interlocked.CompareExchange(
+                    ref _sendEpochDeliveredBytes,
+                    DeliveryEpochUpdating,
+                    epochDeliveredBytes) != epochDeliveredBytes)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            return PublishDeliveryEpoch(sendTimestamp, epochDeliveredBytes, out deliveredBytes);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long PublishDeliveryEpoch(
+        long sendTimestamp,
+        long previousEpochDeliveredBytes,
+        out long deliveredBytes)
+    {
+        // The loop-top delivery read can predate a newer epoch value observed by the
+        // successful CAS. Re-read after winning so publication never regresses that value.
+        // A redundant publisher must also preserve the first send timestamp already chosen
+        // for the epoch; moving it forward would narrow the send-axis delivery interval.
+        deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
+        if (deliveredBytes != previousEpochDeliveredBytes)
+            Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
+
+        Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
+        return Volatile.Read(ref _sendEpochFirstTimestamp);
+    }
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
     /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
@@ -515,6 +575,12 @@ internal sealed class BrokerUnackedByteBudget
         var deliveredDelta = totalDelivered - sendSnapshot.DeliveredBytes;
 
         var intervalTicks = rttTicks;
+        if (sendSnapshot.DeliveryEpochFirstSendTimestamp > 0)
+        {
+            intervalTicks = Math.Max(
+                intervalTicks,
+                sendSnapshot.SendTimestamp - sendSnapshot.DeliveryEpochFirstSendTimestamp);
+        }
         if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
             intervalTicks = Math.Max(intervalTicks, nowTicks - sendSnapshot.DeliveredTimestamp);
         Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
@@ -865,7 +931,6 @@ internal sealed class BrokerUnackedByteBudget
 
             _capacityProbeRateSum += bytesPerSecond;
             _capacityProbeRttSumSeconds += rttSeconds;
-            _capacityProbeMaxRate = Math.Max(_capacityProbeMaxRate, bytesPerSecond);
             _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
@@ -891,10 +956,9 @@ internal sealed class BrokerUnackedByteBudget
                 || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
             if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
-                // Use the strongest rate actually demonstrated by this successful probe as
-                // the next rung's baseline. Otherwise a slow first response depresses the
-                // average and unchanged steady-state traffic falsely succeeds again.
-                _capacityProbeBaselineRate = Math.Max(averageRate, _capacityProbeMaxRate);
+                // Compare like with like across rungs. A single clustered-response peak is not
+                // a sustainable baseline and would make the next average-rate rung unwinnable.
+                _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
                 _capacityProbeStartTimestamp = nowTicks;
                 ResetCapacityProbeSamples();
@@ -913,7 +977,8 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks < _nextProbeTimestamp)
             return;
 
-        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
+        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks
+            && HasCapacityProbeDemand())
         {
             _capacityProbeStartTimestamp = nowTicks;
             _capacityProbeBaselineRate = GetWindowAverageRate();
@@ -932,6 +997,15 @@ internal sealed class BrokerUnackedByteBudget
         _nextProbeTimestamp = nowTicks + probeIntervalTicks;
     }
 
+    private bool HasCapacityProbeDemand()
+    {
+        var budgetBytes = Volatile.Read(ref _budgetBytes);
+        var minimumDemandBytes = Math.Max(
+            1,
+            (long)(budgetBytes * CapacityProbeDemandFraction));
+        return Volatile.Read(ref _unackedBytes) >= minimumDemandBytes;
+    }
+
     private static long GetProbeIntervalTicks(long rttTicks)
         => rttTicks >= MaxProbeIntervalTicks / ProbeIntervalRtts
             ? MaxProbeIntervalTicks
@@ -941,7 +1015,6 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capacityProbeRateSum = 0;
         _capacityProbeRttSumSeconds = 0;
-        _capacityProbeMaxRate = 0;
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -11,8 +11,14 @@ namespace Dekaf.Producer;
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
 /// by the broker's drain rate; capping the standing bytes to
 /// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
-/// periodically refreshed minimum RTT or the loaded serving RTT, so standing queue delay
-/// cannot replace the base RTT while replicated service time still keeps the pipe full.
+/// periodically refreshed minimum RTT or the loaded serving RTT, so replicated service time
+/// still keeps the pipe full. Raw round trips include the drain time of bytes the budget
+/// itself admitted ahead of the request, so RTT samples are queue-corrected at intake (raw
+/// RTT minus unacked-at-send over the measured max rate) before feeding the minimum and
+/// serving estimates, and the serving EWMA is additionally clamped to a bounded multiple of
+/// the minimum: an uncorrected floor of <c>1.5 × servingRtt</c> has loop gain above one —
+/// each budget raise lengthens the RTT that justifies the next raise until the budget rides
+/// its cap (the 3-broker acks=all latency ratchet, #2009).
 /// <para>
 /// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
 /// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
@@ -49,7 +55,8 @@ internal sealed class BrokerUnackedByteBudget
         long DeliveredTimestamp,
         long SendTimestamp,
         bool AppLimited,
-        long OldestBatchTimestamp);
+        long OldestBatchTimestamp,
+        long UnackedBytesAtSend);
 
     /// <summary>
     /// Budget ceiling in batches per connection. Sized so a ~1 GB/s drain with ~30 ms ack
@@ -98,13 +105,13 @@ internal sealed class BrokerUnackedByteBudget
     private static readonly long MinRttWindowTicks = 10 * Stopwatch.Frequency;
 
     /// <summary>
-    /// Minimum target-only drain interval used to refresh base RTT without standing
-    /// queue delay. Long-base-RTT links probe for at least one observed round-trip.
+    /// Minimum queue-drain interval used to refresh base RTT without standing queue
+    /// delay. Long-base-RTT links probe for at least one observed round-trip.
     /// </summary>
     private static readonly long MinRttProbeDurationTicks = Stopwatch.Frequency / 20;
 
     /// <summary>
-    /// Maximum target-only drain interval. An RTT outlier must not disable the retained
+    /// Maximum queue-drain interval. An RTT outlier must not disable the retained
     /// RTT safety floor for its full (potentially multi-second) duration.
     /// </summary>
     private static readonly long MaxMinRttProbeDurationTicks = Stopwatch.Frequency / 4;
@@ -116,12 +123,32 @@ internal sealed class BrokerUnackedByteBudget
     private const double RttSafetyMultiplier = 1.5;
     private const double MinRttProbeSafetyMultiplier = 1.0;
 
+    /// <summary>Ceiling on the loaded serving RTT as a multiple of the queue-drained minimum
+    /// RTT. The serving EWMA includes queueing delay the budget itself admitted, so letting
+    /// it grow the RTT floor unboundedly is a positive-feedback loop with gain above one;
+    /// clamping bounds the floor at <c>RttSafetyMultiplier × this × minRtt</c> (3 × BDP) —
+    /// enough slack for replication service-time variance without the ratchet.</summary>
+    private const double ServingRttClampMultiplier = 2.0;
+
+    /// <summary>Standing unacked bytes at this multiple of the freshly computed budget prove
+    /// the previous budget over-admitted; decay smoothing then yields to the recompute.</summary>
+    private const long StandingQueueDecayBypassMultiplier = 2;
+
+    /// <summary>Lower bound on queue-corrected RTT samples as a fraction of the raw round
+    /// trip, so an overestimated drain rate cannot collapse the corrected service estimate
+    /// (and with it the RTT floor) toward zero.</summary>
+    private const double MinCorrectedRttFraction = 0.25;
+
     private const int ProbeIntervalRtts = 8;
     // A capacity probe needs one RTT for the enlarged budget to reach the wire,
     // then three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
-    private const double RttFloorProbeBudgetMultiplier = 1.5;
+    /// <summary>A probe confirms capacity only when rate rises without the round trip
+    /// inflating past this tolerance. Through a saturated broker, delivered rate never drops
+    /// when queue is added, so a rate-only acceptance test converts every probe into budget
+    /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
+    private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
 
     // Cross-thread state.
@@ -156,6 +183,8 @@ internal sealed class BrokerUnackedByteBudget
     private long _windowMaxOccupancyBytes;
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
+    private double _rawServingRttEwmaSeconds;
+    private double _lastNormalRttFloorSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
     private long _minRttTimestamp;
@@ -168,6 +197,8 @@ internal sealed class BrokerUnackedByteBudget
     private long _capacityProbeEvaluationDeadlineTimestamp;
     private double _capacityProbeBaselineRate;
     private double _capacityProbeRateSum;
+    private double _capacityProbeRttSumSeconds;
+    private double _capacityProbePreProbeRttSeconds;
     private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
     private double _deliveryLatencyEwmaSeconds;
@@ -239,7 +270,8 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Read(ref _lastDeliveredTimestamp),
             sendTimestamp,
             appLimited,
-            oldestBatchTimestamp);
+            oldestBatchTimestamp,
+            Volatile.Read(ref _unackedBytes));
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
     /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
@@ -397,13 +429,30 @@ internal sealed class BrokerUnackedByteBudget
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0
             && (nowTicks < _minRttProbeUntilTimestamp
                 || (nowTicks == _minRttProbeUntilTimestamp && _servingRttEwmaSeconds > 0));
-        UpdateMinRtt(rttSeconds, nowTicks);
+        // Queue-corrected service RTT: the raw round trip includes the time this request
+        // spent behind bytes the budget itself admitted (unacked at send, drained at the
+        // measured max rate). Feeding raw RTTs into the minimum and serving estimates lets
+        // self-queueing masquerade as service time and re-inflate the RTT floor those
+        // estimates size (#2009). The windowed-max rate under-corrects (biased-safe), and a
+        // fraction guard bounds outlier over-correction.
+        var serviceRttSeconds = CorrectRttForSelfQueueing(
+            rttSeconds,
+            sendSnapshot.UnackedBytesAtSend,
+            ackedBytes);
+        UpdateMinRtt(serviceRttSeconds, rttSeconds, nowTicks);
         if (loadedSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
-                ? rttSeconds
+                ? serviceRttSeconds
                 : _servingRttEwmaSeconds
-                    + ServingRttEwmaWeight * (rttSeconds - _servingRttEwmaSeconds);
+                    + ServingRttEwmaWeight * (serviceRttSeconds - _servingRttEwmaSeconds);
+            // Raw (uncorrected) companion estimate for the capacity probe: probe samples are
+            // raw round trips, so their acceptance baseline must live in the same domain —
+            // a corrected baseline under standing load would reject every probe.
+            _rawServingRttEwmaSeconds = _rawServingRttEwmaSeconds == 0
+                ? rttSeconds
+                : _rawServingRttEwmaSeconds
+                    + ServingRttEwmaWeight * (rttSeconds - _rawServingRttEwmaSeconds);
         }
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
         UpdateDeliveryLatency(
@@ -435,7 +484,7 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
-        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, nowTicks);
+        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, rttSeconds, nowTicks);
     }
 
     /// <summary>
@@ -488,7 +537,13 @@ internal sealed class BrokerUnackedByteBudget
         var admissionWasBlocked = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
         _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
 
-        var targetRatio = _targetSeconds / latencyEstimate;
+        // Seal-to-send alone is blind to bytes already written and queued at the broker —
+        // the delay the budget most directly controls. Standing queue delay beyond the
+        // floor-sanctioned occupancy is that signal; controlling on the larger of the two
+        // lets the governor see broker-side queueing that never shows up between seal and
+        // socket write (#2009).
+        var controlLatencySeconds = Math.Max(latencyEstimate, GetStandingQueueDelaySeconds());
+        var targetRatio = _targetSeconds / controlLatencySeconds;
         double adjustment;
         if (targetRatio < 1)
             adjustment = Math.Max(MinimumLatencyAdjustmentFactor, targetRatio);
@@ -502,6 +557,24 @@ internal sealed class BrokerUnackedByteBudget
             MinimumLatencyBudgetScale,
             1.0));
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
+    }
+
+    /// <summary>Producer-controlled standing queue delay: unacked bytes over the drain rate,
+    /// less the occupancy the budget's own RTT floor sanctions to keep the pipe full. Delay
+    /// inside the sanctioned floor is not actionable — shrinking the scale cannot reduce a
+    /// budget the floor holds up — so charging it to the governor would only wind the scale
+    /// down against a wall.</summary>
+    private double GetStandingQueueDelaySeconds()
+    {
+        var effectiveMaxRate = GetEffectiveMaxRate();
+        if (effectiveMaxRate <= 0)
+            return 0;
+
+        var sanctionedSeconds = Math.Max(
+            _lastNormalRttFloorSeconds,
+            _hasMinRttSample ? _minRttSeconds : 0);
+        var standingSeconds = UnackedBytes / effectiveMaxRate;
+        return Math.Max(0, standingSeconds - sanctionedSeconds);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -518,14 +591,30 @@ internal sealed class BrokerUnackedByteBudget
         _requestRttMicrosLog2Histogram[rttBucket]++;
     }
 
-    private void UpdateMinRtt(double rttSeconds, long nowTicks)
+    /// <summary>Removes the drain time of bytes already unacked at send from a measured
+    /// round trip, leaving an estimate of the broker's service time. The correction is
+    /// bounded below by <see cref="MinCorrectedRttFraction"/> of the raw round trip so a
+    /// rate-estimate outlier cannot collapse the RTT floor the result feeds.</summary>
+    private double CorrectRttForSelfQueueing(double rttSeconds, long unackedBytesAtSend, long ackedBytes)
+    {
+        var effectiveMaxRate = GetEffectiveMaxRate();
+        var queueAheadBytes = unackedBytesAtSend - ackedBytes;
+        if (effectiveMaxRate <= 0 || queueAheadBytes <= 0)
+            return rttSeconds;
+
+        return Math.Max(
+            rttSeconds * MinCorrectedRttFraction,
+            rttSeconds - queueAheadBytes / effectiveMaxRate);
+    }
+
+    private void UpdateMinRtt(double serviceRttSeconds, double rawRttSeconds, long nowTicks)
     {
         if (!_hasMinRttSample)
         {
-            _minRttSeconds = rttSeconds;
+            _minRttSeconds = serviceRttSeconds;
             _minRttTimestamp = nowTicks;
             _hasMinRttSample = true;
-            StartMinRttProbe(nowTicks, rttSeconds);
+            StartMinRttProbe(nowTicks, rawRttSeconds);
             return;
         }
 
@@ -537,20 +626,22 @@ internal sealed class BrokerUnackedByteBudget
             }
             else
             {
-                _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, rttSeconds);
+                _minRttProbeMinimumSeconds = Math.Min(_minRttProbeMinimumSeconds, serviceRttSeconds);
                 return;
             }
         }
 
-        if (rttSeconds < _minRttSeconds)
+        if (serviceRttSeconds < _minRttSeconds)
         {
-            _minRttSeconds = rttSeconds;
+            _minRttSeconds = serviceRttSeconds;
             _minRttTimestamp = nowTicks;
             return;
         }
 
+        // Probe duration is sized from the raw round trip: draining the standing queue
+        // takes real wall-clock time even when the corrected service estimate is small.
         if (nowTicks - _minRttTimestamp >= MinRttWindowTicks)
-            StartMinRttProbe(nowTicks, rttSeconds);
+            StartMinRttProbe(nowTicks, rawRttSeconds);
     }
 
     private void CompleteExpiredMinRttProbe(long nowTicks)
@@ -657,6 +748,7 @@ internal sealed class BrokerUnackedByteBudget
         double bytesPerSecond,
         long sendTimestamp,
         long rttTicks,
+        double rttSeconds,
         long nowTicks)
     {
         var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
@@ -683,6 +775,7 @@ internal sealed class BrokerUnackedByteBudget
                 return;
 
             _capacityProbeRateSum += bytesPerSecond;
+            _capacityProbeRttSumSeconds += rttSeconds;
             _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
@@ -693,14 +786,22 @@ internal sealed class BrokerUnackedByteBudget
             if (nowTicks < _capacityProbeEvaluationDeadlineTimestamp)
                 return;
 
+            // Real headroom shows as rate-up with a flat round trip. A saturated broker also
+            // shows rate-not-down when the probe adds queue, so a rate-only test would accept
+            // every probe under load and ratchet the budget into standing latency. The rate
+            // gate stays primary; the RTT guard (raw-domain baseline vs raw probe samples,
+            // <= 0 only when reflection-seeded in tests) catches the queue-dominated regime
+            // where round trips inflate well past the tolerance.
             var averageRate = _capacityProbeRateSum / _capacityProbeRateSampleCount;
-            if (averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            var averageRttSeconds = _capacityProbeRttSumSeconds / _capacityProbeRateSampleCount;
+            var rttHeld = _capacityProbePreProbeRttSeconds <= 0
+                || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
+            if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
                 _capacityProbeBaselineRate = averageRate;
+                _capacityProbePreProbeRttSeconds = averageRttSeconds;
                 _capacityProbeStartTimestamp = nowTicks;
-                _capacityProbeRateSum = 0;
-                _capacityProbeRateSampleCount = 0;
-                _capacityProbeEvaluationDeadlineTimestamp = 0;
+                ResetCapacityProbeSamples();
                 Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             }
             else
@@ -719,9 +820,12 @@ internal sealed class BrokerUnackedByteBudget
         {
             _capacityProbeStartTimestamp = nowTicks;
             _capacityProbeBaselineRate = GetEffectiveMaxRate();
-            _capacityProbeRateSum = 0;
-            _capacityProbeRateSampleCount = 0;
-            _capacityProbeEvaluationDeadlineTimestamp = 0;
+            // Raw-domain baseline to match the raw probe samples; the queue-corrected
+            // serving EWMA sits below loaded round trips and would fail every probe.
+            _capacityProbePreProbeRttSeconds = _rawServingRttEwmaSeconds > 0
+                ? _rawServingRttEwmaSeconds
+                : rttSeconds;
+            ResetCapacityProbeSamples();
             Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             Volatile.Write(ref _capacityProbeActive, true);
         }
@@ -736,11 +840,17 @@ internal sealed class BrokerUnackedByteBudget
             ? MaxProbeIntervalTicks
             : ProbeIntervalRtts * rttTicks;
 
-    private void DeactivateCapacityProbe()
+    private void ResetCapacityProbeSamples()
     {
         _capacityProbeRateSum = 0;
+        _capacityProbeRttSumSeconds = 0;
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
+    }
+
+    private void DeactivateCapacityProbe()
+    {
+        ResetCapacityProbeSamples();
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
     }
@@ -814,11 +924,14 @@ internal sealed class BrokerUnackedByteBudget
         var elapsedSeconds = _lastBudgetUpdateTimestamp == 0
             ? 0
             : Math.Max(0, (double)(nowTicks - _lastBudgetUpdateTimestamp) / Stopwatch.Frequency);
+        // _unackedBytes shares a contended cache line with every appender's Interlocked.Add;
+        // only pay for the read when the decay bound can actually consult it.
         var budget = BoundBudgetDecay(
             _lastNormalBudgetBytes,
             computedBudget,
             elapsedSeconds,
-            admissionWasBlocked);
+            admissionWasBlocked,
+            admissionWasBlocked ? UnackedBytes : 0);
         budget = Math.Min(budget, _capBytes);
         _lastNormalBudgetBytes = budget;
         _lastBudgetUpdateTimestamp = nowTicks;
@@ -833,7 +946,8 @@ internal sealed class BrokerUnackedByteBudget
         long previousBudget,
         long computedBudget,
         double elapsedSeconds,
-        bool admissionWasBlocked)
+        bool admissionWasBlocked,
+        long unackedBytes)
     {
         if (!admissionWasBlocked
             || computedBudget >= previousBudget
@@ -841,6 +955,13 @@ internal sealed class BrokerUnackedByteBudget
         {
             return computedBudget;
         }
+
+        // Under saturation admission is always blocked, so blocks alone cannot distinguish
+        // protected demand from a standing queue the recompute is trying to drain. Bytes at
+        // a multiple of the fresh budget are that proof — smoothing would preserve the
+        // over-admission for minutes at 10%/s.
+        if (unackedBytes >= StandingQueueDecayBypassMultiplier * computedBudget)
+            return computedBudget;
 
         var decayFraction = Math.Min(1.0, MaximumBudgetDecayPerSecond * elapsedSeconds);
         var minimumBudget = (long)Math.Ceiling(previousBudget * (1.0 - decayFraction));
@@ -864,24 +985,26 @@ internal sealed class BrokerUnackedByteBudget
         else
         {
             var latencyGovernedTargetSeconds = _targetSeconds * _latencyBudgetScale;
+            // The serving EWMA and the minimum RTT are queue-corrected at sample intake
+            // (see OnAcked), so neither re-inflates from queueing this budget admitted;
+            // the clamp below is a residual guard for correction error.
             var loadAwareRttSeconds = _retainedLoadedMaxRate > 0
-                ? Math.Max(minRttSeconds, _servingRttEwmaSeconds)
+                ? Math.Max(
+                    minRttSeconds,
+                    Math.Min(_servingRttEwmaSeconds, ServingRttClampMultiplier * minRttSeconds))
                 : minRttSeconds;
             var rttFloorSeconds = minRttProbeActive
                 ? MinRttProbeSafetyMultiplier * minRttSeconds
                 : RttSafetyMultiplier * loadAwareRttSeconds;
+            if (!minRttProbeActive)
+                _lastNormalRttFloorSeconds = rttFloorSeconds;
             var horizonSeconds = _hasMinRttSample
                 ? Math.Max(latencyGovernedTargetSeconds, rttFloorSeconds)
                 : latencyGovernedTargetSeconds;
             rateBudgetBytes = effectiveMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)
-            {
-                var multiplier = rttFloorSeconds > latencyGovernedTargetSeconds
-                    ? RttFloorProbeBudgetMultiplier
-                    : ProbeBudgetMultiplier;
-                estimatedBytes *= multiplier;
-            }
+                estimatedBytes *= ProbeBudgetMultiplier;
 
             budget = (long)estimatedBytes;
         }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -24,7 +24,7 @@ namespace Dekaf.Producer;
 /// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
 /// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
 /// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
-/// than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// than 20ms are ignored because host scheduling and burst quantization can dominate them. A separate
 /// per-request rate remains available to the capacity probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
@@ -188,8 +188,10 @@ internal sealed class BrokerUnackedByteBudget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
-    // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
-    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
+    private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // Shorter loaded epochs are dominated by timer, scheduler, and burst quantization on common hosts.
+    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 50);
     // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
     private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
     private const long NoDeliveryEpoch = -1;
@@ -340,7 +342,7 @@ internal sealed class BrokerUnackedByteBudget
         var continuesSerializedRateCycle = appLimited
             && deliveredTimestamp != 0
             && deliveryGapTicks >= 0
-            && deliveryGapTicks < MinimumLoadedRateSampleTicks;
+            && deliveryGapTicks < MaximumSerializedRateCycleGapTicks;
         var rateAppLimited = appLimited && !continuesSerializedRateCycle;
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -626,6 +626,17 @@ internal sealed class BrokerUnackedByteBudget
             // latency approaches target (adjustment -> 1 as targetRatio -> 1).
             adjustment = Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
         }
+        else if (_latencyBudgetScale < 1.0)
+        {
+            // A transient queue can legitimately derate the budget, but once measured
+            // latency is back below target the controller must return to its neutral scale.
+            // Requiring another admission block here makes the derating self-sealing: the
+            // smaller budget removes the pressure event that would restore it. Recovery
+            // without pressure stops at 1.0; only the branch above may probe past parity.
+            adjustment = Math.Min(
+                MaximumLatencyAdjustmentFactor,
+                1.0 / _latencyBudgetScale);
+        }
         else
         {
             adjustment = 1.0;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -21,10 +21,10 @@ namespace Dekaf.Producer;
 /// its cap (the 3-broker acks=all latency ratchet, #2009).
 /// <para>
 /// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
-/// epoch; loaded sends retain its delivered-byte and first-send anchors even as acknowledgements
-/// advance the current delivery clock. The sample is cumulative delivered bytes over the full
-/// epoch elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples
-/// shorter than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
+/// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
+/// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
+/// than 2ms are ignored because host scheduling resolution can dominate them. A separate
 /// per-request rate remains available to the capacity probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
@@ -189,6 +189,8 @@ internal sealed class BrokerUnackedByteBudget
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
     // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
     private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
+    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -367,13 +369,16 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
-            // A loaded pipe belongs to the existing send epoch even after acknowledgements
-            // advance the delivery counter. Reset only when a send observes an empty pipe;
-            // otherwise serialized send/ack cycles collapse back to requestBytes / ownRTT.
-            if (!appLimited && epochDeliveredBytes != NoDeliveryEpoch)
+            // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
+            // app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
+            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
+            if (!appLimited
+                && epochDeliveredBytes != NoDeliveryEpoch
+                && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)
             {
                 deliveryEpochDeliveredBytes = epochDeliveredBytes;
-                return Volatile.Read(ref _sendEpochFirstTimestamp);
+                return epochFirstSendTimestamp;
             }
 
             if (Interlocked.CompareExchange(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -240,7 +240,6 @@ internal sealed class BrokerUnackedByteBudget
     private long _lastLatencyControlAdmissionBlockEvents;
     private long _lastNormalBudgetBytes;
     private long _lastBudgetUpdateTimestamp;
-    private long _lastBudgetAdmissionBlockEvents;
 
     public BrokerUnackedByteBudget(
         double targetSeconds,
@@ -440,7 +439,7 @@ internal sealed class BrokerUnackedByteBudget
         CompleteExpiredMinRttProbe(nowTicks);
         if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
             DeactivateCapacityProbe();
-        RecomputeBudget(nowTicks, consumeAdmissionBlockEvents: false);
+        RecomputeBudget(nowTicks);
     }
 
     /// <summary>
@@ -553,7 +552,7 @@ internal sealed class BrokerUnackedByteBudget
         if (writtenUnackedPeak > 0)
             AddOccupancySample(writtenUnackedPeak);
 
-        RecomputeBudget(nowTicks, consumeAdmissionBlockEvents: true);
+        RecomputeBudget(nowTicks);
     }
 
     private void UpdateDeliveryLatency(
@@ -975,7 +974,7 @@ internal sealed class BrokerUnackedByteBudget
         return maximum;
     }
 
-    private void RecomputeBudget(long nowTicks, bool consumeAdmissionBlockEvents)
+    private void RecomputeBudget(long nowTicks)
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
         var postProbeMinRttSeconds = _minRttSeconds;
@@ -985,10 +984,7 @@ internal sealed class BrokerUnackedByteBudget
             minRttProbeActive: false,
             capacityProbeActive: false,
             postProbeMinRttSeconds);
-        var normalBudget = ApplyNormalBudgetDecayHysteresis(
-            computedNormalBudget,
-            nowTicks,
-            consumeAdmissionBlockEvents);
+        var normalBudget = ApplyNormalBudgetDecayHysteresis(computedNormalBudget, nowTicks);
         var probeBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: true,
@@ -1013,34 +1009,25 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _budgetBytes, budget);
     }
 
-    private long ApplyNormalBudgetDecayHysteresis(
-        long computedBudget,
-        long nowTicks,
-        bool consumeAdmissionBlockEvents)
+    private long ApplyNormalBudgetDecayHysteresis(long computedBudget, long nowTicks)
     {
-        // Smooth downward changes only while fresh admission blocks prove demand.
-        // Capping decay at 10%/s prevents the short estimator window from draining
-        // the budget faster than a loaded pipeline can demonstrate recovery.
-        var admissionBlockEvents = AdmissionBlockEvents;
-        var admissionWasBlocked = admissionBlockEvents > _lastBudgetAdmissionBlockEvents;
+        // Smooth every downward change. Capping decay at 10%/s prevents the short
+        // estimator window (including the first cold-start sample) from draining the
+        // budget faster than a loaded pipeline can demonstrate recovery.
         var elapsedSeconds = _lastBudgetUpdateTimestamp == 0
             ? 0
             : Math.Max(0, (double)(nowTicks - _lastBudgetUpdateTimestamp) / Stopwatch.Frequency);
         // _unackedBytes shares a contended cache line with every appender's Interlocked.Add;
-        // only pay for the read when the decay bound can actually consult it.
+        // only pay for the read when a downward move can consult the queue bypass.
+        var unackedBytes = computedBudget < _lastNormalBudgetBytes ? UnackedBytes : 0;
         var budget = BoundBudgetDecay(
             _lastNormalBudgetBytes,
             computedBudget,
             elapsedSeconds,
-            admissionWasBlocked,
-            admissionWasBlocked ? UnackedBytes : 0);
+            unackedBytes);
         budget = Math.Min(budget, _capBytes);
         _lastNormalBudgetBytes = budget;
         _lastBudgetUpdateTimestamp = nowTicks;
-        // SetCap may run immediately before the ack pass that owns this pressure signal.
-        // Only that pass consumes the cursor, so scaling cannot erase decay protection.
-        if (consumeAdmissionBlockEvents)
-            _lastBudgetAdmissionBlockEvents = admissionBlockEvents;
         return budget;
     }
 
@@ -1048,24 +1035,19 @@ internal sealed class BrokerUnackedByteBudget
         long previousBudget,
         long computedBudget,
         double elapsedSeconds,
-        bool admissionWasBlocked,
         long unackedBytes)
     {
-        if (!admissionWasBlocked
-            || computedBudget >= previousBudget
-            || elapsedSeconds <= 0)
-        {
+        if (computedBudget >= previousBudget)
             return computedBudget;
-        }
 
-        // Under saturation admission is always blocked, so blocks alone cannot distinguish
-        // protected demand from a standing queue the recompute is trying to drain. Bytes at
-        // a multiple of the fresh budget are that proof — smoothing would preserve the
-        // over-admission for minutes at 10%/s.
+        // Bytes at a multiple of the fresh budget prove the old budget over-admitted;
+        // smoothing would otherwise preserve the standing queue for minutes at 10%/s.
         if (unackedBytes >= StandingQueueDecayBypassMultiplier * computedBudget)
             return computedBudget;
 
-        var decayFraction = Math.Min(1.0, MaximumBudgetDecayPerSecond * elapsedSeconds);
+        var decayFraction = Math.Min(
+            1.0,
+            MaximumBudgetDecayPerSecond * Math.Max(0, elapsedSeconds));
         var minimumBudget = (long)Math.Ceiling(previousBudget * (1.0 - decayFraction));
         return Math.Max(computedBudget, minimumBudget);
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -22,10 +22,12 @@ namespace Dekaf.Producer;
 /// <para>
 /// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
 /// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
-/// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
-/// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
-/// than 20ms are ignored because host scheduling and burst quantization can dominate them. A separate
-/// per-request rate remains available to the capacity probe, which needs each probe admission's
+/// for a rolling interval bounded at 250ms. The sample is cumulative delivered bytes over the
+/// full epoch elapsed time, bounded below by the request sojourn and delivery clock. Samples
+/// shorter than 100ms are ignored because host scheduling and burst quantization can dominate
+/// them. A short truly app-limited sample may seed an empty estimator, but cannot replace an
+/// established sustainable rate. A separate per-request rate remains available to the capacity
+/// probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
 /// </para>
@@ -187,9 +189,11 @@ internal sealed class BrokerUnackedByteBudget
     // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
     private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
     // Shorter loaded epochs are dominated by timer, scheduler, and burst quantization on common hosts.
-    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 50);
+    private static readonly long MinimumSustainableRateSampleTicks = Math.Max(
+        1,
+        Stopwatch.Frequency / 10);
     // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
-    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
+    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 4);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -391,7 +395,7 @@ internal sealed class BrokerUnackedByteBudget
             }
 
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
-            // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // rate-app-limited boundaries or after 250ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
             if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
@@ -589,7 +593,6 @@ internal sealed class BrokerUnackedByteBudget
             && deliveryIdleTicks >= WindowDurationTicks;
         var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
-        var loadedRateEpoch = !sendSnapshot.RateAppLimited;
         var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
         {
@@ -672,8 +675,11 @@ internal sealed class BrokerUnackedByteBudget
         var requestBytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / requestIntervalTicks;
         var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
             / deliveryEpochIntervalTicks;
+        var bootstrapsEmptyEstimator = sendSnapshot.RateAppLimited
+            && GetEffectiveMaxRate() == 0;
         if (deliveryEpochBytesPerSecond > 0
-            && (!loadedRateEpoch || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
+            && (deliveryEpochIntervalTicks >= MinimumSustainableRateSampleTicks
+                || bootstrapsEmptyEstimator))
         {
             AddRateSample(deliveryEpochBytesPerSecond, retainLoadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -68,7 +68,10 @@ internal sealed class BrokerUnackedByteBudget
 
     private const int WindowBucketCount = 20;
     private const double WindowBucketSeconds = 0.100;
-    private const double LoadedRateHalfLifeSeconds = 60.0;
+    // Retain demonstrated loaded capacity across transient GC/scheduler stalls. Recovery probes
+    // provide the upward path, but a short dip must not become the admission ceiling within one
+    // minute and create a self-reinforcing rate/budget decay loop.
+    private const double LoadedRateHalfLifeSeconds = 600.0;
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
     private const double DeliveryLatencyEwmaWeight = 0.125;
@@ -191,8 +194,11 @@ internal sealed class BrokerUnackedByteBudget
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
     private readonly double _targetSeconds;
+    private readonly long _probeResponseHorizonTicks;
     private long _capBytes;
     private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
+    private readonly double[] _rateBucketSums = new double[WindowBucketCount];
+    private readonly int[] _rateBucketSampleCounts = new int[WindowBucketCount];
     private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
     // Per-request diagnostics: log2 histograms of acked request sizes and RTTs. Incremented
     // only by the owning send loop; snapshot copies use per-element volatile reads, so
@@ -201,6 +207,8 @@ internal sealed class BrokerUnackedByteBudget
     private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
+    private double _windowRateSum;
+    private int _windowRateSampleCount;
     private double _retainedLoadedMaxRate;
     private long _windowMaxOccupancyBytes;
     private double _minRttSeconds;
@@ -221,8 +229,11 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbeRateSum;
     private double _capacityProbeRttSumSeconds;
     private double _capacityProbePreProbeRttSeconds;
+    private double _capacityProbeMaxRate;
     private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
+    private long _capacityProbeSuccessCount;
+    private long _capacityProbeFailureCount;
     private double _deliveryLatencyEwmaSeconds;
     private double _latencyBudgetScale = 1.0;
     private long _nextLatencyControlTimestamp;
@@ -231,9 +242,16 @@ internal sealed class BrokerUnackedByteBudget
     private long _lastBudgetUpdateTimestamp;
     private long _lastBudgetAdmissionBlockEvents;
 
-    public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
+    public BrokerUnackedByteBudget(
+        double targetSeconds,
+        long floorBytes,
+        long initialCapBytes,
+        double lingerSeconds = 0)
     {
         _targetSeconds = targetSeconds;
+        _probeResponseHorizonTicks = Math.Max(
+            1,
+            (long)(Math.Max(0, targetSeconds + lingerSeconds) * Stopwatch.Frequency));
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, initialCapBytes);
         _lastNormalBudgetBytes = _capBytes;
@@ -264,6 +282,10 @@ internal sealed class BrokerUnackedByteBudget
     internal long MinimumRttMicros => Volatile.Read(ref _minimumRttMicros);
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
+
+    internal long CapacityProbeSuccessCount => Volatile.Read(ref _capacityProbeSuccessCount);
+
+    internal long CapacityProbeFailureCount => Volatile.Read(ref _capacityProbeFailureCount);
 
     /// <summary>EWMA of controllable seal-to-send queue latency. The diagnostic property
     /// retains its original name for compatibility.</summary>
@@ -506,7 +528,14 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
-        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, rttSeconds, nowTicks);
+        UpdateCapacityProbe(
+            bytesPerSecond,
+            sendSnapshot.OldestBatchTimestamp != 0
+                ? sendSnapshot.OldestBatchTimestamp
+                : sendSnapshot.SendTimestamp,
+            rttTicks,
+            rttSeconds,
+            nowTicks);
     }
 
     /// <summary>
@@ -720,8 +749,12 @@ internal sealed class BrokerUnackedByteBudget
         if (elapsed >= WindowBucketCount)
         {
             Array.Clear(_rateBucketMaxValues);
+            Array.Clear(_rateBucketSums);
+            Array.Clear(_rateBucketSampleCounts);
             Array.Clear(_occupancyBucketMaxValues);
             _windowMaxRate = 0;
+            _windowRateSum = 0;
+            _windowRateSampleCount = 0;
             _windowMaxOccupancyBytes = 0;
         }
         else
@@ -734,7 +767,11 @@ internal sealed class BrokerUnackedByteBudget
                 recomputeRate |= _windowMaxRate > 0 && _rateBucketMaxValues[slot] >= _windowMaxRate;
                 recomputeOccupancy |= _windowMaxOccupancyBytes > 0
                     && _occupancyBucketMaxValues[slot] >= _windowMaxOccupancyBytes;
+                _windowRateSum -= _rateBucketSums[slot];
+                _windowRateSampleCount -= _rateBucketSampleCounts[slot];
                 _rateBucketMaxValues[slot] = 0;
+                _rateBucketSums[slot] = 0;
+                _rateBucketSampleCounts[slot] = 0;
                 _occupancyBucketMaxValues[slot] = 0;
             }
 
@@ -760,7 +797,11 @@ internal sealed class BrokerUnackedByteBudget
     {
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
+        _rateBucketSums[slot] += bytesPerSecond;
+        _rateBucketSampleCounts[slot]++;
         _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
+        _windowRateSum += bytesPerSecond;
+        _windowRateSampleCount++;
         if (sustainedIdle)
             _retainedLoadedMaxRate = 0;
         else if (loadedSample)
@@ -768,6 +809,10 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     private double GetEffectiveMaxRate() => Math.Max(_windowMaxRate, _retainedLoadedMaxRate);
+
+    private double GetWindowAverageRate() => _windowRateSampleCount > 0
+        ? _windowRateSum / _windowRateSampleCount
+        : 0;
 
     private void AddOccupancySample(long bytes)
     {
@@ -778,15 +823,18 @@ internal sealed class BrokerUnackedByteBudget
 
     private void UpdateCapacityProbe(
         double bytesPerSecond,
-        long sendTimestamp,
+        long admissionTimestamp,
         long rttTicks,
         double rttSeconds,
         long nowTicks)
     {
         var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
+        var evaluationWindowTicks = Math.Max(
+            ProbeEvaluationRtts * rttTicks,
+            _probeResponseHorizonTicks);
         var probeDurationTicks = Math.Max(
             probeIntervalTicks,
-            (ProbeEvaluationRtts + 1L) * rttTicks);
+            rttTicks + evaluationWindowTicks);
         if (_nextProbeTimestamp == 0)
             _nextProbeTimestamp = nowTicks + probeIntervalTicks;
 
@@ -799,19 +847,22 @@ internal sealed class BrokerUnackedByteBudget
                 return;
             }
 
-            // A response can contribute only when its request was sent after the larger
-            // budget was published. Collect a full RTT of wholly-probed responses before
-            // judging growth: response ordering across connection lanes can otherwise let
-            // one small request cancel the probe before the added budget reaches the wire.
-            if (sendTimestamp < _capacityProbeStartTimestamp)
+            // A response can contribute only when every batch in its request was admitted
+            // after the larger budget was published. Send time is too late: a request sent
+            // during the probe can still contain batches sealed under the old budget.
+            if (admissionTimestamp < _capacityProbeStartTimestamp)
                 return;
 
             _capacityProbeRateSum += bytesPerSecond;
             _capacityProbeRttSumSeconds += rttSeconds;
+            _capacityProbeMaxRate = Math.Max(_capacityProbeMaxRate, bytesPerSecond);
             _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
-                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + ProbeEvaluationRtts * rttTicks;
+                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + evaluationWindowTicks;
+                Volatile.Write(
+                    ref _capacityProbeDeadlineTimestamp,
+                    Math.Max(_capacityProbeDeadlineTimestamp, nowTicks + evaluationWindowTicks));
                 return;
             }
 
@@ -830,10 +881,14 @@ internal sealed class BrokerUnackedByteBudget
                 || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
             if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
-                _capacityProbeBaselineRate = averageRate;
+                // Use the strongest rate actually demonstrated by this successful probe as
+                // the next rung's baseline. Otherwise a slow first response depresses the
+                // average and unchanged steady-state traffic falsely succeeds again.
+                _capacityProbeBaselineRate = Math.Max(averageRate, _capacityProbeMaxRate);
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
                 _capacityProbeStartTimestamp = nowTicks;
                 ResetCapacityProbeSamples();
+                Interlocked.Increment(ref _capacityProbeSuccessCount);
                 Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             }
             else
@@ -851,7 +906,7 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
         {
             _capacityProbeStartTimestamp = nowTicks;
-            _capacityProbeBaselineRate = GetEffectiveMaxRate();
+            _capacityProbeBaselineRate = GetWindowAverageRate();
             // Raw-domain baseline to match the raw probe samples; the queue-corrected
             // serving EWMA sits below loaded round trips and would fail every probe.
             _capacityProbePreProbeRttSeconds = _rawServingRttEwmaSeconds > 0
@@ -876,12 +931,16 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capacityProbeRateSum = 0;
         _capacityProbeRttSumSeconds = 0;
+        _capacityProbeMaxRate = 0;
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }
 
     private void DeactivateCapacityProbe()
     {
+        if (_capacityProbeActive)
+            Interlocked.Increment(ref _capacityProbeFailureCount);
+
         ResetCapacityProbeSamples();
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -306,6 +306,10 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
     public required long AdmissionBlockCount { get; init; }
+    // Optional for backward compatibility with persisted stress results captured before
+    // probe outcomes were added; missing JSON values naturally deserialize as zero.
+    public long CapacityProbeSuccessCount { get; init; }
+    public long CapacityProbeFailureCount { get; init; }
     /// <summary>Controllable seal-to-send queue-latency EWMA. Name retained for diagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -61,6 +61,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly CancellationTokenSource _senderCts;
     private readonly Task _senderTask;
     private readonly Task _lingerTask;
+    private readonly PeriodicTimer _lingerTimer;
     private readonly ConcurrentDictionary<Task, byte> _partitionEnrollmentTasks = new();
 
     // Per-broker sender threads: each broker gets a dedicated BrokerSender with its own
@@ -421,6 +422,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
 
         _senderCts = new CancellationTokenSource();
+        _lingerTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
         _senderTask = Task.Factory.StartNew(
             () => SenderLoopAsync(_senderCts.Token),
             CancellationToken.None,
@@ -3277,6 +3279,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var lastOrphanSweepTicks = Stopwatch.GetTimestamp();
 
         _accumulator.RegisterLingerWakeupShutdownToken(cancellationToken);
+        using var cancellationRegistration = cancellationToken.UnsafeRegister(
+            static state => ((PeriodicTimer)state!).Dispose(),
+            _lingerTimer);
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -3287,11 +3292,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 var orphanWaitMs = ticksUntilOrphanSweep <= 0
                     ? 0
                     : Math.Max(1, (int)Math.Ceiling(ticksUntilOrphanSweep * 1000.0 / Stopwatch.Frequency));
-                var waitMs = _accumulator.HasPendingLingerBatches && orphanWaitMs > 0
-                    ? 1
-                    : orphanWaitMs;
 
-                await _accumulator.WaitForLingerWakeupAsync(waitMs).ConfigureAwait(false);
+                if (_accumulator.HasPendingLingerBatches)
+                {
+                    if (!await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
+                        break;
+                }
+                else
+                {
+                    await _accumulator.WaitForLingerWakeupAsync(orphanWaitMs).ConfigureAwait(false);
+                }
+
                 await _accumulator.ExpireLingerAsync(cancellationToken).ConfigureAwait(false);
 
                 // Periodic orphan sweep: fail in-flight batches that exceeded delivery timeout.
@@ -4191,6 +4202,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _senderCts.Dispose();
+        _lingerTimer.Dispose();
         _transactionLock.Dispose();
         _initLock.Dispose();
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3295,6 +3295,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (_accumulator.HasPendingLingerBatches)
                 {
+                    BeforeActiveLingerTimerWaitForTest?.Invoke();
                     if (!await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
                         break;
                 }
@@ -3323,6 +3324,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
         }
     }
+
+    internal Action? BeforeActiveLingerTimerWaitForTest;
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -307,12 +307,15 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             $"Producer is generating messages faster than the network can send them. " +
             $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
 
-        TryFail(exception);
+        if (TryFail(exception))
+            accumulator.DrainPendingAppendsIfHead(this);
     }
 
     private void OnCancellation()
     {
-        TryFail(new OperationCanceledException(_cancellationToken));
+        var accumulator = _accumulator;
+        if (TryFail(new OperationCanceledException(_cancellationToken)))
+            accumulator?.DrainPendingAppendsIfHead(this);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -15,6 +15,7 @@ namespace Dekaf.Producer;
 /// </summary>
 public sealed class ProducerOptions
 {
+    internal const int DefaultMaxConnectionsPerBroker = 3;
     internal const int IdempotentMaxInFlightRequestsPerConnection = 5;
     internal const int NonIdempotentDefaultMaxInFlightRequestsPerConnection = 100;
     internal const int MaxAllowedMaxInFlightRequestsPerConnection = 1_000_000;
@@ -579,7 +580,7 @@ public sealed class ProducerOptions
     /// <summary>
     /// Maximum connections per broker when adaptive scaling is enabled.
     /// The producer will not scale beyond this limit regardless of buffer pressure.
-    /// Must be at least 1. Default: 10.
+    /// Must be at least 1. Default: 3.
     /// </summary>
     public int MaxConnectionsPerBroker
     {
@@ -591,7 +592,7 @@ public sealed class ProducerOptions
         }
     }
 
-    private readonly int _maxConnectionsPerBroker = 10;
+    private readonly int _maxConnectionsPerBroker = DefaultMaxConnectionsPerBroker;
 
     /// <summary>
     /// Test-only override for the adaptive-scaling cooldown window (milliseconds).

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1342,6 +1342,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
+    private long _pendingAppendDrainEntryCount;
 
     /// <summary>
     /// Per-partition state matching Java's Deque&lt;ProducerBatch&gt; design.
@@ -1989,6 +1990,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
             return false;
 
+        Interlocked.Increment(ref _pendingAppendDrainEntryCount);
         var ownsDrainGuard = true;
         try
         {
@@ -2032,17 +2034,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
                         }
 
-                        var admissionBlocked = IsBrokerAdmissionBlocked(
-                            candidate.Topic,
-                            candidate.Partition,
-                            recordBlockEvent: false,
-                            out var admissionRecheckDelayMs);
-                        if (admissionBlocked)
+                        if (TryGetAdmissionRecheckAt(
+                                candidate.Topic,
+                                candidate.Partition,
+                                out var recheckAt))
                         {
-                            var recheckAt = admissionRecheckDelayMs == Timeout.Infinite
-                                ? 0
-                                : Dekaf.MonotonicClock.GetMilliseconds()
-                                  + Math.Max(1, admissionRecheckDelayMs);
                             _pendingAppends.Enqueue(candidate);
                             candidate.ScheduleAdmissionRecheck(recheckAt);
                             _blockedPendingPartitionRecheckTimes.Add(
@@ -2131,6 +2127,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 Volatile.Write(ref _draining, 0);
             }
         }
+    }
+
+    /// <summary>
+    /// Rescans after a failed append only when it occupied the FIFO head. Tail failures
+    /// cannot unblock another operation; suppressing their scans coalesces a timeout or
+    /// cancellation storm into the single scan triggered by the head.
+    /// </summary>
+    internal void DrainPendingAppendsIfHead(PendingAppend completed)
+    {
+        lock (_pendingAppendQueueLock)
+        {
+            if (!_pendingAppends.TryPeek(out var head)
+                || !ReferenceEquals(head, completed))
+            {
+                return;
+            }
+        }
+
+        DrainPendingAppends();
     }
 
     /// <summary>
@@ -2960,8 +2975,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
+        bool wasQueueEmpty;
         lock (_pendingAppendQueueLock)
+        {
+            wasQueueEmpty = _pendingAppends.IsEmpty;
             _pendingAppends.Enqueue(op);
+        }
 
         // Close TOCTOU window: if DisposeAsync ran between the _disposed check above and the
         // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
@@ -2977,8 +2996,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
         }
 
-        // Try immediate serve — memory may have been freed between TryReserveMemory and now
-        DrainPendingAppends();
+        // Close the memory-release TOCTOU window for the first queued operation. Later
+        // admission-blocked appends arm their own broker deadline without rescanning the
+        // queue; memory-blocked appends rely on ReleaseMemory's unconditional drain.
+        if (wasQueueEmpty)
+        {
+            DrainPendingAppends();
+        }
+        else
+        {
+            if (TryGetAdmissionRecheckAt(topic, partition, out var recheckAt))
+                op.ScheduleAdmissionRecheck(recheckAt);
+        }
 
         return new ValueTask<bool>(op, op.Version);
     }
@@ -4024,6 +4053,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal int PendingAppendCountForTest => _pendingAppends.Count;
 
+    internal long PendingAppendDrainEntryCountForTest =>
+        Volatile.Read(ref _pendingAppendDrainEntryCount);
+
     /// <summary>
     /// Gets the current buffer utilization as a ratio (0.0 to 1.0+).
     /// Used by adaptive connection scaling to confirm buffer is actually full.
@@ -4745,6 +4777,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
             currentBudget.RecordAdmissionBlock();
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryGetAdmissionRecheckAt(
+        string topic,
+        int partition,
+        out long recheckAt)
+    {
+        recheckAt = 0;
+        if (!IsBrokerAdmissionBlocked(
+                topic,
+                partition,
+                recordBlockEvent: false,
+                out var recheckDelayMilliseconds))
+        {
+            return false;
+        }
+
+        if (recheckDelayMilliseconds != Timeout.Infinite)
+        {
+            recheckAt = Dekaf.MonotonicClock.GetMilliseconds()
+                + Math.Max(1, recheckDelayMilliseconds);
+        }
+
         return true;
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1124,8 +1124,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly AsyncAutoResetSignal _wakeupSignal = new();
 
     /// <summary>
-    /// Signals the linger loop when an unsealed batch is created or gains its first awaiter.
-    /// This keeps the 1 ms linger cadence armed only while batches need it.
+    /// Arms the periodic linger cadence when the first unsealed batch becomes active.
     /// </summary>
     private readonly AsyncAutoResetSignal _lingerWakeupSignal = new();
 
@@ -2593,10 +2592,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         bool signalLingerLoop = true)
     {
         if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
+        {
             _lingerPartitions.Enqueue(topicPartition);
-
-        if (signalLingerLoop)
-            _lingerWakeupSignal.Signal();
+            if (signalLingerLoop)
+                _lingerWakeupSignal.Signal();
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4686,7 +4686,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
-            initialCapBytes: cap);
+            initialCapBytes: cap,
+            lingerSeconds: _options.LingerMs / 1000.0);
     }
 
     /// <summary>
@@ -5109,6 +5110,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         MinRttMicros = budget.MinimumRttMicros,
         MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
         AdmissionBlockCount = budget.AdmissionBlockEvents,
+        CapacityProbeSuccessCount = budget.CapacityProbeSuccessCount,
+        CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
         DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
         LatencyBudgetScale = budget.LatencyBudgetScale,
         RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5551,6 +5551,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         LogFlushStarted(0, inFlightCount);
 
         ProducerDebugCounters.RecordFlushCall();
+
+        // A final partial batch must not enter the sender behind older sealed batches that
+        // are still queued or carried over. Under a deep admission budget, publishing the
+        // partial batch into that active pipeline can let it overtake one or more full
+        // same-partition batches during the flush boundary. Drain the existing pipeline
+        // first, then seal the current batches into a fresh ordered wave.
+        if (inFlightCount > 0)
+            await WaitForAllBatchesCompleteAsync(cancellationToken).ConfigureAwait(false);
+
         await SealBatchesAsync(sealAll: true, cancellationToken).ConfigureAwait(false);
 
         // Wait for all in-flight batches to complete using counter-based tracking

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1183,7 +1183,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private long _oldestBatchCreatedTicks = long.MaxValue;
 
     // Track whether there are unsealed batches containing awaited produces (ProduceAsync).
-    // These need micro-linger checks regardless of LingerMs, so ExpireLingerAsync drains the
+    // These need short-linger checks regardless of LingerMs, so ExpireLingerAsync drains the
     // active linger queue when this counter is non-zero. Count is per batch, not per message.
     private int _pendingAwaitedProduceCount;
 
@@ -4360,7 +4360,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Fast path 2: if the oldest batch hasn't reached linger time yet AND there are no
         // pending awaited produces, skip active queue checks. Awaited produces (ProduceAsync)
-        // use a micro-linger (min(1ms, LingerMs/10)) so they need more frequent checks.
+        // use a short linger (min(2ms, LingerMs/2)) so they need more frequent checks.
         if (Volatile.Read(ref _pendingAwaitedProduceCount) == 0)
         {
             var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
@@ -5971,6 +5971,9 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
 /// </summary>
 internal sealed class PartitionBatch
 {
+    private const double AwaitedLingerFraction = 0.5;
+    private const double MaximumAwaitedLingerMilliseconds = 2.0;
+
     private TopicPartition _topicPartition;
     private int _partitionCount;
     private ProducerOptions _options;
@@ -6583,8 +6586,8 @@ internal sealed class PartitionBatch
     /// The worst case of a stale read is harmless - we'll catch it on the next check.
     ///
     /// Smart batching strategy:
-    /// - If there are completion sources waiting (awaited produces), use a micro-linger
-    ///   of min(1ms, LingerMs/10) to let co-temporal messages batch together
+    /// - If there are completion sources waiting (awaited produces), use a short linger
+    ///   of min(2ms, LingerMs/2) to let co-temporal messages batch together
     /// - When LingerMs == 0, awaited produces still flush immediately
     /// - Fire-and-forget messages wait for full linger time
     /// This balances low latency for awaited produces with efficient batching.
@@ -6600,13 +6603,22 @@ internal sealed class PartitionBatch
 
         var elapsedMs = Stopwatch.GetElapsedTime(_createdStopwatchTimestamp, nowStopwatchTimestamp).TotalMilliseconds;
 
-        // Awaited produces: use micro-linger instead of immediate flush.
-        // When LingerMs > 0 (default is 5), wait min(1ms, LingerMs/10) to let co-temporal messages batch.
+        // Awaited produces: use a short linger instead of immediate flush. A sub-millisecond
+        // threshold seals on the first 1 ms timer tick, making request size depend on host timer
+        // coalescing. Waiting min(2ms, LingerMs/2) keeps batching stable across timer granularity.
         // When LingerMs == 0, flush immediately.
         // Fire-and-forget messages (Send) don't add completion sources, so they
         // still benefit from full linger time batching.
         if (Volatile.Read(ref _completionSourceCount) > 0)
-            return lingerMs == 0 || elapsedMs >= Math.Min(1.0, lingerMs / 10.0);
+        {
+            if (lingerMs == 0)
+                return true;
+
+            var awaitedLingerMilliseconds = Math.Min(
+                MaximumAwaitedLingerMilliseconds,
+                lingerMs * AwaitedLingerFraction);
+            return elapsedMs >= awaitedLingerMilliseconds;
+        }
 
         return elapsedMs >= lingerMs;
     }

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -58,6 +58,37 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
         _topicDataScratchCount = 0;
     }
 
+    internal bool TryGetSingleBatch(
+        out ProduceRequestTopicData topic,
+        out ProduceRequestPartitionData partition,
+        out RecordBatch batch)
+    {
+        topic = null!;
+        partition = null!;
+        batch = null!;
+
+        if (_topicDataScratch is { } topicDataScratch)
+        {
+            if (_topicDataScratchCount != 1)
+                return false;
+
+            topic = topicDataScratch[0];
+        }
+        else
+        {
+            if (TopicData.Count != 1)
+                return false;
+
+            topic = TopicData[0];
+        }
+
+        if (!topic.TryGetSinglePartition(out partition) || partition.Records.Count != 1)
+            return false;
+
+        batch = partition.Records[0];
+        return true;
+    }
+
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
         writer.WriteCompactNullableString(TransactionalId);
@@ -114,6 +145,25 @@ public sealed class ProduceRequestTopicData
         _partitionDataScratch = null;
         _partitionDataScratchStart = 0;
         _partitionDataScratchCount = 0;
+    }
+
+    internal bool TryGetSinglePartition(out ProduceRequestPartitionData partition)
+    {
+        partition = null!;
+        if (_partitionDataScratch is { } partitionDataScratch)
+        {
+            if (_partitionDataScratchCount != 1)
+                return false;
+
+            partition = partitionDataScratch[_partitionDataScratchStart];
+            return true;
+        }
+
+        if (PartitionData.Count != 1)
+            return false;
+
+        partition = PartitionData[0];
+        return true;
     }
 
     public void Write(ref KafkaProtocolWriter writer, short version)

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1784,12 +1784,15 @@ internal static class Crc32C
 {
     private const int TableSize = 256;
     private const int SliceCount = 8;
+    private const int PositiveIntBitCount = 31;
 #if !NETSTANDARD2_0
     private const int HardwareParallelChunkSize = 512;
     private const int HardwareParallelBlockSize = HardwareParallelChunkSize * 3;
 #endif
 
     private static readonly uint[] Table = GenerateTable();
+    // Element n applies 2^n zero bytes to a CRC, so arbitrary lengths compose from set bits.
+    private static readonly uint[][] ByteShiftPowerOperators = CreateByteShiftPowerOperators();
 #if !NETSTANDARD2_0
     private static readonly uint[] HardwareShiftChunk = CreateShiftOperator(HardwareParallelChunkSize);
     private static readonly uint[] HardwareShiftTwoChunks = CreateShiftOperator(HardwareParallelChunkSize * 2);
@@ -2079,10 +2082,24 @@ internal static class Crc32C
 
         for (var bit = 0; bit < 32; bit++)
         {
-            shift[bit] = ShiftCrc32C(1u << bit, byteCount);
+            shift[bit] = ShiftCrc32CSlow(1u << bit, byteCount);
         }
 
         return shift;
+    }
+
+    private static uint[][] CreateByteShiftPowerOperators()
+    {
+        var operators = new uint[PositiveIntBitCount][];
+        operators[0] = CreateShiftOperator(1);
+        for (var bit = 1; bit < operators.Length; bit++)
+        {
+            var next = new uint[32];
+            SquareMatrix(next, operators[bit - 1]);
+            operators[bit] = next;
+        }
+
+        return operators;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2106,6 +2123,28 @@ internal static class Crc32C
     }
 
     private static uint ShiftCrc32C(uint crc, int byteCount)
+    {
+        if (byteCount <= 0)
+        {
+            return crc;
+        }
+
+        var bit = 0;
+        while (byteCount != 0)
+        {
+            if ((byteCount & 1) != 0)
+            {
+                crc = ShiftCrc32C(crc, ByteShiftPowerOperators[bit]);
+            }
+
+            byteCount >>= 1;
+            bit++;
+        }
+
+        return crc;
+    }
+
+    private static uint ShiftCrc32CSlow(uint crc, int byteCount)
     {
         if (byteCount <= 0)
         {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1097,6 +1097,63 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         }
     }
 
+    internal bool TryWriteSegmentedHeader(
+        IBufferWriter<byte> output,
+        CompressionType compression,
+        out ReadOnlyMemory<byte> encodedRecords)
+    {
+        uint encodedRecordsCrc;
+        CompressionType effectiveCompression;
+        if (PreCompressedRecords is { } preCompressedRecords)
+        {
+            encodedRecords = preCompressedRecords.AsMemory(0, PreCompressedLength);
+            encodedRecordsCrc = PreCompressedRecordsCrc;
+            effectiveCompression = PreCompressedType;
+        }
+        else if (compression == CompressionType.None && _hasPreEncodedRecords)
+        {
+            encodedRecords = _preEncodedRecords;
+            encodedRecordsCrc = _preEncodedRecordsCrc;
+            effectiveCompression = CompressionType.None;
+        }
+        else
+        {
+            encodedRecords = default;
+            return false;
+        }
+
+        var writer = new KafkaProtocolWriter(output);
+        writer.WriteInt64(BaseOffset);
+        writer.WriteInt32(BatchHeaderSize + encodedRecords.Length);
+        writer.WriteInt32(PartitionLeaderEpoch);
+        writer.WriteUInt8(Magic);
+
+        var crcAndContentSpan = output.GetSpan(sizeof(uint) + CrcContentFixedSize);
+        var contentSpan = crcAndContentSpan[sizeof(uint)..];
+        var attributes = (short)Attributes;
+        if (effectiveCompression != CompressionType.None)
+            attributes = (short)((attributes & ~0x07) | (int)effectiveCompression);
+
+        BinaryPrimitives.WriteInt16BigEndian(contentSpan, attributes);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[2..], LastOffsetDelta);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[6..], BaseTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[14..], MaxTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[22..], ProducerId);
+        BinaryPrimitives.WriteInt16BigEndian(contentSpan[30..], ProducerEpoch);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[32..], BaseSequence);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[36..], Records.Count);
+
+        var headerCrc = Crc32C.Compute(contentSpan[..CrcContentFixedSize]);
+        var crc = Crc32C.Combine(headerCrc, encodedRecordsCrc, encodedRecords.Length);
+        BinaryPrimitives.WriteInt32BigEndian(crcAndContentSpan, (int)crc);
+        output.Advance(sizeof(uint) + CrcContentFixedSize);
+        return true;
+    }
+
+    internal bool CanWriteSegmented(CompressionType compression)
+        => PreCompressedRecords is not null
+            || (compression == CompressionType.None && _hasPreEncodedRecords);
+
     internal int GetEncodedSize(CompressionType compression = CompressionType.None)
     {
         var recordsLength = GetEncodedRecordsLength(compression);

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -43,6 +43,32 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_InitialWidthAboveImplicitMaximum_ExpandsMaximum()
+    {
+        await using var client = Kafka.Connect()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionsPerBroker(5)
+            .Build();
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(5);
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task RootClient_InitialWidthAboveExplicitMaximum_ThrowsOnBuild()
+    {
+        await Assert.That(() => Kafka.Connect()
+                .WithBootstrapServers("localhost:9092")
+                .WithMaxConnectionsPerBroker(3)
+                .WithConnectionsPerBroker(5)
+                .Build())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task RootClient_CreatedProducer_DisposeDoesNotDisposeSharedPool()
     {
         var client = Kafka.Connect("localhost:9092");

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -32,6 +32,17 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_CreatedProducer_UsesDefaultAdaptiveMaximumOf3()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task RootClient_CreatedProducer_DisposeDoesNotDisposeSharedPool()
     {
         var client = Kafka.Connect("localhost:9092");

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Net.Security;
 using Dekaf.Metadata;
 using Dekaf.Networking;
+using Dekaf.Consumer;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Builder;
@@ -40,6 +41,17 @@ public sealed class KafkaClientBuilderTests
         var options = GetField<ProducerOptions>(producer, "_options");
 
         await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task RootClient_CreatedConsumer_UsesDefaultAdaptiveMaximumOf4()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var consumer = client.CreateConsumer<string, string>().Build();
+
+        var options = GetField<ConsumerOptions>(consumer, "_options");
+
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(4);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -5,10 +5,12 @@ using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
+using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Security;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -105,6 +107,162 @@ public sealed class KafkaConnectionTests
         var capacity = KafkaConnection.GetPreSerializeInitialCapacity<ProduceResponse>(request);
 
         await Assert.That(capacity).IsEqualTo(1_048_704);
+    }
+
+    [Test]
+    [Arguments(CompressionType.None)]
+    [Arguments(CompressionType.Gzip)]
+    public async Task SingleBatchProduceSegments_MatchContiguousSerialization(CompressionType compression)
+    {
+        var recordBytes = "arena-backed-records"u8.ToArray();
+        var batch = new RecordBatch
+        {
+            BaseOffset = 17,
+            PartitionLeaderEpoch = 3,
+            LastOffsetDelta = 0,
+            BaseTimestamp = 1234,
+            MaxTimestamp = 1234,
+            ProducerId = 42,
+            ProducerEpoch = 2,
+            BaseSequence = 7,
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        batch.SetPreEncodedRecords(recordBytes);
+        batch.PreCompress(compression, null);
+        var encodedRecordsBackingArray = batch.PreCompressedRecords ?? recordBytes;
+
+        var partition = new ProduceRequestPartitionData
+        {
+            Index = 5,
+            Records = [batch],
+            Compression = compression
+        };
+        var topic = new ProduceRequestTopicData { Name = "segment-topic" };
+        topic.SetPartitionDataScratch([partition], 0, 1);
+        var request = new ProduceRequest
+        {
+            TransactionalId = "tx-id",
+            Acks = -1,
+            TimeoutMs = 30_000
+        };
+        request.SetTopicDataScratch([topic], 1);
+
+        const short apiVersion = 12;
+        const int correlationId = 123;
+        var headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+            .GetRequestHeaderVersion(apiVersion);
+        var expectedBody = new ArrayBufferWriter<byte>();
+        var expectedWriter = new KafkaProtocolWriter(expectedBody);
+        new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = "segment-client",
+            HeaderVersion = headerVersion
+        }.Write(ref expectedWriter);
+        request.Write(ref expectedWriter, apiVersion);
+        var expected = new byte[sizeof(int) + expectedWriter.BytesWritten];
+        BinaryPrimitives.WriteInt32BigEndian(expected, expectedWriter.BytesWritten);
+        expectedBody.WrittenSpan.CopyTo(expected.AsSpan(sizeof(int)));
+
+        var connection = new KafkaConnection("localhost", 9092, "segment-client");
+        var segmented = connection.TryPreSerializeSingleBatchProduceRequest(
+            request,
+            correlationId,
+            apiVersion,
+            headerVersion,
+            out var metadataArray,
+            out var prefixLength,
+            out var encodedRecords,
+            out var suffixOffset,
+            out var suffixLength);
+
+        await Assert.That(segmented).IsTrue();
+        try
+        {
+            var actual = new byte[prefixLength + encodedRecords.Count + suffixLength];
+            metadataArray.AsSpan(0, prefixLength).CopyTo(actual);
+            encodedRecords.AsSpan().CopyTo(actual.AsSpan(prefixLength));
+            metadataArray.AsSpan(suffixOffset, suffixLength)
+                .CopyTo(actual.AsSpan(prefixLength + encodedRecords.Count));
+
+            await Assert.That(actual).IsEquivalentTo(expected);
+            await Assert.That(encodedRecords.Array).IsSameReferenceAs(encodedRecordsBackingArray);
+        }
+        finally
+        {
+            DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+            batch.ReturnPreCompressedBuffer();
+        }
+    }
+
+    [Test]
+    public async Task ConsumeSentSegments_PartialSend_AdvancesAcrossSegmentBoundary()
+    {
+        var first = new byte[3];
+        var second = new byte[4];
+        var third = new byte[2];
+        var segments = new List<ArraySegment<byte>>
+        {
+            new(first),
+            new(second),
+            new(third)
+        };
+
+        KafkaConnection.ConsumeSentSegments(segments, 5);
+
+        await Assert.That(segments.Count).IsEqualTo(2);
+        await Assert.That(segments[0].Array).IsSameReferenceAs(second);
+        await Assert.That(segments[0].Offset).IsEqualTo(2);
+        await Assert.That(segments[0].Count).IsEqualTo(2);
+        await Assert.That(segments[1].Array).IsSameReferenceAs(third);
+
+        KafkaConnection.ConsumeSentSegments(segments, 4);
+
+        await Assert.That(segments).IsEmpty();
+    }
+
+    [Test]
+    public async Task SingleBatchProduceSegments_UnpreparedCompressedBatch_FallsBack()
+    {
+        var batch = new RecordBatch
+        {
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        var request = new ProduceRequest
+        {
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "fallback-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData
+                        {
+                            Records = [batch],
+                            Compression = CompressionType.Gzip
+                        }
+                    ]
+                }
+            ]
+        };
+        var connection = new KafkaConnection("localhost", 9092);
+
+        var segmented = connection.TryPreSerializeSingleBatchProduceRequest(
+            request,
+            correlationId: 1,
+            apiVersion: 12,
+            headerVersion: 2,
+            out var metadataArray,
+            out _,
+            out _,
+            out _,
+            out _);
+
+        await Assert.That(segmented).IsFalse();
+        await Assert.That(metadataArray).IsNull();
     }
 
     [Test]
@@ -691,6 +849,80 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    [Timeout(10_000)]
+    public async Task SendFireAndForgetAsync_SingleBatchProduce_WritesValidSegmentedFrame(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var batch = new RecordBatch
+            {
+                BaseOffset = 9,
+                LastOffsetDelta = 0,
+                BaseTimestamp = 4567,
+                MaxTimestamp = 4567,
+                Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+            };
+            batch.SetPreEncodedRecords("borrowed-record-data"u8.ToArray());
+            var request = new ProduceRequest
+            {
+                Acks = 0,
+                TimeoutMs = 30_000,
+                TopicData =
+                [
+                    new ProduceRequestTopicData
+                    {
+                        Name = "socket-topic",
+                        PartitionData =
+                        [
+                            new ProduceRequestPartitionData
+                            {
+                                Index = 2,
+                                Records = [batch]
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            const short apiVersion = 12;
+            await connection.SendFireAndForgetAsync<ProduceRequest, ProduceResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+
+            var actual = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(actual.AsSpan(4));
+            var expectedBuffer = new ArrayBufferWriter<byte>();
+            var expectedWriter = new KafkaProtocolWriter(expectedBuffer);
+            new RequestHeader
+            {
+                ApiKey = ApiKey.Produce,
+                ApiVersion = apiVersion,
+                CorrelationId = correlationId,
+                HeaderVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+                    .GetRequestHeaderVersion(apiVersion)
+            }.Write(ref expectedWriter);
+            request.Write(ref expectedWriter, apiVersion);
+
+            await Assert.That(actual).IsEquivalentTo(expectedBuffer.WrittenSpan.ToArray());
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
     [Arguments(-1)]
     [Arguments(1_048_577)]
     public async Task SendSaslMessageAsync_InvalidResponseFrameSize_ThrowsKafkaExceptionBeforeRent(int responseSize)
@@ -762,6 +994,36 @@ public sealed class KafkaConnectionTests
 
         await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsEqualTo(0);
         await Assert.That(writeLock.CurrentCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task WriteTimeout_BorrowedWrite_AbortsAndWaitsForWriteCompletion(
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var writeCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var waitTask = InvokeAwaitBorrowedFrameWriteAsync(
+                connection,
+                writeCompletion.Task,
+                callerOwnsTimeout: true,
+                cts.Token)
+            .AsTask();
+
+        // Unlike a copied frame, a borrowed payload cannot outlive its producer resource pin.
+        // The timeout aborts the connection immediately but stays pending until the send unwinds.
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsNotEqualTo(0);
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        writeCompletion.SetResult();
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await waitTask.WaitAsync(cancellationToken));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await Assert.That(exception.Message).Contains("Flush timeout");
     }
 
     [Test]
@@ -996,6 +1258,22 @@ public sealed class KafkaConnectionTests
             BindingFlags.NonPublic | BindingFlags.Instance);
         if (method is null)
             throw new InvalidOperationException("AwaitFrameWriteAsync was not found.");
+
+        var result = method.Invoke(connection, [writeTask, 1, callerOwnsTimeout, cancellationToken]);
+        await ((ValueTask)result!).ConfigureAwait(false);
+    }
+
+    private static async ValueTask InvokeAwaitBorrowedFrameWriteAsync(
+        KafkaConnection connection,
+        Task writeTask,
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "AwaitBorrowedFrameWriteAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method is null)
+            throw new InvalidOperationException("AwaitBorrowedFrameWriteAsync was not found.");
 
         var result = method.Invoke(connection, [writeTask, 1, callerOwnsTimeout, cancellationToken]);
         await ((ValueTask)result!).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -24,6 +24,12 @@ public class AdaptiveScalingTests
         });
     }
 
+    private static int GetConfiguredMaximumConnections(object builder) =>
+        (int)builder.GetType()
+            .GetField("_maxConnectionsPerBroker", System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(builder)!;
+
     private static async ValueTask AppendOneRecordAsync(RecordAccumulator accumulator)
     {
         var pooledKey = new PooledMemory(null, 0, isNull: true);
@@ -219,6 +225,37 @@ public class AdaptiveScalingTests
     #endregion
 
     #region Builder Validation Tests
+
+    [Test]
+    public async Task WithAdaptiveConnections_DefaultsMaximumTo_3()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithAdaptiveConnections();
+
+        await Assert.That(GetConfiguredMaximumConnections(builder)).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task WithConnectionsPerBroker_AboveImplicitMaximum_ExpandsMaximum()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithConnectionsPerBroker(5);
+
+        await Assert.That(GetConfiguredMaximumConnections(builder)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task WithAdaptiveConnections_BeforeLargerInitialWidth_ThrowsOnBuild()
+    {
+        await Assert.That(() =>
+        {
+            Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers("localhost:9092")
+                .WithAdaptiveConnections()
+                .WithConnectionsPerBroker(5)
+                .Build();
+        }).Throws<InvalidOperationException>();
+    }
 
     [Test]
     public async Task WithAdaptiveConnections_MaxLessThanConnectionsPerBroker_ThrowsOnBuild()

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -652,15 +652,16 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         // Both requests were sent before either delivery.
-        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.005), appLimited: false);
-        var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.001) - Seconds(0.005), appLimited: false);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.020), appLimited: false);
+        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.019), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample covers the full delivery epoch: 2,000 bytes over 6ms from the
-        // first send to the second acknowledgement = 333,333 B/s aggregate drain.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(3_333);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 21ms from the
+        // first send to the second acknowledgement = 95,238 B/s aggregate drain. The
+        // 20ms measured RTT horizon therefore publishes a 1,904-byte budget.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_904);
     }
 
     [Test]
@@ -1457,8 +1458,8 @@ public sealed class BrokerUnackedByteBudgetTests
         var sendSnapshots = new BrokerUnackedByteBudget.DeliverySnapshot[5];
 
         // All requests enter the same delivery epoch before any response arrives. The tail
-        // request has only a 0.5 ms own RTT, but its delivered delta spans the full 4 ms send
-        // burst. Using own RTT alone reports 10 GB/s from a 1.25 GB/s stream.
+        // request has only a 0.5 ms own RTT, so using own RTT alone reports 10 GB/s for the
+        // short burst. The mature sample must average the full epoch instead.
         for (var i = 0; i < sendSnapshots.Length; i++)
         {
             sendSnapshots[i] = budget.SnapshotDelivery(
@@ -1473,10 +1474,12 @@ public sealed class BrokerUnackedByteBudgetTests
                 sendSnapshots[i],
                 T0 + Seconds(0.0041 + i * 0.0001));
         }
-        budget.CompleteAckedPass(T0 + Seconds(0.0045));
+        var matureEpochSend = budget.SnapshotDelivery(T0 + Seconds(0.005), appLimited: false);
+        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.020));
+        budget.CompleteAckedPass(T0 + Seconds(0.020));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_000_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_200_000_000)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(295_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(305_000_000)
             .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
     }
 
@@ -1551,7 +1554,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
+    public async Task LoadedDeliveryEpoch_RejectsShortBurstThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1561,13 +1564,17 @@ public sealed class BrokerUnackedByteBudgetTests
         var firstSend = budget.SnapshotDelivery(T0, appLimited: false);
         budget.OnAcked(1_000_000, firstSend, T0 + Seconds(0.0005));
         await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0)
-            .Because("a sub-2ms loaded sample is dominated by scheduler and timer resolution");
+            .Because("a short loaded sample is dominated by scheduler and burst quantization");
 
         var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: false);
         budget.OnAcked(1_000_000, secondSend, T0 + Seconds(0.0025));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0);
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(800_000_000)
-            .Because("the accepted sample covers 2MB over the full 2.5ms loaded epoch");
+        var thirdSend = budget.SnapshotDelivery(T0 + Seconds(0.003), appLimited: false);
+        budget.OnAcked(1_000_000, thirdSend, T0 + Seconds(0.020));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(150_000_000)
+            .Because("the accepted sample covers 3MB over the full 20ms loaded epoch");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -445,6 +445,43 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_RecentNaturalSampleSkipsDrainProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 500, 0.005, T0, appLimitedAtSend: false);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051), appLimitedAtSend: true);
+        for (var second = 1; second <= 9; second++)
+            Ack(budget, 500, 0.005, T0 + Seconds(second), appLimitedAtSend: true);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.2), appLimitedAtSend: false);
+
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp")).IsEqualTo(0)
+            .Because("a recent empty-pipe RTT already refreshed the base RTT without narrowing admission");
+    }
+
+    [Test]
+    public async Task MinimumRtt_NaturalSampleCompletesProbeWithBestObservedRtt()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.010);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_minRttProbeMinimumSeconds", 0.004);
+
+        Ack(budget, 600, 0.006, T0, appLimitedAtSend: true);
+
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(4_000)
+            .Because("ending a drain on a natural sample must retain the probe's best earlier RTT");
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp")).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -190,6 +190,31 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task DeliveryLatencyBelowTarget_RestoresReducedScaleToNeutralWithoutAdmissionPressure()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        SetField(budget, "_latencyBudgetScale", 0.25);
+
+        var now = T0;
+        for (var i = 0; i < 40; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.003));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001)
+            .Because("transient queue control must not leave the normal budget permanently derated");
+    }
+
+    [Test]
     public async Task DeliveryLatencySample_UsesSealToSendQueueDelay_NotBrokerRoundTrip()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1524,6 +1524,33 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task BackToBackAppLimitedSend_ContinuesRollingRateEpoch()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.0005));
+
+        var hotSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: true);
+        await Assert.That(hotSend.AppLimited).IsTrue();
+        await Assert.That(hotSend.RateAppLimited).IsFalse()
+            .Because("an immediate post-ack send is a serialized loaded rate cycle");
+        await Assert.That(hotSend.DeliveryEpochDeliveredBytes).IsEqualTo(0);
+        await Assert.That(hotSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(T0);
+        budget.OnAcked(1_000, hotSend, T0 + Seconds(0.0011));
+
+        var idleSend = budget.SnapshotDelivery(T0 + Seconds(0.004), appLimited: true);
+        await Assert.That(idleSend.RateAppLimited).IsTrue();
+        await Assert.That(idleSend.DeliveryEpochDeliveredBytes).IsEqualTo(2_000);
+        await Assert.That(idleSend.DeliveryEpochFirstSendTimestamp)
+            .IsEqualTo(T0 + Seconds(0.004))
+            .Because("a real empty-pipe gap starts a fresh rate epoch");
+    }
+
+    [Test]
     public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1684,7 +1711,7 @@ public sealed class BrokerUnackedByteBudgetTests
             budget.OnAcked(
                 1,
                 new BrokerUnackedByteBudget.DeliverySnapshot(
-                    i, 0, i, 0, now - 1, true, 0, 0),
+                    i, 0, i, 0, now - 1, true, true, 0, 0),
                 now);
         }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -799,6 +799,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_CollectsThreeRtts_ThenRevertsWithoutRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -861,6 +862,28 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
             .Because("one noisy high sample must not ratchet a three-RTT low-rate probe");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_SuccessCarriesAverageRateToNextRung_NotSinglePeak()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", 42_000.0);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
+            .IsEqualTo(18_000.0).Within(0.001)
+            .Because("the next probe rung must compare average rate with average rate");
     }
 
     [Test]
@@ -1077,6 +1100,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_CollectsFullRttBeforeJudgingRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1097,13 +1121,12 @@ public sealed class BrokerUnackedByteBudgetTests
             targetSeconds: 0.5,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
+        budget.Charge(5_500);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
-        budget.Charge(5_500);
-
         await Assert.That(budget.IsOverBudget()).IsTrue()
             .Because("occupancy above the normal budget must reach the deadline-aware gate");
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse()
@@ -1134,6 +1157,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_WaitsForSampleWhollyAdmittedUnderProbe()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1212,6 +1236,7 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
         Ack(budget, 10, 0.001, T0);
+        budget.Charge(100);
         SetField(budget, "_retainedLoadedMaxRate", 100_000.0);
         SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
 
@@ -1222,9 +1247,25 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_DoesNotArmWhileAdmissionGateHasNoDemand()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        Ack(budget, 10, 0.001, T0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
+
+        Ack(budget, 10, 0.001, T0 + Seconds(0.008));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("raising an underfilled gate cannot reveal delivery headroom");
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0)
+            .Because("lack of demand is not evidence that a capacity probe failed");
+    }
+
+    [Test]
     public async Task PeriodicProbe_RatchetsWhileWhollyProbedRateRises()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1242,8 +1283,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
-        // The ratcheted level gets another three-RTT average. No further growth publishes
-        // the discovered base budget without the temporary 1.25x multiplier.
+        // The ratcheted level gets another full-window average. Comparing average with
+        // average lets the sustained 25% gain advance the next rung as well.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.300));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.400));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.500));
@@ -1252,9 +1293,9 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.800));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
         Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
-        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
-        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
     }
 
     [Test]
@@ -1346,6 +1387,39 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task TailOfBurstAck_UsesSendAxisAcrossDeliveryEpoch()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+        var sendSnapshots = new BrokerUnackedByteBudget.DeliverySnapshot[5];
+
+        // All requests enter the same delivery epoch before any response arrives. The tail
+        // request has only a 0.5 ms own RTT, but its delivered delta spans the full 4 ms send
+        // burst. Using own RTT alone reports 10 GB/s from a 1.25 GB/s stream.
+        for (var i = 0; i < sendSnapshots.Length; i++)
+        {
+            sendSnapshots[i] = budget.SnapshotDelivery(
+                T0 + Seconds(i * 0.001),
+                appLimited: i == 0);
+        }
+
+        for (var i = 0; i < sendSnapshots.Length; i++)
+        {
+            budget.OnAcked(
+                1_000_000,
+                sendSnapshots[i],
+                T0 + Seconds(0.0041 + i * 0.0001));
+        }
+        budget.CompleteAckedPass(T0 + Seconds(0.0045));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_200_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_400_000_000)
+            .Because("a cumulative delivery delta must include its delivery epoch's send time");
+    }
+
+    [Test]
     public async Task AckAxis_LoadedGapSpreadsDeliveryOverArrivalTime()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -1396,11 +1470,10 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_WithoutFurtherAck_RevertsAfterEightRtts()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_500);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
-
-        budget.Charge(5_500);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse();
         await Assert.That(budget.GetAdmissionRecheckDelayMilliseconds(T0 + Seconds(0.900)))
@@ -1455,6 +1528,72 @@ public sealed class BrokerUnackedByteBudgetTests
         })));
 
         await Assert.That(budget.UnackedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DeliverySnapshots_NeverRegressUnderConcurrentAcknowledgements()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        using var start = new Barrier(participantCount: 9);
+        var regressionCount = 0;
+
+        var readers = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait();
+            var previousDeliveredBytes = 0L;
+            for (var i = 0; i < 100_000; i++)
+            {
+                var snapshot = budget.SnapshotDelivery(i + 1, appLimited: false);
+                if (snapshot.DeliveredBytes < previousDeliveredBytes)
+                    Interlocked.Increment(ref regressionCount);
+                previousDeliveredBytes = snapshot.DeliveredBytes;
+            }
+        })).ToArray();
+
+        start.SignalAndWait();
+        for (var i = 0; i < 50_000; i++)
+        {
+            var now = T0 + i + 1;
+            budget.OnAcked(
+                1,
+                new BrokerUnackedByteBudget.DeliverySnapshot(
+                    i, 0, 0, now - 1, true, 0, 0),
+                now);
+        }
+
+        await Task.WhenAll(readers);
+        await Assert.That(regressionCount).IsEqualTo(0)
+            .Because("a completed send snapshot cannot predate an earlier snapshot on the same connection");
+    }
+
+    [Test]
+    public async Task DeliveryEpoch_RedundantPublisherPreservesFirstSendAnchor()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        const long deliveredBytes = 100;
+        const long firstSendTimestamp = 6_000;
+        const long stalePublisherTimestamp = 7_000;
+        const long deliveryEpochUpdating = -2;
+
+        SetField(budget, "_totalDeliveredBytes", deliveredBytes);
+        SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
+        SetField(budget, "_sendEpochFirstTimestamp", firstSendTimestamp);
+
+        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null };
+        var anchor = (long)typeof(BrokerUnackedByteBudget)
+            .GetMethod("PublishDeliveryEpoch", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(budget, arguments)!;
+
+        await Assert.That(anchor).IsEqualTo(firstSendTimestamp);
+        await Assert.That(arguments[2]).IsEqualTo(deliveredBytes);
+        await Assert.That(GetField<long>(budget, "_sendEpochFirstTimestamp")).IsEqualTo(firstSendTimestamp);
+        await Assert.That(GetField<long>(budget, "_sendEpochDeliveredBytes")).IsEqualTo(deliveredBytes);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -92,6 +92,8 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i < 6; i++)
         {
             now += Seconds(0.110);
+            // Sender-backlog shrink requires the wire to demonstrably carry the budget.
+            budget.ObserveWrittenUnackedBytes(8_000);
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
@@ -162,6 +164,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i < 6; i++)
         {
             now += Seconds(0.110);
+            budget.ObserveWrittenUnackedBytes(8_000);
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
@@ -876,15 +879,43 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task StandingQueueDelayAboveTarget_ShrinksLatencyScale()
+    public async Task BrokerQueueDelayAboveTarget_ShrinksLatencyScale()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 32_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
-        budget.Charge(100_000); // 100ms of standing queue at 1 MB/s — 10x the target.
 
+        // Batches leave the sender 2ms after sealing but sit 50ms at the broker: latency the
+        // seal-to-send sample cannot see. No wire-occupancy evidence is required — broker
+        // queueing always responds to admission.
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.050),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.052));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.5)
+            .Because("seal-to-ack beyond the base round trip is queueing the budget controls");
+    }
+
+    [Test]
+    public async Task SendLoopBacklog_WithoutWireOccupancy_DoesNotShrinkScale()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        // 19ms of seal-to-send backlog with an empty wire: the send loop, not broker
+        // admission, is the bottleneck. Shrinking would starve the sender below capacity.
         var now = T0;
         for (var i = 0; i < 6; i++)
         {
@@ -892,13 +923,67 @@ public sealed class BrokerUnackedByteBudgetTests
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.020));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001)
+            .Because("sender backlog with an underfilled wire is not actionable by admission");
+    }
+
+    [Test]
+    public async Task AdmissionPressureWithLatencyHeadroom_GrowsBudgetBeyondRateParity()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+
+        // The drain estimate only ever measures traffic the gate admitted, so rate x target
+        // is self-confirming at any throughput (#2008). Blocked demand with latency headroom
+        // must grow the budget past that parity so real capacity can be discovered.
+        var now = T0;
+        for (var i = 0; i < 30; i++)
+        {
+            now += Seconds(0.110);
+            budget.RecordAdmissionBlock();
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.002));
             Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
-        budget.Release(100_000);
 
-        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.5)
-            .Because("bytes queued beyond the socket are latency the seal-to-send sample cannot see");
+        await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(1.5);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(15_000);
+    }
+
+    [Test]
+    public async Task LatencyBudgetScale_IsBoundedAboveByCeiling()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0;
+        for (var i = 0; i < 80; i++)
+        {
+            now += Seconds(0.110);
+            budget.RecordAdmissionBlock();
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.002));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(10.0).Within(0.000_001)
+            .Because("a stale-high scale must stay within a short shrink-back window");
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(100_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -12,6 +12,7 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerUnackedByteBudgetTests
 {
+    private const long BudgetDecayBypassBytes = 1L << 40;
     private static readonly long Frequency = Stopwatch.Frequency;
 
     /// <summary>An arbitrary positive anchor: tick 0 means "no window anchored yet".</summary>
@@ -49,7 +50,43 @@ public sealed class BrokerUnackedByteBudgetTests
             ackedBytes,
             snapshotAtSend ?? budget.SnapshotDelivery(nowTicks - Seconds(rttSeconds), appLimitedAtSend),
             nowTicks);
-        budget.CompleteAckedPass(nowTicks);
+        CompleteAckedPassWithoutDecay(budget, nowTicks);
+    }
+
+    /// <summary>
+    /// Most state-machine tests isolate estimator output from decay hysteresis. A standing
+    /// queue deliberately invokes the production bypass so those tests can assert the raw
+    /// computed budget; dedicated decay tests below exercise smoothing separately.
+    /// </summary>
+    private static void CompleteAckedPassWithoutDecay(
+        BrokerUnackedByteBudget budget,
+        long nowTicks)
+    {
+        budget.Charge(BudgetDecayBypassBytes);
+        try
+        {
+            budget.CompleteAckedPass(nowTicks);
+        }
+        finally
+        {
+            budget.Release(BudgetDecayBypassBytes);
+        }
+    }
+
+    private static void SetCapWithoutDecay(
+        BrokerUnackedByteBudget budget,
+        long capBytes,
+        long nowTicks)
+    {
+        budget.Charge(BudgetDecayBypassBytes);
+        try
+        {
+            budget.SetCap(capBytes, nowTicks);
+        }
+        finally
+        {
+            budget.Release(BudgetDecayBypassBytes);
+        }
     }
 
     /// <summary>
@@ -284,7 +321,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
 
-        budget.SetCap(1_000_000, T0);
+        SetCapWithoutDecay(budget, 1_000_000, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(22_500)
             .Because("replicated serving RTT, not base RTT, determines the loaded BDP");
@@ -307,7 +344,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
 
-        budget.SetCap(1_000_000, T0);
+        SetCapWithoutDecay(budget, 1_000_000, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(10_000)
             .Because("queue-inflated serving RTT must not raise the floor it feeds back into");
@@ -328,7 +365,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_capacityProbeActive", true);
         SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
 
-        budget.SetCap(1_000_000, T0);
+        SetCapWithoutDecay(budget, 1_000_000, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(12_500)
             .Because("probing exactly when the RTT floor dominates accelerated the ratchet; " +
@@ -432,7 +469,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
 
-        budget.SetCap(1_000_000, T0 + Seconds(10.401));
+        SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(10.401));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
     }
@@ -464,7 +501,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         Ack(budget, 500, 0.005, T0 + Seconds(10.25));
         SetField(budget, "_retainedLoadedMaxRate", 0.0);
-        budget.SetCap(1_000_000, T0 + Seconds(10.25));
+        SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(10.25));
         budget.Charge(2_000);
 
         // Once the probe expires without another ack, admission must use the refreshed
@@ -561,7 +598,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.001) - Seconds(0.005), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
-        budget.CompleteAckedPass(T0 + Seconds(0.001));
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
         // The second sample's delivered-counter delta covers both deliveries: 2,000 bytes
         // over its own 5ms sojourn = 400,000 B/s aggregate drain, independent of the 1ms
@@ -724,7 +761,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task SetCap_DoesNotConsumeAdmissionPressureBeforeAckPass()
+    public async Task SetCap_AndAckPass_BothRateLimitBudgetDecay()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.5,
@@ -733,14 +770,11 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_windowMaxRate", 1_000.0);
         SetField(budget, "_lastNormalBudgetBytes", 100_000L);
         SetField(budget, "_lastBudgetUpdateTimestamp", T0);
-        budget.RecordAdmissionBlock();
-
         budget.SetCap(1_000_000, T0 + Seconds(1.0));
         await Assert.That(budget.BudgetBytes).IsEqualTo(90_000);
 
         budget.CompleteAckedPass(T0 + Seconds(2.0));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(81_000)
-            .Because("the ack pass must still observe pressure seen just before SetCap");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(81_000);
     }
 
     [Test]
@@ -830,23 +864,28 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task BudgetDecay_IsRateLimitedOnlyWhileAdmissionBlocks()
+    public async Task BudgetDecay_IsRateLimitedWithoutAdmissionBlocks()
     {
-        var blocked = BrokerUnackedByteBudget.BoundBudgetDecay(
+        var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
             elapsedSeconds: 1.0,
-            admissionWasBlocked: true,
-            unackedBytes: 0);
-        var unblocked = BrokerUnackedByteBudget.BoundBudgetDecay(
-            previousBudget: 100_000,
-            computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            admissionWasBlocked: false,
             unackedBytes: 0);
 
-        await Assert.That(blocked).IsEqualTo(90_000);
-        await Assert.That(unblocked).IsEqualTo(10_000);
+        await Assert.That(budget).IsEqualTo(90_000);
+    }
+
+    [Test]
+    public async Task BudgetDecay_FirstRecomputePreservesColdStartBudget()
+    {
+        var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
+            previousBudget: 100_000,
+            computedBudget: 10_000,
+            elapsedSeconds: 0,
+            unackedBytes: 0);
+
+        await Assert.That(budget).IsEqualTo(100_000)
+            .Because("the first estimator sample has no elapsed decay interval");
     }
 
     [Test]
@@ -859,13 +898,11 @@ public sealed class BrokerUnackedByteBudgetTests
             previousBudget: 100_000,
             computedBudget: 10_000,
             elapsedSeconds: 1.0,
-            admissionWasBlocked: true,
             unackedBytes: 20_000);
         var modestOccupancy = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
             elapsedSeconds: 1.0,
-            admissionWasBlocked: true,
             unackedBytes: 19_999);
 
         await Assert.That(standingQueue).IsEqualTo(10_000);
@@ -1296,7 +1333,7 @@ public sealed class BrokerUnackedByteBudgetTests
             sendSnapshots[i] = budget.SnapshotDelivery(T0 + Seconds(i * 0.00001), appLimited: false);
         for (var i = 0; i < 5; i++)
             budget.OnAcked(1_000_000, sendSnapshots[i], T0 + Seconds(0.100 + i * 0.00001));
-        budget.CompleteAckedPass(T0 + Seconds(0.100 + 4 * 0.00001));
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.100 + 4 * 0.00001));
 
         // Each sample measures the cumulative delivered delta over its own ~100ms sojourn;
         // the last one reads the true aggregate drain of ~50 MB/s.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -12,7 +12,6 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerUnackedByteBudgetTests
 {
-    private const long BudgetDecayBypassBytes = 1L << 40;
     private static readonly long Frequency = Stopwatch.Frequency;
 
     /// <summary>An arbitrary positive anchor: tick 0 means "no window anchored yet".</summary>
@@ -62,15 +61,8 @@ public sealed class BrokerUnackedByteBudgetTests
         BrokerUnackedByteBudget budget,
         long nowTicks)
     {
-        budget.Charge(BudgetDecayBypassBytes);
-        try
-        {
-            budget.CompleteAckedPass(nowTicks);
-        }
-        finally
-        {
-            budget.Release(BudgetDecayBypassBytes);
-        }
+        SetField(budget, "_lastNormalBudgetBytes", 0L);
+        budget.CompleteAckedPass(nowTicks);
     }
 
     private static void SetCapWithoutDecay(
@@ -78,15 +70,8 @@ public sealed class BrokerUnackedByteBudgetTests
         long capBytes,
         long nowTicks)
     {
-        budget.Charge(BudgetDecayBypassBytes);
-        try
-        {
-            budget.SetCap(capBytes, nowTicks);
-        }
-        finally
-        {
-            budget.Release(BudgetDecayBypassBytes);
-        }
+        SetField(budget, "_lastNormalBudgetBytes", 0L);
+        budget.SetCap(capBytes, nowTicks);
     }
 
     /// <summary>
@@ -954,8 +939,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 0);
+            elapsedSeconds: 1.0);
 
         await Assert.That(budget).IsEqualTo(90_000);
     }
@@ -966,32 +950,41 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 0,
-            unackedBytes: 0);
+            elapsedSeconds: 0);
 
         await Assert.That(budget).IsEqualTo(100_000)
             .Because("the first estimator sample has no elapsed decay interval");
     }
 
     [Test]
-    public async Task BudgetDecay_YieldsWhenStandingQueueProvesOverAdmission()
+    public async Task BudgetDecay_StandingQueueCannotBypassTimeBound()
     {
-        // Admission blocks constantly under saturation, so blocks alone cannot gate the
-        // hysteresis. Standing bytes at twice the fresh budget prove the old budget
-        // over-admitted; the recompute must land immediately instead of at 10%/s.
-        var standingQueue = BrokerUnackedByteBudget.BoundBudgetDecay(
+        var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 20_000);
-        var modestOccupancy = BrokerUnackedByteBudget.BoundBudgetDecay(
-            previousBudget: 100_000,
-            computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 19_999);
+            elapsedSeconds: 1.0);
 
-        await Assert.That(standingQueue).IsEqualTo(10_000);
-        await Assert.That(modestOccupancy).IsEqualTo(90_000);
+        await Assert.That(budget).IsEqualTo(90_000)
+            .Because("standing occupancy must not collapse the budget faster than elapsed time permits");
+    }
+
+    [Test]
+    public async Task BudgetDecay_SustainedIdleRestoresColdStartBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.001), appLimited: true);
+        budget.OnAcked(1, firstSend, T0);
+        SetField(budget, "_lastNormalBudgetBytes", 10_000L);
+        SetField(budget, "_budgetBytes", 10_000L);
+
+        var idleSend = budget.SnapshotDelivery(T0 + Seconds(3.0), appLimited: true);
+        budget.OnAcked(1, idleSend, T0 + Seconds(3.001));
+        budget.CompleteAckedPass(T0 + Seconds(3.001));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -242,8 +242,33 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task Budget_RttGuard_UsesServingRttEwmaUnderLoad()
+    public async Task Budget_RttGuard_UsesServingRttEwmaWithinClampUnderLoad()
     {
+        // Base RTT 10ms, loaded serving RTT 15ms — within the 2x clamp, so the loaded
+        // estimate (which includes replication service time) sizes the floor.
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.010);
+        SetField(budget, "_servingRttEwmaSeconds", 0.015);
+        SetField(budget, "_windowMaxRate", 1_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+
+        budget.SetCap(1_000_000, T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(22_500)
+            .Because("replicated serving RTT, not base RTT, determines the loaded BDP");
+    }
+
+    [Test]
+    public async Task Budget_RttGuard_ClampsQueueInflatedServingRtt()
+    {
+        // Base RTT 1ms but the loaded serving RTT reads 20ms — that excess is queueing the
+        // budget itself admitted. Unclamped, the floor would be 1.5 × 20ms = 30,000 bytes,
+        // re-inflating the RTT it is derived from (the #2009 ratchet). The clamp bounds the
+        // floor at 1.5 × 2 × base RTT = 3ms; the 10ms target then governs.
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
@@ -256,12 +281,12 @@ public sealed class BrokerUnackedByteBudgetTests
 
         budget.SetCap(1_000_000, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(30_000)
-            .Because("replicated serving RTT, not base RTT, determines the loaded BDP");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000)
+            .Because("queue-inflated serving RTT must not raise the floor it feeds back into");
     }
 
     [Test]
-    public async Task RttFloorCapacityProbe_UsesExtraHeadroom()
+    public async Task RttFloorCapacityProbe_UsesUniformHeadroom()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -277,8 +302,9 @@ public sealed class BrokerUnackedByteBudgetTests
 
         budget.SetCap(1_000_000, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(45_000)
-            .Because("an RTT-floor-bound pipe needs a wider probe than the normal 1.25x step");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(12_500)
+            .Because("probing exactly when the RTT floor dominates accelerated the ratchet; " +
+                "the probe step is uniform");
     }
 
     [Test]
@@ -291,9 +317,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(1.0));
 
         // Both samples measure 100,000 B/s. The later back-to-back 100ms service sample
-        // raises the loaded horizon while the retained 5ms base RTT remains unchanged.
+        // raises the loaded horizon — clamped to twice the retained 5ms base RTT, so the
+        // floor is 1.5 × 10ms — while the base RTT itself remains unchanged.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(2_531);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 
     [Test]
@@ -429,9 +456,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.25));
 
         // No ack landed inside the 100ms drain. The late loaded sample must not replace
-        // the retained 5ms base RTT, but it does restore a serving-RTT safety horizon.
+        // the retained 5ms base RTT, but it does restore a serving-RTT safety horizon
+        // (clamped to twice the base RTT).
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(2_531);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 
     [Test]
@@ -755,15 +783,122 @@ public sealed class BrokerUnackedByteBudgetTests
             previousBudget: 100_000,
             computedBudget: 10_000,
             elapsedSeconds: 1.0,
-            admissionWasBlocked: true);
+            admissionWasBlocked: true,
+            unackedBytes: 0);
         var unblocked = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
             elapsedSeconds: 1.0,
-            admissionWasBlocked: false);
+            admissionWasBlocked: false,
+            unackedBytes: 0);
 
         await Assert.That(blocked).IsEqualTo(90_000);
         await Assert.That(unblocked).IsEqualTo(10_000);
+    }
+
+    [Test]
+    public async Task BudgetDecay_YieldsWhenStandingQueueProvesOverAdmission()
+    {
+        // Admission blocks constantly under saturation, so blocks alone cannot gate the
+        // hysteresis. Standing bytes at twice the fresh budget prove the old budget
+        // over-admitted; the recompute must land immediately instead of at 10%/s.
+        var standingQueue = BrokerUnackedByteBudget.BoundBudgetDecay(
+            previousBudget: 100_000,
+            computedBudget: 10_000,
+            elapsedSeconds: 1.0,
+            admissionWasBlocked: true,
+            unackedBytes: 20_000);
+        var modestOccupancy = BrokerUnackedByteBudget.BoundBudgetDecay(
+            previousBudget: 100_000,
+            computedBudget: 10_000,
+            elapsedSeconds: 1.0,
+            admissionWasBlocked: true,
+            unackedBytes: 19_999);
+
+        await Assert.That(standingQueue).IsEqualTo(10_000);
+        await Assert.That(modestOccupancy).IsEqualTo(90_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RejectsRateGainWhenRttInflates()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_windowMaxRate", 10_000.0);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(10.0));
+        SetField(budget, "_capacityProbeActive", true);
+        SetField(budget, "_capacityProbePreProbeRttSeconds", 0.100);
+
+        // Delivered rate rises 25%, but every round trip now takes 1.5x the pre-probe RTT:
+        // through a saturated broker the "gain" is standing queue, not headroom.
+        Ack(budget, 1_875, 0.150, T0 + Seconds(0.150), appLimitedAtSend: false);
+        Ack(budget, 1_875, 0.150, T0 + Seconds(0.300), appLimitedAtSend: false);
+        Ack(budget, 1_875, 0.150, T0 + Seconds(0.450), appLimitedAtSend: false);
+        Ack(budget, 1_875, 0.150, T0 + Seconds(0.600), appLimitedAtSend: false);
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("rate-up with RTT-up is added queueing, not capacity");
+    }
+
+    [Test]
+    public async Task ServingRttFeedback_DoesNotRatchetBudgetTowardCap()
+    {
+        // Saturated-broker model (#2009): drain rate is fixed at 1 MB/s, the admitted queue
+        // always sits at the published budget, and every loaded round trip measures base RTT
+        // (5ms) plus the standing queue's drain time. Uncorrected, budget = 1.5 x rate x
+        // (base + budget/rate) has loop gain 1.5 and rides the 32 MB cap; with queue-corrected
+        // RTT sensing the 10ms target governs and the budget stays near rate x target.
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+
+        var now = T0;
+        Ack(budget, 5_000, 0.005, now);
+        for (var i = 0; i < 100; i++)
+        {
+            var standingBytes = Math.Max(0, budget.BudgetBytes - 5_000);
+            var rtt = 0.005 + standingBytes / 1_000_000.0;
+            now += Seconds(rtt);
+            var requestBytes = (long)(1_000_000 * rtt);
+            budget.Charge(standingBytes + requestBytes);
+            budget.RecordAdmissionBlock();
+            Ack(budget, requestBytes, rtt, now, appLimitedAtSend: false);
+            budget.Release(standingBytes + requestBytes);
+        }
+
+        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(20_000)
+            .Because("self-admitted queueing must not masquerade as service time in the RTT floor");
+    }
+
+    [Test]
+    public async Task StandingQueueDelayAboveTarget_ShrinksLatencyScale()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        budget.Charge(100_000); // 100ms of standing queue at 1 MB/s — 10x the target.
+
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.002));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+        budget.Release(100_000);
+
+        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.5)
+            .Because("bytes queued beyond the socket are latency the seal-to-send sample cannot see");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -585,6 +585,23 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task LoadedRatePeak_OneMinuteDipDoesNotBecomeNewAdmissionCeiling()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
+        for (var second = 2; second <= 60; second += 2)
+            Ack(budget, 100, 0.100, T0 + Seconds(second), appLimitedAtSend: false);
+
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_500)
+            .Because("a transient one-minute rate dip must not self-ratchet a saturated producer");
+    }
+
+    [Test]
     public async Task AppLimitedSend_AfterBriefDrainRetainsLoadedRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -739,8 +756,14 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
 
     [Test]
@@ -774,6 +797,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 500, 0.100, T0 + Seconds(0.200), appLimitedAtSend: false);
         Ack(budget, 500, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
         Ack(budget, 500, 0.100, T0 + Seconds(0.400), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.500), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.600), appLimitedAtSend: false);
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
             .Because("one noisy high sample must not ratchet a three-RTT low-rate probe");
@@ -826,7 +851,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_RejectsRateGainWhenRttInflates()
     {
         var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.5,
+            targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
         SetField(budget, "_windowMaxRate", 10_000.0);
@@ -1066,9 +1091,72 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        // Three RTTs of wholly-probed responses confirm no gain and end the probe.
+        // Target horizon is longer than three RTTs, so measurement continues until 500ms
+        // after the first wholly admitted response.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.500));
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RejectsBatchAdmittedBeforeProbeEvenWhenSentAfterProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeActive", true);
+
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: T0 + Seconds(0.010),
+            appLimited: true,
+            oldestBatchTimestamp: T0 - Seconds(0.010));
+        Ack(budget, 200, 0.001, T0 + Seconds(0.011), snapshot);
+
+        await Assert.That(GetField<int>(budget, "_capacityProbeRateSampleCount")).IsEqualTo(0)
+            .Because("a send after probe start can still contain work admitted under the old budget");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_EvaluationWindowCoversTargetHorizonAndLinger()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000,
+            lingerSeconds: 0.005);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeActive", true);
+
+        var now = T0 + Seconds(0.020);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: T0 + Seconds(0.001));
+        Ack(budget, 20, 0.001, now, snapshot);
+
+        var evaluationDeadline = GetField<long>(budget, "_capacityProbeEvaluationDeadlineTimestamp");
+        await Assert.That(evaluationDeadline - now).IsGreaterThanOrEqualTo(Seconds(0.015))
+            .Because("probe-added admissions need a full target horizon plus linger to affect delivery rate");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_UsesWindowAverageBaseline_NotDecayingRetainedPeak()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        Ack(budget, 10, 0.001, T0);
+        SetField(budget, "_retainedLoadedMaxRate", 100_000.0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
+
+        Ack(budget, 10, 0.001, T0 + Seconds(0.008));
+
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate")).IsEqualTo(10_000.0)
+            .Because("a stale retained peak must not make every recovery probe impossible");
     }
 
     [Test]
@@ -1103,6 +1191,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
         Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -427,6 +427,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_ProbeBoundsSingleWindowGrowth()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.001);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0);
+        SetField(budget, "_minRttProbeMinimumSeconds", 0.010);
+
+        Ack(budget, 10_000, 0.010, T0, appLimitedAtSend: false);
+
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(1_250)
+            .Because("one partially queued refresh must not multiply the BDP floor");
+    }
+
+    [Test]
     public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -606,6 +606,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task AppLimitedShortSample_CannotReplaceEstablishedRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0);
+        Ack(budget, 1_000_000, 0.001, T0 + Seconds(0.100));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(10_000)
+            .Because("a short idle-gap response may seed cold start but cannot ratchet a populated estimator");
+    }
+
+    [Test]
     public async Task Budget_RecoversWhenRateRises()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -614,7 +629,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var shrunken = budget.BudgetBytes;
 
         // Faster drain in the next window must grow the budget back (no ratchet-down).
-        Ack(budget, 12_000, 0.001, T0 + Seconds(2.0));
+        Ack(budget, 12_000, 0.100, T0 + Seconds(2.0));
 
         await Assert.That(budget.BudgetBytes).IsGreaterThan(shrunken);
     }
@@ -637,16 +652,16 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         // Both requests were sent before either delivery.
-        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.020), appLimited: false);
-        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.019), appLimited: false);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.100), appLimited: false);
+        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.099), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample covers the full delivery epoch: 2,000 bytes over 21ms from the
-        // first send to the second acknowledgement = 95,238 B/s aggregate drain. The
-        // 20ms measured RTT horizon therefore publishes a 1,904-byte budget.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_904);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 101ms from the
+        // first send to the second acknowledgement = 19,801 B/s aggregate drain. The
+        // 100ms measured RTT horizon therefore publishes a 1,980-byte budget.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_980);
     }
 
     [Test]
@@ -667,7 +682,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
 
         Ack(budget, 1_000, 0.100, T0);
-        for (var i = 1; i <= 20; i++)
+        for (var i = 1; i <= 23; i++)
             Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
@@ -1329,14 +1344,14 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(8_787);
 
         // The probe averages three RTTs before ratcheting to the higher level.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
 
         // The ratcheted level gets another full-window average. Comparing average with
         // average lets the sustained 25% gain advance the next rung as well.
@@ -1457,7 +1472,7 @@ public sealed class BrokerUnackedByteBudgetTests
         {
             sendSnapshots[i] = budget.SnapshotDelivery(
                 T0 + Seconds(i * 0.001),
-                appLimited: i == 0);
+                appLimited: false);
         }
 
         for (var i = 0; i < sendSnapshots.Length; i++)
@@ -1468,11 +1483,11 @@ public sealed class BrokerUnackedByteBudgetTests
                 T0 + Seconds(0.0041 + i * 0.0001));
         }
         var matureEpochSend = budget.SnapshotDelivery(T0 + Seconds(0.005), appLimited: false);
-        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.020));
-        budget.CompleteAckedPass(T0 + Seconds(0.020));
+        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.100));
+        budget.CompleteAckedPass(T0 + Seconds(0.100));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(295_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(305_000_000)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(59_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(61_000_000)
             .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
     }
 
@@ -1501,7 +1516,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task LoadedDeliveryEpoch_RollsAfterOneHundredMilliseconds()
+    public async Task LoadedDeliveryEpoch_RollsAfterTwoHundredFiftyMilliseconds()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1511,7 +1526,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
         budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
 
-        var nextEpochTimestamp = T0 + Seconds(0.101);
+        var nextEpochTimestamp = T0 + Seconds(0.251);
         var loadedSend = budget.SnapshotDelivery(nextEpochTimestamp, appLimited: false);
 
         await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
@@ -1565,9 +1580,13 @@ public sealed class BrokerUnackedByteBudgetTests
 
         var thirdSend = budget.SnapshotDelivery(T0 + Seconds(0.003), appLimited: false);
         budget.OnAcked(1_000_000, thirdSend, T0 + Seconds(0.020));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0);
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(150_000_000)
-            .Because("the accepted sample covers 3MB over the full 20ms loaded epoch");
+        var fourthSend = budget.SnapshotDelivery(T0 + Seconds(0.021), appLimited: false);
+        budget.OnAcked(1_000_000, fourthSend, T0 + Seconds(0.100));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(40_000_000)
+            .Because("the accepted sample covers 4MB over the full 100ms loaded epoch");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1505,6 +1505,25 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task LoadedDeliveryEpoch_RollsAfterOneHundredMilliseconds()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
+
+        var nextEpochTimestamp = T0 + Seconds(0.101);
+        var loadedSend = budget.SnapshotDelivery(nextEpochTimestamp, appLimited: false);
+
+        await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(loadedSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(nextEpochTimestamp)
+            .Because("a continuously loaded producer must still adapt to capacity changes");
+    }
+
+    [Test]
     public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1536,7 +1555,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
         Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(99_019);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1721,6 +1721,55 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task DeliveryEpochSnapshots_NeverMixConcurrentPublisherGenerations(
+        CancellationToken ct)
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        const int publisherIterations = 100_000;
+        const long deliveryEpochUpdating = -2;
+        using var start = new Barrier(participantCount: 5);
+        var publisherComplete = 0;
+        var mixedGenerationCount = 0;
+
+        SetField(budget, "_totalDeliveredBytes", 0L);
+        SetField(budget, "_sendEpochDeliveredBytes", 0L);
+        SetField(budget, "_sendEpochFirstTimestamp", 0L);
+
+        var readers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait(ct);
+            while (!ct.IsCancellationRequested && Volatile.Read(ref publisherComplete) == 0)
+            {
+                var snapshot = budget.SnapshotDelivery(sendTimestamp: 1, appLimited: false);
+                if (snapshot.DeliveryEpochFirstSendTimestamp
+                    != snapshot.DeliveryEpochDeliveredBytes * 10)
+                {
+                    Interlocked.Increment(ref mixedGenerationCount);
+                }
+            }
+        }, ct)).ToArray();
+
+        start.SignalAndWait(ct);
+        for (var generation = 1; generation <= publisherIterations; generation++)
+        {
+            SetField(budget, "_totalDeliveredBytes", (long)generation);
+            SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
+            SetField(budget, "_sendEpochFirstTimestamp", generation * 10L);
+            Thread.Yield();
+            SetField(budget, "_sendEpochDeliveredBytes", (long)generation);
+        }
+        Volatile.Write(ref publisherComplete, 1);
+
+        await Task.WhenAll(readers).WaitAsync(ct);
+        await Assert.That(mixedGenerationCount).IsEqualTo(0)
+            .Because("the delivered-byte and first-send anchors belong to one publication");
+    }
+
+    [Test]
     public async Task DeliveryEpoch_RedundantPublisherPreservesFirstSendAnchor()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -320,6 +320,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.015);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
@@ -343,6 +344,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.020);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
@@ -362,6 +364,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.020);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
         SetField(budget, "_capacityProbeActive", true);
         SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
 
@@ -655,10 +658,9 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample's delivered-counter delta covers both deliveries: 2,000 bytes
-        // over its own 5ms sojourn = 400,000 B/s aggregate drain, independent of the 1ms
-        // gap between the two acknowledgements.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(4_000);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 6ms from the
+        // first send to the second acknowledgement = 333,333 B/s aggregate drain.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_333);
     }
 
     [Test]
@@ -747,8 +749,12 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: true);
         Ack(budget, 1_000, 0.100, T0 + Seconds(0.100), appLimitedAtSend: true);
 
-        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsGreaterThan(0)
-            .Because("recent delivery distinguishes a depth-one loaded pipe from real idle");
+        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsEqualTo(0)
+            .Because("an empty-pipe own-RTT sample must not persist as loaded capacity");
+        await Assert.That(GetField<double>(budget, "_windowMaxRate")).IsGreaterThan(0)
+            .Because("depth-one traffic still needs immediate windowed budget sizing");
+        await Assert.That(GetField<bool>(budget, "_hasLoadedServingSample")).IsTrue()
+            .Because("recent delivery still establishes a loaded serving-RTT horizon");
         await Assert.That(GetField<double>(budget, "_servingRttEwmaSeconds")).IsGreaterThan(0);
     }
 
@@ -1438,7 +1444,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // The initial minimum-RTT probe now retains one BDP instead of draining the pipe;
         // this remains far below the cap the broken estimator pegged.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(4_998_000);
     }
 
     [Test]
@@ -1469,9 +1475,53 @@ public sealed class BrokerUnackedByteBudgetTests
         }
         budget.CompleteAckedPass(T0 + Seconds(0.0045));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_200_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_400_000_000)
-            .Because("a cumulative delivery delta must include its delivery epoch's send time");
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_000_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_200_000_000)
+            .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
+    }
+
+    [Test]
+    public async Task LoadedDeliveryEpoch_SpansAcknowledgementsUntilPipeBecomesAppLimited()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
+
+        var loadedSend = budget.SnapshotDelivery(T0 + Seconds(0.006), appLimited: false);
+        await Assert.That(loadedSend.DeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(0)
+            .Because("delivery progress must not reset an epoch while the pipe remains loaded");
+        await Assert.That(loadedSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(T0);
+
+        var appLimitedSend = budget.SnapshotDelivery(T0 + Seconds(0.007), appLimited: true);
+        await Assert.That(appLimitedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(appLimitedSend.DeliveryEpochFirstSendTimestamp)
+            .IsEqualTo(T0 + Seconds(0.007))
+            .Because("an empty-pipe send starts a new delivery epoch");
+    }
+
+    [Test]
+    public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: false);
+        budget.OnAcked(1_000_000, firstSend, T0 + Seconds(0.0005));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0)
+            .Because("a sub-2ms loaded sample is dominated by scheduler and timer resolution");
+
+        var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: false);
+        budget.OnAcked(1_000_000, secondSend, T0 + Seconds(0.0025));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(800_000_000)
+            .Because("the accepted sample covers 2MB over the full 2.5ms loaded epoch");
     }
 
     [Test]
@@ -1486,7 +1536,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
         Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(99_019);
     }
 
     [Test]
@@ -1615,7 +1665,7 @@ public sealed class BrokerUnackedByteBudgetTests
             budget.OnAcked(
                 1,
                 new BrokerUnackedByteBudget.DeliverySnapshot(
-                    i, 0, 0, now - 1, true, 0, 0),
+                    i, 0, i, 0, now - 1, true, 0, 0),
                 now);
         }
 
@@ -1640,13 +1690,14 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
         SetField(budget, "_sendEpochFirstTimestamp", firstSendTimestamp);
 
-        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null };
+        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null, null };
         var anchor = (long)typeof(BrokerUnackedByteBudget)
             .GetMethod("PublishDeliveryEpoch", BindingFlags.Instance | BindingFlags.NonPublic)!
             .Invoke(budget, arguments)!;
 
         await Assert.That(anchor).IsEqualTo(firstSendTimestamp);
         await Assert.That(arguments[2]).IsEqualTo(deliveredBytes);
+        await Assert.That(arguments[3]).IsEqualTo(deliveredBytes);
         await Assert.That(GetField<long>(budget, "_sendEpochFirstTimestamp")).IsEqualTo(firstSendTimestamp);
         await Assert.That(GetField<long>(budget, "_sendEpochDeliveredBytes")).IsEqualTo(deliveredBytes);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Threading.Channels;
 using Dekaf.Producer;
 
@@ -56,6 +57,48 @@ public class ProducerCancellationTests
 
         await disposal.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(disposal.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
+    public async Task Cancellation_StopsActiveLingerTimerPromptly()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithLinger(TimeSpan.FromMinutes(1))
+            .Build();
+        var accumulator = GetField<RecordAccumulator>(producer, "_accumulator");
+        var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
+        var lingerTask = GetField<Task>(producer, "_lingerTask");
+
+        try
+        {
+            // Append directly so the active linger path is covered without requiring Kafka I/O.
+            await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None);
+            await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
+
+            // Let the linger loop consume the wakeup and enter its periodic active cadence.
+            await Task.Delay(20);
+            senderCts.Cancel();
+
+            await lingerTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(lingerTask.IsCompletedSuccessfully).IsTrue();
+        }
+        finally
+        {
+            senderCts.Cancel();
+            await accumulator.DisposeAsync();
+            await producer.DisposeAsync();
+        }
     }
 
     [Test]
@@ -288,4 +331,9 @@ public class ProducerCancellationTests
             await accumulator.DisposeAsync();
         }
     }
+
+    private static T GetField<T>(object instance, string name)
+        => (T)instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(instance)!;
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -69,6 +69,11 @@ public class ProducerCancellationTests
         var accumulator = GetField<RecordAccumulator>(producer, "_accumulator");
         var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
         var lingerTask = GetField<Task>(producer, "_lingerTask");
+        var activeLingerWaitEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetField(
+            producer,
+            "BeforeActiveLingerTimerWaitForTest",
+            (Action)(() => activeLingerWaitEntered.TrySetResult(true)));
 
         try
         {
@@ -86,8 +91,7 @@ public class ProducerCancellationTests
                 CancellationToken.None);
             await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
 
-            // Let the linger loop consume the wakeup and enter its periodic active cadence.
-            await Task.Delay(20);
+            await activeLingerWaitEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
             senderCts.Cancel();
 
             await lingerTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -336,4 +340,9 @@ public class ProducerCancellationTests
         => (T)instance.GetType()
             .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(instance)!;
+
+    private static void SetField<T>(object instance, string name, T value)
+        => instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(instance, value);
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -205,11 +205,15 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.MinRttMicros).IsGreaterThan(0);
         await Assert.That(current.MaxRateBytesPerSec).IsGreaterThan(0);
         await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
+        await Assert.That(current.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(current.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
         await Assert.That(current.RequestRttMicrosLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(sample.BrokerId).IsEqualTo(7);
+        await Assert.That(sample.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(sample.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -146,6 +146,13 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task MaxConnectionsPerBroker_DefaultsTo_3()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task Partitioner_DefaultsTo_Default()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1858,6 +1858,100 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task FlushAsync_WaitsForSealedPipelineBeforePublishingFinalPartialBatch()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 30,
+            LingerMs = 10
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+        ReadyBatch? sealedBatch = null;
+        ReadyBatch? finalBatch = null;
+
+        try
+        {
+            var firstCompletion = pool.Rent();
+            var secondCompletion = pool.Rent();
+            var firstCompletionTask = firstCompletion.Task;
+            var secondCompletionTask = secondCompletion.Task;
+            var value = new byte[16];
+
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                firstCompletion)).IsTrue();
+
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                secondCompletion)).IsTrue();
+
+            await Assert.That(accumulator.TryDrainBatch(out sealedBatch)).IsTrue();
+
+            var flushTask = accumulator.FlushAsync(CancellationToken.None).AsTask();
+
+            await Assert.That(flushTask.IsCompleted).IsFalse();
+            await Assert.That(accumulator.TryDrainBatch(out _)).IsFalse()
+                .Because("the final partial batch must remain unpublished while an older batch is in flight");
+
+            sealedBatch!.CompleteSend(baseOffset: 10, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(sealedBatch);
+            accumulator.ReturnReadyBatch(sealedBatch);
+            sealedBatch = null;
+
+            await TestWait.UntilAsync(
+                () => accumulator.TryDrainBatch(out finalBatch),
+                TimeSpan.FromSeconds(5));
+
+            finalBatch!.CompleteSend(baseOffset: 11, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(finalBatch);
+            accumulator.ReturnReadyBatch(finalBatch);
+            finalBatch = null;
+
+            await flushTask.WaitAsync(TimeSpan.FromSeconds(5));
+            _ = await firstCompletionTask;
+            _ = await secondCompletionTask;
+        }
+        finally
+        {
+            if (sealedBatch is not null)
+            {
+                accumulator.OnBatchExitsPipeline(sealedBatch);
+                accumulator.ReturnReadyBatch(sealedBatch);
+            }
+
+            if (finalBatch is not null)
+            {
+                accumulator.OnBatchExitsPipeline(finalBatch);
+                accumulator.ReturnReadyBatch(finalBatch);
+            }
+
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ReadyBatch_Cleanup_CalledTwice_OnlyExecutesOnce()
     {
         // This test verifies that Cleanup() uses an interlocked guard to ensure

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3572,6 +3572,83 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_QueuedBurstScansPendingQueueOnce()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var tasks = new Task<bool>[32];
+
+        await Assert.That(accumulator.TryReserveMemoryForTest(4096)).IsTrue();
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = accumulator.AppendFromSpansAsync(
+                "test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, CancellationToken.None).AsTask();
+        }
+
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(tasks.Length);
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(1)
+            .Because("one blocked burst must not rescan its growing pending queue per message");
+
+        await accumulator.DisposeAsync();
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected: disposal completes every deliberately blocked append.
+        }
+    }
+
+    [Test]
+    public async Task AppendFromSpansAsync_CancellationStormRescansOnlyAtHead()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var cancellationSources = Enumerable.Range(0, 32)
+            .Select(_ => new CancellationTokenSource())
+            .ToArray();
+        var tasks = new Task<bool>[cancellationSources.Length];
+
+        await Assert.That(accumulator.TryReserveMemoryForTest(4096)).IsTrue();
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = accumulator.AppendFromSpansAsync(
+                "test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, cancellationSources[i].Token).AsTask();
+        }
+
+        for (var i = cancellationSources.Length - 1; i > 0; i--)
+            cancellationSources[i].Cancel();
+
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(1)
+            .Because("tail cancellations cannot unblock the FIFO head");
+
+        cancellationSources[0].Cancel();
+
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(2)
+            .Because("the head cancellation coalesces the completed burst into one scan");
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: every deliberately blocked append was cancelled.
+        }
+
+        foreach (var cancellationSource in cancellationSources)
+            cancellationSource.Dispose();
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_ReopenedMemory_PreservesPendingAppendFifo()
     {
         var options = new ProducerOptions
@@ -3616,9 +3693,9 @@ public class RecordAccumulatorTests
 
             await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
 
-            // Free memory without draining. The next append must join behind the queued
-            // operation; its immediate drain serves the older append before completing.
-            SetBufferedBytesForTest(accumulator, 3000);
+            // A release wakes one queue drain. The next append must not overtake the older
+            // operation that the wake just served.
+            accumulator.ReleaseMemory(fillSize);
 
             var hotResult = await accumulator.AppendFromSpansAsync(
                 topicPartition.Topic, topicPartition.Partition,

--- a/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
@@ -5,9 +5,9 @@ using Dekaf.Producer;
 namespace Dekaf.Tests.Unit.Producer;
 
 /// <summary>
-/// Tests for PartitionBatch.ShouldFlush() micro-linger behavior.
-/// When LingerMs > 0, awaited produces (with completion sources) use a micro-linger
-/// of min(1ms, LingerMs/10) instead of flushing immediately.
+/// Tests for PartitionBatch.ShouldFlush() short-linger behavior.
+/// When LingerMs > 0, awaited produces (with completion sources) use a short linger
+/// of min(2ms, LingerMs/2) instead of flushing immediately.
 /// When LingerMs == 0, awaited produces flush immediately.
 /// </summary>
 public class ShouldFlushTests
@@ -100,7 +100,26 @@ public class ShouldFlushTests
         await Assert.That(result).IsTrue();
     }
 
-    // --- LingerMs = 5: micro-linger = 0.5ms ---
+    // --- LingerMs = 1: short linger uses half the configured linger ---
+
+    [Test]
+    [Arguments(0.4, false)]
+    [Arguments(0.5, true)]
+    public async Task LingerMs1_WithCompletionSources_UsesHalfLinger(
+        double ageMilliseconds,
+        bool expected)
+    {
+        var batch = CreateBatch();
+
+        SetRecordCount(batch, 1);
+        SetCompletionSourceCount(batch, 1);
+        var now = SetCreatedAtMillisecondsAgo(batch, ageMilliseconds);
+
+        var result = InvokeShouldFlush(batch, now, lingerMs: 1);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // --- LingerMs = 5: short linger caps at 2ms ---
 
     [Test]
     public async Task LingerMs5_WithCompletionSources_Age0ms_DoesNotFlush()
@@ -109,61 +128,61 @@ public class ShouldFlushTests
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0); // Age = 0ms, micro-linger = 0.5ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 0); // Age = 0ms, short linger = 2ms
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 5);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs5_WithCompletionSources_AgeAtMicroLinger_Flushes()
+    public async Task LingerMs5_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.5); // Age = 0.5ms = micro-linger threshold
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
+
+        var result = InvokeShouldFlush(batch, now, lingerMs: 5);
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task LingerMs5_WithCompletionSources_Age2ms_Flushes()
+    {
+        var batch = CreateBatch();
+
+        SetRecordCount(batch, 1);
+        SetCompletionSourceCount(batch, 1);
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 5);
         await Assert.That(result).IsTrue();
     }
 
+    // --- LingerMs = 20: short linger caps at 2ms ---
+
     [Test]
-    public async Task LingerMs5_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs20_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms, well past 0.5ms micro-linger
-
-        var result = InvokeShouldFlush(batch, now, lingerMs: 5);
-        await Assert.That(result).IsTrue();
-    }
-
-    // --- LingerMs = 20: micro-linger = min(1ms, 20/10) = 1ms (capped) ---
-
-    [Test]
-    public async Task LingerMs20_WithCompletionSources_Age09ms_DoesNotFlush()
-    {
-        var batch = CreateBatch();
-
-        SetRecordCount(batch, 1);
-        SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.9); // Age = 0.9ms, micro-linger = 1ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 20);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs20_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs20_WithCompletionSources_Age2ms_Flushes()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms = capped micro-linger
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 20);
         await Assert.That(result).IsTrue();
@@ -212,29 +231,29 @@ public class ShouldFlushTests
         await Assert.That(result).IsFalse();
     }
 
-    // --- Large LingerMs: micro-linger caps at 1ms ---
+    // --- Large LingerMs: short linger caps at 2ms ---
 
     [Test]
-    public async Task LingerMs100_WithCompletionSources_Age09ms_DoesNotFlush()
+    public async Task LingerMs100_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.9); // micro-linger = min(1ms, 100/10) = 1ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 100);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs100_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs100_WithCompletionSources_Age2ms_Flushes()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms = capped micro-linger
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 100);
         await Assert.That(result).IsTrue();

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -247,6 +247,23 @@ public sealed class ConnectionScaleReportingTests
                         BufferPressureDelta = 120,
                         SendLoopPressureDelta = 340
                     }
+                ],
+                BrokerBudgetSamples =
+                [
+                    new ProducerBrokerBudgetDiagnostic
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(6),
+                        BrokerId = 1,
+                        BudgetBytes = 8 * 1024 * 1024,
+                        UnackedBytes = 6 * 1024 * 1024,
+                        MinRttMicros = 800,
+                        MaxRateBytesPerSec = 750_000_000,
+                        AdmissionBlockCount = 12,
+                        DeliveryLatencyEwmaMicros = 2_500,
+                        LatencyBudgetScale = 1.0,
+                        CapacityProbeSuccessCount = 3,
+                        CapacityProbeFailureCount = 2
+                    }
                 ]
             }
         };
@@ -269,6 +286,10 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("6.0s / 2,500 msg/s");
         await Assert.That(markdown).Contains("Producer Request Diagnostics - Fire-and-Forget");
         await Assert.That(markdown).Contains("| Dekaf | 1 | 2,500 | 500.00 | 256.0 KiB |");
+        await Assert.That(markdown).Contains("Producer Budget Timeline - Fire-and-Forget");
+        await Assert.That(markdown).Contains("8.0 MiB");
+        await Assert.That(markdown).Contains("750.0 MB/s");
+        await Assert.That(markdown).Contains("3/2");
         await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
         await Assert.That(markdown).Contains("42");
         await Assert.That(markdown).Contains("connection transition");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class ConsumerFetchDiagnosticsTests
 {
     [Test]
-    [NotInParallel("MeterListener")]
+    [NotInParallel]
     public async Task Listener_CollectsFetchDurationAndTopicBytes()
     {
         var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
@@ -42,3 +42,19 @@ public class Crc32CBenchmarks
     public uint Software()
         => Crc32C.ComputeSoftware(_data);
 }
+
+/// <summary>
+/// Benchmarks the CRC combination used to join a record-batch header checksum with its
+/// precomputed encoded-record checksum.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class Crc32CCombineBenchmarks
+{
+    [Params(40, 512, 4_096, 65_536, 850_000, 1_048_576)]
+    public int SuffixSize { get; set; }
+
+    [Benchmark]
+    public uint Combine()
+        => Crc32C.Combine(0xA1B2C3D4u, 0x10203040u, SuffixSize);
+}

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -31,6 +31,7 @@ internal static class MarkdownReporter
             GenerateThroughputTable(sb, title, groupResults);
             GenerateConnectionScaleTimeline(sb, groupResults, label);
             GenerateProducerRequestDiagnostics(sb, groupResults, label);
+            GenerateProducerBudgetTimeline(sb, groupResults, label);
             GenerateConsumerFetchTimeline(sb, groupResults, label);
             GenerateLatencyOutlierTimeline(sb, groupResults, label);
 
@@ -251,6 +252,45 @@ internal static class MarkdownReporter
 
         sb.AppendLine();
         sb.AppendLine("*Average bytes/request is Kafka ProduceRequest body bytes; smaller requests at higher request rates indicate batching fragmentation.*");
+        sb.AppendLine();
+    }
+
+    private static void GenerateProducerBudgetTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BrokerBudgetSamples ?? [])
+                .Select(sample => (Result: result, Sample: sample)))
+            .OrderBy(row => row.Sample.CapturedAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        var displayedRows = SampleEvenly(rows, MaxTimelineRows);
+        var omittedRows = rows.Count - displayedRows.Count;
+
+        sb.AppendLine($"## Producer Budget Timeline - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
+        sb.AppendLine("|--------|------------|-------:|------------------|---------:|----------------------:|-----------------:|---------------------------|");
+        foreach (var row in displayedRows)
+        {
+            var nearest = row.Result.Throughput.IntervalSamples
+                .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CapturedAtUtc).TotalMilliseconds));
+            var throughput = nearest is null
+                ? "-"
+                : $"{nearest.ElapsedSeconds:F1}s / {nearest.MessagesPerSecond:N0} msg/s";
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss.fff} | {row.Sample.BrokerId} | " +
+                $"{row.Sample.BudgetBytes / 1_048_576.0:F1} MiB / {row.Sample.UnackedBytes / 1_048_576.0:F1} MiB | " +
+                $"{row.Sample.MaxRateBytesPerSec / 1_000_000.0:F1} MB/s | " +
+                $"{row.Sample.CapacityProbeSuccessCount:N0}/{row.Sample.CapacityProbeFailureCount:N0} | " +
+                $"{row.Sample.AdmissionBlockCount:N0} | {throughput} |");
+        }
+        if (omittedRows > 0)
+            sb.AppendLine($"*{omittedRows:N0} budget sample(s) omitted; rows sampled across the full timeline.*");
         sb.AppendLine();
     }
 


### PR DESCRIPTION
Fixes #2009.
Fixes #2008.
Fixes #2010.
Fixes #2011.
Fixes #2035.
Fixes #2034.
Fixes #2043.

## Problem

Stress validation exposed coupled producer-control and scheduling failures:

- **#2009:** 3-broker delivery latency reached 26x target because `servingRttEwma` measured queueing admitted by the budget itself, creating a gain-above-one feedback loop.
- **#2008/#2010:** the feed-forward budget had no reliable upward recovery path; probe window mismatches and transient stalls caused stuck-low throughput.
- **#2011:** the one-shot active linger timer was rearmed for every send wave, dominating CPU and collapsing 1-broker acks-all throughput.
- **#2035:** the first acknowledgement snapped the 32 MiB cold-start cap to about 3.8 MiB because downward hysteresis applied only after admission blocks and treated the first elapsed interval as zero.

## Fix

1. Queue-correct RTT samples before updating minimum and serving estimates.
2. Bound loaded serving RTT to `2 x minRtt`, preventing residual feedback ratchets.
3. Compare capacity-probe rate and RTT in matching raw domains over wholly admitted traffic.
4. Retain demonstrated loaded capacity through transient stalls and report probe outcomes.
5. Let latency-governed scale grow above parity under proven demand; distinguish broker queueing from sender backlog when shrinking.
6. Preserve the standing-queue fast-drain bypass while rate-limiting every ordinary downward budget recompute to 10%/s, including the zero-elapsed first sample.
7. Arm linger with the existing idle-to-active signal, then use a reusable `PeriodicTimer` for active cadence; signal only on the first queue transition.
8. Isolate the process-wide consumer fetch diagnostics listener test from unrelated parallel tests.

## Tests

- Budget-controller state-machine suite: 73/73.
- Full net10 unit suite: 5,423/5,423.
- Release build: 0 warnings, 0 errors.
- Exact-head CI [29321669673](https://github.com/thomhurst/Dekaf/actions/runs/29321669673) and 15-minute stress [29327573274](https://github.com/thomhurst/Dekaf/actions/runs/29327573274) passed at `389f4667`; final Claude review must be CLEAR before merge.

## Validation gate

Merge remains gated on one exact-head 15-minute stress run proving:

- 3-broker p95 delivery latency <= 3x target.
- 1-broker acks-all throughput within the baseline band.
- Round-trip produce >= 200k msg/s and CPU <= 6.9 us/msg.




## Final exact-head validation

At `389f4667`:

- CI run 29321669673 passed.
- Stress run 29327573274 passed all 15 jobs.
- Worst 3-broker p95 delivery latency: 24.75 ms (< 3x 10 ms target).
- 1-broker acks-all: 1,285,376 median msg/s, zero errors.
- Roundtrip: 532,899 produce msg/s, 4.01 CPU us/msg, 2,000,000/2,000,000 consumed, zero missing/duplicate/corrupt/out-of-order/mispartitioned messages.

