### PR TITLE
perf(producer): restore request coalescing

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -471,6 +471,41 @@ def format_connection_scale_timeline(results, title):
     return lines
 
 
+def format_producer_request_diagnostics(results, title):
+    """Show per-broker ProduceRequest rate and average size so fragmentation is visible."""
+    rows = [
+        (result, diagnostic)
+        for result in results
+        for diagnostic in (
+            (result.get('producerDeliveryDiagnostics') or {}).get('brokerProduceRequests') or []
+        )
+    ]
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: (row[0].get('client', ''), row[1].get('brokerId', 0)))
+    lines = [
+        f"## Producer Request Diagnostics - {title}",
+        "",
+        "| Client | Broker | Requests | Requests/s | Avg bytes/request |",
+        "|--------|-------:|---------:|-----------:|------------------:|",
+    ]
+    for result, diagnostic in rows:
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {diagnostic.get('brokerId', '-')} | "
+            f"{diagnostic.get('requestCount', 0):,} | "
+            f"{diagnostic.get('requestsPerSecond', 0):.2f} | "
+            f"{format_bytes(diagnostic.get('averageRequestBytes', 0))} |"
+        )
+
+    lines.extend([
+        "",
+        "*Average bytes/request is Kafka ProduceRequest body bytes; smaller requests at higher request rates indicate batching fragmentation.*",
+        "",
+    ])
+    return lines
+
+
 def format_latency_outlier_timeline(results, title):
     """Correlate sampled delivery stalls with scaling, throughput, and GC."""
     rows = [
@@ -758,6 +793,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
             output.extend(format_connection_scale_timeline(scenario_results, title))
+            output.extend(format_producer_request_diagnostics(scenario_results, title))
             output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -3,6 +3,7 @@ import unittest
 from stress_report import (
     format_roundtrip_validation_table,
     format_connection_scale_timeline,
+    format_producer_request_diagnostics,
     format_throughput_table,
     generate_scenario_tables,
     intra_run_throughput,
@@ -35,6 +36,22 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 
 
 class StressReportTests(unittest.TestCase):
+    def test_producer_request_diagnostics_surface_per_broker_fragmentation(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["producerDeliveryDiagnostics"] = {
+            "brokerProduceRequests": [{
+                "brokerId": 1,
+                "requestCount": 2500,
+                "requestsPerSecond": 500,
+                "averageRequestBytes": 262144,
+            }]
+        }
+
+        report = "\n".join(format_producer_request_diagnostics([value], "Producer"))
+
+        self.assertIn("Producer Request Diagnostics - Producer", report)
+        self.assertIn("| Dekaf | 1 | 2,500 | 500.00 | 256.00 KB |", report)
+
     def test_connection_scale_timeline_correlates_nearest_throughput_sample(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value["throughput"]["intervalSamples"] = [

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -113,6 +113,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     // dispatch must not implicitly add the wider throughput-oriented coalescing delay.
     private const int WaveCoalesceQuietMicroseconds = 1000;
     private const int WaveCoalesceMaxMicroseconds = 2000;
+    private const int WaveCoalesceLingerDivisor = 5;
     private const int ZeroLingerWaveCoalesceQuietMicroseconds = 75;
     private const int ZeroLingerWaveCoalesceMaxMicroseconds = 500;
 
@@ -1066,9 +1067,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Sum individually framed batch sizes, matching RecordAccumulator.Drain's
         // conservative request budget across batches from separate drain passes.
         var coalescedRequestBudgetUsed = 0L;
-        var waveCoalesceBounds = SelectWaveCoalesceBounds(
-            _options.LingerMs,
-            _options.DeliveryLatencyTargetMs);
+        var waveCoalesceBounds = SelectWaveCoalesceBounds(_options.LingerMs);
         var waveCoalesceMaxTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.MaximumMicroseconds);
         var waveCoalesceQuietTicks = MicrosecondsToStopwatchTicks(waveCoalesceBounds.QuietMicroseconds);
         var waveCoalesceArmed = true;
@@ -1349,7 +1348,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && coalescedCount < maxCoalesce
                     && coalescedPartitions.Count < _knownPartitions.Count
                     && carryOver.Count == 0
-                    && waveCoalesceGate.ShouldSpin()
+                    && waveCoalesceGate.ShouldSpin(Stopwatch.GetTimestamp())
                     && ShouldMicroLinger(
                         coalescedBatches,
                         coalescedCount,
@@ -1400,7 +1399,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         }
                     }
 
-                    waveCoalesceGate.OnSpinCompleted(coalescedCount > coalescedCountBeforeSpin);
+                    waveCoalesceGate.OnSpinCompleted(
+                        coalescedCount > coalescedCountBeforeSpin,
+                        Stopwatch.GetTimestamp());
                 }
 
                 // ── 6. Send or wait ──
@@ -1759,7 +1760,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 if (sentThisIteration)
                 {
                     waveCoalesceArmed = true;
-                    waveCoalesceGate.OnSent();
                 }
 
                 // ── 7. Compute timeout and wait ──
@@ -2232,22 +2232,21 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
 
-    internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(
-        int lingerMs,
-        int deliveryLatencyTargetMs)
+    internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(int lingerMs)
     {
-        (int QuietMicroseconds, int MaximumMicroseconds) bounds = lingerMs == 0
-            ? (ZeroLingerWaveCoalesceQuietMicroseconds, ZeroLingerWaveCoalesceMaxMicroseconds)
-            : (WaveCoalesceQuietMicroseconds, WaveCoalesceMaxMicroseconds);
-        if (deliveryLatencyTargetMs <= 0)
-            return bounds;
+        if (lingerMs == 0)
+            return (ZeroLingerWaveCoalesceQuietMicroseconds, ZeroLingerWaveCoalesceMaxMicroseconds);
 
-        var targetMicroseconds = (long)deliveryLatencyTargetMs * 1_000;
-        var quietCap = Math.Max(1, targetMicroseconds / 20);
-        var maximumCap = Math.Max(quietCap, targetMicroseconds / 10);
-        return (
-            (int)Math.Min(bounds.QuietMicroseconds, quietCap),
-            (int)Math.Min(bounds.MaximumMicroseconds, maximumCap));
+        var lingerMicroseconds = (long)lingerMs * 1_000;
+        var quietMicroseconds = Math.Clamp(
+            lingerMicroseconds / WaveCoalesceLingerDivisor,
+            1,
+            WaveCoalesceQuietMicroseconds);
+        var maximumMicroseconds = Math.Clamp(
+            lingerMicroseconds * 2 / WaveCoalesceLingerDivisor,
+            quietMicroseconds,
+            WaveCoalesceMaxMicroseconds);
+        return ((int)quietMicroseconds, (int)maximumMicroseconds);
     }
 
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
@@ -3454,7 +3453,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 // Build coalesced ProduceRequest (reuses pre-allocated scratch structures)
                 var request = scratch.Build(batches, generations, count);
-                _accumulator.RecordProduceRequest(count);
+                _accumulator.RecordProduceRequest(_brokerId, count, request.RequestBodySizeHint);
 
                 // Handle Acks.None (fire-and-forget)
                 if (_options.Acks == Acks.None)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -268,12 +268,21 @@ internal sealed class ProducerDeliveryDiagnosticsSnapshot
     public long ProduceRequestCount { get; init; }
     public double ProduceRequestElapsedSeconds { get; init; }
     public double ProduceRequestsPerSecond { get; init; }
+    public List<ProducerBrokerRequestDiagnostic> BrokerProduceRequests { get; init; } = [];
     public List<ProducerCoalesceWidthDiagnostic> CoalesceWidthHistogram { get; init; } = [];
     public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgets { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgetSamples { get; init; } = [];
     public List<ConnectionReapDiagnostic> ConnectionReapEvents { get; init; } = [];
     public List<ProducerConnectionScaleDiagnostic> ConnectionScaleEvents { get; init; } = [];
+}
+
+internal sealed class ProducerBrokerRequestDiagnostic
+{
+    public required int BrokerId { get; init; }
+    public required long RequestCount { get; init; }
+    public required double RequestsPerSecond { get; init; }
+    public required double AverageRequestBytes { get; init; }
 }
 
 internal sealed class ProducerCoalesceWidthDiagnostic

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1044,6 +1044,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly List<ProducerConnectionScaleDiagnostic> _connectionScaleEvents = [];
     private readonly List<ProducerBrokerBudgetDiagnostic> _brokerBudgetSamples = [];
     private readonly long[]? _coalesceWidthCounts;
+    private readonly ConcurrentDictionary<int, ProducerRequestDiagnosticCounters>? _brokerProduceRequestCounters;
     private long _produceRequestCount;
     private long _produceRequestDiagnosticsStartedAt;
     private long _nextBrokerBudgetDiagnosticTimestampMs;
@@ -2070,6 +2071,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (options.EnableDeliveryDiagnostics)
         {
             _coalesceWidthCounts = new long[MaxTrackedCoalesceWidth + 2];
+            _brokerProduceRequestCounters = new ConcurrentDictionary<int, ProducerRequestDiagnosticCounters>();
             _produceRequestDiagnosticsStartedAt = Stopwatch.GetTimestamp();
         }
 
@@ -4810,6 +4812,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             });
         }
 
