### PR TITLE
perf(producer): lower adaptive ceiling to three

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -88,7 +88,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private IRetryPolicy? _retryPolicy;
     private bool _enableAdaptiveConnections = true;
-    private int _maxConnectionsPerBroker = 10;
+    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private bool _isMaxConnectionsPerBrokerConfigured;
     private bool _enableDeliveryDiagnostics;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
@@ -103,6 +104,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
         _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+        _isMaxConnectionsPerBrokerConfigured = true;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -279,13 +281,15 @@ public sealed class ProducerBuilder<TKey, TValue>
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
+        if (!_isMaxConnectionsPerBrokerConfigured)
+            _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
         return this;
     }
 
     /// <summary>
     /// Configures the maximum connections for adaptive connection scaling.
     /// Adaptive scaling is enabled by default — this method only needs to be called
-    /// to change the maximum from the default of 10.
+    /// to change the maximum from the default of 3.
     /// <para>
     /// When sustained backpressure is detected, the producer will automatically add connections
     /// per broker (up to <paramref name="maxConnections"/>) to increase drain throughput.
@@ -297,13 +301,15 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// are removed after sustained low utilization.
     /// </para>
     /// </summary>
-    /// <param name="maxConnections">Maximum connections per broker. Default: 10.</param>
-    public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(int maxConnections = 10)
+    /// <param name="maxConnections">Maximum connections per broker. Default: 3.</param>
+    public ProducerBuilder<TKey, TValue> WithAdaptiveConnections(
+        int maxConnections = ProducerOptions.DefaultMaxConnectionsPerBroker)
     {
         ThrowIfClientOwnedConnectionSettings();
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnections, 1);
         _enableAdaptiveConnections = true;
         _maxConnectionsPerBroker = maxConnections;
+        _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
 

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -5,6 +5,7 @@ using Admin;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
+using Dekaf.Producer;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public sealed class KafkaClientBuilder
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
-    private int _maxConnectionsPerBroker = 10;
+    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -15,6 +15,7 @@ namespace Dekaf.Producer;
 /// </summary>
 public sealed class ProducerOptions
 {
+    internal const int DefaultMaxConnectionsPerBroker = 3;
     internal const int IdempotentMaxInFlightRequestsPerConnection = 5;
     internal const int NonIdempotentDefaultMaxInFlightRequestsPerConnection = 100;
     internal const int MaxAllowedMaxInFlightRequestsPerConnection = 1_000_000;
@@ -579,7 +580,7 @@ public sealed class ProducerOptions
     /// <summary>
     /// Maximum connections per broker when adaptive scaling is enabled.
     /// The producer will not scale beyond this limit regardless of buffer pressure.
-    /// Must be at least 1. Default: 10.
+    /// Must be at least 1. Default: 3.
     /// </summary>
     public int MaxConnectionsPerBroker
     {
@@ -591,7 +592,7 @@ public sealed class ProducerOptions
         }
     }
 
-    private readonly int _maxConnectionsPerBroker = 10;
+    private readonly int _maxConnectionsPerBroker = DefaultMaxConnectionsPerBroker;
 
     /// <summary>
     /// Test-only override for the adaptive-scaling cooldown window (milliseconds).

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -32,6 +32,17 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_CreatedProducer_UsesDefaultAdaptiveMaximumOf3()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task RootClient_CreatedProducer_DisposeDoesNotDisposeSharedPool()
     {
         var client = Kafka.Connect("localhost:9092");

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScalingTests.cs
@@ -24,6 +24,12 @@ public class AdaptiveScalingTests
         });
     }
 
+    private static int GetConfiguredMaximumConnections(object builder) =>
+        (int)builder.GetType()
+            .GetField("_maxConnectionsPerBroker", System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(builder)!;
+
     private static async ValueTask AppendOneRecordAsync(RecordAccumulator accumulator)
     {
         var pooledKey = new PooledMemory(null, 0, isNull: true);
@@ -219,6 +225,37 @@ public class AdaptiveScalingTests
     #endregion
 
     #region Builder Validation Tests
+
+    [Test]
+    public async Task WithAdaptiveConnections_DefaultsMaximumTo_3()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithAdaptiveConnections();
+
+        await Assert.That(GetConfiguredMaximumConnections(builder)).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task WithConnectionsPerBroker_AboveImplicitMaximum_ExpandsMaximum()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithConnectionsPerBroker(5);
+
+        await Assert.That(GetConfiguredMaximumConnections(builder)).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task WithAdaptiveConnections_BeforeLargerInitialWidth_ThrowsOnBuild()
+    {
+        await Assert.That(() =>
+        {
+            Kafka.CreateProducer<string, string>()
+                .WithBootstrapServers("localhost:9092")
+                .WithAdaptiveConnections()
+                .WithConnectionsPerBroker(5)
+                .Build();
+        }).Throws<InvalidOperationException>();
+    }
 
     [Test]
     public async Task WithAdaptiveConnections_MaxLessThanConnectionsPerBroker_ThrowsOnBuild()

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -146,6 +146,13 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task MaxConnectionsPerBroker_DefaultsTo_3()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task Partitioner_DefaultsTo_Default()
     {
         var options = CreateOptions();


### PR DESCRIPTION
## Summary

- lower standalone and shared-client producer adaptive connection ceilings from 10 to 3
- preserve explicit adaptive maxima and automatically expand the implicit ceiling for larger configured initial widths
- add standalone, shared-client, auto-expand, and explicit-order regression coverage

Six partition-affined connections oversubscribe the two-core dedicated producer runner. Exact full stress telemetry repeatedly scaled 1 -> 2 -> 5 -> 6, then churned 6 -> 5 -> 6, while the useful throughput shape was observed around three connections. This changes the tuning default without removing opt-in capacity for higher-latency or larger hosts.

## Validation

- `dotnet build src/Dekaf/Dekaf.csproj -c Release -f netstandard2.0` (0 warnings)
- `dotnet build src/Dekaf/Dekaf.csproj -c Release -f net10.0` (0 warnings)
- net10 unit tests: 5,445/5,445
- net8 unit tests: 5,338/5,338

Refs #2033