### PR TITLE
fix(producer): defang admission blips

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -772,10 +772,18 @@ internal sealed class BrokerUnackedByteBudget
         if (naturalMinRttSample
             && serviceRttSeconds <= _minRttSeconds * ProbeRttGrowthTolerance)
         {
-            _minRttSeconds = Math.Min(_minRttSeconds, serviceRttSeconds);
-            _minRttTimestamp = nowTicks;
-            _minRttProbeMinimumSeconds = double.MaxValue;
-            _minRttProbeUntilTimestamp = 0;
+            if (_minRttProbeUntilTimestamp != 0)
+            {
+                _minRttProbeMinimumSeconds = Math.Min(
+                    _minRttProbeMinimumSeconds,
+                    serviceRttSeconds);
+                CompleteMinRttProbe(nowTicks);
+            }
+            else
+            {
+                _minRttSeconds = Math.Min(_minRttSeconds, serviceRttSeconds);
+                _minRttTimestamp = nowTicks;
+            }
             return;
         }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -548,7 +548,11 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds,
             sendSnapshot.UnackedBytesAtSend,
             ackedBytes);
-        UpdateMinRtt(serviceRttSeconds, rttSeconds, nowTicks);
+        UpdateMinRtt(
+            serviceRttSeconds,
+            rttSeconds,
+            nowTicks,
+            naturalMinRttSample: sendSnapshot.AppLimited && !sustainedIdle);
         if (loadedSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
@@ -750,7 +754,11 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds - queueAheadBytes / effectiveMaxRate);
     }
 
-    private void UpdateMinRtt(double serviceRttSeconds, double rawRttSeconds, long nowTicks)
+    private void UpdateMinRtt(
+        double serviceRttSeconds,
+        double rawRttSeconds,
+        long nowTicks,
+        bool naturalMinRttSample)
     {
         if (!_hasMinRttSample)
         {
@@ -758,6 +766,16 @@ internal sealed class BrokerUnackedByteBudget
             _minRttTimestamp = nowTicks;
             _hasMinRttSample = true;
             StartMinRttProbe(nowTicks, rawRttSeconds);
+            return;
+        }
+
+        if (naturalMinRttSample
+            && serviceRttSeconds <= _minRttSeconds * ProbeRttGrowthTolerance)
+        {
+            _minRttSeconds = Math.Min(_minRttSeconds, serviceRttSeconds);
+            _minRttTimestamp = nowTicks;
+            _minRttProbeMinimumSeconds = double.MaxValue;
+            _minRttProbeUntilTimestamp = 0;
             return;
         }
 

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -308,14 +308,14 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
 
         if (TryFail(exception))
-            accumulator.DrainPendingAppends();
+            accumulator.DrainPendingAppendsIfHead(this);
     }
 
     private void OnCancellation()
     {
         var accumulator = _accumulator;
         if (TryFail(new OperationCanceledException(_cancellationToken)))
-            accumulator?.DrainPendingAppends();
+            accumulator?.DrainPendingAppendsIfHead(this);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -307,12 +307,15 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             $"Producer is generating messages faster than the network can send them. " +
             $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
 
-        TryFail(exception);
+        if (TryFail(exception))
+            accumulator.DrainPendingAppends();
     }
 
     private void OnCancellation()
     {
-        TryFail(new OperationCanceledException(_cancellationToken));
+        var accumulator = _accumulator;
+        if (TryFail(new OperationCanceledException(_cancellationToken)))
+            accumulator?.DrainPendingAppends();
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2034,17 +2034,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             continue;
                         }
 
-                        var admissionBlocked = IsBrokerAdmissionBlocked(
-                            candidate.Topic,
-                            candidate.Partition,
-                            recordBlockEvent: false,
-                            out var admissionRecheckDelayMs);
-                        if (admissionBlocked)
+                        if (TryGetAdmissionRecheckAt(
+                                candidate.Topic,
+                                candidate.Partition,
+                                out var recheckAt))
                         {
-                            var recheckAt = admissionRecheckDelayMs == Timeout.Infinite
-                                ? 0
-                                : Dekaf.MonotonicClock.GetMilliseconds()
-                                  + Math.Max(1, admissionRecheckDelayMs);
                             _pendingAppends.Enqueue(candidate);
                             candidate.ScheduleAdmissionRecheck(recheckAt);
                             _blockedPendingPartitionRecheckTimes.Add(
@@ -2133,6 +2127,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 Volatile.Write(ref _draining, 0);
             }
         }
