### PR TITLE
Surface interior record corruption to consumers

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -370,13 +370,21 @@ internal sealed class PendingFetchData : IDisposable
 
         AttachParsedRecordSlab(_batches);
 
-        for (var i = 0; i < _batches.Count; i++)
+        try
         {
-            var batch = _batches[i];
-            batch.EnsureAllRecordsParsed();
-            if (batch.Records is Protocol.Records.LazyRecordList lazyList)
-                lazyList.EnsureAllParsed();
+            for (var i = 0; i < _batches.Count; i++)
+            {
+                var batch = _batches[i];
+                batch.EnsureAllRecordsParsed();
+                if (batch.Records is Protocol.Records.LazyRecordList lazyList)
+                    lazyList.EnsureAllParsed();
+            }
         }
+        catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
+        {
+            throw new ConsumeException($"Failed to parse record batch for {Topic}-{PartitionIndex}.", ex);
+        }
+
         _eagerParsed = true;
     }
 

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -126,17 +126,24 @@ public readonly record struct Record
         var length = reader.ReadVarInt();
         if (length < 0)
             throw new MalformedProtocolDataException($"Invalid record length {length}");
-        if (length > reader.Remaining)
-            throw new InsufficientDataException();
 
+        var availableBodyBytes = reader.Remaining;
         var bodyStart = reader.Consumed;
         try
         {
             return ReadBody(ref reader, length, bodyStart);
         }
-        catch (InsufficientDataException ex)
+        catch (RecordBodyLengthMismatchException ex)
+        {
+            throw new MalformedProtocolDataException(ex.Message, ex);
+        }
+        catch (InsufficientDataException ex) when (length <= availableBodyBytes)
         {
             throw new MalformedProtocolDataException("Record body cannot be parsed within its declared length", ex);
+        }
+        catch (MalformedProtocolDataException) when (length > availableBodyBytes)
+        {
+            throw new InsufficientDataException();
         }
     }
 
