### PR TITLE
Offset-commit safety: fix mid-batch fetch redelivery + pin never-commit-past-unconsumed invariants

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -161,6 +161,15 @@ internal sealed class PendingFetchData : IDisposable
     private long _emittedMessageCount;
     private long _emittedBytesConsumed;
 
+    /// <summary>
+    /// Records with offsets below this value are skipped when iteration starts.
+    /// The broker returns whole record batches, so a fetch positioned mid-batch
+    /// (e.g. resuming from a committed offset that falls inside a batch) receives
+    /// leading records below the requested offset; yielding them would re-deliver
+    /// records the application already consumed. -1 disables skipping.
+    /// </summary>
+    private long _skipRecordsBelowOffset = -1;
+
     private PendingFetchData() { }
 
     /// <summary>
@@ -169,7 +178,8 @@ internal sealed class PendingFetchData : IDisposable
     public static PendingFetchData Create(string topic, int partitionIndex, IReadOnlyList<RecordBatch> batches,
         IReadOnlyList<AbortedTransaction>? abortedTransactions = null,
         IPooledMemory? memoryOwner = null,
-        string? activityName = null)
+        string? activityName = null,
+        long skipRecordsBelowOffset = -1)
     {
         var instance = Rent();
         instance.Topic = topic;
@@ -178,6 +188,7 @@ internal sealed class PendingFetchData : IDisposable
         instance.TopicPartition = new TopicPartition(topic, partitionIndex);
         instance._batches = batches;
         instance._memoryOwner = memoryOwner;
+        instance._skipRecordsBelowOffset = skipRecordsBelowOffset;
 
         for (var i = 0; i < batches.Count; i++)
             batches[i].AttachConsumerPoolOwner(instance, instance.HeaderGeneration);
@@ -418,7 +429,10 @@ internal sealed class PendingFetchData : IDisposable
         {
             _batchIndex = 0;
             _recordIndex = 0;
-            return HasCurrentRecordOrMarkExhausted();
+            if (!HasCurrentRecordOrMarkExhausted())
+                return false;
+
+            return _skipRecordsBelowOffset < 0 || SkipRecordsBelowStartOffset();
         }
 
         // Try next record in current batch (uses cached count to avoid Records property access)
@@ -459,6 +473,30 @@ internal sealed class PendingFetchData : IDisposable
 
         IsExhausted = true;
         return false;
+    }
+
+    /// <summary>
+    /// Advances past leading records below the requested fetch offset. Only the first
+    /// batch of a fetch can straddle the requested offset (batch base offsets increase
+    /// monotonically), so this one-time loop is bounded by a single batch in practice
+    /// and adds no per-record cost to steady-state iteration.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool SkipRecordsBelowStartOffset()
+    {
+        while (CurrentBaseOffset + CurrentRecord.OffsetDelta < _skipRecordsBelowOffset)
+        {
+            _recordIndex++;
+            if (_recordIndex < _currentRecordsCount)
+                continue;
+
+            _batchIndex++;
+            _recordIndex = 0;
+            if (!HasCurrentRecordOrMarkExhausted())
+                return false;
+        }
+
+        return true;
     }
 
     private bool HasCurrentRecord()
@@ -593,6 +631,7 @@ internal sealed class PendingFetchData : IDisposable
         IsExhausted = false;
         _emittedMessageCount = 0;
         _emittedBytesConsumed = 0;
+        _skipRecordsBelowOffset = -1;
         PartitionIndex = 0;
         TopicPartition = default;
         Topic = null!;
@@ -1873,8 +1912,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             }
 
                             TrackConsumedPosition(pending, offset, messageBytes);
-                            // Position dictionaries are flushed once per fetch; auto-commit reads
-                            // the published active snapshot without touching the pending queue.
+                            // Committable state advances only at fetch-boundary flushes; see
+                            // AutoCommitLoopAsync for the offset-safety contract this preserves.
 
                             // Store raw byte references for DLQ lazy capture (zero-copy — just memory slices)
                             if (rawTrackingEnabled)
@@ -2971,7 +3010,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 partitionResponse.PartitionIndex,
                                 records,
                                 partitionResponse.AbortedTransactions,
-                                activityName: activityName);
+                                activityName: activityName,
+                                skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1));
 
                             // Collect for later - we'll assign memory owner to the last one
                             pendingItems.Add(pending);
@@ -3097,6 +3137,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return true;
     }
 