+    }
+
+    /// <summary>
+    /// Rescans after a failed append only when it occupied the FIFO head. Tail failures
+    /// cannot unblock another operation; suppressing their scans coalesces a timeout or
+    /// cancellation storm into the single scan triggered by the head.
+    /// </summary>
+    internal void DrainPendingAppendsIfHead(PendingAppend completed)
+    {
+        lock (_pendingAppendQueueLock)
+        {
+            if (!_pendingAppends.TryPeek(out var head)
+                || !ReferenceEquals(head, completed))
+            {
+                return;
+            }
+        }
+
+        DrainPendingAppends();
     }
 
     /// <summary>
@@ -2992,17 +3005,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         else
         {
-            var admissionBlocked = IsBrokerAdmissionBlocked(
-                topic,
-                partition,
-                recordBlockEvent: false,
-                out var admissionRecheckDelayMs);
-            if (admissionBlocked && admissionRecheckDelayMs != Timeout.Infinite)
-            {
-                op.ScheduleAdmissionRecheck(
-                    Dekaf.MonotonicClock.GetMilliseconds()
-                    + Math.Max(1, admissionRecheckDelayMs));
-            }
+            if (TryGetAdmissionRecheckAt(topic, partition, out var recheckAt))
+                op.ScheduleAdmissionRecheck(recheckAt);
         }
 
         return new ValueTask<bool>(op, op.Version);
@@ -4773,6 +4777,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
             currentBudget.RecordAdmissionBlock();
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryGetAdmissionRecheckAt(
+        string topic,
+        int partition,
+        out long recheckAt)
+    {
+        recheckAt = 0;
+        if (!IsBrokerAdmissionBlocked(
+                topic,
+                partition,
+                recordBlockEvent: false,
+                out var recheckDelayMilliseconds))
+        {
+            return false;
+        }
+
+        if (recheckDelayMilliseconds != Timeout.Infinite)
+        {
+            recheckAt = Dekaf.MonotonicClock.GetMilliseconds()
+                + Math.Max(1, recheckDelayMilliseconds);
+        }
+
         return true;
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1342,6 +1342,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
+    private long _nextPendingAdmissionRecheckTickCount;
+    private long _pendingAppendDrainEntryCount;
 
     /// <summary>
     /// Per-partition state matching Java's Deque&lt;ProducerBatch&gt; design.
@@ -1983,12 +1985,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal bool DrainPendingAppends()
     {
         if (_pendingAppends.IsEmpty)
+        {
+            Volatile.Write(ref _nextPendingAdmissionRecheckTickCount, 0);
             return true;
+        }
 
         // Only one thread drains at a time — others return immediately.
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
             return false;
 
+        Interlocked.Increment(ref _pendingAppendDrainEntryCount);
         var ownsDrainGuard = true;
         try
         {
@@ -2004,6 +2010,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     _pendingAppendScan.Clear();
                     _drainablePendingAppends.Clear();
                     _blockedPendingPartitionRecheckTimes.Clear();
+                    var nextAdmissionRecheckAt = long.MaxValue;
 
                     var remainingToInspect = _pendingAppends.Count;
                     while (remainingToInspect-- > 0 && _pendingAppends.TryDequeue(out var candidate))
@@ -2045,6 +2052,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                   + Math.Max(1, admissionRecheckDelayMs);
                             _pendingAppends.Enqueue(candidate);
                             candidate.ScheduleAdmissionRecheck(recheckAt);
+                            if (recheckAt != 0)
+                                nextAdmissionRecheckAt = Math.Min(nextAdmissionRecheckAt, recheckAt);
                             _blockedPendingPartitionRecheckTimes.Add(
                                 topicPartition,
                                 recheckAt);
@@ -2061,6 +2070,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         _drainablePendingAppends.Add(candidate);
                     }
 
+                    Volatile.Write(
+                        ref _nextPendingAdmissionRecheckTickCount,
+                        nextAdmissionRecheckAt == long.MaxValue ? 0 : nextAdmissionRecheckAt);
                     _pendingAppendScan.Clear();
                     madeProgress = _drainablePendingAppends.Count > 0;
                 }
@@ -2960,8 +2972,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             completionSource, callback, recordSize, startTicks, deadline,
             this, _pendingAppendPool, cancellationToken);
 
