### PR TITLE
perf(producer): replace 1ms linger poll with deadline-based wait

### DIFF
--- a/src/Dekaf/Internal/AsyncAutoResetSignal.cs
+++ b/src/Dekaf/Internal/AsyncAutoResetSignal.cs
@@ -51,6 +51,7 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
     /// </summary>
     private CancellationTokenRegistration _shutdownRegistration;
     private int _shutdownRegistered; // 0 = not registered, 1 = registered — guarded by Interlocked
+    private int _shutdownRequested; // 0 = running, 1 = shutdown requested — terminal once set
     private CancellationToken _shutdownToken;
 
     public AsyncAutoResetSignal()
@@ -82,22 +83,22 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
         if (!cancellationToken.CanBeCanceled)
             return;
 
-        // If already cancelled, skip registration. UnsafeRegister would fire the
-        // callback synchronously (state=Idle, CAS fails, no-op), but set
-        // _shutdownRegistered=1 — preventing future registration and silently
-        // disabling shutdown cancellation for all subsequent WaitAsync calls.
-        if (cancellationToken.IsCancellationRequested)
-            return;
-
         // Atomic guard: only the first caller registers.
         if (Interlocked.CompareExchange(ref _shutdownRegistered, 1, 0) != 0)
             return;
 
         _shutdownToken = cancellationToken;
