### PR TITLE
Guard partitioned processing against auto-commit and document the consume-loop data-loss footgun

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -255,9 +255,10 @@ string? memberId = consumer.MemberId;
 
 ## Complete Example
 
-This example processes orders with at-least-once semantics: auto offset store is disabled, and
-offsets are stored only after processing succeeds, so a failed order is redelivered instead of
-being silently committed away. Background auto-commit still handles the actual commits.
+This example processes orders with at-least-once semantics: auto offset store is disabled,
+offsets are stored only after processing succeeds, and a processing failure stops the consumer
+instead of skipping the order — so the failed order is redelivered on restart rather than being
+silently committed away. Background auto-commit still handles the actual commits.
 
 ```csharp
 using Dekaf;
@@ -303,10 +304,11 @@ public class OrderConsumer : BackgroundService
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to process order {OrderId}", message.Key);
-                    // Offset not stored: the order is redelivered after the consumer
-                    // restarts or the partition is reassigned. Continuing here still
-                    // processes later messages, but their stored offsets will also
-                    // re-cover this one — dead-letter the failure if you continue.
+                    // Offset not stored: rethrow so the host restarts the consumer and
+                    // the order is redelivered. Do NOT swallow and continue — storing
+                    // any later offset would commit past this one and lose it. If you
+                    // must keep consuming, dead-letter the failed order first.
+                    throw;
                 }
             }
         }

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -171,6 +171,18 @@ catch (ConsumeException ex)
 }
 ```
 
+:::caution Catching an exception does not stop the commit
+With the default configuration (auto-commit + auto offset store), a message's offset is staged
+for commit the moment `ConsumeAsync` yields it to you — *before* your processing runs. If your
+handler throws and you log-and-continue like above, the failed message's offset is still
+committed within the auto-commit interval (5 seconds by default), and the message will never be
+redelivered. No crash is required for this loss — a swallowed exception is enough.
+
+If losing failed messages is not acceptable, disable auto offset store and store offsets only
+after processing succeeds (see the complete example below), or switch to
+[manual commits](offset-management.md).
+:::
+
 ## Graceful Shutdown
 
 Always dispose the consumer properly:
@@ -243,6 +255,10 @@ string? memberId = consumer.MemberId;
 
 ## Complete Example
 
