### PR TITLE
fix(client): preserve consumer ceiling

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -103,7 +103,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _bootstrapServers = clientInfrastructure.BootstrapServers;
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
-        _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+        _maxConnectionsPerBroker = clientInfrastructure.ProducerMaxConnectionsPerBroker;
         _isMaxConnectionsPerBrokerConfigured = true;
     }
 
@@ -1424,7 +1424,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _prefetchPipelineDepth = 3;
     private int _connectionsPerBroker = 2;
     private bool _enableAdaptiveConnections = true;
-    private int _maxConnectionsPerBroker = 4;
+    private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -33,6 +33,8 @@ public enum OffsetCommitMode
 /// </summary>
 public sealed class ConsumerOptions
 {
+    internal const int DefaultMaxConnectionsPerBroker = 4;
+
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
     /// </summary>
@@ -419,7 +421,7 @@ public sealed class ConsumerOptions
         }
     }
 
-    private readonly int _maxConnectionsPerBroker = 4;
+    private readonly int _maxConnectionsPerBroker = DefaultMaxConnectionsPerBroker;
 
     /// <summary>
     /// Whether to enable adaptive fetch sizing based on consumer throughput.

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -2,6 +2,7 @@ namespace Dekaf;
 
 using System.Net.Security;
 using Admin;
+using Dekaf.Consumer;
 using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -95,7 +96,8 @@ public sealed class KafkaClientBuilder
     private int _socketReceiveBufferBytes;
     private int _connectionsPerBroker = 1;
     private int _maxInFlightRequestsPerConnection = 5;
-    private int _maxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
+    private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
+    private int _producerMaxConnectionsPerBroker = ProducerOptions.DefaultMaxConnectionsPerBroker;
     private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
@@ -371,7 +373,10 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfGreaterThan(connectionsPerBroker, 32);
         _connectionsPerBroker = connectionsPerBroker;
         if (!_isMaxConnectionsPerBrokerConfigured)
+        {
             _maxConnectionsPerBroker = Math.Max(_maxConnectionsPerBroker, connectionsPerBroker);
+            _producerMaxConnectionsPerBroker = Math.Max(_producerMaxConnectionsPerBroker, connectionsPerBroker);
+        }
         return this;
     }
 
@@ -387,6 +392,7 @@ public sealed class KafkaClientBuilder
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(maxConnectionsPerBroker, 1);
         _maxConnectionsPerBroker = maxConnectionsPerBroker;
+        _producerMaxConnectionsPerBroker = maxConnectionsPerBroker;
         _isMaxConnectionsPerBrokerConfigured = true;
         return this;
     }
@@ -485,6 +491,7 @@ public sealed class KafkaClientBuilder
             ConnectionsPerBroker = _connectionsPerBroker,
             MaxInFlightRequestsPerConnection = _maxInFlightRequestsPerConnection,
             MaxConnectionsPerBroker = _maxConnectionsPerBroker,
+            ProducerMaxConnectionsPerBroker = _producerMaxConnectionsPerBroker,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             MetadataMaxAge = _metadataMaxAge,
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
@@ -525,6 +532,7 @@ internal sealed class KafkaClientOptions
     public int ConnectionsPerBroker { get; init; }
     public int MaxInFlightRequestsPerConnection { get; init; }
     public int MaxConnectionsPerBroker { get; init; }
+    public int ProducerMaxConnectionsPerBroker { get; init; }
     public int ConnectionsMaxIdleMs { get; init; }
     public TimeSpan? MetadataMaxAge { get; init; }
     public MetadataRecoveryStrategy MetadataRecoveryStrategy { get; init; }
@@ -547,7 +555,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory,
         int connectionsPerBroker,
-        int maxConnectionsPerBroker)
+        int maxConnectionsPerBroker,
+        int producerMaxConnectionsPerBroker)
     {
         BootstrapServers = bootstrapServers;
         ConnectionPool = connectionPool;
@@ -556,6 +565,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         LoggerFactory = loggerFactory;
         ConnectionsPerBroker = connectionsPerBroker;
         MaxConnectionsPerBroker = maxConnectionsPerBroker;
+        ProducerMaxConnectionsPerBroker = producerMaxConnectionsPerBroker;
     }
 
     public IReadOnlyList<string> BootstrapServers { get; }
@@ -565,6 +575,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     public ILoggerFactory? LoggerFactory { get; }
     public int ConnectionsPerBroker { get; }
     public int MaxConnectionsPerBroker { get; }
+    public int ProducerMaxConnectionsPerBroker { get; }
 
     public static KafkaClientInfrastructure Create(KafkaClientOptions options)
     {
@@ -630,7 +641,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             new ClientMemoryBudget(options.MemoryBudgetBytes),
             options.LoggerFactory,
             options.ConnectionsPerBroker,
-            options.MaxConnectionsPerBroker);
+            options.MaxConnectionsPerBroker,
+            options.ProducerMaxConnectionsPerBroker);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3295,6 +3295,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (_accumulator.HasPendingLingerBatches)
                 {
+                    BeforeActiveLingerTimerWaitForTest?.Invoke();
                     if (!await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
                         break;
                 }
@@ -3323,6 +3324,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
         }
     }
+
+    internal Action? BeforeActiveLingerTimerWaitForTest;
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Net.Security;
 using Dekaf.Metadata;
 using Dekaf.Networking;
+using Dekaf.Consumer;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Unit.Builder;
@@ -40,6 +41,17 @@ public sealed class KafkaClientBuilderTests
         var options = GetField<ProducerOptions>(producer, "_options");
 
         await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task RootClient_CreatedConsumer_UsesDefaultAdaptiveMaximumOf4()
+    {
+        await using var client = Kafka.Connect("localhost:9092");
+        await using var consumer = client.CreateConsumer<string, string>().Build();
+
+        var options = GetField<ConsumerOptions>(consumer, "_options");
+
+        await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(4);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -69,6 +69,11 @@ public class ProducerCancellationTests
         var accumulator = GetField<RecordAccumulator>(producer, "_accumulator");
         var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
         var lingerTask = GetField<Task>(producer, "_lingerTask");
+        var activeLingerWaitEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetField(
+            producer,
+            "BeforeActiveLingerTimerWaitForTest",
+            (Action)(() => activeLingerWaitEntered.TrySetResult(true)));
 
         try
         {
@@ -86,8 +91,7 @@ public class ProducerCancellationTests
                 CancellationToken.None);
             await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
 
-            // Let the linger loop consume the wakeup and enter its periodic active cadence.
-            await Task.Delay(20);
+            await activeLingerWaitEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
             senderCts.Cancel();
 
             await lingerTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -336,4 +340,9 @@ public class ProducerCancellationTests
         => (T)instance.GetType()
             .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(instance)!;
+
+    private static void SetField<T>(object instance, string name, T value)
+        => instance.GetType()
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(instance, value);
 }


### PR DESCRIPTION
## Summary

- preserve the root client's producer adaptive maximum of 3
- restore the root consumer and shared-pool adaptive maximum of 4
- replace timing-based linger cancellation coverage with deterministic synchronization

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net10.0 --no-restore`
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net8.0 --no-restore`
- focused `KafkaClientBuilderTests` and `ProducerCancellationTests`: 25/25 passed on net10.0 and net8.0

Stacked on #2019.