+        bool wasQueueEmpty;
         lock (_pendingAppendQueueLock)
+        {
+            wasQueueEmpty = _pendingAppends.IsEmpty;
             _pendingAppends.Enqueue(op);
+        }
 
         // Close TOCTOU window: if DisposeAsync ran between the _disposed check above and the
         // Enqueue, this op would sit in the queue until its timer fires. Fail it promptly.
@@ -2977,8 +2993,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
         }
 
-        // Try immediate serve — memory may have been freed between TryReserveMemory and now
-        DrainPendingAppends();
+        // Close the memory-release TOCTOU window for the first queued operation. Later
+        // appends join the same wake-driven drain instead of rescanning the growing queue.
+        if (wasQueueEmpty)
+        {
+            DrainPendingAppends();
+        }
+        else
+        {
+            var admissionRecheckAt = Volatile.Read(
+                ref _nextPendingAdmissionRecheckTickCount);
+            if (admissionRecheckAt != 0)
+                op.ScheduleAdmissionRecheck(admissionRecheckAt);
+        }
 
         return new ValueTask<bool>(op, op.Version);
     }
@@ -4023,6 +4050,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal long BufferPressureEvents => Volatile.Read(ref _bufferPressureEvents);
 
     internal int PendingAppendCountForTest => _pendingAppends.Count;
+
+    internal long PendingAppendDrainEntryCountForTest =>
+        Volatile.Read(ref _pendingAppendDrainEntryCount);
 
     /// <summary>
     /// Gets the current buffer utilization as a ratio (0.0 to 1.0+).

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1342,7 +1342,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
-    private long _nextPendingAdmissionRecheckTickCount;
     private long _pendingAppendDrainEntryCount;
 
     /// <summary>
@@ -1985,10 +1984,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal bool DrainPendingAppends()
     {
         if (_pendingAppends.IsEmpty)
-        {
-            Volatile.Write(ref _nextPendingAdmissionRecheckTickCount, 0);
             return true;
-        }
 
         // Only one thread drains at a time — others return immediately.
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
@@ -2010,7 +2006,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                     _pendingAppendScan.Clear();
                     _drainablePendingAppends.Clear();
                     _blockedPendingPartitionRecheckTimes.Clear();
-                    var nextAdmissionRecheckAt = long.MaxValue;
 
                     var remainingToInspect = _pendingAppends.Count;
                     while (remainingToInspect-- > 0 && _pendingAppends.TryDequeue(out var candidate))
@@ -2052,8 +2047,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                   + Math.Max(1, admissionRecheckDelayMs);
                             _pendingAppends.Enqueue(candidate);
                             candidate.ScheduleAdmissionRecheck(recheckAt);
-                            if (recheckAt != 0)
-                                nextAdmissionRecheckAt = Math.Min(nextAdmissionRecheckAt, recheckAt);
                             _blockedPendingPartitionRecheckTimes.Add(
                                 topicPartition,
                                 recheckAt);
@@ -2070,9 +2063,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         _drainablePendingAppends.Add(candidate);
                     }
 
-                    Volatile.Write(
-                        ref _nextPendingAdmissionRecheckTickCount,
-                        nextAdmissionRecheckAt == long.MaxValue ? 0 : nextAdmissionRecheckAt);
                     _pendingAppendScan.Clear();
                     madeProgress = _drainablePendingAppends.Count > 0;
                 }
@@ -2994,17 +2984,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         // Close the memory-release TOCTOU window for the first queued operation. Later
-        // appends join the same wake-driven drain instead of rescanning the growing queue.
+        // admission-blocked appends arm their own broker deadline without rescanning the
+        // queue; memory-blocked appends rely on ReleaseMemory's unconditional drain.
         if (wasQueueEmpty)
         {
             DrainPendingAppends();
         }
         else
         {
-            var admissionRecheckAt = Volatile.Read(
-                ref _nextPendingAdmissionRecheckTickCount);
-            if (admissionRecheckAt != 0)
-                op.ScheduleAdmissionRecheck(admissionRecheckAt);
+            var admissionBlocked = IsBrokerAdmissionBlocked(
+                topic,
+                partition,
+                recordBlockEvent: false,
+                out var admissionRecheckDelayMs);
+            if (admissionBlocked && admissionRecheckDelayMs != Timeout.Infinite)
+            {
+                op.ScheduleAdmissionRecheck(
+                    Dekaf.MonotonicClock.GetMilliseconds()
+                    + Math.Max(1, admissionRecheckDelayMs));
+            }
         }
 
         return new ValueTask<bool>(op, op.Version);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -463,6 +463,25 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_NaturalSampleCompletesProbeWithBestObservedRtt()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.010);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_minRttProbeMinimumSeconds", 0.004);
