### PR TITLE
fix(producer): bound delivery epoch rates

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -53,6 +53,7 @@ internal sealed class BrokerUnackedByteBudget
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
         long DeliveredTimestamp,
+        long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
         long OldestBatchTimestamp,
@@ -175,6 +176,8 @@ internal sealed class BrokerUnackedByteBudget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
+    private const long NoDeliveryEpoch = -1;
+    private const long DeliveryEpochUpdating = -2;
 
     // Cross-thread state.
     private long _unackedBytes;
@@ -190,6 +193,8 @@ internal sealed class BrokerUnackedByteBudget
     // via volatile reads by parallel connection sends at send time.
     private long _totalDeliveredBytes;
     private long _lastDeliveredTimestamp;
+    private long _sendEpochDeliveredBytes = NoDeliveryEpoch;
+    private long _sendEpochFirstTimestamp;
 
     // Single-writer state (owning send loop only; constructor runs before the loop starts).
     private readonly long _floorBytes;
@@ -229,7 +234,6 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbeRateSum;
     private double _capacityProbeRttSumSeconds;
     private double _capacityProbePreProbeRttSeconds;
-    private double _capacityProbeMaxRate;
     private int _capacityProbeRateSampleCount;
     private bool _capacityProbeActive;
     private long _capacityProbeSuccessCount;
@@ -308,13 +312,50 @@ internal sealed class BrokerUnackedByteBudget
         long sendTimestamp,
         bool appLimited,
         long oldestBatchTimestamp = 0)
-        => new(
-            Volatile.Read(ref _totalDeliveredBytes),
+    {
+        var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
+            sendTimestamp,
+            out var deliveredBytes);
+        return new DeliverySnapshot(
+            deliveredBytes,
             Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
             oldestBatchTimestamp,
             Volatile.Read(ref _unackedBytes));
+    }
+
+    private long CaptureDeliveryEpoch(long sendTimestamp, out long deliveredBytes)
+    {
+        var spinner = new SpinWait();
+        while (true)
+        {
+            deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
+            var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
+            if (epochDeliveredBytes == deliveredBytes)
+                return Volatile.Read(ref _sendEpochFirstTimestamp);
+
+            if (epochDeliveredBytes == DeliveryEpochUpdating)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            if (Interlocked.CompareExchange(
+                    ref _sendEpochDeliveredBytes,
+                    DeliveryEpochUpdating,
+                    epochDeliveredBytes) != epochDeliveredBytes)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
+            Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
+            return sendTimestamp;
+        }
+    }
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see
     /// <see cref="HistogramBucketCount"/> for bucket semantics).</summary>
@@ -515,6 +556,12 @@ internal sealed class BrokerUnackedByteBudget
         var deliveredDelta = totalDelivered - sendSnapshot.DeliveredBytes;
 
         var intervalTicks = rttTicks;
+        if (sendSnapshot.DeliveryEpochFirstSendTimestamp > 0)
+        {
+            intervalTicks = Math.Max(
+                intervalTicks,
+                sendSnapshot.SendTimestamp - sendSnapshot.DeliveryEpochFirstSendTimestamp);
+        }
         if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
             intervalTicks = Math.Max(intervalTicks, nowTicks - sendSnapshot.DeliveredTimestamp);
         Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
@@ -865,7 +912,6 @@ internal sealed class BrokerUnackedByteBudget
 
             _capacityProbeRateSum += bytesPerSecond;
             _capacityProbeRttSumSeconds += rttSeconds;
-            _capacityProbeMaxRate = Math.Max(_capacityProbeMaxRate, bytesPerSecond);
             _capacityProbeRateSampleCount++;
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
@@ -891,10 +937,9 @@ internal sealed class BrokerUnackedByteBudget
                 || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
             if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
             {
-                // Use the strongest rate actually demonstrated by this successful probe as
-                // the next rung's baseline. Otherwise a slow first response depresses the
-                // average and unchanged steady-state traffic falsely succeeds again.
-                _capacityProbeBaselineRate = Math.Max(averageRate, _capacityProbeMaxRate);
+                // Compare like with like across rungs. A single clustered-response peak is not
+                // a sustainable baseline and would make the next average-rate rung unwinnable.
+                _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
                 _capacityProbeStartTimestamp = nowTicks;
                 ResetCapacityProbeSamples();
@@ -913,7 +958,8 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks < _nextProbeTimestamp)
             return;
 