+        foreach (var (brokerId, counters) in _brokerProduceRequestCounters!.OrderBy(entry => entry.Key))
+        {
+            var requestCount = Interlocked.Read(ref counters.RequestCount);
+            if (requestCount == 0)
+                continue;
+
+            var requestBytes = Interlocked.Read(ref counters.RequestBytes);
+            snapshot.BrokerProduceRequests.Add(new ProducerBrokerRequestDiagnostic
+            {
+                BrokerId = brokerId,
+                RequestCount = requestCount,
+                RequestsPerSecond = produceRequestElapsedSeconds > 0
+                    ? requestCount / produceRequestElapsedSeconds
+                    : 0,
+                AverageRequestBytes = requestBytes / (double)requestCount
+            });
+        }
+
         var capturedAtUtc = snapshot.CapturedAtUtc;
         foreach (var (brokerId, budget) in _brokerUnackedBudgets)
             snapshot.BrokerBudgets.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc, includeHistograms: true));
@@ -4827,7 +4847,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void RecordProduceRequest(int coalesceWidth)
+    internal void RecordProduceRequest(int brokerId, int coalesceWidth, int requestBytes)
     {
         var widthCounts = _coalesceWidthCounts;
         if (widthCounts is null)
@@ -4835,6 +4855,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         Interlocked.Increment(ref _produceRequestCount);
         Interlocked.Increment(ref widthCounts[Math.Min(coalesceWidth, MaxTrackedCoalesceWidth + 1)]);
+        var counters = _brokerProduceRequestCounters!.GetOrAdd(
+            brokerId,
+            static _ => new ProducerRequestDiagnosticCounters());
+        Interlocked.Increment(ref counters.RequestCount);
+        Interlocked.Add(ref counters.RequestBytes, requestBytes);
     }
 
     internal void ResetProduceRequestDiagnostics()
