### PR TITLE
perf(protocol): precompute CRC shift operators

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1784,12 +1784,15 @@ internal static class Crc32C
 {
     private const int TableSize = 256;
     private const int SliceCount = 8;
+    private const int PositiveIntBitCount = 31;
 #if !NETSTANDARD2_0
     private const int HardwareParallelChunkSize = 512;
     private const int HardwareParallelBlockSize = HardwareParallelChunkSize * 3;
 #endif
 
     private static readonly uint[] Table = GenerateTable();
+    // Element n applies 2^n zero bytes to a CRC, so arbitrary lengths compose from set bits.
+    private static readonly uint[][] ByteShiftPowerOperators = CreateByteShiftPowerOperators();
 #if !NETSTANDARD2_0
     private static readonly uint[] HardwareShiftChunk = CreateShiftOperator(HardwareParallelChunkSize);
     private static readonly uint[] HardwareShiftTwoChunks = CreateShiftOperator(HardwareParallelChunkSize * 2);
@@ -2079,10 +2082,24 @@ internal static class Crc32C
 
         for (var bit = 0; bit < 32; bit++)
         {
-            shift[bit] = ShiftCrc32C(1u << bit, byteCount);
+            shift[bit] = ShiftCrc32CSlow(1u << bit, byteCount);
         }
 
         return shift;
+    }
+
+    private static uint[][] CreateByteShiftPowerOperators()
+    {
+        var operators = new uint[PositiveIntBitCount][];
+        operators[0] = CreateShiftOperator(1);
+        for (var bit = 1; bit < operators.Length; bit++)
+        {
+            var next = new uint[32];
+            SquareMatrix(next, operators[bit - 1]);
+            operators[bit] = next;
+        }
+
+        return operators;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2106,6 +2123,28 @@ internal static class Crc32C
     }
 
     private static uint ShiftCrc32C(uint crc, int byteCount)
+    {
+        if (byteCount <= 0)
+        {
+            return crc;
+        }
+
+        var bit = 0;
+        while (byteCount != 0)
+        {
+            if ((byteCount & 1) != 0)
+            {
+                crc = ShiftCrc32C(crc, ByteShiftPowerOperators[bit]);
+            }
+
+            byteCount >>= 1;
+            bit++;
+        }
+
+        return crc;
+    }
+
+    private static uint ShiftCrc32CSlow(uint crc, int byteCount)
     {
         if (byteCount <= 0)
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
@@ -42,3 +42,19 @@ public class Crc32CBenchmarks
     public uint Software()
         => Crc32C.ComputeSoftware(_data);
 }
+
+/// <summary>
+/// Benchmarks the CRC combination used to join a record-batch header checksum with its
+/// precomputed encoded-record checksum.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class Crc32CCombineBenchmarks
+{
+    [Params(40, 512, 4_096, 65_536, 850_000, 1_048_576)]
+    public int SuffixSize { get; set; }
+
+    [Benchmark]
+    public uint Combine()
+        => Crc32C.Combine(0xA1B2C3D4u, 0x10203040u, SuffixSize);
+}


### PR DESCRIPTION
## Summary

- precompute CRC32C zero-byte shift operators for every positive `int` length bit
- compose arbitrary `Crc32C.Combine` lengths from cached GF(2) operators instead of rebuilding matrices per record batch
- add representative record-batch combine benchmarks

The plaintext scatter/gather PRODUCE path precomputes encoded-record CRCs, then combines each with its 40-byte record-batch header CRC. The previous arbitrary-length combine rebuilt and squared GF(2) matrices on every request. At the #2033 run shape (~850 KiB/request, 1,544 requests/s), this consumed about 0.051 CPU core solely to join two already-computed checksums.

## Benchmark

`Crc32CCombineBenchmarks` (`net10.0`, ShortRun):

| Suffix | Before | After | Improvement |
|---:|---:|---:|---:|
| 40 B | 2.860 us | 29.07 ns | 98x |
| 65,536 B | 25.241 us | 17.33 ns | 1,456x |
| 850,000 B | 33.387 us | 149.12 ns | 224x |
| 1,048,576 B | 35.135 us | 18.62 ns | 1,887x |

Zero allocations before and after.

## Validation

- `netstandard2.0` build: 0 warnings/errors
- `net10.0` build: 0 warnings/errors
- net10 unit tests: 5,445/5,445
- net8 unit tests: 5,338/5,338 (two unrelated timing flakes passed individually, then full rerun green)
- CRC focused tests: net10 11/11; net8 5/5
- local 2-minute idempotent stress: 225,074 effective msg/s, 1.21 CPU us/msg, zero errors, 36.05 ms p95

Refs #2033