### PR TITLE
fix(producer): give the unacked budget an upward force past rate parity (#2008)

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -74,9 +74,31 @@ internal sealed class BrokerUnackedByteBudget
     private const double DeliveryLatencyEwmaWeight = 0.125;
     private const double ServingRttEwmaWeight = 0.125;
     private const double MinimumLatencyBudgetScale = 0.10;
+
+    /// <summary>
+    /// Upper bound on the latency budget scale. Above 1.0 the scale is the budget's only
+    /// unconditional upward force (#2008): the drain-rate estimate is measured from traffic
+    /// the admission gate itself admitted, so <c>rate × target</c> is self-confirming at any
+    /// throughput level — without headroom above parity the budget can never discover broker
+    /// or sender capacity beyond whatever it happens to be admitting. The controller grows
+    /// the scale only while admission is blocking (proof of demand) and measured delivery
+    /// latency sits below target, and growth decelerates as latency approaches target. The
+    /// bound keeps a stale-high scale's overshoot window short: shrinking back to parity
+    /// from here takes ~8 control intervals (~0.8 s).
+    /// </summary>
+    private const double MaximumLatencyBudgetScale = 10.0;
     private const double MinimumLatencyAdjustmentFactor = 0.75;
     private const double MaximumLatencyAdjustmentFactor = 1.05;
     private const double MaximumBudgetDecayPerSecond = 0.10;
+
+    /// <summary>
+    /// The scale shrinks only while written-unacked occupancy demonstrates at least this
+    /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
+    /// means the send loop, not broker admission, is the bottleneck — shrinking admission
+    /// there cannot reduce the latency, it only starves the sender below its capacity
+    /// (the 1-broker collapse mode of #2008).
+    /// </summary>
+    private const double ShrinkOccupancyFraction = 0.5;
 
     /// <summary>
     /// Log2 histogram buckets for per-request diagnostics. Request sizes shift by
@@ -184,7 +206,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
-    private double _lastNormalRttFloorSeconds;
+    private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
     private long _minRttTimestamp;
@@ -513,15 +535,24 @@ internal sealed class BrokerUnackedByteBudget
         if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= sendTimestamp)
             return;
 
-        // Only producer-controlled queueing belongs in the controller. Broker RTT, linger
-        // before sealing, and response scheduling cannot be reduced by shrinking admission;
-        // including them made the target an equilibrium setpoint and suppressed fan-out.
         var sampleSeconds = (double)(sendTimestamp - oldestBatchTimestamp) / Stopwatch.Frequency;
         var latencyEstimate = _deliveryLatencyEwmaSeconds == 0
             ? sampleSeconds
             : _deliveryLatencyEwmaSeconds
                 + DeliveryLatencyEwmaWeight * (sampleSeconds - _deliveryLatencyEwmaSeconds);
         Volatile.Write(ref _deliveryLatencyEwmaSeconds, latencyEstimate);