+        if (cancellationToken.IsCancellationRequested)
+        {
+            Volatile.Write(ref _shutdownRequested, 1);
+            return;
+        }
+
         _shutdownRegistration = cancellationToken.UnsafeRegister(
             static state =>
             {
                 var self = (AsyncAutoResetSignal)state!;
+                Volatile.Write(ref self._shutdownRequested, 1);
                 // Shutdown requested — complete the waiter if one is pending.
                 if (Interlocked.CompareExchange(ref self._state, Idle, Waiting) == Waiting)
                 {
@@ -144,6 +145,8 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
     /// </remarks>
     public ValueTask<bool> WaitAsync(int timeoutMs)
     {
+        ThrowIfShutdownRequested();
+
         // Fast path: if already signaled, consume it immediately (no allocation).
         var previous = Interlocked.CompareExchange(ref _state, Idle, Signaled);
         if (previous == Signaled)
@@ -168,6 +171,15 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
             return new ValueTask<bool>(true);
         }
 
+        // Shutdown can race the loop's cancellation check and this wait registration.
+        // The callback latches cancellation even when no waiter exists; this recheck
+        // completes a waiter registered after such an idle callback.
+        if (Volatile.Read(ref _shutdownRequested) != 0
+            && Interlocked.CompareExchange(ref _state, Idle, Waiting) == Waiting)
+        {
+            _core.SetException(new OperationCanceledException(_shutdownToken));
+        }
+
         // Now in Waiting state — safe to arm timer. If timer fires immediately,
         // it will see Waiting, CAS succeeds, and SetResult(false) is called correctly.
         // If Signal() already completed _core (Waiting→Idle + SetResult), the timer's
@@ -182,6 +194,12 @@ internal sealed class AsyncAutoResetSignal : IValueTaskSource<bool>, IDisposable
 
         // Return the awaitable — Signal(), timeout, or shutdown will complete _core.
         return new ValueTask<bool>(this, _core.Version);
+    }
+
+    private void ThrowIfShutdownRequested()
+    {
+        if (Volatile.Read(ref _shutdownRequested) != 0)
+            throw new OperationCanceledException(_shutdownToken);
     }
 
     private void DisarmTimer()

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3292,8 +3292,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 {
                     // Deadline wait: sleep until the earliest pending batch can reach its
                     // linger deadline instead of polling a fixed 1 ms tick (~1,000 threadpool
-                    // wakes/s under any active workload). A new batch or a first awaited
-                    // produce signals the wakeup so the wait re-arms with a shorter deadline.
+                    // wakes/s under any active workload). A batch with an earlier deadline or
+                    // a first awaited produce signals the wakeup so the wait re-arms.
                     var lingerWaitMs = _accumulator.GetMillisUntilEarliestLingerDeadline(orphanWaitMs);
                     BeforeActiveLingerWaitForTest?.Invoke();
                     await _accumulator.WaitForLingerWakeupAsync(lingerWaitMs).ConfigureAwait(false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -61,7 +61,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly CancellationTokenSource _senderCts;
     private readonly Task _senderTask;
     private readonly Task _lingerTask;
-    private readonly PeriodicTimer _lingerTimer;
     private readonly ConcurrentDictionary<Task, byte> _partitionEnrollmentTasks = new();
 
     // Per-broker sender threads: each broker gets a dedicated BrokerSender with its own
@@ -422,7 +421,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         GcConfigurationCheck.WarnIfWorkstationGc(_logger);
 
         _senderCts = new CancellationTokenSource();
-        _lingerTimer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
         _senderTask = Task.Factory.StartNew(
             () => SenderLoopAsync(_senderCts.Token),
             CancellationToken.None,
@@ -3279,9 +3277,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var lastOrphanSweepTicks = Stopwatch.GetTimestamp();
 
         _accumulator.RegisterLingerWakeupShutdownToken(cancellationToken);
-        using var cancellationRegistration = cancellationToken.UnsafeRegister(
-            static state => ((PeriodicTimer)state!).Dispose(),
-            _lingerTimer);
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -3295,9 +3290,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (_accumulator.HasPendingLingerBatches)
                 {
-                    BeforeActiveLingerTimerWaitForTest?.Invoke();
-                    if (!await _lingerTimer.WaitForNextTickAsync(CancellationToken.None).ConfigureAwait(false))
-                        break;
+                    // Deadline wait: sleep until the earliest pending batch can reach its
+                    // linger deadline instead of polling a fixed 1 ms tick (~1,000 threadpool
+                    // wakes/s under any active workload). A new batch or a first awaited
+                    // produce signals the wakeup so the wait re-arms with a shorter deadline.
+                    var lingerWaitMs = _accumulator.GetMillisUntilEarliestLingerDeadline(orphanWaitMs);
+                    BeforeActiveLingerWaitForTest?.Invoke();
+                    await _accumulator.WaitForLingerWakeupAsync(lingerWaitMs).ConfigureAwait(false);
                 }
                 else
                 {
@@ -3325,7 +3324,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
     }
 
-    internal Action? BeforeActiveLingerTimerWaitForTest;
+    internal Action? BeforeActiveLingerWaitForTest;
 
     /// <inheritdoc />
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
@@ -4205,7 +4204,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         _senderCts.Dispose();
-        _lingerTimer.Dispose();
         _transactionLock.Dispose();
         _initLock.Dispose();
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1192,7 +1192,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // checks O(active unsealed partitions) instead of O(all partitions ever touched).
     private readonly ConcurrentQueue<TopicPartition> _lingerPartitions = new();
 
-    // Even when no linger sweep is active, odd while a sweep owns _flushLingerLock.
+    // Even when no batch sweep is active, odd while a sweep owns _flushLingerLock.
     // New batches compare the version observed before updating the deadline hint with the
     // version after queueing. A changed or odd version means the sweep may have missed the
     // batch, so the linger loop must be woken after the sweep raises the hint.
@@ -1240,6 +1240,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal Action? PurgeAppendWaitObservedForTest;
     internal Action? AfterLingerQueueSnapshotForTest;
+    internal Action<TopicPartition>? AfterFlushPartitionVisitedForTest;
 
     /// <summary>
     /// True after CloseAsync has been called. Used by the sender loop to know
@@ -4638,9 +4639,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             // FlushAsync will seal everything, so there's no work lost.
             if (!_flushLingerLock.Wait(0, CancellationToken.None))
                 return;
-
-            Interlocked.Increment(ref _lingerSweepVersion);
         }
+
+        Interlocked.Increment(ref _lingerSweepVersion);
 
         try
         {
@@ -4656,6 +4657,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 {
                     if (TrySealCurrentBatch(kvp.Key, kvp.Value, now, sealAll: true, cancellationToken, ref newOldestTicks, ref sawUnknownDeadline))
                         anySealed = true;
+                    AfterFlushPartitionVisitedForTest?.Invoke(kvp.Key);
                 }
             }
             else
@@ -4699,8 +4701,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
             else
             {
-                // After sealing all, reset oldest batch tracking
-                Volatile.Write(ref _oldestBatchCreatedTicks, long.MaxValue);
+                // A concurrent append may have lowered the hint while this sweep was
+                // visiting another partition. Preserve that value; its version check
+                // also wakes the linger loop when the flush snapshot missed its batch.
+                Interlocked.CompareExchange(ref _oldestBatchCreatedTicks, long.MaxValue, observedOldestTicks);
             }
 
             if (anySealed)
@@ -4708,9 +4712,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         finally
         {
-            if (!sealAll)
-                Interlocked.Increment(ref _lingerSweepVersion);
-
+            Interlocked.Increment(ref _lingerSweepVersion);
             _flushLingerLock.Release();
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2627,27 +2627,29 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void TrackCurrentBatchForLinger(PartitionDeque pd, TopicPartition topicPartition, PartitionBatch batch)
     {
-        TrackOldestBatchCreated(batch.CreatedAtStopwatchTimestamp);
-        QueueLingerPartition(pd, topicPartition);
+        var shortensDeadline = TrackOldestBatchCreated(batch.CreatedAtStopwatchTimestamp);
+        QueueLingerPartition(pd, topicPartition, signalLingerLoop: shortensDeadline);
     }
 
-    private void TrackOldestBatchCreated(long createdTicks)
+    private bool TrackOldestBatchCreated(long createdTicks)
     {
         var current = Volatile.Read(ref _oldestBatchCreatedTicks);
         while (createdTicks < current)
         {
             var original = Interlocked.CompareExchange(ref _oldestBatchCreatedTicks, createdTicks, current);
             if (original == current)
-                break;
+                return true;
             current = original;
         }
+
+        return false;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void QueueLingerPartition(
         PartitionDeque pd,
         TopicPartition topicPartition,
-        bool signalLingerLoop = true)
+        bool signalLingerLoop)
     {
         if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
         {
@@ -2831,7 +2833,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 }
                                 else if (completionSource is not null)
                                 {
-                                    QueueLingerPartition(pd, topicPartition);
+                                    QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
                                 }
                                 batchToReturn = rentedBatch;
                                 rentedBatch = null;
@@ -3407,7 +3409,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 }
                                 else if (completionSource is not null)
                                 {
-                                    QueueLingerPartition(pd, topicPartition);
+                                    QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
                                 }
                             }
                         }
@@ -3756,7 +3758,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         else if (completionSource is not null)
         {
-            QueueLingerPartition(pd, new TopicPartition(topic, partition));
+            QueueLingerPartition(pd, new TopicPartition(topic, partition), signalLingerLoop: false);
         }
 
         return true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1192,6 +1192,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // checks O(active unsealed partitions) instead of O(all partitions ever touched).
     private readonly ConcurrentQueue<TopicPartition> _lingerPartitions = new();
 
+    // Even when no linger sweep is active, odd while a sweep owns _flushLingerLock.
+    // New batches compare the version observed before updating the deadline hint with the
+    // version after queueing. A changed or odd version means the sweep may have missed the
+    // batch, so the linger loop must be woken after the sweep raises the hint.
+    private int _lingerSweepVersion;
+
     // Push-based notification queue for partitions with sealed batches ready to send.
     // Populated by append rotation, SealBatchesAsync, and Reenqueue when a batch
     // enters a partition deque. Drained by Ready() instead of scanning all _partitionDeques,
@@ -1233,6 +1239,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private int _closed;
 
     internal Action? PurgeAppendWaitObservedForTest;
+    internal Action? AfterLingerQueueSnapshotForTest;
 
     /// <summary>
     /// True after CloseAsync has been called. Used by the sender loop to know
@@ -2627,8 +2634,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void TrackCurrentBatchForLinger(PartitionDeque pd, TopicPartition topicPartition, PartitionBatch batch)
     {
+        var observedSweepVersion = Volatile.Read(ref _lingerSweepVersion);
         var shortensDeadline = TrackOldestBatchCreated(batch.CreatedAtStopwatchTimestamp);
-        QueueLingerPartition(pd, topicPartition, signalLingerLoop: shortensDeadline);
+        QueueLingerPartition(
+            pd,
+            topicPartition,
+            signalLingerLoop: shortensDeadline,
+            signalOnConcurrentSweep: true,
+            observedSweepVersion);
     }
 
     private bool TrackOldestBatchCreated(long createdTicks)
@@ -2650,12 +2663,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         PartitionDeque pd,
         TopicPartition topicPartition,
         bool signalLingerLoop)
+        => QueueLingerPartition(
+            pd,
+            topicPartition,
+            signalLingerLoop,
+            signalOnConcurrentSweep: false,
+            observedSweepVersion: 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void QueueLingerPartition(
+        PartitionDeque pd,
+        TopicPartition topicPartition,
+        bool signalLingerLoop,
+        bool signalOnConcurrentSweep,
+        int observedSweepVersion)
     {
         if (Interlocked.Exchange(ref pd.LingerQueued, 1) == 0)
         {
             _lingerPartitions.Enqueue(topicPartition);
-            if (signalLingerLoop)
+            if (signalLingerLoop
+                || (signalOnConcurrentSweep
+                    && ((observedSweepVersion & 1) != 0
+                        || Volatile.Read(ref _lingerSweepVersion) != observedSweepVersion)))
+            {
                 _lingerWakeupSignal.Signal();
+            }
         }
     }
 
@@ -4606,6 +4638,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             // FlushAsync will seal everything, so there's no work lost.
             if (!_flushLingerLock.Wait(0, CancellationToken.None))
                 return;
+
+            Interlocked.Increment(ref _lingerSweepVersion);
         }
 
         try
@@ -4627,6 +4661,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             else
             {
                 var count = _lingerPartitions.Count;
+                AfterLingerQueueSnapshotForTest?.Invoke();
                 for (var i = 0; i < count; i++)
                 {
                     if (!_lingerPartitions.TryDequeue(out var topicPartition))
@@ -4673,6 +4708,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         finally
         {
+            if (!sealAll)
+                Interlocked.Increment(ref _lingerSweepVersion);
+
             _flushLingerLock.Release();
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2195,6 +2195,30 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal bool HasPendingLingerBatches => HasUnsealedBatches();
 
     /// <summary>
+    /// Computes how long the linger loop may sleep before the earliest unsealed batch can
+    /// reach its linger deadline. Based on the oldest-batch hint (a lower bound on the oldest
+    /// unsealed batch's creation time), so the result can only wake the loop early, never late.
+    /// Clamped to [1, <paramref name="maxWaitMs"/>]: the 1 ms floor prevents a busy spin when
+    /// a deadline has already passed (e.g. a muted partition defers its seal past linger).
+    /// </summary>
+    internal int GetMillisUntilEarliestLingerDeadline(int maxWaitMs)
+    {
+        // Any batch holding an awaited produce seals on the shorter awaited window,
+        // so the wait horizon must shrink to it while such a batch is pending.
+        var effectiveLingerMs = Volatile.Read(ref _pendingAwaitedProduceCount) > 0
+            ? PartitionBatch.GetAwaitedLingerWindowMilliseconds(_options.LingerMs)
+            : _options.LingerMs;
+
+        var oldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
+        var elapsedMs = oldestTicks == long.MaxValue
+            ? 0.0
+            : Stopwatch.GetElapsedTime(oldestTicks).TotalMilliseconds;
+
+        var remainingMs = effectiveLingerMs - elapsedMs;
+        return Math.Clamp((int)Math.Ceiling(remainingMs), 1, Math.Max(1, maxWaitMs));
+    }
+
+    /// <summary>
     /// Registers a shutdown token with the wakeup signal so cancellation wakes the sender loop
     /// without per-wait allocation. Must be called once before the sender loop starts waiting.
     /// </summary>
@@ -2799,7 +2823,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
-                                    Interlocked.Increment(ref _pendingAwaitedProduceCount);
+                                    TrackPendingAwaitedProduceBatch();
                                 if (ShouldSealAppendedBatch(currentBatch))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
@@ -2839,7 +2863,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
-                                    Interlocked.Increment(ref _pendingAwaitedProduceCount);
+                                    TrackPendingAwaitedProduceBatch();
                                 if (ShouldSealAppendedBatch(newBatch))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
@@ -3368,7 +3392,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsReservation = false;
                                 ownsHeaderResources = false;
                                 if (reservedFirstAwaitedProduceInBatch)
-                                    Interlocked.Increment(ref _pendingAwaitedProduceCount);
+                                    TrackPendingAwaitedProduceBatch();
 
                                 if (ShouldSealAppendedBatch(reservedAppendBatch))
                                 {
@@ -3715,7 +3739,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             ProducerDebugCounters.RecordMessageAppended(hasCompletionSource: completionSource is not null);
 
             if (result.FirstCompletionSourceInBatch)
-                Interlocked.Increment(ref _pendingAwaitedProduceCount);
+                TrackPendingAwaitedProduceBatch();
 
             if (ShouldSealAppendedBatch(currentBatch))
             {
@@ -3873,6 +3897,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         Interlocked.Decrement(ref _pendingAwaitedProduceCount);
         released = true;
+    }
+
+    /// <summary>
+    /// Tracks the first awaited produce landing in an unsealed batch. That shortens the
+    /// batch's effective linger to the awaited window, so if the linger loop is parked on
+    /// a full-LingerMs deadline wait it must wake and re-arm with the shorter one. Only the
+    /// 0→1 transition signals: while the count stays positive the loop already waits on the
+    /// awaited window.
+    /// </summary>
+    private void TrackPendingAwaitedProduceBatch()
+    {
+        if (Interlocked.Increment(ref _pendingAwaitedProduceCount) == 1)
+            _lingerWakeupSignal.Signal();
     }
 
     private bool TryCompleteDetachedBatchForCleanup(
@@ -4478,6 +4515,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </remarks>
     public ValueTask ExpireLingerAsync(CancellationToken cancellationToken)
     {
+        // Cheap per-wake clock check (two volatile reads); runs before the fast paths so
+        // budget samples keep flowing while sealed batches drain (no unsealed work to do).
+        // The deadline-based linger wait bounds the call rate, so this is no longer per-tick.
         MaybeRecordBrokerBudgetDiagnosticSample();
 
         // Fast path 1: no unsealed batches to check - avoid queue draining and async overhead entirely
@@ -4571,12 +4611,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             var now = Stopwatch.GetTimestamp();
             var newOldestTicks = long.MaxValue;
             var anySealed = false;
+            var observedOldestTicks = Volatile.Read(ref _oldestBatchCreatedTicks);
+            var sawUnknownDeadline = false;
 
             if (sealAll)
             {
                 foreach (var kvp in _partitionDeques)
                 {
-                    if (TrySealCurrentBatch(kvp.Key, kvp.Value, now, sealAll: true, cancellationToken, ref newOldestTicks))
+                    if (TrySealCurrentBatch(kvp.Key, kvp.Value, now, sealAll: true, cancellationToken, ref newOldestTicks, ref sawUnknownDeadline))
                         anySealed = true;
                 }
             }
@@ -4592,19 +4634,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         continue;
 
                     MarkLingerPartitionDequeued(pd);
-                    if (TrySealCurrentBatch(topicPartition, pd, now, sealAll: false, cancellationToken, ref newOldestTicks))
+                    if (TrySealCurrentBatch(topicPartition, pd, now, sealAll: false, cancellationToken, ref newOldestTicks, ref sawUnknownDeadline))
                         anySealed = true;
                 }
             }
 
             if (!sealAll)
             {
-                // This is a best-effort lower-bound hint. Linger mode drains a queue snapshot,
-                // so a concurrent append or queued partition outside this snapshot may be older
-                // than newOldestTicks. Only lower the hint; raising it can delay an already
-                // expired batch until a newer batch reaches linger.
-                if (newOldestTicks != long.MaxValue)
-                    TrackOldestBatchCreated(newOldestTicks);
+                // The sweep visited every queued partition, so newOldestTicks is the creation
+                // time of the oldest surviving batch in the snapshot (long.MaxValue when all
+                // sealed). Raise the hint to it so the linger loop's deadline wait tracks live
+                // batches instead of long-sealed ones. Two guards keep raising safe:
+                // - CAS from the value observed at sweep start: a concurrent lower (an append
+                //   racing this sweep) must win, or its batch could wait a full extra linger.
+                // - Skip the raise when a partition was requeued mid-rotation: its batch's
+                //   creation time is unknown, and the stale hint keeps the next wait at the
+                //   1 ms floor until the following sweep observes it.
+                // A batch created after the snapshot is never delayed by the raise: queueing
+                // its partition signals the linger wakeup, which re-arms the deadline wait.
+                if (sawUnknownDeadline
+                    || Interlocked.CompareExchange(ref _oldestBatchCreatedTicks, newOldestTicks, observedOldestTicks) != observedOldestTicks)
+                {
+                    // Fall back to lower-only maintenance of the hint.
+                    if (newOldestTicks != long.MaxValue)
+                        TrackOldestBatchCreated(newOldestTicks);
+                }
             }
             else
             {
@@ -4630,7 +4684,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         long now,
         bool sealAll,
         CancellationToken cancellationToken,
-        ref long newOldestTicks)
+        ref long newOldestTicks,
+        ref bool sawUnknownDeadline)
     {
         ReadyBatch? sealedBatch = null;
         PartitionBatch? batchToComplete = null;
@@ -4680,6 +4735,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
             if (!sealAll)
             {
+                // Rotation/append in progress: the surviving batch's creation time cannot be
+                // read safely, so the sweep's newOldestTicks does not cover it.
+                sawUnknownDeadline = true;
                 QueueLingerPartition(pd, topicPartition, signalLingerLoop: false);
                 break;
             }
@@ -6188,6 +6246,13 @@ internal sealed class PartitionBatch
     private const double AwaitedLingerFraction = 0.5;
     private const double MaximumAwaitedLingerMilliseconds = 2.0;
 
+    /// <summary>
+    /// The shortened linger window applied to a batch once it holds an awaited produce:
+    /// min(2ms, LingerMs/2). Shared with the linger loop's deadline-wait computation.
+    /// </summary>
+    internal static double GetAwaitedLingerWindowMilliseconds(int lingerMs) =>
+        Math.Min(MaximumAwaitedLingerMilliseconds, lingerMs * AwaitedLingerFraction);
+
     private TopicPartition _topicPartition;
     private int _partitionCount;
     private ProducerOptions _options;
@@ -6828,10 +6893,7 @@ internal sealed class PartitionBatch
             if (lingerMs == 0)
                 return true;
 
-            var awaitedLingerMilliseconds = Math.Min(
-                MaximumAwaitedLingerMilliseconds,
-                lingerMs * AwaitedLingerFraction);
-            return elapsedMs >= awaitedLingerMilliseconds;
+            return elapsedMs >= GetAwaitedLingerWindowMilliseconds(lingerMs);
         }
 
         return elapsedMs >= lingerMs;

--- a/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/AsyncAutoResetSignalTests.cs
@@ -1,0 +1,34 @@
+using Dekaf.Internal;
+
+namespace Dekaf.Tests.Unit.Internal;
+
+public class AsyncAutoResetSignalTests
+{
+    [Test]
+    public async Task WaitAsync_AfterIdleShutdown_ThrowsCancellation()
+    {
+        using var signal = new AsyncAutoResetSignal();
+        using var cancellation = new CancellationTokenSource();
+
+        signal.RegisterShutdownToken(cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.That(async () =>
+                await signal.WaitAsync(Timeout.Infinite).AsTask().WaitAsync(TimeSpan.FromSeconds(1)))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task WaitAsync_AfterPreCancelledRegistration_ThrowsCancellation()
+    {
+        using var signal = new AsyncAutoResetSignal();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        signal.RegisterShutdownToken(cancellation.Token);
+
+        await Assert.That(async () =>
+                await signal.WaitAsync(Timeout.Infinite).AsTask().WaitAsync(TimeSpan.FromSeconds(1)))
+            .Throws<OperationCanceledException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -14,6 +14,16 @@ namespace Dekaf.Tests.Unit.Producer;
 internal static class AccumulatorTestHelpers
 {
     /// <summary>
+    /// Reads a private instance field via reflection.
+    /// </summary>
+    public static T GetPrivateField<T>(object instance, string fieldName)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' not found on {instance.GetType().Name}.");
+        return (T)field.GetValue(instance)!;
+    }
+
+    /// <summary>
     /// Seals the partition's current batch via reflection and returns the ReadyBatch.
     /// </summary>
     public static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, string topic, int partition = 0)

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -24,6 +24,18 @@ internal static class AccumulatorTestHelpers
     }
 
     /// <summary>
+    /// Runs the accumulator's flush-mode batch sweep without waiting for delivery.
+    /// </summary>
+    public static ValueTask SealAllAsync(RecordAccumulator accumulator)
+    {
+        var method = typeof(RecordAccumulator).GetMethod(
+            "SealBatchesAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("SealBatchesAsync was not found.");
+        return (ValueTask)method.Invoke(accumulator, [true, CancellationToken.None])!;
+    }
+
+    /// <summary>
     /// Seals the partition's current batch via reflection and returns the ReadyBatch.
     /// </summary>
     public static ReadyBatch CompleteCurrentBatch(RecordAccumulator accumulator, string topic, int partition = 0)

--- a/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
@@ -1,0 +1,179 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for the linger loop's deadline-based wait (issue #2114): instead of polling a
+/// fixed 1 ms timer, the loop sleeps until the earliest pending batch can reach its
+/// linger deadline and is re-armed by wakeup signals when that deadline shortens.
+/// </summary>
+public class LingerDeadlineWaitTests
+{
+    private static ProducerOptions CreateOptions(int lingerMs) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        LingerMs = lingerMs
+    };
+
+    private static ValueTask<bool> AppendAsync(
+        RecordAccumulator accumulator,
+        PooledValueTaskSource<RecordMetadata>? completionSource = null,
+        int partition = 0) =>
+        accumulator.AppendAsync(
+            "test-topic",
+            partition,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null,
+            PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completionSource,
+            callback: null,
+            CancellationToken.None);
+
+    private static long GetOldestBatchHint(RecordAccumulator accumulator) =>
+        AccumulatorTestHelpers.GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks");
+
+    private static int GetUnsealedBatchCount(RecordAccumulator accumulator) =>
+        AccumulatorTestHelpers.GetPrivateField<int>(accumulator, "_unsealedBatchCount");
+
+    [Test]
+    public async Task NoBatches_WaitClampedToMaxAndLinger()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 10_000));
+        try
+        {
+            // No oldest-batch hint: the horizon is the full linger window, capped by maxWaitMs.
+            await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 5_000)).IsEqualTo(5_000);
+            await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 30_000)).IsEqualTo(10_000);
+            // maxWaitMs of 0 (orphan sweep due) still floors at 1 to avoid a busy spin.
+            await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 0)).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FireAndForgetBatch_WaitTracksFullLingerDeadline()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        try
+        {
+            await AppendAsync(accumulator);
+
+            var waitMs = accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 120_000);
+
+            // Fresh batch: remaining linger is the full window minus scheduling slop.
+            await Assert.That(waitMs).IsGreaterThan(30_000);
+            await Assert.That(waitMs).IsLessThanOrEqualTo(60_000);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task AwaitedBatch_WaitShrinksToAwaitedWindow()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            await AppendAsync(accumulator, pool.Rent());
+
+            var waitMs = accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 120_000);
+
+            // An awaited produce seals on min(2ms, LingerMs/2), so the wait must not
+            // exceed the 2 ms awaited window.
+            await Assert.That(waitMs).IsGreaterThanOrEqualTo(1);
+            await Assert.That(waitMs).IsLessThanOrEqualTo(2);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ZeroLinger_WaitFloorsAtOneMillisecond()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 0));
+        try
+        {
+            await AppendAsync(accumulator);
+
+            // Deadline already passed: floor at 1 ms (the old fixed-tick cadence) instead of 0,
+            // which would busy-spin the linger loop.
+            await Assert.That(accumulator.GetMillisUntilEarliestLingerDeadline(maxWaitMs: 5_000)).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FirstAwaitedProduceInExistingBatch_SignalsLingerWakeup()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            // Fire-and-forget append queues the partition and signals; consume that signal.
+            await AppendAsync(accumulator);
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(5_000)).IsTrue();
+
+            var wakeup = accumulator.WaitForLingerWakeupAsync(10_000).AsTask();
+            await Assert.That(wakeup.IsCompleted).IsFalse();
+
+            // First awaited produce lands in the existing batch: the partition is already
+            // linger-queued, so only the awaited 0→1 transition can signal. Without it the
+            // linger loop would sleep out the full 60 s deadline it armed for the
+            // fire-and-forget batch instead of re-arming on the 2 ms awaited window.
+            await AppendAsync(accumulator, pool.Rent());
+
+            await Assert.That(await wakeup.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task LingerSweep_RaisesOldestBatchHintToSurvivingBatch(CancellationToken cancellationToken)
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            // Batch A (partition 0): awaited, seals on the 2 ms awaited window.
+            await AppendAsync(accumulator, pool.Rent(), partition: 0);
+            // Batch B (partition 1): fire-and-forget, survives the sweep for 60 s.
+            await AppendAsync(accumulator, partition: 1);
+
+            var hintBeforeSweep = GetOldestBatchHint(accumulator);
+            await Assert.That(hintBeforeSweep).IsNotEqualTo(long.MaxValue);
+
+            // Run linger sweeps until batch A expires and seals, leaving only batch B.
+            while (GetUnsealedBatchCount(accumulator) != 1)
+            {
+                await accumulator.ExpireLingerAsync(CancellationToken.None);
+                await Task.Delay(5, cancellationToken);
+            }
+
+            // The sweep must raise the hint from sealed batch A's creation time to
+            // surviving batch B's, so the next deadline wait tracks a live batch instead
+            // of flooring at 1 ms against a long-sealed one.
+            await Assert.That(GetOldestBatchHint(accumulator)).IsGreaterThan(hintBeforeSweep);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
@@ -144,6 +144,29 @@ public class LingerDeadlineWaitTests
     }
 
     [Test]
