### PR TITLE
Commit auto offsets before partition revocation

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -35,10 +35,11 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // Signal before publication to defeat assignment ABA (A -> B -> A with the same final set).
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoking;
     // Runs after assignment publication but before user revoke callbacks and the next heartbeat.
-    // KafkaConsumer uses this window to commit revoked offsets before acknowledging ownership changes.
+    // Assignment snapshots wait for this hook so KafkaConsumer cannot discard dirty revoked offsets first.
     private readonly Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>?
         _onPartitionsRevokedAsync;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
+    private Task _pendingRevocationCommit = Task.CompletedTask;
     // Assignment publication and revocation history form one snapshot. Rebalance callbacks
     // run only after this lock is released so user code cannot extend its critical section.
     private readonly Lock _assignmentStateLock = new();
@@ -223,18 +224,28 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
     }
 
-    internal (TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)
-        GetAssignmentSnapshotAndDrainRevocations()
+    internal async ValueTask<(TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)>
+        GetAssignmentSnapshotAndDrainRevocationsAsync(CancellationToken cancellationToken)
     {
-        lock (_assignmentStateLock)
+        while (true)
         {
-            HashSet<TopicPartition>? revoked = null;
-            while (_revokedPartitionsSinceLastSync.TryDequeue(out var partition))
+            Task pendingRevocationCommit;
+            lock (_assignmentStateLock)
             {
-                (revoked ??= []).Add(partition);
+                pendingRevocationCommit = _pendingRevocationCommit;
+                if (pendingRevocationCommit.IsCompleted)
+                {
+                    HashSet<TopicPartition>? revoked = null;
+                    while (_revokedPartitionsSinceLastSync.TryDequeue(out var partition))
+                    {
+                        (revoked ??= []).Add(partition);
+                    }
+
+                    return (_assignedPartitions, Volatile.Read(ref _assignmentVersion), revoked);
+                }
             }
 
-            return (_assignedPartitions, Volatile.Read(ref _assignmentVersion), revoked);
+            await pendingRevocationCommit.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -977,7 +988,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly record struct ConsumerHeartbeatResult(
         bool AssignmentChanged,
         IReadOnlyList<TopicPartition>? Revoked,
-        IReadOnlyList<TopicPartition>? Assigned);
+        IReadOnlyList<TopicPartition>? Assigned,
+        TaskCompletionSource<bool>? RevocationCommitCompletion = null);
 
     /// <summary>
     /// Resets member identity and assignment to the pre-join state.
@@ -1020,16 +1032,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         ConsumerHeartbeatResult result,
         CancellationToken cancellationToken)
     {
-        await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var rebalanceListenerLockHeld = false;
         try
         {
+            await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            rebalanceListenerLockHeld = true;
             await FireConsumerProtocolRebalanceListenersCoreAsync(
                 result,
                 cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            _rebalanceListenerLock.Release();
+            CompleteRevocationCommit(result);
+            if (rebalanceListenerLockHeld)
+                _rebalanceListenerLock.Release();
         }
     }
 
@@ -1042,8 +1058,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         if (result.Revoked is { Count: > 0 } revoked)
         {
-            if (_onPartitionsRevokedAsync is not null)
-                await _onPartitionsRevokedAsync(revoked, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_onPartitionsRevokedAsync is not null)
+                    await _onPartitionsRevokedAsync(revoked, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                CompleteRevocationCommit(result);
+            }
 
             await InvokeRebalanceListenersAsync(
                 "OnPartitionsRevoked",
@@ -1059,6 +1082,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 static (listener, partitions, token) => listener.OnPartitionsAssignedAsync(partitions, token),
                 cancellationToken).ConfigureAwait(false);
     }
+
+    private static void CompleteRevocationCommit(ConsumerHeartbeatResult result)
+        => result.RevocationCommitCompletion?.TrySetResult(true);
 
     /// <summary>
     /// Sends a ConsumerGroupHeartbeat request and processes the response.
@@ -1160,9 +1186,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
 
         var rebalanceListenerLockHeld = false;
+        ConsumerHeartbeatResult result = default;
         try
         {
-            ConsumerHeartbeatResult result;
             using (assignmentProcessing)
             {
                 await _rebalanceListenerLock.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -1198,6 +1224,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
         finally
         {
+            CompleteRevocationCommit(result);
             if (rebalanceListenerLockHeld)
                 _rebalanceListenerLock.Release();
         }
@@ -1411,6 +1438,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
 
         var changed = revoked is { Count: > 0 } || assigned is { Count: > 0 };
+        TaskCompletionSource<bool>? revocationCommitCompletion = null;
+        if (revoked is { Count: > 0 }
+            && _options.OffsetCommitMode == OffsetCommitMode.Auto
+            && _onPartitionsRevokedAsync is not null)
+        {
+            revocationCommitCompletion = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
         if (changed)
         {
             NotifyRevoking(revoked);
@@ -1422,6 +1458,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 if (revoked is not null)
                     EnqueueRevokedPartitions(revoked);
+                if (revocationCommitCompletion is not null)
+                    _pendingRevocationCommit = revocationCommitCompletion.Task;
             }
 
             if (revoked is not null)
@@ -1430,7 +1468,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             LogConsumerProtocolAssignmentUpdate(assigned?.Count ?? 0, revoked?.Count ?? 0);
         }
 
-        return new ConsumerHeartbeatResult(changed, revoked, assigned);
+        return new ConsumerHeartbeatResult(changed, revoked, assigned, revocationCommitCompletion);
     }
 
     private void NotifyRevoking(IReadOnlyList<TopicPartition>? revoked)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -34,6 +34,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // Heartbeats can revoke and reassign a partition between poll-loop snapshots.
     // Signal before publication to defeat assignment ABA (A -> B -> A with the same final set).
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoking;
+    // Runs after assignment publication but before user revoke callbacks and the next heartbeat.
+    // KafkaConsumer uses this window to commit revoked offsets before acknowledging ownership changes.
+    private readonly Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>?
+        _onPartitionsRevokedAsync;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
     // Assignment publication and revocation history form one snapshot. Rebalance callbacks
     // run only after this lock is released so user code cannot extend its critical section.
@@ -104,7 +108,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             logger,
             getConnectionCount,
             onPartitionsRevoked,
-            onPartitionsRevoking: null)
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: null)
     {
     }
 