+
+        // Measured seal-to-ack is the delivery latency users experience from the moment a
+        // batch is eligible to send. The queue-drained base RTT is subtracted before the
+        // control decision: broker round-trip time cannot be reduced by shrinking admission,
+        // and charging it to the controller is what turned the target into an equilibrium
+        // setpoint that suppressed fan-out (#1988). What remains — sender backlog plus
+        // broker-side queueing — is exactly the delay the budget controls (#2008, #2009).
+        var sealToAckSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
+        _sealToAckEwmaSeconds = _sealToAckEwmaSeconds == 0
+            ? sealToAckSeconds
+            : _sealToAckEwmaSeconds
+                + DeliveryLatencyEwmaWeight * (sealToAckSeconds - _sealToAckEwmaSeconds);
 
         if (_nextLatencyControlTimestamp == 0)
         {
@@ -537,44 +568,45 @@ internal sealed class BrokerUnackedByteBudget
         var admissionWasBlocked = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
         _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
 
-        // Seal-to-send alone is blind to bytes already written and queued at the broker —
-        // the delay the budget most directly controls. Standing queue delay beyond the
-        // floor-sanctioned occupancy is that signal; controlling on the larger of the two
-        // lets the governor see broker-side queueing that never shows up between seal and
-        // socket write (#2009).
-        var controlLatencySeconds = Math.Max(latencyEstimate, GetStandingQueueDelaySeconds());
+        var baseRttSeconds = _hasMinRttSample ? _minRttSeconds : 0;
+        var brokerQueueSeconds = _sealToAckEwmaSeconds - baseRttSeconds;
+        var controlLatencySeconds = Math.Max(latencyEstimate, brokerQueueSeconds);
         var targetRatio = _targetSeconds / controlLatencySeconds;
         double adjustment;
         if (targetRatio < 1)
-            adjustment = Math.Max(MinimumLatencyAdjustmentFactor, targetRatio);
+        {
+            // Broker-side queueing always responds to admission — shrink acts on it
+            // unconditionally. When the seal-to-send backlog dominates instead, shrink only
+            // if the wire is demonstrably carrying the budget: backlog with an underfilled
+            // wire means the send loop, not admission, is the bottleneck, and shrinking
+            // there starves the sender below its capacity without reducing the backlog
+            // (the 1-broker collapse mode of #2008).
+            var senderBacklogDominates = latencyEstimate >= brokerQueueSeconds;
+            var shrinkActionable = !senderBacklogDominates
+                || _windowMaxOccupancyBytes
+                    >= ShrinkOccupancyFraction * _lastNormalBudgetBytes;
+            adjustment = shrinkActionable
+                ? Math.Max(MinimumLatencyAdjustmentFactor, targetRatio)
+                : 1.0;
+        }
         else if (admissionWasBlocked)
+        {
+            // The budget's only unconditional upward force: blocked demand with measured
+            // latency below target grows the scale past rate parity, breaking the
+            // self-confirming rate x target equilibrium (#2008). Growth decelerates as
+            // latency approaches target (adjustment -> 1 as targetRatio -> 1).
             adjustment = Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
+        }
         else
+        {
             adjustment = 1.0;
+        }
 
         Volatile.Write(ref _latencyBudgetScale, Math.Clamp(
             _latencyBudgetScale * adjustment,
             MinimumLatencyBudgetScale,
-            1.0));
+            MaximumLatencyBudgetScale));
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
-    }
-
-    /// <summary>Producer-controlled standing queue delay: unacked bytes over the drain rate,
-    /// less the occupancy the budget's own RTT floor sanctions to keep the pipe full. Delay
-    /// inside the sanctioned floor is not actionable — shrinking the scale cannot reduce a
-    /// budget the floor holds up — so charging it to the governor would only wind the scale
-    /// down against a wall.</summary>
-    private double GetStandingQueueDelaySeconds()
-    {
-        var effectiveMaxRate = GetEffectiveMaxRate();
-        if (effectiveMaxRate <= 0)
-            return 0;
-
-        var sanctionedSeconds = Math.Max(
-            _lastNormalRttFloorSeconds,
-            _hasMinRttSample ? _minRttSeconds : 0);
-        var standingSeconds = UnackedBytes / effectiveMaxRate;
-        return Math.Max(0, standingSeconds - sanctionedSeconds);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -996,8 +1028,6 @@ internal sealed class BrokerUnackedByteBudget
             var rttFloorSeconds = minRttProbeActive
                 ? MinRttProbeSafetyMultiplier * minRttSeconds
                 : RttSafetyMultiplier * loadAwareRttSeconds;
-            if (!minRttProbeActive)
-                _lastNormalRttFloorSeconds = rttFloorSeconds;
             var horizonSeconds = _hasMinRttSample
                 ? Math.Max(latencyGovernedTargetSeconds, rttFloorSeconds)
                 : latencyGovernedTargetSeconds;

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -92,6 +92,8 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i < 6; i++)
         {
             now += Seconds(0.110);
+            // Sender-backlog shrink requires the wire to demonstrably carry the budget.
+            budget.ObserveWrittenUnackedBytes(8_000);
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
@@ -162,6 +164,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i < 6; i++)
         {
             now += Seconds(0.110);
+            budget.ObserveWrittenUnackedBytes(8_000);
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
@@ -876,15 +879,43 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task StandingQueueDelayAboveTarget_ShrinksLatencyScale()
+    public async Task BrokerQueueDelayAboveTarget_ShrinksLatencyScale()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 32_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
-        budget.Charge(100_000); // 100ms of standing queue at 1 MB/s — 10x the target.
 
+        // Batches leave the sender 2ms after sealing but sit 50ms at the broker: latency the
+        // seal-to-send sample cannot see. No wire-occupancy evidence is required — broker
+        // queueing always responds to admission.
+        var now = T0;
+        for (var i = 0; i < 6; i++)
+        {
+            now += Seconds(0.110);
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.050),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.052));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.5)
+            .Because("seal-to-ack beyond the base round trip is queueing the budget controls");
+    }
+
+    [Test]
+    public async Task SendLoopBacklog_WithoutWireOccupancy_DoesNotShrinkScale()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        // 19ms of seal-to-send backlog with an empty wire: the send loop, not broker
+        // admission, is the bottleneck. Shrinking would starve the sender below capacity.
         var now = T0;
         for (var i = 0; i < 6; i++)
         {
@@ -892,13 +923,67 @@ public sealed class BrokerUnackedByteBudgetTests
             var snapshot = budget.SnapshotDelivery(
                 now - Seconds(0.001),
                 appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.020));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001)
