### PR TITLE
fix(producer): use periodic active linger cadence

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -61,6 +61,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly CancellationTokenSource _senderCts;
     private readonly Task _senderTask;
     private readonly Task _lingerTask;
+    private readonly PeriodicTimer _lingerTimer;
     private readonly ConcurrentDictionary<Task, byte> _partitionEnrollmentTasks = new();
 
     // Per-broker sender threads: each broker gets a dedicated BrokerSender with its own
@@ -421,6 +422,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
 
         _senderCts = new CancellationTokenSource();
+        _lingerTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
         _senderTask = Task.Factory.StartNew(
             () => SenderLoopAsync(_senderCts.Token),
             CancellationToken.None,
@@ -3277,6 +3279,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var lastOrphanSweepTicks = Stopwatch.GetTimestamp();
 
         _accumulator.RegisterLingerWakeupShutdownToken(cancellationToken);
+        using var cancellationRegistration = cancellationToken.UnsafeRegister(
+            static state => ((PeriodicTimer)state!).Dispose(),
+            _lingerTimer);
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -3287,11 +3292,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 var orphanWaitMs = ticksUntilOrphanSweep <= 0
                     ? 0
                     : Math.Max(1, (int)Math.Ceiling(ticksUntilOrphanSweep * 1000.0 / Stopwatch.Frequency));
-                var waitMs = _accumulator.HasPendingLingerBatches && orphanWaitMs > 0
-                    ? 1
-                    : orphanWaitMs;
 
-                await _accumulator.WaitForLingerWakeupAsync(waitMs).ConfigureAwait(false);
+                if (_accumulator.HasPendingLingerBatches)
+                {
+                    if (!await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
+                        break;
+                }
+                else
+                {
+                    await _accumulator.WaitForLingerWakeupAsync(orphanWaitMs).ConfigureAwait(false);
+                }
+
                 await _accumulator.ExpireLingerAsync(cancellationToken).ConfigureAwait(false);
 
                 // Periodic orphan sweep: fail in-flight batches that exceeded delivery timeout.
@@ -4191,6 +4202,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _senderCts.Dispose();
+        _lingerTimer.Dispose();
         _transactionLock.Dispose();
         _initLock.Dispose();
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1124,8 +1124,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly AsyncAutoResetSignal _wakeupSignal = new();
 
     /// <summary>
-    /// Signals the linger loop when an unsealed batch is created or gains its first awaiter.
-    /// This keeps the 1 ms linger cadence armed only while batches need it.
+    /// Arms the periodic linger cadence when the first unsealed batch becomes active.
     /// </summary>
     private readonly AsyncAutoResetSignal _lingerWakeupSignal = new();
 
@@ -2593,10 +2592,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         bool signalLingerLoop = true)
     {
         if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
+        {
             _lingerPartitions.Enqueue(topicPartition);
-
-        if (signalLingerLoop)
-            _lingerWakeupSignal.Signal();
+            if (signalLingerLoop)
+                _lingerWakeupSignal.Signal();
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Threading.Channels;
 using Dekaf.Producer;
 
@@ -56,6 +57,48 @@ public class ProducerCancellationTests
 
         await disposal.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(disposal.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
+    public async Task Cancellation_StopsActiveLingerTimerPromptly()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithLinger(TimeSpan.FromMinutes(1))
+            .Build();
+        var accumulator = GetField<RecordAccumulator>(producer, "_accumulator");
+        var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
+        var lingerTask = GetField<Task>(producer, "_lingerTask");
+
+        try
+        {
+            // Append directly so the active linger path is covered without requiring Kafka I/O.
+            await accumulator.AppendAsync(
+                "test-topic",
+                partition: 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                new PooledMemory(null, 0, isNull: true),
+                new PooledMemory(null, 0, isNull: true),
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                CancellationToken.None);
+            await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
+
+            // Let the linger loop consume the wakeup and enter its periodic active cadence.
+            await Task.Delay(20);
+            senderCts.Cancel();
+
+            await lingerTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(lingerTask.IsCompletedSuccessfully).IsTrue();
+        }
+        finally
+        {
+            senderCts.Cancel();
+            await accumulator.DisposeAsync();
+            await producer.DisposeAsync();
+        }
     }
 
     [Test]
@@ -288,4 +331,9 @@ public class ProducerCancellationTests
             await accumulator.DisposeAsync();
         }
     }
+
+    private static T GetField<T>(object instance, string name)
+        => (T)instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(instance)!;
 }


### PR DESCRIPTION
## Summary
- use `AsyncAutoResetSignal` only to arm linger processing from idle
- use reusable `PeriodicTimer` ticks while unsealed batches remain active
- signal only when a partition first enters the active linger queue
- cover cancellation while the periodic active cadence is armed
- preserve later budget, request-coalescing, and transactional fixes on PR #2019

## Root cause
A local commit bisect identified `8e6295ef` (`perf(producer): arm linger scheduler`) as the first bad commit. It replaced reusable periodic ticks with repeated one-shot 1 ms timer rearming, fragmenting request formation and cutting throughput.

Identical 2-minute Testcontainers acks-all A/B on the PR #2019 head:

| Variant | msg/s | median msg/s | msg/request | CPU us/msg |
|---|---:|---:|---:|---:|
| one-shot active timer | 65,799 | 67,496 | 293.3 | 3.777 |
| hybrid periodic-active cadence | 182,044 | 183,495 | 822.5 | 1.755 |

Parent/first-bad bisect confirmation:
- `796fa085` (good): 200,803 msg/s
- `8e6295ef` (bad): 69,847 msg/s

The producer loop remains signal-blocked while idle and consumes periodic ticks only while unsealed batches exist. The PeriodicTimer object remains alive for the producer lifetime, so its underlying timer still ticks in the background; the fix avoids the much costlier one-shot 1 ms rearming regression.

## Validation
- active-cadence cancellation regression: pass
- 10/10 producer cancellation tests pass
- 5,422/5,422 net10 unit tests pass
- Release build: 0 warnings, 0 errors

Stacked on #2019 so its exact-head stress gate can validate the combined producer-control fixes.

Refs #2011