### PR TITLE
Rethrow asynchronous completion-source faults

### DIFF
--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -46,6 +46,12 @@ internal static class DekafMetrics
             unit: "{exception}",
             description: "Exceptions isolated from inline transactional produce continuations.");
 
+    internal static readonly Counter<long> CompletionSourceFaults =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "dekaf.producer.completion_source.faults",
+            unit: "{fault}",
+            description: "Producer completion-source faults isolated while completing messages.");
+
     // Consumer metrics
     internal static readonly Counter<long> MessagesReceived =
         DekafDiagnostics.Meter.CreateCounter<long>(

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -34,6 +34,8 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     /// </summary>
     public short Version => _core.Version;
 
+    internal bool RunContinuationsAsynchronously => _core.RunContinuationsAsynchronously;
+
     /// <summary>
     /// Associates this source with a pool for automatic return on completion.
     /// </summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -415,6 +415,7 @@ internal static class ProducerContainerPools
 
 internal static class PooledCompletionSource
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TrySetResult(
         PooledValueTaskSource<RecordMetadata>? source,
         RecordMetadata metadata)
@@ -422,6 +423,16 @@ internal static class PooledCompletionSource
         if (source is null)
             return false;
 
+        return source.RunContinuationsAsynchronously
+            ? source.TrySetResult(metadata)
+            : TrySetResultInline(source, metadata);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetResultInline(
+        PooledValueTaskSource<RecordMetadata> source,
+        RecordMetadata metadata)
+    {
         try
         {
             return source.TrySetResult(metadata);
@@ -435,6 +446,7 @@ internal static class PooledCompletionSource
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TrySetException(
         PooledValueTaskSource<RecordMetadata>? source,
         Exception exception)
@@ -442,6 +454,16 @@ internal static class PooledCompletionSource
         if (source is null)
             return false;
 
+        return source.RunContinuationsAsynchronously
+            ? source.TrySetException(exception)
+            : TrySetExceptionInline(source, exception);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetExceptionInline(
+        PooledValueTaskSource<RecordMetadata> source,
+        Exception exception)
+    {
         try
         {
             return source.TrySetException(exception);
@@ -453,6 +475,7 @@ internal static class PooledCompletionSource
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TrySetCanceled(
         PooledValueTaskSource<RecordMetadata>? source,
         CancellationToken cancellationToken)
@@ -460,6 +483,16 @@ internal static class PooledCompletionSource
         if (source is null)
             return false;
 
+        return source.RunContinuationsAsynchronously
+            ? source.TrySetCanceled(cancellationToken)
+            : TrySetCanceledInline(source, cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetCanceledInline(
+        PooledValueTaskSource<RecordMetadata> source,
+        CancellationToken cancellationToken)
+    {
         try
         {
             return source.TrySetCanceled(cancellationToken);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -424,8 +424,24 @@ internal static class PooledCompletionSource
             return false;
 
         return source.RunContinuationsAsynchronously
-            ? source.TrySetResult(metadata)
+            ? TrySetResultAsynchronous(source, metadata)
             : TrySetResultInline(source, metadata);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetResultAsynchronous(
+        PooledValueTaskSource<RecordMetadata> source,
+        RecordMetadata metadata)
+    {
+        try
+        {
+            return source.TrySetResult(metadata);
+        }
+        catch
+        {
+            RecordCompletionSourceFault();
+            return false;
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -455,8 +471,24 @@ internal static class PooledCompletionSource
             return false;
 
         return source.RunContinuationsAsynchronously
-            ? source.TrySetException(exception)
+            ? TrySetExceptionAsynchronous(source, exception)
             : TrySetExceptionInline(source, exception);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetExceptionAsynchronous(
+        PooledValueTaskSource<RecordMetadata> source,
+        Exception exception)
+    {
+        try
+        {
+            return source.TrySetException(exception);
+        }
+        catch
+        {
+            RecordCompletionSourceFault();
+            return false;
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -484,8 +516,24 @@ internal static class PooledCompletionSource
             return false;
 
         return source.RunContinuationsAsynchronously
-            ? source.TrySetCanceled(cancellationToken)
+            ? TrySetCanceledAsynchronous(source, cancellationToken)
             : TrySetCanceledInline(source, cancellationToken);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TrySetCanceledAsynchronous(
+        PooledValueTaskSource<RecordMetadata> source,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return source.TrySetCanceled(cancellationToken);
+        }
+        catch
+        {
+            RecordCompletionSourceFault();
+            return false;
+        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -511,6 +559,9 @@ internal static class PooledCompletionSource
         ProducerDebugCounters.RecordInlineContinuationException();
         Diagnostics.DekafMetrics.InlineContinuationExceptions.Add(1);
     }
+
+    private static void RecordCompletionSourceFault() =>
+        Diagnostics.DekafMetrics.CompletionSourceFaults.Add(1);
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -26,6 +26,7 @@ public sealed class DekafMetricInstrumentTests
         DekafMetrics.ProduceErrors.Add(0);
         DekafMetrics.Retries.Add(0);
         DekafMetrics.InlineContinuationExceptions.Add(0);
+        DekafMetrics.CompletionSourceFaults.Add(0);
         DekafMetrics.MessagesReceived.Add(0);
         DekafMetrics.BytesReceived.Add(0);
         DekafMetrics.RebalanceDuration.Record(0);
@@ -37,6 +38,7 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
         await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
         await Assert.That(instrumentNames).Contains("dekaf.producer.inline_continuation.exceptions");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.completion_source.faults");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
         await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1199,7 +1199,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackOrder = new List<(int partition, long offset)>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (tp, offset, _, _, ex) =>
         {
@@ -1270,6 +1271,7 @@ public sealed class BrokerSenderMuteOrderingTests
     /// p1 succeeds → batch C (p1) proceeds immediately, batch D (p0) blocked.
     /// </summary>
     [Test]
+    [NotInParallel]
     [Timeout(30_000)]
     public async Task RetriableError_OnOnePartition_DoesNotBlockOtherPartitions(CancellationToken ct)
     {
@@ -1295,7 +1297,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackPartitions = new List<(int partition, long offset)>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (tp, offset, _, _, ex) =>
         {
@@ -1389,7 +1392,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackPartitions = new List<(int partition, long offset)>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (tp, offset, _, _, ex) =>
         {
@@ -1476,7 +1480,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackOffsets = new List<long>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (_, offset, _, _, ex) =>
         {
@@ -1561,7 +1566,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackOffsets = new List<long>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (_, offset, _, _, ex) =>
         {
@@ -1624,6 +1630,7 @@ public sealed class BrokerSenderMuteOrderingTests
     /// next send includes A retry(p0) + C(p1) coalesced → both succeed.
     /// </summary>
     [Test]
+    [NotInParallel]
     [Timeout(30_000)]
     public async Task MutedPartitionHeldBack_UnmutedPartitionProceed(CancellationToken ct)
     {
@@ -1649,7 +1656,10 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackList = new List<(int partition, long offset)>();
-        var allAcknowledged = new TaskCompletionSource();
+        // The final acknowledgement runs on the sender thread. Do not resume the test
+        // inline there: its finally block disposes and joins that same sender loop.
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (tp, offset, _, _, ex) =>
         {
@@ -1874,7 +1884,8 @@ public sealed class BrokerSenderMuteOrderingTests
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackList = new List<(int partition, long offset)>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (tp, offset, _, _, ex) =>
         {

--- a/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
@@ -14,26 +14,36 @@ public sealed class PooledCompletionSourceMetricsTests
     [Arguments(CompletionKind.Result)]
     [Arguments(CompletionKind.Exception)]
     [Arguments(CompletionKind.Canceled)]
-    public async Task AsynchronousCompletionSourceFault_IsRethrown(CompletionKind completionKind)
+    public async Task AsynchronousCompletionSourceFault_IsIsolatedAndRecorded(CompletionKind completionKind)
     {
-        long recordedExceptions = 0;
-        using var listener = CreateInlineContinuationExceptionListener(
-            measurement => Interlocked.Add(ref recordedExceptions, measurement));
+        long inlineExceptions = 0;
+        long sourceFaults = 0;
+        using var listener = CreateCompletionExceptionListener((instrument, measurement) =>
+        {
+            if (instrument == "dekaf.producer.inline_continuation.exceptions")
+                Interlocked.Add(ref inlineExceptions, measurement);
+            else if (instrument == "dekaf.producer.completion_source.faults")
+                Interlocked.Add(ref sourceFaults, measurement);
+        });
 
         await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 1);
         var source = pool.Rent();
         CompleteCoreWithoutUpdatingSourceState(source);
 
-        await Assert.That(() => Complete(source, completionKind)).Throws<InvalidOperationException>();
-        await Assert.That(Volatile.Read(ref recordedExceptions)).IsEqualTo(0);
+        await Assert.That(Complete(source, completionKind)).IsFalse();
+        await Assert.That(Volatile.Read(ref inlineExceptions)).IsEqualTo(0);
+        await Assert.That(Volatile.Read(ref sourceFaults)).IsEqualTo(1);
     }
 
     [Test]
     public async Task ThrowingInlineContinuation_RecordsReleaseMetric()
     {
         long recordedExceptions = 0;
-        using var listener = CreateInlineContinuationExceptionListener(
-            measurement => Interlocked.Add(ref recordedExceptions, measurement));
+        using var listener = CreateCompletionExceptionListener((instrument, measurement) =>
+        {
+            if (instrument == "dekaf.producer.inline_continuation.exceptions")
+                Interlocked.Add(ref recordedExceptions, measurement);
+        });
 
         await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 1);
         var source = pool.Rent();
@@ -54,21 +64,21 @@ public sealed class PooledCompletionSourceMetricsTests
         _ = awaiter.GetResult();
     }
 
-    private static MeterListener CreateInlineContinuationExceptionListener(Action<long> onMeasurement)
+    private static MeterListener CreateCompletionExceptionListener(Action<string, long> onMeasurement)
     {
         var listener = new MeterListener();
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
             if (instrument.Meter.Name == DekafDiagnostics.MeterName
-                && instrument.Name == "dekaf.producer.inline_continuation.exceptions")
+                && instrument.Name is "dekaf.producer.inline_continuation.exceptions"
+                    or "dekaf.producer.completion_source.faults")
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
         };
         listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
         {
-            if (instrument.Name == "dekaf.producer.inline_continuation.exceptions")
-                onMeasurement(measurement);
+            onMeasurement(instrument.Name, measurement);
         });
         listener.Start();
         return listener;

--- a/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledCompletionSourceMetricsTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.Metrics;
+using System.Reflection;
+using System.Threading.Tasks.Sources;
 using Dekaf.Diagnostics;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
@@ -9,24 +11,29 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class PooledCompletionSourceMetricsTests
 {
     [Test]
+    [Arguments(CompletionKind.Result)]
+    [Arguments(CompletionKind.Exception)]
+    [Arguments(CompletionKind.Canceled)]
+    public async Task AsynchronousCompletionSourceFault_IsRethrown(CompletionKind completionKind)
+    {
+        long recordedExceptions = 0;
+        using var listener = CreateInlineContinuationExceptionListener(
+            measurement => Interlocked.Add(ref recordedExceptions, measurement));
+
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 1);
+        var source = pool.Rent();
+        CompleteCoreWithoutUpdatingSourceState(source);
+
+        await Assert.That(() => Complete(source, completionKind)).Throws<InvalidOperationException>();
+        await Assert.That(Volatile.Read(ref recordedExceptions)).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ThrowingInlineContinuation_RecordsReleaseMetric()
     {
         long recordedExceptions = 0;
-        using var listener = new MeterListener();
-        listener.InstrumentPublished = (instrument, meterListener) =>
-        {
-            if (instrument.Meter.Name == DekafDiagnostics.MeterName
-                && instrument.Name == "dekaf.producer.inline_continuation.exceptions")
-            {
-                meterListener.EnableMeasurementEvents(instrument);
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            if (instrument.Name == "dekaf.producer.inline_continuation.exceptions")
-                Interlocked.Add(ref recordedExceptions, measurement);
-        });
-        listener.Start();
+        using var listener = CreateInlineContinuationExceptionListener(
+            measurement => Interlocked.Add(ref recordedExceptions, measurement));
 
         await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 1);
         var source = pool.Rent();
@@ -45,5 +52,60 @@ public sealed class PooledCompletionSourceMetricsTests
         await Assert.That(completed).IsTrue();
         await Assert.That(Volatile.Read(ref recordedExceptions)).IsEqualTo(1);
         _ = awaiter.GetResult();
+    }
+
+    private static MeterListener CreateInlineContinuationExceptionListener(Action<long> onMeasurement)
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName
+                && instrument.Name == "dekaf.producer.inline_continuation.exceptions")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == "dekaf.producer.inline_continuation.exceptions")
+                onMeasurement(measurement);
+        });
+        listener.Start();
+        return listener;
+    }
+
+    private static void CompleteCoreWithoutUpdatingSourceState(PooledValueTaskSource<RecordMetadata> source)
+    {
+        var coreField = typeof(PooledValueTaskSource<RecordMetadata>).GetField(
+            "_core",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var core = (ManualResetValueTaskSourceCore<RecordMetadata>)coreField.GetValue(source)!;
+        core.SetResult(default!);
+        coreField.SetValue(source, core);
+    }
+
+    private static bool Complete(
+        PooledValueTaskSource<RecordMetadata> source,
+        CompletionKind completionKind) => completionKind switch
+    {
+        CompletionKind.Result => PooledCompletionSource.TrySetResult(source, new RecordMetadata
+        {
+            Topic = "test-topic",
+            Partition = 0,
+            Offset = 0,
+            Timestamp = DateTimeOffset.UnixEpoch
+        }),
+        CompletionKind.Exception => PooledCompletionSource.TrySetException(
+            source,
+            new InvalidOperationException("expected source failure")),
+        CompletionKind.Canceled => PooledCompletionSource.TrySetCanceled(source, CancellationToken.None),
+        _ => throw new ArgumentOutOfRangeException(nameof(completionKind))
+    };
+
+    public enum CompletionKind
+    {
+        Result,
+        Exception,
+        Canceled
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks.Sources;
 using Dekaf.Producer;
@@ -816,6 +817,63 @@ public class PooledValueTaskSourceTests
         }
 
         await Assert.That(await doneTask.ConfigureAwait(false)).IsEqualTo(succeeds);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task ReadyBatch_AsynchronousSourceFault_DoesNotStrandSiblingCompletions(bool succeeds)
+    {
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>(maxPoolSize: 3);
+        var first = pool.Rent();
+        var faulted = pool.Rent();
+        var third = pool.Rent();
+        var firstTask = first.Task;
+        var faultedTask = faulted.Task;
+        var thirdTask = third.Task;
+        CompleteCoreWithoutUpdatingSourceState(faulted);
+
+        var sources = ProducerContainerPools.CompletionSources.Rent(3);
+        sources[0] = first;
+        sources[1] = faulted;
+        sources[2] = third;
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition("test-topic", 0),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 3,
+            dataSize: 0);
+
+        if (succeeds)
+        {
+            batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+            await Assert.That((await firstTask.ConfigureAwait(false)).Offset).IsEqualTo(7);
+            _ = await faultedTask.ConfigureAwait(false);
+            await Assert.That((await thirdTask.ConfigureAwait(false)).Offset).IsEqualTo(9);
+        }
+        else
+        {
+            var expected = new InvalidOperationException("delivery failed");
+            batch.Fail(expected);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await firstTask.ConfigureAwait(false));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await faultedTask.ConfigureAwait(false));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await thirdTask.ConfigureAwait(false));
+        }
+    }
+
+    private static void CompleteCoreWithoutUpdatingSourceState(
+        PooledValueTaskSource<RecordMetadata> source)
+    {
+        var coreField = typeof(PooledValueTaskSource<RecordMetadata>).GetField(
+            "_core",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var core = (ManualResetValueTaskSourceCore<RecordMetadata>)coreField.GetValue(source)!;
+        core.SetResult(default!);
+        coreField.SetValue(source, core);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- classify inline user-continuation exceptions separately from genuine completion-source faults
- isolate async completion-source faults per message so sibling completions and cleanup always continue
- report genuine faults through `dekaf.producer.completion_source.faults` and return `false` instead of reporting success
- make producer ordering-test acknowledgements asynchronous to prevent sender-thread reentrant disposal

## Test plan
- net8.0 full unit suite: 5,290 passed
- net10.0 full unit suite: 5,395 passed
- ReadyBatch async source-fault success/failure regression: 2 passed

Closes #2014