### PR TITLE
fix(producer): bound loaded delivery rate

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -370,22 +370,31 @@ internal sealed class BrokerUnackedByteBudget
         {
             deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
             var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
-            if (epochDeliveredBytes == deliveredBytes)
-            {
-                deliveryEpochDeliveredBytes = epochDeliveredBytes;
-                return Volatile.Read(ref _sendEpochFirstTimestamp);
-            }
-
             if (epochDeliveredBytes == DeliveryEpochUpdating)
             {
                 spinner.SpinOnce();
                 continue;
             }
 
+            // The timestamp and delivered marker form one publication. Re-read the marker
+            // after the timestamp so a reader spanning another publisher's two writes retries
+            // instead of pairing an old byte anchor with a new time anchor.
+            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
+            if (Volatile.Read(ref _sendEpochDeliveredBytes) != epochDeliveredBytes)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            if (epochDeliveredBytes == deliveredBytes)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
+                return epochFirstSendTimestamp;
+            }
+
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
             // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
-            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
             if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
                 && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -20,13 +20,14 @@ namespace Dekaf.Producer;
 /// each budget raise lengthens the RTT that justifies the next raise until the budget rides
 /// its cap (the 3-broker acks=all latency ratchet, #2009).
 /// <para>
-/// Drain rate is measured per acknowledged request, BBR-style: each request snapshots the
-/// cumulative delivered-bytes counter at send time, and its rate sample is the delivered
-/// delta over the larger of the request's own sojourn and the interval since the delivery
-/// clock at send (sojourn only for app-limited sends, where the pipe was empty and the
-/// preceding interval is idle time). The denominator is therefore never smaller than one
-/// real round trip, so response-pass timing (hot polling, clustered completions,
-/// processing stalls) cannot manufacture inflated samples.
+/// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
+/// epoch; loaded sends retain its delivered-byte and first-send anchors even as acknowledgements
+/// advance the current delivery clock. The sample is cumulative delivered bytes over the full
+/// epoch elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples
+/// shorter than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// per-request rate remains available to the capacity probe, which needs each probe admission's
+/// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
+/// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
 /// </para>
 /// <para>
 /// Ownership contract: <see cref="Charge"/>/<see cref="Release"/>/<see cref="IsOverBudget"/>/
@@ -44,8 +45,8 @@ namespace Dekaf.Producer;
 internal sealed class BrokerUnackedByteBudget
 {
     /// <summary>
-    /// Per-send token minted by <see cref="SnapshotDelivery"/>: the delivery clock (cumulative
-    /// delivered bytes and the timestamp of the most recent delivery), the pre-write send
+    /// Per-send token minted by <see cref="SnapshotDelivery"/>: the current delivery clock,
+    /// the loaded delivery epoch's delivered-byte and first-send anchors, the pre-write send
     /// timestamp, and whether the broker pipe was empty at send. Carried opaquely on the
     /// in-flight request and redeemed by <see cref="OnAcked"/> when the response arrives, so
     /// the values that must be captured together cannot drift apart at call sites.
@@ -53,6 +54,7 @@ internal sealed class BrokerUnackedByteBudget
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
         long DeliveredTimestamp,
+        long DeliveryEpochDeliveredBytes,
         long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
@@ -185,6 +187,8 @@ internal sealed class BrokerUnackedByteBudget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
+    // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
+    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -228,6 +232,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
+    private bool _hasLoadedServingSample;
     private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
     private bool _hasMinRttSample;
@@ -310,8 +315,9 @@ internal sealed class BrokerUnackedByteBudget
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
     /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
-    /// epoch changes are CAS-published so parallel sends cannot regress the delivered-byte
-    /// marker; the independent last-delivery timestamp may only conservatively widen a sample.
+    /// epoch changes at app-limited boundaries are CAS-published so parallel sends cannot
+    /// regress the delivered-byte marker; loaded sends reuse the published epoch. The
+    /// independent last-delivery timestamp may only conservatively widen a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -324,10 +330,13 @@ internal sealed class BrokerUnackedByteBudget
     {
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,
+            appLimited,
+            out var deliveryEpochDeliveredBytes,
             out var deliveredBytes);
         return new DeliverySnapshot(
             deliveredBytes,
             Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveryEpochDeliveredBytes,
             deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
@@ -335,7 +344,11 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Read(ref _unackedBytes));
     }
 
-    private long CaptureDeliveryEpoch(long sendTimestamp, out long deliveredBytes)
+    private long CaptureDeliveryEpoch(
+        long sendTimestamp,
+        bool appLimited,
+        out long deliveryEpochDeliveredBytes,
+        out long deliveredBytes)
     {
         var spinner = new SpinWait();
         while (true)
@@ -343,12 +356,24 @@ internal sealed class BrokerUnackedByteBudget
             deliveredBytes = Volatile.Read(ref _totalDeliveredBytes);
             var epochDeliveredBytes = Volatile.Read(ref _sendEpochDeliveredBytes);
             if (epochDeliveredBytes == deliveredBytes)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
                 return Volatile.Read(ref _sendEpochFirstTimestamp);
+            }
 
             if (epochDeliveredBytes == DeliveryEpochUpdating)
             {
                 spinner.SpinOnce();
                 continue;
+            }
+
+            // A loaded pipe belongs to the existing send epoch even after acknowledgements
+            // advance the delivery counter. Reset only when a send observes an empty pipe;
+            // otherwise serialized send/ack cycles collapse back to requestBytes / ownRTT.
+            if (!appLimited && epochDeliveredBytes != NoDeliveryEpoch)
+            {
+                deliveryEpochDeliveredBytes = epochDeliveredBytes;
+                return Volatile.Read(ref _sendEpochFirstTimestamp);
             }
 
             if (Interlocked.CompareExchange(
@@ -360,7 +385,11 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
-            return PublishDeliveryEpoch(sendTimestamp, epochDeliveredBytes, out deliveredBytes);
+            return PublishDeliveryEpoch(
+                sendTimestamp,
+                epochDeliveredBytes,
+                out deliveryEpochDeliveredBytes,
+                out deliveredBytes);
         }
     }
 
@@ -368,6 +397,7 @@ internal sealed class BrokerUnackedByteBudget
     private long PublishDeliveryEpoch(
         long sendTimestamp,
         long previousEpochDeliveredBytes,
+        out long deliveryEpochDeliveredBytes,
         out long deliveredBytes)
     {
         // The loop-top delivery read can predate a newer epoch value observed by the
@@ -379,6 +409,7 @@ internal sealed class BrokerUnackedByteBudget
             Volatile.Write(ref _sendEpochFirstTimestamp, sendTimestamp);
 
         Volatile.Write(ref _sendEpochDeliveredBytes, deliveredBytes);
+        deliveryEpochDeliveredBytes = deliveredBytes;
         return Volatile.Read(ref _sendEpochFirstTimestamp);
     }
 
