### PR TITLE
feat(consumer)!: at-least-once delivery by default + intent-level processing API

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -17,6 +17,10 @@ on:
         description: 'Bounded message count for round-trip correctness scenario'
         required: false
         default: '250000'
+      consumer_fetch_diagnostics:
+        description: 'Enable Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead to the measured window)'
+        required: false
+        default: 'false'
 
 concurrency:
   group: stress-tests
@@ -251,6 +255,12 @@ jobs:
           trap 'kill $DISK_MONITOR_PID 2>/dev/null || true' EXIT
 
           cd tools/Dekaf.StressTests
+          # Consumer fetch diagnostics are opt-in: they add Dekaf-only overhead inside the
+          # measured window, so measurement runs keep them off and debug dispatches enable them.
+          EXTRA_ARGS=""
+          if [ "${{ github.event.inputs.consumer_fetch_diagnostics }}" = "true" ]; then
+            EXTRA_ARGS="--consumer-fetch-diagnostics"
+          fi
           # Client pinned to its own cores: whichever client pushes more through the
           # same cores is genuinely faster, instead of both saturating the broker.
           paired_samples=${{ matrix.paired_samples || 1 }}
@@ -274,6 +284,7 @@ jobs:
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 1 \
               --producer-delivery-diagnostics \
+              ${EXTRA_ARGS} \
               --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
               --output ./results
           done
@@ -288,6 +299,7 @@ jobs:
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
               --producer-delivery-diagnostics \
+              ${EXTRA_ARGS} \
               --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
               --output ./results
           fi

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -81,6 +81,8 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithGroupInstanceId(...)` | `GroupInstanceId` | String |
 | `WithGroupRemoteAssignor(...)` | `GroupRemoteAssignor` | Common values: `uniform`, `range` |
 | `WithOffsetCommitMode(...)` | `OffsetCommitMode` | `Auto` or `Manual` |
+| `WithOffsetStoreTiming(...)` | `OffsetStoreTiming` | `AfterProcessing` (default, at-least-once) or `OnDelivery` (at-most-once) |
+| `WithAutoOffsetStore(...)` | `EnableAutoOffsetStore` | Boolean; disable for explicit `StoreOffset` acknowledgment |
 | `WithAutoCommitInterval(...)` | `AutoCommitIntervalMs` | Milliseconds |
 | `WithAutoOffsetReset(...)` | `AutoOffsetReset` | `Latest`, `Earliest`, `None` |
 | `WithAutoOffsetResetByDuration(...)` | `AutoOffsetReset`, `AutoOffsetResetDuration` | Use `AutoOffsetReset: ByDuration` plus a duration, or Kafka-style `by_duration:PT24H` |
@@ -161,6 +163,22 @@ How offsets are committed (matches Kafka's `enable.auto.commit`):
 ```csharp
 .WithOffsetCommitMode(OffsetCommitMode.Auto)    // Automatic commit in background (default)
 .WithOffsetCommitMode(OffsetCommitMode.Manual)  // You call CommitAsync() explicitly
+```
+
+### Processing Guarantees
+
+Intent-level methods that configure commit mode, offset storage, and staging timing together
+(see [Delivery Semantics](../consumer/delivery-semantics.md)):
+
+```csharp
+.WithAtLeastOnceProcessing()  // The default, stated explicitly: offsets become committable
+                              // only after the loop demonstrably processed the record
+.WithAtMostOnceProcessing()   // Confluent-style: offsets committable at delivery,
+                              // before processing runs
+.WithAutoOffsetStore(false)   // Strict at-least-once: only offsets you pass to
+                              // StoreOffset(...) are ever committed
+.WithOffsetStoreTiming(OffsetStoreTiming.AfterProcessing) // Granular knob behind the
+                              // intent methods (AfterProcessing | OnDelivery)
 ```
 
 ### WithAutoCommitInterval
@@ -386,6 +404,8 @@ For transactional reads:
 | `WithGroupId` | null | Consumer group ID |
 | `WithGroupInstanceId` | null | Static membership ID |
 | `WithOffsetCommitMode` | Auto | Offset management mode |
+| `WithOffsetStoreTiming` | AfterProcessing | When offsets become committable (at-least-once default) |
+| `WithAutoOffsetStore` | true | Automatic offset staging |
 | `WithAutoCommitInterval` | 5000ms | Auto-commit interval |
 | `WithAutoOffsetReset`, `WithAutoOffsetResetByDuration` | Latest | Start position |
 | `WithFetchMinBytes` | 1 | Minimum fetch bytes |

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -255,7 +255,7 @@ string? memberId = consumer.MemberId;
 
 ## Complete Example
 
-This example processes orders with at-least-once semantics: auto offset store is disabled,
+This example processes orders with at-least-once semantics: automatic offset storage is disabled,
 offsets are stored only after processing succeeds, and a processing failure stops the consumer
 instead of skipping the order — so the failed order is redelivered on restart rather than being
 silently committed away. Background auto-commit still handles the actual commits.
@@ -278,7 +278,7 @@ public class OrderConsumer : BackgroundService
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("order-processor")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithAutoOffsetStore(false)  // Only commit offsets we explicitly store
+            .WithAtLeastOnceProcessing() // Only commit offsets we explicitly store
             .SubscribeTo("orders")
             .BuildAsync();
 

--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -171,16 +171,17 @@ catch (ConsumeException ex)
 }
 ```
 
-:::caution Catching an exception does not stop the commit
-With the default configuration (auto-commit + auto offset store), a message's offset is staged
-for commit the moment `ConsumeAsync` yields it to you — *before* your processing runs. If your
-handler throws and you log-and-continue like above, the failed message's offset is still
-committed within the auto-commit interval (5 seconds by default), and the message will never be
-redelivered. No crash is required for this loss — a swallowed exception is enough.
+:::caution Catching an exception still acknowledges the message
+Dekaf's default is at-least-once: a message that makes your handler **throw out of the loop**
+is not committed and is redelivered after a restart or rebalance. But the loop cannot see
+inside your `catch` — if you log-and-continue like above, the next loop iteration counts the
+failed message as processed and its offset is committed within the auto-commit interval
+(5 seconds by default). The message is then never redelivered.
 
-If losing failed messages is not acceptable, disable auto offset store and store offsets only
-after processing succeeds (see the complete example below), or switch to
-[manual commits](offset-management.md).
+If you need to catch exceptions and keep consuming *without* losing failed messages, disable
+auto offset store and store offsets only after processing succeeds (see the complete example
+below), or switch to [manual commits](offset-management.md). The full contract is on the
+[Delivery Semantics](delivery-semantics.md) page.
 :::
 
 ## Graceful Shutdown
@@ -255,10 +256,14 @@ string? memberId = consumer.MemberId;
 
 ## Complete Example
 
-This example processes orders with at-least-once semantics: automatic offset storage is disabled,
-offsets are stored only after processing succeeds, and a processing failure stops the consumer
-instead of skipping the order — so the failed order is redelivered on restart rather than being
-silently committed away. Background auto-commit still handles the actual commits.
+This example processes orders with strict at-least-once semantics: automatic offset storage is
+disabled, offsets are stored only after processing succeeds, and a processing failure stops the
+consumer instead of skipping the order — so the failed order is redelivered on restart rather
+than being silently committed away. Background auto-commit still handles the actual commits.
+
+The explicit `StoreOffset` pattern is stricter than Dekaf's (already at-least-once) default:
+it keeps failed orders safe even when an exception is caught somewhere and the loop continues,
+because nothing is committed without your explicit acknowledgment.
 
 ```csharp
 using Dekaf;
@@ -278,7 +283,7 @@ public class OrderConsumer : BackgroundService
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("order-processor")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithAtLeastOnceProcessing() // Only commit offsets we explicitly store
+            .WithAutoOffsetStore(false) // Only commit offsets we explicitly store
             .SubscribeTo("orders")
             .BuildAsync();
 

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Consumer Groups

--- a/docs/docs/consumer/delivery-semantics.md
+++ b/docs/docs/consumer/delivery-semantics.md
@@ -1,0 +1,235 @@
+---
+sidebar_position: 2
+---
+
+# Delivery Semantics
+
+What happens to a message when your processing fails? This page is the definitive reference for
+Dekaf's delivery guarantees: what the defaults give you, exactly when an offset becomes
+committable, and how to switch to a different guarantee when your workload needs it.
+
+## TL;DR
+
+- **Dekaf's default is at-least-once.** A record's offset only becomes committable once your
+  code has demonstrably moved past it. If processing throws out of the consume loop, that
+  record is *not* committed and is redelivered after a restart or rebalance.
+- **Duplicates are part of the contract.** At-least-once means "never lost, possibly repeated" —
+  make processing idempotent.
+- **This differs from Confluent.Kafka**, whose auto-commit default is effectively at-most-once
+  (offsets become committable at delivery, before processing). Use
+  `WithAtMostOnceProcessing()` if you migrated from Confluent and want that behavior.
+- **Catching an exception and continuing still counts as processed.** The consume loop cannot
+  see inside your `catch`. For strict per-record acknowledgment, use
+  [explicit offset storage](#explicit-acknowledgment-strict-at-least-once).
+
+## How the Default Works
+
+Kafka consumers do not acknowledge individual messages; they commit *positions* ("everything
+before offset N is done"). The design question every client must answer is: **when does a
+delivered record's offset become committable?**
+
+Dekaf's answer, by default: **when the application has proven it processed the record** — by
+asking for the next one.
+
+```csharp
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessAsync(msg);   // If this throws, msg is NOT committed → redelivered.
+}                              // Asking for the next msg proves this one was processed.
+```
+
+In a sequential `await foreach` loop, the loop body must finish before the enumerator is asked
+for the next record. Dekaf uses that request as the acknowledgment signal:
+
+1. When a record is yielded to you, it is **in doubt** — delivered, but not yet committable.
+2. When you request the next record (or batch), the previous one is marked **proven**.
+3. Proven offsets are staged in batches (once per fetch, not per message — this costs nothing
+   on the hot path) and the background auto-commit loop commits them every
+   `AutoCommitIntervalMs` (default 5000 ms).
+4. If your loop body throws — or you `break` — the enumerator is disposed without that final
+   request, so the in-doubt record is never staged. The next consumer to own the partition
+   starts from the last proven offset and redelivers it.
+
+The same "a new call proves the previous record" contract applies to `ConsumeOneAsync` and to
+`ConsumeBatchAsync` (where the unit of proof is the whole batch).
+
+This is the same contract as the Java client's poll-loop auto-commit — commits only ever cover
+records from *completed* loop iterations — but tracked per record rather than per poll.
+
+## Choosing a Guarantee
+
+| You want | Configuration | On processing failure |
+|----------|---------------|----------------------|
+| At-least-once (default) | Nothing — or `WithAtLeastOnceProcessing()` to make it explicit | Record redelivered if the failure exits the loop |
+| At-least-once, strict per-record acks | `WithAutoOffsetStore(false)` + `StoreOffset` after success | Record redelivered even if you catch and continue |
+| At-most-once (Confluent-style) | `WithAtMostOnceProcessing()` | Record may be committed anyway — never redelivered |
+| Full manual control | `WithOffsetCommitMode(OffsetCommitMode.Manual)` + `CommitAsync` | You decide |
+| Exactly-once | Transactions or transactional outbox | See [Exactly-Once](offset-management.md#achieving-exactly-once) |
+
+### At-Least-Once (the default)
+
+```csharp
+using Dekaf;
+
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithAtLeastOnceProcessing() // optional — this is the default; call it to state intent
+    .SubscribeTo("my-topic")
+    .BuildAsync();
+
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessAsync(msg);
+}
+```
+
+Guarantees, precisely:
+
+- Processing throws and the exception leaves the loop → the failing record and everything after
+  it is redelivered. **No loss.**
+- Process crash / OOM / kill → everything not yet committed is redelivered. **No loss.**
+- Graceful shutdown by cancelling the token → all processed records are committed on dispose.
+  **No loss, no duplicates.**
+- Rebalance → partitions hand off at the last committed offset; the in-flight tail is
+  redelivered to the new owner. **No loss, possible duplicates.**
+
+What it does *not* protect against:
+
+:::caution Catch-and-continue acknowledges the record
+```csharp
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    try { await ProcessAsync(msg); }
+    catch (Exception ex) { _logger.LogError(ex, "oops"); } // swallowed
+    // The loop continues → the next iteration proves msg "processed" → it commits.
+}
+```
+The consume loop cannot distinguish "processed successfully" from "failed but the exception was
+swallowed". If you need failed records preserved while the loop continues, either dead-letter
+them before continuing, or use [explicit acknowledgment](#explicit-acknowledgment-strict-at-least-once).
+:::
+
+:::caution Breaking out of the loop leaves the last record uncommitted
+`break` and an exception look identical to the enumerator, so the record you were holding when
+you broke is conservatively treated as unproven — it will be redelivered on the next start.
+That is safe (a duplicate, not a loss), but if you want an exact handoff, commit explicitly
+after the loop:
+
+```csharp
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessAsync(msg);
+    if (SomeCondition) break;
+}
+await consumer.CommitAsync(); // vouches for everything delivered so far
+```
+
+Shutting down by cancelling the consume token does *not* have this caveat — cancellation is
+observed while waiting for the next record, after the previous one was proven.
+:::
+
+### Explicit Acknowledgment (strict at-least-once)
+
+Auto-commit stays on, but nothing is staged automatically: only offsets you explicitly store
+are ever committed. This survives catch-and-continue, hands the acknowledgment decision to your
+code, and still avoids per-message commit round-trips.
+
+```csharp
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithAutoOffsetStore(false)   // nothing staged automatically
+    .SubscribeTo("my-topic")
+    .BuildAsync();
+
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessAsync(msg);
+    consumer.StoreOffset(msg);    // cheap, in-memory; background loop commits it
+}
+```
+
+:::caution Offsets are positions, not per-message acks
+Storing a later offset also commits everything before it. If record 41 failed and you keep
+consuming and store record 42, record 41 is committed away with it. Dead-letter the failure or
+stop the partition before moving on.
+:::
+
+### At-Most-Once (Confluent-style)
+
+A record's offset is staged for commit the moment it is delivered — before your code runs. A
+record whose processing fails may already be committed, and is then never redelivered.
+
+```csharp
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithAtMostOnceProcessing()
+    .SubscribeTo("my-topic")
+    .BuildAsync();
+```
+
+Use when occasional loss is preferable to duplicate work: metrics, logs, ephemeral state where
+a stale update is worse than a missing one. This matches the Confluent.Kafka / librdkafka
+auto-commit convention, so it is also the drop-in choice when migrating a workload that already
+tolerates it.
+
+### Manual Commits
+
+```csharp
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithOffsetCommitMode(OffsetCommitMode.Manual)
+    .SubscribeTo("my-topic")
+    .BuildAsync();
+
+await foreach (var msg in consumer.ConsumeAsync(ct))
+{
+    await ProcessAsync(msg);
+    await consumer.CommitAsync();  // network round-trip; batch for throughput
+}
+```
+
+See [Offset Management](offset-management.md) for commit batching strategies.
+
+## How Other Clients Compare
+
+| | Dekaf (default) | Java client (default) | Confluent.Kafka (default) |
+|---|---|---|---|
+| Auto-commit | background loop, 5 s | inside `poll()`, 5 s | background thread, 5 s |
+| Offset committable | after processing proven (next pull) | previous poll's records, on next `poll()` | at delivery, before processing |
+| Throw out of the loop | redelivered | redelivered | **lost** (commit may already cover it) |
+| Catch-and-continue | committed (acknowledged by continuing) | committed | committed |
+| Effective guarantee | at-least-once | at-least-once* | at-most-once |
+
+\* For the canonical single-threaded poll loop. Both Dekaf's and Java's guarantee assume the
+records from an iteration are processed before the next pull; handing records to background
+workers and pulling immediately voids it in every client. For that pattern use the
+[Partitioned Processing API](partitioned-processing-api.md), which tracks per-record completion
+explicitly — Dekaf refuses to run it on a default-configured consumer for exactly this reason.
+
+## Explicit Commit Semantics
+
+`CommitAsync()` (no arguments) commits the **current position** — everything delivered so far,
+*including* a record you are still holding. An explicit commit is you vouching for what you have
+seen; it is the escape hatch for clean handoffs after `break` and before `CloseAsync()`.
+
+`CloseAsync()` / `DisposeAsync()` commit only **proven** offsets. Closing because processing
+blew up must not commit the record that blew up.
+
+`GetPosition()` reports the position including in-doubt records, but never stages anything.
+
+## Duplicates: the fine print
+
+At-least-once redelivery happens at these boundaries — size your idempotency accordingly:
+
+- **Failure exit:** the failing record and any records after it in already-fetched batches.
+- **Crash:** everything after the last background commit (up to `AutoCommitIntervalMs` of work,
+  plus the current fetch).
+- **`break` without `CommitAsync()`:** exactly one record (the one you were holding).
+- **Rebalance:** the in-flight tail of each moved partition.
+
+Idempotent processing turns all of these into non-events. Common patterns: upsert by key,
+unique-constraint insert with conflict-ignore, or dedup on `(topic, partition, offset)`.

--- a/docs/docs/consumer/delivery-semantics.md
+++ b/docs/docs/consumer/delivery-semantics.md
@@ -228,7 +228,8 @@ At-least-once redelivery happens at these boundaries — size your idempotency a
 - **Failure exit:** the failing record and any records after it in already-fetched batches.
 - **Crash:** everything after the last background commit (up to `AutoCommitIntervalMs` of work,
   plus the current fetch).
-- **`break` without `CommitAsync()`:** exactly one record (the one you were holding).
+- **`break` without `CommitAsync()`:** exactly one record for record-at-a-time APIs (the one
+  you were holding), or up to the full current batch for batch APIs (the batch is the proof unit).
 - **Rebalance:** the in-flight tail of each moved partition.
 
 Idempotent processing turns all of these into non-events. Common patterns: upsert by key,

--- a/docs/docs/consumer/linq-extensions.md
+++ b/docs/docs/consumer/linq-extensions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # LINQ Extensions

--- a/docs/docs/consumer/manual-assignment.md
+++ b/docs/docs/consumer/manual-assignment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Manual Partition Assignment

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -67,7 +67,7 @@ using Dekaf;
 var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
-    .WithAutoOffsetStore(false)  // Auto-commit only commits explicitly stored offsets
+    .WithAtLeastOnceProcessing() // Auto-commit only commits explicitly stored offsets
     .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
@@ -80,6 +80,9 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 `StoreOffset` is a cheap in-memory operation; the background auto-commit loop batches the actual
 network commits. If processing throws before `StoreOffset`, the message's offset is never staged
 and it will be redelivered.
+
+`WithAtLeastOnceProcessing()` is intent-level shorthand for
+`WithOffsetCommitMode(OffsetCommitMode.Auto).WithAutoOffsetStore(false)`.
 
 :::caution
 Offsets are positions, not per-message acknowledgements. Storing a later offset also commits
@@ -267,7 +270,7 @@ follow the configured auto-offset-reset policy.
 | Mode | Semantics | Risk |
 |------|-----------|------|
 | Auto (defaults) | At-most-once | Loses messages whose processing failed — no crash required |
-| Auto + `WithAutoOffsetStore(false)` + `StoreOffset` after process | At-least-once | May reprocess on crash |
+| `WithAtLeastOnceProcessing()` + `StoreOffset` after process | At-least-once | May reprocess on crash |
 | Manual (commit after process) | At-least-once | May reprocess on crash |
 | Manual + External storage | Exactly-once | Most complex |
 
@@ -291,7 +294,7 @@ await dbTransaction.CommitAsync();
 
 ## Best Practices
 
-1. **Make commits reflect completed processing** for most applications - either Manual mode, or auto-commit with `WithAutoOffsetStore(false)` + `StoreOffset` after each successfully processed message
+1. **Make commits reflect completed processing** for most applications - either Manual mode, or `WithAtLeastOnceProcessing()` + `StoreOffset` after each successfully processed message
 
 2. **Batch your commits** - committing after every message is slow
 

--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Offset Management
@@ -43,23 +43,26 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 }
 ```
 
-**Pros:** Simple, no extra code needed
-**Cons:** Messages might be committed before processing completes
+**Pros:** Simple, no extra code needed — and safe by default
+**Cons:** Duplicates are possible after failures; processing must be idempotent
 