@@ -200,9 +207,11 @@ public readonly record struct Record
     private static void ValidateBodyLength(int declaredLength, long consumedLength)
     {
         if (consumedLength != declaredLength)
-            throw new MalformedProtocolDataException(
+            throw new RecordBodyLengthMismatchException(
                 $"Record body length mismatch: declared {declaredLength}, consumed {consumedLength}");
     }
+
+    private sealed class RecordBodyLengthMismatchException(string message) : Exception(message);
 
     private static void ValidateHeaderCount(int headerCount, int recordBodyLength, long bodyBytesRead, long readerRemaining)
     {

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -13,9 +13,6 @@ namespace Dekaf.Protocol.Records;
 /// </summary>
 public readonly record struct Record
 {
-    // Length prefix plus the six required one-byte record-body fields.
-    internal const int MinimumEncodedSize = 7;
-
     // Even empty headers need two wire bytes. This limit already represents at least
     // 512 KiB of header metadata while bounding pooled-array amplification and parse work.
     internal const int MaxReasonableHeaderCount = 256 * 1024;
@@ -126,8 +123,22 @@ public readonly record struct Record
         var length = reader.ReadVarInt();
         if (length < 0)
             throw new MalformedProtocolDataException($"Invalid record length {length}");
+        if (length > reader.Remaining)
+            throw new InsufficientDataException();
 
         var bodyStart = reader.Consumed;
+        try
+        {
+            return ReadBody(ref reader, length, bodyStart);
+        }
+        catch (InsufficientDataException ex)
+        {
+            throw new MalformedProtocolDataException("Record body cannot be parsed within its declared length", ex);
+        }
+    }
+
+    private static Record ReadBody(ref KafkaProtocolReader reader, int length, long bodyStart)
+    {
         var attributes = (byte)reader.ReadInt8();
         var timestampDelta = reader.ReadVarLong();
         var offsetDelta = reader.ReadVarInt();
@@ -144,7 +155,6 @@ public readonly record struct Record
         ValidateHeaderCount(headerCount, length, reader.Consumed - bodyStart, reader.Remaining);
 
         Header[]? headers = null;
-
         if (headerCount > 0)
         {
             // Rent from ArrayPool to avoid per-record allocation.
@@ -154,15 +164,19 @@ public readonly record struct Record
             try
             {
                 for (var i = 0; i < headerCount; i++)
-                {
                     headers[i] = Header.Read(ref reader);
-                }
+
+                ValidateBodyLength(length, reader.Consumed - bodyStart);
             }
             catch
             {
                 ArrayPool<Header>.Shared.Return(headers, clearArray: true);
                 throw;
             }
+        }
+        else
+        {
+            ValidateBodyLength(length, reader.Consumed - bodyStart);
         }
 
         return new Record
@@ -178,6 +192,13 @@ public readonly record struct Record
             Headers = headers,
             HeaderCount = headerCount
         };
+    }
+
+    private static void ValidateBodyLength(int declaredLength, long consumedLength)
+    {
+        if (consumedLength != declaredLength)
+            throw new MalformedProtocolDataException(
+                $"Record body length mismatch: declared {declaredLength}, consumed {consumedLength}");
     }
 
     private static void ValidateHeaderCount(int headerCount, int recordBodyLength, long bodyBytesRead, long readerRemaining)

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -13,6 +13,9 @@ namespace Dekaf.Protocol.Records;
 /// </summary>
 public readonly record struct Record
 {
+    // Length prefix plus the six required one-byte record-body fields.
+    internal const int MinimumEncodedSize = 7;
+
     // Even empty headers need two wire bytes. This limit already represents at least
     // 512 KiB of header metadata while bounding pooled-array amplification and parse work.
     internal const int MaxReasonableHeaderCount = 256 * 1024;

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -13,6 +13,9 @@ namespace Dekaf.Protocol.Records;
 /// </summary>
 public readonly record struct Record
 {
+    // Length varint plus six mandatory one-byte body fields.
+    internal const int MinimumEncodedSize = 7;
+
     // Even empty headers need two wire bytes. This limit already represents at least
     // 512 KiB of header metadata while bounding pooled-array amplification and parse work.
     internal const int MaxReasonableHeaderCount = 256 * 1024;

--- a/src/Dekaf/Protocol/Records/Record.cs
+++ b/src/Dekaf/Protocol/Records/Record.cs
@@ -128,10 +128,18 @@ public readonly record struct Record
             throw new MalformedProtocolDataException($"Invalid record length {length}");
 
         var availableBodyBytes = reader.Remaining;
-        var bodyStart = reader.Consumed;
+        var bodyReader = reader;
+        var bodyStart = bodyReader.Consumed;
+        if (length <= availableBodyBytes)
+        {
+            bodyReader = new KafkaProtocolReader(reader.GetRemainingSequence().Slice(0, length));
+            bodyStart = 0;
+            reader.Skip(length);
+        }
+
         try
         {
-            return ReadBody(ref reader, length, bodyStart);
+            return ReadBody(ref bodyReader, length, bodyStart);
         }
         catch (RecordBodyLengthMismatchException ex)
         {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -546,7 +546,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         int declaredCount) =>
         exception is InsufficientDataException ||
         exception is MalformedProtocolDataException &&
-        (remaining == 0 || parsedCount == declaredCount - 1);
+        (remaining < Record.MinimumEncodedSize || parsedCount == declaredCount - 1);
 
     private void EnsureLazyRecordsParsedUpTo(int index)
     {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -539,6 +539,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal const int MaxReasonableLazyRecordCount = 1_000_000;
 
+    internal static bool IsTruncatedRecordTail(long remaining, int parsedCount, int declaredCount) =>
+        parsedCount == declaredCount - 1 || remaining < Record.MinimumEncodedSize;
+
     private void EnsureLazyRecordsParsedUpTo(int index)
     {
         if (_parsedRecords is null)
@@ -573,7 +576,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 _parsedRecordCount++;
                 _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
             }
-            catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
+            catch (Exception ex) when (
+                ex is InsufficientDataException or MalformedProtocolDataException &&
+                IsTruncatedRecordTail(reader.Remaining, _parsedRecordCount, _recordCount))
             {
                 Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedRecordCount} of {_recordCount} records parsed successfully.");
                 _recordCount = _parsedRecordCount;
@@ -1656,13 +1661,13 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _parsedRecords[_parsedCount++] = record;
                 _nextParseOffset = readerStartOffset + (int)reader.Consumed;
             }
-            catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
+            catch (Exception ex) when (
+                ex is InsufficientDataException or MalformedProtocolDataException &&
+                RecordBatch.IsTruncatedRecordTail(reader.Remaining, _parsedCount, _count))
             {
-                // Truncated fetch response or malformed varint — no more complete records
-                // can be parsed. Cap the count to what we've successfully parsed so far to
-                // prevent further attempts. This mirrors the partial batch handling in
-                // FetchResponse. MalformedProtocolDataException covers malformed variable-length
-                // integers that throw "Malformed variable-length integer".
+                // The raw record data ended before the declared record count. Cap the count to
+                // the successfully parsed records. A failure with bytes remaining is interior
+                // corruption and must propagate rather than silently dropping later records.
                 Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedCount} of {_count} records parsed successfully.");
                 _count = _parsedCount;
                 break;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -539,6 +539,15 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal const int MaxReasonableLazyRecordCount = 1_000_000;
 
+    internal static bool IsTruncatedRecordTail(
+        Exception exception,
+        long remaining,
+        int parsedCount,
+        int declaredCount) =>
+        exception is InsufficientDataException ||
+        exception is MalformedProtocolDataException &&
+        (remaining == 0 || parsedCount == declaredCount - 1);
+
     private void EnsureLazyRecordsParsedUpTo(int index)
     {
         if (_parsedRecords is null)
@@ -573,9 +582,11 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 _parsedRecordCount++;
                 _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
             }
-            catch (Exception ex) when (
-                ex is InsufficientDataException ||
-                ex is MalformedProtocolDataException && _parsedRecordCount == _recordCount - 1)
+            catch (Exception ex) when (IsTruncatedRecordTail(
+                ex,
+                reader.Remaining,
+                _parsedRecordCount,
+                _recordCount))
             {
                 Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedRecordCount} of {_recordCount} records parsed successfully.");
                 _recordCount = _parsedRecordCount;
@@ -1658,9 +1669,11 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _parsedRecords[_parsedCount++] = record;
                 _nextParseOffset = readerStartOffset + (int)reader.Consumed;
             }
-            catch (Exception ex) when (
-                ex is InsufficientDataException ||
-                ex is MalformedProtocolDataException && _parsedCount == _count - 1)
+            catch (Exception ex) when (RecordBatch.IsTruncatedRecordTail(
+                ex,
+                reader.Remaining,
+                _parsedCount,
+                _count))
             {
                 // The raw record data ended before the declared record count. Cap the count to
                 // the successfully parsed records. A failure with bytes remaining is interior

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -547,70 +547,16 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     {
         if (exception is InsufficientDataException)
         {
-            // A valid framed suffix proves bytes after the failed record belong to another
-            // record, so the short read is interior corruption rather than end truncation.
-            return parsedCount == declaredCount - 1 ||
-                   !HasCompleteRecordSuffix(availableRecordData);
+            // An incomplete record body has no trusted boundary: opaque key, value, or
+            // header bytes can look like a valid record. Preserve tail-truncation behavior
+            // rather than infer an interior record from payload contents.
+            return true;
         }
 
         // Issue #2065 intentionally excludes corruption in the final declared record.
         return exception is MalformedProtocolDataException &&
                (availableRecordData.Length < Record.MinimumEncodedSize ||
                 parsedCount == declaredCount - 1);
-    }
-
-    private static bool HasCompleteRecordSuffix(ReadOnlyMemory<byte> data)
-    {
-        for (var offset = 1; offset <= data.Length - Record.MinimumEncodedSize; offset++)
-        {
-            var suffix = data[offset..];
-            if (!TryReadRecordLength(suffix.Span, out var bodyLength, out var prefixLength) ||
-                bodyLength < Record.MinimumEncodedSize - 1 ||
-                bodyLength != suffix.Length - prefixLength)
-            {
-                continue;
-            }
-
-            var reader = new KafkaProtocolReader(suffix);
-            try
-            {
-                var record = Record.Read(ref reader);
-                if (record.Headers is not null)
-                    ArrayPool<Header>.Shared.Return(record.Headers, clearArray: true);
-
-                if (reader.Remaining == 0)
-                    return true;
-            }
-            catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
-            {
-                // This byte offset does not begin a complete record; continue scanning.
-            }
-        }
-
-        return false;
-    }
-
-    private static bool TryReadRecordLength(
-        ReadOnlySpan<byte> data,
-        out int length,
-        out int prefixLength)
-    {
-        uint encoded = 0;
-        for (var index = 0; index < 5 && index < data.Length; index++)
-        {
-            var current = data[index];
-            encoded |= (uint)(current & 0x7F) << (index * 7);
-            if ((current & 0x80) == 0)
-            {
-                length = (int)(encoded >> 1) ^ -(int)(encoded & 1);
-                prefixLength = index + 1;
-                return true;
-            }
-        }
-
-        length = 0;
-        prefixLength = 0;
-        return false;
     }
 
     private void EnsureLazyRecordsParsedUpTo(int index)
@@ -1745,8 +1691,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _count))
             {
                 // The raw record data ended before the declared record count. Cap the count to
-                // the successfully parsed records. A failure with bytes remaining is interior
-                // corruption and must propagate rather than silently dropping later records.
+                // the successfully parsed records. Unambiguous interior corruption propagates.
                 Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedCount} of {_count} records parsed successfully.");
                 _count = _parsedCount;
                 break;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -541,12 +541,77 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal static bool IsTruncatedRecordTail(
         Exception exception,
-        long availableRecordBytes,
+        ReadOnlyMemory<byte> availableRecordData,
         int parsedCount,
-        int declaredCount) =>
-        exception is InsufficientDataException ||
-        exception is MalformedProtocolDataException &&
-        (availableRecordBytes < Record.MinimumEncodedSize || parsedCount == declaredCount - 1);
+        int declaredCount)
+    {
+        if (exception is InsufficientDataException)
+        {
+            // A valid framed suffix proves bytes after the failed record belong to another
+            // record, so the short read is interior corruption rather than end truncation.
+            return parsedCount == declaredCount - 1 ||
+                   !HasCompleteRecordSuffix(availableRecordData);
+        }
+
+        // Issue #2065 intentionally excludes corruption in the final declared record.
+        return exception is MalformedProtocolDataException &&
+               (availableRecordData.Length < Record.MinimumEncodedSize ||
+                parsedCount == declaredCount - 1);
+    }
+
+    private static bool HasCompleteRecordSuffix(ReadOnlyMemory<byte> data)
+    {
+        for (var offset = 1; offset <= data.Length - Record.MinimumEncodedSize; offset++)
+        {
+            var suffix = data[offset..];
+            if (!TryReadRecordLength(suffix.Span, out var bodyLength, out var prefixLength) ||
+                bodyLength < Record.MinimumEncodedSize - 1 ||
+                bodyLength != suffix.Length - prefixLength)
+            {
+                continue;
+            }
+
+            var reader = new KafkaProtocolReader(suffix);
+            try
+            {
+                var record = Record.Read(ref reader);
+                if (record.Headers is not null)
+                    ArrayPool<Header>.Shared.Return(record.Headers, clearArray: true);
+
+                if (reader.Remaining == 0)
+                    return true;
+            }
+            catch (Exception ex) when (ex is InsufficientDataException or MalformedProtocolDataException)
+            {
+                // This byte offset does not begin a complete record; continue scanning.
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadRecordLength(
+        ReadOnlySpan<byte> data,
+        out int length,
+        out int prefixLength)
+    {
+        uint encoded = 0;
+        for (var index = 0; index < 5 && index < data.Length; index++)
+        {
+            var current = data[index];
+            encoded |= (uint)(current & 0x7F) << (index * 7);
+            if ((current & 0x80) == 0)
+            {
+                length = (int)(encoded >> 1) ^ -(int)(encoded & 1);
+                prefixLength = index + 1;
+                return true;
+            }
+        }
+
+        length = 0;
+        prefixLength = 0;
+        return false;
+    }
 
     private void EnsureLazyRecordsParsedUpTo(int index)
     {
@@ -576,7 +641,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 _parsedRecordsOffset = 0;
             }
 
-            var availableRecordBytes = reader.Remaining;
+            var availableRecordData = _rawRecordData.Slice(
+                readerStartOffset + (int)reader.Consumed);
             try
             {
                 _parsedRecords[_parsedRecordsOffset + _parsedRecordCount] = Record.Read(ref reader);
@@ -585,7 +651,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             }
             catch (Exception ex) when (IsTruncatedRecordTail(
                 ex,
-                availableRecordBytes,
+                availableRecordData,
                 _parsedRecordCount,
                 _recordCount))
             {
@@ -1664,7 +1730,8 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _parsedRecords = newArray;
             }
 
-            var availableRecordBytes = reader.Remaining;
+            var availableRecordData = _rawData.Slice(
+                readerStartOffset + (int)reader.Consumed);
             try
             {
                 var record = Record.Read(ref reader);
@@ -1673,7 +1740,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
             }
             catch (Exception ex) when (RecordBatch.IsTruncatedRecordTail(
                 ex,
-                availableRecordBytes,
+                availableRecordData,
                 _parsedCount,
                 _count))
             {

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -539,9 +539,6 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal const int MaxReasonableLazyRecordCount = 1_000_000;
 
-    internal static bool IsTruncatedRecordTail(long remaining, int parsedCount, int declaredCount) =>
-        parsedCount == declaredCount - 1 || remaining < Record.MinimumEncodedSize;
-
     private void EnsureLazyRecordsParsedUpTo(int index)
     {
         if (_parsedRecords is null)
@@ -577,8 +574,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 _nextRecordParseOffset = readerStartOffset + (int)reader.Consumed;
             }
             catch (Exception ex) when (
-                ex is InsufficientDataException or MalformedProtocolDataException &&
-                IsTruncatedRecordTail(reader.Remaining, _parsedRecordCount, _recordCount))
+                ex is InsufficientDataException ||
+                ex is MalformedProtocolDataException && _parsedRecordCount == _recordCount - 1)
             {
                 Trace.WriteLine($"Dekaf: Record parsing error ({ex.GetType().Name}) — {_parsedRecordCount} of {_recordCount} records parsed successfully.");
                 _recordCount = _parsedRecordCount;
@@ -1662,8 +1659,8 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _nextParseOffset = readerStartOffset + (int)reader.Consumed;
             }
             catch (Exception ex) when (
-                ex is InsufficientDataException or MalformedProtocolDataException &&
-                RecordBatch.IsTruncatedRecordTail(reader.Remaining, _parsedCount, _count))
+                ex is InsufficientDataException ||
+                ex is MalformedProtocolDataException && _parsedCount == _count - 1)
             {
                 // The raw record data ended before the declared record count. Cap the count to
                 // the successfully parsed records. A failure with bytes remaining is interior

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -541,12 +541,12 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal static bool IsTruncatedRecordTail(
         Exception exception,
-        long remaining,
+        long availableRecordBytes,
         int parsedCount,
         int declaredCount) =>
         exception is InsufficientDataException ||
         exception is MalformedProtocolDataException &&
-        (remaining < Record.MinimumEncodedSize || parsedCount == declaredCount - 1);
+        (availableRecordBytes < Record.MinimumEncodedSize || parsedCount == declaredCount - 1);
 
     private void EnsureLazyRecordsParsedUpTo(int index)
     {
@@ -576,6 +576,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 _parsedRecordsOffset = 0;
             }
 
+            var availableRecordBytes = reader.Remaining;
             try
             {
                 _parsedRecords[_parsedRecordsOffset + _parsedRecordCount] = Record.Read(ref reader);
@@ -584,7 +585,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             }
             catch (Exception ex) when (IsTruncatedRecordTail(
                 ex,
-                reader.Remaining,
+                availableRecordBytes,
                 _parsedRecordCount,
                 _recordCount))
             {
@@ -1663,6 +1664,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
                 _parsedRecords = newArray;
             }
 
+            var availableRecordBytes = reader.Remaining;
             try
             {
                 var record = Record.Read(ref reader);
@@ -1671,7 +1673,7 @@ internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable
             }
             catch (Exception ex) when (RecordBatch.IsTruncatedRecordTail(
                 ex,
-                reader.Remaining,
+                availableRecordBytes,
                 _parsedCount,
                 _count))
             {

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -216,6 +216,30 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_LongTruncatedTail_ReducesCountToParseableRecords()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = new byte[100] }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var firstTwoBuffer = new ArrayBufferWriter<byte>();
+        var firstTwoWriter = new KafkaProtocolWriter(firstTwoBuffer);
+        records[0].Write(ref firstTwoWriter);
+        records[1].Write(ref firstTwoWriter);
+        var truncatedData = buffer.WrittenMemory[..(firstTwoBuffer.WrittenCount + 40)];
+        using var lazyList = LazyRecordList.Create(truncatedData, count: 5);
+
+        await Assert.That(lazyList.ToArray()).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task LazyRecordList_CompletelyTruncated_ReducesCountToZero()
     {
         // Arrange: provide just 1 byte of data but claim 5 records

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -216,6 +216,31 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_InteriorOversizedRecordLength_Throws()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = "value-2"u8.ToArray() }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes[firstRecordBuffer.WrittenCount] = 0x7E; // Zig-zag encoded length 63.
+        using var lazyList = LazyRecordList.Create(bytes, count: records.Length);
+
+        await Assert.That(() => lazyList.ToArray()).Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
     public async Task LazyRecordList_ShortMalformedTail_ReducesCountToParseableRecords()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -216,7 +216,7 @@ public class LazyRecordListTests
     }
 
     [Test]
-    public async Task LazyRecordList_ExhaustedMalformedTail_ReducesCountToParseableRecords()
+    public async Task LazyRecordList_ShortMalformedTail_ReducesCountToParseableRecords()
     {
         var records = new[]
         {
@@ -228,9 +228,9 @@ public class LazyRecordListTests
         foreach (var record in records)
             record.Write(ref writer);
 
-        var bytes = new byte[buffer.WrittenCount + 5];
+        var bytes = new byte[buffer.WrittenCount + 6];
         buffer.WrittenSpan.CopyTo(bytes);
-        bytes.AsSpan(buffer.WrittenCount).Fill(0x80);
+        bytes.AsSpan(buffer.WrittenCount, 5).Fill(0x80);
         using var lazyList = LazyRecordList.Create(bytes, count: 5);
 
         await Assert.That(lazyList.ToArray()).Count().IsEqualTo(2);

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -268,6 +268,33 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_InteriorShortReadWithCompleteSuffix_Throws()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = new byte[] { 0x01 } },
+            new Record { OffsetDelta = 1, Value = new byte[] { 0x02 } },
+            new Record { OffsetDelta = 2, Value = new byte[] { 0x03 } }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        var secondRecordOffset = firstRecordBuffer.WrittenCount;
+        bytes[secondRecordOffset] = 0x7E; // Zig-zag encoded record body length 63.
+        bytes[secondRecordOffset + 5] = 0x7E; // Zig-zag encoded value length 63.
+        using var lazyList = LazyRecordList.Create(bytes, count: records.Length);
+
+        await Assert.That(() => lazyList.ToArray()).Throws<InsufficientDataException>();
+    }
+
+    [Test]
     public async Task LazyRecordList_ShortMalformedTail_ReducesCountToParseableRecords()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -191,6 +191,31 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_InteriorMalformedVarint_Throws()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = "value-2"u8.ToArray() }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes.AsSpan(firstRecordBuffer.WrittenCount, 6).Fill(0x80);
+        using var lazyList = LazyRecordList.Create(bytes, count: records.Length);
+
+        await Assert.That(() => lazyList.ToArray()).Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
     public async Task LazyRecordList_CompletelyTruncated_ReducesCountToZero()
     {
         // Arrange: provide just 1 byte of data but claim 5 records

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -216,6 +216,27 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_ExhaustedMalformedTail_ReducesCountToParseableRecords()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var bytes = new byte[buffer.WrittenCount + 5];
+        buffer.WrittenSpan.CopyTo(bytes);
+        bytes.AsSpan(buffer.WrittenCount).Fill(0x80);
+        using var lazyList = LazyRecordList.Create(bytes, count: 5);
+
+        await Assert.That(lazyList.ToArray()).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task LazyRecordList_LongTruncatedTail_ReducesCountToParseableRecords()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -268,7 +268,7 @@ public class LazyRecordListTests
     }
 
     [Test]
-    public async Task LazyRecordList_InteriorShortReadWithCompleteSuffix_Throws()
+    public async Task LazyRecordList_TruncatedPayloadEndingInRecordLikeBytes_ReducesCount()
     {
         var records = new[]
         {
@@ -287,11 +287,13 @@ public class LazyRecordListTests
 
         var bytes = buffer.WrittenSpan.ToArray();
         var secondRecordOffset = firstRecordBuffer.WrittenCount;
+        // The oversized lengths make every remaining byte part of the truncated second
+        // record. Its payload ends with bytes that also encode a complete third record.
         bytes[secondRecordOffset] = 0x7E; // Zig-zag encoded record body length 63.
         bytes[secondRecordOffset + 5] = 0x7E; // Zig-zag encoded value length 63.
         using var lazyList = LazyRecordList.Create(bytes, count: records.Length);
 
-        await Assert.That(() => lazyList.ToArray()).Throws<InsufficientDataException>();
+        await Assert.That(lazyList.ToArray()).Count().IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/LazyRecordListTests.cs
@@ -241,6 +241,33 @@ public class LazyRecordListTests
     }
 
     [Test]
+    public async Task LazyRecordList_InteriorValueLengthCannotConsumeFollowingRecord()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = new byte[] { 0x01 } },
+            new Record { OffsetDelta = 1, Value = new byte[] { 0x02 } },
+            new Record { OffsetDelta = 2, Value = new byte[] { 0x03 } }
+        };
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        foreach (var record in records)
+            record.Write(ref writer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        // One-byte length, attributes, timestamp delta, offset delta, then key length.
+        var secondValueLengthOffset = firstRecordBuffer.WrittenCount + 5;
+        bytes[secondValueLengthOffset] = 0x0E; // Zig-zag encoded length 7.
+        using var lazyList = LazyRecordList.Create(bytes, count: records.Length);
+
+        await Assert.That(() => lazyList.ToArray()).Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
     public async Task LazyRecordList_ShortMalformedTail_ReducesCountToParseableRecords()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -177,6 +177,45 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PendingFetchData_InteriorValueLengthCannotConsumeFollowingRecord()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = new byte[] { 0x01 } },
