### PR TITLE
fix(producer): repair capacity-probe recovery (#2010)

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -471,6 +471,60 @@ def format_connection_scale_timeline(results, title):
     return lines
 
 
+def format_producer_budget_timeline(results, title):
+    """Correlate producer budget/rate/probe state with throughput intervals."""
+    rows = []
+    for result in results:
+        diagnostics = result.get('producerDeliveryDiagnostics') or {}
+        for sample in diagnostics.get('brokerBudgetSamples') or []:
+            rows.append((result, sample))
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('capturedAtUtc', ''))
+    lines = [
+        f"## Producer Budget Timeline - {title}",
+        "",
+        "| Client | Sample UTC | Broker | Budget / unacked | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |",
+        "|--------|------------|-------:|------------------|---------:|----------------------:|-----------------:|---------------------------|",
+    ]
+    for result, sample in rows:
+        sample_time = _parse_timestamp(sample.get('capturedAtUtc'))
+        intervals = result.get('throughput', {}).get('intervalSamples') or []
+        timestamped_intervals = [
+            (interval, _parse_timestamp(interval.get('capturedAtUtc')))
+            for interval in intervals
+        ]
+        timestamped_intervals = [
+            (interval, captured_at)
+            for interval, captured_at in timestamped_intervals
+            if captured_at is not None
+        ]
+        nearest = min(
+            timestamped_intervals,
+            key=lambda item: abs((item[1] - sample_time).total_seconds()),
+            default=(None, None),
+        )[0] if sample_time is not None else None
+        throughput = '-'
+        if nearest is not None:
+            throughput = (
+                f"{nearest.get('elapsedSeconds', 0):.1f}s / "
+                f"{nearest.get('messagesPerSecond', 0):,.0f} msg/s"
+            )
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {sample.get('capturedAtUtc', '-')} | "
+            f"{sample.get('brokerId', '-')} | "
+            f"{sample.get('budgetBytes', 0) / 1_048_576:.1f} MiB / "
+            f"{sample.get('unackedBytes', 0) / 1_048_576:.1f} MiB | "
+            f"{sample.get('maxRateBytesPerSec', 0) / 1_000_000:.1f} MB/s | "
+            f"{sample.get('capacityProbeSuccessCount', 0):,}/"
+            f"{sample.get('capacityProbeFailureCount', 0):,} | "
+            f"{sample.get('admissionBlockCount', 0):,} | {throughput} |"
+        )
+    lines.append("")
+    return lines
+
+
 def format_latency_outlier_timeline(results, title):
     """Correlate sampled delivery stalls with scaling, throughput, and GC."""
     rows = [
@@ -758,6 +812,7 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             scenario_results = scenarios[scenario_key]
             output.extend(format_throughput_table(scenario_results, f"{title} Throughput", include_ratio=include_ratio))
             output.extend(format_connection_scale_timeline(scenario_results, title))
+            output.extend(format_producer_budget_timeline(scenario_results, title))
             output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -3,6 +3,7 @@ import unittest
 from stress_report import (
     format_roundtrip_validation_table,
     format_connection_scale_timeline,
+    format_producer_budget_timeline,
     format_throughput_table,
     generate_scenario_tables,
     intra_run_throughput,
@@ -66,6 +67,33 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("1→2", report)
         self.assertIn("20.0s / 2,000 msg/s", report)
         self.assertIn("120/150", report)
+
+    def test_producer_budget_timeline_surfaces_probe_outcomes(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["throughput"]["intervalSamples"] = [{
+            "capturedAtUtc": "2026-07-12T02:20:50+00:00",
+            "elapsedSeconds": 20.0,
+            "messagesPerSecond": 2000.0,
+        }]
+        value["producerDeliveryDiagnostics"] = {
+            "brokerBudgetSamples": [{
+                "capturedAtUtc": "2026-07-12T02:20:49+00:00",
+                "brokerId": 1,
+                "budgetBytes": 8 * 1024 * 1024,
+                "unackedBytes": 6 * 1024 * 1024,
+                "maxRateBytesPerSec": 750_000_000,
+                "capacityProbeSuccessCount": 3,
+                "capacityProbeFailureCount": 2,
+                "admissionBlockCount": 12,
+            }]
+        }
+
+        report = "\n".join(format_producer_budget_timeline([value], "Producer"))
+
+        self.assertIn("8.0 MiB", report)
+        self.assertIn("750.0 MB/s", report)
+        self.assertIn("3/2", report)
+        self.assertIn("20.0s / 2,000 msg/s", report)
 
     def test_scenario_tables_surface_latency_outlier_diagnostics(self):
         value = stress_result("Dekaf", effective_rate=1400)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -68,7 +68,10 @@ internal sealed class BrokerUnackedByteBudget
 
     private const int WindowBucketCount = 20;
     private const double WindowBucketSeconds = 0.100;
-    private const double LoadedRateHalfLifeSeconds = 60.0;
+    // Retain demonstrated loaded capacity across transient GC/scheduler stalls. Recovery probes
+    // provide the upward path, but a short dip must not become the admission ceiling within one
+    // minute and create a self-reinforcing rate/budget decay loop.
+    private const double LoadedRateHalfLifeSeconds = 600.0;
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
     private const double DeliveryLatencyEwmaWeight = 0.125;
@@ -191,8 +194,11 @@ internal sealed class BrokerUnackedByteBudget
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
     private readonly double _targetSeconds;
+    private readonly long _probeResponseHorizonTicks;
     private long _capBytes;
     private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
+    private readonly double[] _rateBucketSums = new double[WindowBucketCount];
+    private readonly int[] _rateBucketSampleCounts = new int[WindowBucketCount];
     private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
     // Per-request diagnostics: log2 histograms of acked request sizes and RTTs. Incremented
     // only by the owning send loop; snapshot copies use per-element volatile reads, so
@@ -201,6 +207,8 @@ internal sealed class BrokerUnackedByteBudget
     private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
+    private double _windowRateSum;
+    private int _windowRateSampleCount;
     private double _retainedLoadedMaxRate;
     private long _windowMaxOccupancyBytes;
     private double _minRttSeconds;
@@ -221,8 +229,11 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbeRateSum;
     private double _capacityProbeRttSumSeconds;
     private double _capacityProbePreProbeRttSeconds;
+    private double _capacityProbeMaxRate;
     private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
+    private long _capacityProbeSuccessCount;
+    private long _capacityProbeFailureCount;
     private double _deliveryLatencyEwmaSeconds;
     private double _latencyBudgetScale = 1.0;
     private long _nextLatencyControlTimestamp;
@@ -231,9 +242,16 @@ internal sealed class BrokerUnackedByteBudget
     private long _lastBudgetUpdateTimestamp;
     private long _lastBudgetAdmissionBlockEvents;
 
-    public BrokerUnackedByteBudget(double targetSeconds, long floorBytes, long initialCapBytes)
+    public BrokerUnackedByteBudget(
+        double targetSeconds,
+        long floorBytes,
+        long initialCapBytes,
+        double lingerSeconds = 0)
     {
         _targetSeconds = targetSeconds;
+        _probeResponseHorizonTicks = Math.Max(
+            1,
+            (long)(Math.Max(0, targetSeconds + lingerSeconds) * Stopwatch.Frequency));
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, initialCapBytes);
         _lastNormalBudgetBytes = _capBytes;
@@ -264,6 +282,10 @@ internal sealed class BrokerUnackedByteBudget
     internal long MinimumRttMicros => Volatile.Read(ref _minimumRttMicros);
 
     internal long MaxRateBytesPerSecond => Volatile.Read(ref _maxRateBytesPerSecond);
+
+    internal long CapacityProbeSuccessCount => Volatile.Read(ref _capacityProbeSuccessCount);
+
+    internal long CapacityProbeFailureCount => Volatile.Read(ref _capacityProbeFailureCount);
 
     /// <summary>EWMA of controllable seal-to-send queue latency. The diagnostic property
     /// retains its original name for compatibility.</summary>
@@ -506,7 +528,14 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
-        UpdateCapacityProbe(bytesPerSecond, sendSnapshot.SendTimestamp, rttTicks, rttSeconds, nowTicks);
+        UpdateCapacityProbe(
+            bytesPerSecond,
+            sendSnapshot.OldestBatchTimestamp != 0
+                ? sendSnapshot.OldestBatchTimestamp
+                : sendSnapshot.SendTimestamp,
+            rttTicks,
+            rttSeconds,
+            nowTicks);
     }
 
     /// <summary>
@@ -720,8 +749,12 @@ internal sealed class BrokerUnackedByteBudget
         if (elapsed >= WindowBucketCount)
         {
             Array.Clear(_rateBucketMaxValues);
+            Array.Clear(_rateBucketSums);
+            Array.Clear(_rateBucketSampleCounts);
             Array.Clear(_occupancyBucketMaxValues);
             _windowMaxRate = 0;
+            _windowRateSum = 0;
+            _windowRateSampleCount = 0;
             _windowMaxOccupancyBytes = 0;
         }
         else
@@ -734,7 +767,11 @@ internal sealed class BrokerUnackedByteBudget
                 recomputeRate |= _windowMaxRate > 0 && _rateBucketMaxValues[slot] >= _windowMaxRate;
                 recomputeOccupancy |= _windowMaxOccupancyBytes > 0
                     && _occupancyBucketMaxValues[slot] >= _windowMaxOccupancyBytes;
+                _windowRateSum -= _rateBucketSums[slot];
+                _windowRateSampleCount -= _rateBucketSampleCounts[slot];
                 _rateBucketMaxValues[slot] = 0;
+                _rateBucketSums[slot] = 0;
+                _rateBucketSampleCounts[slot] = 0;
                 _occupancyBucketMaxValues[slot] = 0;
             }
 
@@ -760,7 +797,11 @@ internal sealed class BrokerUnackedByteBudget
     {
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
+        _rateBucketSums[slot] += bytesPerSecond;
+        _rateBucketSampleCounts[slot]++;
         _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
+        _windowRateSum += bytesPerSecond;
+        _windowRateSampleCount++;
         if (sustainedIdle)
             _retainedLoadedMaxRate = 0;
         else if (loadedSample)
@@ -768,6 +809,10 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     private double GetEffectiveMaxRate() => Math.Max(_windowMaxRate, _retainedLoadedMaxRate);
+
+    private double GetWindowAverageRate() => _windowRateSampleCount > 0
+        ? _windowRateSum / _windowRateSampleCount
+        : 0;
 
     private void AddOccupancySample(long bytes)
     {
@@ -778,15 +823,18 @@ internal sealed class BrokerUnackedByteBudget
 
     private void UpdateCapacityProbe(
         double bytesPerSecond,
-        long sendTimestamp,
+        long admissionTimestamp,
         long rttTicks,
         double rttSeconds,
         long nowTicks)
     {
         var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
+        var evaluationWindowTicks = Math.Max(
+            ProbeEvaluationRtts * rttTicks,
+            _probeResponseHorizonTicks);
         var probeDurationTicks = Math.Max(
             probeIntervalTicks,
-            (ProbeEvaluationRtts + 1L) * rttTicks);
+            rttTicks + evaluationWindowTicks);
         if (_nextProbeTimestamp == 0)
             _nextProbeTimestamp = nowTicks + probeIntervalTicks;
 
@@ -799,19 +847,22 @@ internal sealed class BrokerUnackedByteBudget
                 return;
             }
 
-            // A response can contribute only when its request was sent after the larger
-            // budget was published. Collect a full RTT of wholly-probed responses before
-            // judging growth: response ordering across connection lanes can otherwise let
-            // one small request cancel the probe before the added budget reaches the wire.
-            if (sendTimestamp < _capacityProbeStartTimestamp)
+            // A response can contribute only when every batch in its request was admitted
+            // after the larger budget was published. Send time is too late: a request sent
+            // during the probe can still contain batches sealed under the old budget.
+            if (admissionTimestamp < _capacityProbeStartTimestamp)
                 return;
 
             _capacityProbeRateSum += bytesPerSecond;
             _capacityProbeRttSumSeconds += rttSeconds;
+            _capacityProbeMaxRate = Math.Max(_capacityProbeMaxRate, bytesPerSecond);
             _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
-                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + ProbeEvaluationRtts * rttTicks;
+                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + evaluationWindowTicks;
+                Volatile.Write(
+                    ref _capacityProbeDeadlineTimestamp,
+                    Math.Max(_capacityProbeDeadlineTimestamp, nowTicks + evaluationWindowTicks));
                 return;
             }
 
@@ -830,10 +881,14 @@ internal sealed class BrokerUnackedByteBudget
                 || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
             if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
-                _capacityProbeBaselineRate = averageRate;
+                // Use the strongest rate actually demonstrated by this successful probe as
+                // the next rung's baseline. Otherwise a slow first response depresses the
+                // average and unchanged steady-state traffic falsely succeeds again.
+                _capacityProbeBaselineRate = Math.Max(averageRate, _capacityProbeMaxRate);
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
                 _capacityProbeStartTimestamp = nowTicks;
                 ResetCapacityProbeSamples();
+                Interlocked.Increment(ref _capacityProbeSuccessCount);
                 Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             }
             else
