### PR TITLE
Post-merge review follow-ups for #2073

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -304,10 +304,13 @@ public class OrderConsumer : BackgroundService
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to process order {OrderId}", message.Key);
-                    // Offset not stored: rethrow so the host restarts the consumer and
-                    // the order is redelivered. Do NOT swallow and continue — storing
-                    // any later offset would commit past this one and lose it. If you
-                    // must keep consuming, dead-letter the failed order first.
+                    // Offset not stored: rethrow so the failure isn't silently
+                    // swallowed. By default this stops the host process; pair it
+                    // with a process supervisor (systemd, Kubernetes, container
+                    // restart policy) so the service restarts and the order is
+                    // redelivered. Do NOT swallow and continue — storing any later
+                    // offset would commit past this one and lose it. If you must
+                    // keep consuming, dead-letter the failed order first.
                     throw;
                 }
             }

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -26,6 +26,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
     private readonly Dictionary<TopicPartition, long> _storedOffsets = [];
+    private readonly string? _groupId;
     private readonly string? _memberId;
     private string? _subscriptionPattern;
     private bool _disposed;
@@ -68,7 +69,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         _keyDeserializer = keyDeserializer ?? throw new ArgumentNullException(nameof(keyDeserializer));
         _valueDeserializer = valueDeserializer ?? throw new ArgumentNullException(nameof(valueDeserializer));
         _options = options ?? throw new ArgumentNullException(nameof(options));
-        _memberId = options.GroupId is null ? null : options.MemberId ?? Guid.NewGuid().ToString("N");
+        // Match KafkaConsumer, which treats an empty GroupId as "no consumer group"
+        // (no coordinator, no commits). Normalizing here keeps every group-dependent
+        // code path in this class consistent with production behavior.
+        _groupId = string.IsNullOrEmpty(options.GroupId) ? null : options.GroupId;
+        _memberId = _groupId is null ? null : options.MemberId ?? Guid.NewGuid().ToString("N");
     }
 
     public IReadOnlySet<string> Subscription
@@ -109,11 +114,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     public string? MemberId => _memberId;
 
-    public ConsumerGroupMetadata? ConsumerGroupMetadata => _options.GroupId is null || _memberId is null
+    public ConsumerGroupMetadata? ConsumerGroupMetadata => _groupId is null || _memberId is null
         ? null
         : new ConsumerGroupMetadata
         {
-            GroupId = _options.GroupId,
+            GroupId = _groupId,
             GenerationId = 1,
             MemberId = _memberId
         };
@@ -128,7 +133,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
-    bool IConsumerCommitModeSource.HasConsumerGroup => !string.IsNullOrEmpty(_options.GroupId);
+    bool IConsumerCommitModeSource.HasConsumerGroup => _groupId is not null;
 
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;
@@ -196,7 +201,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         if (string.IsNullOrWhiteSpace(pattern))
             throw new ArgumentException("Subscription pattern must be specified.", nameof(pattern));
 
-        if (string.IsNullOrWhiteSpace(_options.GroupId))
+        if (string.IsNullOrWhiteSpace(_groupId))
             throw new InvalidOperationException("Server-side regex subscriptions require a consumer group ID.");
 
         ThrowIfDisposed();
@@ -334,8 +339,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        if (_options.GroupId is not null)
-            _cluster.CommitOffsets(_options.GroupId, offsets);
+        if (_groupId is not null)
+            _cluster.CommitOffsets(_groupId, offsets);
 
         return ValueTask.CompletedTask;
     }
@@ -395,9 +400,9 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        var offset = _options.GroupId is null
+        var offset = _groupId is null
             ? null
-            : _cluster.GetCommittedOffset(_options.GroupId, partition);
+            : _cluster.GetCommittedOffset(_groupId, partition);
 
         return ValueTask.FromResult(offset);
     }
