### PR TITLE
perf(producer): remove full-body send copy

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -135,6 +135,7 @@ public sealed partial class KafkaConnection :
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly SemaphoreSlim _scatterGatherSenderLock = new(1, 1);
     private SocketScatterGatherSender? _scatterGatherSender;
 
     private Task? _receiveTask;
@@ -1483,8 +1484,12 @@ public sealed partial class KafkaConnection :
         int suffixOffset,
         int suffixLength)
     {
+        var scatterGatherSenderLockHeld = false;
         try
         {
+            await _scatterGatherSenderLock.WaitAsync().ConfigureAwait(false);
+            scatterGatherSenderLockHeld = true;
+
             var socket = _socket ?? throw new InvalidOperationException("Not connected");
             if (_stream is null)
                 throw new InvalidOperationException("Not connected");
@@ -1516,7 +1521,12 @@ public sealed partial class KafkaConnection :
         }
         finally
         {
-            _scatterGatherSender?.Segments.Clear();
+            if (scatterGatherSenderLockHeld)
+            {
+                _scatterGatherSender?.Segments.Clear();
+                SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
+            }
+
             DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
             SemaphoreHelper.ReleaseSafely(_writeLock);
         }
@@ -3444,18 +3454,21 @@ public sealed partial class KafkaConnection :
         _reauthTimer?.Dispose();
         _reauthLock.Dispose();
         _connectLock.Dispose();
-        await _writeLock.WaitAsync().ConfigureAwait(false);
+        // The sender is shared by segmented writes. Use its dedicated lifetime lock so
+        // background write-failure disposal cannot transiently reacquire _writeLock after the
+        // faulted writer releases it. This still waits for an active socket send to unwind.
+        await _scatterGatherSenderLock.WaitAsync().ConfigureAwait(false);
         try
         {
             _scatterGatherSender?.Dispose();
         }
         finally
         {
-            SemaphoreHelper.ReleaseSafely(_writeLock);
+            SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
         }
 
-        // Do not dispose _writeLock here. Writers queued before disposal must still acquire it,
-        // observe the disposed connection, and release it from their finally blocks.
+        // Do not dispose either write semaphore here. Writers queued before disposal must still
+        // acquire them, observe the disposed connection, and release them from finally blocks.
         _timeoutCtsPool.Clear();
         _ownedTokenProvider?.Dispose();
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -16,6 +16,7 @@ using Dekaf.Internal;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
@@ -134,6 +135,7 @@ public sealed partial class KafkaConnection :
     private readonly CancellationTokenSourcePool _timeoutCtsPool;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private SocketScatterGatherSender? _scatterGatherSender;
 
     private Task? _receiveTask;
     private CancellationTokenSource? _receiveCts;
@@ -1319,6 +1321,49 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
+        if (!_isTls
+            && _socket is not null
+            && request is ProduceRequest produceRequest
+            && TryPreSerializeSingleBatchProduceRequest(
+                produceRequest,
+                correlationId,
+                apiVersion,
+                headerVersion,
+                out var metadataArray,
+                out var prefixLength,
+                out var encodedRecords,
+                out var suffixOffset,
+                out var suffixLength))
+        {
+            try
+            {
+                await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                        _writeLock,
+                        nameof(KafkaConnection),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+                throw;
+            }
+
+            var segmentedWriteTask = WriteSegmentedFrameHoldingLockAsync(
+                metadataArray,
+                prefixLength,
+                encodedRecords,
+                suffixOffset,
+                suffixLength);
+            await AwaitBorrowedFrameWriteAsync(
+                    segmentedWriteTask,
+                    correlationId,
+                    callerOwnsTimeout,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
         var clearSerializedArray = KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.SaslAuthenticate;
         try
@@ -1338,6 +1383,162 @@ public sealed partial class KafkaConnection :
         // socket write mid-frame (see AwaitFrameWriteAsync).
         var writeTask = WriteFrameHoldingLockAsync(serializedArray, serializedLength, clearSerializedArray);
         await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal bool TryPreSerializeSingleBatchProduceRequest(
+        ProduceRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion,
+        out byte[] metadataArray,
+        out int prefixLength,
+        out ArraySegment<byte> encodedRecords,
+        out int suffixOffset,
+        out int suffixLength)
+    {
+        metadataArray = null!;
+        prefixLength = 0;
+        encodedRecords = default;
+        suffixOffset = 0;
+        suffixLength = 0;
+
+        if (!request.TryGetSingleBatch(out var topic, out var partition, out var batch))
+            return false;
+
+        if (!batch.CanWriteSegmented(partition.Compression))
+            return false;
+
+        using var metadataWriter = new RentedBufferWriter(
+            DefaultPreSerializeInitialCapacity,
+            MessageSizePrefixLength);
+        var writer = new KafkaProtocolWriter(metadataWriter);
+        var header = new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = _clientId,
+            HeaderVersion = headerVersion
+        };
+
+        header.Write(ref writer);
+        var headerLength = writer.BytesWritten;
+
+        writer.WriteCompactNullableString(request.TransactionalId);
+        writer.WriteInt16(request.Acks);
+        writer.WriteInt32(request.TimeoutMs);
+        writer.WriteUnsignedVarInt(2); // one topic, compact count is item count + 1
+        writer.WriteCompactString(topic.Name);
+        writer.WriteUnsignedVarInt(2); // one partition
+        writer.WriteInt32(partition.Index);
+
+        var encodedBatchSize = batch.GetEncodedSize(partition.Compression);
+        writer.WriteUnsignedVarInt(checked(encodedBatchSize + 1));
+        if (!batch.TryWriteSegmentedHeader(
+                metadataWriter,
+                partition.Compression,
+                out var encodedRecordsMemory)
+            || !MemoryMarshal.TryGetArray(encodedRecordsMemory, out encodedRecords))
+        {
+            encodedRecords = default;
+            return false;
+        }
+
+        var segmentedBatchSize = RecordBatch.TotalBatchHeaderSize + encodedRecords.Count;
+        if (encodedBatchSize != segmentedBatchSize)
+        {
+            throw new KafkaException(
+                ErrorCode.CorruptMessage,
+                $"PRODUCE segmented framing mismatch for partition {partition.Index}: " +
+                $"declared batch length {encodedBatchSize} but segmented header and records total " +
+                $"{segmentedBatchSize} bytes.");
+        }
+
+        writer.AddBytesWritten(encodedBatchSize);
+        prefixLength = metadataWriter.WrittenCount;
+        writer.WriteEmptyTaggedFields(); // partition
+        writer.WriteEmptyTaggedFields(); // topic
+        writer.WriteEmptyTaggedFields(); // request
+        suffixOffset = prefixLength;
+        suffixLength = metadataWriter.WrittenCount - prefixLength;
+
+        var bodyLength = writer.BytesWritten - headerLength;
+        if (request.RequestBodySizeHint > 0 && bodyLength != request.RequestBodySizeHint)
+        {
+            throw new KafkaException(
+                ErrorCode.CorruptMessage,
+                $"PRODUCE segmented body mismatch: size hint {request.RequestBodySizeHint} but serialized {bodyLength} bytes.");
+        }
+
+        var totalLength = checked(metadataWriter.WrittenCount + encodedRecords.Count);
+        (metadataArray, _) = metadataWriter.DetachBuffer();
+        BinaryPrimitives.WriteInt32BigEndian(metadataArray, totalLength - MessageSizePrefixLength);
+        return true;
+    }
+
+    private async Task WriteSegmentedFrameHoldingLockAsync(
+        byte[] metadataArray,
+        int prefixLength,
+        ArraySegment<byte> encodedRecords,
+        int suffixOffset,
+        int suffixLength)
+    {
+        try
+        {
+            var socket = _socket ?? throw new InvalidOperationException("Not connected");
+            if (_stream is null)
+                throw new InvalidOperationException("Not connected");
+
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(KafkaConnection));
+
+            var sender = _scatterGatherSender ??= new SocketScatterGatherSender();
+            var sendSegments = sender.Segments;
+            sendSegments.Add(new ArraySegment<byte>(metadataArray, 0, prefixLength));
+            if (encodedRecords.Count > 0)
+                sendSegments.Add(encodedRecords);
+            if (suffixLength > 0)
+                sendSegments.Add(new ArraySegment<byte>(metadataArray, suffixOffset, suffixLength));
+
+            while (sendSegments.Count > 0)
+            {
+                var bytesSent = await sender.SendAsync(socket).ConfigureAwait(false);
+                if (bytesSent <= 0)
+                    throw new IOException("Socket closed while writing a Kafka request frame.");
+
+                ConsumeSentSegments(sendSegments, bytesSent);
+            }
+        }
+        catch
+        {
+            AbortAfterWriteFailure();
+            throw;
+        }
+        finally
+        {
+            _scatterGatherSender?.Segments.Clear();
+            DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+            SemaphoreHelper.ReleaseSafely(_writeLock);
+        }
+    }
+
+    internal static void ConsumeSentSegments(List<ArraySegment<byte>> segments, int bytesSent)
+    {
+        while (bytesSent > 0)
+        {
+            var segment = segments[0];
+            if (bytesSent < segment.Count)
+            {
+                segments[0] = new ArraySegment<byte>(
+                    segment.Array!,
+                    segment.Offset + bytesSent,
+                    segment.Count - bytesSent);
+                return;
+            }
+
+            bytesSent -= segment.Count;
+            segments.RemoveAt(0);
+        }
     }
 
     /// <summary>
@@ -1386,10 +1587,35 @@ public sealed partial class KafkaConnection :
     /// write one further request timeout to finish before forcibly aborting the connection to
     /// unblock a socket write stuck on a dead broker.
     /// </summary>
-    private async ValueTask AwaitFrameWriteAsync(
+    private ValueTask AwaitFrameWriteAsync(
         Task writeTask,
         int correlationId,
         bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+        => AwaitFrameWriteCoreAsync(
+            writeTask,
+            correlationId,
+            callerOwnsTimeout,
+            payloadIsBorrowed: false,
+            cancellationToken);
+
+    private ValueTask AwaitBorrowedFrameWriteAsync(
+        Task writeTask,
+        int correlationId,
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+        => AwaitFrameWriteCoreAsync(
+            writeTask,
+            correlationId,
+            callerOwnsTimeout,
+            payloadIsBorrowed: true,
+            cancellationToken);
+
+    private async ValueTask AwaitFrameWriteCoreAsync(
+        Task writeTask,
+        int correlationId,
+        bool callerOwnsTimeout,
+        bool payloadIsBorrowed,
         CancellationToken cancellationToken)
     {
 #if DEBUG
@@ -1410,7 +1636,11 @@ public sealed partial class KafkaConnection :
             // Any OperationCanceledException here means the caller's timeout elapsed.
             catch (OperationCanceledException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
@@ -1426,18 +1656,45 @@ public sealed partial class KafkaConnection :
             }
             catch (OperationCanceledException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 throw new OperationCanceledException(cancellationToken);
             }
             catch (TimeoutException)
             {
-                AbandonFrameWrite(writeTask, correlationId);
+                if (payloadIsBorrowed)
+                    await AbortAndObserveFrameWriteAsync(writeTask).ConfigureAwait(false);
+                else
+                    AbandonFrameWrite(writeTask, correlationId);
+
                 LogFlushTimeout(_options.RequestTimeout.TotalMilliseconds, correlationId, BrokerId);
 
                 throw new KafkaException(
                     ErrorCode.RequestTimedOut,
                     $"Flush timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms on connection to broker {BrokerId}");
             }
+        }
+    }
+
+    /// <summary>
+    /// Borrowed producer buffers cannot outlive their caller. Abort a stalled socket write and
+    /// observe its completion before the caller can release or recycle the batch resources.
+    /// </summary>
+    private async Task AbortAndObserveFrameWriteAsync(Task writeTask)
+    {
+        if (!writeTask.IsCompleted)
+            AbortAfterWriteFailure();
+
+        try
+        {
+            await writeTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The timeout/cancellation remains the caller-visible failure.
         }
     }
 
@@ -3021,6 +3278,79 @@ public sealed partial class KafkaConnection :
         }
     }
 
+    private sealed class SocketScatterGatherSender : IValueTaskSource<int>, IDisposable
+    {
+        private readonly SocketAsyncEventArgs _eventArgs = new();
+        private ManualResetValueTaskSourceCore<int> _core = new()
+        {
+            RunContinuationsAsynchronously = true
+        };
+
+        public SocketScatterGatherSender()
+        {
+            _eventArgs.Completed += CompleteSend;
+        }
+
+        public List<ArraySegment<byte>> Segments { get; } = new(3);
+
+        public ValueTask<int> SendAsync(Socket socket)
+        {
+            Debug.Assert(_eventArgs.BufferList is null, "Scatter/gather sender reused before completion");
+            _core.Reset();
+            _eventArgs.BufferList = Segments;
+            _eventArgs.SocketFlags = SocketFlags.None;
+
+            try
+            {
+                if (socket.SendAsync(_eventArgs))
+                    return new ValueTask<int>(this, _core.Version);
+
+                var bytesTransferred = GetSynchronousResult();
+                _eventArgs.BufferList = null;
+                return new ValueTask<int>(bytesTransferred);
+            }
+            catch
+            {
+                _eventArgs.BufferList = null;
+                throw;
+            }
+        }
+
+        private int GetSynchronousResult()
+        {
+            if (_eventArgs.SocketError != SocketError.Success)
+                throw new SocketException((int)_eventArgs.SocketError);
+
+            return _eventArgs.BytesTransferred;
+        }
+
+        private void CompleteSend(object? sender, SocketAsyncEventArgs eventArgs)
+        {
+            eventArgs.BufferList = null;
+            if (eventArgs.SocketError == SocketError.Success)
+                _core.SetResult(eventArgs.BytesTransferred);
+            else
+                _core.SetException(new SocketException((int)eventArgs.SocketError));
+        }
+
+        public int GetResult(short token) => _core.GetResult(token);
+
+        public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
+
+        public void Dispose()
+        {
+            _eventArgs.Completed -= CompleteSend;
+            _eventArgs.Dispose();
+        }
+    }
+
     public ValueTask DisposeAsync()
         => new(EnsureDisposeStarted());
 
@@ -3114,8 +3444,18 @@ public sealed partial class KafkaConnection :
         _reauthTimer?.Dispose();
         _reauthLock.Dispose();
         _connectLock.Dispose();
-        // Do not dispose _writeLock here. A frame write may still be unwinding after
-        // stream/socket disposal unblocks it; its finally block must release the lock.
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _scatterGatherSender?.Dispose();
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_writeLock);
+        }
+
+        // Do not dispose _writeLock here. Writers queued before disposal must still acquire it,
+        // observe the disposed connection, and release it from their finally blocks.
         _timeoutCtsPool.Clear();
         _ownedTokenProvider?.Dispose();
 