+    public async Task NewerFireAndForgetBatch_DoesNotSignalLingerWakeup()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        try
+        {
+            await AppendAsync(accumulator, partition: 0);
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(5_000)).IsTrue();
+
+            var wakeup = accumulator.WaitForLingerWakeupAsync(100).AsTask();
+
+            // A newer batch cannot shorten the existing batch's linger deadline, so it
+            // must not interrupt an active wait that is already armed for that deadline.
+            await AppendAsync(accumulator, partition: 1);
+
+            await Assert.That(await wakeup).IsFalse();
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(30_000)]
     public async Task LingerSweep_RaisesOldestBatchHintToSurvivingBatch(CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
@@ -238,4 +238,45 @@ public class LingerDeadlineWaitTests
             await accumulator.DisposeAsync();
         }
     }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task BatchQueuedAfterFlushVisitedPartition_SignalsLingerWakeup(CancellationToken cancellationToken)
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        using var partitionVisited = new ManualResetEventSlim();
+        using var continueFlush = new ManualResetEventSlim();
+        try
+        {
+            await AppendAsync(accumulator, partition: 0);
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(5_000)).IsTrue();
+
+            accumulator.AfterFlushPartitionVisitedForTest = topicPartition =>
+            {
+                if (topicPartition.Partition != 0)
+                    return;
+
+                partitionVisited.Set();
+                continueFlush.Wait(cancellationToken);
+            };
+
+            var flushSweep = Task.Run(
+                async () => await AccumulatorTestHelpers.SealAllAsync(accumulator),
+                cancellationToken);
+
+            partitionVisited.Wait(cancellationToken);
+            await AppendAsync(accumulator, partition: 0);
+            continueFlush.Set();
+            await flushSweep;
+
+            await Assert.That(GetUnsealedBatchCount(accumulator)).IsEqualTo(1);
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(100)).IsTrue();
+        }
+        finally
+        {
+            continueFlush.Set();
+            accumulator.AfterFlushPartitionVisitedForTest = null;
+            await accumulator.DisposeAsync();
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
@@ -199,4 +199,43 @@ public class LingerDeadlineWaitTests
             await accumulator.DisposeAsync();
         }
     }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task BatchQueuedAfterSweepSnapshot_SignalsLingerWakeup(CancellationToken cancellationToken)