+            new Record { OffsetDelta = 1, Value = new byte[] { 0x02 } },
+            new Record { OffsetDelta = 2, Value = new byte[] { 0x03 } }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        // One-byte length, attributes, timestamp delta, offset delta, then key length.
+        var secondValueLengthOffset = RecordBatch.TotalBatchHeaderSize + firstRecordBuffer.WrittenCount + 5;
+        bytes[secondValueLengthOffset] = 0x0E; // Zig-zag encoded length 7.
+        var corrupt = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [corrupt]);
+
+        ConsumeException? exception = null;
+        try
+        {
+            pending.EagerParseAll();
+        }
+        catch (ConsumeException caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.InnerException).IsTypeOf<MalformedProtocolDataException>();
+    }
+
+    [Test]
     public async Task PendingFetchData_LongTruncatedTail_CapsRecordCount()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -216,6 +216,45 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PendingFetchData_InteriorShortReadWithCompleteSuffix_ThrowsConsumeException()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = new byte[] { 0x01 } },
+            new Record { OffsetDelta = 1, Value = new byte[] { 0x02 } },
+            new Record { OffsetDelta = 2, Value = new byte[] { 0x03 } }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        var secondRecordOffset = RecordBatch.TotalBatchHeaderSize + firstRecordBuffer.WrittenCount;
+        bytes[secondRecordOffset] = 0x7E;
+        bytes[secondRecordOffset + 5] = 0x7E;
+        var corrupt = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [corrupt]);
+
+        ConsumeException? exception = null;
+        try
+        {
+            pending.EagerParseAll();
+        }
+        catch (ConsumeException caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+    }
+
+    [Test]
     public async Task PendingFetchData_LongTruncatedTail_CapsRecordCount()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -140,6 +140,43 @@ public class RecordBatchTests
     }
 
     [Test]