+            .Because("sender backlog with an underfilled wire is not actionable by admission");
+    }
+
+    [Test]
+    public async Task AdmissionPressureWithLatencyHeadroom_GrowsBudgetBeyondRateParity()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+
+        // The drain estimate only ever measures traffic the gate admitted, so rate x target
+        // is self-confirming at any throughput (#2008). Blocked demand with latency headroom
+        // must grow the budget past that parity so real capacity can be discovered.
+        var now = T0;
+        for (var i = 0; i < 30; i++)
+        {
+            now += Seconds(0.110);
+            budget.RecordAdmissionBlock();
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
                 oldestBatchTimestamp: now - Seconds(0.002));
             Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
-        budget.Release(100_000);
 
-        await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.5)
-            .Because("bytes queued beyond the socket are latency the seal-to-send sample cannot see");
+        await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(1.5);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(15_000);
+    }
+
+    [Test]
+    public async Task LatencyBudgetScale_IsBoundedAboveByCeiling()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0;
+        for (var i = 0; i < 80; i++)
+        {
+            now += Seconds(0.110);
+            budget.RecordAdmissionBlock();
+            var snapshot = budget.SnapshotDelivery(
+                now - Seconds(0.001),
+                appLimited: true,
+                oldestBatchTimestamp: now - Seconds(0.002));
+            Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        }
+
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(10.0).Within(0.000_001)
+            .Because("a stale-high scale must stay within a short shrink-back window");
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(100_000);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #2008. **Stacked on #2019** (base branch = `fix/2009-unacked-budget-rtt-ratchet`; retarget to `main` when #2019 merges) — both PRs rework the same governor and #2008's growth mechanism depends on #2019's honest (queue-corrected) RTT sensing for its shrink signal.

## Problem

Run [29254448922](https://github.com/thomhurst/Dekaf/actions/runs/29254448922): 1-broker producer throughput halved (~1.6M → ~830k msg/s, scenario-independent; acks-all 0.69x Confluent) with buffer 2-4% full and <1 core in use. The budget was feed-forward `R̂ × target` where R̂ is measured from acks of traffic the gate itself admitted — self-confirming at any throughput level. After cold start collapsed it, nothing could climb back: the scale governor was capped at 1.0, capacity probes are structurally broken (#2010), and the seal→send-only latency sensor slammed the scale to 0.10 on a CPU-bound sender (shrinking admission can't drain a sender-side backlog; it only starves throughput).

## Fix

1. **Upward force: scale ceiling 1.0 → 10.0.** The existing MIMD controller already grows 1.05×/100ms on blocked-demand-with-headroom; the parity clamp was the blocker. Growth is gated on admission blocks (idle producers unaffected) and decelerates as measured latency approaches target — the target becomes a true setpoint the budget climbs toward capacity.
2. **Control on measured seal→ack − queue-drained base RTT.** Replaces the bytes-derived standing-delay term from #2019: `unacked/R̂` always reads ≈ horizon under a binding gate (circular), so it can't see headroom; direct measurement can (the run itself measured p50 1.65ms against a 10ms target while throughput was halved). Subtracting the honest base RTT (queue-corrected minimum from #2019) keeps the #1988 high-RTT guard: latency admission cannot reduce is never charged to the controller.
3. **Shrink discrimination (issue item 4).** Broker-side queueing (seal→ack beyond base RTT) always shrinks — it responds to admission. Seal→send backlog shrinks only when written-unacked occupancy shows the wire carrying ≥ half the budget; backlog with an underfilled wire means the send loop is the bottleneck (the 1b collapse mode).
4. **Budget floor deliberately NOT restored** (issue item 2): the depth-1 equilibrium is escaped by growth instead, avoiding the fan-out standing-latency hazard the `floorBytes: 1` comment documents (fixed per-broker byte floor × many low-rate brokers).

## Why this doesn't reignite #2009's 3-broker ratchet

Growth stops when `sealToAck − minRtt ≥ target`, i.e. standing latency ≈ base + target (~15ms at 10ms target on 3b acks=all) — inside the p50 ≤ 2× Confluent gate — and the #2019 clamp/probe/decay guards remain underneath. The overshoot window of a stale-high scale is ~0.8s (0.75×/100ms shrink from ceiling).

## Tests

New: growth-beyond-parity, scale ceiling bound, sender-backlog-no-shrink (wire empty), broker-queue-shrink (replaces the standing-delay test). Updated: shrink tests now supply wire-occupancy evidence. Full suite 5,399: pass ×2 (one occurrence of the known pre-existing #2018 flake, unrelated).

## Validation gate

Same dual gate as #2019 (inversion history #1843/#1988/#2009): a stress run must hold **1-broker FnF/acks-all/idempotent ≥ baseline band** (this PR's target: recover toward ≥1.4M FnF) **and 3-broker p95 ≤ 3× target** simultaneously. Companion issue #2010 (probe timescale/statistic) remains open — probes are now secondary to scale growth but still worth fixing for estimator-dip recovery.
