### PR TITLE
fix(producer): bound minimum RTT refresh

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -164,6 +164,12 @@ internal sealed class BrokerUnackedByteBudget
     /// (and with it the RTT floor) toward zero.</summary>
     private const double MinCorrectedRttFraction = 0.25;
 
+    /// <summary>Maximum upward movement accepted from one minimum-RTT refresh. A drain
+    /// probe can remain partially queued across parallel connections; bounding one window
+    /// prevents that transient from multiplying the BDP floor, while repeated refreshes
+    /// still converge when the path's base RTT has genuinely increased.</summary>
+    private const double MinRttRefreshGrowthFactor = 1.25;
+
     private const int ProbeIntervalRtts = 8;
     // A capacity probe needs one RTT for the enlarged budget to reach the wire,
     // then three wholly-probed RTTs to average before accepting or rejecting growth.
@@ -724,7 +730,11 @@ internal sealed class BrokerUnackedByteBudget
     private void CompleteMinRttProbe(long nowTicks)
     {
         if (_minRttProbeMinimumSeconds != double.MaxValue)
-            _minRttSeconds = _minRttProbeMinimumSeconds;
+        {
+            _minRttSeconds = Math.Min(
+                _minRttProbeMinimumSeconds,
+                _minRttSeconds * MinRttRefreshGrowthFactor);
+        }
 
         // If the probe expired without an ack, retain the prior minimum and re-arm its
         // freshness window. An idle gap is not a base-RTT measurement.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -427,6 +427,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task MinimumRtt_ProbeBoundsSingleWindowGrowth()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.001);
+        SetField(budget, "_minRttProbeUntilTimestamp", T0);
+        SetField(budget, "_minRttProbeMinimumSeconds", 0.010);
+
+        Ack(budget, 10_000, 0.010, T0, appLimitedAtSend: false);
+
+        await Assert.That(budget.MinimumRttMicros).IsEqualTo(1_250)
+            .Because("one partially queued refresh must not multiply the BDP floor");
+    }
+
+    [Test]
     public async Task MinimumRtt_ExpiredWindowProbeUsesCurrentRttDuration()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);


### PR DESCRIPTION
## Summary
- cap one min-RTT refresh window to 25% upward growth
- keep immediate downward refreshes unchanged
- add deterministic state-machine coverage for a partially queued probe outlier

## Verification
- net10 build: 0 warnings, 0 errors
- BrokerUnackedByteBudgetTests: 74/74
- full net10 unit suite: 5,424/5,424

Closes #2043

Parent: #2019