@@ -851,7 +906,7 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
         {
             _capacityProbeStartTimestamp = nowTicks;
-            _capacityProbeBaselineRate = GetEffectiveMaxRate();
+            _capacityProbeBaselineRate = GetWindowAverageRate();
             // Raw-domain baseline to match the raw probe samples; the queue-corrected
             // serving EWMA sits below loaded round trips and would fail every probe.
             _capacityProbePreProbeRttSeconds = _rawServingRttEwmaSeconds > 0
@@ -876,12 +931,16 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capacityProbeRateSum = 0;
         _capacityProbeRttSumSeconds = 0;
+        _capacityProbeMaxRate = 0;
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }
 
     private void DeactivateCapacityProbe()
     {
+        if (_capacityProbeActive)
+            Interlocked.Increment(ref _capacityProbeFailureCount);
+
         ResetCapacityProbeSamples();
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -292,6 +292,10 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     public required long MinRttMicros { get; init; }
     public required long MaxRateBytesPerSec { get; init; }
     public required long AdmissionBlockCount { get; init; }
+    // Optional for backward compatibility with persisted stress results captured before
+    // probe outcomes were added; missing JSON values naturally deserialize as zero.
+    public long CapacityProbeSuccessCount { get; init; }
+    public long CapacityProbeFailureCount { get; init; }
     /// <summary>Controllable seal-to-send queue-latency EWMA. Name retained for diagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4556,7 +4556,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
-            initialCapBytes: cap);
+            initialCapBytes: cap,
+            lingerSeconds: _options.LingerMs / 1000.0);
     }
 
     /// <summary>