@@ -531,8 +562,13 @@ internal sealed class BrokerUnackedByteBudget
         var sustainedIdle = sendSnapshot.AppLimited
             && sendSnapshot.DeliveredTimestamp != 0
             && deliveryIdleTicks >= WindowDurationTicks;
-        var loadedSample = !sendSnapshot.AppLimited
+        var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
+        var loadedRateSample = !sendSnapshot.AppLimited;
+        if (sustainedIdle)
+            _hasLoadedServingSample = false;
+        else if (loadedServingSample)
+            _hasLoadedServingSample = true;
         // The deadline ack may establish the first loaded serving estimate (depth-one traffic),
         // but must not drag an existing estimate toward the queue-drained probe RTT.
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0
@@ -553,7 +589,7 @@ internal sealed class BrokerUnackedByteBudget
             rttSeconds,
             nowTicks,
             naturalMinRttSample: sendSnapshot.AppLimited && !sustainedIdle);
-        if (loadedSample && !minRttProbeActive)
+        if (loadedServingSample && !minRttProbeActive)
         {
             _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
                 ? serviceRttSeconds
@@ -575,36 +611,46 @@ internal sealed class BrokerUnackedByteBudget
 
         RecordRequestHistograms(ackedBytes, rttSeconds);
 
-        // BBR delivery-rate sample: delivered-counter delta over the larger of the request's
-        // own sojourn and the ack-axis interval (time since the delivery clock at send). The
-        // sojourn bounds the denominator below by one real round trip, so clustered response
-        // passes cannot inflate the sample; the ack axis spreads a processing-stall backlog
-        // over the wall time the deliveries actually took.
+        // Keep two delivery-rate axes. The request axis attributes immediate delivery credit
+        // to one capacity probe. The epoch axis estimates sustainable rate from all delivery
+        // since the pipe last became loaded, including the first send's RTT; loaded sends keep
+        // that anchor across intervening acknowledgements. Thus a serialized request cannot
+        // claim requestBytes / ownRTT as broker capacity on every fast response.
         var totalDelivered = _totalDeliveredBytes + ackedBytes;
         Volatile.Write(ref _totalDeliveredBytes, totalDelivered);
         var deliveredDelta = totalDelivered - sendSnapshot.DeliveredBytes;
+        var deliveryEpochDelta = totalDelivered - sendSnapshot.DeliveryEpochDeliveredBytes;
 
-        var intervalTicks = rttTicks;
+        var requestIntervalTicks = rttTicks;
+        if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
+        {
+            requestIntervalTicks = Math.Max(
+                requestIntervalTicks,
+                nowTicks - sendSnapshot.DeliveredTimestamp);
+        }
+
+        var deliveryEpochIntervalTicks = requestIntervalTicks;
         if (sendSnapshot.DeliveryEpochFirstSendTimestamp > 0)
         {
-            intervalTicks = Math.Max(
-                intervalTicks,
-                sendSnapshot.SendTimestamp - sendSnapshot.DeliveryEpochFirstSendTimestamp);
+            deliveryEpochIntervalTicks = Math.Max(
+                deliveryEpochIntervalTicks,
+                nowTicks - sendSnapshot.DeliveryEpochFirstSendTimestamp);
         }
-        if (!sendSnapshot.AppLimited && sendSnapshot.DeliveredTimestamp != 0)
-            intervalTicks = Math.Max(intervalTicks, nowTicks - sendSnapshot.DeliveredTimestamp);
         Volatile.Write(ref _lastDeliveredTimestamp, nowTicks);
 
         AdvanceWindow(nowTicks);
-        var bytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / intervalTicks;
-        if (bytesPerSecond > 0)
+        var requestBytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / requestIntervalTicks;
+        var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
+            / deliveryEpochIntervalTicks;
+        if (deliveryEpochBytesPerSecond > 0
+            && (!loadedRateSample || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
         {
-            AddRateSample(bytesPerSecond, loadedSample, sustainedIdle);
+            AddRateSample(deliveryEpochBytesPerSecond, loadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 
         UpdateCapacityProbe(
-            bytesPerSecond,
+            requestBytesPerSecond,
             sendSnapshot.OldestBatchTimestamp != 0
                 ? sendSnapshot.OldestBatchTimestamp
                 : sendSnapshot.SendTimestamp,
@@ -1181,7 +1227,7 @@ internal sealed class BrokerUnackedByteBudget
             // The serving EWMA and the minimum RTT are queue-corrected at sample intake
             // (see OnAcked), so neither re-inflates from queueing this budget admitted;
             // the clamp below is a residual guard for correction error.
-            var loadAwareRttSeconds = _retainedLoadedMaxRate > 0
+            var loadAwareRttSeconds = _hasLoadedServingSample
                 ? Math.Max(
                     minRttSeconds,
                     Math.Min(_servingRttEwmaSeconds, ServingRttClampMultiplier * minRttSeconds))

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -47,9 +47,9 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>
     /// Per-send token minted by <see cref="SnapshotDelivery"/>: the current delivery clock,
     /// the loaded delivery epoch's delivered-byte and first-send anchors, the pre-write send
-    /// timestamp, and whether the broker pipe was empty at send. Carried opaquely on the
-    /// in-flight request and redeemed by <see cref="OnAcked"/> when the response arrives, so
-    /// the values that must be captured together cannot drift apart at call sites.
+    /// timestamp, whether the broker pipe was empty, and whether the rate epoch was app-limited
+    /// at send. Carried opaquely on the in-flight request and redeemed by <see cref="OnAcked"/>
+    /// when the response arrives, so values captured together cannot drift apart at call sites.
     /// </summary>
     internal readonly record struct DeliverySnapshot(
         long DeliveredBytes,
@@ -58,6 +58,7 @@ internal sealed class BrokerUnackedByteBudget
         long DeliveryEpochFirstSendTimestamp,
         long SendTimestamp,
         bool AppLimited,
+        bool RateAppLimited,
         long OldestBatchTimestamp,
         long UnackedBytesAtSend);
 
@@ -317,9 +318,10 @@ internal sealed class BrokerUnackedByteBudget
     /// Cross-thread: parallel connection sends mint the per-request delivery token immediately
     /// before the socket write (so <paramref name="sendTimestamp"/> can never postdate the
     /// response's arrival), feeding it back to <see cref="OnAcked"/> on the response. Delivery
-    /// epoch changes at app-limited boundaries are CAS-published so parallel sends cannot
-    /// regress the delivered-byte marker; loaded sends reuse the published epoch. The
-    /// independent last-delivery timestamp may only conservatively widen a sample.
+    /// epoch changes at rate-app-limited boundaries are CAS-published so parallel sends cannot
+    /// regress the delivered-byte marker; loaded and immediately post-delivery sends reuse the
+    /// published epoch. The independent last-delivery timestamp may only conservatively widen
+    /// a sample.
     /// </summary>
     /// <param name="sendTimestamp">Stopwatch timestamp taken just before the socket write.</param>
     /// <param name="appLimited">True when the broker pipe was empty at send time.</param>
@@ -330,25 +332,36 @@ internal sealed class BrokerUnackedByteBudget
         bool appLimited,
         long oldestBatchTimestamp = 0)
     {
+        var deliveredTimestamp = Volatile.Read(ref _lastDeliveredTimestamp);
+        var deliveryGapTicks = sendTimestamp - deliveredTimestamp;
+        // An empty pipe sent immediately after an ack is a serialized loaded rate cycle, not
+        // idle application time. Negative gaps can arise from concurrent delivery publication
+        // and cannot prove that ordering, so they remain rate-app-limited.
+        var continuesSerializedRateCycle = appLimited
+            && deliveredTimestamp != 0
+            && deliveryGapTicks >= 0
+            && deliveryGapTicks < MinimumLoadedRateSampleTicks;
+        var rateAppLimited = appLimited && !continuesSerializedRateCycle;
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,
-            appLimited,
+            rateAppLimited,
             out var deliveryEpochDeliveredBytes,
             out var deliveredBytes);
         return new DeliverySnapshot(
             deliveredBytes,
-            Volatile.Read(ref _lastDeliveredTimestamp),
+            deliveredTimestamp,
             deliveryEpochDeliveredBytes,
             deliveryEpochFirstSendTimestamp,
             sendTimestamp,
             appLimited,
+            rateAppLimited,
             oldestBatchTimestamp,
             Volatile.Read(ref _unackedBytes));
     }
 
     private long CaptureDeliveryEpoch(
         long sendTimestamp,
-        bool appLimited,
+        bool rateAppLimited,
         out long deliveryEpochDeliveredBytes,
         out long deliveredBytes)
     {
@@ -370,10 +383,10 @@ internal sealed class BrokerUnackedByteBudget
             }
 
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
-            // app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
             var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
-            if (!appLimited
+            if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
                 && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)
             {
@@ -569,7 +582,8 @@ internal sealed class BrokerUnackedByteBudget
             && deliveryIdleTicks >= WindowDurationTicks;
         var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
-        var loadedRateSample = !sendSnapshot.AppLimited;
+        var loadedRateEpoch = !sendSnapshot.RateAppLimited;
+        var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
             _hasLoadedServingSample = false;
         else if (loadedServingSample)
@@ -648,9 +662,9 @@ internal sealed class BrokerUnackedByteBudget
         var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
             / deliveryEpochIntervalTicks;
         if (deliveryEpochBytesPerSecond > 0
-            && (!loadedRateSample || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
+            && (!loadedRateEpoch || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
         {
-            AddRateSample(deliveryEpochBytesPerSecond, loadedRateSample, sustainedIdle);
+            AddRateSample(deliveryEpochBytesPerSecond, retainLoadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());
         }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -159,10 +159,6 @@ internal sealed class BrokerUnackedByteBudget
     /// enough slack for replication service-time variance without the ratchet.</summary>
     private const double ServingRttClampMultiplier = 2.0;
 
-    /// <summary>Standing unacked bytes at this multiple of the freshly computed budget prove
-    /// the previous budget over-admitted; decay smoothing then yields to the recompute.</summary>
-    private const long StandingQueueDecayBypassMultiplier = 2;
-
     /// <summary>Lower bound on queue-corrected RTT samples as a fraction of the raw round
     /// trip, so an overestimated drain rate cannot collapse the corrected service estimate
     /// (and with it the RTT floor) toward zero.</summary>
@@ -596,7 +592,11 @@ internal sealed class BrokerUnackedByteBudget
         var loadedRateEpoch = !sendSnapshot.RateAppLimited;
         var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
+        {
             _hasLoadedServingSample = false;
+            _lastNormalBudgetBytes = _capBytes;
+            _lastBudgetUpdateTimestamp = nowTicks;
+        }
         else if (loadedServingSample)
             _hasLoadedServingSample = true;
         // The deadline ack may establish the first loaded serving estimate (depth-one traffic),
@@ -1202,14 +1202,10 @@ internal sealed class BrokerUnackedByteBudget
         var elapsedSeconds = _lastBudgetUpdateTimestamp == 0
             ? 0
             : Math.Max(0, (double)(nowTicks - _lastBudgetUpdateTimestamp) / Stopwatch.Frequency);
-        // _unackedBytes shares a contended cache line with every appender's Interlocked.Add;
-        // only pay for the read when a downward move can consult the queue bypass.
-        var unackedBytes = computedBudget < _lastNormalBudgetBytes ? UnackedBytes : 0;
         var budget = BoundBudgetDecay(
             _lastNormalBudgetBytes,
             computedBudget,
-            elapsedSeconds,
-            unackedBytes);
+            elapsedSeconds);
         budget = Math.Min(budget, _capBytes);
         _lastNormalBudgetBytes = budget;
         _lastBudgetUpdateTimestamp = nowTicks;
@@ -1219,15 +1215,9 @@ internal sealed class BrokerUnackedByteBudget
     internal static long BoundBudgetDecay(
         long previousBudget,
         long computedBudget,
-        double elapsedSeconds,
-        long unackedBytes)
+        double elapsedSeconds)
     {
         if (computedBudget >= previousBudget)
-            return computedBudget;
-
-        // Bytes at a multiple of the fresh budget prove the old budget over-admitted;
-        // smoothing would otherwise preserve the standing queue for minutes at 10%/s.
-        if (unackedBytes >= StandingQueueDecayBypassMultiplier * computedBudget)
             return computedBudget;
 
         var decayFraction = Math.Min(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -24,7 +24,7 @@ namespace Dekaf.Producer;
 /// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
 /// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
 /// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
-/// than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// than 20ms are ignored because host scheduling and burst quantization can dominate them. A separate
 /// per-request rate remains available to the capacity probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
@@ -188,8 +188,10 @@ internal sealed class BrokerUnackedByteBudget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
-    // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
-    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
+    private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // Shorter loaded epochs are dominated by timer, scheduler, and burst quantization on common hosts.
+    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 50);
     // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
     private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
     private const long NoDeliveryEpoch = -1;
@@ -340,7 +342,7 @@ internal sealed class BrokerUnackedByteBudget
         var continuesSerializedRateCycle = appLimited
             && deliveredTimestamp != 0
             && deliveryGapTicks >= 0
-            && deliveryGapTicks < MinimumLoadedRateSampleTicks;
+            && deliveryGapTicks < MaximumSerializedRateCycleGapTicks;
         var rateAppLimited = appLimited && !continuesSerializedRateCycle;
         var deliveryEpochFirstSendTimestamp = CaptureDeliveryEpoch(
             sendTimestamp,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -21,10 +21,10 @@ namespace Dekaf.Producer;
 /// its cap (the 3-broker acks=all latency ratchet, #2009).
 /// <para>
 /// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
-/// epoch; loaded sends retain its delivered-byte and first-send anchors even as acknowledgements
-/// advance the current delivery clock. The sample is cumulative delivered bytes over the full
-/// epoch elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples
-/// shorter than 2ms are ignored because host scheduling resolution can dominate them. A separate
+/// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
+/// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
+/// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
+/// than 2ms are ignored because host scheduling resolution can dominate them. A separate
 /// per-request rate remains available to the capacity probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
@@ -189,6 +189,8 @@ internal sealed class BrokerUnackedByteBudget
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
     // Shorter loaded epochs are dominated by timer and scheduler quantization on common hosts.
     private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 500);
+    // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
+    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -367,13 +369,16 @@ internal sealed class BrokerUnackedByteBudget
                 continue;
             }
 
-            // A loaded pipe belongs to the existing send epoch even after acknowledgements
-            // advance the delivery counter. Reset only when a send observes an empty pipe;
-            // otherwise serialized send/ack cycles collapse back to requestBytes / ownRTT.
-            if (!appLimited && epochDeliveredBytes != NoDeliveryEpoch)
+            // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
+            // app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
+            var epochFirstSendTimestamp = Volatile.Read(ref _sendEpochFirstTimestamp);
+            if (!appLimited
+                && epochDeliveredBytes != NoDeliveryEpoch
+                && sendTimestamp - epochFirstSendTimestamp < MaximumLoadedDeliveryEpochTicks)
             {
                 deliveryEpochDeliveredBytes = epochDeliveredBytes;
-                return Volatile.Read(ref _sendEpochFirstTimestamp);
+                return epochFirstSendTimestamp;
             }
 
             if (Interlocked.CompareExchange(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -22,10 +22,12 @@ namespace Dekaf.Producer;
 /// <para>
 /// Sustainable drain rate is measured over a delivery epoch. An app-limited send starts the
 /// epoch; loaded sends retain its delivered-byte and first-send anchors across acknowledgements
-/// for a bounded rolling interval. The sample is cumulative delivered bytes over the full epoch
-/// elapsed time, bounded below by the request sojourn and delivery clock. Loaded samples shorter
-/// than 20ms are ignored because host scheduling and burst quantization can dominate them. A separate
-/// per-request rate remains available to the capacity probe, which needs each probe admission's
+/// for a rolling interval bounded at 250ms. The sample is cumulative delivered bytes over the
+/// full epoch elapsed time, bounded below by the request sojourn and delivery clock. Samples
+/// shorter than 100ms are ignored because host scheduling and burst quantization can dominate
+/// them. A short truly app-limited sample may seed an empty estimator, but cannot replace an
+/// established sustainable rate. A separate per-request rate remains available to the capacity
+/// probe, which needs each probe admission's
 /// immediate response. These axes prevent serialized send/ack cycles, hot polling, clustered
 /// completions, and processing stalls from manufacturing inflated sustainable-rate samples.
 /// </para>
@@ -187,9 +189,11 @@ internal sealed class BrokerUnackedByteBudget
     // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
     private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
     // Shorter loaded epochs are dominated by timer, scheduler, and burst quantization on common hosts.
-    private static readonly long MinimumLoadedRateSampleTicks = Math.Max(1, Stopwatch.Frequency / 50);
+    private static readonly long MinimumSustainableRateSampleTicks = Math.Max(
+        1,
+        Stopwatch.Frequency / 10);
     // Bound smoothing so a continuously loaded producer still tracks capacity changes promptly.
-    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 10);
+    private static readonly long MaximumLoadedDeliveryEpochTicks = Math.Max(1, Stopwatch.Frequency / 4);
     private const long NoDeliveryEpoch = -1;
     private const long DeliveryEpochUpdating = -2;
 
@@ -391,7 +395,7 @@ internal sealed class BrokerUnackedByteBudget
             }
 
             // A loaded pipe keeps a bounded rolling epoch across acknowledgements. Reset at
-            // rate-app-limited boundaries or after 100ms: the lower bound prevents serialized
+            // rate-app-limited boundaries or after 250ms: the lower bound prevents serialized
             // requestBytes / ownRTT spikes; the upper bound preserves capacity adaptation.
             if (!rateAppLimited
                 && epochDeliveredBytes != NoDeliveryEpoch
@@ -589,7 +593,6 @@ internal sealed class BrokerUnackedByteBudget
             && deliveryIdleTicks >= WindowDurationTicks;
         var loadedServingSample = !sendSnapshot.AppLimited
             || (sendSnapshot.DeliveredTimestamp != 0 && !sustainedIdle);
-        var loadedRateEpoch = !sendSnapshot.RateAppLimited;
         var retainLoadedRateSample = !sendSnapshot.AppLimited;
         if (sustainedIdle)
         {
@@ -672,8 +675,11 @@ internal sealed class BrokerUnackedByteBudget
         var requestBytesPerSecond = deliveredDelta * (double)Stopwatch.Frequency / requestIntervalTicks;
         var deliveryEpochBytesPerSecond = deliveryEpochDelta * (double)Stopwatch.Frequency
             / deliveryEpochIntervalTicks;
+        var bootstrapsEmptyEstimator = sendSnapshot.RateAppLimited
+            && GetEffectiveMaxRate() == 0;
         if (deliveryEpochBytesPerSecond > 0
-            && (!loadedRateEpoch || deliveryEpochIntervalTicks >= MinimumLoadedRateSampleTicks))
+            && (deliveryEpochIntervalTicks >= MinimumSustainableRateSampleTicks
+                || bootstrapsEmptyEstimator))
         {
             AddRateSample(deliveryEpochBytesPerSecond, retainLoadedRateSample, sustainedIdle);
             Volatile.Write(ref _maxRateBytesPerSecond, (long)GetEffectiveMaxRate());

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5551,6 +5551,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         LogFlushStarted(0, inFlightCount);
 
         ProducerDebugCounters.RecordFlushCall();
+
+        // A final partial batch must not enter the sender behind older sealed batches that
+        // are still queued or carried over. Under a deep admission budget, publishing the
+        // partial batch into that active pipeline can let it overtake one or more full
+        // same-partition batches during the flush boundary. Drain the existing pipeline
+        // first, then seal the current batches into a fresh ordered wave.
+        if (inFlightCount > 0)
+            await WaitForAllBatchesCompleteAsync(cancellationToken).ConfigureAwait(false);
+
         await SealBatchesAsync(sealAll: true, cancellationToken).ConfigureAwait(false);
 
         // Wait for all in-flight batches to complete using counter-based tracking

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -652,15 +652,16 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         // Both requests were sent before either delivery.
-        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.005), appLimited: false);
-        var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.001) - Seconds(0.005), appLimited: false);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.020), appLimited: false);
+        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.019), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample covers the full delivery epoch: 2,000 bytes over 6ms from the
-        // first send to the second acknowledgement = 333,333 B/s aggregate drain.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(3_333);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 21ms from the
+        // first send to the second acknowledgement = 95,238 B/s aggregate drain. The
+        // 20ms measured RTT horizon therefore publishes a 1,904-byte budget.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_904);
     }
 
     [Test]
