### PR TITLE
Test producer redelivery across broker restart

### DIFF
--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -96,6 +96,8 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
         var productionPaused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var resumeProduction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var acknowledgedValues = new List<string>(MessageCount);
+        using var productionCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        Task? production = null;
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)
@@ -110,13 +112,13 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
 
         try
         {
-            var production = ProduceAcrossRestartAsync(
+            production = ProduceAcrossRestartAsync(
                 producer,
                 topic,
                 acknowledgedValues,
                 productionPaused,
                 resumeProduction.Task,
-                cancellationToken);
+                productionCancellation.Token);
             await productionPaused.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             stoppedBrokerId = leaderBrokerId;
@@ -140,8 +142,27 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
         finally
         {
             resumeProduction.TrySetResult();
-            if (stoppedBrokerId is { } brokerId)
-                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+            productionCancellation.Cancel();
+            try
+            {
+                if (stoppedBrokerId is { } brokerId)
+                    await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (production is not null)
+                {
+                    try
+                    {
+                        await production.ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // The primary test path observes production failures. On an earlier
+                        // failure, cancellation and this await prevent an abandoned faulted task.
+                    }
+                }
+            }
         }
     }
 
@@ -196,7 +217,7 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
             }
             catch (KafkaException exception) when (
                 !cancellationToken.IsCancellationRequested &&
-                exception is (ProduceException or KafkaTimeoutException))
+                (exception is KafkaTimeoutException || exception.IsRetriable))
             {
                 // Delivery failures are allowed; losing a successfully acknowledged record is not.
             }

--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -119,7 +119,11 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
                 productionPaused,
                 resumeProduction.Task,
                 productionCancellation.Token);
-            await productionPaused.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var pauseOrProduction = await Task.WhenAny(productionPaused.Task, production)
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (ReferenceEquals(pauseOrProduction, production))
+                await production.ConfigureAwait(false);
 
             stoppedBrokerId = leaderBrokerId;
             await kafka.StopBrokerAsync(leaderBrokerId, cancellationToken).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -194,7 +194,9 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
                 }, cancellationToken).ConfigureAwait(false);
                 acknowledgedValues.Add(payload);
             }
-            catch (ProduceException) when (!cancellationToken.IsCancellationRequested)
+            catch (KafkaException exception) when (
+                !cancellationToken.IsCancellationRequested &&
+                exception is (ProduceException or KafkaTimeoutException))
             {
                 // Delivery failures are allowed; losing a successfully acknowledged record is not.
             }

--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Integration;
@@ -83,6 +84,67 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
         }
     }
 
+    [Test]
+    [Timeout(240_000)]
+    public async Task Producer_NonIdempotent_BrokerRestart_DoesNotLoseAcknowledgedRecords(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync().ConfigureAwait(false);
+        var leaderBrokerId = await kafka.GetPartitionLeaderIdAsync(topic, cancellationToken)
+            .ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+        var productionPaused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resumeProduction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var acknowledgedValues = new List<string>(MessageCount);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"non-idempotent-restart-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithIdempotence(false)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var production = ProduceAcrossRestartAsync(
+                producer,
+                topic,
+                acknowledgedValues,
+                productionPaused,
+                resumeProduction.Task,
+                cancellationToken);
+            await productionPaused.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            stoppedBrokerId = leaderBrokerId;
+            await kafka.StopBrokerAsync(leaderBrokerId, cancellationToken).ConfigureAwait(false);
+            resumeProduction.TrySetResult();
+            _ = await kafka.WaitForPartitionLeaderChangeAsync(topic, leaderBrokerId, cancellationToken)
+                .ConfigureAwait(false);
+
+            await production.ConfigureAwait(false);
+            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            await Assert.That(acknowledgedValues).Count().IsGreaterThanOrEqualTo(InitialMessageCount);
+            await Assert.That(acknowledgedValues.Select(int.Parse)).Contains(value => value >= InitialMessageCount);
+            await AssertAcknowledgedBrokerRecordsAsync(topic, acknowledgedValues, cancellationToken)
+                .ConfigureAwait(false);
+
+            await kafka.StartBrokerAsync(leaderBrokerId, cancellationToken).ConfigureAwait(false);
+            await kafka.WaitForInSyncReplicasAsync(topic, 3, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+        }
+        finally
+        {
+            resumeProduction.TrySetResult();
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
     private static async Task ProduceRangeAsync(
         IKafkaProducer<string, string> producer,
         string topic,
@@ -101,6 +163,41 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
                 Value = value.ToString()
             }, cancellationToken).ConfigureAwait(false);
             acknowledgements.Add(metadata);