@@ -115,7 +120,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         ILogger<ConsumerCoordinator>? logger,
         Func<int>? getConnectionCount,
         Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked,
-        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking)
+        Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking,
+        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? onPartitionsRevokedAsync = null)
     {
         _options = options;
         _connectionPool = connectionPool;
@@ -123,6 +129,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         _rebalanceListener = options.RebalanceListener;
         _onPartitionsRevoked = onPartitionsRevoked;
         _onPartitionsRevoking = onPartitionsRevoking;
+        _onPartitionsRevokedAsync = onPartitionsRevokedAsync;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConsumerCoordinator>.Instance;
         _getCoordinationConnectionIndex = getConnectionCount is not null
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
@@ -1033,12 +1040,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (!result.AssignmentChanged)
             return;
 
-        if (result.Revoked is { Count: > 0 })
+        if (result.Revoked is { Count: > 0 } revoked)
+        {
+            if (_onPartitionsRevokedAsync is not null)
+                await _onPartitionsRevokedAsync(revoked, cancellationToken).ConfigureAwait(false);
+
             await InvokeRebalanceListenersAsync(
                 "OnPartitionsRevoked",
-                result.Revoked,
+                revoked,
                 static (listener, partitions, token) => listener.OnPartitionsRevokedAsync(partitions, token),
                 cancellationToken).ConfigureAwait(false);
+        }
 
         if (result.Assigned is { Count: > 0 })
             await InvokeRebalanceListenersAsync(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1219,7 +1219,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     ? () => Volatile.Read(ref _appliedConnectionCount)
                     : null,
                 onPartitionsRevoked: null,
-                onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear);
+                onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear,
+                onPartitionsRevokedAsync: CommitRevokedOffsetsAsync);
         }
 
         _prefetchBuffer = new MpscFetchBuffer(CalculatePrefetchBufferCapacity(options));
@@ -3955,7 +3956,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             .ConfigureAwait(false);
     }
 
