### PR TITLE
test(consumer): remove slow-path timer race

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -92,7 +92,7 @@ public sealed class ConsumeOneFastPathTests
         await using var consumer = CreateInitializedConsumer(queuedMinMessages: 2, fetch);
         MarkManualAssignmentCurrent(consumer);
 
-        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+        var result = await consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         await Assert.That(GetTimeoutCtsPoolCount(consumer)).IsEqualTo(1);
@@ -108,7 +108,7 @@ public sealed class ConsumeOneFastPathTests
         await using var consumer = CreateInitializedGroupedConsumer(fetch, OffsetCommitMode.Auto);
         MarkManualAssignmentCurrent(consumer);
 
-        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
+        var result = await consumer.ConsumeOneAsync(Timeout.InfiniteTimeSpan, CancellationToken.None);
 
         await Assert.That(result).IsNotNull();
         await Assert.That(GetTimeoutCtsPoolCount(consumer)).IsEqualTo(1);


### PR DESCRIPTION
## Summary
- remove the unrelated one-second API timer from two slow-path routing tests
- keep timeout behavior covered by dedicated timeout tests
- make queued-data assertions insensitive to thread-pool load

## Validation
- Release unit build: 0 warnings, 0 errors
- slow-path repetitions: 50/50 per TFM
- `ConsumeOneFastPathTests`: 24/24 per TFM
- full unit suite: net10.0 5487/5487; net8.0 5380/5380

Closes #2099