### PR TITLE
perf(producer): fast-path single response

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2249,6 +2249,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         return batch.RecordCount != 1 || batch.CompletionSourcesCount != 1;
     }
 
+    /// <summary>
+    /// True when a response can be matched directly to its only batch without populating
+    /// the reusable topic-partition lookup.
+    /// </summary>
+    internal static bool IsDirectSingleBatchResponse(
+        int batchCount,
+        int responseTopicCount,
+        int responsePartitionCount,
+        TopicPartition expected,
+        string responseTopic,
+        int responsePartition)
+        => batchCount == 1
+            && responseTopicCount == 1
+            && responsePartitionCount == 1
+            && expected.Topic == responseTopic
+            && expected.Partition == responsePartition;
+
     internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(int lingerMs)
     {
         if (lingerMs == 0)
@@ -2722,18 +2739,39 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var response = task.GetResult();
                 ObserveBrokerThrottle(response.ThrottleTimeMs);
                 var allPartitionsSucceeded = true;
+                ProduceResponsePartitionData? directResponse = null;
                 // Reuse caller-provided dictionary to avoid per-response allocation.
                 // The dictionary is cleared after use in ProcessResponseBatches.
                 var responseLookup = reusableResponseLookup;
-                for (var t = 0; t < response.TopicCount; t++)
+                if (count == 1
+                    && batches[0] is { } directBatch
+                    && response.TopicCount == 1
+                    && response.Responses[0].PartitionCount == 1
+                    && IsDirectSingleBatchResponse(
+                        count,
+                        response.TopicCount,
+                        response.Responses[0].PartitionCount,
+                        directBatch.TopicPartition,
+                        response.Responses[0].Name,
+                        response.Responses[0].PartitionResponses[0].Index))
                 {
-                    ref var topicResp = ref response.Responses[t];
-                    for (var p = 0; p < topicResp.PartitionCount; p++)
+                    var partitionResponse = response.Responses[0].PartitionResponses[0];
+                    directResponse = partitionResponse;
+                    allPartitionsSucceeded = partitionResponse.ErrorCode == ErrorCode.None;
+                }
+                else
+                {
+                    for (var t = 0; t < response.TopicCount; t++)
                     {
-                        if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
-                            allPartitionsSucceeded = false;
-                        responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
-                        responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] = topicResp.PartitionResponses[p];
+                        ref var topicResp = ref response.Responses[t];
+                        for (var p = 0; p < topicResp.PartitionCount; p++)
+                        {
+                            if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
+                                allPartitionsSucceeded = false;
+                            responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
+                            responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] =
+                                topicResp.PartitionResponses[p];
+                        }
                     }
                 }
 
@@ -2759,13 +2797,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         Enumerable.Range(0, count)
                             .Where(idx => batches[idx] is not null)
                             .Select(idx => $"{batches[idx].TopicPartition.Topic}-{batches[idx].TopicPartition.Partition}"));
-                    var respKeys = responseLookup is not null
-                        ? string.Join(", ", responseLookup.Keys.Select(k => $"{k.Topic}-{k.Partition}"))
-                        : "(empty)";
-                    LogProduceResponseProcessed(_instanceId, _brokerId, task.Id, count, batchKeys, responseLookup?.Count ?? 0, respKeys);
+                    var respKeys = directResponse is not null
+                        ? $"{batches[0].TopicPartition.Topic}-{directResponse.Value.Index}"
+                        : responseLookup is not null
+                            ? string.Join(", ", responseLookup.Keys.Select(k => $"{k.Topic}-{k.Partition}"))
+                            : "(empty)";
+                    LogProduceResponseProcessed(_instanceId, _brokerId, task.Id, count, batchKeys,
+                        directResponse is not null ? 1 : responseLookup?.Count ?? 0, respKeys);
                 }
 
