### PR TITLE
ci(stress): balance paired producer acceptance

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-from math import isfinite
+from math import exp, isfinite, log
 from statistics import median
 
 SCENARIO_TITLES = {
@@ -21,6 +21,27 @@ SCENARIO_TITLES = {
 
 LATENCY_RATIO_THRESHOLD = 2.0
 MAX_TIMELINE_ROWS = 100
+
+
+def results_with_run_metadata(data):
+    """Flatten a result envelope while retaining run-level pairing metadata."""
+    raw_results = data.get('results') if isinstance(data, dict) else None
+    if not isinstance(raw_results, list):
+        return [data]
+
+    metadata_fields = (
+        'pairedClientOrder',
+        'pairedSampleIndex',
+        'pairedSampleCount',
+    )
+    results = []
+    for raw_result in raw_results:
+        result = dict(raw_result)
+        for field in metadata_fields:
+            if field in data and field not in result:
+                result[field] = data[field]
+        results.append(result)
+    return results
 
 
 def group_by_scenario(results):
@@ -294,7 +315,16 @@ def _latency_identity(result):
         result.get('messageSizeBytes'),
         _latency_consumer_seed_batch_size(result),
         _latency_roundtrip_messages(result),
+        paired_order_identity(result),
     )
+
+
+def paired_order_identity(result):
+    """Use client order as an identity dimension only for repeated paired samples."""
+    sample_count = result.get('pairedSampleCount')
+    if isinstance(sample_count, int) and sample_count > 1:
+        return result.get('pairedClientOrder')
+    return None
 
 
 def _latency_consumer_seed_batch_size(result):
@@ -327,6 +357,92 @@ def comparison_rate(result):
     return rate if rate is not None else effective_rate(result)
 
 
+def geometric_mean(values):
+    """Geometric mean for positive finite benchmark samples."""
+    samples = list(values)
+    if not samples or any(
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not isfinite(value)
+        or value <= 0
+        for value in samples
+    ):
+        return None
+    return exp(sum(log(value) for value in samples) / len(samples))
+
+
+def client_sample_groups(results):
+    """Group exact client variants while preserving their published display names."""
+    groups = {}
+    for result in results:
+        client = str(result.get('client', 'Unknown'))
+        key = client.casefold()
+        if key not in groups:
+            groups[key] = {'client': client, 'results': []}
+        groups[key]['results'].append(result)
+    return groups
+
+
+def aggregate_client_rate(results):
+    """Aggregate repeated comparison samples without overweighting either run order."""
+    return geometric_mean([comparison_rate(result) for result in results])
+
+
+def format_order_balanced_aggregate(results):
+    """Summarize repeated same-VM samples when both paired client orders are present."""
+    groups = client_sample_groups(results)
+    dekaf = groups.get('dekaf')
+    confluent = groups.get('confluent')
+    if not dekaf or not confluent:
+        return []
+
+    required_orders = {'dekaf-first', 'confluent-first'}
+    if any(
+        not required_orders.issubset({
+            str(result.get('pairedClientOrder', '')).casefold()
+            for result in group['results']
+        })
+        for group in (dekaf, confluent)
+    ):
+        return []
+
+    dekaf_aggregate = aggregate_client_rate(dekaf['results'])
+    confluent_aggregate = aggregate_client_rate(confluent['results'])
+    if dekaf_aggregate is None or confluent_aggregate is None:
+        return []
+
+    lines = [
+        "### Order-Balanced Aggregate",
+        "",
+        "| Client | Samples | Geomean comparison msg/s | Sample range | Median CPU μs/msg | Comparison Ratio |",
+        "|--------|--------:|--------------------------:|--------------|------------------:|-----------------:|",
+    ]
+    for group, aggregate_rate in (
+        (dekaf, dekaf_aggregate),
+        (confluent, confluent_aggregate),
+    ):
+        samples = group['results']
+        rates = [comparison_rate(result) for result in samples]
+        cpu_samples = [
+            value for result in samples
+            if (value := cpu_micros_per_message(result)) is not None
+        ]
+        cpu = f"{median(cpu_samples):.2f}" if cpu_samples else '-'
+        ratio = aggregate_rate / confluent_aggregate
+        lines.append(
+            f"| {group['client']} | {len(samples)} | {aggregate_rate:,.0f} | "
+            f"{min(rates):,.0f}–{max(rates):,.0f} | {cpu} | {ratio:.2f}x |"
+        )
+
+    lines.extend([
+        "",
+        "*The aggregate uses the geometric mean across balanced same-VM samples run in "
+        "both `dekaf-first` and `confluent-first` order. Raw ordered samples remain below.*",
+        "",
+    ])
+    return lines
+
+
 def allocated_per_message(result):
     """Heap allocation per application message, or None when unavailable."""
     serialized = result.get('allocatedBytesPerMessage')
@@ -343,11 +459,15 @@ def allocated_per_message(result):
 
 def find_confluent_baseline(results):
     """Find Confluent throughput as a baseline for ratio calculations."""
-    for r in results:
-        if r.get('client', '').lower() == 'confluent':
-            rate = comparison_rate(r)
-            if rate > 0:
-                return rate
+    confluent_results = [
+        result for result in results
+        if result.get('client', '').lower() == 'confluent'
+    ]
+    if confluent_results:
+        rate = aggregate_client_rate(confluent_results)
+        if rate is not None:
+            return rate
+        return None
     return min((comparison_rate(r) or 1 for r in results), default=1)
 
 
@@ -373,6 +493,8 @@ def format_throughput_table(results, title, include_ratio=False):
     lines.append(f"## {title} ({workload})")
     lines.append("")
 
+    lines.extend(format_order_balanced_aggregate(results))
+
     if include_ratio:
         lines.append("| Client | CPU μs/msg | CPU μs/request | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Standing cores | Comparison Ratio |")
         lines.append("|--------|------------|----------------|--------------|--------------|-------|-------------|--------|----------------|--------|----------------|------------------|")
@@ -382,9 +504,17 @@ def format_throughput_table(results, title, include_ratio=False):
 
     baseline = find_confluent_baseline(results) if include_ratio else 0
     sorted_results = sorted(results, key=throughput_sort_key)
+    client_counts = {
+        key: len(group['results'])
+        for key, group in client_sample_groups(results).items()
+    }
 
     for r in sorted_results:
         client = r.get('client', 'Unknown')
+        if client_counts.get(str(client).casefold(), 0) > 1:
+            order = r.get('pairedClientOrder')
+            if order:
+                client = f"{client} ({order})"
         throughput = r.get('throughput', {})
         msg_sec = effective_rate(r)
         mb_sec = effective_mb_rate(r)
@@ -399,8 +529,9 @@ def format_throughput_table(results, title, include_ratio=False):
         cpu_us_per_msg, cpu_us_per_request, cores_used = format_cpu_columns(r)
 
         if include_ratio:
-            ratio = comparison_rate(r) / baseline if baseline > 0 else 1.0
-            lines.append(f"| {client} | {cpu_us_per_msg} | {cpu_us_per_request} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio:.2f}x |")
+            ratio = comparison_rate(r) / baseline if _positive_finite_number(baseline) else None
+            ratio_text = f"{ratio:.2f}x" if ratio is not None else '-'
+            lines.append(f"| {client} | {cpu_us_per_msg} | {cpu_us_per_request} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} | {ratio_text} |")
         else:
             lines.append(f"| {client} | {cpu_us_per_msg} | {cpu_us_per_request} | {msg_sec:,.0f} | {median_msg_sec} | {drift} | {slope} | {mb_sec:.2f} | {accepted} | {errors} | {cores_used} |")
 
@@ -785,21 +916,30 @@ def _parse_timestamp(value):
 
 def format_comparison_callout(results, title):
     """Generate Docusaurus admonition comparing Dekaf vs Confluent throughput."""
-    dekaf = next((r for r in results if r.get('client', '').lower() == 'dekaf'), None)
-    confluent = next((r for r in results if r.get('client', '').lower() == 'confluent'), None)
+    groups = client_sample_groups(results)
+    dekaf = groups.get('dekaf')
+    confluent = groups.get('confluent')
 
     if not (dekaf and confluent):
         return []
 
-    dekaf_rate = comparison_rate(dekaf)
-    confluent_rate = comparison_rate(confluent)
-    if confluent_rate <= 0:
+    dekaf_rate = aggregate_client_rate(dekaf['results'])
+    confluent_rate = aggregate_client_rate(confluent['results'])
+    if dekaf_rate is None or confluent_rate is None or confluent_rate <= 0:
         return []
 
     lines = []
     throughput_ratio = dekaf_rate / confluent_rate
-    dekaf_cpu = cpu_micros_per_message(dekaf)
-    confluent_cpu = cpu_micros_per_message(confluent)
+    dekaf_cpu_samples = [
+        value for result in dekaf['results']
+        if (value := cpu_micros_per_message(result)) is not None
+    ]
+    confluent_cpu_samples = [
+        value for result in confluent['results']
+        if (value := cpu_micros_per_message(result)) is not None
+    ]
+    dekaf_cpu = median(dekaf_cpu_samples) if dekaf_cpu_samples else None
+    confluent_cpu = median(confluent_cpu_samples) if confluent_cpu_samples else None
     label = title.lower()
 
     if dekaf_cpu is not None and confluent_cpu is not None and dekaf_cpu > 0 and confluent_cpu > 0:

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -10,6 +10,7 @@ from stress_report import (
     cpu_micros_per_message,
     effective_rate,
     intra_run_throughput,
+    paired_order_identity,
     paired_latency_thresholds,
 )
 
@@ -29,6 +30,8 @@ _IDENTITY_FIELDS = (
     "consumerSeedBatchSizeBytes",
     "consumerConnectionsPerBroker",
     "roundTripMessages",
+    "pairedClientOrder",
+    "pairedSampleCount",
 )
 
 _METRICS = {
@@ -89,6 +92,7 @@ def _identity(result):
         _consumer_seed_batch_size(result),
         _consumer_connections_per_broker(result),
         _roundtrip_messages(result),
+        paired_order_identity(result),
     )
 
 
@@ -109,6 +113,7 @@ def _pair_identity(result):
         result.get("messageSizeBytes"),
         _consumer_seed_batch_size(result),
         _roundtrip_messages(result),
+        paired_order_identity(result),
     )
 
 

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -10,6 +10,7 @@ from stress_report import (
     generate_scenario_tables,
     intra_run_throughput,
     paired_latency_thresholds,
+    results_with_run_metadata,
 )
 
 
