### PR TITLE
Reduce transactional producer send-loop CPU

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -72,9 +72,24 @@ def cpu_micros_per_message(result):
     return cpu_time_seconds * 1_000_000 / total_messages
 
 
+def cpu_micros_per_request(result):
+    """CPU microseconds per produce request, derived when needed."""
+    cpu_us_per_request = result.get('cpuMicrosPerRequest')
+    if cpu_us_per_request is not None:
+        return cpu_us_per_request
+
+    cpu_time_seconds = result.get('cpuTimeSeconds')
+    request_count = result.get('produceRequestCount')
+    if request_count is None:
+        request_count = (result.get('producerDeliveryDiagnostics') or {}).get('produceRequestCount')
+    if cpu_time_seconds is None or not request_count:
+        return None
+    return cpu_time_seconds * 1_000_000 / request_count
+
+
 def average_cores_used(result):
     """Average cores used, derived when older result files omit it."""
-    cores_used = result.get('averageCoresUsed')
+    cores_used = result.get('standingCores', result.get('averageCoresUsed'))
     if cores_used is not None:
         return cores_used
 
@@ -86,11 +101,13 @@ def average_cores_used(result):
 
 
 def format_cpu_columns(result):
-    """Format CPU-per-message / cores-used values, or '-' when not recorded."""
+    """Format CPU-per-message, CPU-per-request, and standing cores."""
     cpu_us_per_msg = cpu_micros_per_message(result)
+    cpu_us_per_request = cpu_micros_per_request(result)
     cores_used = average_cores_used(result)
     return (
         f"{cpu_us_per_msg:.2f}" if cpu_us_per_msg is not None else '-',
+        f"{cpu_us_per_request:.2f}" if cpu_us_per_request is not None else '-',
         f"{cores_used:.2f}" if cores_used is not None else '-',
     )
 
@@ -357,11 +374,11 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append("")
 
     if include_ratio:
-        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |")
-        lines.append("|--------|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|------------------|")
+        lines.append("| Client | CPU μs/msg | CPU μs/request | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Standing cores | Comparison Ratio |")
+        lines.append("|--------|------------|----------------|--------------|--------------|-------|-------------|--------|----------------|--------|----------------|------------------|")
     else:
-        lines.append("| Client | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used |")
-        lines.append("|--------|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|")
+        lines.append("| Client | CPU μs/msg | CPU μs/request | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Standing cores |")
+        lines.append("|--------|------------|----------------|--------------|--------------|-------|-------------|--------|----------------|--------|----------------|")
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
     sorted_results = sorted(results, key=throughput_sort_key)
@@ -379,13 +396,13 @@ def format_throughput_table(results, title, include_ratio=False):
         accepted_rate = accepted_messages_per_second(r)
         accepted = f"{accepted_rate:,.0f}" if accepted_rate is not None else '-'
         errors = throughput.get('totalErrors', 0)
-        cpu_us_per_msg, cores_used = format_cpu_columns(r)
+        cpu_us_per_msg, cpu_us_per_request, cores_used = format_cpu_columns(r)
 
         if include_ratio:
             ratio = comparison_rate(r) / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {cpu_us_per_request} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
         else:
