### PR TITLE
perf(stress): stabilize consumer GC topology

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -128,6 +128,11 @@ jobs:
     env:
       BROKER_CPUS: 0-5
       CLIENT_CPUS: 6,7
+      # .NET 10 DATAS can shrink Server GC heap count at Gen2 boundaries on the
+      # two-core consumer runner, creating permanent throughput steps unrelated to
+      # either Kafka client. Pin consumer jobs to stable Server GC topology so paired
+      # comparisons measure client work; producer jobs retain the runtime default.
+      DOTNET_GCDynamicAdaptationMode: ${{ startsWith(matrix.scenario, 'consumer') && '0' || '1' }}
       # Broker log dirs live on tmpfs so disk I/O never caps ingestion. Sized above the
       # worst-case retention overshoot (see KafkaEnvironment.RetentionConfig for the
       # math); a fill halts the broker, so the disk monitor below samples usage during

--- a/docs/docs/performance.md
+++ b/docs/docs/performance.md
@@ -178,6 +178,19 @@ await foreach (var batch in consumer.ConsumeAsync(cts.Token).Batch(100))
 }
 ```
 
+For sustained CPU-bound consumers on .NET 10 Server GC, watch throughput and GC
+telemetry over time. If permanent throughput steps line up with Gen2 collections and
+a changing GC heap count, benchmark with dynamic GC adaptation disabled:
+
+```bash
+DOTNET_GCDynamicAdaptationMode=0 dotnet MyConsumer.dll
+```
+
+Set the variable before process startup. Disabling DATAS keeps the Server GC heap
+topology stable, which can improve sustained throughput on tightly CPU-pinned
+workloads, but it may retain more managed memory. Keep the runtime default unless an
+A/B test of your production-shaped workload shows the same Gen2-correlated decay.
+
 #### Low Latency
 
 ```csharp

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class ConsumerFetchDiagnosticsTests
 {
     [Test]
-    [NotInParallel]
+    [NotInParallel("MeterListener")]
     public async Task Listener_CollectsFetchDurationAndTopicBytes()
     {
         var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
@@ -36,7 +36,7 @@ public sealed class ConsumerFetchDiagnosticsTests
     }
 
     [Test]
-    [NotInParallel]
+    [NotInParallel("MeterListener")]
     public async Task Listener_RejectsConcurrentConsumerDiagnosticsTracker()
     {
         using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -9,7 +9,7 @@ namespace Dekaf.Tests.Unit.StressTests;
 public sealed class ConsumerFetchDiagnosticsTests
 {
     [Test]
-    [NotInParallel("MeterListener")]
+    [NotInParallel]
     public async Task Listener_CollectsFetchDurationAndTopicBytes()
     {
         var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
@@ -36,7 +36,7 @@ public sealed class ConsumerFetchDiagnosticsTests
     }
 
     [Test]
-    [NotInParallel("MeterListener")]
+    [NotInParallel]
     public async Task Listener_RejectsConcurrentConsumerDiagnosticsTracker()
     {
         using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic");
@@ -71,6 +71,34 @@ public sealed class ConsumerFetchDiagnosticsTests
         await Assert.That(sample.PrefetchBufferDepth).IsEqualTo(3);
         await Assert.That(sample.PrefetchDepth).IsEqualTo(5);
         await Assert.That(sample.PrefetchedBytes).IsEqualTo(4_096);
+    }
+
+    [Test]
+    public async Task TakeSample_ReportsPerIntervalGcDiagnostics()
+    {
+        var startedAt = new DateTimeOffset(2026, 7, 13, 10, 0, 0, TimeSpan.Zero);
+        var gcSnapshots = new Queue<GcDiagnosticSnapshot>(
+        [
+            new GcDiagnosticSnapshot(10, 4, 2, 100, 20 * 1024 * 1024, 2, 1, true),
+            new GcDiagnosticSnapshot(13, 6, 3, 145, 24 * 1024 * 1024, 1, 1, true)
+        ]);
+        using var tracker = new ConsumerFetchDiagnosticsTracker(
+            "consumer-topic",
+            listenToMetrics: false,
+            captureGcDiagnostics: gcSnapshots.Dequeue);
+        tracker.Start(CreateConsumerSnapshot(startedAt));
+
+        tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddMinutes(1)));
+
+        var sample = tracker.GetSnapshot().Samples.Single();
+        await Assert.That(sample.Gen0Collections).IsEqualTo(3);
+        await Assert.That(sample.Gen1Collections).IsEqualTo(2);
+        await Assert.That(sample.Gen2Collections).IsEqualTo(1);
+        await Assert.That(sample.GcPauseDurationMs).IsEqualTo(45);
+        await Assert.That(sample.GcHeapSizeBytes).IsEqualTo(24 * 1024 * 1024);
+        await Assert.That(sample.GcHeapCount).IsEqualTo(1);
+        await Assert.That(sample.GcDynamicAdaptationMode).IsEqualTo(1);
+        await Assert.That(sample.ServerGc).IsTrue();
     }
 
     [Test]
@@ -134,7 +162,15 @@ public sealed class ConsumerFetchDiagnosticsTests
                     PendingFetchDepth = 2,
                     PrefetchBufferDepth = 3,
                     PrefetchDepth = 5,
-                    PrefetchedBytes = 8_388_608
+                    PrefetchedBytes = 8_388_608,
+                    Gen0Collections = 3,
+                    Gen1Collections = 2,
+                    Gen2Collections = 1,
+                    GcPauseDurationMs = 45,
+                    GcHeapSizeBytes = 24 * 1024 * 1024,
+                    GcHeapCount = 1,
+                    GcDynamicAdaptationMode = 0,
+                    ServerGc = true
                 }
             ],
             ConnectionReapEvents =