+    {
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        using var snapshotTaken = new ManualResetEventSlim();
+        using var continueSweep = new ManualResetEventSlim();
+        try
+        {
+            await AppendAsync(accumulator, pool.Rent(), partition: 0);
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(5_000)).IsTrue();
+
+            accumulator.AfterLingerQueueSnapshotForTest = () =>
+            {
+                snapshotTaken.Set();
+                continueSweep.Wait(cancellationToken);
+            };
+
+            await Task.Delay(5, cancellationToken);
+            var sweep = Task.Run(
+                async () => await accumulator.ExpireLingerAsync(CancellationToken.None),
+                cancellationToken);
+
+            snapshotTaken.Wait(cancellationToken);
+            await AppendAsync(accumulator, partition: 1);
+            continueSweep.Set();
+            await sweep;
+
+            await Assert.That(await accumulator.WaitForLingerWakeupAsync(100)).IsTrue();
+        }
+        finally
+        {
+            continueSweep.Set();
+            accumulator.AfterLingerQueueSnapshotForTest = null;
+            await accumulator.DisposeAsync();
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -46,7 +46,7 @@ public class ProducerCancellationTests
     }
 
     [Test]
-    public async Task DisposeAsync_StopsPendingLingerTimerPromptly()
+    public async Task DisposeAsync_StopsPendingLingerWaitPromptly()
     {
         var producer = Kafka.CreateProducer<string, string>()
             .WithBootstrapServers("localhost:9092")
@@ -60,7 +60,7 @@ public class ProducerCancellationTests
     }
 
     [Test]