@@ -4846,7 +4871,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         Interlocked.Exchange(ref _produceRequestCount, 0);
         for (var width = 1; width < widthCounts.Length; width++)
             Interlocked.Exchange(ref widthCounts[width], 0);
+        foreach (var counters in _brokerProduceRequestCounters!.Values)
+        {
+            Interlocked.Exchange(ref counters.RequestCount, 0);
+            Interlocked.Exchange(ref counters.RequestBytes, 0);
+        }
         Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
+    }
+
+    private sealed class ProducerRequestDiagnosticCounters
+    {
+        public long RequestCount;
+        public long RequestBytes;
     }
 
     internal void RecordConnectionScaleEvent(

--- a/src/Dekaf/Producer/WaveCoalesceGate.cs
+++ b/src/Dekaf/Producer/WaveCoalesceGate.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Dekaf.Producer;
 
 /// <summary>
@@ -6,9 +8,9 @@ namespace Dekaf.Producer;
 /// arrives; on workloads whose requests are effectively single-partition (large batches,
 /// few partitions per broker) that wait is pure CPU burn on every wave. After
 /// <see cref="FruitlessSpinSuppressThreshold"/> consecutive spins that coalesced nothing,
-/// the gate closes and only re-opens for a single probe spin every
-/// <see cref="SuppressedReprobeSendInterval"/> sends, so a workload shift back toward
-/// coalescible waves is still detected quickly.
+/// the gate closes and only re-opens for a probe after a short time interval. Time-based
+/// recovery lets a low-rate workload probe on its next wave instead of remaining suppressed
+/// for an arbitrarily long fixed number of sends.
 /// </summary>
 internal struct WaveCoalesceGate
 {
@@ -19,43 +21,39 @@ internal struct WaveCoalesceGate
     internal const int FruitlessSpinSuppressThreshold = 8;
 
     /// <summary>
-    /// Sends between probe spins while suppressed. Keeps steady-state waste to one quiet
-    /// window per this many waves (&lt;0.1% of a core at millisecond wave cadence) while
-    /// re-detecting coalescible workloads within one interval.
+    /// Minimum time between probe spins while suppressed. Keeps steady-state spin cost bounded
+    /// under high request rates while allowing the first wave after a low-rate idle period to
+    /// detect a workload shift immediately.
     /// </summary>
-    internal const int SuppressedReprobeSendInterval = 64;
+    internal static readonly long SuppressedReprobeIntervalTicks = Math.Max(1, Stopwatch.Frequency / 20);
 
     private int _consecutiveFruitlessSpins;
-    private int _sendsSinceSuppressed;
+    private long _nextProbeTimestamp;
 
     private readonly bool IsSuppressed => _consecutiveFruitlessSpins >= FruitlessSpinSuppressThreshold;
 
     /// <summary>Whether the next wave may enter the coalesce spin.</summary>
-    public readonly bool ShouldSpin()
-        => !IsSuppressed || _sendsSinceSuppressed >= SuppressedReprobeSendInterval;
+    public readonly bool ShouldSpin(long nowTicks)
+        => !IsSuppressed || nowTicks >= _nextProbeTimestamp;
 
     /// <summary>
     /// Records the outcome of a spin permitted by <see cref="ShouldSpin"/>.
     /// A spin that coalesced at least one additional batch re-opens the gate.
     /// </summary>
-    public void OnSpinCompleted(bool coalescedAdditionalBatch)
+    public void OnSpinCompleted(bool coalescedAdditionalBatch, long nowTicks)
     {
         if (coalescedAdditionalBatch)
         {
             _consecutiveFruitlessSpins = 0;
+            _nextProbeTimestamp = 0;
         }
-        else if (!IsSuppressed)
+        else
         {
-            _consecutiveFruitlessSpins++;
+            if (!IsSuppressed)
+                _consecutiveFruitlessSpins++;
+
+            if (IsSuppressed)
+                _nextProbeTimestamp = nowTicks + SuppressedReprobeIntervalTicks;
         }
-
-        _sendsSinceSuppressed = 0;
-    }
-
-    /// <summary>Advances the probe schedule while suppressed. Call once per completed send pass.</summary>
-    public void OnSent()
-    {
-        if (IsSuppressed)
-            _sendsSinceSuppressed++;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -172,20 +172,21 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
-    public async Task SelectWaveCoalesceBounds_ZeroLingerRetainsLowLatencyBounds()
+    public async Task SelectWaveCoalesceBounds_ScalesWithLingerAndRetainsHardCaps()
     {
-        var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0, deliveryLatencyTargetMs: 10);
-        var configuredLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 5, deliveryLatencyTargetMs: 10);
-        var oneMillisecondTarget = BrokerSender.SelectWaveCoalesceBounds(
-            lingerMs: 5,
-            deliveryLatencyTargetMs: 1);
+        var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);
+        var oneMillisecondLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 1);
+        var configuredLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 5);
+        var longLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 20);
 
         await Assert.That(zeroLinger.QuietMicroseconds).IsEqualTo(75);
         await Assert.That(zeroLinger.MaximumMicroseconds).IsEqualTo(500);