@@ -1457,8 +1458,8 @@ public sealed class BrokerUnackedByteBudgetTests
         var sendSnapshots = new BrokerUnackedByteBudget.DeliverySnapshot[5];
 
         // All requests enter the same delivery epoch before any response arrives. The tail
-        // request has only a 0.5 ms own RTT, but its delivered delta spans the full 4 ms send
-        // burst. Using own RTT alone reports 10 GB/s from a 1.25 GB/s stream.
+        // request has only a 0.5 ms own RTT, so using own RTT alone reports 10 GB/s for the
+        // short burst. The mature sample must average the full epoch instead.
         for (var i = 0; i < sendSnapshots.Length; i++)
         {
             sendSnapshots[i] = budget.SnapshotDelivery(
@@ -1473,10 +1474,12 @@ public sealed class BrokerUnackedByteBudgetTests
                 sendSnapshots[i],
                 T0 + Seconds(0.0041 + i * 0.0001));
         }
-        budget.CompleteAckedPass(T0 + Seconds(0.0045));
+        var matureEpochSend = budget.SnapshotDelivery(T0 + Seconds(0.005), appLimited: false);
+        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.020));
+        budget.CompleteAckedPass(T0 + Seconds(0.020));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_000_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_200_000_000)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(295_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(305_000_000)
             .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
     }
 