-    public async Task Cancellation_StopsActiveLingerTimerPromptly()
+    public async Task Cancellation_StopsActiveLingerWaitPromptly()
     {
         var producer = Kafka.CreateProducer<string, string>()
             .WithBootstrapServers("localhost:9092")
@@ -72,7 +72,7 @@ public class ProducerCancellationTests
         var activeLingerWaitEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         SetField(
             producer,
-            "BeforeActiveLingerTimerWaitForTest",
+            "BeforeActiveLingerWaitForTest",
             (Action)(() => activeLingerWaitEntered.TrySetResult(true)));
 
         try

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorReadyTests.cs
@@ -1126,7 +1126,7 @@ public class RecordAccumulatorReadyTests
     }
 
     [Test]
-    public async Task ExpireLingerAsync_DoesNotRaiseOldestBatchHint()
+    public async Task ExpireLingerAsync_RaisesStaleOldestBatchHintToSurvivingBatch()
     {
         var options = CreateTestOptions(batchSize: 100_000, lingerMs: 10_000);
         var accumulator = new RecordAccumulator(options);
@@ -1143,14 +1143,17 @@ public class RecordAccumulatorReadyTests
             await Assert.That(appended).IsTrue();
 
             var createdTicks = GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks");
-            var olderHint = Math.Max(0, createdTicks - Stopwatch.Frequency * 20);
-            SetPrivateField(accumulator, "_oldestBatchCreatedTicks", olderHint);
+            var staleHint = Math.Max(0, createdTicks - Stopwatch.Frequency * 20);
+            SetPrivateField(accumulator, "_oldestBatchCreatedTicks", staleHint);
             var lingerQueue = GetPrivateField<ConcurrentQueue<TopicPartition>>(accumulator, "_lingerPartitions");
 
             await accumulator.ExpireLingerAsync(CancellationToken.None);
 
+            // The sweep visited every queued partition, so it raises the stale hint to the
+            // surviving batch's creation time. Without the raise, the linger loop's deadline
+            // wait would floor at 1 ms against the long-gone hint (issue #2114).
             await Assert.That(GetPrivateField<long>(accumulator, "_oldestBatchCreatedTicks"))
-                .IsEqualTo(olderHint);
+                .IsEqualTo(createdTicks);
             await Assert.That(lingerQueue.Count).IsEqualTo(1);
         }
         finally