-        await Assert.That(configuredLinger.QuietMicroseconds).IsEqualTo(500);
-        await Assert.That(configuredLinger.MaximumMicroseconds).IsEqualTo(1_000);
-        await Assert.That(oneMillisecondTarget.QuietMicroseconds).IsEqualTo(50);
-        await Assert.That(oneMillisecondTarget.MaximumMicroseconds).IsEqualTo(100);
+        await Assert.That(oneMillisecondLinger.QuietMicroseconds).IsEqualTo(200);
+        await Assert.That(oneMillisecondLinger.MaximumMicroseconds).IsEqualTo(400);
+        await Assert.That(configuredLinger.QuietMicroseconds).IsEqualTo(1_000);
+        await Assert.That(configuredLinger.MaximumMicroseconds).IsEqualTo(2_000);
+        await Assert.That(longLinger.QuietMicroseconds).IsEqualTo(1_000);
+        await Assert.That(longLinger.MaximumMicroseconds).IsEqualTo(2_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -8,15 +8,15 @@ public sealed class ProducerDeliveryDiagnosticsTests
     private static ProducerOptions CreateOptions(
         bool enableDeliveryDiagnostics = false,
         int deliveryLatencyTargetMs = 0) => new()
-    {
-        BootstrapServers = ["localhost:9092"],
-        ClientId = "diagnostics-test",
-        BufferMemory = ulong.MaxValue,
-        BatchSize = 60,
-        LingerMs = 10_000,
-        EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
-        DeliveryLatencyTargetMs = deliveryLatencyTargetMs
-    };
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "diagnostics-test",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 60,
+            LingerMs = 10_000,
+            EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
+            DeliveryLatencyTargetMs = deliveryLatencyTargetMs
+        };
 
     [Test]
     public async Task SnapshotDeliveryDiagnostics_DefaultDisabled_ReturnsDisabledSnapshot()