-            lines.append(f"| {client} | {cpu_us_per_msg} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
+            lines.append(f"| {client} | {cpu_us_per_msg} | {cpu_us_per_request} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
 
     lines.append("")
 

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -277,6 +277,19 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("Slope %/min", report)
         self.assertIn("-35.9%", report)
 
+    def test_throughput_table_surfaces_request_cpu_and_standing_cores(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value.update({
+            "cpuTimeSeconds": 0.2,
+            "produceRequestCount": 500,
+        })
+
+        report = "\n".join(format_throughput_table([value], "Producer Throughput"))
+
+        self.assertIn("CPU μs/request", report)
+        self.assertIn("Standing cores", report)
+        self.assertIn("| 200.00 | 400.00 |", report)
+
     def test_intra_run_throughput_accepts_stable_samples(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value.update({
@@ -359,7 +372,7 @@ class StressReportTests(unittest.TestCase):
         dekaf_columns = [column.strip() for column in rows[0].strip("|").split("|")]
 
         self.assertTrue(rows[0].startswith("| Dekaf"))
-        self.assertEqual("-", dekaf_columns[3])
+        self.assertEqual("-", dekaf_columns[4])
         self.assertIn("| 2.00x |", rows[0])
 
     def test_transactional_scenario_reports_verification_counts(self):

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -778,7 +778,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         _responseCompletionCallback = () =>
         {
-            _eventChannel.Writer.TryWrite(SendLoopEvent.ResponseReady());
+            if (ShouldPublishResponseReadyEvent(Volatile.Read(ref _totalMaxInFlight)))
+                _eventChannel.Writer.TryWrite(SendLoopEvent.ResponseReady());
             _anyResponseCompleted.Signal();
         };
         _cts = new CancellationTokenSource();
@@ -1044,10 +1045,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// Main send loop: drains events from the unified channel, coalesces batches by partition,
     /// and sends pipelined requests. Single-threaded: coalescing is deterministically FIFO.
     ///
-    /// All wake-up sources (new batches, response completions, partition unmutes) flow through
-    /// <see cref="_eventChannel"/>. The loop drains all available events, processes responses
-    /// inline, then waits on a single <c>WaitToReadAsync</c> with a computed timeout — like
-    /// Java Kafka's Sender.poll() model.
+    /// New batches, partition unmutes, and pipelined response completions flow through
+    /// <see cref="_eventChannel"/>. A capacity-one sender uses its direct response signal instead,
+    /// avoiding a redundant channel event. The loop processes responses inline like Java Kafka's
+    /// Sender.poll() model.
     /// </summary>
     private async Task SendLoopAsync(CancellationToken cancellationToken)
     {
@@ -1168,7 +1169,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // Signal events (ResponseReady, Unmute) may have woken us up — processing
                 // completed responses here handles them. Batch events stay in the channel
                 // and are read lazily during coalescing (step 5) to avoid O(n²) carry-over growth.
-                ProcessCompletedResponses(carryOver, cancellationToken, responseLookup);
+                if (Volatile.Read(ref _totalPendingResponseCount) > 0)
+                    ProcessCompletedResponses(carryOver, cancellationToken, responseLookup);
 
                 // ── 2. Pick up send-failed retries ──
                 // Process these through the common retriable-error path. In particular, a
@@ -1204,7 +1206,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 // ── 3. Handle timed-out requests (Java handleTimedOutRequests pattern) ──
-                HandleTimedOutRequests(carryOver, cancellationToken);
+                var pendingResponseCount = Volatile.Read(ref _totalPendingResponseCount);
+                if (pendingResponseCount > 0
+                    && (pendingResponseCount > 1
+                        || carryOver.Count > 0
+                        || !_sendFailedRetries.IsEmpty
+                        || !_loopExitRedeliveries.IsEmpty
+                        || IsRequestTimeoutDue()))
+                {
+                    HandleTimedOutRequests(carryOver, cancellationToken);
+                }
 
                 // ── 4. Epoch bump (Java-style client-side, KIP-360) ──
                 // Synchronous: no network call, just epoch+1 + per-partition sequence reset.
@@ -1445,7 +1456,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             // contain unread NewBatch events that cause immediate (synchronous)
                             // return, creating a spin loop that starves the thread pool and
                             // prevents I/O completion callbacks from running.
-                            await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
+                            await WaitForAnyResponseAsync(
+                                    SelectPendingResponseWaitMs(ComputeNextWakeupMs(carryOver)),
+                                    cancellationToken)
+                                .ConfigureAwait(false);
                             pendingCount = Volatile.Read(ref _totalPendingResponseCount);
                             pendingBytes = Interlocked.Read(ref _totalPendingResponseBytes);
                         }
@@ -1528,7 +1542,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                 var responseWaitMs = ComputeThrottledResponseWaitMs(
                                     throttleDelayMs,
                                     nextDeadlineMs);
-                                await WaitForAnyResponseAsync(cancellationToken, responseWaitMs)
+                                await WaitForAnyResponseAsync(responseWaitMs, cancellationToken)
                                     .ConfigureAwait(false);
                                 continue;
                             }
@@ -1855,7 +1869,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         // synchronously and can starve response callbacks. Poll briefly so
                         // fresh work for another connection waits at most 1 ms while the
                         // guaranteed asynchronous yield lets acknowledgements make progress.
-                        await WaitForAnyResponseAsync(cancellationToken, BlockedBucketPollIntervalMs)
+                        await WaitForAnyResponseAsync(BlockedBucketPollIntervalMs, cancellationToken)
                             .ConfigureAwait(false);
                     }
                     else
@@ -1863,7 +1877,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         // Either carry-over exists (muted partitions may generate stale events),
                         // or at in-flight capacity limit, or no progress was made this iteration —
                         // wait for a response only.
-                        await WaitForAnyResponseAsync(cancellationToken).ConfigureAwait(false);
+                        await WaitForAnyResponseAsync(
+                                SelectPendingResponseWaitMs(ComputeNextWakeupMs(carryOver)),
+                                cancellationToken)
+                            .ConfigureAwait(false);
                     }
                 }
                 else if (carryOver.Count > 0)
@@ -2959,7 +2976,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     /// <summary>
     /// Java-style request timeout handling (handleTimedOutRequests pattern).
-    /// On every send loop iteration, checks if ANY pending response has exceeded the
+    /// When the scheduled deadline is due, or multiple requests/work queues require a sweep,
+    /// checks if ANY pending response has exceeded the
     /// request timeout. If so, removes ALL entries from the connection's pending list and processes
     /// each batch — exactly like Java's NetworkClient.handleTimedOutRequests() which closes
     /// the connection and calls cancelInFlightRequests() for the node.
@@ -3129,6 +3147,25 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return Math.Max(1, (int)(delayTicks * 1000.0 / Stopwatch.Frequency));
     }
 
+    private bool IsRequestTimeoutDue()
+    {
+        var now = _getTimestamp();
+        var requestTimeoutTicks = _options.RequestTimeoutTicks;
+        for (var connectionIndex = 0;
+             connectionIndex < _pendingResponsesByConnection.Length;
+             connectionIndex++)
+        {
+            var pendingResponses = _pendingResponsesByConnection[connectionIndex];
+            for (var i = 0; i < pendingResponses.Count; i++)
+            {
+                if (now >= pendingResponses[i].RequestStartTime + requestTimeoutTicks)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Handles a single batch that received a retriable error. Checks delivery timeout,
     /// mutes the partition, signals epoch bump if needed, sets backoff, and adds to carry-over.
@@ -3274,17 +3311,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Waits for any pending response to complete using an <see cref="AsyncAutoResetSignal"/>,
-    /// with a bounded periodic wake-up to re-sweep delivery timeouts for zombie entries.
-    /// Signal may be missed if multiple responses complete between iterations;
-    /// the 100ms default fallback ensures we don't wait indefinitely.
+    /// Waits for any pending response to complete using an <see cref="AsyncAutoResetSignal"/>
+    /// for the supplied interval. The normal response-only path supplies the next request
+    /// deadline; shorter polling intervals remain available for blocked buckets and throttling.
     ///
     /// Zero-allocation in steady state: the signal uses a reusable internal timer for
     /// the timeout and a one-time shutdown token registration for cancellation.
     /// </summary>
     private async ValueTask WaitForAnyResponseAsync(
-        CancellationToken cancellationToken,
-        int timeoutMs = ResponsePollIntervalMs)
+        int timeoutMs,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -3292,6 +3328,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Throws OperationCanceledException only on shutdown (via RegisterShutdownToken).
         await _anyResponseCompleted.WaitAsync(timeoutMs).ConfigureAwait(false);
     }
+
+    internal static bool ShouldPublishResponseReadyEvent(int totalMaxInFlight)
+        => totalMaxInFlight > 1;
+
+    internal static int SelectPendingResponseWaitMs(int nextWakeupMs)
+        => Math.Max(1, nextWakeupMs);
 
     internal static int ComputeThrottledResponseWaitMs(int throttleDelayMs, int batchDeadlineMs)
         => Math.Min(ResponsePollIntervalMs, Math.Min(throttleDelayMs, batchDeadlineMs));

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2152,11 +2152,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         _onRecordAppended = onRecordAppended;
         _resolveLeaderId = resolveLeaderId;
         _unackedBudgetEnabled = options.DeliveryLatencyTargetMs > 0 && resolveLeaderId is not null;
+        _produceRequestDiagnosticsStartedAt = Stopwatch.GetTimestamp();
         if (options.EnableDeliveryDiagnostics)
         {
             _coalesceWidthCounts = new long[MaxTrackedCoalesceWidth + 2];
             _brokerProduceRequestCounters = new ConcurrentDictionary<int, ProducerRequestDiagnosticCounters>();
-            _produceRequestDiagnosticsStartedAt = Stopwatch.GetTimestamp();
         }
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
@@ -4843,10 +4843,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         if (!_options.EnableDeliveryDiagnostics)
         {
+            var measurementStartedAt = Volatile.Read(ref _produceRequestDiagnosticsStartedAt);
+            var requestCount = Interlocked.Read(ref _produceRequestCount);
+            var elapsedSeconds = Math.Max(
+                0,
+                (Stopwatch.GetTimestamp() - measurementStartedAt) / (double)Stopwatch.Frequency);
             return new ProducerDeliveryDiagnosticsSnapshot
             {
                 CapturedAtUtc = DateTimeOffset.UtcNow,
-                DiagnosticsEnabled = false
+                DiagnosticsEnabled = false,
+                ProduceRequestCount = requestCount,
+                ProduceRequestElapsedSeconds = elapsedSeconds,
+                ProduceRequestsPerSecond = elapsedSeconds > 0
+                    ? requestCount / elapsedSeconds
+                    : 0
             };
         }
 
@@ -4933,11 +4943,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void RecordProduceRequest(int brokerId, int coalesceWidth, int requestBytes)
     {
+        Interlocked.Increment(ref _produceRequestCount);
         var widthCounts = _coalesceWidthCounts;
         if (widthCounts is null)
             return;
 
-        Interlocked.Increment(ref _produceRequestCount);
         Interlocked.Increment(ref widthCounts[Math.Min(coalesceWidth, MaxTrackedCoalesceWidth + 1)]);
         var counters = _brokerProduceRequestCounters!.GetOrAdd(
             brokerId,
@@ -4948,11 +4958,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal void ResetProduceRequestDiagnostics()
     {
+        Interlocked.Exchange(ref _produceRequestCount, 0);
+        Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
         var widthCounts = _coalesceWidthCounts;
         if (widthCounts is null)
             return;
 
-        Interlocked.Exchange(ref _produceRequestCount, 0);
         for (var width = 1; width < widthCounts.Length; width++)
             Interlocked.Exchange(ref widthCounts[width], 0);
         foreach (var counters in _brokerProduceRequestCounters!.Values)
@@ -4960,7 +4971,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             Interlocked.Exchange(ref counters.RequestCount, 0);
             Interlocked.Exchange(ref counters.RequestBytes, 0);
         }
-        Volatile.Write(ref _produceRequestDiagnosticsStartedAt, Stopwatch.GetTimestamp());
     }
 
     private sealed class ProducerRequestDiagnosticCounters

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -172,6 +172,24 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    public async Task ShouldPublishResponseReadyEvent_DepthOneUsesDirectSignalOnly()
+    {
+        await Assert.That(BrokerSender.ShouldPublishResponseReadyEvent(totalMaxInFlight: 1))
+            .IsFalse();
+        await Assert.That(BrokerSender.ShouldPublishResponseReadyEvent(totalMaxInFlight: 2))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task SelectPendingResponseWaitMs_UsesRequestDeadline()
+    {
+        await Assert.That(BrokerSender.SelectPendingResponseWaitMs(nextWakeupMs: 30_000))
+            .IsEqualTo(30_000);
+        await Assert.That(BrokerSender.SelectPendingResponseWaitMs(nextWakeupMs: 0))
+            .IsEqualTo(1);
+    }
+
+    [Test]
     public async Task SelectWaveCoalesceBounds_ScalesWithLingerAndRetainsHardCaps()
     {
         var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -143,14 +143,15 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
-    public async Task ProduceRequestDiagnostics_Disabled_DoesNotRecord()
+    public async Task ProduceRequestDiagnostics_Disabled_RecordsOnlyLightweightRequestCount()
     {
         await using var accumulator = new RecordAccumulator(CreateOptions());
 
         accumulator.RecordProduceRequest(brokerId: 1, coalesceWidth: 2, requestBytes: 200);
         var snapshot = accumulator.GetDeliveryDiagnosticsSnapshot();
 
-        await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(0);
+        await Assert.That(snapshot.DiagnosticsEnabled).IsFalse();
+        await Assert.That(snapshot.ProduceRequestCount).IsEqualTo(1);
         await Assert.That(snapshot.CoalesceWidthHistogram).IsEmpty();
         await Assert.That(snapshot.BrokerProduceRequests).IsEmpty();
     }

--- a/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/TransactionalReportingTests.cs
@@ -1,5 +1,6 @@
 using Dekaf.StressTests.Metrics;
 using Dekaf.StressTests.Reporting;
+using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.StressTests;
 
@@ -63,6 +64,31 @@ public sealed class TransactionalReportingTests
     }
 
     [Test]
+    public async Task Generate_TransactionalResult_ReportsCpuPerRequestAndStandingCores()
+    {
+        var result = CreateResult(
+            CreateVerification(),
+            elapsedSeconds: 100,
+            cpuTimeSeconds: 20,
+            produceRequestCount: 50);
+        var results = new StressTestResults
+        {
+            RunStartedAtUtc = result.StartedAtUtc,
+            RunCompletedAtUtc = result.CompletedAtUtc,
+            MachineName = "test",
+            ProcessorCount = 4,
+            Results = [result]
+        };
+
+        var markdown = MarkdownReporter.Generate(results);
+
+        await Assert.That(result.CpuMicrosPerRequest).IsEqualTo(400_000);
+        await Assert.That(result.StandingCores).IsEqualTo(0.2);
+        await Assert.That(markdown).Contains("CPU μs/request");
+        await Assert.That(markdown).Contains("Standing cores");
+    }
+
+    [Test]
     public async Task CheckForFailures_DuplicateTransactionalRecord_FailsRun()
     {
         var verification = CreateVerification(duplicateMessages: 1);
@@ -96,7 +122,9 @@ public sealed class TransactionalReportingTests
         TransactionVerificationSnapshot verification,
         string client = "Dekaf",
         double elapsedSeconds = 900,
-        long? allocatedBytes = 0)
+        long? allocatedBytes = 0,
+        double? cpuTimeSeconds = null,
+        long? produceRequestCount = null)
     {
         var now = DateTime.UtcNow;
         return new StressTestResult
@@ -119,6 +147,10 @@ public sealed class TransactionalReportingTests
                 ErrorSamples = []
             },
             DeliveredMessages = verification.DeliveredMessages,
+            CpuTimeSeconds = cpuTimeSeconds,
+            ProducerDeliveryDiagnostics = produceRequestCount is { } requestCount
+                ? new ProducerDeliveryDiagnosticsSnapshot { ProduceRequestCount = requestCount }
+                : null,
             GcStats = new GcSnapshot
             {
                 Gen0Collections = 0,

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -102,8 +102,8 @@ internal static class MarkdownReporter
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
             sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
             sb.AppendLine();
-            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Cores Used | Comparison Ratio |");
-            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|--------------|--------------|-------|-------------|--------|----------------|--------|------------|------------------|");
+            sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | CPU μs/request | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Standing cores | Comparison Ratio |");
+            sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|----------------|--------------|--------------|-------|-------------|--------|----------------|--------|----------------|------------------|");
 
             var baseline = sizeResults
                 .Where(r => r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase))
@@ -125,7 +125,8 @@ internal static class MarkdownReporter
                 var slope = result.ThroughputSlopePercentPerMinute is { } slopePercent ? $"{slopePercent:+0.00;-0.00;0.00}%" : "-";
                 var accepted = result.AcceptedMessagesPerSecond is { } acceptedRate ? acceptedRate.ToString("N0") : "-";
                 var cpuPerMessage = result.CpuMicrosPerMessage is { } cpu ? $"{cpu:F2}" : "-";
-                var coresUsed = result.AverageCoresUsed is { } cores ? $"{cores:F2}" : "-";
+                var cpuPerRequest = result.CpuMicrosPerRequest is { } requestCpu ? $"{requestCpu:F2}" : "-";
+                var standingCores = result.StandingCores is { } cores ? $"{cores:F2}" : "-";
                 // Errors column includes broker-side delivery failures so a run that lost
                 // accepted messages can never render a clean zero; the "dlv" suffix keeps
                 // "client loop broke" distinguishable from "broker rejected accepted messages".
@@ -133,7 +134,7 @@ internal static class MarkdownReporter
                 var errors = deliveryErrors > 0
                     ? $"{result.Throughput.TotalErrors} (+{deliveryErrors} dlv)"
                     : result.Throughput.TotalErrors.ToString()!;
-                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {rate,12:N0} | {median,12} | {drift,7} | {slope,11} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {errors,6} | {coresUsed,10} | {ratio:F2}x |");
+                sb.AppendLine($"| {result.Client.PadRight(clientWidth)} | {cpuPerMessage,10} | {cpuPerRequest,14} | {rate,12:N0} | {median,12} | {drift,7} | {slope,11} | {result.EffectiveMegabytesPerSecond,6:F2} | {accepted,14} | {errors,6} | {standingCores,14} | {ratio:F2}x |");
             }
 
             sb.AppendLine();

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -145,10 +145,26 @@ internal sealed class StressTestResult
             ? cpu * 1_000_000.0 / Throughput.TotalMessages
             : null;
 
+    public long? ProduceRequestCount =>
+        ProducerDeliveryDiagnostics is { ProduceRequestCount: > 0 } diagnostics
+            ? diagnostics.ProduceRequestCount
+            : null;
+
+    public double? CpuMicrosPerRequest =>
+        CpuTimeSeconds is { } cpu && ProduceRequestCount is { } requestCount
+            ? cpu * 1_000_000.0 / requestCount
+            : null;
+
     public double? AverageCoresUsed =>
         CpuTimeSeconds is { } cpu && Throughput.ElapsedSeconds > 0
             ? cpu / Throughput.ElapsedSeconds
             : null;
+
+    /// <summary>
+    /// Average process CPU demand across the full wall-clock measurement window.
+    /// This is the standing core count for latency-bound scenarios.
+    /// </summary>
+    public double? StandingCores => AverageCoresUsed;
 
     public double? AllocatedBytesPerMessage =>
         GcStats.AllocatedBytes is { } allocated && Throughput.TotalMessages > 0

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -72,7 +72,7 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             options.Topic,
             options.Partitions,
             cancellationToken).ConfigureAwait(false);
-        StressTestHelpers.ResetProducerDeliveryDiagnostics(producer, options);
+        StressTestHelpers.ResetProducerDeliveryDiagnostics(producer);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -183,7 +183,7 @@ internal static class StressTestHelpers
             ProducerWarmupMessageCount,
             throughput,
             "Warmup drain").ConfigureAwait(false);
-        ResetProducerDeliveryDiagnostics(producer, options);
+        ResetProducerDeliveryDiagnostics(producer);
         return startOffset;
     }
 