--- a/src/Dekaf/Networking/RentedBufferWriter.cs
+++ b/src/Dekaf/Networking/RentedBufferWriter.cs
@@ -30,6 +30,8 @@ internal sealed class RentedBufferWriter : IBufferWriter<byte>, IDisposable
         _buffer = DekafPools.SerializationBuffers.Rent(initialCapacity + offset);
     }
 
+    internal int WrittenCount => _written;
+
     /// <summary>
     /// Detaches the underlying rented array. The caller owns the array and must return it
     /// to <see cref="DekafPools.SerializationBuffers"/>. After this call, the writer must not be used.

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -58,6 +58,37 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
         _topicDataScratchCount = 0;
     }
 
+    internal bool TryGetSingleBatch(
+        out ProduceRequestTopicData topic,
+        out ProduceRequestPartitionData partition,
+        out RecordBatch batch)
+    {
+        topic = null!;
+        partition = null!;
+        batch = null!;
+
+        if (_topicDataScratch is { } topicDataScratch)
+        {
+            if (_topicDataScratchCount != 1)
+                return false;
+
+            topic = topicDataScratch[0];
+        }
+        else
+        {
+            if (TopicData.Count != 1)
+                return false;
+
+            topic = TopicData[0];
+        }
+
+        if (!topic.TryGetSinglePartition(out partition) || partition.Records.Count != 1)
+            return false;
+
+        batch = partition.Records[0];
+        return true;
+    }
+
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
         writer.WriteCompactNullableString(TransactionalId);