@@ -95,17 +95,24 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await using var accumulator = new RecordAccumulator(
             CreateOptions(enableDeliveryDiagnostics: true));
 
-        accumulator.RecordProduceRequest(coalesceWidth: 1);
-        accumulator.RecordProduceRequest(coalesceWidth: 2);
-        accumulator.RecordProduceRequest(coalesceWidth: 2);
-        accumulator.RecordProduceRequest(coalesceWidth: 65);
-        accumulator.RecordProduceRequest(coalesceWidth: 100);
+        accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 1, requestBytes: 100);
+        accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 2, requestBytes: 300);
+        accumulator.RecordProduceRequest(brokerId: 2, coalesceWidth: 2, requestBytes: 1_000);
+        accumulator.RecordProduceRequest(brokerId: 2, coalesceWidth: 65, requestBytes: 1_000);
+        accumulator.RecordProduceRequest(brokerId: 2, coalesceWidth: 100, requestBytes: 1_000);
 
         var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
 
         await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(5);
         await Assert.That(snapshot.ProduceRequestElapsedSeconds).IsGreaterThanOrEqualTo(0);
         await Assert.That(snapshot.ProduceRequestsPerSecond).IsGreaterThanOrEqualTo(0);
+        var broker1 = snapshot.BrokerProduceRequests.Single(diagnostic => diagnostic.BrokerId == 1);
+        var broker2 = snapshot.BrokerProduceRequests.Single(diagnostic => diagnostic.BrokerId == 2);
+        await Assert.That(broker1.RequestCount).IsEqualTo(2);
+        await Assert.That(broker1.RequestsPerSecond).IsGreaterThanOrEqualTo(0);
+        await Assert.That(broker1.AverageRequestBytes).IsEqualTo(200);
+        await Assert.That(broker2.RequestCount).IsEqualTo(3);
+        await Assert.That(broker2.AverageRequestBytes).IsEqualTo(1_000);
         await Assert.That(snapshot.CoalesceWidthHistogram.Single(bucket => bucket.MinimumWidth == 1).RequestCount)
             .IsEqualTo(1);
         await Assert.That(snapshot.CoalesceWidthHistogram.Single(bucket => bucket.MinimumWidth == 2).RequestCount)
@@ -120,17 +127,19 @@ public sealed class ProducerDeliveryDiagnosticsTests
     {
         await using var accumulator = new RecordAccumulator(
             CreateOptions(enableDeliveryDiagnostics: true));
-        accumulator.RecordProduceRequest(coalesceWidth: 4);
+        accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 4, requestBytes: 400);
 
         accumulator.ResetProduceRequestDiagnostics();
         var reset = accumulator.GetDeliveryDiagnosticsSnapshot();
-        accumulator.RecordProduceRequest(coalesceWidth: 3);
+        accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 3, requestBytes: 300);
         var afterRequest = accumulator.GetDeliveryDiagnosticsSnapshot();
 
         await Assert.That(reset.ProduceRequestCount).IsEqualTo(0);
         await Assert.That(reset.CoalesceWidthHistogram).IsEmpty();
+        await Assert.That(reset.BrokerProduceRequests).IsEmpty();
         await Assert.That(afterRequest.ProduceRequestCount).IsEqualTo(1);
         await Assert.That(afterRequest.CoalesceWidthHistogram.Single().MinimumWidth).IsEqualTo(3);
+        await Assert.That(afterRequest.BrokerProduceRequests.Single().AverageRequestBytes).IsEqualTo(300);
     }
 
     [Test]