@@ -4932,6 +4933,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         MinRttMicros = budget.MinimumRttMicros,
         MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
         AdmissionBlockCount = budget.AdmissionBlockEvents,
+        CapacityProbeSuccessCount = budget.CapacityProbeSuccessCount,
+        CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
         DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
         LatencyBudgetScale = budget.LatencyBudgetScale,
         RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -585,6 +585,23 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task LoadedRatePeak_OneMinuteDipDoesNotBecomeNewAdmissionCeiling()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
+
+        Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
+        for (var second = 2; second <= 60; second += 2)
+            Ack(budget, 100, 0.100, T0 + Seconds(second), appLimitedAtSend: false);
+
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_500)
+            .Because("a transient one-minute rate dip must not self-ratchet a saturated producer");
+    }
+
+    [Test]
     public async Task AppLimitedSend_AfterBriefDrainRetainsLoadedRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -739,8 +756,14 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
 
     [Test]
@@ -774,6 +797,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 500, 0.100, T0 + Seconds(0.200), appLimitedAtSend: false);
         Ack(budget, 500, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
         Ack(budget, 500, 0.100, T0 + Seconds(0.400), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.500), appLimitedAtSend: false);
+        Ack(budget, 500, 0.100, T0 + Seconds(0.600), appLimitedAtSend: false);
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
             .Because("one noisy high sample must not ratchet a three-RTT low-rate probe");