-                ProcessResponseBatches(pending, responseLookup, response.NodeEndpoints,
+                ProcessResponseBatches(pending, directResponse, responseLookup, response.NodeEndpoints,
                     carryOver, cancellationToken, task.Id);
 
                 // Clear for reuse on next response (avoids per-response dictionary allocation)
@@ -2822,6 +2863,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void ProcessResponseBatches(
         PendingResponse pending,
+        ProduceResponsePartitionData? directResponse,
         Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? responseLookup,
         IReadOnlyList<NodeEndpoint> nodeEndpoints,
         PartitionCarryOver carryOver,
@@ -2857,8 +2899,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // This is safe because partitionResponse is only consumed when foundResponse is true,
                 // in which case TryGetValue has populated it with the real response data.
                 var partitionResponse = default(ProduceResponsePartitionData);
-                var foundResponse = responseLookup is not null
-                    && responseLookup.TryGetValue((expectedTopic, expectedPartition), out partitionResponse);
+                var foundResponse = false;
+                if (directResponse is { } direct)
+                {
+                    partitionResponse = direct;
+                    foundResponse = true;
+                }
+                else if (responseLookup is not null)
+                    foundResponse = responseLookup.TryGetValue(
+                        (expectedTopic, expectedPartition),
+                        out partitionResponse);
 
                 if (!foundResponse)
                 {

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2250,20 +2250,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// True when a response can be matched directly to its only batch without populating
-    /// the reusable topic-partition lookup.
+    /// True when a response partition belongs to the expected batch. The caller proves the
+    /// single-batch/single-response shape before indexing pooled response arrays.
     /// </summary>
-    internal static bool IsDirectSingleBatchResponse(
-        int batchCount,
-        int responseTopicCount,
-        int responsePartitionCount,
+    internal static bool IsMatchingResponsePartition(
         TopicPartition expected,
         string responseTopic,
         int responsePartition)
-        => batchCount == 1
-            && responseTopicCount == 1
-            && responsePartitionCount == 1
-            && expected.Topic == responseTopic
+        => expected.Topic == responseTopic
             && expected.Partition == responsePartition;
 
     internal static (int QuietMicroseconds, int MaximumMicroseconds) SelectWaveCoalesceBounds(int lingerMs)
@@ -2747,10 +2741,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     && batches[0] is { } directBatch
                     && response.TopicCount == 1
                     && response.Responses[0].PartitionCount == 1
-                    && IsDirectSingleBatchResponse(
-                        count,
-                        response.TopicCount,
-                        response.Responses[0].PartitionCount,
+                    && IsMatchingResponsePartition(
                         directBatch.TopicPartition,
                         response.Responses[0].Name,
                         response.Responses[0].PartitionResponses[0].Index))

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -172,6 +172,34 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    public async Task IsDirectSingleBatchResponse_RequiresExactOnePartitionMatch()
+    {
+        var expected = new TopicPartition("test-topic", 2);
+
+        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
+            batchCount: 1,
+            responseTopicCount: 1,
+            responsePartitionCount: 1,
+            expected,
+            responseTopic: "test-topic",
+            responsePartition: 2)).IsTrue();
+        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
+            batchCount: 2,
+            responseTopicCount: 1,
+            responsePartitionCount: 1,
+            expected,
+            responseTopic: "test-topic",
+            responsePartition: 2)).IsFalse();
+        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
+            batchCount: 1,
+            responseTopicCount: 1,
+            responsePartitionCount: 1,
+            expected,
+            responseTopic: "other-topic",
+            responsePartition: 2)).IsFalse();
+    }
+
+    [Test]
     public async Task ShouldPublishResponseReadyEvent_DepthOneUsesDirectSignalOnly()
     {
         await Assert.That(BrokerSender.ShouldPublishResponseReadyEvent(totalMaxInFlight: 1))

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -172,28 +172,19 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
-    public async Task IsDirectSingleBatchResponse_RequiresExactOnePartitionMatch()
+    public async Task IsMatchingResponsePartition_RequiresExactTopicPartition()
     {
         var expected = new TopicPartition("test-topic", 2);
 
-        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
-            batchCount: 1,
-            responseTopicCount: 1,
-            responsePartitionCount: 1,
+        await Assert.That(BrokerSender.IsMatchingResponsePartition(
             expected,
             responseTopic: "test-topic",
             responsePartition: 2)).IsTrue();
-        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
-            batchCount: 2,
-            responseTopicCount: 1,
-            responsePartitionCount: 1,
+        await Assert.That(BrokerSender.IsMatchingResponsePartition(
             expected,
             responseTopic: "test-topic",
-            responsePartition: 2)).IsFalse();
-        await Assert.That(BrokerSender.IsDirectSingleBatchResponse(
-            batchCount: 1,
-            responseTopicCount: 1,
-            responsePartitionCount: 1,
+            responsePartition: 3)).IsFalse();
+        await Assert.That(BrokerSender.IsMatchingResponsePartition(
             expected,
             responseTopic: "other-topic",
             responsePartition: 2)).IsFalse();


### PR DESCRIPTION
## Summary

- bypass the topic-partition response dictionary when one ProduceResponse partition exactly matches one pending batch
- preserve the existing lookup path for multi-partition, mismatched, empty, error, and stale/null batch shapes
- cover exact-match eligibility and the existing stale-after-write end-to-end regression

## Performance

Identical local 2-minute, 1-broker transactional EOS runs (1,000 B messages):

| | CPU us/msg | CPU us/request | Median msg/s |
|---|---:|---:|---:|
| `main` | 653.78 | 653.27 | 65 |
| this branch | 568.91 | 568.47 | 65 |

The fast path removes 84.87 us/msg (13.0%) while preserving throughput. That absolute saving matches the issue's CI gap (358.38 vs 274.28 us/msg). EOS verification passed exactly: 5,900 committed delivered, 1,900 aborted leaked 0, duplicates 0, shortfall 0.

## Test plan

- [x] BrokerSender send-loop suite: 57/57
- [x] full net10 unit suite: 5,409/5,409
- [x] Release build: 0 warnings, 0 errors
- [x] local transactional EOS A/B and Confluent calibration

Closes #2037