@@ -1551,7 +1554,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
+    public async Task LoadedDeliveryEpoch_RejectsShortBurstThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1561,13 +1564,17 @@ public sealed class BrokerUnackedByteBudgetTests
         var firstSend = budget.SnapshotDelivery(T0, appLimited: false);
         budget.OnAcked(1_000_000, firstSend, T0 + Seconds(0.0005));
         await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0)
-            .Because("a sub-2ms loaded sample is dominated by scheduler and timer resolution");
+            .Because("a short loaded sample is dominated by scheduler and burst quantization");
 
         var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: false);
         budget.OnAcked(1_000_000, secondSend, T0 + Seconds(0.0025));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0);
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(800_000_000)
-            .Because("the accepted sample covers 2MB over the full 2.5ms loaded epoch");
+        var thirdSend = budget.SnapshotDelivery(T0 + Seconds(0.003), appLimited: false);
+        budget.OnAcked(1_000_000, thirdSend, T0 + Seconds(0.020));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(150_000_000)
+            .Because("the accepted sample covers 3MB over the full 20ms loaded epoch");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1524,6 +1524,33 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task BackToBackAppLimitedSend_ContinuesRollingRateEpoch()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.0005));
+
+        var hotSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: true);
+        await Assert.That(hotSend.AppLimited).IsTrue();
+        await Assert.That(hotSend.RateAppLimited).IsFalse()
+            .Because("an immediate post-ack send is a serialized loaded rate cycle");
+        await Assert.That(hotSend.DeliveryEpochDeliveredBytes).IsEqualTo(0);
+        await Assert.That(hotSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(T0);
+        budget.OnAcked(1_000, hotSend, T0 + Seconds(0.0011));
+
+        var idleSend = budget.SnapshotDelivery(T0 + Seconds(0.004), appLimited: true);
+        await Assert.That(idleSend.RateAppLimited).IsTrue();
+        await Assert.That(idleSend.DeliveryEpochDeliveredBytes).IsEqualTo(2_000);
+        await Assert.That(idleSend.DeliveryEpochFirstSendTimestamp)
+            .IsEqualTo(T0 + Seconds(0.004))
+            .Because("a real empty-pipe gap starts a fresh rate epoch");
+    }
+
+    [Test]
     public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1684,7 +1711,7 @@ public sealed class BrokerUnackedByteBudgetTests
             budget.OnAcked(
                 1,
                 new BrokerUnackedByteBudget.DeliverySnapshot(
-                    i, 0, i, 0, now - 1, true, 0, 0),
+                    i, 0, i, 0, now - 1, true, true, 0, 0),
                 now);
         }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -12,7 +12,6 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerUnackedByteBudgetTests
 {
-    private const long BudgetDecayBypassBytes = 1L << 40;
     private static readonly long Frequency = Stopwatch.Frequency;
 
     /// <summary>An arbitrary positive anchor: tick 0 means "no window anchored yet".</summary>
@@ -62,15 +61,8 @@ public sealed class BrokerUnackedByteBudgetTests
         BrokerUnackedByteBudget budget,
         long nowTicks)
     {
-        budget.Charge(BudgetDecayBypassBytes);
-        try
-        {
-            budget.CompleteAckedPass(nowTicks);
-        }
-        finally
-        {
-            budget.Release(BudgetDecayBypassBytes);
-        }
+        SetField(budget, "_lastNormalBudgetBytes", 0L);
+        budget.CompleteAckedPass(nowTicks);
     }
 
     private static void SetCapWithoutDecay(
@@ -78,15 +70,8 @@ public sealed class BrokerUnackedByteBudgetTests
         long capBytes,
         long nowTicks)
     {
-        budget.Charge(BudgetDecayBypassBytes);
-        try
-        {
-            budget.SetCap(capBytes, nowTicks);
-        }
-        finally
-        {
-            budget.Release(BudgetDecayBypassBytes);
-        }
+        SetField(budget, "_lastNormalBudgetBytes", 0L);
+        budget.SetCap(capBytes, nowTicks);
     }
 
     /// <summary>