@@ -826,7 +851,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_RejectsRateGainWhenRttInflates()
     {
         var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.5,
+            targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
         SetField(budget, "_windowMaxRate", 10_000.0);
@@ -1066,9 +1091,72 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
 
-        // Three RTTs of wholly-probed responses confirm no gain and end the probe.
+        // Target horizon is longer than three RTTs, so measurement continues until 500ms
+        // after the first wholly admitted response.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
+        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(1.500));
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RejectsBatchAdmittedBeforeProbeEvenWhenSentAfterProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeActive", true);
+
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: T0 + Seconds(0.010),
+            appLimited: true,
+            oldestBatchTimestamp: T0 - Seconds(0.010));
+        Ack(budget, 200, 0.001, T0 + Seconds(0.011), snapshot);
+
+        await Assert.That(GetField<int>(budget, "_capacityProbeRateSampleCount")).IsEqualTo(0)
+            .Because("a send after probe start can still contain work admitted under the old budget");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_EvaluationWindowCoversTargetHorizonAndLinger()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000,
+            lingerSeconds: 0.005);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeActive", true);
+
+        var now = T0 + Seconds(0.020);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: T0 + Seconds(0.001));
+        Ack(budget, 20, 0.001, now, snapshot);
+
+        var evaluationDeadline = GetField<long>(budget, "_capacityProbeEvaluationDeadlineTimestamp");
+        await Assert.That(evaluationDeadline - now).IsGreaterThanOrEqualTo(Seconds(0.015))
+            .Because("probe-added admissions need a full target horizon plus linger to affect delivery rate");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_UsesWindowAverageBaseline_NotDecayingRetainedPeak()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        Ack(budget, 10, 0.001, T0);
+        SetField(budget, "_retainedLoadedMaxRate", 100_000.0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
+
+        Ack(budget, 10, 0.001, T0 + Seconds(0.008));
+
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate")).IsEqualTo(10_000.0)
+            .Because("a stale retained peak must not make every recovery probe impossible");
     }
 
     [Test]