+    /// <summary>
+    /// Records the yielded record in the pending fetch and, in auto-commit mode, publishes
+    /// the next position to the active consumed snapshot. The snapshot is read only by
+    /// <see cref="CommitAsync(CancellationToken)"/>, close, and <see cref="GetPosition"/> —
+    /// never by the background auto-commit loop — so publishing before the record is
+    /// yielded cannot make it committable early.
+    /// </summary>
     private void TrackConsumedPosition(PendingFetchData pending, long offset, int messageBytes)
     {
         pending.TrackConsumed(offset, messageBytes);
@@ -6073,7 +6120,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             partitionResponse.PartitionIndex,
                             records,
                             partitionResponse.AbortedTransactions,
-                            activityName: activityName));
+                            activityName: activityName,
+                            skipRecordsBelowOffset: _fetchPositions.GetValueOrDefault(tp, -1)));
                     }
                     else
                     {
@@ -6904,6 +6952,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         oldCts?.Dispose();
     }
 
+    /// <summary>
+    /// Background auto-commit timer loop. Offset-safety contract: this loop commits only
+    /// stored offsets (<see cref="CommitStoredOffsetsAsync"/>), which are populated at
+    /// fetch-boundary position flushes — i.e. only for records the caller has already
+    /// iterated past. It never reads the active consumed snapshot, so a record that has
+    /// been yielded but not yet processed (or prefetched but not yet yielded) can never be
+    /// committed by this loop. Commits are skipped unless the coordinator is Stable, which
+    /// prevents committing with a stale generation mid-rebalance. On failure it retries
+    /// once after 200ms, then waits for the next interval.
+    /// </summary>
     private async Task AutoCommitLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)