@@ -114,6 +145,25 @@ public sealed class ProduceRequestTopicData
         _partitionDataScratch = null;
         _partitionDataScratchStart = 0;
         _partitionDataScratchCount = 0;
+    }
+
+    internal bool TryGetSinglePartition(out ProduceRequestPartitionData partition)
+    {
+        partition = null!;
+        if (_partitionDataScratch is { } partitionDataScratch)
+        {
+            if (_partitionDataScratchCount != 1)
+                return false;
+
+            partition = partitionDataScratch[_partitionDataScratchStart];
+            return true;
+        }
+
+        if (PartitionData.Count != 1)
+            return false;
+
+        partition = PartitionData[0];
+        return true;
     }
 
     public void Write(ref KafkaProtocolWriter writer, short version)

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1097,6 +1097,63 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         }
     }
 
+    internal bool TryWriteSegmentedHeader(
+        IBufferWriter<byte> output,
+        CompressionType compression,
+        out ReadOnlyMemory<byte> encodedRecords)
+    {
+        uint encodedRecordsCrc;
+        CompressionType effectiveCompression;
+        if (PreCompressedRecords is { } preCompressedRecords)
+        {
+            encodedRecords = preCompressedRecords.AsMemory(0, PreCompressedLength);
+            encodedRecordsCrc = PreCompressedRecordsCrc;
+            effectiveCompression = PreCompressedType;
+        }
+        else if (compression == CompressionType.None && _hasPreEncodedRecords)
+        {
+            encodedRecords = _preEncodedRecords;
+            encodedRecordsCrc = _preEncodedRecordsCrc;
+            effectiveCompression = CompressionType.None;
+        }
+        else
+        {
+            encodedRecords = default;
+            return false;
+        }
+
+        var writer = new KafkaProtocolWriter(output);
+        writer.WriteInt64(BaseOffset);
+        writer.WriteInt32(BatchHeaderSize + encodedRecords.Length);
+        writer.WriteInt32(PartitionLeaderEpoch);
+        writer.WriteUInt8(Magic);
+
+        var crcAndContentSpan = output.GetSpan(sizeof(uint) + CrcContentFixedSize);
+        var contentSpan = crcAndContentSpan[sizeof(uint)..];
+        var attributes = (short)Attributes;
+        if (effectiveCompression != CompressionType.None)
+            attributes = (short)((attributes & ~0x07) | (int)effectiveCompression);
+
+        BinaryPrimitives.WriteInt16BigEndian(contentSpan, attributes);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[2..], LastOffsetDelta);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[6..], BaseTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[14..], MaxTimestamp);
+        BinaryPrimitives.WriteInt64BigEndian(contentSpan[22..], ProducerId);
+        BinaryPrimitives.WriteInt16BigEndian(contentSpan[30..], ProducerEpoch);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[32..], BaseSequence);
+        BinaryPrimitives.WriteInt32BigEndian(contentSpan[36..], Records.Count);
+
+        var headerCrc = Crc32C.Compute(contentSpan[..CrcContentFixedSize]);
+        var crc = Crc32C.Combine(headerCrc, encodedRecordsCrc, encodedRecords.Length);
+        BinaryPrimitives.WriteInt32BigEndian(crcAndContentSpan, (int)crc);
+        output.Advance(sizeof(uint) + CrcContentFixedSize);
+        return true;
+    }
+
+    internal bool CanWriteSegmented(CompressionType compression)
+        => PreCompressedRecords is not null
+            || (compression == CompressionType.None && _hasPreEncodedRecords);
+
     internal int GetEncodedSize(CompressionType compression = CompressionType.None)
     {
         var recordsLength = GetEncodedRecordsLength(compression);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -998,6 +998,36 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(5_000)]