-:::caution
-In auto mode a message's offset is staged for commit as soon as it is *consumed*, not when it is
-successfully processed. Loss does not require a crash: if your handler throws and you catch the
-exception and keep consuming, the failed message's offset is still committed on the next
-auto-commit tick (every 5 seconds by default), on rebalance, and on graceful shutdown — the
-message is gone. Use this mode as-is only when occasional message loss is acceptable (logs,
-metrics, etc.), or pair it with manual offset store (below).
+:::info Dekaf's auto-commit default is at-least-once
+Unlike Confluent.Kafka, a message's offset only becomes committable once your loop has
+demonstrably moved past it — by requesting the next message. If your handler throws and the
+exception exits the loop, the failed message is **not** committed and is redelivered after a
+restart or rebalance. See [Delivery Semantics](delivery-semantics.md) for the full contract,
+including the two caveats (catch-and-continue counts as processed; `break` leaves the last
+message uncommitted unless you `CommitAsync()`).
+Prefer stating the intent explicitly with `WithAtLeastOnceProcessing()`. For Confluent-style
+at-most-once staging, use `WithAtMostOnceProcessing()`.
 :::
 
 ### Auto-Commit with Manual Offset Store
 
-The middle ground between the two modes: keep background auto-commit, but only let it commit
-offsets you have explicitly marked as processed. This gives at-least-once semantics without a
-commit round-trip in your processing loop.
+Keep background auto-commit, but only let it commit offsets you have explicitly marked as
+processed. This is the strict form of at-least-once: unlike the default, it survives
+catch-and-continue, because acknowledgment is your explicit `StoreOffset` call rather than
+loop progress.
 
 ```csharp
 using Dekaf;
@@ -67,7 +70,7 @@ using Dekaf;
 var consumer = await Kafka.CreateConsumer<string, string>()
     .WithBootstrapServers("localhost:9092")
     .WithGroupId("my-group")
-    .WithAtLeastOnceProcessing() // Auto-commit only commits explicitly stored offsets
+    .WithAutoOffsetStore(false) // Auto-commit only commits explicitly stored offsets
     .BuildAsync();
 
 await foreach (var msg in consumer.ConsumeAsync(ct))
@@ -79,10 +82,7 @@ await foreach (var msg in consumer.ConsumeAsync(ct))
 
 `StoreOffset` is a cheap in-memory operation; the background auto-commit loop batches the actual
 network commits. If processing throws before `StoreOffset`, the message's offset is never staged
-and it will be redelivered.
-
-`WithAtLeastOnceProcessing()` is intent-level shorthand for
-`WithOffsetCommitMode(OffsetCommitMode.Auto).WithAutoOffsetStore(false)`.
+and it will be redelivered — even if you catch the exception and keep consuming.
 
 :::caution
 Offsets are positions, not per-message acknowledgements. Storing a later offset also commits
@@ -267,10 +267,15 @@ follow the configured auto-offset-reset policy.
 
 ## Delivery Semantics
 
+The full contract — including exactly when an offset becomes committable and how Dekaf compares
+to the Java and Confluent clients — lives on the
+[Delivery Semantics](delivery-semantics.md) page. Summary:
+
 | Mode | Semantics | Risk |
 |------|-----------|------|
-| Auto (defaults) | At-most-once | Loses messages whose processing failed — no crash required |
-| `WithAtLeastOnceProcessing()` + `StoreOffset` after process | At-least-once | May reprocess on crash |
+| Auto (defaults, = `WithAtLeastOnceProcessing()`) | At-least-once | May reprocess after failures; swallowed exceptions still commit |
+| `WithAutoOffsetStore(false)` + `StoreOffset` after process | At-least-once (strict) | May reprocess on crash |
+| `WithAtMostOnceProcessing()` | At-most-once | Loses messages whose processing failed |
 | Manual (commit after process) | At-least-once | May reprocess on crash |
 | Manual + External storage | Exactly-once | Most complex |
 
@@ -294,7 +299,7 @@ await dbTransaction.CommitAsync();
 
 ## Best Practices
 
-1. **Make commits reflect completed processing** for most applications - either Manual mode, or `WithAtLeastOnceProcessing()` + `StoreOffset` after each successfully processed message
+1. **Make commits reflect completed processing** - the default already does this for sequential loops; add `WithAutoOffsetStore(false)` + `StoreOffset` after each successfully processed message when you catch exceptions and keep consuming, or use Manual mode
 
 2. **Batch your commits** - committing after every message is slow
 

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -208,9 +208,11 @@ and `PartitionCommitPolicy.UserManaged` also remains allowed for applications
 that accept auto-commit semantics.
 
 This check inspects the commit configuration of Dekaf's own consumer
-implementations (`KafkaConsumer` and the testing `InMemoryConsumer`). A custom
-`IKafkaConsumer` implementation or a wrapper around a Dekaf consumer is not
-inspected and will not fail fast — if you wrap a consumer, ensure the underlying
+implementations (`KafkaConsumer` and the testing `InMemoryConsumer`). Custom
+implementations and wrappers can opt into the same guard by implementing
+`IConsumerCommitConfiguration` and forwarding `OffsetCommitMode`,
+`EnableAutoOffsetStore`, and `HasConsumerGroup`. Types that do not implement that
+interface cannot be inspected and will not fail fast, so ensure their underlying
 configuration follows the rules above.
 
 Transactions remain user-managed. If a processor writes transactionally, send

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -197,7 +197,7 @@ void the runtime's at-least-once tracking. `RunPartitionedAsync` therefore throw
 `InvalidOperationException` when the consumer uses that combination together with
 a runtime-managed commit policy (`CommitCompletedOnRevoke` or
 `CommitCompletedPeriodically`). For at-least-once partitioned processing, configure
-the consumer with `OffsetCommitMode.Manual`, or with `WithAutoOffsetStore(false)` —
+the consumer with `OffsetCommitMode.Manual`, or with `WithAtLeastOnceProcessing()` —
 with the automatic store disabled, the background loop has nothing of its own to
 commit, so only the runtime's `MarkProcessed`-tracked commits advance offsets. The
 combination of auto commit and `PartitionCommitPolicy.UserManaged` also remains

--- a/docs/docs/consumer/partitioned-processing-api.md
+++ b/docs/docs/consumer/partitioned-processing-api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Partitioned Async Processing
@@ -191,17 +191,21 @@ Runtime-managed revoke and shutdown commits may batch completed offsets for
 multiple partitions into one `CommitAsync` call.
 
 Auto commit mode with automatic offset store (`OffsetCommitMode.Auto` +
-`EnableAutoOffsetStore = true`, the consumer defaults) stages and commits consumed
-positions in the background regardless of `MarkProcessed`, which would silently
-void the runtime's at-least-once tracking. `RunPartitionedAsync` therefore throws
-`InvalidOperationException` when the consumer uses that combination together with
-a runtime-managed commit policy (`CommitCompletedOnRevoke` or
-`CommitCompletedPeriodically`). For at-least-once partitioned processing, configure
-the consumer with `OffsetCommitMode.Manual`, or with `WithAtLeastOnceProcessing()` —
-with the automatic store disabled, the background loop has nothing of its own to
-commit, so only the runtime's `MarkProcessed`-tracked commits advance offsets. The
-combination of auto commit and `PartitionCommitPolicy.UserManaged` also remains
-allowed for applications that accept auto-commit semantics.
+`EnableAutoOffsetStore = true`, the consumer defaults) stages offsets based on
+consume-loop progress. The partitioned runtime pulls records off the loop and
+dispatches them to workers, so loop progress no longer proves processing — the
+background loop would stage and commit records regardless of `MarkProcessed`,
+silently voiding the runtime's at-least-once tracking. This applies to both
+`OffsetStoreTiming` values, since neither ties staging to worker completion.
+`RunPartitionedAsync` therefore throws `InvalidOperationException` when the
+consumer uses that combination together with a runtime-managed commit policy
+(`CommitCompletedOnRevoke` or `CommitCompletedPeriodically`). For at-least-once
+partitioned processing, configure the consumer with `OffsetCommitMode.Manual`, or
+with `WithAutoOffsetStore(false)` — with the automatic store disabled, the
+background loop has nothing of its own to commit, so only the runtime's
+`MarkProcessed`-tracked commits advance offsets. The combination of auto commit
+and `PartitionCommitPolicy.UserManaged` also remains allowed for applications
+that accept auto-commit semantics.
 
 This check inspects the commit configuration of Dekaf's own consumer
 implementations (`KafkaConsumer` and the testing `InMemoryConsumer`). A custom

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -863,6 +863,7 @@ internal static class DekafOptionsBinding
         builder.WithOffsetCommitMode(options.OffsetCommitMode);
         builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(options.AutoCommitIntervalMs));
         builder.WithAutoOffsetStore(options.EnableAutoOffsetStore);
+        builder.WithOffsetStoreTiming(options.OffsetStoreTiming);
         if (options.AutoOffsetReset == AutoOffsetReset.ByDuration)
             builder.WithAutoOffsetResetByDuration(options.AutoOffsetResetDuration ?? TimeSpan.Zero);
         else
@@ -1220,6 +1221,8 @@ internal static class DekafConfigurationBinding
             builder.WithAutoCommitInterval(TimeSpan.FromMilliseconds(autoCommitIntervalMs));
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.EnableAutoOffsetStore), out var enableAutoOffsetStore))
             builder.WithAutoOffsetStore(enableAutoOffsetStore);
+        if (TryGetValue<OffsetStoreTiming>(configuration, nameof(ConsumerOptions.OffsetStoreTiming), out var offsetStoreTiming))
+            builder.WithOffsetStoreTiming(offsetStoreTiming);
         if (TryGetAutoOffsetReset(configuration, out var autoOffsetReset, out var autoOffsetResetDuration))
         {
             if (autoOffsetReset == AutoOffsetReset.ByDuration)

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -14,7 +14,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     IConsumerPositions,
     IConsumerPartitions,
     IConsumerOffsets,
-    IConsumerCommitModeSource
+    IConsumerCommitConfiguration
 {
     private readonly object _gate = new();
     private readonly InMemoryKafkaCluster _cluster;
@@ -129,11 +129,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     public IConsumerOffsets Offsets => this;
 
-    OffsetCommitMode IConsumerCommitModeSource.OffsetCommitMode => _options.OffsetCommitMode;
+    OffsetCommitMode IConsumerCommitConfiguration.OffsetCommitMode => _options.OffsetCommitMode;
 
-    bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
+    bool IConsumerCommitConfiguration.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
-    bool IConsumerCommitModeSource.HasConsumerGroup => _groupId is not null;
+    bool IConsumerCommitConfiguration.HasConsumerGroup => _groupId is not null;
 
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaConsumer<TKey, TValue>.Subscription => Subscription;

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -250,7 +250,16 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             var result = await ConsumeOneAsync(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
             if (result.HasValue)
+            {
                 yield return result.Value;
+
+                // Resuming after the yield proves that the caller processed this record.
+                // Do this before the loop observes cancellation, matching KafkaConsumer.
+                lock (_gate)
+                {
+                    ProveInDoubtRecordUnderLock();
+                }
+            }
         }
     }
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -701,6 +701,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         _paused.Clear();
         _positions.Clear();
         _storedOffsets.Clear();
+        _inDoubtNextOffset = -1;
 
         foreach (var (partition, position) in nextPositions)
         {

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -26,6 +26,11 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly HashSet<TopicPartition> _paused = [];
     private readonly Dictionary<TopicPartition, long> _positions = [];
     private readonly Dictionary<TopicPartition, long> _storedOffsets = [];
+    // In-doubt record under OffsetStoreTiming.AfterProcessing: delivered but not yet proven
+    // processed. Staged for commit only when the next consume call or an explicit commit
+    // proves it; an unwind (or close) leaves it unstaged so it is redelivered.
+    private TopicPartition _inDoubtPartition;
+    private long _inDoubtNextOffset = -1;
     private readonly string? _groupId;
     private readonly string? _memberId;
     private string? _subscriptionPattern;
@@ -233,6 +238,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _paused.Clear();
             _positions.Clear();
             _storedOffsets.Clear();
+            _inDoubtNextOffset = -1;
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -326,7 +332,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         ThrowIfDisposed();
 
         lock (_gate)
+        {
+            // Explicit commit: the caller vouches for everything delivered so far,
+            // including the in-doubt record still being processed.
+            ProveInDoubtRecordUnderLock();
             CommitStoredOffsets();
+        }
 
         return ValueTask.CompletedTask;
     }
@@ -422,6 +433,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         lock (_gate)
         {
             var partition = new TopicPartition(offset.Topic, offset.Partition);
+            DiscardInDoubtRecordUnderLock(partition);
             _positions[partition] = offset.Offset;
             if (_options.EnableAutoOffsetStore)
                 _storedOffsets[partition] = offset.Offset;
@@ -438,6 +450,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             foreach (var partition in SelectTargetPartitions(partitions))
             {
                 var position = _cluster.GetWatermarks(partition).Low;
+                DiscardInDoubtRecordUnderLock(partition);
                 _positions[partition] = position;
                 if (_options.EnableAutoOffsetStore)
                     _storedOffsets[partition] = position;
@@ -455,6 +468,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             foreach (var partition in SelectTargetPartitions(partitions))
             {
                 var position = _cluster.GetWatermarks(partition).High;
+                DiscardInDoubtRecordUnderLock(partition);
                 _positions[partition] = position;
                 if (_options.EnableAutoOffsetStore)
                     _storedOffsets[partition] = position;
@@ -486,6 +500,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _paused.Clear();
             _positions.Clear();
             _storedOffsets.Clear();
+            _inDoubtNextOffset = -1;
             UnregisterConsumerGroupMemberUnderLock();
         }
     }
@@ -522,6 +537,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 _paused.Remove(partition);
                 _positions.Remove(partition);
                 _storedOffsets.Remove(partition);
+                DiscardInDoubtRecordUnderLock(partition);
             }
 
             RegisterConsumerGroupMemberUnderLock();
@@ -589,6 +605,10 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         lock (_gate)
         {
+            // A new consume call proves the previously delivered record was processed
+            // (poll contract) — stage it before delivering the next one.
+            ProveInDoubtRecordUnderLock();
+
             foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
             {
                 if (_paused.Contains(partition))
@@ -603,10 +623,18 @@ public sealed class InMemoryConsumer<TKey, TValue> :
                 selected = record;
                 selectedPartition = partition;
                 _positions[partition] = record.Offset + 1;
-                if (_options.EnableAutoOffsetStore)
-                    _storedOffsets[partition] = record.Offset + 1;
-                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                    CommitStoredOffsets();
+                if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
+                {
+                    if (_options.EnableAutoOffsetStore)
+                        _storedOffsets[partition] = record.Offset + 1;
+                    if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                        CommitStoredOffsets();
+                }
+                else
+                {
+                    _inDoubtPartition = partition;
+                    _inDoubtNextOffset = record.Offset + 1;
+                }
                 break;
             }
         }
@@ -619,6 +647,30 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
         result = ToConsumeResult(selectedPartition, selected);
         return true;
+    }
+
+    /// <summary>
+    /// Stages (and under Auto mode commits) the in-doubt record's offset. Called when the
+    /// application demonstrably moved past it: a subsequent consume call or explicit commit.
+    /// </summary>
+    private void ProveInDoubtRecordUnderLock()
+    {
+        if (_inDoubtNextOffset < 0)
+            return;
+
+        if (_options.EnableAutoOffsetStore)
+            _storedOffsets[_inDoubtPartition] = _inDoubtNextOffset;
+
+        _inDoubtNextOffset = -1;
+
+        if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+            CommitStoredOffsets();
+    }
+
+    private void DiscardInDoubtRecordUnderLock(TopicPartition partition)
+    {
+        if (_inDoubtNextOffset >= 0 && _inDoubtPartition.Equals(partition))
+            _inDoubtNextOffset = -1;
     }
 
     private ConsumeResult<TKey, TValue> ToConsumeResult(TopicPartition topicPartition, InMemoryRecord record)

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -516,6 +516,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             {
                 var partition = new TopicPartition(offset.Topic, offset.Partition);
                 var position = offset.Offset >= 0 ? offset.Offset : GetStartOffset(partition);
+                DiscardInDoubtRecordUnderLock(partition);
                 _assignment.Add(partition);
                 _positions[partition] = position;
             }

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -601,53 +601,79 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private bool TryConsumeOne(out ConsumeResult<TKey, TValue> result)
     {
-        InMemoryRecord? selected = null;
-        TopicPartition selectedPartition = default;
-
-        lock (_gate)
+        var previousRecordProven = false;
+        while (true)
         {
-            // A new consume call proves the previously delivered record was processed
-            // (poll contract) — stage it before delivering the next one.
-            ProveInDoubtRecordUnderLock();
+            InMemoryRecord? selected = null;
+            TopicPartition selectedPartition = default;
+            long selectedPosition = -1;
 
-            foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+            lock (_gate)
             {
-                if (_paused.Contains(partition))
-                    continue;
+                if (!previousRecordProven)
+                {
+                    // A new consume call proves the previously delivered record was processed
+                    // (poll contract) — stage it before selecting the next one.
+                    ProveInDoubtRecordUnderLock();
+                    previousRecordProven = true;
+                }
 
-                if (!_positions.TryGetValue(partition, out var position))
-                    continue;
+                foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+                {
+                    if (_paused.Contains(partition))
+                        continue;
 
-                if (!_cluster.TryRead(partition, position, out var record))
-                    continue;
+                    if (!_positions.TryGetValue(partition, out var position))
+                        continue;
 
-                selected = record;
-                selectedPartition = partition;
-                _positions[partition] = record.Offset + 1;
+                    if (!_cluster.TryRead(partition, position, out var record))
+                        continue;
+
+                    selected = record;
+                    selectedPartition = partition;
+                    selectedPosition = position;
+                    break;
+                }
+            }
+
+            if (selected is null)
+            {
+                result = default;
+                return false;
+            }
+
+            // Run user deserializers before advancing any delivery or commit state. A failure
+            // leaves the selected offset untouched so the next consume retries the record.
+            var selectedResult = ToConsumeResult(selectedPartition, selected);
+
+            lock (_gate)
+            {
+                // Assignment/seek or another consumer call may have changed the position while
+                // user code deserialized. Retry selection instead of publishing a stale result.
+                if (!_positions.TryGetValue(selectedPartition, out var currentPosition)
+                    || currentPosition != selectedPosition)
+                {
+                    continue;
+                }
+
+                _positions[selectedPartition] = selected.Offset + 1;
                 if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
                 {
                     if (_options.EnableAutoOffsetStore)
-                        _storedOffsets[partition] = record.Offset + 1;
+                        _storedOffsets[selectedPartition] = selected.Offset + 1;
                     if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
                         CommitStoredOffsets();
                 }
                 else
                 {
-                    _inDoubtPartition = partition;
-                    _inDoubtNextOffset = record.Offset + 1;
+                    _inDoubtPartition = selectedPartition;
+                    _inDoubtNextOffset = selected.Offset + 1;
                 }
-                break;
             }
-        }
 
-        if (selected is null)
-        {
-            result = default;
-            return false;
+            result = selectedResult;
+            return true;
         }
-
-        result = ToConsumeResult(selectedPartition, selected);
-        return true;
     }
 
     /// <summary>

--- a/src/Dekaf.Testing/InMemoryConsumerOptions.cs
+++ b/src/Dekaf.Testing/InMemoryConsumerOptions.cs
@@ -34,6 +34,15 @@ public sealed class InMemoryConsumerOptions
     public bool EnableAutoOffsetStore { get; init; } = true;
 
     /// <summary>
+    /// Controls when automatically stored offsets become committable, mirroring
+    /// <see cref="ConsumerOptions.OffsetStoreTiming"/>. The default
+    /// (<see cref="OffsetStoreTiming.AfterProcessing"/>) stages a record only once the
+    /// next consume call proves it was processed; <see cref="OffsetStoreTiming.OnDelivery"/>
+    /// stages it immediately at delivery.
+    /// </summary>
+    public OffsetStoreTiming OffsetStoreTiming { get; init; } = OffsetStoreTiming.AfterProcessing;
+
+    /// <summary>
     /// Member ID reported by the fake consumer.
     /// </summary>
     public string? MemberId { get; init; }

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1583,9 +1583,27 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures background offset commits that include only messages explicitly marked as processed.
+    /// </summary>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Sets <see cref="OffsetCommitMode.Auto"/> and disables automatic offset storage. After each
+    /// message is processed successfully, call
+    /// <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>. If processing
+    /// fails before the offset is stored, the message is redelivered after restart or rebalance.
+    /// </remarks>
+    public ConsumerBuilder<TKey, TValue> WithAtLeastOnceProcessing()
+    {
+        _offsetCommitMode = OffsetCommitMode.Auto;
+        _enableAutoOffsetStore = false;
+        return this;
+    }
+
+    /// <summary>
     /// Controls whether consumed offsets are stored automatically for background auto-commit.
     /// Disable this and call <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>
     /// after processing succeeds to get Confluent-style manual offset store with auto-commit.
+    /// <see cref="WithAtLeastOnceProcessing"/> configures that combination directly.
     /// </summary>
     public ConsumerBuilder<TKey, TValue> WithAutoOffsetStore(bool enabled = true)
     {

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1377,6 +1377,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private OffsetCommitMode _offsetCommitMode = OffsetCommitMode.Auto;
     private int _autoCommitIntervalMs = 5000;
     private bool _enableAutoOffsetStore = true;
+    private OffsetStoreTiming _offsetStoreTiming = OffsetStoreTiming.AfterProcessing;
     private AutoOffsetReset _autoOffsetReset = AutoOffsetReset.Latest;
     private TimeSpan? _autoOffsetResetDuration;
     private int _fetchMinBytes = 1;
@@ -1583,23 +1584,61 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
-    /// Configures background offset commits that include only messages explicitly marked as processed.
+    /// Configures at-least-once processing: offsets are committed in the background, but a
+    /// record's offset only becomes committable once the application has demonstrably moved
+    /// past it. This is Dekaf's default — call this method to make the intent explicit.
     /// </summary>
     /// <returns>The builder instance for method chaining.</returns>
     /// <remarks>
-    /// Sets <see cref="OffsetCommitMode.Auto"/> and disables automatic offset storage. After each
-    /// message is processed successfully, call
-    /// <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>. If processing
-    /// fails before the offset is stored, the message is redelivered after restart or rebalance.
+    /// Sets <see cref="OffsetCommitMode.Auto"/>, automatic offset storage, and
+    /// <see cref="OffsetStoreTiming.AfterProcessing"/>. In a sequential consume loop
+    /// (<c>await foreach</c>), requesting the next record proves the previous one was
+    /// processed; an exception that exits the loop leaves the failing record uncommitted so
+    /// it is redelivered after a restart or rebalance. Duplicates are possible — processing
+    /// must be idempotent. A caught-and-swallowed exception inside the loop body still counts
+    /// as processed once the loop continues; for strict per-record acknowledgment use
+    /// <see cref="WithAutoOffsetStore"/> (false) with
+    /// <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>.
     /// </remarks>
     public ConsumerBuilder<TKey, TValue> WithAtLeastOnceProcessing()
-        => WithOffsetCommitMode(OffsetCommitMode.Auto).WithAutoOffsetStore(false);
+        => WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoOffsetStore(true)
+            .WithOffsetStoreTiming(OffsetStoreTiming.AfterProcessing);
+
+    /// <summary>
+    /// Configures at-most-once processing: a record's offset is staged for background commit
+    /// the moment it is delivered, before processing runs. A record whose processing fails may
+    /// already be committed and is then never redelivered.
+    /// </summary>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Sets <see cref="OffsetCommitMode.Auto"/>, automatic offset storage, and
+    /// <see cref="OffsetStoreTiming.OnDelivery"/>. This matches the Confluent/librdkafka
+    /// auto-commit convention. Use when occasional message loss is preferable to duplicate
+    /// processing.
+    /// </remarks>
+    public ConsumerBuilder<TKey, TValue> WithAtMostOnceProcessing()
+        => WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoOffsetStore(true)
+            .WithOffsetStoreTiming(OffsetStoreTiming.OnDelivery);
+
+    /// <summary>
+    /// Controls when automatically stored offsets become committable. Prefer the intent-level
+    /// <see cref="WithAtLeastOnceProcessing"/> / <see cref="WithAtMostOnceProcessing"/> methods.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithOffsetStoreTiming(OffsetStoreTiming timing)
+    {
+        _offsetStoreTiming = timing;
+        return this;
+    }
 
     /// <summary>
     /// Controls whether consumed offsets are stored automatically for background auto-commit.
     /// Disable this and call <see cref="IKafkaConsumer{TKey,TValue}.StoreOffset(ConsumeResult{TKey,TValue})"/>
-    /// after processing succeeds to get Confluent-style manual offset store with auto-commit.
-    /// <see cref="WithAtLeastOnceProcessing"/> configures that combination directly.
+    /// after processing succeeds to get strict per-record acknowledgment: only explicitly
+    /// stored offsets are ever committed, so a record that fails before its
+    /// <c>StoreOffset</c> call is always redelivered — even when the failure is caught and
+    /// the loop continues.
     /// </summary>
     public ConsumerBuilder<TKey, TValue> WithAutoOffsetStore(bool enabled = true)
     {
@@ -2611,6 +2650,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             OffsetCommitMode = _offsetCommitMode,
             AutoCommitIntervalMs = _autoCommitIntervalMs,
             EnableAutoOffsetStore = _enableAutoOffsetStore,
+            OffsetStoreTiming = _offsetStoreTiming,
             AutoOffsetReset = _autoOffsetReset,
             AutoOffsetResetDuration = _autoOffsetResetDuration,
             FetchMinBytes = _fetchMinBytes,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1593,11 +1593,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// fails before the offset is stored, the message is redelivered after restart or rebalance.
     /// </remarks>
     public ConsumerBuilder<TKey, TValue> WithAtLeastOnceProcessing()
-    {
-        _offsetCommitMode = OffsetCommitMode.Auto;
-        _enableAutoOffsetStore = false;
-        return this;
-    }
+        => WithOffsetCommitMode(OffsetCommitMode.Auto).WithAutoOffsetStore(false);
 
     /// <summary>
     /// Controls whether consumed offsets are stored automatically for background auto-commit.

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -224,11 +224,13 @@ namespace Dekaf.Consumer
                 if (_recordsYielded >= _batch._maxRecords)
                 {
                     pending.TryBufferNext();
+                    _canContinue = false;
                     return false;
                 }
 
                 if (!pending.MoveNext())
                 {
+                    _canContinue = false;
                     return false;
                 }
 

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -117,6 +117,7 @@ namespace Dekaf.Consumer
         private readonly IDeserializer<TValue>? _valueDeserializer;
         private readonly BatchIterationGuard _iterationGuard;
         private readonly Action<TopicPartition, long, int>? _storeOffsetOnDelivery;
+        private readonly Action<PendingFetchData, long>? _rewindAfterDeliveryFailure;
         private readonly int _maxRecords;
         private long _count;
 
@@ -125,7 +126,8 @@ namespace Dekaf.Consumer
             IDeserializer<TValue>? valueDeserializer,
             BatchIterationGuard iterationGuard = default,
             Action<TopicPartition, long, int>? storeOffsetOnDelivery = null,
-            int maxRecords = int.MaxValue)
+            int maxRecords = int.MaxValue,
+            Action<PendingFetchData, long>? rewindAfterDeliveryFailure = null)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
@@ -134,6 +136,7 @@ namespace Dekaf.Consumer
             _iterationGuard = iterationGuard;
             _storeOffsetOnDelivery = storeOffsetOnDelivery;
             _maxRecords = maxRecords;
+            _rewindAfterDeliveryFailure = rewindAfterDeliveryFailure;
         }
 
         /// <summary>
@@ -183,7 +186,7 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeResult<TKey, TValue>>
         {
             private readonly ConsumeBatch<TKey, TValue> _batch;
-            private readonly bool _canContinue;
+            private bool _canContinue;
             private int _observedVersion;
             private int _recordsYielded;
 
@@ -239,22 +242,31 @@ namespace Dekaf.Consumer
                 int messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
                                    (record.IsValueNull ? 0 : record.Value.Length);
 
-                Current = new ConsumeResult<TKey, TValue>(
-                    topic: pending.Topic,
-                    partition: pending.PartitionIndex,
-                    offset: offset,
-                    keyData: record.Key,
-                    isKeyNull: record.IsKeyNull,
-                    valueData: record.Value,
-                    isValueNull: record.IsValueNull,
-                    pooledHeaders: record.Headers,
-                    pooledHeaderCount: record.HeaderCount,
-                    headerOwner: pending,
-                    timestampMs: timestampMs,
-                    timestampType: timestampType,
-                    leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
-                    keyDeserializer: _batch._keyDeserializer,
-                    valueDeserializer: _batch._valueDeserializer);
+                try
+                {
+                    Current = new ConsumeResult<TKey, TValue>(
+                        topic: pending.Topic,
+                        partition: pending.PartitionIndex,
+                        offset: offset,
+                        keyData: record.Key,
+                        isKeyNull: record.IsKeyNull,
+                        valueData: record.Value,
+                        isValueNull: record.IsValueNull,
+                        pooledHeaders: record.Headers,
+                        pooledHeaderCount: record.HeaderCount,
+                        headerOwner: pending,
+                        timestampMs: timestampMs,
+                        timestampType: timestampType,
+                        leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
+                        keyDeserializer: _batch._keyDeserializer,
+                        valueDeserializer: _batch._valueDeserializer);
+                }
+                catch
+                {
+                    _canContinue = false;
+                    _batch._rewindAfterDeliveryFailure?.Invoke(pending, offset);
+                    throw;
+                }
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))
                     return false;

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -116,6 +116,7 @@ namespace Dekaf.Consumer
         private readonly IDeserializer<TKey>? _keyDeserializer;
         private readonly IDeserializer<TValue>? _valueDeserializer;
         private readonly BatchIterationGuard _iterationGuard;
+        private readonly Action<TopicPartition, long, int>? _storeOffsetOnDelivery;
         private readonly int _maxRecords;
         private long _count;
 
@@ -123,6 +124,7 @@ namespace Dekaf.Consumer
             IDeserializer<TKey>? keyDeserializer,
             IDeserializer<TValue>? valueDeserializer,
             BatchIterationGuard iterationGuard = default,
+            Action<TopicPartition, long, int>? storeOffsetOnDelivery = null,
             int maxRecords = int.MaxValue)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
@@ -130,6 +132,7 @@ namespace Dekaf.Consumer
             _keyDeserializer = keyDeserializer;
             _valueDeserializer = valueDeserializer;
             _iterationGuard = iterationGuard;
+            _storeOffsetOnDelivery = storeOffsetOnDelivery;
             _maxRecords = maxRecords;
         }
 
@@ -257,6 +260,10 @@ namespace Dekaf.Consumer
                     return false;
 
                 pending.TrackConsumed(offset, messageBytes);
+                _batch._storeOffsetOnDelivery?.Invoke(
+                    pending.TopicPartition,
+                    offset + 1,
+                    pending.LastYieldedLeaderEpoch);
                 _recordsYielded++;
                 _batch._count++;
 

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -42,17 +42,20 @@ namespace Dekaf.Consumer
     {
         private readonly PendingFetchData _pendingFetchData;
         private readonly BatchIterationGuard _iterationGuard;
+        private readonly Action<TopicPartition, long, int>? _storeOffsetOnDelivery;
         private readonly int _maxRecords;
         private long _count;
 
         internal ConsumeRawBatch(
             PendingFetchData pendingFetchData,
             BatchIterationGuard iterationGuard = default,
+            Action<TopicPartition, long, int>? storeOffsetOnDelivery = null,
             int maxRecords = int.MaxValue)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxRecords, 1);
             _pendingFetchData = pendingFetchData;
             _iterationGuard = iterationGuard;
+            _storeOffsetOnDelivery = storeOffsetOnDelivery;
             _maxRecords = maxRecords;
         }
 
@@ -169,6 +172,10 @@ namespace Dekaf.Consumer
                     return false;
 
                 pending.TrackConsumed(offset, messageBytes);
+                _batch._storeOffsetOnDelivery?.Invoke(
+                    pending.TopicPartition,
+                    offset + 1,
+                    pending.LastYieldedLeaderEpoch);
                 _recordsYielded++;
                 _batch._count++;
 

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -106,7 +106,7 @@ namespace Dekaf.Consumer
         public struct Enumerator : IEnumerator<ConsumeRawRecord>
         {
             private readonly ConsumeRawBatch _batch;
-            private readonly bool _canContinue;
+            private bool _canContinue;
             private int _observedVersion;
             private int _recordsYielded;
 
@@ -143,11 +143,13 @@ namespace Dekaf.Consumer
                 if (_recordsYielded >= _batch._maxRecords)
                 {
                     pending.TryBufferNext();
+                    _canContinue = false;
                     return false;
                 }
 
                 if (!pending.MoveNext())
                 {
+                    _canContinue = false;
                     return false;
                 }
 

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -29,6 +29,30 @@ public enum OffsetCommitMode
 }
 
 /// <summary>
+/// Controls when a consumed record's offset is staged (stored) for commit under
+/// automatic offset storage (<see cref="ConsumerOptions.EnableAutoOffsetStore"/>).
+/// </summary>
+public enum OffsetStoreTiming
+{
+    /// <summary>
+    /// A record's offset is staged only once the application has demonstrably moved past it —
+    /// by requesting the next record or batch, completing a fetch, or committing explicitly.
+    /// A record whose processing throws out of the consume loop is never staged and is
+    /// redelivered after a restart or rebalance. This is the default and gives at-least-once
+    /// delivery for sequential consume loops.
+    /// </summary>
+    AfterProcessing,
+
+    /// <summary>
+    /// A record's offset is staged the moment it is delivered to the application, before
+    /// processing runs. A record whose processing fails can still be committed, so it is
+    /// not redelivered: at-most-once delivery. This matches the Confluent/librdkafka
+    /// auto-commit convention and costs additional per-message bookkeeping.
+    /// </summary>
+    OnDelivery
+}
+
+/// <summary>
 /// Configuration options for the Kafka consumer.
 /// </summary>
 public sealed class ConsumerOptions
@@ -85,6 +109,15 @@ public sealed class ConsumerOptions
     /// automatic background commits enabled.
     /// </summary>
     public bool EnableAutoOffsetStore { get; init; } = true;
+
+    /// <summary>
+    /// Controls when automatically stored offsets become committable.
+    /// Default is <see cref="OffsetStoreTiming.AfterProcessing"/> (at-least-once for
+    /// sequential consume loops). Use <see cref="OffsetStoreTiming.OnDelivery"/> for
+    /// Confluent-style at-most-once staging. Ignored when
+    /// <see cref="EnableAutoOffsetStore"/> is false.
+    /// </summary>
+    public OffsetStoreTiming OffsetStoreTiming { get; init; } = OffsetStoreTiming.AfterProcessing;
 
     /// <summary>
     /// Auto offset reset behavior.

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -181,7 +181,9 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 /// preserve commit-safety validation performed by processing extensions such as
 /// <c>RunPartitionedAsync</c>.
 /// A grouped consumer using <see cref="OffsetCommitMode.Auto"/> with automatic offset storage
-/// enabled can commit messages before application processing completes.
+/// enabled stages offsets based on consume-loop progress; when records are handed to
+/// out-of-band workers (as partitioned processing does), that progress no longer proves
+/// processing, so offsets could be committed before processing completes.
 /// </remarks>
 public interface IConsumerCommitConfiguration
 {

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -174,6 +174,28 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
 }
 
 /// <summary>
+/// Optional capability exposing a consumer's effective offset-commit configuration.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in consumers implement this interface. Consumer wrappers can implement it to
+/// preserve commit-safety validation performed by processing extensions such as
+/// <c>RunPartitionedAsync</c>.
+/// A grouped consumer using <see cref="OffsetCommitMode.Auto"/> with automatic offset storage
+/// enabled can commit messages before application processing completes.
+/// </remarks>
+public interface IConsumerCommitConfiguration
+{
+    /// <summary>Gets whether offsets are committed automatically or explicitly.</summary>
+    OffsetCommitMode OffsetCommitMode { get; }
+
+    /// <summary>Gets whether consumed offsets are staged automatically for commit.</summary>
+    bool EnableAutoOffsetStore { get; }
+
+    /// <summary>Gets whether the consumer is configured to participate in a consumer group.</summary>
+    bool HasConsumerGroup { get; }
+}
+
+/// <summary>
 /// Position and seek operations for a Kafka consumer.
 /// </summary>
 public interface IConsumerPositions

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2162,6 +2162,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
+                if (TryDiscardExhaustedPendingFetch())
+                    continue;
+
                 PendingFetchData pending = _pendingFetches.Peek();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
@@ -2312,6 +2315,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (ClearFetchBufferForPendingCoordinatorRevocations())
                     continue;
 
+                if (TryDiscardExhaustedPendingFetch())
+                    continue;
+
                 PendingFetchData pending = _pendingFetches.Peek();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
@@ -2396,8 +2402,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             || (pending.IsExhausted && yieldedBatchProcessed)
             || !IsCurrentlyAssigned(pending.TopicPartition))
         {
-            DequeuePendingFetch().Dispose();
+            DisposeQueuedFetch(DequeuePendingFetch());
         }
+    }
+
+    private bool TryDiscardExhaustedPendingFetch()
+    {
+        if (_pendingFetches.Count == 0 || !_pendingFetches.Peek().IsExhausted)
+            return false;
+
+        DisposeQueuedFetch(DequeuePendingFetch());
+        return true;
     }
 
     private void StartPrefetch()
@@ -3205,6 +3220,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             if (TryReadActiveConsumedPosition(out var partition, out var nextOffset, out var leaderEpoch, out var version))
             {
+                if (_pendingFetches.Count > 0)
+                {
+                    var activePending = _pendingFetches.Peek();
+                    if (activePending.TopicPartition.Equals(partition)
+                        && activePending.LastYieldedOffset + 1 == nextOffset
+                        && activePending.LastYieldedLeaderEpoch == leaderEpoch)
+                    {
+                        activePending.MarkYieldedProcessed();
+                    }
+                }
+
                 ApplyConsumedPosition(partition, nextOffset, leaderEpoch);
                 ClearActiveConsumedPosition(partition, nextOffset, version);
                 return true;
@@ -3218,7 +3244,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // record still being processed. Mark it proven so the flush stages it.
         var pending = _pendingFetches.Peek();
         pending.MarkYieldedProcessed();
-        return FlushConsumedPositions(pending);
+        var flushed = FlushConsumedPositions(pending);
+
+        if (pending.IsExhausted
+            && _pendingFetches.Count > 0
+            && ReferenceEquals(_pendingFetches.Peek(), pending))
+        {
+            DisposeQueuedFetch(DequeuePendingFetch());
+        }
+
+        return flushed;
     }
 
     private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position, out int leaderEpoch)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -962,6 +962,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // CancellationTokenSource pool to avoid allocations in hot paths
     private readonly CancellationTokenSourcePool _ctsPool;
     private readonly Action<TopicPartition, long, int>? _storeOffsetOnDelivery;
+    private readonly Action<PendingFetchData, long> _rewindBatchAfterDeliveryFailure;
 
     // Cached metric tags per topic to avoid per-message TagList allocation
     // Plain Dictionary is safe: only accessed from the single ConsumeAsync loop thread
@@ -1185,6 +1186,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                  && options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery
             ? StoreOffsetCore
             : null;
+        _rewindBatchAfterDeliveryFailure = RewindAfterDeliveryFailure;
         _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
 
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
@@ -2183,7 +2185,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             batchIterationVersion,
                             CanContinueBatchIteration),
                         _storeOffsetOnDelivery,
-                        _options.MaxPollRecords);
+                        _options.MaxPollRecords,
+                        _rewindBatchAfterDeliveryFailure);
                     batchYielded = true;
                     yield return batch;
                     // Resumption = the caller requested the next batch, proving this one was

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3220,20 +3220,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             if (TryReadActiveConsumedPosition(out var partition, out var nextOffset, out var leaderEpoch, out var version))
             {
-                if (_pendingFetches.Count > 0)
-                {
-                    var activePending = _pendingFetches.Peek();
-                    if (activePending.TopicPartition.Equals(partition)
+                PendingFetchData? activePending = _pendingFetches.Count > 0
+                    ? _pendingFetches.Peek()
+                    : null;
+                if (activePending is null
+                    || (activePending.TopicPartition.Equals(partition)
                         && activePending.LastYieldedOffset + 1 == nextOffset
-                        && activePending.LastYieldedLeaderEpoch == leaderEpoch)
-                    {
-                        activePending.MarkYieldedProcessed();
-                    }
+                        && activePending.LastYieldedLeaderEpoch == leaderEpoch))
+                {
+                    activePending?.MarkYieldedProcessed();
+                    ApplyConsumedPosition(partition, nextOffset, leaderEpoch);
+                    ClearActiveConsumedPosition(partition, nextOffset, version);
+                    return true;
                 }
 
-                ApplyConsumedPosition(partition, nextOffset, leaderEpoch);
+                // A batch API may have advanced the same pending fetch without publishing
+                // a new record snapshot. Discard the stale snapshot and vouch for the fetch.
                 ClearActiveConsumedPosition(partition, nextOffset, version);
-                return true;
             }
         }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1848,6 +1848,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 while (_pendingFetches.Count > 0)
                 {
                     var pending = _pendingFetches.Peek();
+                    // A fresh ConsumeAsync stream is another pull and therefore proves any
+                    // record retained when a previous stream was disposed at its yield point.
+                    pending.MarkYieldedProcessed();
                     var pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                     long? batchProcessingStarted = _adaptiveFetchSizer is not null
                         ? Stopwatch.GetTimestamp() : null;
@@ -2166,6 +2169,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     continue;
 
                 PendingFetchData pending = _pendingFetches.Peek();
+                pending.MarkYieldedProcessed();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
                 var resumedAfterYield = false;
@@ -2319,6 +2323,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     continue;
 
                 PendingFetchData pending = _pendingFetches.Peek();
+                pending.MarkYieldedProcessed();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
                 var resumedAfterYield = false;
@@ -2408,9 +2413,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool TryDiscardExhaustedPendingFetch()
     {
-        if (_pendingFetches.Count == 0 || !_pendingFetches.Peek().IsExhausted)
+        if (_pendingFetches.Count == 0)
             return false;
 
+        var pending = _pendingFetches.Peek();
+        if (!pending.IsExhausted)
+            return false;
+
+        pending.MarkYieldedProcessed();
+        FlushConsumedPositions(pending);
         DisposeQueuedFetch(DequeuePendingFetch());
         return true;
     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2390,7 +2390,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             ReportAdaptiveProcessingComplete(processingDuration);
         }
 
-        if (disposePending || pending.IsExhausted || !IsCurrentlyAssigned(pending.TopicPartition))
+        // Keep a fully-enumerated but unproven batch queued when the caller breaks the outer
+        // stream. A following explicit CommitAsync can then vouch for that clean handoff.
+        if (disposePending
+            || (pending.IsExhausted && yieldedBatchProcessed)
+            || !IsCurrentlyAssigned(pending.TopicPartition))
         {
             DequeuePendingFetch().Dispose();
         }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1868,6 +1868,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // does not kill the consumer permanently. The yield must be outside
                         // the try block (CS1626), so we build the result first then yield below.
                         var readingProtocolData = true;
+                        var offset = -1L;
                         try
                         {
                             if (!pending.MoveNext())
@@ -1882,7 +1883,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             // Use cached batch properties (updated once per batch transition
                             // in MoveNext) to avoid per-message property access overhead on
                             // RecordBatch (Volatile.Read + disposed check per access).
-                            var offset = pending.CurrentBaseOffset + record.OffsetDelta;
+                            offset = pending.CurrentBaseOffset + record.OffsetDelta;
                             var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
 
                             // Use batch-level cached timestamp type (computed once per batch
@@ -1954,7 +1955,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 _currentRawValue = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;
                             }
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException) when (readingProtocolData)
                         {
                             throw;
                         }
@@ -1968,6 +1969,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             previousActivity = null;
                             LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                             break;
+                        }
+                        catch (Exception) when (!readingProtocolData)
+                        {
+                            RewindAfterDeliveryFailure(pending, offset);
+                            throw;
                         }
 
                         yield return nextResult;
@@ -3966,13 +3972,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 while (true)
                 {
                     var readingProtocolData = true;
+                    var offset = -1L;
                     try
                     {
                         if (!pending.MoveNext())
                             break;
 
                         var record = pending.CurrentRecord;
-                        var offset = pending.CurrentBaseOffset + record.OffsetDelta;
+                        offset = pending.CurrentBaseOffset + record.OffsetDelta;
                         var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
                         var timestampType = pending.CurrentTimestampType;
                         var messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
@@ -4029,7 +4036,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         return true;
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (readingProtocolData)
                     {
                         throw;
                     }
@@ -4038,6 +4045,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     {
                         LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                         break;
+                    }
+                    catch (Exception) when (!readingProtocolData)
+                    {
+                        RewindAfterDeliveryFailure(pending, offset);
+                        throw;
                     }
                 }
             }
@@ -4061,6 +4073,28 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Discards records following a deserializer or consume-interceptor failure and resumes
+    /// the partition at the failed record. Otherwise a later consume could prove a higher
+    /// offset from the same fetch and commit past the record that was never delivered.
+    /// </summary>
+    private void RewindAfterDeliveryFailure(PendingFetchData pending, long failedOffset)
+    {
+        var partition = pending.TopicPartition;
+
+        // Keep fetch invalidation and the replacement position atomic with background
+        // prefetch publication, matching Seek's ordering guarantee.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            // Preserve the successfully processed prefix before disposing this fetch.
+            FlushConsumedPositions(pending);
+            ClearFetchBufferForPartitions([partition]);
+            _positions[partition] = failedOffset;
+            _fetchPositions[partition] = failedOffset;
+            _eofEmitted.TryRemove(partition, out _);
+        }
     }
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -961,7 +961,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // CancellationTokenSource pool to avoid allocations in hot paths
     private readonly CancellationTokenSourcePool _ctsPool;
-    private readonly Action<TopicPartition, long, int> _storeOffsetOnDelivery;
+    private readonly Action<TopicPartition, long, int>? _storeOffsetOnDelivery;
 
     // Cached metric tags per topic to avoid per-message TagList allocation
     // Plain Dictionary is safe: only accessed from the single ConsumeAsync loop thread
@@ -1181,7 +1181,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             consumerSizes.ParsedRecordSlabsPerBucket);
         RatchetRecordWrapperPools(partitionCount: 64);
         _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
-        _storeOffsetOnDelivery = StoreOffsetCore;
+        _storeOffsetOnDelivery = options.EnableAutoOffsetStore
+                                 && options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery
+            ? StoreOffsetCore
+            : null;
         _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
 
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
@@ -2179,7 +2182,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             _batchIterationEpoch,
                             batchIterationVersion,
                             CanContinueBatchIteration),
-                        EagerOffsetStore ? _storeOffsetOnDelivery : null,
+                        _storeOffsetOnDelivery,
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
@@ -2326,7 +2329,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             _batchIterationEpoch,
                             batchIterationVersion,
                             CanContinueBatchIteration),
-                        EagerOffsetStore ? _storeOffsetOnDelivery : null,
+                        _storeOffsetOnDelivery,
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -147,6 +147,27 @@ internal sealed class PendingFetchData : IDisposable
     public int LastYieldedLeaderEpoch { get; private set; } = -1;
 
     /// <summary>
+    /// Highest yielded offset the application has demonstrably moved past — set when the
+    /// caller requests the next record/batch after a yield. Offsets at or below this value
+    /// are safe to stage for auto-commit (at-least-once); the gap between
+    /// <see cref="ProvenOffset"/> and <see cref="LastYieldedOffset"/> is the in-doubt record
+    /// whose processing may have failed, and must not be staged on unwind.
+    /// </summary>
+    public long ProvenOffset { get; private set; } = -1;
+    public int ProvenLeaderEpoch { get; private set; } = -1;
+
+    /// <summary>
+    /// Marks everything yielded so far as processed. Called on the consume paths at the
+    /// point the application requests more data (next MoveNextAsync/ConsumeOne call),
+    /// which proves the previously yielded record or batch was handled.
+    /// </summary>
+    public void MarkYieldedProcessed()
+    {
+        ProvenOffset = LastYieldedOffset;
+        ProvenLeaderEpoch = LastYieldedLeaderEpoch;
+    }
+
+    /// <summary>
     /// Tracks total bytes consumed in this pending fetch.
     /// </summary>
     public long TotalBytesConsumed { get; private set; }
@@ -626,6 +647,8 @@ internal sealed class PendingFetchData : IDisposable
         CurrentTimestampType = default;
         LastYieldedOffset = -1;
         LastYieldedLeaderEpoch = -1;
+        ProvenOffset = -1;
+        ProvenLeaderEpoch = -1;
         TotalBytesConsumed = 0;
         MessageCount = 0;
         IsExhausted = false;
@@ -1954,6 +1977,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
                             break;
 
+                        // Reaching this line means the caller requested the next record, which
+                        // proves the record yielded above was processed. Enumerator disposal
+                        // (loop-body exception, break) resumes directly into finally blocks and
+                        // never executes this, leaving the in-doubt record unproven.
+                        pending.MarkYieldedProcessed();
+
                         if (--recordsUntilPollRefresh == 0)
                         {
                             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
@@ -2123,6 +2152,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 PendingFetchData pending = _pendingFetches.Peek();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
+                var resumedAfterYield = false;
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? Stopwatch.GetTimestamp() : null;
 
@@ -2144,6 +2174,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
+                    // Resumption = the caller requested the next batch, proving this one was
+                    // processed. Enumerator disposal skips straight to the finally block.
+                    resumedAfterYield = true;
                     await RecordPollAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
@@ -2153,7 +2186,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         pendingFetchesVersion,
                         metricsEnabled,
                         batchProcessingStarted,
-                        disposePending: !batchYielded);
+                        disposePending: !batchYielded,
+                        yieldedBatchProcessed: resumedAfterYield);
                 }
             }
 
@@ -2266,6 +2300,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 PendingFetchData pending = _pendingFetches.Peek();
                 int pendingFetchesVersion = Volatile.Read(ref _pendingFetchesVersion);
                 var batchYielded = false;
+                var resumedAfterYield = false;
                 long? batchProcessingStarted = _adaptiveFetchSizer is not null
                     ? Stopwatch.GetTimestamp() : null;
 
@@ -2285,6 +2320,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
+                    // Resumption = the caller requested the next batch, proving this one was
+                    // processed. Enumerator disposal skips straight to the finally block.
+                    resumedAfterYield = true;
                     await RecordPollAsync(cancellationToken).ConfigureAwait(false);
                 }
                 finally
@@ -2294,7 +2332,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         pendingFetchesVersion,
                         metricsEnabled,
                         batchProcessingStarted,
-                        disposePending: !batchYielded);
+                        disposePending: !batchYielded,
+                        yieldedBatchProcessed: resumedAfterYield);
                 }
             }
 
@@ -2312,13 +2351,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int pendingFetchesVersion,
         bool metricsEnabled,
         long? batchProcessingStarted,
-        bool disposePending)
+        bool disposePending,
+        bool yieldedBatchProcessed)
     {
         if (Volatile.Read(ref _pendingFetchesVersion) != pendingFetchesVersion)
             return;
 
         if (_pendingFetches.Count == 0 || !ReferenceEquals(_pendingFetches.Peek(), pending))
             return;
+
+        if (yieldedBatchProcessed)
+            pending.MarkYieldedProcessed();
 
         FlushConsumedPositions(pending);
 
@@ -3078,11 +3121,51 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!TryGetConsumedPosition(pending, out var tp, out var nextOffset, out var leaderEpoch))
             return false;
 
-        ApplyConsumedPosition(tp, nextOffset, leaderEpoch);
-        ClearActiveConsumedPosition(tp, nextOffset);
+        // Positions always advance past everything yielded (delivery semantics), but the
+        // committable stored offset advances only past records the application has
+        // demonstrably processed (ProvenOffset — see MarkYieldedProcessed). On an unwind
+        // the in-doubt record between ProvenOffset and LastYieldedOffset is therefore
+        // never staged, which is what makes the default at-least-once. In OnDelivery
+        // mode every yielded offset was already staged at delivery, so staging the full
+        // yielded range here is idempotent.
+        _positions[tp] = nextOffset;
+        SetLastConsumedLeaderEpoch(tp, leaderEpoch);
+
+        var stagedFullYieldedRange = true;
+        if (_options.EnableAutoOffsetStore)
+        {
+            if (EagerOffsetStore)
+            {
+                StoreOffsetCore(tp, nextOffset, leaderEpoch);
+            }
+            else
+            {
+                if (pending.ProvenOffset >= 0)
+                    StoreOffsetCore(tp, pending.ProvenOffset + 1, pending.ProvenLeaderEpoch);
+                stagedFullYieldedRange = pending.ProvenOffset + 1 >= nextOffset;
+            }
+        }
+
+        if (!_prefetchEnabled)
+        {
+            _fetchPositions[tp] = nextOffset;
+        }
+
+        // Keep the active snapshot alive while an in-doubt record remains unstaged so a
+        // later explicit CommitAsync can still vouch for it (break → CommitAsync → close).
+        if (stagedFullYieldedRange)
+            ClearActiveConsumedPosition(tp, nextOffset);
+
         return true;
     }
 
+    private bool EagerOffsetStore => _options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery;
+
+    /// <summary>
+    /// Full-staging position apply used by explicit-commit paths (<see cref="CommitAsync(CancellationToken)"/>):
+    /// stages everything yielded, including a record the application may still be holding.
+    /// An explicit commit is the caller vouching for everything delivered so far.
+    /// </summary>
     private void ApplyConsumedPosition(TopicPartition partition, long nextOffset, int leaderEpoch)
     {
         RecordConsumedPosition(partition, nextOffset, leaderEpoch);
@@ -3108,7 +3191,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_pendingFetches.Count == 0)
             return false;
 
-        return FlushConsumedPositions(_pendingFetches.Peek());
+        // Explicit commit: the caller vouches for everything yielded so far, including a
+        // record still being processed. Mark it proven so the flush stages it.
+        var pending = _pendingFetches.Peek();
+        pending.MarkYieldedProcessed();
+        return FlushConsumedPositions(pending);
     }
 
     private bool TryGetActiveConsumedPosition(TopicPartition partition, out long position, out int leaderEpoch)
@@ -3147,9 +3234,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// <summary>
     /// Records the yielded record in the pending fetch and, in auto-commit mode, publishes
     /// the next position to the active consumed snapshot. The snapshot is read only by
-    /// <see cref="CommitAsync(CancellationToken)"/>, close, and <see cref="GetPosition"/> —
+    /// <see cref="CommitAsync(CancellationToken)"/> and <see cref="GetPosition"/> —
     /// never by the background auto-commit loop — so publishing before the record is
-    /// yielded cannot make it committable early.
+    /// yielded cannot make it committable early. Under <see cref="OffsetStoreTiming.OnDelivery"/>
+    /// the offset additionally becomes committable here, by design (at-most-once).
     /// </summary>
     private void TrackConsumedPosition(PendingFetchData pending, long offset, int messageBytes)
     {
@@ -3158,6 +3246,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
         {
             PublishActiveConsumedPosition(pending.TopicPartition, offset + 1, pending.LastYieldedLeaderEpoch);
+        }
+
+        // OnDelivery (at-most-once) staging: the offset becomes committable the moment the
+        // record is handed out, before processing. Opt-in via WithAtMostOnceProcessing —
+        // costs per-message dictionary writes that the default fetch-boundary flush avoids.
+        if (_options.EnableAutoOffsetStore && EagerOffsetStore)
+        {
+            StoreOffsetCore(pending.TopicPartition, offset + 1, pending.LastYieldedLeaderEpoch);
         }
     }
 
@@ -3822,6 +3918,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var hasInterceptors = _interceptors is not null;
         var rawTrackingEnabled = _rawRecordTrackingEnabled;
 
+        // A new consume call proves the record returned by the previous call was processed
+        // (poll contract), so everything yielded from the head fetch becomes committable.
+        if (_pendingFetches.Count > 0)
+            _pendingFetches.Peek().MarkYieldedProcessed();
+
         while (_pendingFetches.Count > 0)
         {
             if (ClearFetchBufferForPendingCoordinatorRevocations())
@@ -3950,6 +4051,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             FlushActiveConsumedPosition();
         }
+        else if (_pendingFetches.Count > 0)
+        {
+            // Close path: stage offsets already proven processed but not yet flushed
+            // (e.g. mid-fetch ConsumeOne usage) without vouching for the in-doubt last
+            // yielded record the way an explicit CommitAsync does.
+            FlushConsumedPositions(_pendingFetches.Peek());
+        }
 
         return await CommitStoredOffsetsAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -4075,7 +4183,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         if (TryGetActiveConsumedPosition(partition, out var activePosition, out var leaderEpoch))
         {
-            RecordConsumedPosition(partition, activePosition, leaderEpoch);
+            // Materialize the snapshot into _positions for consistency, but do NOT stage it
+            // for commit: the position includes the record currently being processed, and a
+            // read-only query must not make an unproven record committable.
+            _positions[partition] = activePosition;
+            SetLastConsumedLeaderEpoch(partition, leaderEpoch);
             return activePosition;
         }
 
@@ -7100,7 +7212,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 try
                 {
-                    if (await CommitPendingOffsetsAsync(flushActiveConsumedPosition: true, cancellationToken)
+                    // flushActiveConsumedPosition: false — close must not stage the last
+                    // yielded record: its processing is unproven (the consumer may be closing
+                    // because that processing failed). Proven offsets were already flushed by
+                    // the consume paths; committing only those preserves at-least-once.
+                    // Callers that processed everything and want a clean handoff should call
+                    // CommitAsync() before CloseAsync().
+                    if (await CommitPendingOffsetsAsync(flushActiveConsumedPosition: false, cancellationToken)
                         .ConfigureAwait(false))
                     {
                         LogCommittedPendingOffsets();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -742,7 +742,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     IConsumerOffsets,
     IConsumerRebalanceEventSource,
     IConsumerLoggerFactorySource,
-    IConsumerCommitModeSource,
+    IConsumerCommitConfiguration,
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
@@ -1426,11 +1426,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     ILoggerFactory? IConsumerLoggerFactorySource.LoggerFactory => _loggerFactory;
 
-    OffsetCommitMode IConsumerCommitModeSource.OffsetCommitMode => _options.OffsetCommitMode;
+    OffsetCommitMode IConsumerCommitConfiguration.OffsetCommitMode => _options.OffsetCommitMode;
 
-    bool IConsumerCommitModeSource.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
+    bool IConsumerCommitConfiguration.EnableAutoOffsetStore => _options.EnableAutoOffsetStore;
 
-    bool IConsumerCommitModeSource.HasConsumerGroup => !string.IsNullOrEmpty(_options.GroupId);
+    bool IConsumerCommitConfiguration.HasConsumerGroup => !string.IsNullOrEmpty(_options.GroupId);
 
     /// <inheritdoc />
     public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3168,7 +3168,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// </summary>
     private void ApplyConsumedPosition(TopicPartition partition, long nextOffset, int leaderEpoch)
     {
-        RecordConsumedPosition(partition, nextOffset, leaderEpoch);
+        _positions[partition] = nextOffset;
+        SetLastConsumedLeaderEpoch(partition, leaderEpoch);
+        if (_options.EnableAutoOffsetStore)
+            StoreOffsetCore(partition, nextOffset, leaderEpoch);
 
         if (!_prefetchEnabled)
         {
@@ -3412,14 +3415,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             ClearStoredOffset(partition);
         }
-    }
-
-    private void RecordConsumedPosition(TopicPartition partition, long position, int leaderEpoch)
-    {
-        _positions[partition] = position;
-        SetLastConsumedLeaderEpoch(partition, leaderEpoch);
-        if (_options.EnableAutoOffsetStore)
-            StoreOffsetCore(partition, position, leaderEpoch);
     }
 
     private void StoreOffsetCore(TopicPartition partition, long offset, int leaderEpoch)
@@ -4039,23 +4034,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
-        await CommitPendingOffsetsAsync(flushActiveConsumedPosition: true, cancellationToken)
-            .ConfigureAwait(false);
+        // Explicit commit: the caller vouches for everything yielded so far, including
+        // a record still being processed.
+        FlushActiveConsumedPosition();
+        await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask<bool> CommitPendingOffsetsAsync(
-        bool flushActiveConsumedPosition,
-        CancellationToken cancellationToken)
+    /// <summary>
+    /// Close-scope commit: stages offsets already proven processed but not yet flushed
+    /// (e.g. mid-fetch ConsumeOne usage) without vouching for the in-doubt last yielded
+    /// record the way an explicit <see cref="CommitAsync(CancellationToken)"/> does — the
+    /// consumer may be closing precisely because that record's processing failed.
+    /// The background auto-commit loop uses a third, narrower scope: already-staged
+    /// offsets only, via <see cref="CommitStoredOffsetsAsync"/> directly.
+    /// </summary>
+    private async ValueTask<bool> CommitProvenOffsetsAsync(CancellationToken cancellationToken)
     {
-        if (flushActiveConsumedPosition)
+        if (_pendingFetches.Count > 0)
         {
-            FlushActiveConsumedPosition();
-        }
-        else if (_pendingFetches.Count > 0)
-        {
-            // Close path: stage offsets already proven processed but not yet flushed
-            // (e.g. mid-fetch ConsumeOne usage) without vouching for the in-doubt last
-            // yielded record the way an explicit CommitAsync does.
             FlushConsumedPositions(_pendingFetches.Peek());
         }
 
@@ -7212,14 +7208,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 try
                 {
-                    // flushActiveConsumedPosition: false — close must not stage the last
-                    // yielded record: its processing is unproven (the consumer may be closing
-                    // because that processing failed). Proven offsets were already flushed by
-                    // the consume paths; committing only those preserves at-least-once.
-                    // Callers that processed everything and want a clean handoff should call
-                    // CommitAsync() before CloseAsync().
-                    if (await CommitPendingOffsetsAsync(flushActiveConsumedPosition: false, cancellationToken)
-                        .ConfigureAwait(false))
+                    // Close commits proven offsets only — never the in-doubt last yielded
+                    // record. Callers that processed everything and want a clean handoff
+                    // should call CommitAsync() before CloseAsync().
+                    if (await CommitProvenOffsetsAsync(cancellationToken).ConfigureAwait(false))
                     {
                         LogCommittedPendingOffsets();
                     }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -961,6 +961,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     // CancellationTokenSource pool to avoid allocations in hot paths
     private readonly CancellationTokenSourcePool _ctsPool;
+    private readonly Action<TopicPartition, long, int> _storeOffsetOnDelivery;
 
     // Cached metric tags per topic to avoid per-message TagList allocation
     // Plain Dictionary is safe: only accessed from the single ConsumeAsync loop thread
@@ -1180,6 +1181,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             consumerSizes.ParsedRecordSlabsPerBucket);
         RatchetRecordWrapperPools(partitionCount: 64);
         _ctsPool = new CancellationTokenSourcePool(consumerSizes.CancellationTokenSources);
+        _storeOffsetOnDelivery = StoreOffsetCore;
         _logger = loggerFactory?.CreateLogger<KafkaConsumer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConsumer<TKey, TValue>>.Instance;
 
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
@@ -2171,6 +2173,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             _batchIterationEpoch,
                             batchIterationVersion,
                             CanContinueBatchIteration),
+                        EagerOffsetStore ? _storeOffsetOnDelivery : null,
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
@@ -2317,6 +2320,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             _batchIterationEpoch,
                             batchIterationVersion,
                             CanContinueBatchIteration),
+                        EagerOffsetStore ? _storeOffsetOnDelivery : null,
                         _options.MaxPollRecords);
                     batchYielded = true;
                     yield return batch;
@@ -3183,12 +3187,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
         {
-            if (!TryReadActiveConsumedPosition(out var partition, out var nextOffset, out var leaderEpoch, out var version))
-                return false;
-
-            ApplyConsumedPosition(partition, nextOffset, leaderEpoch);
-            ClearActiveConsumedPosition(partition, nextOffset, version);
-            return true;
+            if (TryReadActiveConsumedPosition(out var partition, out var nextOffset, out var leaderEpoch, out var version))
+            {
+                ApplyConsumedPosition(partition, nextOffset, leaderEpoch);
+                ClearActiveConsumedPosition(partition, nextOffset, version);
+                return true;
+            }
         }
 
         if (_pendingFetches.Count == 0)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -3370,6 +3370,33 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ClearActiveConsumedPosition(partition, position, version);
     }
 
+    private void ClearActiveConsumedPosition(TopicPartition partition)
+    {
+        if (!TryReadActiveConsumedPosition(
+                out var activePartition,
+                out var activePosition,
+                out _,
+                out var version)
+            || !activePartition.Equals(partition))
+        {
+            return;
+        }
+
+        ClearActiveConsumedPosition(activePartition, activePosition, version);
+    }
+
+    private void ClearActiveConsumedPosition()
+    {
+        if (TryReadActiveConsumedPosition(
+                out var partition,
+                out var position,
+                out _,
+                out var version))
+        {
+            ClearActiveConsumedPosition(partition, position, version);
+        }
+    }
+
     private void ClearActiveConsumedPosition(TopicPartition partition, long position, int version)
     {
         if (Interlocked.CompareExchange(ref _activeConsumedPositionVersion, version + 1, version) != version)
@@ -4284,6 +4311,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var hadPaused = false;
         foreach (var partition in partitions)
         {
+            ClearActiveConsumedPosition(partition);
             _positions.TryRemove(partition, out _);
             ClearStoredOffset(partition);
             _fetchPositions.TryRemove(partition, out _);
@@ -4326,6 +4354,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void ClearFetchBuffer()
     {
+        ClearActiveConsumedPosition();
         _stuckFetchPositionTracker.Clear();
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
@@ -4364,7 +4393,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             return;
 
         foreach (var partition in removeSet)
+        {
+            ClearActiveConsumedPosition(partition);
             _stuckFetchPositionTracker.Reset(partition);
+        }
 
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
@@ -4590,7 +4622,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Clearing the pending fetch bypasses its normal position flush. Discard the
             // matching auto-commit snapshot so a later commit/position read cannot restore
             // the pre-divergence leader epoch after the reset below clears it.
-            ClearActiveConsumedPosition(partition, resumeOffset);
+            ClearActiveConsumedPosition(partition);
             // The diverging epoch is the last common epoch, not the new leader epoch.
             // Reusing it would make every subsequent fetch report the same divergence.
             ClearLastConsumedLeaderEpoch(partition);

--- a/src/Dekaf/Consumer/PartitionedProcessing.cs
+++ b/src/Dekaf/Consumer/PartitionedProcessing.cs
@@ -211,7 +211,7 @@ public static class PartitionedConsumerExtensions
         if (!options.IsRuntimeManagedCommitPolicy)
             return;
 
-        if (consumer is IConsumerCommitModeSource
+        if (consumer is IConsumerCommitConfiguration
             {
                 OffsetCommitMode: OffsetCommitMode.Auto,
                 EnableAutoOffsetStore: true,
@@ -233,22 +233,6 @@ public static class PartitionedConsumerExtensions
 internal interface IConsumerLoggerFactorySource
 {
     ILoggerFactory? LoggerFactory { get; }
-}
-
-/// <summary>
-/// Exposes a consumer's offset-commit configuration so partitioned processing can reject
-/// consumers whose background auto-commit would bypass processed-offset tracking. Only the
-/// combination of a consumer group, <see cref="OffsetCommitMode.Auto"/>, and automatic offset
-/// store is dangerous: without a group there is no coordinator to commit through, and with the
-/// store disabled nothing is staged for the background loop to commit.
-/// </summary>
-internal interface IConsumerCommitModeSource
-{
-    OffsetCommitMode OffsetCommitMode { get; }
-
-    bool EnableAutoOffsetStore { get; }
-
-    bool HasConsumerGroup { get; }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -530,10 +530,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         if (offsetCommitMode == OffsetCommitMode.Manual)
             await oracle.WaitForFinalCommitsAsync(cancellationToken);
         else
-            await survivor.CommitDeliveredAsync(cancellationToken);
-        await survivor.StopAsync();
-        if (offsetCommitMode == OffsetCommitMode.Auto)
             await WaitForFinalBrokerCommitsAsync(groupId, oracle, cancellationToken);
+        await survivor.StopAsync();
 
         await AssertCompletedScenarioAsync(
             groupId,
@@ -728,8 +726,6 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         await oracle.WaitForAllSequencesAsync(cancellationToken);
         if (offsetCommitMode == OffsetCommitMode.Manual)
             await oracle.WaitForFinalCommitsAsync(cancellationToken);
-        else
-            await survivor.CommitDeliveredAsync(cancellationToken);
 
         await Assert.That(oracle.WasDuplicatedAfterCrash(
                 crashedObservation.Partition,
@@ -737,9 +733,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
             .IsTrue()
             .Because("the crashed member's last uncommitted record must be replayed after session expiry");
 
-        await survivor.StopAsync();
         if (offsetCommitMode == OffsetCommitMode.Auto)
             await WaitForFinalBrokerCommitsAsync(groupId, oracle, cancellationToken);
+        await survivor.StopAsync();
 
         await Assert.That(oracle.UniqueCount).IsEqualTo(PartitionCount * MessagesPerPartition);
         if (offsetCommitMode == OffsetCommitMode.Auto)
@@ -1087,7 +1083,6 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         Task WaitForPartitionAssignedAsync(TopicPartition partition, CancellationToken cancellationToken);
         Task WaitForPartitionUnassignedAsync(TopicPartition partition, CancellationToken cancellationToken);
         Task WaitForObservedCountAsync(int count, CancellationToken cancellationToken);
-        Task CommitDeliveredAsync(CancellationToken cancellationToken);
         Task StopAsync();
     }
 
@@ -1125,8 +1120,6 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         public int ObservedCount => _observed.Value;
 
         public int MaxAssignmentCount => _assignments.MaxAssignmentCount;
-
-        public virtual Task CommitDeliveredAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public void Allow(int count) => _permits.Release(count);
 
@@ -1293,7 +1286,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
                     .ConsumeAsync(StoppingToken)
                     .GetAsyncEnumerator(StoppingToken);
 
-                while (!Oracle.IsComplete)
+                // Auto mode must pull again after the final yield to prove it processed,
+                // and may need to redeliver an unproven tail from a departed member.
+                while (!_explicitlyCommit || !Oracle.IsComplete)
                 {
                     await Permits.WaitAsync(StoppingToken);
                     if (!await enumerator.MoveNextAsync())
@@ -1322,9 +1317,6 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
 
         protected override ValueTask DisposeConsumerAsync() => _consumer.DisposeAsync();
-
-        public override async Task CommitDeliveredAsync(CancellationToken cancellationToken) =>
-            await _consumer.CommitAsync(cancellationToken);
 
         public ValueTask CommitAsync(
             TopicPartitionOffset offset,

--- a/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerGroupRebalanceChaosTests.cs
@@ -529,6 +529,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         await oracle.WaitForAllSequencesAsync(cancellationToken);
         if (offsetCommitMode == OffsetCommitMode.Manual)
             await oracle.WaitForFinalCommitsAsync(cancellationToken);
+        else
+            await survivor.CommitDeliveredAsync(cancellationToken);
         await survivor.StopAsync();
         if (offsetCommitMode == OffsetCommitMode.Auto)
             await WaitForFinalBrokerCommitsAsync(groupId, oracle, cancellationToken);
@@ -726,6 +728,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         await oracle.WaitForAllSequencesAsync(cancellationToken);
         if (offsetCommitMode == OffsetCommitMode.Manual)
             await oracle.WaitForFinalCommitsAsync(cancellationToken);
+        else
+            await survivor.CommitDeliveredAsync(cancellationToken);
 
         await Assert.That(oracle.WasDuplicatedAfterCrash(
                 crashedObservation.Partition,
@@ -1083,6 +1087,7 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         Task WaitForPartitionAssignedAsync(TopicPartition partition, CancellationToken cancellationToken);
         Task WaitForPartitionUnassignedAsync(TopicPartition partition, CancellationToken cancellationToken);
         Task WaitForObservedCountAsync(int count, CancellationToken cancellationToken);
+        Task CommitDeliveredAsync(CancellationToken cancellationToken);
         Task StopAsync();
     }
 
@@ -1120,6 +1125,8 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         public int ObservedCount => _observed.Value;
 
         public int MaxAssignmentCount => _assignments.MaxAssignmentCount;
+
+        public virtual Task CommitDeliveredAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public void Allow(int count) => _permits.Release(count);
 
@@ -1315,6 +1322,9 @@ public sealed class ConsumerGroupRebalanceChaosTests(KafkaTestContainer kafka) :
         }
 
         protected override ValueTask DisposeConsumerAsync() => _consumer.DisposeAsync();
+
+        public override async Task CommitDeliveredAsync(CancellationToken cancellationToken) =>
+            await _consumer.CommitAsync(cancellationToken);
 
         public ValueTask CommitAsync(
             TopicPartitionOffset offset,

--- a/tests/Dekaf.Tests.Integration/RealWorld/AutoCommitBehaviorTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/AutoCommitBehaviorTests.cs
@@ -73,8 +73,10 @@ public sealed class AutoCommitBehaviorTests(KafkaTestContainer kafka) : KafkaInt
         var firstMsg = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts2.Token);
 
         await Assert.That(firstMsg).IsNotNull();
-        // Auto-commit should have committed at least offset 5
-        await Assert.That(firstMsg!.Value.Offset).IsGreaterThanOrEqualTo(5);
+        // At-least-once: breaking out of the loop leaves the 5th record (offset 4)
+        // unproven, so auto-commit covers the proven prefix (offsets 0-3) and the
+        // second consumer resumes at offset 4 — a duplicate, never a loss.
+        await Assert.That(firstMsg!.Value.Offset).IsGreaterThanOrEqualTo(4);
     }
 
     [Test]
@@ -133,13 +135,15 @@ public sealed class AutoCommitBehaviorTests(KafkaTestContainer kafka) : KafkaInt
 
         consumer2.Subscribe(topic);
 
-        // Should get nothing since all 10 messages were committed
+        // At-least-once: close commits the proven prefix (offsets 0-8). The 10th record
+        // (offset 9) was consumed but never proven (the loop broke while holding it), so
+        // it is redelivered — the second consumer sees offset 9 or nothing at all.
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var result = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(5), cts2.Token);
 
         if (result.HasValue)
         {
-            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(10);
+            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(9);
         }
     }
 
@@ -275,9 +279,11 @@ public sealed class AutoCommitBehaviorTests(KafkaTestContainer kafka) : KafkaInt
             if (messages.Count >= 12) break;
         }
 
-        // Should get remaining messages (approximately 12)
+        // Should get the remaining messages. At-least-once: the 8th record (offset 7)
+        // was never proven (the loop broke while holding it), so the second consumer
+        // resumes at offset 7 and redelivers it.
         await Assert.That(messages).Count().IsEqualTo(12);
-        await Assert.That(messages[0].Offset).IsGreaterThanOrEqualTo(8);
+        await Assert.That(messages[0].Offset).IsGreaterThanOrEqualTo(7);
     }
 
     [Test]
@@ -343,11 +349,82 @@ public sealed class AutoCommitBehaviorTests(KafkaTestContainer kafka) : KafkaInt
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var result = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(5), cts2.Token);
 
-        // All partitions committed - no messages to read
+        // At-least-once: the very last consumed record (offset 4 on one partition) was
+        // never proven, so it may be redelivered; everything else is committed.
         if (result.HasValue)
         {
-            // If we get a message, it should be beyond what was consumed
-            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(5);
+            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(4);
         }
+    }
+
+    [Test]
+    public async Task AutoCommit_ProcessingFailureExitsLoop_FailedMessageRedelivered()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"auto-redeliver-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+
+        // First consumer processes two messages, then "fails" on offset 2 with an
+        // exception that exits the consume loop.
+        await using (var consumer1 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithSessionTimeout(TimeSpan.FromMilliseconds(10000))
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Auto)
+            .WithAutoCommitInterval(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync())
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            consumer1.Subscribe(topic);
+
+            try
+            {
+                await foreach (var msg in consumer1.ConsumeAsync(cts.Token))
+                {
+                    if (msg.Offset == 2)
+                        throw new InvalidOperationException("processing failed");
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected — the failure exits the loop without acknowledging offset 2.
+            }
+
+            await consumer1.CloseAsync();
+        }
+
+        // At-least-once: the failed message (offset 2) must be redelivered to the next
+        // consumer in the group, not silently committed away.
+        await using var consumer2 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithSessionTimeout(TimeSpan.FromMilliseconds(10000))
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer2.Subscribe(topic);
+
+        using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var redelivered = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts2.Token);
+
+        await Assert.That(redelivered).IsNotNull();
+        await Assert.That(redelivered!.Value.Offset).IsEqualTo(2);
+        await Assert.That(redelivered.Value.Value).IsEqualTo("value-2");
     }
 }

--- a/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/GracefulShutdownTests.cs
@@ -326,14 +326,15 @@ public sealed class GracefulShutdownTests(KafkaTestContainer kafka) : KafkaInteg
 
         consumer2.Subscribe(topic);
 
-        // Try to consume - should get nothing since all offsets were committed
+        // At-least-once: the 5th record (offset 4) was consumed but the loop broke while
+        // holding it, so it is unproven and redelivered. Everything before it is committed.
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var result = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(5), cts2.Token);
 
-        // Either null (no messages) or offset >= 5 (already committed)
+        // Either null (no messages) or offset >= 4 (proven prefix committed)
         if (result.HasValue)
         {
-            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(5);
+            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(4);
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/RealWorld/OffsetCommitSafetyTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/OffsetCommitSafetyTests.cs
@@ -60,10 +60,13 @@ public sealed class OffsetCommitSafetyTests(KafkaTestContainer kafka) : KafkaInt
             await consumer.CloseAsync();
         }
 
-        // Everything was consumed, so close-commit must land exactly at the log end:
-        // lower would lose the final commit, higher would skip messages on restart.
+        // The loop broke while holding the final record (offset messageCount - 1), so it
+        // is unproven and close-commit lands exactly one below the log end: higher would
+        // skip messages on restart, lower would lose proven progress. The final record is
+        // redelivered on restart — at-least-once, never a loss. (Call CommitAsync() before
+        // close for an exact handoff.)
         var finalOffsets = await admin.ListConsumerGroupOffsetsAsync(groupId);
-        await Assert.That(finalOffsets[partition]).IsEqualTo(messageCount);
+        await Assert.That(finalOffsets[partition]).IsEqualTo(messageCount - 1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
+++ b/tests/Dekaf.Tests.Integration/StoreOffsetTests.cs
@@ -375,6 +375,9 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
 
             // Poll for auto-commit to propagate instead of using a fixed delay.
             // On slow CI runners, 500ms may not be enough for the commit round-trip.
+            // At-least-once: the 3rd record (offset 2) was consumed but the loop broke
+            // while holding it, so it is unproven — auto-commit covers offsets 0-1 and
+            // the committed offset lands at 2.
             var tp = new TopicPartition(topic, 0);
             using var commitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             long? committedOffset = null;
@@ -383,7 +386,7 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
                 try
                 {
                     var committed = await consumer1.GetCommittedOffsetAsync(tp).ConfigureAwait(false);
-                    if (committed >= 3)
+                    if (committed >= 2)
                     {
                         committedOffset = committed;
                         break;
@@ -400,7 +403,7 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
 
             // Ensure the polling loop did not exit due to timeout — auto-commit must have propagated.
             await Assert.That(committedOffset).IsNotNull();
-            await Assert.That(committedOffset!.Value).IsGreaterThanOrEqualTo(3);
+            await Assert.That(committedOffset!.Value).IsGreaterThanOrEqualTo(2);
         }
 
         // Second consumer: should start after the auto-committed offset
@@ -420,12 +423,11 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var result = await consumer2.ConsumeOneAsync(TimeSpan.FromSeconds(10), cts2.Token).ConfigureAwait(false);
 
-        // If we got a message, it should be from offset 3 or later (after auto-committed offset)
-        // If the topic is empty (all consumed and committed), result may be null
+        // If we got a message, it should be offset 2 (the unproven in-doubt record,
+        // redelivered) or later. If the topic is fully committed, result may be null.
         if (result.HasValue)
         {
-            // Assert - auto-commit should have committed the consumed offsets, so we start at 3+
-            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(3);
+            await Assert.That(result.Value.Offset).IsGreaterThanOrEqualTo(2);
         }
         else
         {
@@ -449,7 +451,7 @@ public class OffsetCommitModeTests(KafkaTestContainer kafka) : KafkaIntegrationT
             }
 
             await Assert.That(committedValue).IsNotNull();
-            await Assert.That(committedValue!.Value).IsGreaterThanOrEqualTo(3);
+            await Assert.That(committedValue!.Value).IsGreaterThanOrEqualTo(2);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -193,7 +193,8 @@ public class ConsumerBuilderValidationTests
             .WithBootstrapServers("localhost:9092")
             .WithGroupId("group-a")
             .WithOffsetCommitMode(OffsetCommitMode.Manual)
-            .WithAutoOffsetStore()
+            .WithAutoOffsetStore(false)
+            .WithOffsetStoreTiming(OffsetStoreTiming.OnDelivery)
             .WithAtLeastOnceProcessing()
             .Build();
 
@@ -201,10 +202,71 @@ public class ConsumerBuilderValidationTests
         var commitConfiguration = (IConsumerCommitConfiguration)consumer;
 
         await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
-        await Assert.That(options.EnableAutoOffsetStore).IsFalse();
+        await Assert.That(options.EnableAutoOffsetStore).IsTrue();
+        await Assert.That(options.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.AfterProcessing);
         await Assert.That(commitConfiguration.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
-        await Assert.That(commitConfiguration.EnableAutoOffsetStore).IsFalse();
+        await Assert.That(commitConfiguration.EnableAutoOffsetStore).IsTrue();
         await Assert.That(commitConfiguration.HasConsumerGroup).IsTrue();
+    }
+
+    [Test]
+    public async Task WithAtLeastOnceProcessing_MatchesDefaults()
+    {
+        await using var defaultConsumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+        await using var explicitConsumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithAtLeastOnceProcessing()
+            .Build();
+
+        var defaultOptions = GetConsumerOptions(defaultConsumer);
+        var explicitOptions = GetConsumerOptions(explicitConsumer);
+
+        await Assert.That(defaultOptions.OffsetCommitMode).IsEqualTo(explicitOptions.OffsetCommitMode);
+        await Assert.That(defaultOptions.EnableAutoOffsetStore).IsEqualTo(explicitOptions.EnableAutoOffsetStore);
+        await Assert.That(defaultOptions.OffsetStoreTiming).IsEqualTo(explicitOptions.OffsetStoreTiming);
+        await Assert.That(defaultOptions.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.AfterProcessing);
+    }
+
+    [Test]
+    public async Task WithAtMostOnceProcessing_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var result = builder.WithAtMostOnceProcessing();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithAtMostOnceProcessing_ConfiguresOnDeliveryStaging()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
+            .WithAtMostOnceProcessing()
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+
+        await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
+        await Assert.That(options.EnableAutoOffsetStore).IsTrue();
+        await Assert.That(options.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.OnDelivery);
+    }
+
+    [Test]
+    public async Task WithOffsetStoreTiming_SetsOption()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithOffsetStoreTiming(OffsetStoreTiming.OnDelivery)
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.OnDelivery);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -177,6 +177,37 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithAtLeastOnceProcessing_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        var result = builder.WithAtLeastOnceProcessing();
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithAtLeastOnceProcessing_ConfiguresCommitIntent()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore()
+            .WithAtLeastOnceProcessing()
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        var commitConfiguration = (IConsumerCommitConfiguration)consumer;
+
+        await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
+        await Assert.That(options.EnableAutoOffsetStore).IsFalse();
+        await Assert.That(commitConfiguration.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Auto);
+        await Assert.That(commitConfiguration.EnableAutoOffsetStore).IsFalse();
+        await Assert.That(commitConfiguration.HasConsumerGroup).IsTrue();
+    }
+
+    [Test]
     public async Task WithAutoOffsetReset_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -523,7 +523,7 @@ public sealed class ConsumerDirtyCommitTests
         int leaderEpoch)
     {
         var method = typeof(KafkaConsumer<string, string>).GetMethod(
-            "RecordConsumedPosition",
+            "ApplyConsumedPosition",
             BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         method.Invoke(consumer, [partition, position, leaderEpoch]);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerMaxPollRecordsTests.cs
@@ -61,7 +61,7 @@ public sealed class ConsumerMaxPollRecordsTests
     }
 
     [Test]
-    public async Task ConsumeBatchAsync_ExactMaxPollRecordsMultiple_RemovesExhaustedFetch()
+    public async Task ConsumeBatchAsync_ExactMaxPollRecordsMultiple_RetainsExhaustedFetchUntilCommit()
     {
         await using var consumer = CreateConsumerWithPendingFetches(
             maxPollRecords: 2,
@@ -78,6 +78,10 @@ public sealed class ConsumerMaxPollRecordsTests
             .IsEquivalentTo([2L, 3L]);
 
         await enumerator.DisposeAsync();
+
+        await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(1);
+
+        await consumer.CommitAsync(CancellationToken.None);
 
         await Assert.That(GetPendingFetches(consumer).Count).IsEqualTo(0);
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -764,6 +764,34 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
+    public async Task InMemoryConsumer_ConsumeAsync_CancellationProvesProcessedRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+        using var cts = new CancellationTokenSource();
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Subscribe("jobs");
+
+        await foreach (var _ in consumer.ConsumeAsync(cts.Token))
+            cts.Cancel();
+
+        await consumer.CloseAsync();
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(offsets[partition]).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task InMemoryConsumer_CommitAsync_VouchesForInDoubtRecord()
     {
         var cluster = new InMemoryKafkaCluster();

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -183,6 +183,30 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(100L);
     }
 
+    [Test]
+    public async Task IncrementalUnassign_AfterConsume_CommitAsyncDoesNotResurrectRevokedPartition()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        // Yield offset 20: the active snapshot now holds position 21.
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+
+        consumer.IncrementalUnassign([tp]);
+        await consumer.CommitAsync(CancellationToken.None);
+
+        // Partition removal cleared all per-partition state; the stale snapshot must not
+        // bring the revoked partition's position or staged offset back to life.
+        await Assert.That(GetPositions(consumer).ContainsKey(tp)).IsFalse();
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+    }
+
     // --- ConsumeBatchAsync ---
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -217,6 +217,108 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
     }
 
+    [Test]
+    public async Task ConsumeBatchAsync_CommitAsyncInAutoMode_VouchesForIteratedRecords()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                await consumer.CommitAsync(CancellationToken.None);
+                throw new InvalidOperationException("stop after explicit handoff");
+            }
+        }).Throws<InvalidOperationException>();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_CommitAsyncInAutoMode_VouchesForIteratedRecords()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                await consumer.CommitAsync(CancellationToken.None);
+                throw new InvalidOperationException("stop after explicit handoff");
+            }
+        }).Throws<InvalidOperationException>();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_OnDelivery_StagesEachIteratedRecordImmediately()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.OnDelivery, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch)
+                {
+                    await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+                    throw new InvalidOperationException("stop during batch processing");
+                }
+            }
+        }).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumeRawBatchAsync_OnDelivery_StagesEachIteratedRecordImmediately()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.OnDelivery, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch)
+                {
+                    await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+                    throw new InvalidOperationException("stop during batch processing");
+                }
+            }
+        }).Throws<InvalidOperationException>();
+    }
+
     // --- ConsumeOneAsync ---
 
     [Test]
@@ -415,6 +517,34 @@ public sealed class OffsetStoreTimingTests
 
         await Assert.That(offsetsAfterFirst.ContainsKey(partition)).IsFalse();
         await Assert.That(offsetsAfterSecond[partition]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task InMemoryConsumer_ReassignmentDiscardsInDoubtRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Assign(partition);
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        consumer.Assign(partition);
+        var replay = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(first!.Value.Offset).IsEqualTo(0L);
+        await Assert.That(replay!.Value.Offset).IsEqualTo(0L);
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(offsets.ContainsKey(partition)).IsFalse();
     }
 
     // --- Harness ---

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -444,6 +444,43 @@ public sealed class OffsetStoreTimingTests
         }).Throws<InvalidOperationException>();
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ConsumeBatch_OnDeliveryWithAutoStoreDisabled_DoesNotStage(bool raw)
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.OnDelivery, enableAutoOffsetStore: false, fetch);
+
+        await Assert.That(async () =>
+        {
+            if (raw)
+            {
+                await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+                {
+                    foreach (var _ in batch)
+                        throw new InvalidOperationException("stop during batch processing");
+                }
+            }
+            else
+            {
+                await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+                {
+                    foreach (var _ in batch)
+                        throw new InvalidOperationException("stop during batch processing");
+                }
+            }
+        }).Throws<InvalidOperationException>();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)).IsEmpty();
+    }
+
     // --- ConsumeOneAsync ---
 
     [Test]
@@ -711,18 +748,28 @@ public sealed class OffsetStoreTimingTests
         OffsetCommitMode offsetCommitMode,
         OffsetStoreTiming offsetStoreTiming,
         params PendingFetchData[] fetches)
-        => CreateInitializedConsumer(offsetCommitMode, offsetStoreTiming, Serializers.String, fetches);
+        => CreateInitializedConsumer(offsetCommitMode, offsetStoreTiming, Serializers.String, true, fetches);
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        OffsetCommitMode offsetCommitMode,
+        OffsetStoreTiming offsetStoreTiming,
+        bool enableAutoOffsetStore,
+        params PendingFetchData[] fetches)
+        => CreateInitializedConsumer(
+            offsetCommitMode, offsetStoreTiming, Serializers.String, enableAutoOffsetStore, fetches);
 
     private static KafkaConsumer<string, string> CreateInitializedConsumer(
         OffsetCommitMode offsetCommitMode,
         IDeserializer<string> valueDeserializer,
         params PendingFetchData[] fetches)
-        => CreateInitializedConsumer(offsetCommitMode, OffsetStoreTiming.AfterProcessing, valueDeserializer, fetches);
+        => CreateInitializedConsumer(
+            offsetCommitMode, OffsetStoreTiming.AfterProcessing, valueDeserializer, true, fetches);
 
     private static KafkaConsumer<string, string> CreateInitializedConsumer(
         OffsetCommitMode offsetCommitMode,
         OffsetStoreTiming offsetStoreTiming,
         IDeserializer<string> valueDeserializer,
+        bool enableAutoOffsetStore,
         params PendingFetchData[] fetches)
     {
         var consumer = new KafkaConsumer<string, string>(
@@ -731,6 +778,7 @@ public sealed class OffsetStoreTimingTests
                 BootstrapServers = ["localhost:9092"],
                 OffsetCommitMode = offsetCommitMode,
                 OffsetStoreTiming = offsetStoreTiming,
+                EnableAutoOffsetStore = enableAutoOffsetStore,
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200
             },

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -531,6 +531,42 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(batches.Current.First().Offset).IsEqualTo(21L);
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ConsumeBatch_FullyEnumeratedBreakThenCommit_VouchesForBatch(bool raw)
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        if (raw)
+        {
+            await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                break;
+            }
+        }
+        else
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                break;
+            }
+        }
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
     // --- ConsumeOneAsync ---
 
     [Test]
@@ -782,6 +818,35 @@ public sealed class OffsetStoreTimingTests
         var replay = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
 
         await Assert.That(first!.Value.Offset).IsEqualTo(0L);
+        await Assert.That(replay!.Value.Offset).IsEqualTo(0L);
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(offsets.ContainsKey(partition)).IsFalse();
+    }
+
+    [Test]
+    public async Task InMemoryConsumer_DeserializerFailure_RedeliversWithoutCommitting()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            new FailOnceDeserializer("two"),
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "two");
+        consumer.Assign(partition);
+
+        await Assert.That(async () => await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        var replay = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
         await Assert.That(replay!.Value.Offset).IsEqualTo(0L);
         var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
         await Assert.That(offsets.ContainsKey(partition)).IsFalse();

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -481,6 +481,56 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(GetDirtyStoredOffsets(consumer)).IsEmpty();
     }
 
+    [Test]
+    public async Task ConsumeBatchAsync_DeserializerFailure_RewindsForRedelivery()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"),
+                CreateRecord(2, "c", "three"))
+        ]);
+        var deserializer = new FailOnceDeserializer("two");
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, deserializer, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+        await using var batches = consumer.ConsumeBatchAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        using (var records = batches.Current.GetEnumerator())
+        {
+            await Assert.That(records.MoveNext()).IsTrue();
+            await Assert.That(records.Current.Offset).IsEqualTo(20L);
+            var threw = false;
+            try
+            {
+                records.MoveNext();
+            }
+            catch (InvalidOperationException)
+            {
+                threw = true;
+            }
+
+            await Assert.That(threw).IsTrue();
+            await Assert.That(records.MoveNext()).IsFalse();
+        }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)).IsEmpty();
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetFetchPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+
+        InjectPendingFetch(consumer, PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(21,
+                CreateRecord(0, "b", "two"),
+                CreateRecord(1, "c", "three"))
+        ]));
+
+        await Assert.That(await batches.MoveNextAsync()).IsTrue();
+        await Assert.That(batches.Current.First().Offset).IsEqualTo(21L);
+    }
+
     // --- ConsumeOneAsync ---
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -565,6 +565,54 @@ public sealed class OffsetStoreTimingTests
         await consumer.CommitAsync(CancellationToken.None);
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task ConsumeBatch_NewStreamSkipsRetainedExhaustedFetch(bool raw)
+    {
+        var firstFetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20, CreateRecord(0, "a", "one"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, firstFetch);
+
+        if (raw)
+        {
+            await foreach (var batch in consumer.ConsumeRawBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                break;
+            }
+        }
+        else
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                break;
+            }
+        }
+
+        GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(30, CreateRecord(0, "b", "two"))
+        ]));
+
+        if (raw)
+        {
+            await using var batches = consumer.ConsumeRawBatchAsync(CancellationToken.None).GetAsyncEnumerator();
+            await Assert.That(await batches.MoveNextAsync()).IsTrue();
+            await Assert.That(batches.Current.Select(record => record.Offset).ToArray()).IsEquivalentTo([30L]);
+        }
+        else
+        {
+            await using var batches = consumer.ConsumeBatchAsync(CancellationToken.None).GetAsyncEnumerator();
+            await Assert.That(await batches.MoveNextAsync()).IsTrue();
+            await Assert.That(batches.Current.Select(record => record.Offset).ToArray()).IsEquivalentTo([30L]);
+        }
     }
 
     // --- ConsumeOneAsync ---
@@ -629,6 +677,33 @@ public sealed class OffsetStoreTimingTests
         await consumer.CommitAsync(CancellationToken.None);
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
+    public async Task CommitAsync_ThenClose_DoesNotRegressActiveConsumedOffset()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateGroupedCommitCapturingConsumer(requests);
+        InjectPendingFetch(consumer, PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]));
+        await using (var records = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator())
+        {
+            await Assert.That(await records.MoveNextAsync()).IsTrue();
+            await Assert.That(await records.MoveNextAsync()).IsTrue();
+        }
+
+        await consumer.CommitAsync(CancellationToken.None);
+        await consumer.CloseAsync();
+
+        await Assert.That(requests.Count).IsEqualTo(2);
+        await Assert.That(requests.SelectMany(request => request.Topics)
+            .SelectMany(topic => topic.Partitions)
+            .Select(partition => partition.CommittedOffset))
+            .IsEquivalentTo([22L, 22L]);
     }
 
     // --- Close path ---

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -1,0 +1,616 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+using Dekaf.Testing;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+/// <summary>
+/// Delivery-semantics tests for the default at-least-once offset staging
+/// (<see cref="OffsetStoreTiming.AfterProcessing"/>) and the opt-in at-most-once
+/// staging (<see cref="OffsetStoreTiming.OnDelivery"/>).
+/// </summary>
+public sealed class OffsetStoreTimingTests
+{
+    private const string Topic = "test-topic";
+    private const int Partition = 0;
+
+    // --- ConsumeAsync (await foreach) ---
+
+    [Test]
+    public async Task ConsumeAsync_ExceptionOnFirstRecord_LeavesRecordUnstagedForRedelivery()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+            {
+                throw new InvalidOperationException("processing failed");
+            }
+        }).Throws<InvalidOperationException>();
+
+        // The failing record must not be committable, but positions advance past it.
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_ExceptionAfterProcessingSomeRecords_StagesOnlyProvenPrefix()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"),
+                CreateRecord(2, "c", "three"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+            {
+                if (result.Offset == 22)
+                    throw new InvalidOperationException("processing failed");
+            }
+        }).Throws<InvalidOperationException>();
+
+        // Records 20 and 21 were proven processed (the loop pulled past them); the
+        // failing record 22 stays uncommitted and is redelivered after restart.
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(23L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_LoopDrainsFetchAndContinues_StagesEverything()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+        using var cts = new CancellationTokenSource();
+
+        try
+        {
+            await foreach (var result in consumer.ConsumeAsync(cts.Token))
+            {
+                if (result.Offset == 21)
+                {
+                    // Cancel without breaking: the next MoveNextAsync proves this record
+                    // was processed, flushes the fetch boundary, then observes cancellation.
+                    cts.Cancel();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Depending on where cancellation is observed the enumerator may throw.
+        }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_BreakAfterProcessing_LastRecordStaysUnproven()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+        {
+            if (result.Offset == 21)
+                break; // Dispose without pulling again: record 21 remains in doubt.
+        }
+
+        // Record 20 was proven (the loop pulled record 21); record 21 was processed but
+        // the enumerator cannot distinguish break from failure, so it stays unstaged.
+        // Call CommitAsync() before breaking for an exact handoff.
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
+    public async Task CommitAsync_AfterBreak_VouchesForInDoubtRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+        {
+            if (result.Offset == 21)
+                break;
+        }
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        // Explicit commit is the caller vouching for everything delivered so far.
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    // --- ConsumeBatchAsync ---
+
+    [Test]
+    public async Task ConsumeBatchAsync_ExceptionWhileProcessingBatch_LeavesBatchUnstaged()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                foreach (var _ in batch) { }
+                throw new InvalidOperationException("processing failed");
+            }
+        }).Throws<InvalidOperationException>();
+
+        // The whole batch is in doubt — nothing pulled past it, nothing staged.
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_NextPullProvesBatch_StagesIteratedRecords()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+        using var cts = new CancellationTokenSource();
+
+        try
+        {
+            await foreach (var batch in consumer.ConsumeBatchAsync(cts.Token))
+            {
+                foreach (var _ in batch) { }
+                // Cancel without breaking: the next MoveNextAsync proves this batch
+                // was processed before the loop observes cancellation.
+                cts.Cancel();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    // --- ConsumeOneAsync ---
+
+    [Test]
+    public async Task ConsumeOneAsync_DefersStagingUntilNextCall()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+        // First record delivered but not yet proven processed — nothing staged.
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+        // Second call proved the first record; staging happens at the fetch-boundary
+        // flush, which runs on the next call after the fetch is drained.
+        await Assert.That(TryConsumeOneFromPendingFetches(consumer, out _)).IsFalse();
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_OnDeliveryTiming_StagesImmediately()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.OnDelivery, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+
+        // At-most-once: committable the moment the record is handed out.
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
+    public async Task CommitAsync_InAutoMode_StagesInFlightRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+        await Assert.That(GetDirtyStoredOffsets(consumer).ContainsKey(tp)).IsFalse();
+
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    // --- Close path ---
+
+    [Test]
+    public async Task CloseAsync_AutoCommit_CommitsProvenRecordsButNotInDoubtRecord()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateGroupedCommitCapturingConsumer(requests);
+        var tp = new TopicPartition(Topic, Partition);
+        InjectPendingFetch(consumer, PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(10,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]));
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None)).IsNotNull();
+
+        // Record 10 is proven (second call pulled past it); record 11 is in doubt.
+        await consumer.CloseAsync();
+
+        await Assert.That(requests.Count).IsEqualTo(1);
+        var committed = requests.Single().Topics.Single().Partitions.Single();
+        await Assert.That(committed.CommittedOffset).IsEqualTo(11L);
+    }
+
+    // --- InMemoryConsumer parity ---
+
+    [Test]
+    public async Task InMemoryConsumer_Default_DoesNotCommitInDoubtRecordOnClose()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        await producer.ProduceAsync("jobs", "b", "two");
+        consumer.Subscribe("jobs");
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+        await consumer.CloseAsync();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        // First record proven by the second consume call; second record in doubt.
+        await Assert.That(offsets[partition]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task InMemoryConsumer_CommitAsync_VouchesForInDoubtRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Subscribe("jobs");
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+        await consumer.CommitAsync();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(offsets[partition]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task InMemoryConsumer_OnDelivery_CommitsImmediately()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetStoreTiming = OffsetStoreTiming.OnDelivery
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Subscribe("jobs");
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(offsets[partition]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task InMemoryConsumer_NextConsumeCallCommitsProvenRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        await producer.ProduceAsync("jobs", "b", "two");
+        consumer.Subscribe("jobs");
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+        var offsetsAfterFirst = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1))).IsNotNull();
+        var offsetsAfterSecond = await admin.ListConsumerGroupOffsetsAsync("workers");
+
+        await Assert.That(offsetsAfterFirst.ContainsKey(partition)).IsFalse();
+        await Assert.That(offsetsAfterSecond[partition]).IsEqualTo(1);
+    }
+
+    // --- Harness ---
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        OffsetCommitMode offsetCommitMode,
+        params PendingFetchData[] fetches)
+        => CreateInitializedConsumer(offsetCommitMode, OffsetStoreTiming.AfterProcessing, fetches);
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        OffsetCommitMode offsetCommitMode,
+        OffsetStoreTiming offsetStoreTiming,
+        params PendingFetchData[] fetches)
+    {
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = offsetCommitMode,
+                OffsetStoreTiming = offsetStoreTiming,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200
+            },
+            Serializers.String,
+            Serializers.String,
+            loggerFactory: null);
+
+        SetInitialized(consumer);
+
+        foreach (var fetch in fetches)
+            InjectPendingFetch(consumer, fetch);
+
+        return consumer;
+    }
+
+    private static KafkaConsumer<string, string> CreateGroupedCommitCapturingConsumer(
+        List<OffsetCommitRequest> requests)
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+
+        connectionPool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "group-a",
+                        NodeId = 0,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+
+        connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.Arg<OffsetCommitRequest>()!;
+                requests.Add(request);
+                return ValueTask.FromResult(new OffsetCommitResponse
+                {
+                    Topics = request.Topics.Select(topic => new OffsetCommitResponseTopic
+                    {
+                        Name = topic.Name,
+                        Partitions = topic.Partitions.Select(partition => new OffsetCommitResponsePartition
+                        {
+                            PartitionIndex = partition.PartitionIndex,
+                            ErrorCode = ErrorCode.None
+                        }).ToList()
+                    }).ToList()
+                });
+            });
+
+        var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }],
+            Topics = []
+        });
+        metadataManager.SetApiVersion(
+            ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion,
+            FindCoordinatorRequest.HighestSupportedVersion);
+        metadataManager.SetApiVersion(
+            ApiKey.OffsetCommit,
+            OffsetCommitRequest.LowestSupportedVersion,
+            OffsetCommitRequest.HighestSupportedVersion);
+
+        var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "group-a",
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200
+            },
+            Serializers.String,
+            Serializers.String,
+            connectionPool,
+            metadataManager);
+
+        SetInitialized(consumer);
+        MarkManualAssignmentCurrent(consumer);
+        return consumer;
+    }
+
+    private static void InjectPendingFetch(KafkaConsumer<string, string> consumer, PendingFetchData fetch)
+    {
+        var tp = new TopicPartition(fetch.Topic, fetch.PartitionIndex);
+        consumer.Assign(tp);
+        GetFetchPositions(consumer)[tp] = 0;
+        GetPendingFetches(consumer).Enqueue(fetch);
+    }
+
+    private static void SetInitialized(KafkaConsumer<string, string> consumer)
+    {
+        GetField("_initialized").SetValue(consumer, true);
+    }
+
+    private static void MarkManualAssignmentCurrent(KafkaConsumer<string, string> consumer)
+    {
+        var assignmentVersion = GetField("_assignmentEnsureVersion");
+        GetField("_lastManualAssignmentEnsureVersion").SetValue(consumer, assignmentVersion.GetValue(consumer));
+    }
+
+    private static ConcurrentDictionary<TopicPartition, long> GetDirtyStoredOffsets(
+        KafkaConsumer<string, string> consumer)
+        => (ConcurrentDictionary<TopicPartition, long>)GetField("_dirtyStoredOffsets").GetValue(consumer)!;
+
+    private static ConcurrentDictionary<TopicPartition, long> GetPositions(
+        KafkaConsumer<string, string> consumer)
+        => (ConcurrentDictionary<TopicPartition, long>)GetField("_positions").GetValue(consumer)!;
+
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer)
+        => (ConcurrentDictionary<TopicPartition, long>)GetField("_fetchPositions").GetValue(consumer)!;
+
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+        => (Queue<PendingFetchData>)GetField("_pendingFetches").GetValue(consumer)!;
+
+    private static bool TryConsumeOneFromPendingFetches(
+        KafkaConsumer<string, string> consumer,
+        out ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("TryConsumeOneFromPendingFetches", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("TryConsumeOneFromPendingFetches method not found.");
+
+        object?[] args = [null];
+        var consumed = (bool)method.Invoke(consumer, args)!;
+        result = args[0] is ConsumeResult<string, string> consumeResult
+            ? consumeResult
+            : default;
+        return consumed;
+    }
+
+    private static FieldInfo GetField(string fieldName)
+        => typeof(KafkaConsumer<string, string>).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+           ?? throw new InvalidOperationException($"{fieldName} field not found.");
+
+    private static RecordBatch CreateBatch(long baseOffset, params Record[] records)
+    {
+        return new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            BaseTimestamp = 1700000000000L,
+            Attributes = 0,
+            Records = records
+        };
+    }
+
+    private static Record CreateRecord(int offsetDelta, string key, string value)
+    {
+        return new Record
+        {
+            OffsetDelta = offsetDelta,
+            TimestampDelta = 0,
+            Key = Encoding.UTF8.GetBytes(key),
+            IsKeyNull = false,
+            Value = Encoding.UTF8.GetBytes(value),
+            IsValueNull = false,
+            Headers = null,
+            HeaderCount = 0
+        };
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -160,6 +160,29 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
     }
 
+    [Test]
+    public async Task CommitAsync_AfterSeek_DoesNotRestoreInDoubtRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(await consumer.ConsumeOneAsync(
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None)).IsNotNull();
+
+        consumer.Seek(new TopicPartitionOffset(Topic, Partition, 100));
+        await consumer.CommitAsync(CancellationToken.None);
+
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(100L);
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(100L);
+    }
+
     // --- ConsumeBatchAsync ---
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -215,6 +215,33 @@ public sealed class OffsetStoreTimingTests
     }
 
     [Test]
+    public async Task ConsumeAsync_NewStreamProvesRetainedRecord()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await using (var firstStream = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator())
+        {
+            await Assert.That(await firstStream.MoveNextAsync()).IsTrue();
+            await Assert.That(firstStream.Current.Offset).IsEqualTo(20L);
+        }
+
+        await using (var secondStream = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator())
+        {
+            await Assert.That(await secondStream.MoveNextAsync()).IsTrue();
+            await Assert.That(secondStream.Current.Offset).IsEqualTo(21L);
+        }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+    }
+
+    [Test]
     public async Task CommitAsync_AfterBreak_VouchesForInDoubtRecord()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
@@ -578,6 +605,7 @@ public sealed class OffsetStoreTimingTests
             CreateBatch(20, CreateRecord(0, "a", "one"))
         ]);
         await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, firstFetch);
+        var tp = new TopicPartition(Topic, Partition);
 
         if (raw)
         {
@@ -613,6 +641,8 @@ public sealed class OffsetStoreTimingTests
             await Assert.That(await batches.MoveNextAsync()).IsTrue();
             await Assert.That(batches.Current.Select(record => record.Offset).ToArray()).IsEquivalentTo([30L]);
         }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
     }
 
     // --- ConsumeOneAsync ---

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -706,6 +706,39 @@ public sealed class OffsetStoreTimingTests
             .IsEquivalentTo([22L, 22L]);
     }
 
+    [Test]
+    public async Task CommitAsync_AfterSwitchingToBatch_IgnoresStaleActiveSnapshot()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"),
+                CreateRecord(2, "c", "three"))
+        ]);
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await using (var records = consumer.ConsumeAsync(CancellationToken.None).GetAsyncEnumerator())
+        {
+            await Assert.That(await records.MoveNextAsync()).IsTrue();
+            await Assert.That(records.Current.Offset).IsEqualTo(20L);
+        }
+
+        await using (var batches = consumer.ConsumeBatchAsync(CancellationToken.None).GetAsyncEnumerator())
+        {
+            await Assert.That(await batches.MoveNextAsync()).IsTrue();
+            await Assert.That(batches.Current.Select(record => record.Offset).ToArray())
+                .IsEquivalentTo([21L, 22L]);
+
+            await consumer.CommitAsync(CancellationToken.None);
+        }
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(23L);
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(23L);
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+    }
+
     // --- Close path ---
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -77,6 +78,83 @@ public sealed class OffsetStoreTimingTests
         // failing record 22 stays uncommitted and is redelivered after restart.
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(22L);
         await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(23L);
+    }
+
+    [Test]
+    public async Task ConsumeOne_DeserializerFailure_RewindsForRedelivery()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"),
+                CreateRecord(2, "c", "three"))
+        ]);
+        var deserializer = new FailOnceDeserializer("two");
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, deserializer, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(TryConsumeOneFromPendingFetches(consumer, out var first)).IsTrue();
+        await Assert.That(first.Offset).IsEqualTo(20L);
+        await Assert.That(() => TryConsumeOneFromPendingFetches(consumer, out _))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetFetchPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+
+        InjectPendingFetch(consumer, PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(21,
+                CreateRecord(0, "b", "two"),
+                CreateRecord(1, "c", "three"))
+        ]));
+
+        await Assert.That(TryConsumeOneFromPendingFetches(consumer, out var replay)).IsTrue();
+        await Assert.That(replay.Offset).IsEqualTo(21L);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_DeserializerFailure_RewindsForRedelivery()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(20,
+                CreateRecord(0, "a", "one"),
+                CreateRecord(1, "b", "two"),
+                CreateRecord(2, "c", "three"))
+        ]);
+        var deserializer = new FailOnceDeserializer("two");
+        await using var consumer = CreateInitializedConsumer(OffsetCommitMode.Auto, deserializer, fetch);
+        var tp = new TopicPartition(Topic, Partition);
+
+        await Assert.That(async () =>
+        {
+            await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+                await Assert.That(result.Offset).IsEqualTo(20L);
+        }).Throws<InvalidOperationException>();
+
+        await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetFetchPositions(consumer)[tp]).IsEqualTo(21L);
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+
+        InjectPendingFetch(consumer, PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(21,
+                CreateRecord(0, "b", "two"),
+                CreateRecord(1, "c", "three"))
+        ]));
+
+        long? replayOffset = null;
+        await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
+        {
+            replayOffset = result.Offset;
+            break;
+        }
+
+        await Assert.That(replayOffset).IsEqualTo(21L);
     }
 
     [Test]
@@ -594,6 +672,34 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(offsets.ContainsKey(partition)).IsFalse();
     }
 
+    [Test]
+    public async Task InMemoryConsumer_IncrementalReassignmentDiscardsInDoubtRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        var admin = new InMemoryAdminClient(cluster);
+        var partition = new TopicPartition("jobs", 0);
+
+        await producer.ProduceAsync("jobs", "a", "one");
+        consumer.Assign(partition);
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+        var replay = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(first!.Value.Offset).IsEqualTo(0L);
+        await Assert.That(replay!.Value.Offset).IsEqualTo(0L);
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("workers");
+        await Assert.That(offsets.ContainsKey(partition)).IsFalse();
+    }
+
     // --- Harness ---
 
     private static KafkaConsumer<string, string> CreateInitializedConsumer(
@@ -604,6 +710,19 @@ public sealed class OffsetStoreTimingTests
     private static KafkaConsumer<string, string> CreateInitializedConsumer(
         OffsetCommitMode offsetCommitMode,
         OffsetStoreTiming offsetStoreTiming,
+        params PendingFetchData[] fetches)
+        => CreateInitializedConsumer(offsetCommitMode, offsetStoreTiming, Serializers.String, fetches);
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        OffsetCommitMode offsetCommitMode,
+        IDeserializer<string> valueDeserializer,
+        params PendingFetchData[] fetches)
+        => CreateInitializedConsumer(offsetCommitMode, OffsetStoreTiming.AfterProcessing, valueDeserializer, fetches);
+
+    private static KafkaConsumer<string, string> CreateInitializedConsumer(
+        OffsetCommitMode offsetCommitMode,
+        OffsetStoreTiming offsetStoreTiming,
+        IDeserializer<string> valueDeserializer,
         params PendingFetchData[] fetches)
     {
         var consumer = new KafkaConsumer<string, string>(
@@ -616,7 +735,7 @@ public sealed class OffsetStoreTimingTests
                 FetchMaxWaitMs = 200
             },
             Serializers.String,
-            Serializers.String,
+            valueDeserializer,
             loggerFactory: null);
 
         SetInitialized(consumer);
@@ -754,11 +873,38 @@ public sealed class OffsetStoreTimingTests
             ?? throw new InvalidOperationException("TryConsumeOneFromPendingFetches method not found.");
 
         object?[] args = [null];
-        var consumed = (bool)method.Invoke(consumer, args)!;
+        bool consumed;
+        try
+        {
+            consumed = (bool)method.Invoke(consumer, args)!;
+        }
+        catch (TargetInvocationException exception) when (exception.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
+
         result = args[0] is ConsumeResult<string, string> consumeResult
             ? consumeResult
             : default;
         return consumed;
+    }
+
+    private sealed class FailOnceDeserializer(string rejectedValue) : IDeserializer<string>
+    {
+        private bool _failed;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var value = Encoding.UTF8.GetString(data.Span);
+            if (!_failed && value == rejectedValue)
+            {
+                _failed = true;
+                throw new InvalidOperationException("deserialization failed");
+            }
+
+            return value;
+        }
     }
 
     private static FieldInfo GetField(string fieldName)

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1167,7 +1167,7 @@ public sealed class PartitionedConsumerRuntimeTests
         IConsumerOffsets,
         IConsumerRebalanceEventSource,
         IConsumerLoggerFactorySource,
-        IConsumerCommitModeSource
+        IConsumerCommitConfiguration
     {
         private readonly object _gate = new();
         private readonly Queue<ConsumeResult<string, string>> _records = [];

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -315,6 +315,7 @@ public class DependencyInjectionTests
             BootstrapServers = ["broker1:9092"],
             ClientId = "typed-consumer",
             GroupId = "typed-group",
+            OffsetStoreTiming = OffsetStoreTiming.OnDelivery,
             FetchMinBytes = 4096,
             EnableAdaptiveConnections = false,
             UseTls = true,
@@ -336,6 +337,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.BootstrapServers[0]).IsEqualTo("broker1:9092");
         await Assert.That(boundOptions.ClientId).IsEqualTo("typed-consumer");
         await Assert.That(boundOptions.GroupId).IsEqualTo("override-group");
+        await Assert.That(boundOptions.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.OnDelivery);
         await Assert.That(boundOptions.FetchMinBytes).IsEqualTo(4096);
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
         await Assert.That(boundOptions.UseTls).IsTrue();
@@ -732,6 +734,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:OffsetCommitMode"] = "Manual",
             ["Kafka:Consumers:Orders:AutoCommitIntervalMs"] = "2000",
             ["Kafka:Consumers:Orders:EnableAutoOffsetStore"] = "false",
+            ["Kafka:Consumers:Orders:OffsetStoreTiming"] = "OnDelivery",
             ["Kafka:Consumers:Orders:AutoOffsetReset"] = "Earliest",
             ["Kafka:Consumers:Orders:FetchMinBytes"] = "1024",
             ["Kafka:Consumers:Orders:FetchMaxBytes"] = "2097152",
@@ -790,6 +793,7 @@ public class DependencyInjectionTests
         await Assert.That(options.OffsetCommitMode).IsEqualTo(OffsetCommitMode.Manual);
         await Assert.That(options.AutoCommitIntervalMs).IsEqualTo(2000);
         await Assert.That(options.EnableAutoOffsetStore).IsFalse();
+        await Assert.That(options.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.OnDelivery);
         await Assert.That(options.AutoOffsetReset).IsEqualTo(AutoOffsetReset.Earliest);
         await Assert.That(options.FetchMinBytes).IsEqualTo(1024);
         await Assert.That(options.FetchMaxBytes).IsEqualTo(2097152);

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -291,18 +291,10 @@ public class RoundTripMessageCodecTests
         }
     }
 
-    [Test]
-    public async Task ConfluentDeliveryReportFailure_CountsAsDeliveryError()
-    {
-        var throughput = new ThroughputTracker();
-
-        ConfluentProducerRoundTripStressTest.RecordDeliveryReportError(
-            throughput,
-            new ConfluentKafka.Error(ConfluentKafka.ErrorCode.Local_MsgTimedOut));
-
-        await Assert.That(throughput.DeliveryErrorCount).IsEqualTo(1);
-        await Assert.That(throughput.ErrorCount).IsEqualTo(0);
-    }
+    // The Confluent round-trip producer no longer attaches a per-message delivery-report
+    // handler (fairness: librdkafka would invoke the managed delegate for every message,
+    // work the Dekaf error-only listener never does). Loss is caught by the consume-side
+    // completion tracker + CRC validation instead, so there is no handler left to test.
 
     [Test]
     [NotInParallel("MeterListener")]

--- a/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConsumerFetchDiagnosticsTests.cs
@@ -29,7 +29,7 @@ public sealed class ConsumerFetchDiagnosticsTests
                 "different-topic"));
         tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddSeconds(1)));
 
-        var sample = tracker.GetSnapshot().Samples.Single();
+        var sample = tracker.GetSnapshot()!.Samples.Single();
         await Assert.That(sample.FetchRequestCount).IsEqualTo(1);
         await Assert.That(sample.BytesPerFetch).IsEqualTo(2_048);
         await Assert.That(sample.AverageFetchRttMs).IsBetween(19.9, 20.1);
@@ -61,7 +61,7 @@ public sealed class ConsumerFetchDiagnosticsTests
             prefetchBufferDepth: 3,
             prefetchedBytes: 4_096));
 
-        var sample = tracker.GetSnapshot().Samples.Single();
+        var sample = tracker.GetSnapshot()!.Samples.Single();
         await Assert.That(sample.IntervalSeconds).IsEqualTo(60.0);
         await Assert.That(sample.FetchRequestCount).IsEqualTo(2);
         await Assert.That(sample.FetchRequestsPerSecond).IsBetween(0.0333, 0.0334);
@@ -90,7 +90,7 @@ public sealed class ConsumerFetchDiagnosticsTests
 
         tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddMinutes(1)));
 
-        var sample = tracker.GetSnapshot().Samples.Single();
+        var sample = tracker.GetSnapshot()!.Samples.Single();
         await Assert.That(sample.Gen0Collections).IsEqualTo(3);
         await Assert.That(sample.Gen1Collections).IsEqualTo(2);
         await Assert.That(sample.Gen2Collections).IsEqualTo(1);
@@ -124,7 +124,7 @@ public sealed class ConsumerFetchDiagnosticsTests
         };
         tracker.TakeSample(CreateConsumerSnapshot(startedAt.AddMinutes(2), connectionReaps: [reap]));
 
-        var snapshot = tracker.GetSnapshot();
+        var snapshot = tracker.GetSnapshot()!;
         var second = snapshot.Samples[1];
         await Assert.That(second.FetchRequestCount).IsEqualTo(1);
         await Assert.That(second.BytesPerFetch).IsEqualTo(400.0);
@@ -140,7 +140,29 @@ public sealed class ConsumerFetchDiagnosticsTests
 
         tracker.TryTakeSample(() => throw new InvalidOperationException("diagnostic failure"));
 
-        await Assert.That(tracker.GetSnapshot().Samples).IsEmpty();
+        await Assert.That(tracker.GetSnapshot()!.Samples).IsEmpty();
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task DisabledTracker_NoOpsAndReturnsNullSnapshot()
+    {
+        // --consumer-fetch-diagnostics off (the default): no MeterListener registration,
+        // no sampler, no snapshot — the measured window carries zero diagnostics overhead.
+        using var tracker = new ConsumerFetchDiagnosticsTracker("consumer-topic", enabled: false);
+
+        var samplerTask = tracker.RunSamplerAsync(
+            () => throw new InvalidOperationException("must not be called"),
+            CancellationToken.None);
+        tracker.TryTakeSample(() => throw new InvalidOperationException("must not be called"));
+
+        await Assert.That(samplerTask.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(tracker.GetSnapshot()).IsNull();
+
+        // A second (enabled) tracker can register its listener because the disabled one
+        // never claimed the process-wide listener slot.
+        using var enabledTracker = new ConsumerFetchDiagnosticsTracker("consumer-topic");
+        await Assert.That(enabledTracker.GetSnapshot()).IsNotNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -69,7 +69,7 @@ public sealed class InMemoryKafkaClusterTests
 
         await Assert.That(consumer.ConsumerGroupMetadata).IsNull();
         await Assert.That(consumer.MemberId).IsNull();
-        await Assert.That(((IConsumerCommitModeSource)consumer).HasConsumerGroup).IsFalse();
+        await Assert.That(((IConsumerCommitConfiguration)consumer).HasConsumerGroup).IsFalse();
     }
 
     [Test]

--- a/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/ConsumerFetchDiagnosticsTracker.cs
@@ -13,6 +13,7 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
     private static int s_activeMetricListener;
 
     private readonly string _topic;
+    private readonly bool _enabled;
     private readonly MeterListener? _listener;
     private readonly Func<GcDiagnosticSnapshot> _captureGcDiagnostics;
     private readonly List<ConsumerFetchDiagnosticSample> _samples = [];
@@ -29,11 +30,13 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
     internal ConsumerFetchDiagnosticsTracker(
         string topic,
         bool listenToMetrics = true,
-        Func<GcDiagnosticSnapshot>? captureGcDiagnostics = null)
+        Func<GcDiagnosticSnapshot>? captureGcDiagnostics = null,
+        bool enabled = true)
     {
         _topic = topic;
+        _enabled = enabled;
         _captureGcDiagnostics = captureGcDiagnostics ?? CaptureGcDiagnostics;
-        if (!listenToMetrics)
+        if (!enabled || !listenToMetrics)
             return;
         if (Interlocked.CompareExchange(ref s_activeMetricListener, 1, 0) != 0)
             throw new InvalidOperationException("Only one consumer diagnostics metric listener can be active at a time.");
@@ -77,6 +80,9 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
 
     internal void Start(ConsumerDiagnosticSnapshot snapshot)
     {
+        if (!_enabled)
+            return;
+
         _lastSampleAtUtc = snapshot.CapturedAtUtc;
         _lastFetchRequestCount = Interlocked.Read(ref _fetchRequestCount);
         _lastFetchDurationTicks = Interlocked.Read(ref _fetchDurationTicks);
@@ -150,13 +156,18 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
     internal Task RunSamplerAsync(
         Func<ConsumerDiagnosticSnapshot?> captureSnapshot,
         CancellationToken cancellationToken) =>
-        StressTestHelpers.RunPeriodicAsync(
-            SampleInterval,
-            () => TryTakeSample(captureSnapshot),
-            cancellationToken);
+        _enabled
+            ? StressTestHelpers.RunPeriodicAsync(
+                SampleInterval,
+                () => TryTakeSample(captureSnapshot),
+                cancellationToken)
+            : Task.CompletedTask;
 
     internal void TryTakeSample(Func<ConsumerDiagnosticSnapshot?> captureSnapshot)
     {
+        if (!_enabled)
+            return;
+
         try
         {
             if (captureSnapshot() is { } snapshot)
@@ -168,11 +179,13 @@ internal sealed class ConsumerFetchDiagnosticsTracker : IDisposable
         }
     }
 
-    internal ConsumerFetchDiagnosticsSnapshot GetSnapshot() => new()
-    {
-        Samples = [.. _samples],
-        ConnectionReapEvents = [.. _connectionReapEvents]
-    };
+    internal ConsumerFetchDiagnosticsSnapshot? GetSnapshot() => _enabled
+        ? new()
+        {
+            Samples = [.. _samples],
+            ConnectionReapEvents = [.. _connectionReapEvents]
+        }
+        : null;
 
     private bool HasTopic(ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -24,6 +24,7 @@ namespace Dekaf.StressTests;
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
 ///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
+///   --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
 ///   --roundtrip-messages &lt;count&gt;  Bounded message count for producer-roundtrip (default: 250000)
 ///   report --input &lt;path&gt;   Generate report from existing results
 ///   fault [options]          Run fault-injection correctness suite
@@ -127,6 +128,7 @@ public static class Program
             Console.WriteLine($"Resource sample interval: {options.ResourceSampleIntervalSeconds:N0} seconds");
         }
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
+        Console.WriteLine($"Consumer fetch diagnostics: {(options.EnableConsumerFetchDiagnostics ? "enabled (adds Dekaf-only overhead)" : "disabled")}");
         Console.WriteLine($"Dekaf client logs: {StressClientLogging.MinimumLevel}+ " +
             $"(set {StressClientLogging.LogLevelEnvironmentVariable}=Debug for verbose diagnostics)");
         Console.WriteLine($"Progress watchdog: stacks at {ProgressWatchdog.DefaultCaptureAfter.TotalSeconds:F0}s; " +
@@ -229,6 +231,7 @@ public static class Program
             ConnectionsPerBroker = connectionsPerBroker,
             RoundTripMessages = options.RoundTripMessages,
             EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
+            EnableConsumerFetchDiagnostics = options.EnableConsumerFetchDiagnostics,
             ProgressWatchdog = progressWatchdog,
             SoakMessagesPerSecond = options.SoakMessagesPerSecond,
             ResourceSampleIntervalSeconds = options.ResourceSampleIntervalSeconds,
@@ -915,6 +918,9 @@ public static class Program
                 case "--producer-delivery-diagnostics":
                     options.EnableProducerDeliveryDiagnostics = true;
                     break;
+                case "--consumer-fetch-diagnostics":
+                    options.EnableConsumerFetchDiagnostics = true;
+                    break;
                 case "--fault-profile":
                     options.FaultProfile = args[++i].ToLowerInvariant();
                     break;
@@ -1025,6 +1031,7 @@ public static class Program
               --connections-per-broker <n>  TCP connections per broker (default: 1, pass 3 for multi-connection comparison)
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
+              --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
               --soak-messages-per-second <n>   Mixed soak target rate (default: 5000)
               --resource-sample-seconds <n>    Soak resource sample interval (default: 60)
               --soak-warmup-minutes <n>        Samples excluded before trend analysis (default: 60)
@@ -1081,6 +1088,7 @@ public static class Program
         public int SeedMessages { get; set; } = 2_000_000;
         public int RoundTripMessages { get; set; } = 250_000;
         public bool EnableProducerDeliveryDiagnostics { get; set; }
+        public bool EnableConsumerFetchDiagnostics { get; set; }
         public string FaultProfile { get; set; } = "all";
         public int FaultDurationSeconds { get; set; } = 5;
         public int MessagesBeforeFault { get; set; } = 2_000;

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -245,7 +245,10 @@ public static class Program
 
         if (options.ConnectionsPerBroker == 1)
         {
-            // Baseline pass: single connection for fair comparison with Confluent.
+            // Baseline pass: single connection for fair comparison with Confluent. The
+            // Dekaf producer scenarios also pin WithoutAdaptiveConnections() so this stays
+            // true under backpressure; the multi-connection pass below measures the
+            // parallel-connection advantage separately and labels it "Dekaf (Nconn)".
             foreach (var scenario in scenarios)
             {
                 Console.WriteLine();

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -68,6 +68,13 @@ internal static class MarkdownReporter
         {
             sb.AppendLine("*Confluent.Kafka uses native librdkafka; .NET GC allocation counters exclude unmanaged allocations.*");
             sb.AppendLine();
+
+            if (results.Results.Any(r => r.Scenario.Equals("consumer", StringComparison.OrdinalIgnoreCase)
+                    && !r.Client.Equals("Confluent", StringComparison.OrdinalIgnoreCase)))
+            {
+                sb.AppendLine("*Consumer scenarios: Dekaf's ForHighThroughput preset uses 3 connections per broker (2 fetch paths); librdkafka has a single fetch connection and no knob to match. Recorded as ConsumerConnectionsPerBroker in the JSON results.*");
+                sb.AppendLine();
+            }
         }
 
         return sb.ToString();

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentConsumerStressTest.cs
@@ -20,6 +20,13 @@ internal sealed class ConfluentConsumerStressTest : IStressTestScenario
             ClientId = "stress-consumer-confluent",
             GroupId = $"stress-group-confluent-{Guid.NewGuid():N}",
             AutoOffsetReset = ConfluentKafka.AutoOffsetReset.Earliest,
+            // Both clients run their auto-commit defaults: identical 5s commit cadence and
+            // wire traffic. Staging semantics deliberately differ — librdkafka stages
+            // offsets at delivery (at-most-once) while Dekaf stages proven offsets per
+            // fetch (at-least-once, PR #2097) at ~equal per-message cost. Do NOT "match"
+            // them by forcing Dekaf to OffsetStoreTiming.OnDelivery: Dekaf's eager staging
+            // does per-message dictionary writes that librdkafka's internal store doesn't,
+            // which would burden Dekaf with work Confluent isn't doing.
             EnableAutoCommit = true,
             // Match Dekaf's ForHighThroughput() consumer preset so both clients fetch and prefetch
             // with the same bounds. Otherwise Confluent runs on librdkafka's smaller defaults and

--- a/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConfluentStressTestHelpers.cs
@@ -34,6 +34,14 @@ internal static class ConfluentStressTestHelpers
     // is single-message (consumer.Consume) either way. CRC validation is aligned implicitly:
     // ForHighThroughput() sets CheckCrcs=false, matching librdkafka's check.crcs default (false),
     // so neither client re-validates CRC32C on fetch.
+    //
+    // Known unmatchable asymmetry, disclosed rather than hidden: ForHighThroughput() gives the
+    // Dekaf consumer 3 connections per broker (2 usable fetch paths + 1 coordination), while
+    // librdkafka uses a single fetch connection per broker and exposes no knob to add more. The
+    // JSON results record this as ConsumerConnectionsPerBroker (3 vs 1) and the markdown report
+    // carries a caveat line. Dekaf's deserialization path is otherwise identical to Confluent's:
+    // the scenarios deliberately do NOT enable WithCachedStringValues(), which would let Dekaf
+    // skip per-message UTF-8 decode entirely on the identical-value seed data.
 
     /// <summary>Dekaf <c>_fetchMinBytes</c> — fetch.min.bytes.</summary>
     internal const int FetchMinBytes = 1024;

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -54,7 +54,7 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
         consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-batch stress test for {options.DurationMinutes} minutes...");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerBatchStressTest.cs
@@ -29,7 +29,9 @@ internal sealed class ConsumerBatchStressTest : IStressTestScenario
             .WithClientId("stress-consumer-batch-dekaf")
             .WithGroupId($"stress-group-batch-dekaf-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithCachedStringValues()
+            // No WithCachedStringValues(): keep deserialization work identical to the
+            // paired "consumer" scenario so batch-vs-single comparisons measure the API
+            // shape, not a 100%-hit string cache on the identical-value seed data.
             .ForHighThroughput()
             .BuildAsync(cancellationToken);
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawBatchStressTest.cs
@@ -52,7 +52,7 @@ internal sealed class ConsumerRawBatchStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
         consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-raw-batch stress test for {options.DurationMinutes} minutes...");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerRawStressTest.cs
@@ -54,7 +54,7 @@ internal sealed class ConsumerRawStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
         consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer-raw stress test for {options.DurationMinutes} minutes...");

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -24,7 +24,10 @@ internal sealed class ConsumerStressTest : IStressTestScenario
             .WithClientId("stress-consumer-dekaf")
             .WithGroupId($"stress-group-dekaf-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .WithCachedStringValues()
+            // No WithCachedStringValues(): the seeded topic repeats one identical value, so
+            // Dekaf's string cache would hit 100% and skip the per-message UTF-8 decode +
+            // allocation Confluent always pays — inflating both the throughput ratio and
+            // the Alloc/msg comparison. The head-to-head must deserialize like-for-like.
             .ForHighThroughput()
             .BuildAsync(cancellationToken);
 
@@ -47,6 +50,10 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
+        // Dekaf-only diagnostics active inside the measured window (per-fetch MeterListener +
+        // 1-minute snapshot sampler). Accepted overhead: it slightly inflates Dekaf's own
+        // CPU/msg and alloc/msg vs Confluent (works against Dekaf, never for it) and the
+        // fetch-path visibility has repeatedly been what made stress regressions diagnosable.
         using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
         consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 

--- a/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ConsumerStressTest.cs
@@ -50,11 +50,11 @@ internal sealed class ConsumerStressTest : IStressTestScenario
         using var gcStats = new GcStats();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(TimeSpan.FromMinutes(options.DurationMinutes));
-        // Dekaf-only diagnostics active inside the measured window (per-fetch MeterListener +
-        // 1-minute snapshot sampler). Accepted overhead: it slightly inflates Dekaf's own
-        // CPU/msg and alloc/msg vs Confluent (works against Dekaf, never for it) and the
-        // fetch-path visibility has repeatedly been what made stress regressions diagnosable.
-        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic);
+        // Dekaf-only diagnostics (per-fetch MeterListener + 1-minute snapshot sampler) are
+        // opt-in via --consumer-fetch-diagnostics: enabled they slightly inflate Dekaf's own
+        // CPU/msg and alloc/msg vs Confluent, so measurement runs keep them off and debug
+        // runs turn them on when fetch-path visibility is needed to diagnose a regression.
+        using var consumerDiagnostics = new ConsumerFetchDiagnosticsTracker(options.Topic, enabled: options.EnableConsumerFetchDiagnostics);
         consumerDiagnostics.Start(StressTestHelpers.CaptureConsumerDiagnostics(consumer)!);
 
         Console.WriteLine($"  Running Dekaf consumer stress test for {options.DurationMinutes} minutes...");

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -29,6 +29,13 @@ internal sealed class StressTestOptions
     public int ConnectionsPerBroker { get; init; } = 1;
     public int RoundTripMessages { get; init; } = 250_000;
     public bool EnableProducerDeliveryDiagnostics { get; init; }
+
+    /// <summary>
+    /// Enables the Dekaf-only per-fetch diagnostics listener and 1-minute snapshot sampler
+    /// in the consumer scenarios. Off by default so the measured window carries no
+    /// diagnostics overhead; pass <c>--consumer-fetch-diagnostics</c> on debug runs.
+    /// </summary>
+    public bool EnableConsumerFetchDiagnostics { get; init; }
     public required ProgressWatchdog ProgressWatchdog { get; init; }
     public int SoakMessagesPerSecond { get; init; } = 5_000;
     public double ResourceSampleIntervalSeconds { get; init; } = 60;

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAcksAllStressTest.cs
@@ -33,6 +33,10 @@ internal sealed class ProducerAcksAllStressTest : IStressTestScenario
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
+            // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
+            // like-for-like baseline; the multi-connection pass measures that separately.
+            .WithoutAdaptiveConnections()
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncIdempotentStressTest.cs
@@ -29,6 +29,10 @@ internal sealed class ProducerAsyncIdempotentStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
+            // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
+            // like-for-like baseline; the multi-connection pass measures that separately.
+            .WithoutAdaptiveConnections()
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerAsyncStressTest.cs
@@ -29,6 +29,10 @@ internal sealed class ProducerAsyncStressTest : IStressTestScenario
             .WithLinger(TimeSpan.FromMilliseconds(options.LingerMs))
             .WithBatchSize(options.BatchSize)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
+            // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
+            // like-for-like baseline; the multi-connection pass measures that separately.
+            .WithoutAdaptiveConnections()
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerIdempotentStressTest.cs
@@ -32,6 +32,10 @@ internal sealed class ProducerIdempotentStressTest : IStressTestScenario
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
+            // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
+            // like-for-like baseline; the multi-connection pass measures that separately.
+            .WithoutAdaptiveConnections()
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -334,9 +334,10 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         using var produceTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
 
-        Action<ConfluentKafka.DeliveryReport<string, byte[]>> deliveryHandler = report =>
-            RecordDeliveryReportError(throughput, report.Error);
-
+        // No per-message delivery handler: librdkafka would invoke the managed delegate for
+        // every message, CPU the Dekaf side (error-only MeterListener) never pays — the same
+        // skew the acks-all scenario avoids (see ConfluentStressTestHelpers). Lost messages
+        // still fail the run via the consume-side completion tracker + CRC validation.
         Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
         for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
         {
@@ -361,7 +362,7 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                         Key = message.Key,
                         Value = message.Value
                     },
-                    deliveryHandler,
+                    deliveryHandler: null,
                     produceTimeout.Token);
                 throughput.RecordMessage(message.Value.Length);
             }
@@ -430,19 +431,6 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 validation.ConsumedMessages,
                 consumeTimer.Elapsed),
             producerDeliveryDiagnostics: null);
-    }
-
-    internal static void RecordDeliveryReportError(ThroughputTracker throughput, ConfluentKafka.Error error)
-    {
-        if (!error.IsError)
-        {
-            return;
-        }
-
-        throughput.RecordDeliveryError(
-            "Confluent.Kafka.Error",
-            error.ToString(),
-            "Round-trip delivery report");
     }
 
     private static bool ConsumeAndValidate(

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -29,6 +29,10 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
             .WithClientId("stress-roundtrip-consumer-dekaf")
             .WithGroupId($"stress-roundtrip-dekaf-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            // The Confluent round-trip consumer runs EnableAutoCommit=false. Match it:
+            // with Auto mode the background loop would send OffsetCommit RPCs every 5s
+            // during a latency-measured scenario that Confluent's side never pays.
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
             .BuildAsync(cancellationToken);
 
         var builder = Kafka.CreateProducer<string, byte[]>()

--- a/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerStressTest.cs
@@ -33,6 +33,10 @@ internal sealed class ProducerStressTest : IStressTestScenario
             .WithBatchSize(options.BatchSize)
             .WithBufferMemory(StressTestHelpers.ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(options.ConnectionsPerBroker)
+            // Confluent uses exactly the configured connection count. Pin Dekaf too so adaptive
+            // scale-up under backpressure (1 -> 3 connections/broker) cannot leak into the
+            // like-for-like baseline; the multi-connection pass measures that separately.
+            .WithoutAdaptiveConnections()
             .WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
 
         _ = options.Compression switch


### PR DESCRIPTION
## Summary

Redefines Dekaf's consumer defaults for safety: **auto-commit is now at-least-once**. A record's offset only becomes committable once the application has demonstrably moved past it (requesting the next record/batch, a fetch-boundary flush, or an explicit commit). Processing failures that exit the consume loop leave the failing record uncommitted, so it is redelivered after restart/rebalance instead of being silently committed away.

This takes over and extends the original scope of this PR (intent-level builder API for #2071) — the defaults themselves are now safe, and the intent API is layered on top.

### Mechanics
- `PendingFetchData` tracks a **proven offset**, marked when the caller requests the next record (enumerator resumption after `yield` — disposal skips that code, so an unwind leaves the in-doubt record unproven), the next batch pull, or the next `ConsumeOneAsync` call
- `FlushConsumedPositions` stages `proven + 1` for commit while positions still advance past everything yielded; the seqlock snapshot is retained while an in-doubt tail exists so a later explicit `CommitAsync()` can still vouch for it
- Close commits **proven offsets only** (`CommitProvenOffsetsAsync`); `CommitAsync()` still vouches for the in-flight record (explicit commit = caller acknowledgment); `GetPosition` no longer stages offsets as a side effect
- Per-message hot-path cost: two field writes on resumption — no allocations, no dictionary writes (staging stays per-fetch)

### API
- New `OffsetStoreTiming` option: `AfterProcessing` (default) / `OnDelivery`
- `WithAtLeastOnceProcessing()` now states the default explicitly (Auto + auto-store + `AfterProcessing`)
- `WithAtMostOnceProcessing()` — Confluent/librdkafka-style on-delivery staging for workloads that prefer loss over duplicates
- Strict per-record acknowledgment remains `WithAutoOffsetStore(false)` + `StoreOffset(...)` (survives catch-and-continue)
- `IConsumerCommitConfiguration` public capability retained from the original PR; `RunPartitioned*` guard unchanged (pull ≠ processed under out-of-band workers, regardless of timing)
- `InMemoryConsumer` mirrors the same semantics (in-doubt slot proven by the next consume call / explicit commit; discarded on seek/unassign/close)

### Semantics after this change
| Scenario | Outcome |
|---|---|
| Exception exits the loop | Failing record redelivered (was: lost) |
| Crash / kill | Uncommitted tail redelivered (unchanged) |
| Token-cancelled shutdown | Everything processed is committed — no dupes |
| `break` without `CommitAsync()` | Last record redelivered once (documented; `CommitAsync()` for exact handoff) |
| Caught-and-swallowed exception, loop continues | Still committed (Java parity; strict recipe documented) |

### Docs
- New **Delivery Semantics** page: full contract, Dekaf vs Java vs Confluent comparison, all four recipes, duplicate-window fine print
- `basics.md`, `offset-management.md`, `partitioned-processing-api.md`, `consumer-options.md` rewritten around the new default

### Breaking change
Default auto-commit semantics change from at-most-once-ish (staging at yield) to at-least-once. Failure modes shift from *silent loss* to *duplicates* — consumers should be idempotent (they always should have been). Workloads that deliberately relied on at-most-once should add `WithAtMostOnceProcessing()`.

## Validation
- Full unit suite: 5502/5502 on net10.0, 5395/5395 on net8.0
- 15 new delivery-semantics tests (`OffsetStoreTimingTests`): unwind/in-doubt exclusion, proven-prefix staging, batch dispose/pull-proof, break + `CommitAsync` handoff, close-commits-proven-only (end-to-end via captured `OffsetCommitRequest`s), `OnDelivery` immediate staging, `InMemoryConsumer` parity
- Release builds: zero warnings across net10.0/net8.0/netstandard2.0
- 4-agent `/simplify` review applied (commit-scope naming, single-caller chain collapse); reuse/efficiency/altitude otherwise clean

Closes #2071