@@ -38,6 +39,20 @@ def stress_result(client, effective_rate, median_rate=None, is_message_bounded=F
 
 
 class StressReportTests(unittest.TestCase):
+    def test_result_envelope_propagates_paired_sample_metadata(self):
+        envelope = {
+            "pairedClientOrder": "dekaf-first",
+            "pairedSampleIndex": 1,
+            "pairedSampleCount": 2,
+            "results": [stress_result("Dekaf", effective_rate=1400)],
+        }
+
+        results = results_with_run_metadata(envelope)
+
+        self.assertEqual("dekaf-first", results[0]["pairedClientOrder"])
+        self.assertEqual(1, results[0]["pairedSampleIndex"])
+        self.assertEqual(2, results[0]["pairedSampleCount"])
+
     def test_producer_request_diagnostics_surface_per_broker_fragmentation(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value["producerDeliveryDiagnostics"] = {
@@ -367,6 +382,86 @@ class StressReportTests(unittest.TestCase):
 
         self.assertTrue(rows[0].startswith("| Dekaf"))
         self.assertIn("| 2.00x |", rows[0])
+
+    def test_throughput_table_aggregates_order_balanced_samples(self):
+        dekaf_first = stress_result("Dekaf", effective_rate=1_440_000)
+        dekaf_first["pairedClientOrder"] = "dekaf-first"
+        confluent_second = stress_result("Confluent", effective_rate=1_000_000)
+        confluent_second["pairedClientOrder"] = "dekaf-first"
+        confluent_first = stress_result("Confluent", effective_rate=1_210_000)
+        confluent_first["pairedClientOrder"] = "confluent-first"
+        dekaf_second = stress_result("Dekaf", effective_rate=1_690_000)
+        dekaf_second["pairedClientOrder"] = "confluent-first"
+        samples = [dekaf_first, confluent_second, confluent_first, dekaf_second]
+        for sample in samples:
+            sample["scenario"] = "producer"
+
+        report = "\n".join(format_throughput_table(
+            samples,
+            "Producer Throughput",
+            include_ratio=True,
+        ))
+
+        self.assertIn("### Order-Balanced Aggregate", report)
+        self.assertIn("| Dekaf | 2 | 1,560,000 |", report)
+        self.assertIn("| Confluent | 2 | 1,100,000 |", report)
+        self.assertIn("| 1.42x |", report)
+        self.assertIn("Dekaf (dekaf-first)", report)
+        self.assertIn("Dekaf (confluent-first)", report)
+        self.assertIn("both `dekaf-first` and `confluent-first`", report)
+
+        docs_report = "\n".join(generate_scenario_tables(
+            samples,
+            include_callout=True,
+        ))
+        self.assertIn("### Order-Balanced Aggregate", docs_report)
+        self.assertIn("Dekaf is 1.42x faster", docs_report)
+
+    def test_throughput_table_suppresses_aggregate_when_any_sample_is_zero(self):
+        samples = []
+        for client, order, rate in (
+            ("Dekaf", "dekaf-first", 0),
+            ("Confluent", "dekaf-first", 1_000_000),
+            ("Dekaf", "confluent-first", 1_500_000),
+            ("Confluent", "confluent-first", 1_100_000),
+        ):
+            sample = stress_result(client, effective_rate=rate)
+            sample["pairedClientOrder"] = order
+            samples.append(sample)
+
+        report = "\n".join(format_throughput_table(
+            samples,
+            "Producer Throughput",
+            include_ratio=True,
+        ))
+
+        self.assertNotIn("### Order-Balanced Aggregate", report)
+        self.assertIn("| Dekaf (dekaf-first) |", report)
+
+    def test_throughput_table_suppresses_ratios_when_control_aggregate_is_invalid(self):
+        samples = []
+        for client, order, rate in (
+            ("Dekaf", "dekaf-first", 1_400_000),
+            ("Confluent", "dekaf-first", 0),
+            ("Dekaf", "confluent-first", 1_500_000),
+            ("Confluent", "confluent-first", 1_100_000),
+        ):
+            sample = stress_result(client, effective_rate=rate)
+            sample["pairedClientOrder"] = order
+            samples.append(sample)
+
+        lines = format_throughput_table(
+            samples,
+            "Producer Throughput",
+            include_ratio=True,
+        )
+        raw_rows = [
+            line for line in lines
+            if line.startswith("| Dekaf (") or line.startswith("| Confluent (")
+        ]
+
+        self.assertNotIn("### Order-Balanced Aggregate", "\n".join(lines))
+        self.assertTrue(all(row.endswith("| - |") for row in raw_rows))
 
     def test_consumer_table_reports_seed_batch_size(self):
         result = stress_result("Dekaf", effective_rate=2000)

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -361,6 +361,80 @@ class StressTrendTests(unittest.TestCase):
         self.assertEqual("stable", ratio["status"])
         self.assertFalse(should_fail)
 
+    def test_order_balanced_samples_use_their_matching_same_run_control(self):
+        samples = [
+            result(
+                messages_per_second=2000.0,
+                pairedClientOrder="dekaf-first",
+                pairedSampleCount=2,
+            ),
+            result(
+                client="Confluent",
+                messages_per_second=1000.0,
+                pairedClientOrder="dekaf-first",
+                pairedSampleCount=2,
+            ),
+            result(
+                client="Confluent",
+                messages_per_second=2000.0,
+                pairedClientOrder="confluent-first",
+                pairedSampleCount=2,
+            ),
+            result(
+                messages_per_second=3000.0,
+                pairedClientOrder="confluent-first",
+                pairedSampleCount=2,
+            ),
+        ]
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": []},
+            samples,
+            "2026-07-01T02:00:00Z",
+        )
+
+        ratios = sorted(
+            item["current"]
+            for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertEqual([1.5, 2.0], ratios)
+        self.assertEqual(
+            [
+                "dekaf-first",
+                "dekaf-first",
+                "confluent-first",
+                "confluent-first",
+            ],
+            [
+                item["pairedClientOrder"]
+                for item in updated["runs"][-1]["results"]
+            ],
+        )
+        self.assertEqual(
+            [2, 2, 2, 2],
+            [
+                item["pairedSampleCount"]
+                for item in updated["runs"][-1]["results"]
+            ],
+        )
+
+    def test_single_sample_order_does_not_split_existing_trend_history(self):
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": [history_run(i) for i in range(1, 4)]},
+            [result(
+                messages_per_second=1000.0,
+                pairedClientOrder="dekaf-first",
+                pairedSampleCount=1,
+            )],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(3, throughput["baselineCount"])
+
     def test_paired_dekaf_regression_fails_when_control_ratio_also_regresses(self):
         runs = [paired_history_run(i) for i in range(1, 4)]
         runs.append(paired_history_run(

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -28,7 +28,8 @@ env:
 
 jobs:
   # Run each scenario in parallel. Comparable clients run sequentially inside the
-  # same job/VM so published ratios share hardware and noisy-neighbor conditions.
+  # same job/VM so published ratios share hardware and noisy-neighbor conditions;
+  # 1-broker producer acceptance lanes repeat in both client orders.
   stress-test:
     strategy:
       fail-fast: false
@@ -37,9 +38,12 @@ jobs:
           - scenario: producer
             client: all
             brokers: 1
+            paired_samples: 2
             run_3conn: true
             artifact_suffix: -with-3conn
-            timeout_minutes: 105
+            # At a 30-minute dispatch this runs four paired client durations plus
+            # one 3-connection duration; leave setup/publish headroom as well.
+            timeout_minutes: 180
             name: Producer (Paired)
           - scenario: producer
             client: all
@@ -51,9 +55,11 @@ jobs:
           - scenario: producer-idempotent
             client: all
             brokers: 1
+            paired_samples: 2
             run_3conn: true
             artifact_suffix: -with-3conn
-            timeout_minutes: 105
+            # Same five measured durations as the fire-and-forget lane.
+            timeout_minutes: 180
             name: Producer Idempotent (Paired)
           - scenario: producer-idempotent
             client: all
@@ -65,9 +71,11 @@ jobs:
           - scenario: producer-acks-all
             client: all
             brokers: 1
+            paired_samples: 2
             run_3conn: false
             artifact_suffix: ""
-            timeout_minutes: 80
+            # Four measured durations need 120 minutes at a 30-minute dispatch.
+            timeout_minutes: 150
             name: Producer Acks All (Paired)
           - scenario: producer-acks-all
             client: all
@@ -245,25 +253,30 @@ jobs:
           cd tools/Dekaf.StressTests
           # Client pinned to its own cores: whichever client pushes more through the
           # same cores is genuinely faster, instead of both saturating the broker.
-          if (( ${{ github.run_number }} % 2 == 0 )); then
-            export STRESS_CLIENT_ORDER=confluent-first
-          else
-            export STRESS_CLIENT_ORDER=dekaf-first
-          fi
-          echo "Client order: ${STRESS_CLIENT_ORDER}"
+          paired_samples=${{ matrix.paired_samples || 1 }}
+          for sample in $(seq 1 "${paired_samples}"); do
+            if (( (${{ github.run_number }} + sample - 1) % 2 == 0 )); then
+              export STRESS_CLIENT_ORDER=confluent-first
+            else
+              export STRESS_CLIENT_ORDER=dekaf-first
+            fi
+            export STRESS_PAIRED_SAMPLE_INDEX=${sample}
+            export STRESS_PAIRED_SAMPLE_COUNT=${paired_samples}
+            echo "Paired sample ${sample}/${paired_samples}; client order: ${STRESS_CLIENT_ORDER}"
 
-          # Delivery diagnostics are always on in CI so a message-loss failure ships the
-          # in-flight batch dump needed to debug it, instead of "Not captured".
-          taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
-            --duration ${{ github.event.inputs.duration_minutes || '15' }} \
-            --message-size ${{ github.event.inputs.message_size || '1000' }} \
-            --scenario ${{ matrix.scenario }} \
-            --client ${{ matrix.client }} \
-            --brokers ${{ matrix.brokers }} \
-            --connections-per-broker 1 \
-            --producer-delivery-diagnostics \
-            --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
-            --output ./results
+            # Delivery diagnostics are always on in CI so a message-loss failure ships the
+            # in-flight batch dump needed to debug it, instead of "Not captured".
+            taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
+              --duration ${{ github.event.inputs.duration_minutes || '15' }} \
+              --message-size ${{ github.event.inputs.message_size || '1000' }} \
+              --scenario ${{ matrix.scenario }} \
+              --client ${{ matrix.client }} \
+              --brokers ${{ matrix.brokers }} \
+              --connections-per-broker 1 \
+              --producer-delivery-diagnostics \
+              --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
+              --output ./results
+          done
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then
             echo "Running Dekaf 3-connection variant on the same VM"
@@ -373,7 +386,7 @@ jobs:
           import os
           import glob
           from datetime import datetime
-          from stress_report import generate_scenario_tables, format_gc_table
+          from stress_report import generate_scenario_tables, format_gc_table, results_with_run_metadata
 
           # Parse only result envelopes; watchdog diagnostics are separate JSON artifacts.
           json_files = glob.glob("all-results/**/stress-test-results*.json", recursive=True)
@@ -399,7 +412,7 @@ jobs:
                   # Handle both single result and wrapped results format
                   if 'results' in data:
                       # Wrapped format from StressTestResults
-                      all_results.extend(data['results'])
+                      all_results.extend(results_with_run_metadata(data))
                       if run_started is None or data.get('runStartedAtUtc', '') < run_started:
                           run_started = data.get('runStartedAtUtc')
                       if run_completed is None or data.get('runCompletedAtUtc', '') > run_completed:
@@ -514,7 +527,7 @@ jobs:
           import os
           import glob
           from datetime import datetime
-          from stress_report import generate_scenario_tables, format_gc_table
+          from stress_report import generate_scenario_tables, format_gc_table, results_with_run_metadata
 
           output = []
           output.append("---")
@@ -545,7 +558,7 @@ jobs:
                   with open(latest_file) as f:
                       data = json.load(f)
 
-                  results = data.get('results', [])
+                  results = results_with_run_metadata(data)
 
                   output.extend(generate_scenario_tables(results, include_callout=True))
                   output.extend(format_gc_table(results, title="Memory & GC Statistics"))
@@ -571,7 +584,7 @@ jobs:
           output.append("- **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion")
           output.append("- **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts")
           output.append("- **Median Interval Throughput**: table order and comparison ratios use median sampled client-side msg/s when available, which is less sensitive to short late-run stalls than the whole-run mean")
-          output.append("- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM, with client order alternating by workflow run number to reduce order bias")
+          output.append("- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM; 1-broker producer acceptance lanes run twice in opposite client orders and publish a geometric-mean aggregate, while other lanes alternate order by workflow run number")
           output.append("- **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM")
           output.append("- **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured; table headings report the 16KB seed batch size because it amplifies per-batch costs relative to well-batched workloads")
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")

--- a/docs/docs/stress-tests.md
+++ b/docs/docs/stress-tests.md
@@ -1504,7 +1504,7 @@ Stress tests measure sustained performance over extended periods:
 - **RAM-backed Broker Logs**: Kafka log dirs are mounted on tmpfs so disk I/O never caps broker ingestion
 - **Delivered Throughput**: producer tables report broker-confirmed throughput, measured as the end-offset delta across all partitions — not the client-side append rate, which can run far ahead of what the broker ever accepts
 - **Median Interval Throughput**: table order and comparison ratios use median sampled client-side msg/s when available, which is less sensitive to short late-run stalls than the whole-run mean
-- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM, with client order alternating by workflow run number to reduce order bias
+- **Same-VM Pairing**: comparable Dekaf and Confluent scenarios run sequentially inside one job/VM; 1-broker producer acceptance lanes run twice in opposite client orders and publish a geometric-mean aggregate, while other lanes alternate order by workflow run number
 - **Backpressure Parity**: both producers are bounded to the same 512 MB local buffer (Dekaf BufferMemory, librdkafka queue.buffering.max) and block on a full buffer, so neither client can absorb an unbounded backlog into RAM
 - **Consumer Loop Replay**: Consumer tests re-read a pre-seeded topic (seek to beginning when drained) instead of racing a live feeder, so the consumer itself is measured; table headings report the 16KB seed batch size because it amplifies per-batch costs relative to well-batched workloads
 - **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency

--- a/tools/Dekaf.StressTests.Tests/ProgramTests.cs
+++ b/tools/Dekaf.StressTests.Tests/ProgramTests.cs
@@ -1,7 +1,31 @@
+using Dekaf.StressTests.Reporting;
+
 namespace Dekaf.StressTests.Tests;
 
 public class ProgramTests
 {
+    [Test]
+    public async Task StressTestResults_SerializesPairedSampleMetadata()
+    {
+        var results = new StressTestResults
+        {
+            RunStartedAtUtc = DateTime.UtcNow,
+            RunCompletedAtUtc = DateTime.UtcNow,
+            MachineName = "test",
+            ProcessorCount = 2,
+            PairedClientOrder = "dekaf-first",
+            PairedSampleIndex = 1,
+            PairedSampleCount = 2,
+            Results = []
+        };
+
+        var json = results.ToJson();
+
+        await Assert.That(json).Contains("\"pairedClientOrder\": \"dekaf-first\"");
+        await Assert.That(json).Contains("\"pairedSampleIndex\": 1");
+        await Assert.That(json).Contains("\"pairedSampleCount\": 2");
+    }
+
     [Test]
     public async Task EscalateUnobservedTaskExceptions_SuccessfulRunFails()
     {

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -291,6 +291,9 @@ public static class Program
         }
 
         var runCompletedAt = DateTime.UtcNow;
+        var pairedClientOrder = options.Client.Equals("all", StringComparison.OrdinalIgnoreCase)
+            ? NormalizePairedClientOrder(Environment.GetEnvironmentVariable("STRESS_CLIENT_ORDER"))
+            : null;
 
         var allResults = new StressTestResults
         {
@@ -298,6 +301,13 @@ public static class Program
             RunCompletedAtUtc = runCompletedAt,
             MachineName = Environment.MachineName,
             ProcessorCount = Environment.ProcessorCount,
+            PairedClientOrder = pairedClientOrder,
+            PairedSampleIndex = pairedClientOrder is not null
+                ? ReadPositiveEnvironmentInteger("STRESS_PAIRED_SAMPLE_INDEX")
+                : null,
+            PairedSampleCount = pairedClientOrder is not null
+                ? ReadPositiveEnvironmentInteger("STRESS_PAIRED_SAMPLE_COUNT")
+                : null,
             Results = results
         };
 
@@ -329,6 +339,17 @@ public static class Program
         failed |= CheckForResourceTrendFailures(results);
         return failed ? 1 : 0;
     }
+
+    private static string? NormalizePairedClientOrder(string? clientOrder)
+    {
+        var normalized = clientOrder?.ToLowerInvariant();
+        return normalized is "dekaf-first" or "confluent-first" ? normalized : null;
+    }
+
+    private static int? ReadPositiveEnvironmentInteger(string variableName) =>
+        int.TryParse(Environment.GetEnvironmentVariable(variableName), out var value) && value > 0
+            ? value
+            : null;
 
     private static bool CheckForResourceTrendFailures(List<StressTestResult> results)
     {

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -330,6 +330,9 @@ internal sealed class StressTestResults
     public required DateTime RunCompletedAtUtc { get; init; }
     public required string MachineName { get; init; }
     public required int ProcessorCount { get; init; }
+    public string? PairedClientOrder { get; init; }
+    public int? PairedSampleIndex { get; init; }
+    public int? PairedSampleCount { get; init; }
     public required List<StressTestResult> Results { get; init; }
 
     private static readonly JsonSerializerOptions JsonOptions = new()


### PR DESCRIPTION
## Summary

- run the 1-broker fire-and-forget, acks-all, and idempotent comparisons twice on the same VM in opposite client orders
- preserve paired sample metadata and publish raw ordered samples plus a geometric-mean throughput aggregate
- match trend and latency controls within the same client order
- document the order-balanced acceptance method

## Test plan

- [x] `python .github/scripts/test_stress_report.py`
- [x] `python .github/scripts/test_stress_trend.py`
- [x] `dotnet build tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj --configuration Release`
- [x] `tools/Dekaf.StressTests.Tests/bin/Release/net10.0/Dekaf.StressTests.Tests.exe` (27 passed)
- [x] parse `.github/workflows/stress-tests.yml` with PyYAML
- [x] `npm run build --prefix docs`

Closes #2055

Refs #2033