-    private async ValueTask<bool> CommitStoredOffsetsAsync(CancellationToken cancellationToken)
+    private ValueTask<bool> CommitStoredOffsetsAsync(CancellationToken cancellationToken) =>
+        CommitStoredOffsetsAsync(partitions: null, cancellationToken);
+
+    private async ValueTask<bool> CommitStoredOffsetsAsync(
+        TopicPartitionSet? partitions,
+        CancellationToken cancellationToken)
     {
         if (_coordinator is null)
             return false;
@@ -3966,7 +3972,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             // Commit only offsets that changed since the last successful commit.
             // Snapshot the concurrent dictionary to avoid race conditions during enumeration
-            var dirtyOffsetsSnapshot = _dirtyStoredOffsets.ToArray();
+            var dirtyOffsetsSnapshot = partitions is null
+                ? _dirtyStoredOffsets.ToArray()
+                : _dirtyStoredOffsets.Where(kvp => partitions.Contains(kvp.Key)).ToArray();
             offsetCount = dirtyOffsetsSnapshot.Length;
             if (offsetCount == 0)
                 return false;
@@ -4009,6 +4017,36 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return true;
+    }
+
+    private async ValueTask CommitRevokedOffsetsAsync(
+        IReadOnlyList<TopicPartition> partitions,
+        CancellationToken cancellationToken)
+    {
+        if (_options.OffsetCommitMode != OffsetCommitMode.Auto)
+            return;
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_options.RebalanceTimeoutMs);
+
+        try
+        {
+            var revoked = partitions.ToHashSet();
+            if (await CommitStoredOffsetsAsync(revoked, timeout.Token).ConfigureAwait(false))
+                LogCommittedRevokedOffsets();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            LogCommitRevokedOffsetsTimedOut(_options.RebalanceTimeoutMs);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogCommitRevokedOffsetsFailed(ex);
+        }
     }
 
     public async ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default)
@@ -7566,6 +7604,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Auto-commit failed, retrying once")]
     private partial void LogAutoCommitFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Committed stored offsets before partition revocation")]
+    private partial void LogCommittedRevokedOffsets();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Commit of revoked offsets timed out after {TimeoutMs}ms; continuing rebalance")]
+    private partial void LogCommitRevokedOffsetsTimedOut(int timeoutMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to commit revoked offsets; continuing rebalance")]
+    private partial void LogCommitRevokedOffsetsFailed(Exception exception);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Closing consumer gracefully")]
     private partial void LogClosingConsumer();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5087,7 +5087,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 BeforeCoordinatorAssignmentSnapshotForTest?.Invoke();
                 var (coordinatorAssignment, coordinatorAssignmentVersion, coordinatorRevocations) =
-                    coordinator.GetAssignmentSnapshotAndDrainRevocations();
+                    await coordinator.GetAssignmentSnapshotAndDrainRevocationsAsync(cancellationToken)
+                        .ConfigureAwait(false);
                 if (coordinatorRevocations is not null)
                 {
                     unacknowledgedCoordinatorRevocations = (coordinator, coordinatorRevocations);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -536,6 +536,74 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task EnsureAssignmentAsync_RevocationCommitPending_WaitsForCommit(
+        CancellationToken testTimeout)
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetch(connection);
+        var commitStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCommit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        OffsetCommitRequest? commitRequest = null;
+        connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => BlockOffsetCommitAsync(
+                call.ArgAt<OffsetCommitRequest>(0),
+                call.ArgAt<CancellationToken>(2)));
+
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            offsetCommitMode: OffsetCommitMode.Auto);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(testTimeout);
+        var coordinator = GetCoordinator(consumer);
+        var revokedPartition = new TopicPartition("test-topic", 0);
+        var assignedPartition = new TopicPartition("test-topic", 1);
+        consumer.StoreOffset(new TopicPartitionOffset(revokedPartition.Topic, revokedPartition.Partition, 10));
+
+        var revokedResult = ProcessCoordinatorAssignment(coordinator, CreateAssignment(1));
+        var listenerTask = FireConsumerProtocolRebalanceListenersAsync(
+            coordinator,
+            revokedResult,
+            testTimeout).AsTask();
+        await commitStarted.Task.WaitAsync(testTimeout);
+        var assignmentTask = consumer.EnsureAssignmentAsync(testTimeout).AsTask();
+
+        await Assert.That(assignmentTask.IsCompleted).IsFalse();
+        await Assert.That(consumer.Assignment).Contains(revokedPartition);
+
+        releaseCommit.TrySetResult(true);
+        await listenerTask;
+        await assignmentTask;
+
+        await Assert.That(commitRequest).IsNotNull();
+        await Assert.That(consumer.Assignment).DoesNotContain(revokedPartition);
+        await Assert.That(consumer.Assignment).Contains(assignedPartition);
+
+        async ValueTask<OffsetCommitResponse> BlockOffsetCommitAsync(
+            OffsetCommitRequest request,
+            CancellationToken cancellationToken)
+        {
+            commitRequest = request;
+            commitStarted.TrySetResult(true);
+            await releaseCommit.Task.WaitAsync(cancellationToken);
+            return new OffsetCommitResponse { Topics = [] };
+        }
+    }
+
+    [Test]
     public async Task CoordinatorRevocationFetchClear_ConcurrentQueueAndDrain_KeepsPendingFlagConsistent()
     {
         await using var consumer = CreateConsumer();
@@ -903,14 +971,15 @@ public sealed class ConsumerAssignmentFastPathTests
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         int queuedMinMessages = 1,
-        int maxPollIntervalMs = 300_000)
+        int maxPollIntervalMs = 300_000,
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "group-a",
-                OffsetCommitMode = OffsetCommitMode.Manual,
+                OffsetCommitMode = offsetCommitMode,
                 QueuedMinMessages = queuedMinMessages,
                 MaxPollIntervalMs = maxPollIntervalMs
             },
