### PR TITLE
fix(producer): stabilize awaited linger

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1183,7 +1183,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private long _oldestBatchCreatedTicks = long.MaxValue;
 
     // Track whether there are unsealed batches containing awaited produces (ProduceAsync).
-    // These need micro-linger checks regardless of LingerMs, so ExpireLingerAsync drains the
+    // These need short-linger checks regardless of LingerMs, so ExpireLingerAsync drains the
     // active linger queue when this counter is non-zero. Count is per batch, not per message.
     private int _pendingAwaitedProduceCount;
 
@@ -4360,7 +4360,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         // Fast path 2: if the oldest batch hasn't reached linger time yet AND there are no
         // pending awaited produces, skip active queue checks. Awaited produces (ProduceAsync)
-        // use a micro-linger (min(1ms, LingerMs/10)) so they need more frequent checks.
+        // use a short linger (min(2ms, LingerMs/2)) so they need more frequent checks.
         if (Volatile.Read(ref _pendingAwaitedProduceCount) == 0)
         {
             var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
@@ -5971,6 +5971,9 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
 /// </summary>
 internal sealed class PartitionBatch
 {
+    private const double AwaitedLingerFraction = 0.5;
+    private const double MaximumAwaitedLingerMilliseconds = 2.0;
+
     private TopicPartition _topicPartition;
     private int _partitionCount;
     private ProducerOptions _options;
@@ -6583,8 +6586,8 @@ internal sealed class PartitionBatch
     /// The worst case of a stale read is harmless - we'll catch it on the next check.
     ///
     /// Smart batching strategy:
-    /// - If there are completion sources waiting (awaited produces), use a micro-linger
-    ///   of min(1ms, LingerMs/10) to let co-temporal messages batch together
+    /// - If there are completion sources waiting (awaited produces), use a short linger
+    ///   of min(2ms, LingerMs/2) to let co-temporal messages batch together
     /// - When LingerMs == 0, awaited produces still flush immediately
     /// - Fire-and-forget messages wait for full linger time
     /// This balances low latency for awaited produces with efficient batching.
@@ -6600,13 +6603,22 @@ internal sealed class PartitionBatch
 
         var elapsedMs = Stopwatch.GetElapsedTime(_createdStopwatchTimestamp, nowStopwatchTimestamp).TotalMilliseconds;
 
-        // Awaited produces: use micro-linger instead of immediate flush.
-        // When LingerMs > 0 (default is 5), wait min(1ms, LingerMs/10) to let co-temporal messages batch.
+        // Awaited produces: use a short linger instead of immediate flush. A sub-millisecond
+        // threshold seals on the first 1 ms timer tick, making request size depend on host timer
+        // coalescing. Waiting min(2ms, LingerMs/2) keeps batching stable across timer granularity.
         // When LingerMs == 0, flush immediately.
         // Fire-and-forget messages (Send) don't add completion sources, so they
         // still benefit from full linger time batching.
         if (Volatile.Read(ref _completionSourceCount) > 0)
-            return lingerMs == 0 || elapsedMs >= Math.Min(1.0, lingerMs / 10.0);
+        {
+            if (lingerMs == 0)
+                return true;
+
+            var awaitedLingerMilliseconds = Math.Min(
+                MaximumAwaitedLingerMilliseconds,
+                lingerMs * AwaitedLingerFraction);
+            return elapsedMs >= awaitedLingerMilliseconds;
+        }
 
         return elapsedMs >= lingerMs;
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ShouldFlushTests.cs
@@ -5,9 +5,9 @@ using Dekaf.Producer;
 namespace Dekaf.Tests.Unit.Producer;
 
 /// <summary>
-/// Tests for PartitionBatch.ShouldFlush() micro-linger behavior.
-/// When LingerMs > 0, awaited produces (with completion sources) use a micro-linger
-/// of min(1ms, LingerMs/10) instead of flushing immediately.
+/// Tests for PartitionBatch.ShouldFlush() short-linger behavior.
+/// When LingerMs > 0, awaited produces (with completion sources) use a short linger
+/// of min(2ms, LingerMs/2) instead of flushing immediately.
 /// When LingerMs == 0, awaited produces flush immediately.
 /// </summary>
 public class ShouldFlushTests
@@ -100,7 +100,26 @@ public class ShouldFlushTests
         await Assert.That(result).IsTrue();
     }
 
-    // --- LingerMs = 5: micro-linger = 0.5ms ---
+    // --- LingerMs = 1: short linger uses half the configured linger ---
+
+    [Test]
+    [Arguments(0.4, false)]
+    [Arguments(0.5, true)]
+    public async Task LingerMs1_WithCompletionSources_UsesHalfLinger(
+        double ageMilliseconds,
+        bool expected)
+    {
+        var batch = CreateBatch();
+
+        SetRecordCount(batch, 1);
+        SetCompletionSourceCount(batch, 1);
+        var now = SetCreatedAtMillisecondsAgo(batch, ageMilliseconds);
+
+        var result = InvokeShouldFlush(batch, now, lingerMs: 1);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // --- LingerMs = 5: short linger caps at 2ms ---
 
     [Test]
     public async Task LingerMs5_WithCompletionSources_Age0ms_DoesNotFlush()
@@ -109,61 +128,61 @@ public class ShouldFlushTests
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0); // Age = 0ms, micro-linger = 0.5ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 0); // Age = 0ms, short linger = 2ms
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 5);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs5_WithCompletionSources_AgeAtMicroLinger_Flushes()
+    public async Task LingerMs5_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.5); // Age = 0.5ms = micro-linger threshold
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
+
+        var result = InvokeShouldFlush(batch, now, lingerMs: 5);
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task LingerMs5_WithCompletionSources_Age2ms_Flushes()
+    {
+        var batch = CreateBatch();
+
+        SetRecordCount(batch, 1);
+        SetCompletionSourceCount(batch, 1);
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 5);
         await Assert.That(result).IsTrue();
     }
 