+    public async Task WriteTimeout_BorrowedWrite_AbortsAndWaitsForWriteCompletion(
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new KafkaConnection("localhost", 9092);
+        var writeCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var waitTask = InvokeAwaitBorrowedFrameWriteAsync(
+                connection,
+                writeCompletion.Task,
+                callerOwnsTimeout: true,
+                cts.Token)
+            .AsTask();
+
+        // Unlike a copied frame, a borrowed payload cannot outlive its producer resource pin.
+        // The timeout aborts the connection immediately but stays pending until the send unwinds.
+        await Assert.That(GetPrivateField<int>(connection, "_disposed")).IsNotEqualTo(0);
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        writeCompletion.SetResult();
+
+        var exception = await Assert.ThrowsAsync<KafkaException>(async () =>
+            await waitTask.WaitAsync(cancellationToken));
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+        await Assert.That(exception.Message).Contains("Flush timeout");
+    }
+
+    [Test]
+    [Timeout(5_000)]
     public async Task WriteTimeout_AbandonedWriteStuckPastGracePeriod_AbortsConnectionAndReleasesWriteLock(
         CancellationToken cancellationToken)
     {
@@ -1228,6 +1258,22 @@ public sealed class KafkaConnectionTests
             BindingFlags.NonPublic | BindingFlags.Instance);
         if (method is null)
             throw new InvalidOperationException("AwaitFrameWriteAsync was not found.");