@@ -167,6 +203,10 @@ public sealed class ConsumerFetchDiagnosticsTests
         await Assert.That(markdown).Contains("7.50ms");
         await Assert.That(markdown).Contains("1 reap");
         await Assert.That(markdown).Contains("2 / 3 / 5");
+        await Assert.That(markdown).Contains("3 / 2 / 1");
+        await Assert.That(markdown).Contains("45.0ms");
+        await Assert.That(markdown).Contains("24.0 MiB / 1");
+        await Assert.That(markdown).Contains("Server GC; DATAS=0");
     }
 
     [Test]

--- a/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using System.Runtime;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.Networking;
@@ -13,6 +14,7 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
 
     private readonly string _topic;
     private readonly MeterListener? _listener;
+    private readonly Func<GcDiagnosticSnapshot> _captureGcDiagnostics;
     private readonly List<ConsumerFetchDiagnosticSample> _samples = [];
     private DateTimeOffset? _lastSampleAtUtc;
     private long _fetchRequestCount;
@@ -21,11 +23,16 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
     private long _lastFetchRequestCount;
     private long _lastFetchDurationTicks;
     private long _lastReceivedBytes;
+    private GcDiagnosticSnapshot _lastGcDiagnostics;
     private ConnectionReapDiagnostic[] _connectionReapEvents = [];
 
-    internal ConsumerFetchDiagnosticsTracker(string topic, bool listenToMetrics = true)
+    internal ConsumerFetchDiagnosticsTracker(
+        string topic,
+        bool listenToMetrics = true,
+        Func<GcDiagnosticSnapshot>? captureGcDiagnostics = null)
     {
         _topic = topic;
+        _captureGcDiagnostics = captureGcDiagnostics ?? CaptureGcDiagnostics;
         if (!listenToMetrics)
             return;
         if (Interlocked.CompareExchange(ref s_activeMetricListener, 1, 0) != 0)
@@ -74,6 +81,7 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         _lastFetchRequestCount = Interlocked.Read(ref _fetchRequestCount);
         _lastFetchDurationTicks = Interlocked.Read(ref _fetchDurationTicks);
         _lastReceivedBytes = Interlocked.Read(ref _receivedBytes);
+        _lastGcDiagnostics = _captureGcDiagnostics();
         _connectionReapEvents = snapshot.ConnectionReapEvents;
     }
 
@@ -106,6 +114,7 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         var intervalFetches = fetchRequestCount - _lastFetchRequestCount;
         var intervalFetchDurationTicks = fetchDurationTicks - _lastFetchDurationTicks;
         var intervalReceivedBytes = receivedBytes - _lastReceivedBytes;