### PR DESCRIPTION
Fixes #2114

## Problem

The producer linger loop ticked a hard-coded 1 ms `PeriodicTimer` whenever any unsealed batch existed — ~1,000 threadpool wakes/s independent of `LingerMs` and message rate. Profiling on stress run 29379808486 attributed ~35% of transactional on-CPU to this tick (`TimerQueue.TimerThread` in 34.6% of stacks vs Confluent 0.3%; `LowLevelLifoSemaphore.ReleaseCore` 29.1s vs 0.55s). The `PeriodicTimer` also generated TimerQueue work every 1 ms even while the loop parked idle.

## Fix

Deadline-based wait on the existing `AsyncAutoResetSignal` (zero-allocation, reused one-shot timer that only fires on real deadlines):

- **`GetMillisUntilEarliestLingerDeadline`**: sleep until the earliest unsealed batch can reach its effective linger deadline — full `LingerMs`, or the `min(2ms, LingerMs/2)` awaited window while awaited produces are pending — capped by the 5 s orphan sweep, floored at 1 ms (the old cadence) so already-passed deadlines (e.g. muted partitions deferring seals) can never busy-spin.
- **Hint raise**: linger sweeps now raise `_oldestBatchCreatedTicks` to the oldest *surviving* batch via CAS from the value observed at sweep start (concurrent lowers win; raise skipped when a mid-rotation partition hides its creation time). Previously the hint was lower-only, so under sustained load it stayed pinned to long-sealed batches — the deadline wait would have degraded to permanent 1 ms polling without this.
- **Re-arm signals**: the wait re-arms on the existing new-batch queue signal, plus a new signal when the first awaited produce lands in a batch (0→1 pending count) — that transition shortens the deadline of an already-armed full-`LingerMs` wait and previously had no wake path.
- `MaybeRecordBrokerBudgetDiagnosticSample` stays at the top of `ExpireLingerAsync`: with the 1,000x/s tick gone the clock check is per-wake and cheap, and keeping it there preserves budget samples while sealed batches drain.

Expiry precision is unchanged (wake at the deadline, not on a fixed grid), so linger-fed p50 (#2108) should not regress; worst-case staleness degrades to exactly the old 1 ms cadence, never worse.

## Testing

- New `LingerDeadlineWaitTests`: deadline clamping (no-batch / FnF / awaited / zero-linger), awaited 0→1 wakeup signal through an already-queued partition, and hint raise to the surviving batch after a sweep.
- `ExpireLingerAsync_DoesNotRaiseOldestBatchHint` → `ExpireLingerAsync_RaisesStaleOldestBatchHintToSurvivingBatch` (invariant intentionally changed, now asserts exact raise).
- Full unit suite: 5550/5550 pass. Producer integration suite against real Kafka (Testcontainers): 77/77 pass.

## Follow-up candidates (out of scope)

- Mixed FnF+awaited workloads floor at 1 ms while awaited count > 0 (single hint conflates the two linger windows); a second awaited-oldest hint would recover the 2 ms wait.
- A `PartitionDeque`-level created-ticks field would remove the `sawUnknownDeadline` raise-skip under rotation contention.
- Acceptance per the issue: paired-latency gate alongside CPU on the next stress run.