+    public async Task PendingFetchData_InteriorOversizedRecordLength_ThrowsConsumeException()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = "value-2"u8.ToArray() }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes[RecordBatch.TotalBatchHeaderSize + firstRecordBuffer.WrittenCount] = 0x7E;
+        var corrupt = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [corrupt]);
+
+        ConsumeException? exception = null;
+        try
+        {
+            pending.EagerParseAll();
+        }
+        catch (ConsumeException caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.InnerException).IsTypeOf<MalformedProtocolDataException>();
+    }
+
+    [Test]
     public async Task PendingFetchData_LongTruncatedTail_CapsRecordCount()
     {
         var records = new[]

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using Dekaf.Compression;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -98,6 +99,44 @@ public class RecordBatchTests
         await Assert.That(lazy.GetParsedRecordsOffset()).IsEqualTo(0);
         await Assert.That(assigned.GetParsedRecordsArray()).IsNull();
         await Assert.That(assigned.Records[0].Value.ToArray()).IsEquivalentTo("assigned"u8.ToArray());
+    }
+
+    [Test]
+    public async Task PendingFetchData_InteriorRecordCorruption_ThrowsConsumeException()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = "value-2"u8.ToArray() }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstRecordBuffer = new ArrayBufferWriter<byte>();
+        var firstRecordWriter = new KafkaProtocolWriter(firstRecordBuffer);
+        records[0].Write(ref firstRecordWriter);
+
+        var bytes = buffer.WrittenSpan.ToArray();
+        bytes.AsSpan(RecordBatch.TotalBatchHeaderSize + firstRecordBuffer.WrittenCount, 6).Fill(0x80);
+        var corrupt = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [corrupt]);
+
+        ConsumeException? exception = null;
+        try
+        {
+            pending.EagerParseAll();
+        }
+        catch (ConsumeException caught)
+        {
+            exception = caught;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("topic-7");
+        await Assert.That(exception.IsRetriable).IsFalse();
+        await Assert.That(exception.InnerException).IsTypeOf<MalformedProtocolDataException>();
     }
 
     private static RecordBatch ReadWrittenBatch(RecordBatch batch)

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -174,7 +174,7 @@ public class RecordBatchTests
     }
 
     [Test]