+        var gcDiagnostics = _captureGcDiagnostics();
 
         _samples.Add(new ConsumerFetchDiagnosticSample
         {
@@ -120,13 +129,22 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
             PendingFetchDepth = snapshot.PendingFetchDepth,
             PrefetchBufferDepth = snapshot.PrefetchBufferDepth,
             PrefetchDepth = snapshot.PrefetchDepth,
-            PrefetchedBytes = snapshot.PrefetchedBytes
+            PrefetchedBytes = snapshot.PrefetchedBytes,
+            Gen0Collections = Math.Max(0, gcDiagnostics.Gen0Collections - _lastGcDiagnostics.Gen0Collections),
+            Gen1Collections = Math.Max(0, gcDiagnostics.Gen1Collections - _lastGcDiagnostics.Gen1Collections),
+            Gen2Collections = Math.Max(0, gcDiagnostics.Gen2Collections - _lastGcDiagnostics.Gen2Collections),
+            GcPauseDurationMs = Math.Max(0, gcDiagnostics.PauseDurationMs - _lastGcDiagnostics.PauseDurationMs),
+            GcHeapSizeBytes = gcDiagnostics.HeapSizeBytes,
+            GcHeapCount = gcDiagnostics.HeapCount,
+            GcDynamicAdaptationMode = gcDiagnostics.DynamicAdaptationMode,
+            ServerGc = gcDiagnostics.ServerGc
         });
 
         _lastSampleAtUtc = snapshot.CapturedAtUtc;
         _lastFetchRequestCount = fetchRequestCount;
         _lastFetchDurationTicks = fetchDurationTicks;
         _lastReceivedBytes = receivedBytes;
+        _lastGcDiagnostics = gcDiagnostics;
     }
 
     internal Task RunSamplerAsync(
@@ -171,6 +189,34 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         return false;
     }
 
+    private static GcDiagnosticSnapshot CaptureGcDiagnostics()
+    {
+        var memoryInfo = GC.GetGCMemoryInfo();
+        var configuration = GC.GetConfigurationVariables();
+        return new GcDiagnosticSnapshot(
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2),
+            GC.GetTotalPauseDuration().TotalMilliseconds,
+            memoryInfo.HeapSizeBytes,
+            ReadConfigurationInt32(configuration, "HeapCount"),
+            ReadConfigurationInt32(configuration, "GCDynamicAdaptationMode"),
+            GCSettings.IsServerGC);
+    }
+
+    private static int ReadConfigurationInt32(
+        IReadOnlyDictionary<string, object> configuration,
+        string key) =>
+        configuration.TryGetValue(key, out var value)
+            ? value switch
+            {
+                int result => result,
+                long result when result is >= int.MinValue and <= int.MaxValue => (int)result,
+                uint result when result <= int.MaxValue => (int)result,
+                _ => -1
+            }
+            : -1;
+
     public void Dispose()
     {
         _listener?.Dispose();
@@ -197,4 +243,22 @@ internal sealed class ConsumerFetchDiagnosticSample
     public required int PrefetchBufferDepth { get; init; }
     public required int PrefetchDepth { get; init; }
     public required long PrefetchedBytes { get; init; }
+    public int Gen0Collections { get; init; }
+    public int Gen1Collections { get; init; }
+    public int Gen2Collections { get; init; }
+    public double GcPauseDurationMs { get; init; }
+    public long GcHeapSizeBytes { get; init; }
+    public int GcHeapCount { get; init; }
+    public int GcDynamicAdaptationMode { get; init; } = -1;
+    public bool ServerGc { get; init; }
 }
+
+internal readonly record struct GcDiagnosticSnapshot(
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections,
+    double PauseDurationMs,
+    long HeapSizeBytes,
+    int HeapCount,
+    int DynamicAdaptationMode,
+    bool ServerGc);

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -271,8 +271,8 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## Consumer Fetch Timeline - {label}");
         sb.AppendLine();
