### PR TITLE
Reduce producer record admission overhead

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1382,6 +1382,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         public int SlowPathAppendCount;
 
+        /// <summary>
+        /// Broker budget used by the append admission gate. Refreshed at batch seal/routing
+        /// boundaries and whenever the cached budget reports pressure.
+        /// </summary>
+        public BrokerUnackedByteBudget? AdmissionBudget;
+        public int AdmissionBudgetInitialized;
+
         /// <summary>Number of batches in the deque.</summary>
         public int Count => _count;
 
@@ -2910,7 +2917,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             releaseMemoryOnFailure: false);
                         if (sealedBatchToEnqueue is not null)
                         {
-                            sealedBatchToEnqueue.UnackedBudget = ResolveUnackedBudget(
+                            sealedBatchToEnqueue.UnackedBudget = ResolveAndCacheUnackedBudget(
+                                pd,
                                 topic,
                                 partition);
                         }
@@ -3111,6 +3119,40 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         int partitionCount,
         bool returnHeadersOnFailure)
     {
+        // Headerless records dominate every producer mode. When the current batch has room,
+        // encode and commit under one partition-lock acquisition instead of publishing
+        // AppendInProgress and reacquiring the lock after encoding. Rotation and header paths
+        // retain the two-phase protocol.
+        if (headers is null && headerCount == 0)
+        {
+            var appendCommitted = false;
+            try
+            {
+                if (TryAppendFromSpansToCurrentBatchFast(
+                    topic,
+                    partition,
+                    timestamp,
+                    keyData,
+                    keyIsNull,
+                    valueData,
+                    valueIsNull,
+                    completionSource,
+                    callback,
+                    recordSize,
+                    partitionCount,
+                    out appendCommitted))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                if (!appendCommitted)
+                    ReleaseMemory(recordSize);
+                throw;
+            }
+        }
+
         var topicPartition = new TopicPartition(topic, partition);
         var pd = GetOrCreateDeque(topic, partition);
         ReadyBatch? sealedBatchToEnqueue = null;
@@ -3394,7 +3436,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                             releaseMemoryOnFailure: false);
                         if (sealedBatchToEnqueue is not null)
                         {
-                            sealedBatchToEnqueue.UnackedBudget = ResolveUnackedBudget(
+                            sealedBatchToEnqueue.UnackedBudget = ResolveAndCacheUnackedBudget(
+                                pd,
                                 topic,
                                 partition);
                         }
@@ -3607,6 +3650,80 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return AppendFromSpansAfterReservationCore(topic, partition, timestamp, keyData, keyIsNull,
             valueData, valueIsNull, headers, headerCount, completionSource: null, callback,
             recordSize, partitionCount, returnHeadersOnFailure: true);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryAppendFromSpansToCurrentBatchFast(
+        string topic,
+        int partition,
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback,
+        int recordSize,
+        int partitionCount,
+        out bool appendCommitted)
+    {
+        appendCommitted = false;
+        var pd = GetOrCreateDeque(topic, partition);
+        PartitionBatch? batchToComplete = null;
+        int actualBytesAdded;
+
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+
+            if (Volatile.Read(ref _disposed) != 0
+                || pd.RotationInProgress
+                || pd.AppendInProgress
+                || pd.CurrentBatch is not { } currentBatch)
+            {
+                return false;
+            }
+
+            var result = currentBatch.TryAppendFromSpans(
+                timestamp,
+                keyData,
+                keyIsNull,
+                valueData,
+                valueIsNull,
+                headers: null,
+                headerCount: 0,
+                completionSource,
+                callback,
+                estimatedSize: recordSize);
+
+            if (!result.Success)
+                return false;
+
+            appendCommitted = true;
+            actualBytesAdded = result.ActualSizeAdded;
+            ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
+
+            if (result.FirstCompletionSourceInBatch)
+                Interlocked.Increment(ref _pendingAwaitedProduceCount);
+
+            if (ShouldSealAppendedBatch(currentBatch))
+            {
+                batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
+            }
+        }
+
+        NotifyRecordAppended(topic, partition, actualBytesAdded, partitionCount);
+        if (batchToComplete is not null)
+        {
+            var readyBatch = CompleteDetachedBatchAndEnqueue(pd, batchToComplete);
+            if (readyBatch is not null)
+                StartPreSerialization(readyBatch);
+        }
+        else if (completionSource is not null)
+        {
+            QueueLingerPartition(pd, new TopicPartition(topic, partition));
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -3835,7 +3952,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         if (readyBatch is not null)
         {
-            readyBatch.UnackedBudget = ResolveUnackedBudget(
+            readyBatch.UnackedBudget = ResolveAndCacheUnackedBudget(
+                pd,
                 readyBatch.TopicPartition.Topic,
                 readyBatch.TopicPartition.Partition);
         }
@@ -4668,6 +4786,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (GetBrokerUnackedBudget(brokerId) is not { } newBudget)
             return;
 
+        if (_partitionDeques.TryGetValue(batch.TopicPartition, out var partitionDeque))
+        {
+            Volatile.Write(ref partitionDeque.AdmissionBudget, newBudget);
+            Volatile.Write(ref partitionDeque.AdmissionBudgetInitialized, 1);
+        }
+
         var lockTaken = false;
         try
         {
@@ -4732,7 +4856,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var partitionDeque = GetOrCreateDeque(topic, partition);
         if (_unackedBudgetEnabled
-            && IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent: true))
+            && IsBrokerAdmissionBlocked(
+                partitionDeque,
+                topic,
+                partition,
+                recordBlockEvent: true))
             return false;
 
         return Volatile.Read(ref partitionDeque.SlowPathAppendCount) == 0
@@ -4747,11 +4875,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// because the operation already recorded one when it was first gated.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool IsBrokerAdmissionBlocked(string topic, int partition, bool recordBlockEvent)
-        => IsBrokerAdmissionBlocked(topic, partition, recordBlockEvent, out _);
+    private bool IsBrokerAdmissionBlocked(
+        PartitionDeque partitionDeque,
+        string topic,
+        int partition,
+        bool recordBlockEvent)
+        => IsBrokerAdmissionBlocked(
+            partitionDeque,
+            topic,
+            partition,
+            recordBlockEvent,
+            out _);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsBrokerAdmissionBlocked(
+        PartitionDeque partitionDeque,
         string topic,
         int partition,
         bool recordBlockEvent,
@@ -4761,14 +4899,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (!_unackedBudgetEnabled)
             return false;
 
-        var leaderId = _resolveLeaderId!(topic, partition);
-        var currentBudget = leaderId >= 0 ? GetBrokerUnackedBudget(leaderId) : null;
-        if (leaderId < 0
-            || currentBudget is null
-            || !currentBudget.IsOverBudget())
+        var currentBudget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
+        if (currentBudget is null || !currentBudget.IsOverBudget())
         {
             return false;
         }
+
+        // A leader may have changed since this partition last sealed or routed a batch.
+        // Resolve again before actually blocking so a stale, pressured old leader never
+        // causes false backpressure. This lookup is confined to the already-cold path.
+        currentBudget = ResolveAndCacheUnackedBudget(partitionDeque, topic, partition);
+        if (currentBudget is null || !currentBudget.IsOverBudget())
+            return false;
 
         var nowTicks = Stopwatch.GetTimestamp();
         if (!currentBudget.IsOverBudgetAt(nowTicks))
@@ -4787,7 +4929,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         out long recheckAt)
     {
         recheckAt = 0;
+        var partitionDeque = GetOrCreateDeque(topic, partition);
         if (!IsBrokerAdmissionBlocked(
+                partitionDeque,
                 topic,
                 partition,
                 recordBlockEvent: false,
@@ -4803,6 +4947,29 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private BrokerUnackedByteBudget? GetCachedAdmissionBudget(
+        PartitionDeque partitionDeque,
+        string topic,
+        int partition)
+    {
+        if (Volatile.Read(ref partitionDeque.AdmissionBudgetInitialized) == 0)
+            return ResolveAndCacheUnackedBudget(partitionDeque, topic, partition);
+
+        return Volatile.Read(ref partitionDeque.AdmissionBudget);
+    }
+
+    private BrokerUnackedByteBudget? ResolveAndCacheUnackedBudget(
+        PartitionDeque partitionDeque,
+        string topic,
+        int partition)
+    {
+        var budget = ResolveUnackedBudget(topic, partition);
+        Volatile.Write(ref partitionDeque.AdmissionBudget, budget);
+        Volatile.Write(ref partitionDeque.AdmissionBudgetInitialized, 1);
+        return budget;
     }
 
     private BrokerUnackedByteBudget? ResolveUnackedBudget(string topic, int partition)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -451,6 +451,37 @@ public sealed class BrokerUnackedAdmissionTests
     }
 
     [Test]
+    public async Task Appends_ReuseCachedLeaderBudget_UntilRoutingBoundary()
+    {
+        var options = CreateOptions(capOverride: null, batchSize: 16_384);
+        var resolveCount = 0;
+        var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) =>
+            {
+                Interlocked.Increment(ref resolveCount);
+                return LeaderNodeId;
+            });
+
+        try
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                var appended = await accumulator.AppendAsync(
+                    "test-topic", 0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    PooledMemory.Null, PooledMemory.Null, null, 0, null, null, CancellationToken.None);
+                await Assert.That(appended).IsTrue();
+            }
+
+            await Assert.That(resolveCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task LeaderChange_ChargesSubsequentSeals_ToNewBrokerBudget()
     {
         var options = CreateOptions(capOverride: null);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Broker-free benchmark for the complete keyed <see cref="KafkaProducer{TKey,TValue}.FireAsync(string,TKey,TValue)"/>
+/// front-end: metadata cache, serialization, partitioning, timestamping, and accumulator append.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class ProducerFireHotPathBenchmarks
+{
+    private const string Topic = "producer-fire-hot-path";
+    private static readonly string[] Keys = CreateKeys();
+
+    private KafkaProducer<string, string> _producer = null!;
+    private RecordAccumulator _accumulator = null!;
+    private CancellationTokenSource _drainerCts = null!;
+    private Task _drainerTask = null!;
+    private string _value = null!;
+
+    [Params(1000)]
+    public int MessageSize { get; set; }
+
+    [Params(0, 10)]
+    public int DeliveryLatencyTargetMs { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = "producer-fire-hot-path",
+                BufferMemory = 256UL * 1024 * 1024,
+                BatchSize = 1_048_576,
+                LingerMs = 1_000,
+                RequestTimeoutMs = 500,
+                DeliveryTimeoutMs = 1_000,
+                CloseTimeoutMs = 1_000,
+                EnableIdempotence = false,
+                DeliveryLatencyTargetMs = DeliveryLatencyTargetMs,
+                // Keep admission non-blocking so this measures front-end CPU, not drainer scheduling.
+                UnackedByteBudgetCapOverride = 1L << 30,
+            },
+            Serializers.String,
+            Serializers.String);
+
+        await StopBackgroundLoopsAsync(_producer).ConfigureAwait(false);
+        SeedMetadata(_producer);
+        SetInstanceField(_producer, "_initialized", true);
+
+        _accumulator = _producer.RecordAccumulator;
+        _value = new string('x', MessageSize);
+        _drainerCts = new CancellationTokenSource();
+        _drainerTask = Task.Run(() => DrainLoop(_drainerCts.Token));
+
+        FireBatch();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _drainerCts.CancelAsync().ConfigureAwait(false);
+        try
+        {
+            await _drainerTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await _producer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark(OperationsPerInvoke = 100)]
+    public void FireBatch()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var result = _producer.FireAsync(Topic, Keys[i], _value);
+            if (!result.IsCompletedSuccessfully)
+                result.GetAwaiter().GetResult();
+        }
+    }
+
+    private void DrainLoop(CancellationToken cancellationToken)
+    {
+        var spinner = new SpinWait();
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (_accumulator.TryDrainBatch(out var batch))
+            {
+                _accumulator.OnBatchExitsPipeline(batch);
+                _accumulator.ReleaseMemory(batch.DataSize);
+                _accumulator.ReturnReadyBatch(batch);
+                spinner.Reset();
+            }
+            else
+            {
+                spinner.SpinOnce();
+            }
+        }
+    }
+
+    private static string[] CreateKeys()
+    {
+        var keys = new string[10_000];
+        for (var i = 0; i < keys.Length; i++)
+            keys[i] = $"key-{i}";
+        return keys;
+    }
+
+    private static void SeedMetadata(KafkaProducer<string, string> producer)
+    {
+        var metadataManager = GetInstanceField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 },
+            ],
+            ClusterId = "producer-fire-hot-path",
+            ControllerId = 0,
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0],
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    private static async Task StopBackgroundLoopsAsync(KafkaProducer<string, string> producer)
+    {
+        var cancellation = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
+        var senderTask = GetInstanceField<Task>(producer, "_senderTask");
+        var lingerTask = GetInstanceField<Task>(producer, "_lingerTask");
+
+        await cancellation.CancelAsync().ConfigureAwait(false);
+        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+    }
+
+    private static T GetInstanceField<T>(object target, string name)
+    {
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        return (T)target.GetType().GetField(name, Flags)!.GetValue(target)!;
+    }
+
+    private static void SetInstanceField<T>(object target, string name, T value)
+    {
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        target.GetType().GetField(name, Flags)!.SetValue(target, value);
+    }
+}


### PR DESCRIPTION
Closes #2056
Refs #2033

## Summary
- encode and commit headerless records under one partition-lock acquisition when the current batch has room
- apply the fast path to fire-and-forget, callback, and completion-tracked/idempotent records
- cache each partition's broker admission budget and refresh it at seal/reroute boundaries or before pressure blocks
- add a broker-free full `FireAsync` front-end benchmark

## Evidence
- 1000B multi-partition accumulator: 268.02 ns -> 241.36 ns (9.9% faster), zero allocation
- nonblocking full `FireAsync`: 285.2 ns/message, zero allocation
- admission enabled/disabled with nonblocking cap: 285.2/287.3 ns, showing no measurable gate tax after caching
- net10 unit: 5,469/5,469
- net8 unit: 5,362/5,362
- build: zero warnings

Balanced exact-head stress acceptance will be attached before merge.