@@ -954,8 +939,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 0);
+            elapsedSeconds: 1.0);
 
         await Assert.That(budget).IsEqualTo(90_000);
     }
@@ -966,32 +950,41 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 0,
-            unackedBytes: 0);
+            elapsedSeconds: 0);
 
         await Assert.That(budget).IsEqualTo(100_000)
             .Because("the first estimator sample has no elapsed decay interval");
     }
 
     [Test]
-    public async Task BudgetDecay_YieldsWhenStandingQueueProvesOverAdmission()
+    public async Task BudgetDecay_StandingQueueCannotBypassTimeBound()
     {
-        // Admission blocks constantly under saturation, so blocks alone cannot gate the
-        // hysteresis. Standing bytes at twice the fresh budget prove the old budget
-        // over-admitted; the recompute must land immediately instead of at 10%/s.
-        var standingQueue = BrokerUnackedByteBudget.BoundBudgetDecay(
+        var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
             previousBudget: 100_000,
             computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 20_000);
-        var modestOccupancy = BrokerUnackedByteBudget.BoundBudgetDecay(
-            previousBudget: 100_000,
-            computedBudget: 10_000,
-            elapsedSeconds: 1.0,
-            unackedBytes: 19_999);
+            elapsedSeconds: 1.0);
 
