### PR TITLE
Make consumed-position seqlock stress deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
@@ -68,8 +68,10 @@ public sealed class ActiveConsumedPositionSeqlockTests
         // Every published tuple is fully derivable from its position, so any reader
         // observing a (topic, partition, epoch) that does not match its position has
         // seen a torn mix of two writes.
-        const long iterations = 300_000;
-        using var readersStop = new CancellationTokenSource();
+        const long requiredSuccessfulReads = 1_001;
+        using var workersStop = new CancellationTokenSource();
+        var requiredReadsObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var violations = new List<string>();
         var violationLock = new object();
         long successfulReads = 0;
@@ -85,12 +87,13 @@ public sealed class ActiveConsumedPositionSeqlockTests
 
         var readers = Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
         {
-            while (!readersStop.IsCancellationRequested)
+            while (!workersStop.IsCancellationRequested)
             {
                 if (!tryRead(out var partition, out var position, out var leaderEpoch, out _))
                     continue;
 
-                Interlocked.Increment(ref successfulReads);
+                if (Interlocked.Increment(ref successfulReads) == requiredSuccessfulReads)
+                    requiredReadsObserved.TrySetResult();
 
                 var expected = ExpectedTupleFor(position);
                 if (partition != expected.Partition || leaderEpoch != expected.LeaderEpoch)
@@ -104,7 +107,7 @@ public sealed class ActiveConsumedPositionSeqlockTests
 
         var clearer = Task.Run(() =>
         {
-            while (!readersStop.IsCancellationRequested)
+            while (!workersStop.IsCancellationRequested)
             {
                 if (tryRead(out var partition, out var position, out _, out _))
                     clear(partition, position);
@@ -112,18 +115,28 @@ public sealed class ActiveConsumedPositionSeqlockTests
         });
 
         // Single publisher mirrors production: only the consume thread publishes.
-        for (long position = 1; position <= iterations; position++)
+        var publisher = Task.Run(() =>
         {
-            var tuple = ExpectedTupleFor(position);
-            publish(tuple.Partition, position, tuple.LeaderEpoch);
-        }
+            for (long position = 1; !workersStop.IsCancellationRequested; position++)
+            {
+                var tuple = ExpectedTupleFor(position);
+                publish(tuple.Partition, position, tuple.LeaderEpoch);
+            }
+        });
 
-        readersStop.Cancel();
-        await Task.WhenAll([.. readers, clearer]);
+        try
+        {
+            await requiredReadsObserved.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        finally
+        {
+            workersStop.Cancel();
+            await Task.WhenAll([publisher, .. readers, clearer]);
+        }
 
         await Assert.That(violations).IsEmpty();
         // The readers must have actually observed published values for the test to mean anything.
-        await Assert.That(Interlocked.Read(ref successfulReads)).IsGreaterThan(1_000);
+        await Assert.That(Interlocked.Read(ref successfulReads)).IsGreaterThanOrEqualTo(requiredSuccessfulReads);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ActiveConsumedPositionSeqlockTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Serialization;
@@ -68,13 +69,14 @@ public sealed class ActiveConsumedPositionSeqlockTests
         // Every published tuple is fully derivable from its position, so any reader
         // observing a (topic, partition, epoch) that does not match its position has
         // seen a torn mix of two writes.
-        const long requiredSuccessfulReads = 1_001;
+        const long requiredDistinctPositions = 1_001;
         using var workersStop = new CancellationTokenSource();
-        var requiredReadsObserved = new TaskCompletionSource(
+        var requiredPositionsObserved = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedPositions = new ConcurrentDictionary<long, byte>();
         var violations = new List<string>();
         var violationLock = new object();
-        long successfulReads = 0;
+        long distinctPositionCount = 0;
 
         void RecordViolation(string message)
         {
@@ -92,8 +94,11 @@ public sealed class ActiveConsumedPositionSeqlockTests
                 if (!tryRead(out var partition, out var position, out var leaderEpoch, out _))
                     continue;
 
-                if (Interlocked.Increment(ref successfulReads) == requiredSuccessfulReads)
-                    requiredReadsObserved.TrySetResult();
+                if (observedPositions.TryAdd(position, 0)
+                    && Interlocked.Increment(ref distinctPositionCount) == requiredDistinctPositions)
+                {
+                    requiredPositionsObserved.TrySetResult();
+                }
 
                 var expected = ExpectedTupleFor(position);
                 if (partition != expected.Partition || leaderEpoch != expected.LeaderEpoch)
@@ -126,7 +131,11 @@ public sealed class ActiveConsumedPositionSeqlockTests
 
         try
         {
-            await requiredReadsObserved.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await requiredPositionsObserved.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+        catch (TimeoutException)
+        {
+            // Assertions below report torn tuples first, then insufficient progress.
         }
         finally
         {
@@ -135,8 +144,9 @@ public sealed class ActiveConsumedPositionSeqlockTests
         }
 
         await Assert.That(violations).IsEmpty();
-        // The readers must have actually observed published values for the test to mean anything.
-        await Assert.That(Interlocked.Read(ref successfulReads)).IsGreaterThanOrEqualTo(requiredSuccessfulReads);
+        // Distinct positions guarantee the readers crossed same-partition and full-write transitions.
+        await Assert.That(Interlocked.Read(ref distinctPositionCount))
+            .IsGreaterThanOrEqualTo(requiredDistinctPositions);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- replace the fixed publisher iteration window with a required successful-read target
- keep publisher, readers, and clearer concurrent until 1,001 valid reads are observed
- bound progress with a 30-second timeout and always stop/join workers

## Validation
- Release build net10.0 + net8.0: zero warnings
- target test: 25 consecutive passes per framework
- full seqlock class: 3/3 per framework
- full unit suites: net10.0 5471/5471; net8.0 5364/5364

Closes #2083