@@ -1103,6 +1191,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
         Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -175,11 +175,15 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.MinRttMicros).IsGreaterThan(0);
         await Assert.That(current.MaxRateBytesPerSec).IsGreaterThan(0);
         await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
+        await Assert.That(current.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(current.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
         await Assert.That(current.RequestRttMicrosLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(sample.BrokerId).IsEqualTo(7);
+        await Assert.That(sample.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(sample.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -237,6 +237,23 @@ public sealed class ConnectionScaleReportingTests
                         BufferPressureDelta = 120,
                         SendLoopPressureDelta = 340
                     }
+                ],
+                BrokerBudgetSamples =
+                [
+                    new ProducerBrokerBudgetDiagnostic
+                    {
+                        CapturedAtUtc = startedAt.AddSeconds(6),
+                        BrokerId = 1,
+                        BudgetBytes = 8 * 1024 * 1024,
+                        UnackedBytes = 6 * 1024 * 1024,
+                        MinRttMicros = 800,
+                        MaxRateBytesPerSec = 750_000_000,
+                        AdmissionBlockCount = 12,
+                        DeliveryLatencyEwmaMicros = 2_500,
+                        LatencyBudgetScale = 1.0,
+                        CapacityProbeSuccessCount = 3,
+                        CapacityProbeFailureCount = 2
+                    }
                 ]
             }
         };
@@ -257,6 +274,10 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("75%");
         await Assert.That(markdown).Contains("120/340");
         await Assert.That(markdown).Contains("6.0s / 2,500 msg/s");
+        await Assert.That(markdown).Contains("Producer Budget Timeline - Fire-and-Forget");
+        await Assert.That(markdown).Contains("8.0 MiB");
+        await Assert.That(markdown).Contains("750.0 MB/s");
+        await Assert.That(markdown).Contains("3/2");
         await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
         await Assert.That(markdown).Contains("42");
         await Assert.That(markdown).Contains("connection transition");

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -30,6 +30,7 @@ internal static class MarkdownReporter
 
             GenerateThroughputTable(sb, title, groupResults);
             GenerateConnectionScaleTimeline(sb, groupResults, label);
+            GenerateProducerBudgetTimeline(sb, groupResults, label);
             GenerateConsumerFetchTimeline(sb, groupResults, label);
             GenerateLatencyOutlierTimeline(sb, groupResults, label);
 
@@ -219,6 +220,45 @@ internal static class MarkdownReporter
         }
 
         return sampled;