@@ -138,11 +147,12 @@ public sealed class ProducerDeliveryDiagnosticsTests
     {
         await using var accumulator = new RecordAccumulator(CreateOptions());
 
-        accumulator.RecordProduceRequest(coalesceWidth: 2);
+        accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 2, requestBytes: 200);
         var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
 
         await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(0);
         await Assert.That(snapshot.CoalesceWidthHistogram).IsEmpty();
+        await Assert.That(snapshot.BrokerProduceRequests).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/WaveCoalesceGateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/WaveCoalesceGateTests.cs
@@ -9,7 +9,7 @@ public class WaveCoalesceGateTests
     {
         var gate = new WaveCoalesceGate();
 
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(nowTicks: 0)).IsTrue();
     }
 
     [Test]
@@ -18,9 +18,9 @@ public class WaveCoalesceGateTests
         var gate = new WaveCoalesceGate();
 
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold - 1; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(nowTicks: 0)).IsTrue();
     }
 
     [Test]
@@ -29,9 +29,9 @@ public class WaveCoalesceGateTests
         var gate = new WaveCoalesceGate();
 
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        await Assert.That(gate.ShouldSpin()).IsFalse();
+        await Assert.That(gate.ShouldSpin(nowTicks: 0)).IsFalse();
     }
 
     [Test]
@@ -39,47 +39,41 @@ public class WaveCoalesceGateTests
     {
         var gate = new WaveCoalesceGate();
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold - 1; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        gate.OnSpinCompleted(coalescedAdditionalBatch: true);
-        gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+        gate.OnSpinCompleted(coalescedAdditionalBatch: true, nowTicks: 0);
+        gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(nowTicks: 0)).IsTrue();
     }
 
     [Test]
-    public async Task SuppressedGate_ReopensForProbe_AfterReprobeSendInterval()
+    public async Task SuppressedGate_ReopensForProbe_AfterReprobeTimeInterval()
     {
         var gate = new WaveCoalesceGate();
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval - 1; i++)
-            gate.OnSent();
-        await Assert.That(gate.ShouldSpin()).IsFalse();
+        await Assert.That(gate.ShouldSpin(WaveCoalesceGate.SuppressedReprobeIntervalTicks - 1)).IsFalse();
 
-        gate.OnSent();
-
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(WaveCoalesceGate.SuppressedReprobeIntervalTicks)).IsTrue();
     }
 
     [Test]
-    public async Task FruitlessProbe_ResuppressesForAnotherFullInterval()
+    public async Task FruitlessProbe_ResuppressesUntilAnotherTimeIntervalPasses()
     {
         var gate = new WaveCoalesceGate();
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
-        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval; i++)
-            gate.OnSent();
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
+        var firstProbeAt = WaveCoalesceGate.SuppressedReprobeIntervalTicks;
 
-        gate.OnSpinCompleted(coalescedAdditionalBatch: false);
+        gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: firstProbeAt);
 
-        await Assert.That(gate.ShouldSpin()).IsFalse();
-        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval - 1; i++)
-            gate.OnSent();
-        await Assert.That(gate.ShouldSpin()).IsFalse();
-        gate.OnSent();
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(firstProbeAt)).IsFalse();
+        await Assert.That(gate.ShouldSpin(firstProbeAt + WaveCoalesceGate.SuppressedReprobeIntervalTicks - 1))
+            .IsFalse();
+        await Assert.That(gate.ShouldSpin(firstProbeAt + WaveCoalesceGate.SuppressedReprobeIntervalTicks))
+            .IsTrue();
     }
 
     [Test]