+        }
+    }
+
+    private static async Task ProduceAcrossRestartAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        List<string> acknowledgedValues,
+        TaskCompletionSource productionPaused,
+        Task resumeProduction,
+        CancellationToken cancellationToken)
+    {
+        for (var value = 0; value < MessageCount; value++)
+        {
+            if (value == InitialMessageCount)
+            {
+                productionPaused.TrySetResult();
+                await resumeProduction.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            var payload = value.ToString();
+            try
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = 0,
+                    Key = payload,
+                    Value = payload
+                }, cancellationToken).ConfigureAwait(false);
+                acknowledgedValues.Add(payload);
+            }
+            catch (ProduceException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Delivery failures are allowed; losing a successfully acknowledged record is not.
+            }
         }
     }
 
@@ -154,6 +251,35 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
         {
             throw new InvalidOperationException(
                 $"Unexpected duplicate record at offset {extra.Value.Offset}: {extra.Value.Value}.");
+        }
+    }
+
+    private async Task AssertAcknowledgedBrokerRecordsAsync(
+        string topic,
+        IReadOnlyCollection<string> acknowledgedValues,
+        CancellationToken cancellationToken)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"non-idempotent-restart-oracle-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var missing = acknowledgedValues.ToHashSet(StringComparer.Ordinal);
+        while (missing.Count > 0)
+        {
+            var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .ConfigureAwait(false);
+            if (consumed is null)
+            {
+                throw new InvalidOperationException(
+                    $"Timed out with {missing.Count} acknowledged record(s) absent: " +
+                    string.Join(", ", missing.Order(StringComparer.Ordinal).Take(10)));
+            }
+
+            missing.Remove(consumed.Value.Value);
         }
     }
 }

--- a/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerLeaderFailoverIntegrationTests.cs
@@ -92,7 +92,7 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
         var topic = await kafka.CreateReplicatedTopicAsync().ConfigureAwait(false);
         var leaderBrokerId = await kafka.GetPartitionLeaderIdAsync(topic, cancellationToken)
             .ConfigureAwait(false);
-        int? stoppedBrokerId = null;
+        var brokerStopped = false;
         var productionPaused = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var resumeProduction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var acknowledgedValues = new List<string>(MessageCount);
@@ -125,8 +125,8 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
             if (ReferenceEquals(pauseOrProduction, production))
                 await production.ConfigureAwait(false);
 
-            stoppedBrokerId = leaderBrokerId;
             await kafka.StopBrokerAsync(leaderBrokerId, cancellationToken).ConfigureAwait(false);
+            brokerStopped = true;
             resumeProduction.TrySetResult();
             _ = await kafka.WaitForPartitionLeaderChangeAsync(topic, leaderBrokerId, cancellationToken)
                 .ConfigureAwait(false);
@@ -135,13 +135,14 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
             await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             await Assert.That(acknowledgedValues).Count().IsGreaterThanOrEqualTo(InitialMessageCount);
-            await Assert.That(acknowledgedValues.Select(int.Parse)).Contains(value => value >= InitialMessageCount);
+            await Assert.That(acknowledgedValues.Count(value => int.Parse(value) >= InitialMessageCount))
+                .IsGreaterThanOrEqualTo(FailoverMessageCount);
             await AssertAcknowledgedBrokerRecordsAsync(topic, acknowledgedValues, cancellationToken)
                 .ConfigureAwait(false);
 
             await kafka.StartBrokerAsync(leaderBrokerId, cancellationToken).ConfigureAwait(false);
             await kafka.WaitForInSyncReplicasAsync(topic, 3, cancellationToken).ConfigureAwait(false);