@@ -654,8 +659,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private long GetStartOffset(TopicPartition partition)
     {
-        if (_options.GroupId is not null &&
-            _cluster.GetCommittedOffset(_options.GroupId, partition) is { } committed)
+        if (_groupId is not null &&
+            _cluster.GetCommittedOffset(_groupId, partition) is { } committed)
         {
             return committed;
         }
@@ -688,7 +693,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private void CommitOffsetsFrom(Dictionary<TopicPartition, long> positions)
     {
-        if (_options.GroupId is null)
+        if (_groupId is null)
             return;
 
         var assignment = GetCurrentAssignmentUnderLock();
@@ -701,32 +706,32 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             .ToArray();
 
         if (offsets.Length > 0)
-            _cluster.CommitOffsets(_options.GroupId, offsets);
+            _cluster.CommitOffsets(_groupId, offsets);
     }
 
     private IReadOnlySet<TopicPartition> GetCurrentAssignmentUnderLock()
     {
-        if (_options.GroupId is null || _memberId is null)
+        if (_groupId is null || _memberId is null)
             return _assignment;
 
-        var owned = _cluster.GetConsumerGroupAssignment(_options.GroupId, _memberId);
+        var owned = _cluster.GetConsumerGroupAssignment(_groupId, _memberId);
         return owned.Where(_assignment.Contains).ToHashSet();
     }
 
     private void RegisterConsumerGroupMemberUnderLock()
     {
-        if (_options.GroupId is null || _memberId is null)
+        if (_groupId is null || _memberId is null)
             return;
 
-        _cluster.RegisterConsumerGroupMember(_options.GroupId, _memberId, _assignment);
+        _cluster.RegisterConsumerGroupMember(_groupId, _memberId, _assignment);
     }
 
     private void UnregisterConsumerGroupMemberUnderLock()
     {
-        if (_options.GroupId is null || _memberId is null)
+        if (_groupId is null || _memberId is null)
             return;
 
-        _cluster.UnregisterConsumerGroupMember(_options.GroupId, _memberId);
+        _cluster.UnregisterConsumerGroupMember(_groupId, _memberId);
     }
 
     private void ThrowIfDisposed()

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -128,7 +128,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
-    bool IConsumerCommitModeSource.HasConsumerGroup => _options.GroupId is not null;
+    bool IConsumerCommitModeSource.HasConsumerGroup => !string.IsNullOrEmpty(_options.GroupId);
 
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -55,6 +55,67 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task Consumer_EmptyGroupId_BehavesAsNoGroup()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 1);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await Assert.That(consumer.ConsumerGroupMetadata).IsNull();
+        await Assert.That(consumer.MemberId).IsNull();
+        await Assert.That(((IConsumerCommitModeSource)consumer).HasConsumerGroup).IsFalse();
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_EmptyGroupIdWithAutoCommitDefaults_DoesNotThrow()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 1);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "" });
+        consumer.Subscribe("orders");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        try
+        {
+            await consumer.RunPartitionedAsync(
+                static (_, _) => ValueTask.CompletedTask,
+                new PartitionedProcessingOptions(),
+                cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: guard passed (no group), run exited via the cancelled token.
+        }
+    }
+
+    [Test]
+    public async Task RunPartitionedAsync_GroupWithAutoCommitDefaults_Throws()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("orders", partitionCount: 1);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions { GroupId = "workers" });
+        consumer.Subscribe("orders");
+
+        await Assert.That(async () => await consumer.RunPartitionedAsync(
+                static (_, _) => ValueTask.CompletedTask,
+                new PartitionedProcessingOptions(),
+                CancellationToken.None))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task Consumer_ManualCommit_PersistsGroupOffsets()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -85,9 +85,15 @@ public sealed class InMemoryKafkaClusterTests
         // An empty GroupId means no group to auto-commit through, so the commit-mode
         // guard must not fire. The run then fails on the in-memory consumer's missing
         // batch-fetch support — proof execution got past the guard (a guard regression
-        // would surface InvalidOperationException here instead).
+        // would surface InvalidOperationException here instead). The processor drains
+        // its stream rather than returning immediately so the lane exits cleanly and
+        // cannot fault first with its own InvalidOperationException.
         await Assert.That(async () => await consumer.RunPartitionedAsync(
-                static (_, _) => ValueTask.CompletedTask,
+                static async (context, token) =>
+                {
+                    await foreach (var message in context.Messages.WithCancellation(token))
+                        context.MarkProcessed(message);
+                },
                 new PartitionedProcessingOptions(),
                 CancellationToken.None))
             .Throws<NotSupportedException>();

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -73,7 +73,7 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
-    public async Task RunPartitionedAsync_EmptyGroupIdWithAutoCommitDefaults_DoesNotThrow()
+    public async Task RunPartitionedAsync_EmptyGroupIdWithAutoCommitDefaults_PassesCommitModeGuard()
     {
         var cluster = new InMemoryKafkaCluster();
         cluster.CreateTopic("orders", partitionCount: 1);
@@ -82,20 +82,15 @@ public sealed class InMemoryKafkaClusterTests
             new InMemoryConsumerOptions { GroupId = "" });
         consumer.Subscribe("orders");
 
-        using var cts = new CancellationTokenSource();
-        await cts.CancelAsync();
-
-        try
-        {
-            await consumer.RunPartitionedAsync(
+        // An empty GroupId means no group to auto-commit through, so the commit-mode
+        // guard must not fire. The run then fails on the in-memory consumer's missing
+        // batch-fetch support — proof execution got past the guard (a guard regression
+        // would surface InvalidOperationException here instead).
+        await Assert.That(async () => await consumer.RunPartitionedAsync(
                 static (_, _) => ValueTask.CompletedTask,
                 new PartitionedProcessingOptions(),
-                cts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected: guard passed (no group), run exited via the cancelled token.
-        }
+                CancellationToken.None))
+            .Throws<NotSupportedException>();
     }
 
     [Test]


### PR DESCRIPTION
Addresses the two findings from the final automated review on #2073, which landed concurrently with the merge:

1. **`InMemoryConsumer.HasConsumerGroup` diverged from `KafkaConsumer`** — `is not null` vs `!string.IsNullOrEmpty`. For `GroupId = \"\"` the in-memory consumer claimed a group while the real consumer (whose coordinator-creation check also uses `IsNullOrEmpty`) does not, so a guard test against `InMemoryConsumer` would not reproduce production behavior. Aligned to `!string.IsNullOrEmpty`.

2. **basics.md example comment overstated rethrow behavior** — an unhandled exception from `BackgroundService.ExecuteAsync` stops the whole host by default (`BackgroundServiceExceptionBehavior.StopHost`); nothing restarts the consumer in-process. The comment now says to pair the rethrow with a process supervisor (systemd/Kubernetes/container restart policy) for redelivery.