+This example processes orders with at-least-once semantics: auto offset store is disabled, and
+offsets are stored only after processing succeeds, so a failed order is redelivered instead of
+being silently committed away. Background auto-commit still handles the actual commits.
+
 ```csharp
 using Dekaf;
 
@@ -261,6 +277,7 @@ public class OrderConsumer : BackgroundService
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("order-processor")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithAutoOffsetStore(false)  // Only commit offsets we explicitly store
             .SubscribeTo("orders")
             .BuildAsync();
 
@@ -279,11 +296,17 @@ public class OrderConsumer : BackgroundService
                 try
                 {
                     await ProcessOrderAsync(message.Value, stoppingToken);
+
+                    // Mark this offset as safe to commit only after processing succeeded
+                    consumer.StoreOffset(message);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to process order {OrderId}", message.Key);
-                    // Continue processing other messages
+                    // Offset not stored: the order is redelivered after the consumer
+                    // restarts or the partition is reassigned. Continuing here still
+                    // processes later messages, but their stored offsets will also
+                    // re-cover this one — dead-letter the failure if you continue.
                 }
             }
         }

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -47,7 +47,45 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 **Cons:** Messages might be committed before processing completes
 
 :::caution
-If your application crashes after committing but before processing, messages may be lost. Use this mode only when occasional message loss is acceptable (logs, metrics, etc.).
+In auto mode a message's offset is staged for commit as soon as it is *consumed*, not when it is
+successfully processed. Loss does not require a crash: if your handler throws and you catch the
+exception and keep consuming, the failed message's offset is still committed on the next
+auto-commit tick (every 5 seconds by default), on rebalance, and on graceful shutdown — the
+message is gone. Use this mode as-is only when occasional message loss is acceptable (logs,
+metrics, etc.), or pair it with manual offset store (below).
+:::
+
+### Auto-Commit with Manual Offset Store
+
+The middle ground between the two modes: keep background auto-commit, but only let it commit
+offsets you have explicitly marked as processed. This gives at-least-once semantics without a
+commit round-trip in your processing loop.
+
+```csharp
+using Dekaf;
+
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithAutoOffsetStore(false)  // Auto-commit only commits explicitly stored offsets
+    .BuildAsync();
+
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessMessageAsync(msg);  // Process first
+    consumer.StoreOffset(msg);       // Then mark as safe to commit (no network call)
+}
+```
+
+`StoreOffset` is a cheap in-memory operation; the background auto-commit loop batches the actual
+network commits. If processing throws before `StoreOffset`, the message's offset is never staged
+and it will be redelivered.
+
+:::caution
+Offsets are positions, not per-message acknowledgements. Storing a later offset also commits
+everything before it — if you skip a failed message and keep storing later offsets, the failed
+message is still lost. To preserve it, stop consuming the partition, or route the failure to a
+dead-letter topic before moving on.
 :::
 
 ### Manual Mode
@@ -222,7 +260,8 @@ follow the configured auto-offset-reset policy.
 
 | Mode | Semantics | Risk |
 |------|-----------|------|
-| Auto | At-most-once | May lose messages on crash |
+| Auto (defaults) | At-most-once | Loses messages whose processing failed — no crash required |
+| Auto + `WithAutoOffsetStore(false)` + `StoreOffset` after process | At-least-once | May reprocess on crash |
 | Manual (commit after process) | At-least-once | May reprocess on crash |
 | Manual + External storage | Exactly-once | Most complex |
 
@@ -246,7 +285,7 @@ await dbTransaction.CommitAsync();
 
 ## Best Practices
 
-1. **Use Manual mode** for most applications - it gives you control over when offsets are committed
+1. **Make commits reflect completed processing** for most applications - either Manual mode, or auto-commit with `WithAutoOffsetStore(false)` + `StoreOffset` after each successfully processed message
 
 2. **Batch your commits** - committing after every message is slow
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -190,15 +190,18 @@ offset.
 Runtime-managed revoke and shutdown commits may batch completed offsets for
 multiple partitions into one `CommitAsync` call.
 
-Auto commit mode (`OffsetCommitMode.Auto`, the consumer default) commits consumed
+Auto commit mode with automatic offset store (`OffsetCommitMode.Auto` +
+`EnableAutoOffsetStore = true`, the consumer defaults) stages and commits consumed
 positions in the background regardless of `MarkProcessed`, which would silently
 void the runtime's at-least-once tracking. `RunPartitionedAsync` therefore throws
-`InvalidOperationException` when the consumer uses auto commit mode together with
+`InvalidOperationException` when the consumer uses that combination together with
 a runtime-managed commit policy (`CommitCompletedOnRevoke` or
 `CommitCompletedPeriodically`). For at-least-once partitioned processing, configure
-the consumer with `OffsetCommitMode.Manual`. The combination of auto commit and
-`PartitionCommitPolicy.UserManaged` remains allowed for applications that accept
-auto-commit semantics.
+the consumer with `OffsetCommitMode.Manual`, or with `WithAutoOffsetStore(false)` —
+with the automatic store disabled, the background loop has nothing of its own to
+commit, so only the runtime's `MarkProcessed`-tracked commits advance offsets. The
+combination of auto commit and `PartitionCommitPolicy.UserManaged` also remains
+allowed for applications that accept auto-commit semantics.
 
 Transactions remain user-managed. If a processor writes transactionally, send
 the processed offsets to that transaction and do not also let the partitioned

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -203,6 +203,12 @@ commit, so only the runtime's `MarkProcessed`-tracked commits advance offsets. T
 combination of auto commit and `PartitionCommitPolicy.UserManaged` also remains
 allowed for applications that accept auto-commit semantics.
 
+This check inspects the commit configuration of Dekaf's own consumer
+implementations (`KafkaConsumer` and the testing `InMemoryConsumer`). A custom
+`IKafkaConsumer` implementation or a wrapper around a Dekaf consumer is not
+inspected and will not fail fast — if you wrap a consumer, ensure the underlying
+configuration follows the rules above.
+
 Transactions remain user-managed. If a processor writes transactionally, send
 the processed offsets to that transaction and do not also let the partitioned
 runtime commit them outside the transaction.

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -190,10 +190,15 @@ offset.
 Runtime-managed revoke and shutdown commits may batch completed offsets for
 multiple partitions into one `CommitAsync` call.
 
-If the consumer uses auto commit mode, use `PartitionCommitPolicy.UserManaged`
-and understand that auto commit can commit consumed positions before partition
-processing finishes. For at-least-once partitioned processing, prefer
-`OffsetCommitMode.Manual`.
+Auto commit mode (`OffsetCommitMode.Auto`, the consumer default) commits consumed
+positions in the background regardless of `MarkProcessed`, which would silently
+void the runtime's at-least-once tracking. `RunPartitionedAsync` therefore throws
+`InvalidOperationException` when the consumer uses auto commit mode together with
+a runtime-managed commit policy (`CommitCompletedOnRevoke` or
+`CommitCompletedPeriodically`). For at-least-once partitioned processing, configure
+the consumer with `OffsetCommitMode.Manual`. The combination of auto commit and
+`PartitionCommitPolicy.UserManaged` remains allowed for applications that accept
+auto-commit semantics.
 
 Transactions remain user-managed. If a processor writes transactionally, send
 the processed offsets to that transaction and do not also let the partitioned

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -13,7 +13,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
     IConsumerPositions,
     IConsumerPartitions,
-    IConsumerOffsets
+    IConsumerOffsets,
+    IConsumerCommitModeSource
 {
     private readonly object _gate = new();
     private readonly InMemoryKafkaCluster _cluster;
@@ -122,6 +123,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     public IConsumerPartitions Partitions => this;
 
     public IConsumerOffsets Offsets => this;
+
+    OffsetCommitMode IConsumerCommitModeSource.OffsetCommitMode => _options.OffsetCommitMode;
+
+    bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -128,6 +128,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
+    bool IConsumerCommitModeSource.HasConsumerGroup => _options.GroupId is not null;
+
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -703,6 +703,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     IConsumerOffsets,
     IConsumerRebalanceEventSource,
     IConsumerLoggerFactorySource,
+    IConsumerCommitModeSource,
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
@@ -1385,6 +1386,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     ILoggerFactory? IConsumerLoggerFactorySource.LoggerFactory => _loggerFactory;
+
+    OffsetCommitMode IConsumerCommitModeSource.OffsetCommitMode => _options.OffsetCommitMode;
 
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1391,6 +1391,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
+    bool IConsumerCommitModeSource.HasConsumerGroup => !string.IsNullOrEmpty(_options.GroupId);
+
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1389,6 +1389,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     OffsetCommitMode IConsumerCommitModeSource.OffsetCommitMode => _options.OffsetCommitMode;
 
+    bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
+
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -31,6 +31,7 @@ public static class PartitionedConsumerExtensions
         options ??= new PartitionedProcessingOptions();
         options.Validate();
         options.ValidatePartitionProcessor();
+        ThrowIfAutoCommitUnderminesProcessedTracking(consumer, options);
 
         var logger = consumer is IConsumerLoggerFactorySource loggerSource
             ? loggerSource.LoggerFactory?.CreateLogger<PartitionedConsumerRuntime<TKey, TValue>>()
@@ -57,6 +58,7 @@ public static class PartitionedConsumerExtensions
 
         options ??= new PartitionedProcessingOptions();
         options.Validate();
+        ThrowIfAutoCommitUnderminesProcessedTracking(consumer, options);
 
         var logger = consumer is IConsumerLoggerFactorySource loggerSource
             ? loggerSource.LoggerFactory?.CreateLogger<PartitionedConsumerRuntime<TKey, TValue>>()
@@ -83,6 +85,7 @@ public static class PartitionedConsumerExtensions
 
         options ??= new PartitionedProcessingOptions();
         options.Validate();
+        ThrowIfAutoCommitUnderminesProcessedTracking(consumer, options);
 
         var logger = consumer is IConsumerLoggerFactorySource loggerSource
             ? loggerSource.LoggerFactory?.CreateLogger<PartitionedConsumerRuntime<TKey, TValue>>()
@@ -200,11 +203,40 @@ public static class PartitionedConsumerExtensions
 
         return dispatcher.RunAsync(cancellationToken);
     }
+
+    private static void ThrowIfAutoCommitUnderminesProcessedTracking<TKey, TValue>(
+        IKafkaConsumer<TKey, TValue> consumer,
+        PartitionedProcessingOptions options)
+    {
+        if (!options.IsRuntimeManagedCommitPolicy)
+            return;
+
+        if (consumer is IConsumerCommitModeSource { OffsetCommitMode: OffsetCommitMode.Auto })
+        {
+            throw new InvalidOperationException(
+                $"Partitioned processing with {nameof(PartitionCommitPolicy)}.{options.CommitPolicy} requires " +
+                $"{nameof(OffsetCommitMode)}.{nameof(OffsetCommitMode.Manual)}, but the consumer uses " +
+                $"{nameof(OffsetCommitMode)}.{nameof(OffsetCommitMode.Auto)}. Auto-commit commits consumed positions " +
+                "in the background regardless of MarkProcessed, so a failed handler would not prevent its message " +
+                "from being committed. Configure the consumer with WithOffsetCommitMode(OffsetCommitMode.Manual), " +
+                $"or use {nameof(PartitionCommitPolicy)}.{nameof(PartitionCommitPolicy.UserManaged)} if you accept " +
+                "auto-commit semantics.");
+        }
+    }
 }
 
 internal interface IConsumerLoggerFactorySource
 {
     ILoggerFactory? LoggerFactory { get; }
+}
+
+/// <summary>
+/// Exposes the configured <see cref="OffsetCommitMode"/> of a consumer so partitioned processing
+/// can reject auto-commit consumers whose background commits would bypass processed-offset tracking.
+/// </summary>
+internal interface IConsumerCommitModeSource
+{
+    OffsetCommitMode OffsetCommitMode { get; }
 }
 
 /// <summary>
@@ -426,6 +458,13 @@ public sealed class PartitionedProcessingOptions
     /// Gets the interval for periodic completed-offset commits.
     /// </summary>
     public TimeSpan CommitInterval { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// True when the runtime itself commits completed offsets based on MarkProcessed tracking.
+    /// </summary>
+    internal bool IsRuntimeManagedCommitPolicy => CommitPolicy
+        is PartitionCommitPolicy.CommitCompletedOnRevoke
+        or PartitionCommitPolicy.CommitCompletedPeriodically;
 
     internal void Validate()
     {
@@ -1268,11 +1307,7 @@ internal sealed class PartitionedConsumerRuntime<TKey, TValue>
             await _consumer.CommitAsync([offset.Value], cancellationToken).ConfigureAwait(false);
     }
 
-    private bool ShouldCommitOnPartitionStop()
-    {
-        return _options.CommitPolicy is PartitionCommitPolicy.CommitCompletedOnRevoke
-            or PartitionCommitPolicy.CommitCompletedPeriodically;
-    }
+    private bool ShouldCommitOnPartitionStop() => _options.IsRuntimeManagedCommitPolicy;
 
     private int RecordIgnoreRestartFailure(TopicPartition partition)
     {

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -211,7 +211,12 @@ public static class PartitionedConsumerExtensions
         if (!options.IsRuntimeManagedCommitPolicy)
             return;
 
-        if (consumer is IConsumerCommitModeSource { OffsetCommitMode: OffsetCommitMode.Auto, EnableAutoOffsetStore: true })
+        if (consumer is IConsumerCommitModeSource
+            {
+                OffsetCommitMode: OffsetCommitMode.Auto,
+                EnableAutoOffsetStore: true,
+                HasConsumerGroup: true
+            })
         {
             throw new InvalidOperationException(
                 $"Partitioned processing with {nameof(PartitionCommitPolicy)}.{options.CommitPolicy} is incompatible " +
@@ -233,14 +238,17 @@ internal interface IConsumerLoggerFactorySource
 /// <summary>
 /// Exposes a consumer's offset-commit configuration so partitioned processing can reject
 /// consumers whose background auto-commit would bypass processed-offset tracking. Only the
-/// combination of <see cref="OffsetCommitMode.Auto"/> and automatic offset store is dangerous:
-/// with the store disabled, nothing is staged for the background loop to commit.
+/// combination of a consumer group, <see cref="OffsetCommitMode.Auto"/>, and automatic offset
+/// store is dangerous: without a group there is no coordinator to commit through, and with the
+/// store disabled nothing is staged for the background loop to commit.
 /// </summary>
 internal interface IConsumerCommitModeSource
 {
     OffsetCommitMode OffsetCommitMode { get; }
 
     bool EnableAutoOffsetStore { get; }
+
+    bool HasConsumerGroup { get; }
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -211,15 +211,15 @@ public static class PartitionedConsumerExtensions
         if (!options.IsRuntimeManagedCommitPolicy)
             return;
 
-        if (consumer is IConsumerCommitModeSource { OffsetCommitMode: OffsetCommitMode.Auto })
+        if (consumer is IConsumerCommitModeSource { OffsetCommitMode: OffsetCommitMode.Auto, EnableAutoOffsetStore: true })
         {
             throw new InvalidOperationException(
-                $"Partitioned processing with {nameof(PartitionCommitPolicy)}.{options.CommitPolicy} requires " +
-                $"{nameof(OffsetCommitMode)}.{nameof(OffsetCommitMode.Manual)}, but the consumer uses " +
-                $"{nameof(OffsetCommitMode)}.{nameof(OffsetCommitMode.Auto)}. Auto-commit commits consumed positions " +
-                "in the background regardless of MarkProcessed, so a failed handler would not prevent its message " +
-                "from being committed. Configure the consumer with WithOffsetCommitMode(OffsetCommitMode.Manual), " +
-                $"or use {nameof(PartitionCommitPolicy)}.{nameof(PartitionCommitPolicy.UserManaged)} if you accept " +
+                $"Partitioned processing with {nameof(PartitionCommitPolicy)}.{options.CommitPolicy} is incompatible " +
+                $"with the consumer's {nameof(OffsetCommitMode)}.{nameof(OffsetCommitMode.Auto)} + automatic offset " +
+                "store: consumed positions are staged and committed in the background regardless of MarkProcessed, " +
+                "so a failed handler would not prevent its message from being committed. Configure the consumer with " +
+                "WithOffsetCommitMode(OffsetCommitMode.Manual) or WithAutoOffsetStore(false), or use " +
+                $"{nameof(PartitionCommitPolicy)}.{nameof(PartitionCommitPolicy.UserManaged)} if you accept " +
                 "auto-commit semantics.");
         }
     }
@@ -231,12 +231,16 @@ internal interface IConsumerLoggerFactorySource
 }
 
 /// <summary>
-/// Exposes the configured <see cref="OffsetCommitMode"/> of a consumer so partitioned processing
-/// can reject auto-commit consumers whose background commits would bypass processed-offset tracking.
+/// Exposes a consumer's offset-commit configuration so partitioned processing can reject
+/// consumers whose background auto-commit would bypass processed-offset tracking. Only the
+/// combination of <see cref="OffsetCommitMode.Auto"/> and automatic offset store is dangerous:
+/// with the store disabled, nothing is staged for the background loop to commit.
 /// </summary>
 internal interface IConsumerCommitModeSource
 {
     OffsetCommitMode OffsetCommitMode { get; }
+
+    bool EnableAutoOffsetStore { get; }
 }
 
 /// <summary>

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -22,6 +22,7 @@
     <InternalsVisibleTo Include="Dekaf.Compression.Lz4" />
     <InternalsVisibleTo Include="Dekaf.Extensions.Hosting" />
     <InternalsVisibleTo Include="Dekaf.Extensions.DependencyInjection" />
+    <InternalsVisibleTo Include="Dekaf.Testing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1022,13 +1022,20 @@ public sealed class PartitionedConsumerRuntimeTests
     }
 
     [Test]
-    [Arguments(OffsetCommitMode.Auto, PartitionCommitPolicy.UserManaged)]
-    [Arguments(OffsetCommitMode.Manual, PartitionCommitPolicy.CommitCompletedOnRevoke)]
+    [Arguments(OffsetCommitMode.Auto, true, PartitionCommitPolicy.UserManaged)]
+    [Arguments(OffsetCommitMode.Auto, false, PartitionCommitPolicy.CommitCompletedOnRevoke)]
+    [Arguments(OffsetCommitMode.Auto, false, PartitionCommitPolicy.CommitCompletedPeriodically)]
+    [Arguments(OffsetCommitMode.Manual, true, PartitionCommitPolicy.CommitCompletedOnRevoke)]
     public async Task RunPartitionedAsync_AllowedCommitModeCombination_DoesNotThrow(
         OffsetCommitMode offsetCommitMode,
+        bool enableAutoOffsetStore,
         PartitionCommitPolicy commitPolicy)
     {
-        var consumer = new TestConsumer { OffsetCommitMode = offsetCommitMode };
+        var consumer = new TestConsumer
+        {
+            OffsetCommitMode = offsetCommitMode,
+            EnableAutoOffsetStore = enableAutoOffsetStore
+        };
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var runTask = consumer.RunPartitionedAsync(
@@ -1204,6 +1211,8 @@ public sealed class PartitionedConsumerRuntimeTests
         public ILoggerFactory? LoggerFactory { get; init; }
 
         public OffsetCommitMode OffsetCommitMode { get; init; } = OffsetCommitMode.Manual;
+
+        public bool EnableAutoOffsetStore { get; init; } = true;
 
 #if !NET10_0_OR_GREATER
         IReadOnlyCollection<string> IKafkaConsumer<string, string>.Subscription => Subscription;

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -993,6 +993,52 @@ public sealed class PartitionedConsumerRuntimeTests
         ]);
     }
 
+    [Test]
+    [Arguments(PartitionCommitPolicy.CommitCompletedOnRevoke)]
+    [Arguments(PartitionCommitPolicy.CommitCompletedPeriodically)]
+    public async Task RunPartitionedAsync_AutoCommitConsumerWithRuntimeManagedPolicy_Throws(
+        PartitionCommitPolicy commitPolicy)
+    {
+        var consumer = new TestConsumer { OffsetCommitMode = OffsetCommitMode.Auto };
+        var options = new PartitionedProcessingOptions { CommitPolicy = commitPolicy };
+
+        await Assert.That(async () => await consumer.RunPartitionedAsync(
+                static (_, _) => ValueTask.CompletedTask,
+                options,
+                CancellationToken.None))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(async () => await consumer.RunPartitionedAsync(
+                static (PartitionRecordProcessorContext<string, string> _, ConsumeResult<string, string> _, CancellationToken _) => ValueTask.CompletedTask,
+                options,
+                CancellationToken.None))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(async () => await consumer.RunPartitionedBatchesAsync(
+                static (_, _, _) => ValueTask.CompletedTask,
+                options,
+                CancellationToken.None))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments(OffsetCommitMode.Auto, PartitionCommitPolicy.UserManaged)]
+    [Arguments(OffsetCommitMode.Manual, PartitionCommitPolicy.CommitCompletedOnRevoke)]
+    public async Task RunPartitionedAsync_AllowedCommitModeCombination_DoesNotThrow(
+        OffsetCommitMode offsetCommitMode,
+        PartitionCommitPolicy commitPolicy)
+    {
+        var consumer = new TestConsumer { OffsetCommitMode = offsetCommitMode };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            static (_, _) => ValueTask.CompletedTask,
+            new PartitionedProcessingOptions { CommitPolicy = commitPolicy },
+            cts.Token).AsTask();
+
+        await StopRuntimeAsync(cts, runTask);
+    }
+
     private static async ValueTask StopRuntimeAsync(
         CancellationTokenSource cancellationTokenSource,
         Task runTask)
@@ -1091,7 +1137,8 @@ public sealed class PartitionedConsumerRuntimeTests
         IConsumerPartitions,
         IConsumerOffsets,
         IConsumerRebalanceEventSource,
-        IConsumerLoggerFactorySource
+        IConsumerLoggerFactorySource,
+        IConsumerCommitModeSource
     {
         private readonly object _gate = new();
         private readonly Queue<ConsumeResult<string, string>> _records = [];
@@ -1155,6 +1202,8 @@ public sealed class PartitionedConsumerRuntimeTests
         public TaskCompletionSource? ReleaseCommit { get; init; }
 
         public ILoggerFactory? LoggerFactory { get; init; }
+
+        public OffsetCommitMode OffsetCommitMode { get; init; } = OffsetCommitMode.Manual;
 
 #if !NET10_0_OR_GREATER
         IReadOnlyCollection<string> IKafkaConsumer<string, string>.Subscription => Subscription;

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1046,6 +1046,28 @@ public sealed class PartitionedConsumerRuntimeTests
         await StopRuntimeAsync(cts, runTask);
     }
 
+    [Test]
+    public async Task RunPartitionedAsync_AutoCommitConsumerWithoutGroup_DoesNotThrow()
+    {
+        var consumer = new TestConsumer
+        {
+            OffsetCommitMode = OffsetCommitMode.Auto,
+            EnableAutoOffsetStore = true,
+            HasConsumerGroup = false
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var runTask = consumer.RunPartitionedAsync(
+            static (_, _) => ValueTask.CompletedTask,
+            new PartitionedProcessingOptions
+            {
+                CommitPolicy = PartitionCommitPolicy.CommitCompletedPeriodically
+            },
+            cts.Token).AsTask();
+
+        await StopRuntimeAsync(cts, runTask);
+    }
+
     private static async ValueTask StopRuntimeAsync(
         CancellationTokenSource cancellationTokenSource,
         Task runTask)
@@ -1213,6 +1235,8 @@ public sealed class PartitionedConsumerRuntimeTests
         public OffsetCommitMode OffsetCommitMode { get; init; } = OffsetCommitMode.Manual;
 
         public bool EnableAutoOffsetStore { get; init; } = true;
+
+        public bool HasConsumerGroup { get; init; } = true;
 
 #if !NET10_0_OR_GREATER
         IReadOnlyCollection<string> IKafkaConsumer<string, string>.Subscription => Subscription;


### PR DESCRIPTION
Fixes #2069
Fixes #2070

## Problem

With the default consumer configuration (`OffsetCommitMode.Auto` + `EnableAutoOffsetStore = true`), a message's next offset is staged for commit the moment it is yielded to the application — before processing runs. A handler exception that is caught and logged does not prevent the commit: the failed message's offset is committed on the next auto-commit tick (5s default), on rebalance, and on graceful shutdown. No crash is required for the loss.

Two consequences addressed here:

1. **The basic consume loop docs modelled the footgun** — the error-handling example and the "Complete Example" (an order processor!) caught handler exceptions and continued under default auto-commit, silently dropping failed messages. The at-least-once middle path (`WithAutoOffsetStore(false)` + `StoreOffset` after success) was documented only in XML docs.
2. **`RunPartitionedAsync` silently accepted auto-commit consumers**, whose background commits bypass `MarkProcessed` tracking and void the runtime's at-least-once guarantee. The docs warned about this; the code did not.

## Changes

### Safeguard (#2070)
- `RunPartitionedAsync` / `RunPartitionedBatchesAsync` now throw `InvalidOperationException` when the consumer uses `OffsetCommitMode.Auto` together with a runtime-managed commit policy (`CommitCompletedOnRevoke` / `CommitCompletedPeriodically`). The documented `Auto` + `UserManaged` combination remains allowed.
- Commit mode is exposed through a new internal `IConsumerCommitModeSource` (same pattern as `IConsumerLoggerFactorySource`), so the guard only applies to consumers that opt in — test fakes are unaffected.
- Extracted `PartitionedProcessingOptions.IsRuntimeManagedCommitPolicy` so the guard and `ShouldCommitOnPartitionStop` share one definition of "runtime-managed".

### Docs (#2069)
- `basics.md`: caution box in Error Handling explaining that a caught exception does not stop the commit; Complete Example rewritten to at-least-once (`WithAutoOffsetStore(false)` + `StoreOffset` after success) with an honest note that skipping a failed message and storing later offsets still commits past it.
- `offset-management.md`: new "Auto-Commit with Manual Offset Store" section; reworded the crash-only framing of the Auto mode caution; added the pattern to the delivery-semantics table and Best Practices.
- `partitioned-processing-api.md`: documents the new fail-fast behavior.

### Behavior change note

Code that previously called `RunPartitionedAsync` on an auto-commit consumer with the default commit policy now throws at startup instead of running with silently-voided at-least-once semantics. That combination was already documented as unsafe; failing fast is the point of this change.

## Testing

- 3 new unit tests: guard throws for both runtime-managed policies across all three entry points; allowed combinations (`Auto`+`UserManaged`, `Manual`+`CommitCompletedOnRevoke`) still run.
- Full unit suite: 5462/5462 passing.