+
+        Ack(budget, 600, 0.006, T0, appLimitedAtSend: true);
+
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(4_000)
+            .Because("ending a drain on a natural sample must retain the probe's best earlier RTT");
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp")).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -445,6 +445,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_RecentNaturalSampleSkipsDrainProbe()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 500, 0.005, T0, appLimitedAtSend: false);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051), appLimitedAtSend: true);
+        for (var second = 1; second <= 9; second++)
+            Ack(budget, 500, 0.005, T0 + Seconds(second), appLimitedAtSend: true);
+        Ack(budget, 10_000, 0.100, T0 + Seconds(10.2), appLimitedAtSend: false);
+
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp")).IsEqualTo(0)
+            .Because("a recent empty-pipe RTT already refreshed the base RTT without narrowing admission");
+    }
+
+    [Test]
     public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3604,6 +3604,51 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_CancellationStormRescansOnlyAtHead()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var cancellationSources = Enumerable.Range(0, 32)
+            .Select(_ => new CancellationTokenSource())
+            .ToArray();
+        var tasks = new Task<bool>[cancellationSources.Length];
+
+        await Assert.That(accumulator.TryReserveMemoryForTest(4096)).IsTrue();
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = accumulator.AppendFromSpansAsync(
+                "test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, cancellationSources[i].Token).AsTask();
+        }
+
+        for (var i = cancellationSources.Length - 1; i > 0; i--)
+            cancellationSources[i].Cancel();
+
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(1)
+            .Because("tail cancellations cannot unblock the FIFO head");
+
+        cancellationSources[0].Cancel();
+
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(2)
+            .Because("the head cancellation coalesces the completed burst into one scan");
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: every deliberately blocked append was cancelled.
+        }
+
+        foreach (var cancellationSource in cancellationSources)
+            cancellationSource.Dispose();
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_ReopenedMemory_PreservesPendingAppendFifo()
     {
         var options = new ProducerOptions

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3572,6 +3572,38 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task AppendFromSpansAsync_QueuedBurstScansPendingQueueOnce()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var tasks = new Task<bool>[32];
+
+        await Assert.That(accumulator.TryReserveMemoryForTest(4096)).IsTrue();
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = accumulator.AppendFromSpansAsync(
+                "test-topic", 0,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty, keyIsNull: true,
+                ReadOnlySpan<byte>.Empty, valueIsNull: true,
+                null, 0, null, CancellationToken.None).AsTask();
+        }
+
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(tasks.Length);
+        await Assert.That(accumulator.PendingAppendDrainEntryCountForTest).IsEqualTo(1)
+            .Because("one blocked burst must not rescan its growing pending queue per message");
+
+        await accumulator.DisposeAsync();
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Expected: disposal completes every deliberately blocked append.
+        }
+    }
+
+    [Test]
     public async Task AppendFromSpansAsync_ReopenedMemory_PreservesPendingAppendFifo()
     {
         var options = new ProducerOptions
@@ -3616,9 +3648,9 @@ public class RecordAccumulatorTests
 
             await Assert.That(pendingAppendTask.IsCompleted).IsFalse();
 
-            // Free memory without draining. The next append must join behind the queued
-            // operation; its immediate drain serves the older append before completing.
-            SetBufferedBytesForTest(accumulator, 3000);
+            // A release wakes one queue drain. The next append must not overtake the older
+            // operation that the wake just served.
+            accumulator.ReleaseMemory(fillSize);
 
             var hotResult = await accumulator.AppendFromSpansAsync(
                 topicPartition.Topic, topicPartition.Partition,


### PR DESCRIPTION
## Summary\n- use recent natural low-RTT samples instead of periodic admission-narrowing probes\n- scan a blocked pending-append burst once per wake rather than once per message\n- preserve the shared admission recheck when the first queued waiter cancels\n\n## Validation\n- 5,425 net10.0 unit tests pass\n- 27 producer integration tests pass\n- budget benchmark: 14.86 / 17.76 ns, 0 B allocated\n- accumulator 100-byte hot paths: 106-117 ns, 0 B allocated\n\nCloses #2036