-        await Assert.That(standingQueue).IsEqualTo(10_000);
-        await Assert.That(modestOccupancy).IsEqualTo(90_000);
+        await Assert.That(budget).IsEqualTo(90_000)
+            .Because("standing occupancy must not collapse the budget faster than elapsed time permits");
+    }
+
+    [Test]
+    public async Task BudgetDecay_SustainedIdleRestoresColdStartBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.001), appLimited: true);
+        budget.OnAcked(1, firstSend, T0);
+        SetField(budget, "_lastNormalBudgetBytes", 10_000L);
+        SetField(budget, "_budgetBytes", 10_000L);
+
+        var idleSend = budget.SnapshotDelivery(T0 + Seconds(3.0), appLimited: true);
+        budget.OnAcked(1, idleSend, T0 + Seconds(3.001));
+        budget.CompleteAckedPass(T0 + Seconds(3.001));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -606,6 +606,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task AppLimitedShortSample_CannotReplaceEstablishedRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+
+        Ack(budget, 1_000, 0.100, T0);
+        Ack(budget, 1_000_000, 0.001, T0 + Seconds(0.100));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(10_000)
+            .Because("a short idle-gap response may seed cold start but cannot ratchet a populated estimator");
+    }
+
+    [Test]
     public async Task Budget_RecoversWhenRateRises()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
@@ -614,7 +629,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var shrunken = budget.BudgetBytes;
 
         // Faster drain in the next window must grow the budget back (no ratchet-down).
-        Ack(budget, 12_000, 0.001, T0 + Seconds(2.0));
+        Ack(budget, 12_000, 0.100, T0 + Seconds(2.0));
 
         await Assert.That(budget.BudgetBytes).IsGreaterThan(shrunken);
     }
@@ -637,16 +652,16 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         // Both requests were sent before either delivery.
-        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.020), appLimited: false);
-        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.019), appLimited: false);
+        var firstSend = budget.SnapshotDelivery(T0 - Seconds(0.100), appLimited: false);
+        var secondSend = budget.SnapshotDelivery(T0 - Seconds(0.099), appLimited: false);
         budget.OnAcked(1_000, firstSend, T0);
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample covers the full delivery epoch: 2,000 bytes over 21ms from the
-        // first send to the second acknowledgement = 95,238 B/s aggregate drain. The
-        // 20ms measured RTT horizon therefore publishes a 1,904-byte budget.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_904);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 101ms from the
+        // first send to the second acknowledgement = 19,801 B/s aggregate drain. The
+        // 100ms measured RTT horizon therefore publishes a 1,980-byte budget.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_980);
     }
 
     [Test]
@@ -667,7 +682,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
 
         Ack(budget, 1_000, 0.100, T0);
-        for (var i = 1; i <= 20; i++)
+        for (var i = 1; i <= 23; i++)
             Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(500);
@@ -1329,14 +1344,14 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(8_787);
 
         // The probe averages three RTTs before ratcheting to the higher level.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
 
         // The ratcheted level gets another full-window average. Comparing average with
         // average lets the sustained 25% gain advance the next rung as well.
@@ -1457,7 +1472,7 @@ public sealed class BrokerUnackedByteBudgetTests
         {
             sendSnapshots[i] = budget.SnapshotDelivery(
                 T0 + Seconds(i * 0.001),
-                appLimited: i == 0);
+                appLimited: false);
         }
 
         for (var i = 0; i < sendSnapshots.Length; i++)
@@ -1468,11 +1483,11 @@ public sealed class BrokerUnackedByteBudgetTests
                 T0 + Seconds(0.0041 + i * 0.0001));
         }
         var matureEpochSend = budget.SnapshotDelivery(T0 + Seconds(0.005), appLimited: false);
