### PR TITLE
Add callback for filtered consumer messages

### DIFF
--- a/docs/docs/consumer/linq-extensions.md
+++ b/docs/docs/consumer/linq-extensions.md
@@ -67,6 +67,34 @@ await foreach (var msg in consumer.ConsumeAsync(ct)
 
 Filtered-out messages are skipped permanently (see [warning above](#filtering-skips-messages-permanently)). Keep predicates deterministic: a message should be filtered because of *what it is*, not because of *when it arrived* or the current state of your application.
 
+### Handling Filtered Messages Before Continuing
+
+`Where` has an overload that awaits an `onFiltered` callback before requesting the next message. Use it to record, inspect, or park rejected messages:
+
+```csharp
+// Build this consumer with OffsetCommitMode.Manual.
+await foreach (var msg in consumer.ConsumeAsync(ct).Where(
+    CanProcess,
+    async filtered =>
+    {
+        await ParkOnRetryTopicAsync(filtered, ct);
+    },
+    ct))
+{
+    await ProcessAsync(msg);
+    consumer.StoreOffset(msg);
+    await consumer.CommitAsync(ct);
+}
+```
+
+The callback must complete before enumeration continues, and a callback failure stops enumeration. This prevents a later manually committed offset from passing a rejected message before it has been parked.
+
+:::warning Manual commit is required for crash-safe parking
+
+The callback cannot suspend a consumer's background periodic auto-commit. If a rejected message must be parked durably before **any** commit advances past it, configure `OffsetCommitMode.Manual` and commit only after every earlier message has been processed or parked.
+
+:::
+
 ## Select - Transforming Messages
 
 Project messages to a different type:

--- a/src/Dekaf/Consumer/ConsumerExtensions.cs
+++ b/src/Dekaf/Consumer/ConsumerExtensions.cs
@@ -41,6 +41,45 @@ public static class ConsumerExtensions
     }
 
     /// <summary>
+    /// Filters consumed messages and invokes an asynchronous callback for each filtered message.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="source">The source async enumerable of consume results.</param>
+    /// <param name="predicate">The filter predicate.</param>
+    /// <param name="onFiltered">The callback invoked for messages that do not match the predicate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async enumerable of consume results that match the predicate.</returns>
+    /// <remarks>
+    /// The callback completes before the next source message is requested. This allows manual-commit
+    /// consumers to park a filtered message on a retry or dead-letter topic before processing and
+    /// committing later offsets. This method does not suspend periodic auto-commit; use
+    /// <see cref="OffsetCommitMode.Manual"/> when the callback must complete before any commit can
+    /// advance past the filtered message. Callback failures stop enumeration.
+    /// </remarks>
+    public static async IAsyncEnumerable<ConsumeResult<TKey, TValue>> Where<TKey, TValue>(
+        this IAsyncEnumerable<ConsumeResult<TKey, TValue>> source,
+        Func<ConsumeResult<TKey, TValue>, bool> predicate,
+        Func<ConsumeResult<TKey, TValue>, ValueTask> onFiltered,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(onFiltered);
+
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (predicate(item))
+            {
+                yield return item;
+                continue;
+            }
+
+            await onFiltered(item).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     /// Projects each consume result into a new form.
     /// </summary>
     /// <typeparam name="TKey">Key type.</typeparam>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerExtensionsTests.cs
@@ -59,6 +59,89 @@ public sealed class ConsumerExtensionsTests
         });
     }
 
+    [Test]
+    public async Task Where_WithFilteredCallback_InvokesCallbackOnlyForRejectedItems()
+    {
+        var source = CreateResults(("topic", 0, 0), ("topic", 0, 1), ("topic", 0, 2));
+        var filteredOffsets = new List<long>();
+        var yieldedOffsets = new List<long>();
+
+        await foreach (var item in source.Where(
+            result => result.Offset % 2 == 0,
+            result =>
+            {
+                filteredOffsets.Add(result.Offset);
+                return ValueTask.CompletedTask;
+            }))
+        {
+            yieldedOffsets.Add(item.Offset);
+        }
+
+        await Assert.That(yieldedOffsets).IsEquivalentTo([0L, 2L]);
+        await Assert.That(filteredOffsets).IsEquivalentTo([1L]);
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task Where_WithFilteredCallback_AwaitsBeforeRequestingNextItem(
+        CancellationToken cancellationToken)
+    {
+        var callbackStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sourceAdvanced = false;
+        var source = CreateObservedResults(() => sourceAdvanced = true);
+
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var _ in source.Where(
+                _ => false,
+                async _ =>
+                {
+                    callbackStarted.TrySetResult();
+                    await releaseCallback.Task;
+                },
+                cancellationToken))
+            {
+            }
+        }, cancellationToken);
+
+        await callbackStarted.Task.WaitAsync(cancellationToken);
+        await Assert.That(sourceAdvanced).IsFalse();
+
+        releaseCallback.TrySetResult();
+        await enumeration.WaitAsync(cancellationToken);
+
+        await Assert.That(sourceAdvanced).IsTrue();
+    }
+
+    [Test]
+    public async Task Where_WithFilteredCallback_PropagatesCallbackFailure()
+    {
+        var source = CreateResults(("topic", 0, 0));
+        var failure = new InvalidOperationException("parking failed");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in source.Where(
+                _ => false,
+                _ => ValueTask.FromException(failure)))
+            {
+            }
+        });
+    }
+
+    [Test]
+    public async Task Where_NullFilteredCallback_ThrowsArgumentNullException()
+    {
+        var source = CreateResults(("topic", 0, 0));
+        Func<ConsumeResult<string, string>, ValueTask> onFiltered = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+            await foreach (var _ in source.Where(_ => true, onFiltered)) { }
+        });
+    }
+
     #endregion
 
     #region Select
@@ -314,25 +397,35 @@ public sealed class ConsumerExtensionsTests
         params (string Topic, int Partition, long Offset)[] items)
     {
         foreach (var (topic, partition, offset) in items)
-        {
-            yield return new ConsumeResult<string, string>(
-                topic: topic,
-                partition: partition,
-                offset: offset,
-                keyData: default,
-                isKeyNull: true,
-                valueData: default,
-                isValueNull: true,
-                headers: null,
-                timestampMs: 0,
-                timestampType: TimestampType.NotAvailable,
-                leaderEpoch: null,
-                keyDeserializer: null,
-                valueDeserializer: null);
-        }
+            yield return CreateResult(topic, partition, offset);
 
         await Task.CompletedTask; // Ensure truly async
     }
+
+    private static async IAsyncEnumerable<ConsumeResult<string, string>> CreateObservedResults(
+        Action beforeSecondItem)
+    {
+        yield return CreateResult("topic", 0, 0);
+        beforeSecondItem();
+        yield return CreateResult("topic", 0, 1);
+        await Task.CompletedTask;
+    }
+
+    private static ConsumeResult<string, string> CreateResult(string topic, int partition, long offset) =>
+        new(
+            topic: topic,
+            partition: partition,
+            offset: offset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.NotAvailable,
+            leaderEpoch: null,
+            keyDeserializer: null,
+            valueDeserializer: null);
 
     #endregion
 }


### PR DESCRIPTION
## Summary
- add a Where overload that awaits an asynchronous callback for rejected records
- document the manual-commit boundary required for crash-safe parking
- cover callback selection, ordering, failure propagation, and argument validation

## Validation
- ConsumerExtensionsTests: 24/24 on net10.0 and net8.0
- full unit suite: 5476/5476 on net10.0
- full unit suite: 5369/5369 on net8.0

Closes #2068