-        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks)
+        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks
+            && HasCapacityProbeDemand())
         {
             _capacityProbeStartTimestamp = nowTicks;
             _capacityProbeBaselineRate = GetWindowAverageRate();
@@ -932,6 +978,13 @@ internal sealed class BrokerUnackedByteBudget
         _nextProbeTimestamp = nowTicks + probeIntervalTicks;
     }
 
+    private bool HasCapacityProbeDemand()
+    {
+        var budgetBytes = Volatile.Read(ref _budgetBytes);
+        var minimumDemandBytes = Math.Max(1, budgetBytes / 2);
+        return Volatile.Read(ref _unackedBytes) >= minimumDemandBytes;
+    }
+
     private static long GetProbeIntervalTicks(long rttTicks)
         => rttTicks >= MaxProbeIntervalTicks / ProbeIntervalRtts
             ? MaxProbeIntervalTicks
@@ -941,7 +994,6 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capacityProbeRateSum = 0;
         _capacityProbeRttSumSeconds = 0;
-        _capacityProbeMaxRate = 0;
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -354,13 +354,26 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
-            // The loop-top delivery read can predate a newer epoch value observed by the
-            // successful CAS. Re-read after winning so publication never regresses that value.
-            deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
-            Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
-            Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
-            return sendTimestamp;
+            return PublishDeliveryEpoch(sendTimestamp, epochDeliveredBytes, out deliveredBytes);
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long PublishDeliveryEpoch(
+        long sendTimestamp,
+        long previousEpochDeliveredBytes,
+        out long deliveredBytes)
+    {
+        // The loop-top delivery read can predate a newer epoch value observed by the
+        // successful CAS. Re-read after winning so publication never regresses that value.
+        // A redundant publisher must also preserve the first send timestamp already chosen
+        // for the epoch; moving it forward would narrow the send-axis delivery interval.
+        deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
+        if (deliveredBytes != previousEpochDeliveredBytes)
+            Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
+
+        Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
+        return Volatile.Read(ref _sendEpochFirstTimestamp);
     }
 
     /// <summary>Diagnostics: log2 histogram of acked request payload sizes (see

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -36,9 +36,9 @@ namespace Dekaf.Producer;
 /// <see cref="OnAcked"/>, <see cref="CompleteAckedPass"/>, and <see cref="SetCap"/> are
 /// single-writer — only the owning broker's send loop calls them — so the remaining estimator
 /// state needs no synchronization; the computed budget is published with a volatile write.
-/// <see cref="SnapshotDelivery"/> performs two independent volatile reads racing the single
-/// writer; both fields are monotonic, so a torn pair only skews one rate sample marginally
-/// and the windowed max filters it.
+/// <see cref="SnapshotDelivery"/> serializes delivery-epoch publication with a CAS while the
+/// most-recent-delivery timestamp remains an independent monotonic read. Skew between those
+/// clocks only widens one sample marginally.
 /// </para>
 /// </summary>
 internal sealed class BrokerUnackedByteBudget
@@ -170,6 +170,9 @@ internal sealed class BrokerUnackedByteBudget
     // then three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
+    /// <summary>Only probe when standing demand fills at least this fraction of the gate;
+    /// enlarging a more-open gate cannot reveal additional delivery capacity.</summary>
+    private const double CapacityProbeDemandFraction = 0.5;
     /// <summary>A probe confirms capacity only when rate rises without the round trip
     /// inflating past this tolerance. Through a saturated broker, delivered rate never drops
     /// when queue is added, so a rate-only acceptance test converts every probe into budget