-        sb.AppendLine("| Client | Interval end UTC | Fetch req/s | Bytes/fetch | Avg fetch RTT | Queues (pending / buffer / total) | Prefetched | Connection reaps | Nearest throughput |");
-        sb.AppendLine("|--------|------------------|------------:|------------:|--------------:|----------------------------------:|-----------:|-----------------:|-------------------:|");
+        sb.AppendLine("| Client | Interval end UTC | Fetch req/s | Bytes/fetch | Avg fetch RTT | Queues (pending / buffer / total) | Prefetched | Connection reaps | GC delta (0 / 1 / 2) | GC pause | Heap / heaps | GC mode | Nearest throughput |");
+        sb.AppendLine("|--------|------------------|------------:|------------:|--------------:|----------------------------------:|-----------:|-----------------:|----------------------:|---------:|--------------:|---------|-------------------:|");
         foreach (var row in displayedRows)
         {
             var nearest = row.Result.Throughput.IntervalSamples
@@ -284,20 +284,27 @@ internal static class MarkdownReporter
             var reaps = row.Result.ConsumerFetchDiagnostics!.ConnectionReapEvents.Count(reap =>
                 reap.OccurredAtUtc > intervalStart && reap.OccurredAtUtc <= row.Sample.CapturedAtUtc);
             var reapSummary = reaps == 0 ? "-" : $"{reaps} reap{(reaps == 1 ? "" : "s")}";
+            var gcMode = $"{(row.Sample.ServerGc ? "Server" : "Workstation")} GC; " +
+                $"DATAS={(row.Sample.GcDynamicAdaptationMode >= 0 ? row.Sample.GcDynamicAdaptationMode : "?")}";
 
             sb.AppendLine(
                 $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss} | " +
                 $"{row.Sample.FetchRequestsPerSecond:F2} | {FormatDiagnosticBytes(row.Sample.BytesPerFetch)} | " +
                 $"{row.Sample.AverageFetchRttMs:F2}ms | " +
                 $"{row.Sample.PendingFetchDepth} / {row.Sample.PrefetchBufferDepth} / {row.Sample.PrefetchDepth} | " +
-                $"{FormatDiagnosticBytes(row.Sample.PrefetchedBytes)} | {reapSummary} | {throughput} |");
+                $"{FormatDiagnosticBytes(row.Sample.PrefetchedBytes)} | {reapSummary} | " +
+                $"{row.Sample.Gen0Collections} / {row.Sample.Gen1Collections} / {row.Sample.Gen2Collections} | " +
+                $"{row.Sample.GcPauseDurationMs:F1}ms | " +
+                $"{FormatDiagnosticBytes(row.Sample.GcHeapSizeBytes)} / " +
+                $"{(row.Sample.GcHeapCount >= 0 ? row.Sample.GcHeapCount : "?")} | " +
+                $"{gcMode} | {throughput} |");
         }
 
         if (omittedRows > 0)
             sb.AppendLine($"*{omittedRows:N0} fetch sample(s) omitted; rows sampled across the full timeline.*");
 
         sb.AppendLine();
-        sb.AppendLine("*Bytes/fetch is consumed message payload bytes divided by completed fetch requests for the interval; queue depths are point-in-time samples.*");
+        sb.AppendLine("*Bytes/fetch is consumed message payload bytes divided by completed fetch requests for the interval; queue depths, managed heap size, and active GC heap count are point-in-time samples. GC collection counts and pause time are interval deltas. DATAS is .NET dynamic GC adaptation mode.*");
         sb.AppendLine();
     }
 


### PR DESCRIPTION
## Summary
- pin consumer stress jobs to stable Server GC topology after DATAS A/B tied Gen2 boundaries to throughput steps
- add per-minute GC collection deltas, pause time, heap size/count, and runtime mode to the consumer fetch timeline
- document the production DATAS opt-out and memory tradeoff

## Evidence
- 15-minute baseline, 2 logical processors: 3 Gen2 collections, 170,315 msg/s
- identical run with `DOTNET_GCDynamicAdaptationMode=0`: 0 Gen2 collections, 185,218 msg/s (+8.8%)

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- [x] focused `ConsumerFetchDiagnosticsTests` (9/9)
- [x] full net10 unit suite (5,392/5,392)
- [x] `npm run build --prefix docs`

Closes #2012