@@ -1526,7 +1595,7 @@ public sealed class ConsumerAssignmentFastPathTests
         field.SetValue(consumer, -1);
     }
 
-    private static void ProcessCoordinatorAssignment(
+    private static object ProcessCoordinatorAssignment(
         ConsumerCoordinator coordinator,
         ConsumerGroupHeartbeatAssignment assignment)
     {
@@ -1535,7 +1604,22 @@ public sealed class ConsumerAssignmentFastPathTests
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("ProcessConsumerGroupAssignment method not found.");
 
-        method.Invoke(coordinator, [assignment]);
+        return method.Invoke(coordinator, [assignment])
+            ?? throw new InvalidOperationException("ProcessConsumerGroupAssignment returned null.");
+    }
+
+    private static ValueTask FireConsumerProtocolRebalanceListenersAsync(
+        ConsumerCoordinator coordinator,
+        object result,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "FireConsumerProtocolRebalanceListenersAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("FireConsumerProtocolRebalanceListenersAsync method not found.");
+
+        return (ValueTask)(method.Invoke(coordinator, [result, cancellationToken])
+            ?? throw new InvalidOperationException("FireConsumerProtocolRebalanceListenersAsync returned null."));
     }
 
     private static PendingFetchData CreateFetch(int partition, long baseOffset, string value)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1788,6 +1788,84 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task ConsumerProtocol_RevocationHook_CompletesBeforeUserListener(
+        CancellationToken cancellationToken)
+    {
+        SetupFindCoordinator();
+
+        var callCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = count == 1
+                        ? CreateAssignment(TestTopicId, 0, 1)
+                        : CreateAssignment(TestTopicId, 1)
+                });
+            });
+
+        var hookStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHook = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var listenerCallCount = 0;
+        var listener = Substitute.For<IRebalanceListener>();
+        listener.OnPartitionsRevokedAsync(
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Interlocked.Increment(ref listenerCallCount);
+                return ValueTask.CompletedTask;
+            });
+
+        async ValueTask OnPartitionsRevokedAsync(
+            IReadOnlyList<TopicPartition> _partitions,
+            CancellationToken _cancellationToken)
+        {
+            hookStarted.TrySetResult();
+            await releaseHook.Task;
+        }
+
+        var options = CreateConsumerProtocolOptions(
+            rebalanceListener: listener,
+            heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            logger: null,
+            getConnectionCount: null,
+            onPartitionsRevoked: null,
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: OnPartitionsRevokedAsync);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, cancellationToken);
+        await coordinator.StopHeartbeatAsync();
+
+        coordinator.RequestRejoin();
+        var rejoin = coordinator.EnsureActiveGroupAsync(topics, cancellationToken).AsTask();
+        await hookStarted.Task.WaitAsync(cancellationToken);
+
+        await Assert.That(Volatile.Read(ref listenerCallCount)).IsEqualTo(0);
+
+        releaseHook.TrySetResult();
+        await rejoin;
+        await coordinator.StopHeartbeatAsync();
+
+        await Assert.That(Volatile.Read(ref listenerCallCount)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_AssignmentVersion_IncrementsWhenResetClearsAssignment()
     {
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1578,7 +1578,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FencedMemberEpoch);
         await Assert.That(commitRequestCount).IsEqualTo(0);
 
-        var (_, assignmentVersion, _) = coordinator.GetAssignmentSnapshotAndDrainRevocations();
+        var (_, assignmentVersion, _) = await coordinator.GetAssignmentSnapshotAndDrainRevocationsAsync(
+            CancellationToken.None);
         coordinator.AcknowledgeAssignmentSync(assignmentVersion);
         await coordinator.CommitOffsetsAsync(
             [new TopicPartitionOffset("test-topic", 0, 1)],
@@ -1632,7 +1633,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             "_maxPollExpiredAtPollVersion",
             GetCoordinatorLongField(coordinator, "_pollVersion"));
 
-        var (_, assignmentVersion, _) = coordinator.GetAssignmentSnapshotAndDrainRevocations();
+        var (_, assignmentVersion, _) = await coordinator.GetAssignmentSnapshotAndDrainRevocationsAsync(
+            CancellationToken.None);
         coordinator.AcknowledgeAssignmentSync(assignmentVersion);
 
         var exception = await Assert.That(async () =>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -312,6 +312,99 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
+    public async Task Revoke_AutoCommit_CommitsOnlyRevokedDirtyOffsets()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+        var revoked = new TopicPartition("topic-a", 0);
+        var retained = new TopicPartition("topic-a", 1);
+        consumer.StoreOffset(new TopicPartitionOffset(revoked.Topic, revoked.Partition, 10));
+        consumer.StoreOffset(new TopicPartitionOffset(retained.Topic, retained.Partition, 20));
+
+        await CommitRevokedOffsetsAsync(consumer, [revoked]);
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).Count().IsEqualTo(2);
+        await Assert.That(GetCommittedOffsets(requests[0])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10)
+        ]);
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 1, 20)
+        ]);
+    }
+
+    [Test]
+    public async Task Revoke_ManualCommit_DoesNotCommitStoredOffsets()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Manual,
+            enableAutoOffsetStore: false);
+        var revoked = new TopicPartition("topic-a", 0);
+        consumer.StoreOffset(new TopicPartitionOffset(revoked.Topic, revoked.Partition, 10));
+
+        await CommitRevokedOffsetsAsync(consumer, [revoked]);
+
+        await Assert.That(requests).IsEmpty();
+    }
+
+    [Test]
+    public async Task Revoke_WhenCommitFails_PreservesOffsetAndContinues()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        var responseErrors = new Queue<ErrorCode>([ErrorCode.InvalidCommitOffsetSize, ErrorCode.None]);
+        await using var consumer = CreateConsumer(
+            requests,
+            responseErrors,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false);
+        var revoked = new TopicPartition("topic-a", 0);
+        consumer.StoreOffset(new TopicPartitionOffset(revoked.Topic, revoked.Partition, 10));
+
+        await CommitRevokedOffsetsAsync(consumer, [revoked]);
+        await CommitStoredOffsetsAsync(consumer);
+
+        await Assert.That(requests).Count().IsEqualTo(2);
+        await Assert.That(GetCommittedOffsets(requests[1])).IsEquivalentTo(
+        [
+            new TopicPartitionOffset("topic-a", 0, 10)
+        ]);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task Revoke_WhenCommitExceedsRebalanceTimeout_Continues(
+        CancellationToken cancellationToken)
+    {
+        var requests = new List<OffsetCommitRequest>();
+        var commitAttempt = 0;
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            OffsetCommitMode.Auto,
+            enableAutoOffsetStore: false,
+            rebalanceTimeoutMs: 25,
+            onOffsetCommitAsync: token => Interlocked.Increment(ref commitAttempt) == 1
+                ? new ValueTask(Task.Delay(Timeout.InfiniteTimeSpan, token))
+                : ValueTask.CompletedTask);
+        var revoked = new TopicPartition("topic-a", 0);
+        consumer.StoreOffset(new TopicPartitionOffset(revoked.Topic, revoked.Partition, 10));
+
+        await CommitRevokedOffsetsAsync(consumer, [revoked]);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await Assert.That(requests).Count().IsEqualTo(1);
+    }
+
+    [Test]
     public async Task CommitAsync_WhenAutoOffsetStoreDisabled_CommitsOnlyStoredOffset()
     {
         var requests = new List<OffsetCommitRequest>();
@@ -373,20 +466,26 @@ public sealed class ConsumerDirtyCommitTests
         ErrorCode responseError,
         OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
         bool enableAutoOffsetStore = true,
-        Action<CancellationToken>? onOffsetCommit = null)
+        Action<CancellationToken>? onOffsetCommit = null,
+        int rebalanceTimeoutMs = 60_000,
+        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null)
         => CreateConsumer(
             requests,
             new Queue<ErrorCode>([responseError]),
             offsetCommitMode,
             enableAutoOffsetStore,
-            onOffsetCommit);
+            onOffsetCommit,
+            rebalanceTimeoutMs,
+            onOffsetCommitAsync);
 
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
         Queue<ErrorCode> responseErrors,
         OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
         bool enableAutoOffsetStore = true,