@@ -300,9 +303,9 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
-    /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Two
-    /// independent volatile reads — tearing is benign because both fields are monotonic and a
-    /// skewed pair only shifts one rate sample marginally.
+    /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
+    /// epoch changes are CAS-published so parallel sends cannot regress the delivered-byte
+    /// marker; the independent last-delivery timestamp may only conservatively widen a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -351,6 +354,9 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
+            // The loop-top delivery read can predate a newer epoch value observed by the
+            // successful CAS. Re-read after winning so publication never regresses that value.
+            deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
             Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
             Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
             return sendTimestamp;
@@ -981,7 +987,9 @@ internal sealed class BrokerUnackedByteBudget
     private bool HasCapacityProbeDemand()
     {
         var budgetBytes = Volatile.Read(ref _budgetBytes);
-        var minimumDemandBytes = Math.Max(1, budgetBytes / 2);
+        var minimumDemandBytes = Math.Max(
+            1,
+            (long)(budgetBytes * CapacityProbeDemandFraction));
         return Volatile.Read(ref _unackedBytes) >= minimumDemandBytes;
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1531,6 +1531,45 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task DeliverySnapshots_NeverRegressUnderConcurrentAcknowledgements()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        using var start = new Barrier(participantCount: 9);
+        var regressionCount = 0;
+
+        var readers = Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait();
+            var previousDeliveredBytes = 0L;
+            for (var i = 0; i < 100_000; i++)
+            {
+                var snapshot = budget.SnapshotDelivery(i + 1, appLimited: false);
+                if (snapshot.DeliveredBytes < previousDeliveredBytes)
+                    Interlocked.Increment(ref regressionCount);
+                previousDeliveredBytes = snapshot.DeliveredBytes;
+            }
+        })).ToArray();
+
+        start.SignalAndWait();
+        for (var i = 0; i < 50_000; i++)
+        {
+            var now = T0 + i + 1;
+            budget.OnAcked(
+                1,
+                new BrokerUnackedByteBudget.DeliverySnapshot(
+                    i, 0, 0, now - 1, true, 0, 0),
+                now);
+        }
+
+        await Task.WhenAll(readers);
+        await Assert.That(regressionCount).IsEqualTo(0)
+            .Because("a completed send snapshot cannot predate an earlier snapshot on the same connection");
+    }
+
+    [Test]
     public async Task IsOverBudget_TransitionsWithChargesAndReleases()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 100, initialCapBytes: 100);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1570,6 +1570,33 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task DeliveryEpoch_RedundantPublisherPreservesFirstSendAnchor()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        const long deliveredBytes = 100;
+        const long firstSendTimestamp = 6_000;
+        const long stalePublisherTimestamp = 7_000;
+        const long deliveryEpochUpdating = -2;
+
+        SetField(budget, "_totalDeliveredBytes", deliveredBytes);
+        SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
+        SetField(budget, "_sendEpochFirstTimestamp", firstSendTimestamp);
+
+        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null };
+        var anchor = (long)typeof(BrokerUnackedByteBudget)
+            .GetMethod("PublishDeliveryEpoch", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(budget, arguments)!;
+
+        await Assert.That(anchor).IsEqualTo(firstSendTimestamp);
+        await Assert.That(arguments[2]).IsEqualTo(deliveredBytes);
+        await Assert.That(GetField<long>(budget, "_sendEpochFirstTimestamp")).IsEqualTo(firstSendTimestamp);
+        await Assert.That(GetField<long>(budget, "_sendEpochDeliveredBytes")).IsEqualTo(deliveredBytes);
+    }
+
+    [Test]
     public async Task IsOverBudget_TransitionsWithChargesAndReleases()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 100, initialCapBytes: 100);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -799,6 +799,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_CollectsThreeRtts_ThenRevertsWithoutRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -861,6 +862,28 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
             .Because("one noisy high sample must not ratchet a three-RTT low-rate probe");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_SuccessCarriesAverageRateToNextRung_NotSinglePeak()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", 42_000.0);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