-    public async Task PendingFetchData_ExhaustedMalformedTail_CapsRecordCount()
+    public async Task PendingFetchData_ShortMalformedTail_CapsRecordCount()
     {
         var records = new[]
         {
@@ -192,7 +192,7 @@ public class RecordBatchTests
         records[1].Write(ref firstTwoWriter);
 
         var malformedOffset = RecordBatch.TotalBatchHeaderSize + firstTwoBuffer.WrittenCount;
-        var bytes = buffer.WrittenSpan[..(malformedOffset + 5)].ToArray();
+        var bytes = buffer.WrittenSpan[..(malformedOffset + 6)].ToArray();
         bytes.AsSpan(malformedOffset, 5).Fill(0x80);
         BinaryPrimitives.WriteInt32BigEndian(
             bytes.AsSpan(sizeof(long)),

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -173,6 +173,41 @@ public class RecordBatchTests
         await Assert.That(truncated.Records.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task PendingFetchData_ExhaustedMalformedTail_CapsRecordCount()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = "value-2"u8.ToArray() }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstTwoBuffer = new ArrayBufferWriter<byte>();
+        var firstTwoWriter = new KafkaProtocolWriter(firstTwoBuffer);
+        records[0].Write(ref firstTwoWriter);
+        records[1].Write(ref firstTwoWriter);
+
+        var malformedOffset = RecordBatch.TotalBatchHeaderSize + firstTwoBuffer.WrittenCount;
+        var bytes = buffer.WrittenSpan[..(malformedOffset + 5)].ToArray();
+        bytes.AsSpan(malformedOffset, 5).Fill(0x80);
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(sizeof(long)),
+            bytes.Length - sizeof(long) - sizeof(int));
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(RecordBatch.TotalBatchHeaderSize - sizeof(int)),
+            5);
+        var truncated = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [truncated]);
+
+        pending.EagerParseAll();
+
+        await Assert.That(truncated.Records.Count).IsEqualTo(2);
+    }
+
     private static RecordBatch ReadWrittenBatch(RecordBatch batch)
     {
         var buffer = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -139,6 +139,40 @@ public class RecordBatchTests
         await Assert.That(exception.InnerException).IsTypeOf<MalformedProtocolDataException>();
     }
 
