### PR TITLE
fix(client): expand implicit connection maximum

### DIFF
--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -96,6 +96,7 @@ public sealed class KafkaClientBuilder
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
     private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -369,6 +370,8 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfLessThan(connectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
+        if (!_isMaxConnectionsPerBrokerConfigured)
+            _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
         return this;
     }
 
@@ -384,6 +387,7 @@ public sealed class KafkaClientBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
         _maxConnectionsPerBroker = maxConnectionsPerBroker;
+        _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
 

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -43,6 +43,32 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_InitialWidthAboveImplicitMaximum_ExpandsMaximum()
+    {
+        await using var client = Kafka.Connect()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionsPerBroker(5)
+            .Build();
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.ConnectionsPerBroker).IsEqualTo(5);
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task RootClient_InitialWidthAboveExplicitMaximum_ThrowsOnBuild()
+    {
+        await Assert.That(() => Kafka.Connect()
+                .WithBootstrapServers("localhost:9092")
+                .WithMaxConnectionsPerBroker(3)
+                .WithConnectionsPerBroker(5)
+                .Build())
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task RootClient_CreatedProducer_DisposeDoesNotDisposeSharedPool()
     {
         var client = Kafka.Connect("localhost:9092");


### PR DESCRIPTION
## Summary

- expand the shared client's implicit adaptive connection maximum when an explicit initial width is larger
- preserve explicitly configured maxima as hard constraints
- cover both behaviors through `KafkaClientBuilder`

## Root cause

#2049 lowered the shared client's implicit maximum from 10 to 3, but only `ProducerBuilder.WithConnectionsPerBroker` received the matching auto-expand safeguard. `Kafka.Connect().WithConnectionsPerBroker(4..10).Build()` therefore regressed and threw unless callers also configured the maximum.

## Validation

- net10 build: 0 warnings/errors
- net10 focused `KafkaClientBuilderTests`: 14/14
- net8 build: 0 warnings/errors
- net8 focused `KafkaClientBuilderTests`: 14/14

Addresses the blocking exact-head review on #2019.

Refs #2033
