### PR TITLE
docs(consumer): warn that LINQ filters permanently skip messages once committed past

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ await consumer.ForEachAsync(async msg =>
 }, cancellationToken);
 ```
 
+Note: filtered messages are skipped permanently once offsets are committed past them — see [the docs](https://thomhurst.github.io/Dekaf/docs/consumer/linq-extensions#filtering-skips-messages-permanently) before filtering messages you might need later.
+
 ## Offset Management
 
 Dekaf gives you control over when offsets are committed:

--- a/docs/docs/consumer/linq-extensions.md
+++ b/docs/docs/consumer/linq-extensions.md
@@ -14,6 +14,37 @@ All extensions are in the `Dekaf.Consumer` namespace:
 using Dekaf.Consumer;
 ```
 
+## Filtering Skips Messages Permanently
+
+:::warning Filtered messages are gone once you commit past them
+
+The filtering operators (`Where`, `SkipWhile`, `TakeWhile`) run **after** the consumer has already consumed the message and advanced its position. Kafka commits are watermarks, not per-message acknowledgements: committing offset N tells the broker that *everything* below N is done (see [Understanding Offsets](./offset-management.md#understanding-offsets)). There is no way to commit a later message while "keeping" an earlier skipped one.
+
+That means once any commit advances past a skipped message — the periodic auto-commit (the default `OffsetCommitMode.Auto`), `CommitAsync()`, or committing a stored/specific offset for a later message — the skipped message will **never be redelivered** to your consumer group.
+
+Use these operators only when you want to **permanently ignore** some messages on a topic (tombstones, other tenants' keys, irrelevant event types). For a deterministic predicate this is exactly right: redelivering a skipped message would just get it filtered again.
+
+Do **not** use them to *defer* messages you intend to process later:
+
+```csharp
+// ❌ DATA LOSS - messages skipped while unhealthy are dropped forever
+await foreach (var msg in consumer.ConsumeAsync(ct)
+    .Where(_ => downstream.IsHealthy))
+{
+    await ProcessAsync(msg);
+    consumer.StoreOffset(msg);
+    await consumer.CommitAsync(); // commits past every skipped message
+}
+```
+
+If you need to defer instead of drop:
+
+- **Pause consumption** while you can't process — no messages are consumed, so no offsets advance. See [Pausing and Resuming](./basics.md#pausing-and-resuming).
+- **Park unprocessable messages** on a retry or dead-letter topic (and await delivery) *before* committing, then continue.
+- **Use manual commit mode** and only commit offsets where everything below them is truly handled.
+
+:::
+
 ## Where - Filtering Messages
 
 Filter messages based on a predicate:
@@ -33,6 +64,8 @@ await foreach (var msg in consumer.ConsumeAsync(ct)
     // Partition 0 messages containing "important"
 }
 ```
+
+Filtered-out messages are skipped permanently (see [warning above](#filtering-skips-messages-permanently)). Keep predicates deterministic: a message should be filtered because of *what it is*, not because of *when it arrived* or the current state of your application.
 
 ## Select - Transforming Messages
 
@@ -108,6 +141,12 @@ await foreach (var msg in consumer.ConsumeAsync(ct)
 }
 ```
 
+:::caution
+
+The first message that fails the predicate (the `"STOP"` message above) is consumed but never yielded to your loop, and its offset can be committed like any [skipped message](#filtering-skips-messages-permanently) — a restarted consumer resumes *after* it. Don't rely on seeing that boundary message again.
+
+:::
+
 ## SkipWhile - Skipping Initial Messages
 
 Skip messages until a condition becomes false:
@@ -121,6 +160,12 @@ await foreach (var msg in consumer.ConsumeAsync(ct)
     await ProcessAsync(msg);
 }
 ```
+
+:::caution
+
+Everything skipped before the marker is [dropped permanently once committed past](#filtering-skips-messages-permanently). To start from a known position without consuming and discarding messages, prefer [`Seek`](./offset-management.md#seeking-to-offsets).
+
+:::
 
 ## Batch - Grouping Messages
 
@@ -311,3 +356,5 @@ await foreach (var value in consumer.ConsumeAsync(ct)
 
 await AnalyzeSampleAsync(sample);
 ```
+
+Sampling deliberately discards the other 99% of messages. Run it under a dedicated consumer group ID so its committed offsets don't advance past messages a real processing group still needs.

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -100,6 +100,12 @@ This is useful when you need to:
 - Implement custom batching logic
 - Coordinate commits with external systems
 
+:::caution
+
+Skipping by committing past a message is permanent for the consumer group — it will never be redelivered. If the message should be processed *eventually*, park it on a retry or dead-letter topic before committing, or pause the partition instead. See [Filtering Skips Messages Permanently](./linq-extensions.md#filtering-skips-messages-permanently).
+
+:::
+
 ## Commit Strategies
 
 ### Commit After Each Message

--- a/src/Dekaf/Consumer/ConsumerExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerExtensions.cs
@@ -16,6 +16,13 @@ public static class ConsumerExtensions
     /// <param name="predicate">The filter predicate.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of consume results that match the predicate.</returns>
+    /// <remarks>
+    /// Use this only to permanently ignore messages. Filtered messages are already consumed, so
+    /// any commit that follows (including the default periodic auto-commit) advances past them
+    /// and they are never redelivered to the consumer group. Skipped messages are dropped, not
+    /// held back — do not use a stateful or time-based predicate to defer processing; pause
+    /// consumption or park messages on a retry topic instead.
+    /// </remarks>
     public static async IAsyncEnumerable<ConsumeResult<TKey, TValue>> Where<TKey, TValue>(
         this IAsyncEnumerable<ConsumeResult<TKey, TValue>> source,
         Func<ConsumeResult<TKey, TValue>, bool> predicate,
@@ -139,6 +146,11 @@ public static class ConsumerExtensions
     /// <param name="predicate">The predicate to check for each result.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of consume results after the predicate is satisfied.</returns>
+    /// <remarks>
+    /// The skipped prefix is consumed and dropped; once a commit advances past it the skip is
+    /// permanent for the consumer group. To start from a known position without discarding
+    /// messages, seek to the desired offset instead.
+    /// </remarks>
     public static async IAsyncEnumerable<ConsumeResult<TKey, TValue>> SkipWhile<TKey, TValue>(
         this IAsyncEnumerable<ConsumeResult<TKey, TValue>> source,
         Func<ConsumeResult<TKey, TValue>, bool> predicate,
@@ -169,6 +181,11 @@ public static class ConsumerExtensions
     /// <param name="predicate">The predicate to check for each result.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>An async enumerable of consume results while the predicate is satisfied.</returns>
+    /// <remarks>
+    /// The first message that fails the predicate is consumed but never yielded, and its offset
+    /// may be committed like any skipped message — a restarted consumer resumes after it. Do not
+    /// rely on the boundary message being redelivered.
+    /// </remarks>
     public static async IAsyncEnumerable<ConsumeResult<TKey, TValue>> TakeWhile<TKey, TValue>(
         this IAsyncEnumerable<ConsumeResult<TKey, TValue>> source,
         Func<ConsumeResult<TKey, TValue>, bool> predicate,


### PR DESCRIPTION
## Summary

Documents the hazard described in #2068: the consumer LINQ filtering operators (`Where`, `SkipWhile`, `TakeWhile`) run downstream of `ConsumeAsync`, so filtered messages are already consumed and any commit — including the default periodic auto-commit — advances the committed watermark past them. They are never redelivered to the consumer group.

This PR makes the docs explicit that filtering is for **permanently ignoring** messages on a topic (tombstones, other tenants, irrelevant event types), and that skipped messages are **gone after committing past them** — filtering must not be used as a deferral mechanism.

## Changes

- **`docs/docs/consumer/linq-extensions.md`**: new `Filtering Skips Messages Permanently` warning section up top — commit-watermark explanation, a ❌ data-loss anti-pattern example (stateful predicate + commit), and defer-safe alternatives (pause, retry/DLQ parking, manual commit mode). Per-operator cautions for `SkipWhile` (prefer `Seek` for positioning) and `TakeWhile` (the boundary message is consumed but never yielded). Note on running sampling under a dedicated group ID.
- **`docs/docs/consumer/offset-management.md`**: caution on the 'skip messages that failed processing' use case, cross-linked to the new warning.
- **`src/Dekaf/Consumer/ConsumerExtensions.cs`**: XML `<remarks>` on `Where`/`SkipWhile`/`TakeWhile` so the warning surfaces in IntelliSense. Doc comments only — no code changes.
- **`README.md`**: one-line pointer from the Consumer LINQ Extensions section to the docs warning.

The deeper API affordance (a `Where` overload with an `onFiltered` callback for defer-safe parking) is tracked separately in #2068.

## Testing

- `dotnet build src/Dekaf` clean (0 warnings, 0 errors) — XML doc comments well-formed
- Docusaurus admonition syntax and relative link anchors verified against existing docs pages

Refs #2068