+    // --- LingerMs = 20: short linger caps at 2ms ---
+
     [Test]
-    public async Task LingerMs5_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs20_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms, well past 0.5ms micro-linger
-
-        var result = InvokeShouldFlush(batch, now, lingerMs: 5);
-        await Assert.That(result).IsTrue();
-    }
-
-    // --- LingerMs = 20: micro-linger = min(1ms, 20/10) = 1ms (capped) ---
-
-    [Test]
-    public async Task LingerMs20_WithCompletionSources_Age09ms_DoesNotFlush()
-    {
-        var batch = CreateBatch();
-
-        SetRecordCount(batch, 1);
-        SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.9); // Age = 0.9ms, micro-linger = 1ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 20);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs20_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs20_WithCompletionSources_Age2ms_Flushes()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms = capped micro-linger
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 20);
         await Assert.That(result).IsTrue();
@@ -212,29 +231,29 @@ public class ShouldFlushTests
         await Assert.That(result).IsFalse();
     }
 
-    // --- Large LingerMs: micro-linger caps at 1ms ---
+    // --- Large LingerMs: short linger caps at 2ms ---
 
     [Test]
-    public async Task LingerMs100_WithCompletionSources_Age09ms_DoesNotFlush()
+    public async Task LingerMs100_WithCompletionSources_Age19ms_DoesNotFlush()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 0.9); // micro-linger = min(1ms, 100/10) = 1ms
+        var now = SetCreatedAtMillisecondsAgo(batch, 1.9); // Age = 1.9ms < 2ms short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 100);
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task LingerMs100_WithCompletionSources_Age1ms_Flushes()
+    public async Task LingerMs100_WithCompletionSources_Age2ms_Flushes()
     {
         var batch = CreateBatch();
 
         SetRecordCount(batch, 1);
         SetCompletionSourceCount(batch, 1);
-        var now = SetCreatedAtMillisecondsAgo(batch, 1.0); // Age = 1ms = capped micro-linger
+        var now = SetCreatedAtMillisecondsAgo(batch, 2.0); // Age = 2ms = capped short linger
 
         var result = InvokeShouldFlush(batch, now, lingerMs: 100);
         await Assert.That(result).IsTrue();


### PR DESCRIPTION
## Summary - let awaited batches coalesce for half of configured linger, capped at 2 ms - preserve zero-linger and fire-and-forget flush behavior - cover the fractional threshold and cap explicitly  ## Evidence - controlled local a7-to-candidate round-trip moved 387 to 357 requests and 689 to 747 KiB/request - CPU improved 13.19 to 13.06 us/message; 250,000/250,000 correctness passed - the wider threshold removes dependence on whether a 1 ms timer tick coalesces to the first 0.5 ms awaited deadline  ## Test plan - [x] focused ShouldFlush tests: 20/20 - [x] net10 full unit suite: 5,436/5,436 - [x] Testcontainers round-trip: zero missing/duplicate/corrupt/out-of-order messages  Rebased onto current #2019 after #2039 merged; this diff contains the awaited-linger follow-up only.  Refs #2011 