+            .IsEqualTo(18_000.0).Within(0.001)
+            .Because("the next probe rung must compare average rate with average rate");
     }
 
     [Test]
@@ -1077,6 +1100,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_CollectsFullRttBeforeJudgingRateGain()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1097,13 +1121,12 @@ public sealed class BrokerUnackedByteBudgetTests
             targetSeconds: 0.5,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
+        budget.Charge(5_500);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
-        budget.Charge(5_500);
-
         await Assert.That(budget.IsOverBudget()).IsTrue()
             .Because("occupancy above the normal budget must reach the deadline-aware gate");
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse()
@@ -1134,6 +1157,7 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_WaitsForSampleWhollyAdmittedUnderProbe()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1212,6 +1236,7 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
         Ack(budget, 10, 0.001, T0);
+        budget.Charge(100);
         SetField(budget, "_retainedLoadedMaxRate", 100_000.0);
         SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
 
@@ -1222,9 +1247,25 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_DoesNotArmWhileAdmissionGateHasNoDemand()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        Ack(budget, 10, 0.001, T0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
+
+        Ack(budget, 10, 0.001, T0 + Seconds(0.008));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("raising an underfilled gate cannot reveal delivery headroom");
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0)
+            .Because("lack of demand is not evidence that a capacity probe failed");
+    }
+
+    [Test]
     public async Task PeriodicProbe_RatchetsWhileWhollyProbedRateRises()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
@@ -1242,8 +1283,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
         await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
 
-        // The ratcheted level gets another three-RTT average. No further growth publishes
-        // the discovered base budget without the temporary 1.25x multiplier.
+        // The ratcheted level gets another full-window average. Comparing average with
+        // average lets the sustained 25% gain advance the next rung as well.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.300));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.400));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.500));
@@ -1252,9 +1293,9 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.800));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
         Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(7_810);
-        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
-        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
     }
 
     [Test]
@@ -1346,6 +1387,39 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task TailOfBurstAck_UsesSendAxisAcrossDeliveryEpoch()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+        var sendSnapshots = new BrokerUnackedByteBudget.DeliverySnapshot[5];
+
+        // All requests enter the same delivery epoch before any response arrives. The tail
+        // request has only a 0.5 ms own RTT, but its delivered delta spans the full 4 ms send
+        // burst. Using own RTT alone reports 10 GB/s from a 1.25 GB/s stream.
+        for (var i = 0; i < sendSnapshots.Length; i++)
+        {
+            sendSnapshots[i] = budget.SnapshotDelivery(
+                T0 + Seconds(i * 0.001),
+                appLimited: i == 0);
+        }
+
+        for (var i = 0; i < sendSnapshots.Length; i++)
+        {
+            budget.OnAcked(
+                1_000_000,
+                sendSnapshots[i],
+                T0 + Seconds(0.0041 + i * 0.0001));
+        }
+        budget.CompleteAckedPass(T0 + Seconds(0.0045));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_200_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_400_000_000)
+            .Because("a cumulative delivery delta must include its delivery epoch's send time");
+    }
+
+    [Test]
     public async Task AckAxis_LoadedGapSpreadsDeliveryOverArrivalTime()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -1396,11 +1470,10 @@ public sealed class BrokerUnackedByteBudgetTests
     public async Task PeriodicProbe_WithoutFurtherAck_RevertsAfterEightRtts()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        budget.Charge(5_500);
 
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
-
-        budget.Charge(5_500);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse();
         await Assert.That(budget.GetAdmissionRecheckDelayMilliseconds(T0 + Seconds(0.900)))


### PR DESCRIPTION
## Summary\n- measure cumulative delivery over the full send epoch\n- carry window-average rate between probe rungs\n- skip capacity probes while the admission gate has no demand\n\n## Validation\n- 5,424 net10.0 unit tests pass\n- BrokerUnackedByteBudget benchmarks: 15.21 ns / 18.68 ns, 0 B allocated\n\nCloses #2034