+    [Test]
+    public async Task PendingFetchData_LongTruncatedTail_CapsRecordCount()
+    {
+        var records = new[]
+        {
+            new Record { OffsetDelta = 0, Value = "value-0"u8.ToArray() },
+            new Record { OffsetDelta = 1, Value = "value-1"u8.ToArray() },
+            new Record { OffsetDelta = 2, Value = new byte[100] }
+        };
+        using var original = new RecordBatch { Records = records };
+        var buffer = new ArrayBufferWriter<byte>();
+        original.Write(buffer);
+
+        var firstTwoBuffer = new ArrayBufferWriter<byte>();
+        var firstTwoWriter = new KafkaProtocolWriter(firstTwoBuffer);
+        records[0].Write(ref firstTwoWriter);
+        records[1].Write(ref firstTwoWriter);
+
+        var truncatedLength = RecordBatch.TotalBatchHeaderSize + firstTwoBuffer.WrittenCount + 40;
+        var bytes = buffer.WrittenSpan[..truncatedLength].ToArray();
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(sizeof(long)),
+            bytes.Length - sizeof(long) - sizeof(int));
+        BinaryPrimitives.WriteInt32BigEndian(
+            bytes.AsSpan(RecordBatch.TotalBatchHeaderSize - sizeof(int)),
+            5);
+        var truncated = ReadBatch(bytes, checkCrcs: false);
+        using var pending = PendingFetchData.Create("topic", 7, [truncated]);
+
+        pending.EagerParseAll();
+
+        await Assert.That(truncated.Records.Count).IsEqualTo(2);
+    }
+
     private static RecordBatch ReadWrittenBatch(RecordBatch batch)
     {
         var buffer = new ArrayBufferWriter<byte>();
@@ -1624,7 +1658,7 @@ public class RecordBatchTests
     }
 
     [Test]