@@ -87,14 +81,13 @@ public class WaveCoalesceGateTests
     {
         var gate = new WaveCoalesceGate();
         for (var i = 0; i < WaveCoalesceGate.FruitlessSpinSuppressThreshold; i++)
-            gate.OnSpinCompleted(coalescedAdditionalBatch: false);
-        for (var i = 0; i < WaveCoalesceGate.SuppressedReprobeSendInterval; i++)
-            gate.OnSent();
+            gate.OnSpinCompleted(coalescedAdditionalBatch: false, nowTicks: 0);
 
-        gate.OnSpinCompleted(coalescedAdditionalBatch: true);
+        gate.OnSpinCompleted(
+            coalescedAdditionalBatch: true,
+            nowTicks: WaveCoalesceGate.SuppressedReprobeIntervalTicks);
 
-        await Assert.That(gate.ShouldSpin()).IsTrue();
-        gate.OnSent();
-        await Assert.That(gate.ShouldSpin()).IsTrue();
+        await Assert.That(gate.ShouldSpin(WaveCoalesceGate.SuppressedReprobeIntervalTicks)).IsTrue();
+        await Assert.That(gate.ShouldSpin(long.MaxValue)).IsTrue();
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -210,6 +210,16 @@ public sealed class ConnectionScaleReportingTests
                 ProduceRequestCount = 2_500,
                 ProduceRequestElapsedSeconds = 5,
                 ProduceRequestsPerSecond = 500,
+                BrokerProduceRequests =
+                [
+                    new ProducerBrokerRequestDiagnostic
+                    {
+                        BrokerId = 1,
+                        RequestCount = 2_500,
+                        RequestsPerSecond = 500,
+                        AverageRequestBytes = 262_144
+                    }
+                ],
                 CoalesceWidthHistogram =
                 [
                     new ProducerCoalesceWidthDiagnostic
@@ -257,6 +267,8 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("75%");
         await Assert.That(markdown).Contains("120/340");
         await Assert.That(markdown).Contains("6.0s / 2,500 msg/s");
+        await Assert.That(markdown).Contains("Producer Request Diagnostics - Fire-and-Forget");
+        await Assert.That(markdown).Contains("| Dekaf | 1 | 2,500 | 500.00 | 256.0 KiB |");
         await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
         await Assert.That(markdown).Contains("42");
         await Assert.That(markdown).Contains("connection transition");
@@ -269,6 +281,7 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("3 additional latency outlier sample(s) exceeded the bounded diagnostic capacity");
         await Assert.That(json).Contains("\"produceRequestCount\": 2500");
         await Assert.That(json).Contains("\"produceRequestsPerSecond\": 500");
+        await Assert.That(json).Contains("\"averageRequestBytes\": 262144");
         await Assert.That(json).Contains("\"coalesceWidthHistogram\"");
         await Assert.That(json).Contains("\"requestCount\": 2000");
     }

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -30,6 +30,7 @@ internal static class MarkdownReporter
 
             GenerateThroughputTable(sb, title, groupResults);
             GenerateConnectionScaleTimeline(sb, groupResults, label);
+            GenerateProducerRequestDiagnostics(sb, groupResults, label);
             GenerateConsumerFetchTimeline(sb, groupResults, label);
             GenerateLatencyOutlierTimeline(sb, groupResults, label);
 
@@ -219,6 +220,37 @@ internal static class MarkdownReporter
         }
 
         return sampled;
+    }
+
+    private static void GenerateProducerRequestDiagnostics(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BrokerProduceRequests ?? [])
+                .Select(diagnostic => (Result: result, Diagnostic: diagnostic)))
+            .OrderBy(row => row.Result.Client)
+            .ThenBy(row => row.Diagnostic.BrokerId)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        sb.AppendLine($"## Producer Request Diagnostics - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Broker | Requests | Requests/s | Avg bytes/request |");
+        sb.AppendLine("|--------|-------:|---------:|-----------:|------------------:|");
+        foreach (var row in rows)
+        {
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Diagnostic.BrokerId} | " +
+                $"{row.Diagnostic.RequestCount:N0} | {row.Diagnostic.RequestsPerSecond:F2} | " +
+                $"{FormatDiagnosticBytes(row.Diagnostic.AverageRequestBytes)} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("*Average bytes/request is Kafka ProduceRequest body bytes; smaller requests at higher request rates indicate batching fragmentation.*");
+        sb.AppendLine();
     }
 
     private static void GenerateConsumerFetchTimeline(


### PR DESCRIPTION
## Summary
- scale post-seal wave coalescing from configured linger while preserving 1ms/2ms hard caps and zero-linger bounds
- replace fixed 64-send suppression recovery with a 50ms time-based probe cadence
- publish per-broker ProduceRequest rate and average body size in both stress report paths

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- [x] focused wave-coalesce, diagnostics, and report tests (27 passed)
- [x] `python -m unittest test_stress_report.py` (17 passed)
- [x] full net10 unit suite: 5,390 passed; one known #2018 pool-order race failed
- [ ] validate 15-minute producer acceptance gates in next stress workflow run

Closes #2011