-        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.020));
-        budget.CompleteAckedPass(T0 + Seconds(0.020));
+        budget.OnAcked(1_000_000, matureEpochSend, T0 + Seconds(0.100));
+        budget.CompleteAckedPass(T0 + Seconds(0.100));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(295_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(305_000_000)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(59_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(61_000_000)
             .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
     }
 
@@ -1501,7 +1516,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task LoadedDeliveryEpoch_RollsAfterOneHundredMilliseconds()
+    public async Task LoadedDeliveryEpoch_RollsAfterTwoHundredFiftyMilliseconds()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1511,7 +1526,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
         budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
 
-        var nextEpochTimestamp = T0 + Seconds(0.101);
+        var nextEpochTimestamp = T0 + Seconds(0.251);
         var loadedSend = budget.SnapshotDelivery(nextEpochTimestamp, appLimited: false);
 
         await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
@@ -1565,9 +1580,13 @@ public sealed class BrokerUnackedByteBudgetTests
 
         var thirdSend = budget.SnapshotDelivery(T0 + Seconds(0.003), appLimited: false);
         budget.OnAcked(1_000_000, thirdSend, T0 + Seconds(0.020));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0);
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(150_000_000)
-            .Because("the accepted sample covers 3MB over the full 20ms loaded epoch");
+        var fourthSend = budget.SnapshotDelivery(T0 + Seconds(0.021), appLimited: false);
+        budget.OnAcked(1_000_000, fourthSend, T0 + Seconds(0.100));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(40_000_000)
+            .Because("the accepted sample covers 4MB over the full 100ms loaded epoch");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1505,6 +1505,25 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task LoadedDeliveryEpoch_RollsAfterOneHundredMilliseconds()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
+
+        var nextEpochTimestamp = T0 + Seconds(0.101);
+        var loadedSend = budget.SnapshotDelivery(nextEpochTimestamp, appLimited: false);
+
+        await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(loadedSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(nextEpochTimestamp)
+            .Because("a continuously loaded producer must still adapt to capacity changes");
+    }
+
+    [Test]
     public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1536,7 +1555,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
         Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(99_019);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1721,6 +1721,55 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task DeliveryEpochSnapshots_NeverMixConcurrentPublisherGenerations(
+        CancellationToken ct)
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        const int publisherIterations = 100_000;
+        const long deliveryEpochUpdating = -2;
+        using var start = new Barrier(participantCount: 5);
+        var publisherComplete = 0;
+        var mixedGenerationCount = 0;
+
+        SetField(budget, "_totalDeliveredBytes", 0L);
+        SetField(budget, "_sendEpochDeliveredBytes", 0L);
+        SetField(budget, "_sendEpochFirstTimestamp", 0L);
+
+        var readers = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            start.SignalAndWait(ct);
+            while (!ct.IsCancellationRequested && Volatile.Read(ref publisherComplete) == 0)
+            {
+                var snapshot = budget.SnapshotDelivery(sendTimestamp: 1, appLimited: false);
+                if (snapshot.DeliveryEpochFirstSendTimestamp
+                    != snapshot.DeliveryEpochDeliveredBytes * 10)
+                {
+                    Interlocked.Increment(ref mixedGenerationCount);
+                }
+            }
+        }, ct)).ToArray();
+
+        start.SignalAndWait(ct);
+        for (var generation = 1; generation <= publisherIterations; generation++)
+        {
+            SetField(budget, "_totalDeliveredBytes", (long)generation);
+            SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
+            SetField(budget, "_sendEpochFirstTimestamp", generation * 10L);
+            Thread.Yield();
+            SetField(budget, "_sendEpochDeliveredBytes", (long)generation);
+        }
+        Volatile.Write(ref publisherComplete, 1);
+
+        await Task.WhenAll(readers).WaitAsync(ct);
+        await Assert.That(mixedGenerationCount).IsEqualTo(0)
+            .Because("the delivered-byte and first-send anchors belong to one publication");
+    }
+
+    [Test]
     public async Task DeliveryEpoch_RedundantPublisherPreservesFirstSendAnchor()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -320,6 +320,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.015);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
@@ -343,6 +344,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.020);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
@@ -362,6 +364,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_servingRttEwmaSeconds", 0.020);
         SetField(budget, "_windowMaxRate", 1_000_000.0);
         SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_hasLoadedServingSample", true);
         SetField(budget, "_capacityProbeActive", true);
         SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
 
@@ -655,10 +658,9 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.OnAcked(1_000, secondSend, T0 + Seconds(0.001));
         CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.001));
 
-        // The second sample's delivered-counter delta covers both deliveries: 2,000 bytes
-        // over its own 5ms sojourn = 400,000 B/s aggregate drain, independent of the 1ms
-        // gap between the two acknowledgements.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(4_000);
+        // The second sample covers the full delivery epoch: 2,000 bytes over 6ms from the
+        // first send to the second acknowledgement = 333,333 B/s aggregate drain.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_333);
     }
 
     [Test]
@@ -747,8 +749,12 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: true);
         Ack(budget, 1_000, 0.100, T0 + Seconds(0.100), appLimitedAtSend: true);
 
-        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsGreaterThan(0)
-            .Because("recent delivery distinguishes a depth-one loaded pipe from real idle");
+        await Assert.That(GetField<double>(budget, "_retainedLoadedMaxRate")).IsEqualTo(0)
+            .Because("an empty-pipe own-RTT sample must not persist as loaded capacity");
+        await Assert.That(GetField<double>(budget, "_windowMaxRate")).IsGreaterThan(0)
+            .Because("depth-one traffic still needs immediate windowed budget sizing");
+        await Assert.That(GetField<bool>(budget, "_hasLoadedServingSample")).IsTrue()
+            .Because("recent delivery still establishes a loaded serving-RTT horizon");
         await Assert.That(GetField<double>(budget, "_servingRttEwmaSeconds")).IsGreaterThan(0);
     }
 
@@ -1438,7 +1444,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // The initial minimum-RTT probe now retains one BDP instead of draining the pipe;
         // this remains far below the cap the broken estimator pegged.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(4_998_000);
     }
 
     [Test]
@@ -1469,9 +1475,53 @@ public sealed class BrokerUnackedByteBudgetTests
         }
         budget.CompleteAckedPass(T0 + Seconds(0.0045));
 