-    public async Task Record_Read_TruncatedHeaderAfterRent_ThrowsInsufficientData()
+    public async Task Record_Read_TruncatedHeaderAfterRent_ThrowsMalformedProtocolData()
     {
         var body = new ArrayBufferWriter<byte>();
         var bodyWriter = new KafkaProtocolWriter(body);
@@ -1645,11 +1679,12 @@ public class RecordBatchTests
         try
         {
             Record.Read(ref reader);
-            throw new InvalidOperationException("Expected InsufficientDataException was not thrown");
+            throw new InvalidOperationException("Expected MalformedProtocolDataException was not thrown");
         }
-        catch (InsufficientDataException)
+        catch (MalformedProtocolDataException ex)
         {
             // Expected: the rented Header[] is returned before the exception escapes.
+            await Assert.That(ex.InnerException).IsTypeOf<InsufficientDataException>();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/RecordBatchTests.cs
@@ -216,7 +216,7 @@ public class RecordBatchTests
     }
 
     [Test]
-    public async Task PendingFetchData_InteriorShortReadWithCompleteSuffix_ThrowsConsumeException()
+    public async Task PendingFetchData_TruncatedPayloadEndingInRecordLikeBytes_CapsRecordCount()
     {
         var records = new[]
         {
@@ -234,24 +234,16 @@ public class RecordBatchTests
 
         var bytes = buffer.WrittenSpan.ToArray();
         var secondRecordOffset = RecordBatch.TotalBatchHeaderSize + firstRecordBuffer.WrittenCount;
+        // The oversized lengths make every remaining byte part of the truncated second
+        // record. Its payload ends with bytes that also encode a complete third record.
         bytes[secondRecordOffset] = 0x7E;
         bytes[secondRecordOffset + 5] = 0x7E;
         var corrupt = ReadBatch(bytes, checkCrcs: false);
         using var pending = PendingFetchData.Create("topic", 7, [corrupt]);
 
-        ConsumeException? exception = null;
-        try
-        {
-            pending.EagerParseAll();
-        }
-        catch (ConsumeException caught)
-        {
-            exception = caught;
-        }
+        pending.EagerParseAll();
 
-        await Assert.That(exception).IsNotNull();
-        await Assert.That(exception!.IsRetriable).IsFalse();
-        await Assert.That(exception.InnerException).IsTypeOf<InsufficientDataException>();
+        await Assert.That(corrupt.Records.Count).IsEqualTo(1);
     }
 
     [Test]


### PR DESCRIPTION
Closes #2065

## Summary
- preserve benign end-of-batch truncation using the declared record-body length
- propagate interior lazy-record parse failures when a later complete record may remain
- wrap corruption as a non-retriable ConsumeException with topic-partition context
- cover both lazy parsing implementations, including long partial tails

## Validation
- net10.0 unit tests: 5472/5472
- net8.0 unit tests: 5365/5365
- Release builds: zero warnings