+
+        var result = method.Invoke(connection, [writeTask, 1, callerOwnsTimeout, cancellationToken]);
+        await ((ValueTask)result!).ConfigureAwait(false);
+    }
+
+    private static async ValueTask InvokeAwaitBorrowedFrameWriteAsync(
+        KafkaConnection connection,
+        Task writeTask,
+        bool callerOwnsTimeout,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(KafkaConnection).GetMethod(
+            "AwaitBorrowedFrameWriteAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method is null)
+            throw new InvalidOperationException("AwaitBorrowedFrameWriteAsync was not found.");
 
         var result = method.Invoke(connection, [writeTask, 1, callerOwnsTimeout, cancellationToken]);
         await ((ValueTask)result!).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -5,10 +5,12 @@ using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
+using Dekaf.Compression;
 using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Security;
 
 namespace Dekaf.Tests.Unit.Networking;
@@ -105,6 +107,162 @@ public sealed class KafkaConnectionTests
         var capacity = KafkaConnection.GetPreSerializeInitialCapacity<ProduceResponse>(request);
 
         await Assert.That(capacity).IsEqualTo(1_048_704);
+    }
+
+    [Test]
+    [Arguments(CompressionType.None)]
+    [Arguments(CompressionType.Gzip)]
+    public async Task SingleBatchProduceSegments_MatchContiguousSerialization(CompressionType compression)
+    {
+        var recordBytes = "arena-backed-records"u8.ToArray();
+        var batch = new RecordBatch
+        {
+            BaseOffset = 17,
+            PartitionLeaderEpoch = 3,
+            LastOffsetDelta = 0,
+            BaseTimestamp = 1234,
+            MaxTimestamp = 1234,
+            ProducerId = 42,
+            ProducerEpoch = 2,
+            BaseSequence = 7,
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        batch.SetPreEncodedRecords(recordBytes);
+        batch.PreCompress(compression, null);
+        var encodedRecordsBackingArray = batch.PreCompressedRecords ?? recordBytes;
+
+        var partition = new ProduceRequestPartitionData
+        {
+            Index = 5,
+            Records = [batch],
+            Compression = compression
+        };
+        var topic = new ProduceRequestTopicData { Name = "segment-topic" };
+        topic.SetPartitionDataScratch([partition], 0, 1);
+        var request = new ProduceRequest
+        {
+            TransactionalId = "tx-id",
+            Acks = -1,
+            TimeoutMs = 30_000
+        };
+        request.SetTopicDataScratch([topic], 1);
+
+        const short apiVersion = 12;
+        const int correlationId = 123;
+        var headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+            .GetRequestHeaderVersion(apiVersion);
+        var expectedBody = new ArrayBufferWriter<byte>();
+        var expectedWriter = new KafkaProtocolWriter(expectedBody);
+        new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = "segment-client",
+            HeaderVersion = headerVersion
+        }.Write(ref expectedWriter);
+        request.Write(ref expectedWriter, apiVersion);
+        var expected = new byte[sizeof(int) + expectedWriter.BytesWritten];
+        BinaryPrimitives.WriteInt32BigEndian(expected, expectedWriter.BytesWritten);
+        expectedBody.WrittenSpan.CopyTo(expected.AsSpan(sizeof(int)));
+
+        var connection = new KafkaConnection("localhost", 9092, "segment-client");
+        var segmented = connection.TryPreSerializeSingleBatchProduceRequest(
+            request,
+            correlationId,
+            apiVersion,
+            headerVersion,
+            out var metadataArray,
+            out var prefixLength,
+            out var encodedRecords,
+            out var suffixOffset,
+            out var suffixLength);
+
+        await Assert.That(segmented).IsTrue();
+        try
+        {
+            var actual = new byte[prefixLength + encodedRecords.Count + suffixLength];
+            metadataArray.AsSpan(0, prefixLength).CopyTo(actual);
+            encodedRecords.AsSpan().CopyTo(actual.AsSpan(prefixLength));
+            metadataArray.AsSpan(suffixOffset, suffixLength)
+                .CopyTo(actual.AsSpan(prefixLength + encodedRecords.Count));
+
+            await Assert.That(actual).IsEquivalentTo(expected);
+            await Assert.That(encodedRecords.Array).IsSameReferenceAs(encodedRecordsBackingArray);
+        }
+        finally
+        {
+            DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+            batch.ReturnPreCompressedBuffer();
+        }
+    }
+
+    [Test]
+    public async Task ConsumeSentSegments_PartialSend_AdvancesAcrossSegmentBoundary()
+    {
+        var first = new byte[3];
+        var second = new byte[4];
+        var third = new byte[2];
+        var segments = new List<ArraySegment<byte>>
+        {
+            new(first),
+            new(second),
+            new(third)
+        };
+
+        KafkaConnection.ConsumeSentSegments(segments, 5);
+
+        await Assert.That(segments.Count).IsEqualTo(2);
+        await Assert.That(segments[0].Array).IsSameReferenceAs(second);
+        await Assert.That(segments[0].Offset).IsEqualTo(2);
+        await Assert.That(segments[0].Count).IsEqualTo(2);
+        await Assert.That(segments[1].Array).IsSameReferenceAs(third);
+
+        KafkaConnection.ConsumeSentSegments(segments, 4);
+
+        await Assert.That(segments).IsEmpty();
+    }
+
+    [Test]
+    public async Task SingleBatchProduceSegments_UnpreparedCompressedBatch_FallsBack()
+    {
+        var batch = new RecordBatch
+        {
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        var request = new ProduceRequest
+        {
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "fallback-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData
+                        {
+                            Records = [batch],
+                            Compression = CompressionType.Gzip
+                        }
+                    ]
+                }
+            ]
+        };
+        var connection = new KafkaConnection("localhost", 9092);
+
+        var segmented = connection.TryPreSerializeSingleBatchProduceRequest(
+            request,
+            correlationId: 1,
+            apiVersion: 12,
+            headerVersion: 2,
+            out var metadataArray,
+            out _,
+            out _,
+            out _,
+            out _);
+
+        await Assert.That(segmented).IsFalse();
+        await Assert.That(metadataArray).IsNull();
     }
 
     [Test]