--- a/tests/Dekaf.Tests.Integration/RealWorld/OffsetCommitSafetyTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/OffsetCommitSafetyTests.cs
@@ -1,0 +1,348 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration.RealWorld;
+
+/// <summary>
+/// Pins the core offset-safety invariant: the consumer must never commit an offset
+/// past messages the application has not consumed. Loss of this property silently
+/// converts the client from at-least-once to at-most-once.
+/// Covers issues #2059 (auto-commit never commits in-flight/prefetched offsets),
+/// #2060 (deserializer failure never lets commits advance past the poison record),
+/// and #2062 (uncommitted progress on revoked partitions is redelivered, never skipped).
+/// </summary>
+[Category("Consumer")]
+public sealed class OffsetCommitSafetyTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task AutoCommit_InFlightAndPrefetchedMessages_NeverCommitted()
+    {
+        const int messageCount = 50;
+        const int heldMessageIndex = 5;
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"offset-safety-inflight-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+
+        await ProduceMessagesAsync(topic, messageCount);
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+
+        await using (var consumer = await CreateAutoCommitConsumerAsync(groupId, TimeSpan.FromMilliseconds(100)))
+        {
+            consumer.Subscribe(topic);
+
+            var consumed = 0;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            await foreach (var message in consumer.ConsumeAsync(cts.Token))
+            {
+                consumed++;
+
+                if (consumed == heldMessageIndex)
+                {
+                    // Hold this message in-flight while the 100ms auto-commit timer fires
+                    // many times. Prefetch has buffered records far beyond this point, but
+                    // the committed offset must never advance past the consumed boundary:
+                    // committing the held message would be offset `heldMessageIndex`, so
+                    // anything above `message.Offset` is a safety violation.
+                    await AssertCommittedNeverExceedsAsync(
+                        admin, groupId, partition, message.Offset, TimeSpan.FromSeconds(1.5), cts.Token);
+                }
+
+                if (consumed == messageCount)
+                    break;
+            }
+
+            await consumer.CloseAsync();
+        }
+
+        // Everything was consumed, so close-commit must land exactly at the log end:
+        // lower would lose the final commit, higher would skip messages on restart.
+        var finalOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId);
+        await Assert.That(finalOffsets[partition]).IsEqualTo(messageCount);
+    }
+
+    [Test]
+    public async Task Rebalance_UncommittedProgress_RedeliveredNotSkipped()
+    {
+        const int partitions = 2;
+        const int messagesPerPartition = 30;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions);
+        var groupId = $"offset-safety-rebalance-{Guid.NewGuid():N}";
+
+        await ProduceMessagesAsync(topic, messagesPerPartition, partitions);
+
+        // Auto-commit mode with an interval that never elapses: all progress made by the
+        // first consumer stays uncommitted, so when the second consumer joins and takes
+        // over a partition, everything after the last committed position must be
+        // redelivered — a rebalance may create duplicates but must never create gaps.
+        var seen = new ConcurrentDictionary<(int Partition, long Offset), byte>();
+        using var stopConsuming = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        await using var consumerA = await CreateAutoCommitConsumerAsync(groupId, TimeSpan.FromMinutes(10));
+        consumerA.Subscribe(topic);
+        // Consume slowly so the group rebalance happens mid-partition.
+        var consumerATask = ConsumeIntoAsync(consumerA, seen, TimeSpan.FromMilliseconds(100), stopConsuming.Token);
+
+        await WaitForConditionAsync(() => seen.Count >= 10, TimeSpan.FromSeconds(60));
+
+        await using var consumerB = await CreateAutoCommitConsumerAsync(groupId, TimeSpan.FromMinutes(10));
+        consumerB.Subscribe(topic);
+        var consumerBTask = ConsumeIntoAsync(consumerB, seen, TimeSpan.Zero, stopConsuming.Token);
+
+        await WaitForConditionAsync(
+            () => seen.Count >= partitions * messagesPerPartition,
+            TimeSpan.FromSeconds(90));
+
+        stopConsuming.Cancel();
+        await Task.WhenAll(consumerATask, consumerBTask);
+
+        for (var p = 0; p < partitions; p++)
+        {
+            for (long offset = 0; offset < messagesPerPartition; offset++)
+            {
+                await Assert.That(seen.ContainsKey((p, offset)))
+                    .IsTrue()
+                    .Because($"message at partition {p} offset {offset} was skipped across the rebalance");
+            }
+        }
+    }
+
+    [Test]
+    public async Task Resume_CommittedOffsetInsideBatch_StartsExactlyAtCommittedOffset()
+    {
+        const int messageCount = 10;
+        const long committedOffset = 5;
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"offset-safety-midbatch-{Guid.NewGuid():N}";
+
+        // ProduceAllAsync coalesces the messages into few (typically one) record batches,
+        // so the committed offset lands inside a batch. The broker returns whole batches,
+        // and the client must skip the leading records below the fetch position instead
+        // of re-delivering already-committed records.
+        await ProduceMessagesAsync(topic, messageCount);
+
+        await using (var committer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync())
+        {
+            committer.Subscribe(topic);
+            await committer.CommitAsync([new TopicPartitionOffset(topic, 0, committedOffset)]);
+            await committer.CloseAsync();
+        }
+
+        await using var resumed = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        resumed.Subscribe(topic);
+
+        var offsets = new List<long>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var message in resumed.ConsumeAsync(cts.Token))
+        {
+            offsets.Add(message.Offset);
+            if (offsets.Count >= messageCount - committedOffset)
+                break;
+        }
+
+        // Exactly the records from the committed offset onwards, in order — no
+        // re-delivery of committed records, no skipped records.
+        await Assert.That(offsets).IsEquivalentTo(
+            Enumerable.Range((int)committedOffset, (int)(messageCount - committedOffset)).Select(i => (long)i).ToArray());
+    }
+
+    [Test]
+    public async Task PoisonMessage_DeserializerThrows_SurfacesErrorAndNeverCommitsPastPoison()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"offset-safety-poison-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+        const long poisonOffset = 2;
+
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync())
+        {
+            await producer.ProduceAllAsync(
+                new[] { "ok-0", "ok-1", PoisonValueDeserializer.PoisonValue, "ok-3" }
+                    .Select(value => new ProducerMessage<string, string>
+                    {
+                        Topic = topic,
+                        Key = "key",
+                        Value = value
+                    }));
+        }
+
+        await using var admin = KafkaContainer.CreateAdminClient();
+
+        await using (var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoCommitInterval(TimeSpan.FromMilliseconds(100))
+            .WithValueDeserializer(new PoisonValueDeserializer())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync())
+        {
+            consumer.Subscribe(topic);
+
+            var receivedOffsets = new List<long>();
+            Exception? surfaced = null;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
+            {
+                await foreach (var message in consumer.ConsumeAsync(cts.Token))
+                {
+                    receivedOffsets.Add(message.Offset);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                surfaced = ex;
+            }
+
+            // The deserializer failure must surface, not be swallowed with the record skipped.
+            await Assert.That(surfaced).IsNotNull();
+            await Assert.That(receivedOffsets).IsEquivalentTo([0L, 1L]);
+
+            // Let the auto-commit timer fire repeatedly: it may commit the records
+            // delivered before the poison one, but never the poison record itself.
+            await AssertCommittedNeverExceedsAsync(
+                admin, groupId, partition, poisonOffset, TimeSpan.FromMilliseconds(500));
+
+            await consumer.CloseAsync();
+        }
+
+        var finalOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId);
+        await Assert.That(finalOffsets[partition]).IsEqualTo(poisonOffset);
+
+        // A restarted consumer must be redelivered the poison record — it was never
+        // processed, so committing past it would have lost it.
+        await using var resumed = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        resumed.Subscribe(topic);
+
+        using var resumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var redelivered = await resumed.ConsumeOneAsync(TimeSpan.FromSeconds(30), resumeCts.Token);
+
+        await Assert.That(redelivered).IsNotNull();
+        await Assert.That(redelivered!.Value.Offset).IsEqualTo(poisonOffset);
+        await Assert.That(redelivered.Value.Value).IsEqualTo(PoisonValueDeserializer.PoisonValue);
+    }
+
+    private async Task ProduceMessagesAsync(string topic, int messagesPerPartition, int partitions = 1)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAllAsync(Enumerable.Range(0, partitions)
+            .SelectMany(p => Enumerable.Range(0, messagesPerPartition)
+                .Select(i => new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = $"key-{i}",
+                    Value = $"value-{i}",
+                    Partition = p
+                })));
+    }
+
+    /// <summary>
+    /// Polls the broker-committed offset for the group over the given window, asserting it
+    /// never exceeds <paramref name="upperBound"/>. Polls rather than delaying once so a
+    /// violation is caught as soon as the auto-commit timer publishes it.
+    /// </summary>
+    private static async Task AssertCommittedNeverExceedsAsync(
+        IAdminClient admin,
+        string groupId,
+        TopicPartition partition,
+        long upperBound,
+        TimeSpan window,
+        CancellationToken cancellationToken = default)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (elapsed.Elapsed < window)
+        {
+            var committedOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken);
+            if (committedOffsets.TryGetValue(partition, out var committed))
+            {
+                await Assert.That(committed).IsLessThanOrEqualTo(upperBound);
+            }
+
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateAutoCommitConsumerAsync(
+        string groupId,
+        TimeSpan autoCommitInterval)
+    {
+        return await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoCommitInterval(autoCommitInterval)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+    }
+
+    private static Task ConsumeIntoAsync(
+        IKafkaConsumer<string, string> consumer,
+        ConcurrentDictionary<(int Partition, long Offset), byte> seen,
+        TimeSpan perMessageDelay,
+        CancellationToken cancellationToken)
+    {
+        return Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var message in consumer.ConsumeAsync(cancellationToken))
+                {
+                    seen.TryAdd((message.Partition, message.Offset), 0);
+
+                    if (perMessageDelay > TimeSpan.Zero)
+                        await Task.Delay(perMessageDelay, cancellationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the test stops consumption.
+            }
+        }, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// String deserializer that throws on a specific payload, simulating a poison message.
+    /// </summary>
+    private sealed class PoisonValueDeserializer : IDeserializer<string>
+    {
+        public const string PoisonValue = "poison";
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var value = Encoding.UTF8.GetString(data.Span);
+            return value == PoisonValue
+                ? throw new FormatException($"Simulated poison message: '{value}'.")
+                : value;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
@@ -1,0 +1,175 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Concurrency tests for the active consumed position seqlock
+/// (<c>PublishActiveConsumedPosition</c> / <c>TryReadActiveConsumedPosition</c> /
+/// <c>ClearActiveConsumedPosition</c>). In auto-commit mode this seqlock hands the
+/// consume thread's position to commit/close/GetPosition readers; a torn read here
+/// would commit an offset from one partition attributed to another — an offset-safety
+/// violation. Covers issue #2061.
+/// </summary>
+public sealed class ActiveConsumedPositionSeqlockTests
+{
+    private delegate void PublishDelegate(TopicPartition partition, long position, int leaderEpoch);
+    private delegate bool TryReadDelegate(out TopicPartition partition, out long position, out int leaderEpoch, out int version);
+    private delegate void ClearDelegate(TopicPartition partition, long position);
+
+    [Test]
+    public async Task PublishThenRead_ReturnsExactPublishedTuple()
+    {
+        await using var consumer = CreateConsumer();
+        var (publish, tryRead, clear) = CreateSeqlockDelegates(consumer);
+        var partition = new TopicPartition("topic-a", 3);
+
+        publish(partition, 42, 7);
+
+        var read = tryRead(out var readPartition, out var position, out var leaderEpoch, out _);
+
+        await Assert.That(read).IsTrue();
+        await Assert.That(readPartition).IsEqualTo(partition);
+        await Assert.That(position).IsEqualTo(42);
+        await Assert.That(leaderEpoch).IsEqualTo(7);
+
+        clear(partition, 42);
+
+        await Assert.That(tryRead(out _, out _, out _, out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task Clear_WithStalePosition_DoesNotClearNewerPublish()
+    {
+        await using var consumer = CreateConsumer();
+        var (publish, tryRead, clear) = CreateSeqlockDelegates(consumer);
+        var partition = new TopicPartition("topic-a", 0);
+
+        publish(partition, 10, 1);
+        publish(partition, 11, 1);
+
+        // A commit thread that snapshotted position 10 must not wipe the newer position 11.
+        clear(partition, 10);
+
+        var read = tryRead(out var readPartition, out var position, out _, out _);
+
+        await Assert.That(read).IsTrue();
+        await Assert.That(readPartition).IsEqualTo(partition);
+        await Assert.That(position).IsEqualTo(11);
+    }
+
+    [Test]
+    public async Task ConcurrentPublishReadClear_NeverExposesTornTuple()
+    {
+        await using var consumer = CreateConsumer();
+        var (publish, tryRead, clear) = CreateSeqlockDelegates(consumer);
+
+        // Every published tuple is fully derivable from its position, so any reader
+        // observing a (topic, partition, epoch) that does not match its position has
+        // seen a torn mix of two writes.
+        const long iterations = 300_000;
+        using var readersStop = new CancellationTokenSource();
+        var violations = new List<string>();
+        var violationLock = new object();
+        long successfulReads = 0;
+
+        void RecordViolation(string message)
+        {
+            lock (violationLock)
+            {
+                if (violations.Count < 10)
+                    violations.Add(message);
+            }
+        }
+
+        var readers = Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
+        {
+            while (!readersStop.IsCancellationRequested)
+            {
+                if (!tryRead(out var partition, out var position, out var leaderEpoch, out _))
+                    continue;
+
+                Interlocked.Increment(ref successfulReads);
+
+                var expected = ExpectedTupleFor(position);
+                if (partition != expected.Partition || leaderEpoch != expected.LeaderEpoch)
+                {
+                    RecordViolation(
+                        $"Read ({partition}, position {position}, epoch {leaderEpoch}) " +
+                        $"but position {position} was published as ({expected.Partition}, epoch {expected.LeaderEpoch})");
+                }
+            }
+        })).ToArray();
+
+        var clearer = Task.Run(() =>
+        {
+            while (!readersStop.IsCancellationRequested)
+            {
+                if (tryRead(out var partition, out var position, out _, out _))
+                    clear(partition, position);
+            }
+        });
+
+        // Single publisher mirrors production: only the consume thread publishes.
+        for (long position = 1; position <= iterations; position++)
+        {
+            var tuple = ExpectedTupleFor(position);
+            publish(tuple.Partition, position, tuple.LeaderEpoch);
+        }
+
+        readersStop.Cancel();
+        await Task.WhenAll([.. readers, clearer]);
+
+        await Assert.That(violations).IsEmpty();
+        // The readers must have actually observed published values for the test to mean anything.
+        await Assert.That(Interlocked.Read(ref successfulReads)).IsGreaterThan(1_000);
+    }
+
+    /// <summary>
+    /// Derives the unique (partition, epoch) tuple published for a given position.
+    /// Runs of 16 consecutive positions share a partition so both the same-partition
+    /// fast path and the full seqlock write path in PublishActiveConsumedPosition are exercised.
+    /// </summary>
+    private static (TopicPartition Partition, int LeaderEpoch) ExpectedTupleFor(long position)
+    {
+        var partitionIndex = (int)((position / 16) % 5);
+        var topic = partitionIndex % 2 == 0 ? "topic-even" : "topic-odd";
+        return (new TopicPartition(topic, partitionIndex), partitionIndex * 31 + 7);
+    }
+
+    private static (PublishDelegate Publish, TryReadDelegate TryRead, ClearDelegate Clear) CreateSeqlockDelegates(
+        KafkaConsumer<string, string> consumer)
+    {
+        var type = typeof(KafkaConsumer<string, string>);
+
+        var publish = type
+            .GetMethod("PublishActiveConsumedPosition", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .CreateDelegate<PublishDelegate>(consumer);
+
+        var tryRead = type
+            .GetMethod("TryReadActiveConsumedPosition", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .CreateDelegate<TryReadDelegate>(consumer);
+
+        var clear = type
+            .GetMethod(
+                "ClearActiveConsumedPosition",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                [typeof(TopicPartition), typeof(long)])!
+            .CreateDelegate<ClearDelegate>(consumer);
+
+        return (publish, tryRead, clear);
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer()
+    {
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Auto
+            },
+            Serializers.String,
+            Serializers.String);
+    }
+}


### PR DESCRIPTION
## Summary

Audit of offset-commit safety (never lose a message; never commit an offset past unconsumed messages) produced issues #2059-#2067. This PR closes the test-gap issues — and in writing those tests, exposed and fixes a real consumer bug (#2074).

## Bug fix: mid-batch fetch positions re-delivered committed records (#2074)

Brokers return whole record batches. A fetch positioned mid-batch (resume from a committed offset, seek, explicit commit target inside a batch) received the entire straddling batch, and the client yielded the leading records **below** the requested offset — re-delivering records the application had already consumed and committed. Duplicate-delivery direction (no loss), but it breaks committed-offset resume precision and is an exactly-once duplicate-output hazard in consume-transform-produce pipelines.

No existing test caught this because every integration test produces sequentially (`await ProduceAsync` per message), which creates one-record batches: fetch positions were always batch-aligned, so the straddle path never executed.

Fix: `PendingFetchData` captures the requested fetch offset (from `_fetchPositions` at response processing, direct + prefetch paths) and skips leading records below it on first `MoveNext()`. One-time cold-path loop bounded by a single batch; zero added cost to steady-state per-record iteration. Negative positions (SeekToEnd / reset sentinels) disable the skip. The raw-batch consume API intentionally yields whole batches and is unchanged.

## New tests (closes #2059, closes #2060, closes #2061, closes #2062)

`tests/Dekaf.Tests.Integration/RealWorld/OffsetCommitSafetyTests.cs`:
- **AutoCommit_InFlightAndPrefetchedMessages_NeverCommitted** — holds a message in-flight while the 100ms auto-commit timer fires ~15 times, polling broker-committed offsets via AdminClient: committed never exceeds the consumed boundary despite prefetch having buffered the full log; close-commit lands exactly at log end.
- **Rebalance_UncommittedProgress_RedeliveredNotSkipped** — consumer A (auto-commit, interval never fires) consumes mid-partition when consumer B joins; asserts the union of records seen covers every produced message: rebalances may duplicate, never gap. Assertions survive a future commit-on-revoke (#2063).
- **PoisonMessage_DeserializerThrows_SurfacesErrorAndNeverCommitsPastPoison** — deserializer failure surfaces to the caller, commits never pass the poison record, and it is redelivered on restart.
- **Resume_CommittedOffsetInsideBatch_StartsExactlyAtCommittedOffset** — direct regression test for #2074.

`tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs`:
- Deterministic publish/read/clear semantics (including stale-clear not wiping a newer publish) plus a 300k-iteration concurrent hammer where every published tuple is derivable from its position — any torn (partition, offset, epoch) read fails. Runs in ~300ms.

Also documents the auto-commit offset-safety contract on `AutoCommitLoopAsync`/`TrackConsumedPosition` (the background loop commits only fetch-boundary-flushed offsets and never reads the active snapshot), replacing a misleading inline comment.

Integration tests produce via `ProduceAllAsync` so records form real multi-record batches — sequential produce masks batch-straddle bugs entirely.

## Remaining open issues from the audit

#2063 (commit-on-revoke behavior), #2064 (Auto-mode chaos oracle), #2065 (interior batch corruption silently drops tail with CheckCrcs off), #2066 (auto-commit loop resilience tests), #2067 (producer redelivery test gaps).

## Verification

- Unit: 5461/5461 pass (full suite, twice).
- New integration class: 4/4, repeated 4+ runs (stability check for the timing-window tests).
- Regression sweeps: offset/fetch/txn classes 75/75; consumer/group/convenience classes 73/73.