-        Action<CancellationToken>? onOffsetCommit = null)
+        Action<CancellationToken>? onOffsetCommit = null,
+        int rebalanceTimeoutMs = 60_000,
+        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null)
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -421,10 +520,13 @@ public sealed class ConsumerDirtyCommitTests
             {
                 var request = call.Arg<OffsetCommitRequest>()!;
                 requests.Add(CloneRequest(request));
-                onOffsetCommit?.Invoke(call.Arg<CancellationToken>());
+                var token = call.Arg<CancellationToken>();
+                onOffsetCommit?.Invoke(token);
 
                 var error = responseErrors.Count == 0 ? ErrorCode.None : responseErrors.Dequeue();
-                return ValueTask.FromResult(CreateResponse(request, error));
+                return onOffsetCommitAsync is null
+                    ? ValueTask.FromResult(CreateResponse(request, error))
+                    : CompleteOffsetCommitAsync(request, error, onOffsetCommitAsync(token));
             });
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
@@ -448,7 +550,8 @@ public sealed class ConsumerDirtyCommitTests
                 BootstrapServers = ["localhost:9092"],
                 GroupId = "group-a",
                 OffsetCommitMode = offsetCommitMode,
-                EnableAutoOffsetStore = enableAutoOffsetStore
+                EnableAutoOffsetStore = enableAutoOffsetStore,
+                RebalanceTimeoutMs = rebalanceTimeoutMs
             },
             Serializers.String,
             Serializers.String,