@@ -683,6 +841,80 @@ public sealed class KafkaConnectionTests
 
             await Assert.That(frame.Length).IsGreaterThan(8);
             await Assert.That(correlationId).IsGreaterThan(0);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SendFireAndForgetAsync_SingleBatchProduce_WritesValidSegmentedFrame(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var batch = new RecordBatch
+            {
+                BaseOffset = 9,
+                LastOffsetDelta = 0,
+                BaseTimestamp = 4567,
+                MaxTimestamp = 4567,
+                Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+            };
+            batch.SetPreEncodedRecords("borrowed-record-data"u8.ToArray());
+            var request = new ProduceRequest
+            {
+                Acks = 0,
+                TimeoutMs = 30_000,
+                TopicData =
+                [
+                    new ProduceRequestTopicData
+                    {
+                        Name = "socket-topic",
+                        PartitionData =
+                        [
+                            new ProduceRequestPartitionData
+                            {
+                                Index = 2,
+                                Records = [batch]
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            const short apiVersion = 12;
+            await connection.SendFireAndForgetAsync<ProduceRequest, ProduceResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+
+            var actual = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(actual.AsSpan(4));
+            var expectedBuffer = new ArrayBufferWriter<byte>();
+            var expectedWriter = new KafkaProtocolWriter(expectedBuffer);
+            new RequestHeader
+            {
+                ApiKey = ApiKey.Produce,
+                ApiVersion = apiVersion,
+                CorrelationId = correlationId,
+                HeaderVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+                    .GetRequestHeaderVersion(apiVersion)
+            }.Write(ref expectedWriter);
+            request.Write(ref expectedWriter, apiVersion);
+
+            await Assert.That(actual).IsEquivalentTo(expectedBuffer.WrittenSpan.ToArray());
         }
         finally
         {


### PR DESCRIPTION
Refs #2033

Stacked on #2019; merge into that branch first.

What changed:
- emits plaintext single-batch PRODUCE frames with scatter/gather socket I/O
- borrows pre-encoded or pre-compressed record bytes; serializes only framing and batch headers
- retains contiguous fallback for TLS, multi-batch, and unprepared payloads
- aborts timed-out borrowed writes before producer buffers can be recycled
- reuses SocketAsyncEventArgs/IValueTaskSource state to avoid per-send Task allocation

Validation:
- Dekaf netstandard2.0 + net10.0 build: 0 warnings, 0 errors
- exact-head CI: success (29289837740)
- exact-head review: CLEAR (29289831030)
- exact-head 15-minute stress: success (29290480626)
- fixed-3conn 1-broker CPU: FnF 0.76 us/msg, idempotent 0.77 us/msg
- 3-broker p95: FnF 28.15ms, acks-all 22.85ms, idempotent 23.05ms

This removes the redundant full-body copy and meets its CPU/latency goals. #2033 remains open because adaptive 1-broker throughput still overscales to six connections and misses the full paired-ratio gate.