-        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_200_000_000);
-        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_400_000_000)
-            .Because("a cumulative delivery delta must include its delivery epoch's send time");
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThanOrEqualTo(1_000_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsLessThanOrEqualTo(1_200_000_000)
+            .Because("a cumulative delivery delta must include its delivery epoch's full elapsed time");
+    }
+
+    [Test]
+    public async Task LoadedDeliveryEpoch_SpansAcknowledgementsUntilPipeBecomesAppLimited()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: true);
+        budget.OnAcked(1_000, firstSend, T0 + Seconds(0.005));
+
+        var loadedSend = budget.SnapshotDelivery(T0 + Seconds(0.006), appLimited: false);
+        await Assert.That(loadedSend.DeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(loadedSend.DeliveryEpochDeliveredBytes).IsEqualTo(0)
+            .Because("delivery progress must not reset an epoch while the pipe remains loaded");
+        await Assert.That(loadedSend.DeliveryEpochFirstSendTimestamp).IsEqualTo(T0);
+
+        var appLimitedSend = budget.SnapshotDelivery(T0 + Seconds(0.007), appLimited: true);
+        await Assert.That(appLimitedSend.DeliveryEpochDeliveredBytes).IsEqualTo(1_000);
+        await Assert.That(appLimitedSend.DeliveryEpochFirstSendTimestamp)
+            .IsEqualTo(T0 + Seconds(0.007))
+            .Because("an empty-pipe send starts a new delivery epoch");
+    }
+
+    [Test]
+    public async Task LoadedDeliveryEpoch_RejectsSubTwoMillisecondSpikeThenMeasuresCumulativeRate()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 200_000_000);
+
+        var firstSend = budget.SnapshotDelivery(T0, appLimited: false);
+        budget.OnAcked(1_000_000, firstSend, T0 + Seconds(0.0005));
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(0)
+            .Because("a sub-2ms loaded sample is dominated by scheduler and timer resolution");
+
+        var secondSend = budget.SnapshotDelivery(T0 + Seconds(0.0006), appLimited: false);
+        budget.OnAcked(1_000_000, secondSend, T0 + Seconds(0.0025));
+
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(800_000_000)
+            .Because("the accepted sample covers 2MB over the full 2.5ms loaded epoch");
     }
 
     [Test]
@@ -1486,7 +1536,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
         Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(99_019);
     }
 
     [Test]
@@ -1615,7 +1665,7 @@ public sealed class BrokerUnackedByteBudgetTests
             budget.OnAcked(
                 1,
                 new BrokerUnackedByteBudget.DeliverySnapshot(
-                    i, 0, 0, now - 1, true, 0, 0),
+                    i, 0, i, 0, now - 1, true, 0, 0),
                 now);
         }
 
@@ -1640,13 +1690,14 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_sendEpochDeliveredBytes", deliveryEpochUpdating);
         SetField(budget, "_sendEpochFirstTimestamp", firstSendTimestamp);
 
-        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null };
+        var arguments = new object?[] { stalePublisherTimestamp, deliveredBytes, null, null };
         var anchor = (long)typeof(BrokerUnackedByteBudget)
             .GetMethod("PublishDeliveryEpoch", BindingFlags.Instance | BindingFlags.NonPublic)!
             .Invoke(budget, arguments)!;
 
         await Assert.That(anchor).IsEqualTo(firstSendTimestamp);
         await Assert.That(arguments[2]).IsEqualTo(deliveredBytes);
+        await Assert.That(arguments[3]).IsEqualTo(deliveredBytes);
         await Assert.That(GetField<long>(budget, "_sendEpochFirstTimestamp")).IsEqualTo(firstSendTimestamp);
         await Assert.That(GetField<long>(budget, "_sendEpochDeliveredBytes")).IsEqualTo(deliveredBytes);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1858,6 +1858,100 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task FlushAsync_WaitsForSealedPipelineBeforePublishingFinalPartialBatch()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 30,
+            LingerMs = 10
+        };
+        var accumulator = new RecordAccumulator(options);
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var topicPartition = new TopicPartition("test-topic", 0);
+        ReadyBatch? sealedBatch = null;
+        ReadyBatch? finalBatch = null;
+
+        try
+        {
+            var firstCompletion = pool.Rent();
+            var secondCompletion = pool.Rent();
+            var firstCompletionTask = firstCompletion.Task;
+            var secondCompletionTask = secondCompletion.Task;
+            var value = new byte[16];
+
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                firstCompletion)).IsTrue();
+
+            await Assert.That(accumulator.TryAppendFromSpansWithCompletion(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                secondCompletion)).IsTrue();
+
+            await Assert.That(accumulator.TryDrainBatch(out sealedBatch)).IsTrue();
+
+            var flushTask = accumulator.FlushAsync(CancellationToken.None).AsTask();
+
+            await Assert.That(flushTask.IsCompleted).IsFalse();
+            await Assert.That(accumulator.TryDrainBatch(out _)).IsFalse()
+                .Because("the final partial batch must remain unpublished while an older batch is in flight");
+
+            sealedBatch!.CompleteSend(baseOffset: 10, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(sealedBatch);
+            accumulator.ReturnReadyBatch(sealedBatch);
+            sealedBatch = null;
+
+            await TestWait.UntilAsync(
+                () => accumulator.TryDrainBatch(out finalBatch),
+                TimeSpan.FromSeconds(5));
+
+            finalBatch!.CompleteSend(baseOffset: 11, DateTimeOffset.UtcNow);
+            accumulator.OnBatchExitsPipeline(finalBatch);
+            accumulator.ReturnReadyBatch(finalBatch);
+            finalBatch = null;
+
+            await flushTask.WaitAsync(TimeSpan.FromSeconds(5));
+            _ = await firstCompletionTask;
+            _ = await secondCompletionTask;
+        }
+        finally
+        {
+            if (sealedBatch is not null)
+            {
+                accumulator.OnBatchExitsPipeline(sealedBatch);
+                accumulator.ReturnReadyBatch(sealedBatch);
+            }
+
+            if (finalBatch is not null)
+            {
+                accumulator.OnBatchExitsPipeline(finalBatch);
+                accumulator.ReturnReadyBatch(finalBatch);
+            }
+
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task ReadyBatch_Cleanup_CalledTwice_OnlyExecutesOnce()
     {
         // This test verifies that Cleanup() uses an interlocked guard to ensure


### PR DESCRIPTION
## Summary - keep a sustainable delivery epoch across acknowledgements while the broker pipe remains loaded - roll loaded epochs every 250 ms to retain capacity adaptation - reject sustainable rate samples shorter than 100 ms once the estimator is seeded, while preserving per-request capacity-probe feedback - separate the loaded serving-RTT horizon from retained loaded-rate peaks  ## Evidence - exact #2019 base 15-minute 1-broker acks-all measured 30.0 GB/s against 1.33 GB/s actual throughput and hit the 192 MiB cap - controlled local a7-to-candidate round-trip reduced max rate 448 to 253 MB/s and steady budget 1.2-1.7 MiB to 0.5-0.6 MiB - produce throughput held 108,742 to 109,128 msg/s; average request size moved 689 to 755 KiB; CPU improved 13.19 to 12.06 us/message; correctness passed  ## Test plan - [x] net10 focused estimator tests: 86/86 - [x] net10 full unit suite: 5,439/5,439 - [x] net8 full unit suite: 5,332/5,332 - [x] Testcontainers round-trip: 250,000/250,000, zero missing/duplicate/corrupt/out-of-order messages  Rebased onto current #2019 after #2039 merged; this diff contains the rate-bound follow-up only.  Refs #2034   