### PR TITLE
Publish consumer fetch diagnostics

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -1,7 +1,7 @@
 """Shared utilities for stress test result reporting."""
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from math import isfinite
 from statistics import median
 
@@ -20,6 +20,7 @@ SCENARIO_TITLES = {
 }
 
 LATENCY_RATIO_THRESHOLD = 2.0
+MAX_TIMELINE_ROWS = 100
 
 
 def group_by_scenario(results):
@@ -506,6 +507,95 @@ def format_producer_request_diagnostics(results, title):
     return lines
 
 
+def _sample_evenly(rows, maximum_rows):
+    if len(rows) <= maximum_rows:
+        return rows
+
+    return [
+        rows[round(index * (len(rows) - 1) / (maximum_rows - 1))]
+        for index in range(maximum_rows)
+    ]
+
+
+def format_consumer_fetch_timeline(results, title):
+    """Correlate consumer fetch diagnostics with throughput and connection reaps."""
+    rows = [
+        (result, sample)
+        for result in results
+        for sample in (result.get('consumerFetchDiagnostics') or {}).get('samples') or []
+    ]
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('capturedAtUtc', ''))
+    displayed_rows = _sample_evenly(rows, MAX_TIMELINE_ROWS)
+    omitted_rows = len(rows) - len(displayed_rows)
+    lines = [
+        f"## Consumer Fetch Timeline - {title}",
+        "",
+        "| Client | Interval end UTC | Fetch req/s | Bytes/fetch | Avg fetch RTT | Queues (pending / buffer / total) | Prefetched | Connection reaps | Nearest throughput |",
+        "|--------|------------------|------------:|------------:|--------------:|----------------------------------:|-----------:|-----------------:|-------------------:|",
+    ]
+
+    for result, sample in displayed_rows:
+        diagnostics = result.get('consumerFetchDiagnostics') or {}
+        captured_at = _parse_timestamp(sample.get('capturedAtUtc'))
+        timestamped_throughput = [
+            (throughput, timestamp)
+            for throughput in (result.get('throughput') or {}).get('intervalSamples') or []
+            if (timestamp := _parse_timestamp(throughput.get('capturedAtUtc'))) is not None
+        ]
+        nearest = min(
+            timestamped_throughput,
+            key=lambda item: abs((item[1] - captured_at).total_seconds()),
+            default=(None, None),
+        )[0] if captured_at is not None else None
+        throughput_text = '-'
+        if nearest is not None:
+            throughput_text = (
+                f"{nearest.get('elapsedSeconds', 0):.0f}s / "
+                f"{nearest.get('messagesPerSecond', 0):,.0f} msg/s"
+            )
+
+        interval_start = (
+            captured_at - timedelta(seconds=sample.get('intervalSeconds', 0))
+            if captured_at is not None else None
+        )
+        reaps = sum(
+            1
+            for reap in diagnostics.get('connectionReapEvents') or []
+            if interval_start is not None
+            and (occurred_at := _parse_timestamp(reap.get('occurredAtUtc'))) is not None
+            and interval_start < occurred_at <= captured_at
+        )
+        reap_text = '-' if reaps == 0 else f"{reaps} reap{'s' if reaps != 1 else ''}"
+        interval_end_text = (
+            captured_at.strftime('%H:%M:%S')
+            if captured_at is not None else sample.get('capturedAtUtc', '-')
+        )
+
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {interval_end_text} | "
+            f"{sample.get('fetchRequestsPerSecond', 0):.2f} | {format_bytes(sample.get('bytesPerFetch'))} | "
+            f"{sample.get('averageFetchRttMs', 0):.2f}ms | "
+            f"{sample.get('pendingFetchDepth', 0)} / {sample.get('prefetchBufferDepth', 0)} / "
+            f"{sample.get('prefetchDepth', 0)} | {format_bytes(sample.get('prefetchedBytes'))} | "
+            f"{reap_text} | {throughput_text} |"
+        )
+
+    if omitted_rows > 0:
+        lines.append(
+            f"*{omitted_rows:,} fetch sample(s) omitted; rows sampled across the full timeline.*"
+        )
+
+    lines.extend([
+        "",
+        "*Bytes/fetch is consumed message payload bytes divided by completed fetch requests for the interval; queue depths are point-in-time samples.*",
+        "",
+    ])
+    return lines
+
+
 def format_latency_outlier_timeline(results, title):
     """Correlate sampled delivery stalls with scaling, throughput, and GC."""
     rows = [
@@ -794,6 +884,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
             output.extend(format_connection_scale_timeline(scenario_results, title))
             output.extend(format_producer_request_diagnostics(scenario_results, title))
+            output.extend(format_consumer_fetch_timeline(scenario_results, title))
             output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,6 +1,7 @@
 import unittest
 
 from stress_report import (
+    format_consumer_fetch_timeline,
     format_roundtrip_validation_table,
     format_connection_scale_timeline,
     format_producer_request_diagnostics,
@@ -51,6 +52,42 @@ class StressReportTests(unittest.TestCase):
 
         self.assertIn("Producer Request Diagnostics - Producer", report)
         self.assertIn("| Dekaf | 1 | 2,500 | 500.00 | 256.00 KB |", report)
+    def test_consumer_fetch_timeline_surfaces_published_diagnostics(self):
+        value = stress_result("Dekaf", effective_rate=2500)
+        value["scenario"] = "consumer"
+        value["throughput"]["intervalSamples"] = [{
+            "capturedAtUtc": "2026-07-13T10:01:00+00:00",
+            "elapsedSeconds": 60,
+            "messagesPerSecond": 2500,
+        }]
+        value["consumerFetchDiagnostics"] = {
+            "samples": [{
+                "capturedAtUtc": "2026-07-13T10:01:00+00:00",
+                "intervalSeconds": 60,
+                "fetchRequestsPerSecond": 2,
+                "bytesPerFetch": 524288,
+                "averageFetchRttMs": 7.5,
+                "pendingFetchDepth": 2,
+                "prefetchBufferDepth": 3,
+                "prefetchDepth": 5,
+                "prefetchedBytes": 8388608,
+            }],
+            "connectionReapEvents": [{
+                "occurredAtUtc": "2026-07-13T10:00:55+00:00",
+            }],
+        }
+
+        report = "\n".join(format_consumer_fetch_timeline([value], "Consumer"))
+        published_report = "\n".join(generate_scenario_tables([value]))
+
+        self.assertIn("Consumer Fetch Timeline - Consumer", report)
+        self.assertIn("512.00 KB", report)
+        self.assertIn("7.50ms", report)
+        self.assertIn("2 / 3 / 5", report)
+        self.assertIn("8.00 MB", report)
+        self.assertIn("1 reap", report)
+        self.assertIn("60s / 2,500 msg/s", report)
+        self.assertIn("Consumer Fetch Timeline - Consumer", published_report)
 
     def test_connection_scale_timeline_correlates_nearest_throughput_sample(self):
         value = stress_result("Dekaf", effective_rate=1400)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -28,7 +28,10 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     private CancellationTokenSource? _idleReaperCts;
     private Task? _idleReaperTask;
     private readonly object _connectionReapDiagnosticsLock = new();
-    private readonly List<ConnectionReapDiagnostic> _connectionReapEvents = [];
+    private readonly ConnectionReapDiagnostic?[] _connectionReapEvents =
+        new ConnectionReapDiagnostic?[MaxConnectionReapDiagnosticEvents];
+    private int _connectionReapEventCount;
+    private int _nextConnectionReapEventIndex;
 
     /// <summary>
     /// Process-shared memory pool for all clients with this size configuration. Bounds total
@@ -1289,7 +1292,20 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     internal List<ConnectionReapDiagnostic> GetConnectionReapDiagnosticsSnapshot()
     {
         lock (_connectionReapDiagnosticsLock)
-            return [.. _connectionReapEvents];
+        {
+            var snapshot = new List<ConnectionReapDiagnostic>(_connectionReapEventCount);
+            var startIndex = _connectionReapEventCount == MaxConnectionReapDiagnosticEvents
+                ? _nextConnectionReapEventIndex
+                : 0;
+
+            for (var i = 0; i < _connectionReapEventCount; i++)
+            {
+                var index = (startIndex + i) % MaxConnectionReapDiagnosticEvents;
+                snapshot.Add(_connectionReapEvents[index]!);
+            }
+
+            return snapshot;
+        }
     }
 
     IReadOnlyList<ConnectionReapDiagnostic> IConnectionPoolDiagnostics.GetConnectionReapDiagnosticsSnapshot() =>
@@ -1299,17 +1315,18 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     {
         lock (_connectionReapDiagnosticsLock)
         {
-            if (_connectionReapEvents.Count >= MaxConnectionReapDiagnosticEvents)
-                return;
-
-            _connectionReapEvents.Add(new ConnectionReapDiagnostic
+            _connectionReapEvents[_nextConnectionReapEventIndex] = new ConnectionReapDiagnostic
             {
                 OccurredAtUtc = DateTimeOffset.UtcNow,
                 BrokerId = brokerId,
                 ConnectionIndex = connectionIndex,
                 IdleDurationMs = idleDurationMs,
                 IsBootstrapConnection = brokerId < 0
-            });
+            };
+            _nextConnectionReapEventIndex =
+                (_nextConnectionReapEventIndex + 1) % MaxConnectionReapDiagnosticEvents;
+            if (_connectionReapEventCount < MaxConnectionReapDiagnosticEvents)
+                _connectionReapEventCount++;
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -577,7 +577,7 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task ConnectionReapDiagnostics_DropsEventsBeyond256()
+    public async Task ConnectionReapDiagnostics_RetainsMostRecent256Events()
     {
         var pool = new ConnectionPool(
             clientId: "test-client",
@@ -589,14 +589,14 @@ public sealed class ConnectionPoolTests
             var recordDiagnostic = typeof(ConnectionPool).GetMethod(
                 "RecordConnectionReapDiagnostic",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
-            for (var i = 0; i < 257; i++)
+            for (var i = 0; i < 513; i++)
                 recordDiagnostic.Invoke(pool, [i, 0, 1_000L + i]);
 
             var diagnostics = pool.GetConnectionReapDiagnosticsSnapshot();
 
             await Assert.That(diagnostics.Count).IsEqualTo(256);
-            await Assert.That(diagnostics[0].BrokerId).IsEqualTo(0);
-            await Assert.That(diagnostics[^1].BrokerId).IsEqualTo(255);
+            await Assert.That(diagnostics[0].BrokerId).IsEqualTo(257);
+            await Assert.That(diagnostics[^1].BrokerId).IsEqualTo(512);
         }
     }
 


### PR DESCRIPTION
## Summary
- render consumer fetch diagnostics in published stress reports
- correlate fetch samples with connection reaps and nearest throughput
- retain the latest 256 connection reap events in chronological order

## Test plan
- dotnet build tests/Dekaf.Tests.Unit --configuration Release --framework net10.0
- tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe (5,391 passed)
- python -m unittest test_stress_report.py (17 passed)

Closes #2016