### PR TITLE
test(protocol): make RecordBatch pool test deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1247,6 +1247,7 @@ public class RecordBatchTests
         var firstReader = new KafkaProtocolReader(buffer.WrittenMemory);
         var first = RecordBatch.Read(ref firstReader);
         var pending = PendingFetchData.Create("topic", 0, [first]);
+        var pendingGeneration = pending.HeaderGeneration;
 
         RecordBatch.BeginTrackingPoolReturnsForCurrentThread();
         int initialReturnCount;
@@ -1270,7 +1271,7 @@ public class RecordBatchTests
         int staleReturnCount;
         try
         {
-            pending.Dispose();
+            first.DisposeAndReturnConsumerBatch(pending, pendingGeneration);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -1235,7 +1235,7 @@ public class RecordBatchTests
 
     [Test]
     [NotInParallel]
-    public async Task RecordBatch_Read_IsReusedAfterPendingFetchDisposal()
+    public async Task RecordBatch_Read_PendingFetchDisposal_ReturnsBatchAndStaleOwnerIsHarmless()
     {
         var buffer = new ArrayBufferWriter<byte>();
         new RecordBatch
@@ -1247,16 +1247,37 @@ public class RecordBatchTests
         var firstReader = new KafkaProtocolReader(buffer.WrittenMemory);
         var first = RecordBatch.Read(ref firstReader);
         var pending = PendingFetchData.Create("topic", 0, [first]);
-        pending.Dispose();
+
+        RecordBatch.BeginTrackingPoolReturnsForCurrentThread();
+        int initialReturnCount;
+        try
+        {
+            pending.Dispose();
+        }
+        finally
+        {
+            initialReturnCount = RecordBatch.EndTrackingPoolReturnsForCurrentThread();
+        }
 
         var secondReader = new KafkaProtocolReader(buffer.WrittenMemory);
         var second = RecordBatch.Read(ref secondReader);
 
-        await Assert.That(second).IsSameReferenceAs(first);
+        await Assert.That(initialReturnCount).IsEqualTo(1);
         await Assert.That(second.BaseOffset).IsEqualTo(17L);
 
         // Stale owner disposal remains harmless after the batch gets a new lease.
-        pending.Dispose();
+        RecordBatch.BeginTrackingPoolReturnsForCurrentThread();
+        int staleReturnCount;
+        try
+        {
+            pending.Dispose();
+        }
+        finally
+        {
+            staleReturnCount = RecordBatch.EndTrackingPoolReturnsForCurrentThread();
+        }
+
+        await Assert.That(staleReturnCount).IsEqualTo(0);
         await Assert.That(second.Records.Count).IsEqualTo(1);
 
         using var secondOwner = PendingFetchData.Create("topic", 0, [second]);


### PR DESCRIPTION
## Summary
- replace exact `RecordBatch` pool identity assertion with deterministic return counting
- retain stale-owner disposal coverage without assuming pool ordering

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- exact test: 1/1
- `RecordBatchTests`: 52/52
- full net10 unit suite: 5,408/5,408

Fixes #2040.