### PR TITLE
Add transactional continuation isolation opt-out

### DIFF
--- a/docs/docs/producer/transactions.md
+++ b/docs/docs/producer/transactions.md
@@ -30,6 +30,25 @@ await using var producer = await Kafka.CreateProducer<string, string>()
 await producer.InitTransactionsAsync();
 ```
 
+By default, code after `await transaction.ProduceAsync(...)` resumes inline on the broker
+sender thread for maximum throughput. That thread also sends, retries, and handles timeouts
+for other work using the same broker connection, so continuation code must not block or do
+long-running synchronous work.
+
+If your continuation code cannot guarantee that, isolate it from broker processing:
+
+```csharp
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithTransactionalId("my-service-instance-1")
+    .WithInlineTransactionCompletions(false)
+    .BuildAsync();
+```
+
+This schedules transactional produce continuations asynchronously and prevents a blocking
+continuation from stalling sends, retries, or timeout handling on that broker. It adds one
+continuation dispatch per transactional produce.
+
 :::warning
 The transactional ID must be unique per producer instance. If two producers use the same ID, one will be fenced (killed) by Kafka.
 :::

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -30,6 +30,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int _lingerMs;
     private int _batchSize = 1048576;
     private string? _transactionalId;
+    private bool _inlineTransactionCompletions = true;
     private int? _transactionTimeoutMs;
     private bool _enableTwoPhaseCommit;
     private Protocol.Records.CompressionType _compressionType = Protocol.Records.CompressionType.None;
@@ -208,6 +209,20 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithTransactionalId(string transactionalId)
     {
         _transactionalId = transactionalId;
+        return this;
+    }
+
+    /// <summary>
+    /// Controls whether transactional produce continuations run inline on the broker sender thread.
+    /// </summary>
+    /// <param name="enable">
+    /// <see langword="true"/> for maximum throughput; <see langword="false"/> to isolate
+    /// blocking or long-running continuation code from broker send processing.
+    /// </param>
+    /// <remarks>Enabled by default. This setting only affects transactional produce operations.</remarks>
+    public ProducerBuilder<TKey, TValue> WithInlineTransactionCompletions(bool enable = true)
+    {
+        _inlineTransactionCompletions = enable;
         return this;
     }
 
@@ -1208,6 +1223,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             EnableIdempotence = _enableIdempotence,
             ConnectionsPerBroker = _connectionsPerBroker,
             TransactionalId = _transactionalId,
+            InlineTransactionCompletions = _inlineTransactionCompletions,
             EnableTwoPhaseCommit = _enableTwoPhaseCommit,
             TransactionTimeoutMs = _transactionTimeoutMs ?? 60000,
             CloseTimeoutMs = _closeTimeoutMs,

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -194,7 +194,9 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Transactional produce continuations run inline on a broker sender thread shared by
     /// other partitions using that broker connection. Code after each transactional
     /// <see cref="ITransaction{TKey, TValue}.ProduceAsync"/> call must remain non-blocking
-    /// and avoid long-running synchronous work.
+    /// and avoid long-running synchronous work. Configure
+    /// <see cref="ProducerBuilder{TKey,TValue}.WithInlineTransactionCompletions"/> with
+    /// <see langword="false"/> when continuation code cannot meet this constraint.
     /// </remarks>
     ITransaction<TKey, TValue> BeginTransaction();
 
@@ -489,6 +491,8 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
     /// shared by other partitions using that broker connection. Keep code between this
     /// call and the next transactional operation non-blocking and computationally cheap;
     /// synchronous waits or long-running work delay broker-wide send and response processing.
+    /// Configure <see cref="ProducerBuilder{TKey,TValue}.WithInlineTransactionCompletions"/>
+    /// with <see langword="false"/> to run these continuations asynchronously instead.
     /// </remarks>
     ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -498,10 +498,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
     {
+        var runContinuationsAsynchronously = !_options.InlineTransactionCompletions;
         if (_retryPolicy is not null)
-            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: false, cancellationToken);
+            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously, cancellationToken);
 
-        return ProduceAsyncCore(message, runContinuationsAsynchronously: false, cancellationToken);
+        return ProduceAsyncCore(message, runContinuationsAsynchronously, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -307,6 +307,13 @@ public sealed class ProducerOptions
     public string? TransactionalId { get; init; }
 
     /// <summary>
+    /// Whether transactional produce continuations run inline on the broker sender thread.
+    /// Disable this when continuation code may block or perform long-running synchronous work.
+    /// Default is true for maximum transactional throughput.
+    /// </summary>
+    public bool InlineTransactionCompletions { get; init; } = true;
+
+    /// <summary>
     /// Enables KIP-939 two-phase commit participation for transactional producers.
     /// Requires broker support for <c>transaction.version</c> 3 and InitProducerId v6.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -171,6 +171,20 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithInlineTransactionCompletions_Disabled_WiresProducerOption()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithTransactionalId("txn-1")
+            .WithInlineTransactionCompletions(false)
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.InlineTransactionCompletions).IsFalse();
+    }
+
+    [Test]
     public async Task UseGzipCompression_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateProducer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -159,6 +159,66 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
+    public async Task TransactionProduceAsync_InlineDisabled_BlockingContinuationDoesNotBlockCompleter()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-async-transaction-producer",
+            TransactionalId = "test-transaction-id",
+            InlineTransactionCompletions = false,
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 4096,
+            LingerMs = 10,
+            RequestTimeoutMs = 500,
+            DeliveryTimeoutMs = 1000,
+            CloseTimeoutMs = 1000
+        };
+
+        await using var producer = new KafkaProducer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+        await StopProducerBackgroundLoopsAsync(producer);
+        SeedProducerMetadata(producer);
+        SetInstanceField(producer, "_initialized", true);
+        producer._transactionState = TransactionState.Ready;
+        var transaction = producer.BeginTransaction();
+        var produceTask = transaction.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = Topic,
+            Key = "key",
+            Value = "value"
+        });
+        var awaiter = produceTask.GetAwaiter();
+        var continuationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseContinuation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        awaiter.UnsafeOnCompleted(() =>
+        {
+            continuationStarted.TrySetResult();
+            releaseContinuation.Task.GetAwaiter().GetResult();
+        });
+        var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
+
+        var completionTask = Task.Run(() => readyBatch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow));
+        bool completionReturned;
+        try
+        {
+            await continuationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            completionReturned = await Task.WhenAny(completionTask, Task.Delay(500)) == completionTask;
+        }
+        finally
+        {
+            releaseContinuation.TrySetResult();
+        }
+        await completionTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(completionReturned).IsTrue();
+        await Assert.That(awaiter.GetResult().Offset).IsEqualTo(7);
+        producer._transactionState = TransactionState.Ready;
+    }
+
+    [Test]
     public async Task TransactionProduceAsync_SequentialAwaitCanReenterProducerOnSenderThread()
     {
         var options = new ProducerOptions


### PR DESCRIPTION
## Summary
- add WithInlineTransactionCompletions(false) for applications with blocking transactional continuation code
- route opted-out transaction completions through asynchronous dispatch
- preserve inline completions as the throughput-oriented default
- document sender-thread risk and mitigation in API/docs
- prove a blocked continuation cannot block the completion thread when opted out

## Test plan
- dotnet build tests/Dekaf.Tests.Unit --configuration Release --framework net10.0
- tests/Dekaf.Tests.Unit/bin/Release/net10.0/Dekaf.Tests.Unit.exe (5,393 passed)
- npm ci && npm run build in docs (production build passed)

Closes #2015