+    }
+
+    private static void GenerateProducerBudgetTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BrokerBudgetSamples ?? [])
+                .Select(sample => (Result: result, Sample: sample)))
+            .OrderBy(row => row.Sample.CapturedAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        var displayedRows = SampleEvenly(rows, MaxTimelineRows);
+        var omittedRows = rows.Count - displayedRows.Count;
+
+        sb.AppendLine($"## Producer Budget Timeline - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
+        sb.AppendLine("|--------|------------|-------:|------------------|---------:|----------------------:|-----------------:|---------------------------|");
+        foreach (var row in displayedRows)
+        {
+            var nearest = row.Result.Throughput.IntervalSamples
+                .MinBy(sample => Math.Abs((sample.CapturedAtUtc - row.Sample.CapturedAtUtc).TotalMilliseconds));
+            var throughput = nearest is null
+                ? "-"
+                : $"{nearest.ElapsedSeconds:F1}s / {nearest.MessagesPerSecond:N0} msg/s";
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss.fff} | {row.Sample.BrokerId} | " +
+                $"{row.Sample.BudgetBytes / 1_048_576.0:F1} MiB / {row.Sample.UnackedBytes / 1_048_576.0:F1} MiB | " +
+                $"{row.Sample.MaxRateBytesPerSec / 1_000_000.0:F1} MB/s | " +
+                $"{row.Sample.CapacityProbeSuccessCount:N0}/{row.Sample.CapacityProbeFailureCount:N0} | " +
+                $"{row.Sample.AdmissionBlockCount:N0} | {throughput} |");
+        }
+        if (omittedRows > 0)
+            sb.AppendLine($"*{omittedRows:N0} budget sample(s) omitted; rows sampled across the full timeline.*");
+        sb.AppendLine();
     }
 
     private static void GenerateConsumerFetchTimeline(


### PR DESCRIPTION
Stacked on #2020 (which is stacked on #2019). Retarget to `main` after both P0 governor fixes merge.

## Summary
- evaluate capacity probes only from batches admitted after probe start
- measure for at least delivery target + linger and compare probe/window averages
- retain demonstrated loaded capacity across transient one-minute stalls
- expose budget, max-rate, and probe success/failure timelines in both stress reporters

## Test plan
- [x] `BrokerUnackedByteBudgetTests` (71/71)
- [x] full unit suite (5,403/5,403)
- [x] producer admission-probe integration test
- [x] Python stress reporter tests (17/17)
- [x] BenchmarkDotNet short run: 14.35 ns/ack, 19.73 ns/pass, 0 B allocated
- [x] 15-minute issue-only FnF: steady/peak 0.954, no throughput trend-gate breach
- [x] stacked 1-minute comparison: 59.4k msg/s vs #2020 control 56.5k msg/s

Local absolute throughput remains far below the issue family's 1.4M target on both this stack and unchanged #2020, so the P0 dual-gate stress validation remains required before the stack merges.

Closes #2010