@@ -355,14 +355,11 @@ internal static class StressTestHelpers
         IKafkaProducer<TKey, TValue> producer,
         StressTestOptions options)
     {
-        if (!options.EnableProducerDeliveryDiagnostics)
-            return null;
-
         if (producer is not IProducerDiagnostics diagnostics)
             return null;
 
         var snapshot = diagnostics.GetDeliveryDiagnosticsSnapshot();
-        if (snapshot.Batches.Count > 0)
+        if (options.EnableProducerDeliveryDiagnostics && snapshot.Batches.Count > 0)
         {
             Console.WriteLine($"  Captured producer delivery diagnostics: " +
                 $"inFlight={snapshot.InFlightBatchCount:N0}, batches={snapshot.Batches.Count:N0}");
@@ -372,10 +369,9 @@ internal static class StressTestHelpers
     }
 
     internal static void ResetProducerDeliveryDiagnostics<TKey, TValue>(
-        IKafkaProducer<TKey, TValue> producer,
-        StressTestOptions options)
+        IKafkaProducer<TKey, TValue> producer)
     {
-        if (options.EnableProducerDeliveryDiagnostics && producer is IProducerDiagnostics diagnostics)
+        if (producer is IProducerDiagnostics diagnostics)
             diagnostics.ResetProduceRequestDiagnostics();
     }
 

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -46,6 +46,7 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
         var producer = await builder.BuildAsync(cancellationToken).ConfigureAwait(false);
         await producer.InitTransactionsAsync(cancellationToken).ConfigureAwait(false);
         await WarmUpAsync(producer, options.Topic, cancellationToken).ConfigureAwait(false);
+        StressTestHelpers.ResetProducerDeliveryDiagnostics(producer);
 
         GC.Collect();
         GC.WaitForPendingFinalizers();


### PR DESCRIPTION
Closes #2013

## Summary
- avoid empty response scans and redundant response-channel wakes on capacity-one senders
- defer steady depth-one timeout sweeps to the actual request deadline
- retain a lightweight produce-request count when detailed delivery diagnostics are disabled
- report CPU/message, CPU/produce-request, and standing cores in both stress reporters

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release --no-restore` (0 warnings)
- `Dekaf.Tests.Unit.exe` (5,402 passed)
- `python -m unittest test_stress_report.py` (19 passed)
- 2-minute transactional A/B, 2 logical processors, zero linger: CPU 350.10 -> 176.93 us/message; accepted 533 -> 1,549 msg/s; exact EOS verification
- final 1-minute smoke: 176.75 us/message, 176.73 us/request, 0.23 standing cores; 77,000 accepted, 57,800 committed/delivered, zero duplicates/shortfall/aborted leaks