-            stoppedBrokerId = null;
+            brokerStopped = false;
         }
         finally
         {
@@ -149,8 +150,8 @@ public sealed class ProducerLeaderFailoverIntegrationTests(RackAwareKafkaContain
             productionCancellation.Cancel();
             try
             {
-                if (stoppedBrokerId is { } brokerId)
-                    await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+                if (brokerStopped)
+                    await kafka.StartBrokerAsync(leaderBrokerId, CancellationToken.None).ConfigureAwait(false);
             }
             finally
             {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -302,6 +302,83 @@ public sealed class BrokerSenderSendLoopTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_UnexpectedExit_TerminatesEverySurvivingDelivery(
+        CancellationToken cancellationToken)
+    {
+        var connection = new TestKafkaConnection
+        {
+            SendProduceFireAndForgetWithCallerTimeout = () => ValueTask.CompletedTask
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var options = CreateOptions(
+            acks: Acks.None,
+            enableIdempotence: false,
+            lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var injectedFailure = new InvalidOperationException("injected send-loop failure");
+        var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedCount = 0;
+        var crashEnabled = 0;
+        ReadyBatch? queuedDuringCrash = null;
+        BrokerSender? sender = null;
+        sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            rerouteBatch: (batch, _) =>
+            {
+                batch.Fail(injectedFailure);
+                if (Interlocked.Increment(ref reroutedCount) == 2)
+                    allRerouted.TrySetResult();
+            },
+            onWaveCoalesceStarted: () =>
+            {
+                if (Interlocked.Exchange(ref crashEnabled, 0) == 0)
+                    return;
+
+                sender!.Enqueue(queuedDuringCrash!);
+                throw injectedFailure;
+            });
+
+        try
+        {
+            var primeFirst = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
+            var primeSecond = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 1);
+            sender.EnqueueBulk([primeFirst.Batch, primeSecond.Batch]);
+            await Task.WhenAll(primeFirst.Delivery, primeSecond.Delivery).WaitAsync(cancellationToken);
+
+            var coalesced = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
+            var queued = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 1);
+            queuedDuringCrash = queued.Batch;
+            Volatile.Write(ref crashEnabled, 1);
+
+            sender.Enqueue(coalesced.Batch);
+            await allRerouted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(sender.IsAlive).IsFalse();
+            await Assert.That(Volatile.Read(ref reroutedCount)).IsEqualTo(2);
+            await Assert.That(async () => await coalesced.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+            await Assert.That(async () => await queued.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_WaveCoalesce_RearmsWhileResponseIsInFlight(
         CancellationToken cancellationToken)
@@ -483,6 +560,26 @@ public sealed class BrokerSenderSendLoopTests
         }
 
         return batch;
+    }
+
+    private static (ReadyBatch Batch, Task<RecordMetadata> Delivery) CreateTestBatchWithDelivery(
+        ValueTaskSourcePool<RecordMetadata> pool,
+        string topic,
+        int partition)
+    {
+        var batch = new ReadyBatch();
+        var source = pool.Rent();
+        var delivery = source.Task.AsTask();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
+        sources[0] = source;
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 1,
+            dataSize: 100);
+        batch.TrySetMemoryReleased();
+        return (batch, delivery);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks.Sources;
@@ -372,6 +373,75 @@ public sealed class BrokerSenderSendLoopTests
         }
         finally
         {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_UnexpectedExit_RedeliversPendingIdempotentBatches(
+        CancellationToken cancellationToken)
+    {
+        var pendingResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>([pendingResponse]);
+        var (pool, _) = CreateMockConnection(responses);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: true, lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var injectedFailure = new InvalidOperationException("injected pending-response failure");
+        var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedSequences = new ConcurrentQueue<int>();
+        var reroutedCount = 0;
+        var crashEnabled = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            rerouteBatch: (batch, _) =>
+            {
+                reroutedSequences.Enqueue(batch.RecordBatch.BaseSequence);
+                batch.Fail(injectedFailure);
+                if (Interlocked.Increment(ref reroutedCount) == 3)
+                    allRerouted.TrySetResult();
+            },
+            onWaveCoalesceStarted: () =>
+            {
+                if (Interlocked.Exchange(ref crashEnabled, 0) != 0)
+                    throw injectedFailure;
+            });
+
+        try
+        {
+            var pendingFirst = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
+            var pendingSecond = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 1);
+            sender.EnqueueBulk([pendingFirst.Batch, pendingSecond.Batch]);
+            await WaitUntilAsync(() => GetPendingResponseCount(sender) == 1, cancellationToken);
+
+            var coalesced = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
+            Volatile.Write(ref crashEnabled, 1);
+            sender.Enqueue(coalesced.Batch);
+            await allRerouted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(sender.IsAlive).IsFalse();
+            await Assert.That(Volatile.Read(ref reroutedCount)).IsEqualTo(3);
+            await Assert.That(reroutedSequences.Count(sequence => sequence >= 0)).IsEqualTo(2);
+            await Assert.That(async () => await pendingFirst.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+            await Assert.That(async () => await pendingSecond.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+            await Assert.That(async () => await coalesced.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+        }
+        finally
+        {
+            pendingResponse.TrySetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();


### PR DESCRIPTION
## Summary
- verify non-idempotent producers never lose acknowledged records across broker restart
- inject an escaped BrokerSender send-loop failure and prove every surviving delivery terminates
- preserve duplicate-tolerant, loss-intolerant semantics during failover

## Validation
- full unit suite: net10.0 (5473), net8.0 (5366)
- BrokerSenderSendLoopTests: 58/58 on both frameworks
- new restart integration: net10.0 and net8.0
- existing idempotent leader-handoff integration: net10.0

Closes #2067