@@ -533,7 +636,10 @@ public sealed class ConsumerDirtyCommitTests
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
             "CommitStoredOffsetsAsync",
-            BindingFlags.NonPublic | BindingFlags.Instance)!;
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            types: [typeof(CancellationToken)],
+            modifiers: null)!;
 
         var commit = method.Invoke(consumer, [CancellationToken.None])!;
         if (commit is ValueTask valueTask)
@@ -549,6 +655,17 @@ public sealed class ConsumerDirtyCommitTests
         }
 
         throw new InvalidOperationException($"Unexpected CommitStoredOffsetsAsync return type: {commit.GetType()}.");
+    }
+
+    private static async Task CommitRevokedOffsetsAsync(
+        KafkaConsumer<string, string> consumer,
+        IReadOnlyList<TopicPartition> partitions)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CommitRevokedOffsetsAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await (ValueTask)method.Invoke(consumer, [partitions, CancellationToken.None])!;
     }
 
     private static ConsumeResult<string, string> CreateConsumeResult(long offset, int leaderEpoch)
@@ -612,6 +729,15 @@ public sealed class ConsumerDirtyCommitTests
                 })
                 .ToArray()
         };
+    }
+
+    private static async ValueTask<OffsetCommitResponse> CompleteOffsetCommitAsync(
+        OffsetCommitRequest request,
+        ErrorCode error,
+        ValueTask beforeCommit)
+    {
+        await beforeCommit;
+        return CreateResponse(request, error);
     }
 
     private static TopicPartitionOffset[] GetCommittedOffsets(OffsetCommitRequest request)


### PR DESCRIPTION
## Summary
- commit dirty offsets for revoked partitions before user revoke listeners and the next ownership heartbeat
- bound the best-effort commit by the configured rebalance timeout and preserve reprocessing behavior on failure
- leave Manual commit mode unchanged

## Validation
- affected revocation/commit tests: 5/5 on net10.0 and net8.0
- full unit suite: 5482/5482 on net10.0
- full unit suite: 5375/5375 on net8.0
- Release builds: zero warnings on net10.0 and net8.0/netstandard2.0

Closes #2063