### PR TITLE
Cap producer budget horizon by latency target

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -365,7 +365,7 @@ Soft target for per-broker queueing latency (append to broker acknowledgement):
 .WithDeliveryLatencyTarget(TimeSpan.Zero)                 // disable the bound
 ```
 
-Default: 10ms. The producer bounds each broker's unacknowledged bytes to `target × measured ack throughput`, so under sustained overload delivery latency stays near the target instead of growing with the full buffer (bufferbloat). A measured round-trip guard keeps the bound above the bandwidth-delay product, so throughput is never window-limited — on high-latency links the effective latency floor is ~1.5× the broker round-trip. When a broker exceeds its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Until the first drain measurement the bound sits at its ceiling, so short-lived producers are unaffected. Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to restore pre-bound behavior.
+Default: 10ms. The producer bounds each broker's unacknowledged bytes to a preferred measured bandwidth-delay-product safety horizon, capped by `target × measured ack throughput` but never below one measured bandwidth-delay product. This avoids standing queueing under sustained overload (bufferbloat) without making throughput window-limited. When a broker exceeds its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Until the first drain measurement the bound sits at its ceiling, so short-lived producers are unaffected. Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to restore pre-bound behavior.
 
 ### WithSocketSendBufferBytes / WithSocketReceiveBufferBytes
 

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -188,11 +188,10 @@ public sealed class ProducerBuilder<TKey, TValue>
 
     /// <summary>
     /// Sets the soft target for per-broker producer queueing latency (append to ack).
-    /// The producer bounds each broker's unacknowledged bytes to
-    /// <c>target × measured ack throughput</c>, so delivery latency stays near the target
-    /// instead of growing with the full buffer under sustained overload. A measured
-    /// round-trip guard keeps the bound above the bandwidth-delay product, so throughput
-    /// is never window-limited.
+    /// The producer bounds each broker's unacknowledged bytes to a preferred measured
+    /// bandwidth-delay product safety horizon, capped by the target but never below one
+    /// bandwidth-delay product. This avoids standing queueing under sustained overload
+    /// without making throughput window-limited.
     /// </summary>
     /// <param name="target">The latency target. <see cref="TimeSpan.Zero"/> disables the bound.</param>
     /// <remarks>

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -10,9 +10,10 @@ namespace Dekaf.Producer;
 /// instead of growing to the full <see cref="ProducerOptions.BufferMemory"/> reservoir.
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
 /// by the broker's drain rate; capping the standing bytes to
-/// <c>target × measured drain rate</c> caps the latency. The RTT safety floor uses a
-/// periodically refreshed minimum RTT or the loaded serving RTT, so replicated service time
-/// still keeps the pipe full. Raw round trips include the drain time of bytes the budget
+/// <c>target × measured drain rate</c> caps the latency. The RTT safety horizon uses a
+/// periodically refreshed minimum RTT or the loaded serving RTT, capped by the latency target
+/// but never below one measured BDP so replicated service time still keeps the pipe full.
+/// Raw round trips include the drain time of bytes the budget
 /// itself admitted ahead of the request, so RTT samples are queue-corrected at intake (raw
 /// RTT minus unacked-at-send over the measured max rate) before feeding the minimum and
 /// serving estimates, and the serving EWMA is additionally clamped to a bounded multiple of
@@ -147,10 +148,10 @@ internal sealed class BrokerUnackedByteBudget
     /// </summary>
     private static readonly long MaxMinRttProbeDurationTicks = Stopwatch.Frequency / 4;
 
-    /// <summary>Budget never drops below this multiple of the measured bandwidth-delay
-    /// product (rate × RTT). Without this guard a target below the broker RTT would shrink
-    /// the budget below BDP, underfill the pipe, lower the measured rate, and ratchet the
-    /// budget down to the floor — collapsing throughput on high-latency links.</summary>
+    /// <summary>Preferred multiple of the measured bandwidth-delay product (rate × RTT).
+    /// The latency target caps this safety margin, but the horizon never drops below one
+    /// base-RTT BDP; otherwise high-latency links underfill the pipe, lower the measured rate,
+    /// and ratchet the budget down to the floor.</summary>
     private const double RttSafetyMultiplier = 1.5;
     private const double MinRttProbeSafetyMultiplier = 1.0;
 
@@ -1258,11 +1259,12 @@ internal sealed class BrokerUnackedByteBudget
                     minRttSeconds,
                     Math.Min(_servingRttEwmaSeconds, ServingRttClampMultiplier * minRttSeconds))
                 : minRttSeconds;
-            var rttFloorSeconds = minRttProbeActive
+            var rttSafetyHorizonSeconds = minRttProbeActive
                 ? MinRttProbeSafetyMultiplier * minRttSeconds
                 : RttSafetyMultiplier * loadAwareRttSeconds;
+            var latencyCapSeconds = Math.Max(latencyGovernedTargetSeconds, minRttSeconds);
             var horizonSeconds = _hasMinRttSample
-                ? Math.Max(latencyGovernedTargetSeconds, rttFloorSeconds)
+                ? Math.Min(rttSafetyHorizonSeconds, latencyCapSeconds)
                 : latencyGovernedTargetSeconds;
             rateBudgetBytes = effectiveMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -142,10 +142,11 @@ public sealed class ProducerOptions
     /// <summary>
     /// Soft target, in milliseconds, for controllable per-broker producer queueing latency
     /// (batch seal to socket send). Configured linger and broker round-trip time are excluded.
-    /// Bounds the bytes each broker may hold unacknowledged to
-    /// <c>target × measured ack throughput</c>, with a measured round-trip lower guard so
-    /// throughput is never window-limited. When a broker exceeds its budget, message admission
-    /// blocks the same way <see cref="BufferMemory"/> exhaustion does (subject to
+    /// Bounds the bytes each broker may hold unacknowledged to a preferred measured
+    /// bandwidth-delay product safety horizon, capped by
+    /// <c>target × measured ack throughput</c> but never below one measured bandwidth-delay
+    /// product so throughput is not window-limited. When a broker exceeds its budget, message
+    /// admission blocks the same way <see cref="BufferMemory"/> exhaustion does (subject to
     /// <see cref="MaxBlockMs"/> and cancellation). Until the first drain measurement the bound
     /// equals its ceiling, so short-lived producers are unaffected.
     /// Set to 0 to disable the bound entirely. Default: 10.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1342,6 +1342,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly List<PendingAppend> _pendingAppendScan = [];
     private readonly List<PendingAppend> _drainablePendingAppends = [];
     private int _draining; // CAS guard for DrainPendingAppends
+    private long _pendingAppendDrainRequestVersion;
     private long _pendingAppendDrainEntryCount;
 
     /// <summary>
@@ -1980,9 +1981,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// rotating budget-blocked partitions so healthy brokers can progress.
     /// </summary>
     /// <remarks>
-    /// CAS on <c>_draining</c> ensures only one thread drains at a time. After releasing
-    /// the drain lock, we re-check for pending items with available memory to prevent
-    /// missed signals (a release could arrive while we hold the lock).
+    /// CAS on <c>_draining</c> ensures only one thread drains at a time. A caller that finds
+    /// the guard busy increments a request version; after releasing the guard, the owner
+    /// retries if that version changed. This prevents an unacked-budget release from being
+    /// lost when the active owner just observed the old, blocked state.
     /// </remarks>
     /// <returns>
     /// <see langword="false"/> only when another thread already owns the drain guard;
@@ -1993,9 +1995,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (_pendingAppends.IsEmpty)
             return true;
 
-        // Only one thread drains at a time — others return immediately.
+        // Only one thread drains at a time. Record the missed entry so the owner rescans
+        // after publishing the guard as free; a bool is insufficient because an older owner
+        // could consume a newer owner's wake in the handoff window.
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
+        {
+            Interlocked.Increment(ref _pendingAppendDrainRequestVersion);
             return false;
+        }
 
         Interlocked.Increment(ref _pendingAppendDrainEntryCount);
         var ownsDrainGuard = true;
@@ -2003,6 +2010,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             while (true)
             {
+                var drainRequestVersion = Volatile.Read(ref _pendingAppendDrainRequestVersion);
+
                 // Bail if accumulator is being disposed — DisposeAsync will drain the queue.
                 if (Volatile.Read(ref _disposed) != 0)
                     return true;
@@ -2104,11 +2113,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // can enter if we decide not to loop again.
                 ownsDrainGuard = false;
                 Volatile.Write(ref _draining, 0);
+                var drainRequested = Volatile.Read(ref _pendingAppendDrainRequestVersion)
+                    != drainRequestVersion;
 
                 // Re-check: a ReleaseMemory may have arrived while we held the drain lock,
-                // and new pending items may have been enqueued. Only re-enter if we made
-                // progress last round (prevents infinite loop when head item can't be served).
-                if (!madeProgress
+                // and new pending items may have been enqueued. A changed request version
+                // proves another caller observed us busy; otherwise only progress justifies
+                // another pass (preventing a spin while admission remains blocked).
+                if ((!madeProgress && !drainRequested)
                     || _pendingAppends.IsEmpty
                     || (ulong)Volatile.Read(ref _bufferedBytes) >= (ulong)Volatile.Read(ref _maxBufferMemory))
                 {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -91,14 +91,15 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task Budget_AfterRateSample_TracksTargetTimesRate()
+    public async Task Budget_AfterRateSample_TracksRttSafetyTimesRate()
     {
-        // 3,000 B/s at negligible RTT with a 0.5s target => budget 1,500, inside [200, 3,200].
+        // 300,000 B/s × 1.5 × 1ms RTT = 450 bytes, inside [200, 3,200].
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
 
-        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
+        EstablishRate(budget, bytesPerSecond: 300_000, rttSeconds: 0.001);
+        Ack(budget, 300, 0.001, T0 + Seconds(0.051));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(450);
     }
 
     [Test]
@@ -208,7 +209,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
         await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(reducedScale);
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(2_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500)
+            .Because("latency-scale recovery cannot grow the budget beyond its RTT safety horizon");
     }
 
     [Test]
@@ -270,32 +272,31 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 3_200);
 
-        // 1,000,000 B/s × 0.5s = 500,000 bytes — far above the cap.
-        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        // One BDP at 1,000,000 B/s × 100ms is already far above the cap.
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.100);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(3_200);
     }
 
     [Test]
-    public async Task Budget_RttGuard_DominatesWhenRttExceedsTarget()
+    public async Task Budget_HorizonNeverDropsBelowOneBdp()
     {
-        // Target 10ms but the measured round-trip is 100ms: the guard keeps the budget at
-        // 1.5 × BDP (rate × RTT) so throughput is never window-limited.
+        // Target 10ms but measured RTT is 100ms: an impossible target still retains one BDP.
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.100);
         Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
 
-        // 100,000 B/s × max(0.010, 1.5 × 0.100) = 15,000 bytes (±tick-quantization of the RTT).
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(14_990);
-        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(15_010);
+        // 100,000 B/s × 100ms = 10,000 bytes (±tick-quantization of the RTT).
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(9_990);
+        await Assert.That(budget.BudgetBytes).IsLessThanOrEqualTo(10_010);
     }
 
     [Test]
     public async Task Budget_RttGuard_UsesServingRttEwmaWithinClampUnderLoad()
     {
-        // Base RTT 10ms, loaded serving RTT 15ms — within the 2x clamp, so the loaded
-        // estimate (which includes replication service time) sizes the floor.
+        // Base RTT 10ms, loaded serving RTT 15ms — the 10ms target caps the preferred
+        // 1.5 × serving-RTT safety margin at one base-RTT BDP.
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
@@ -309,8 +310,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(22_500)
-            .Because("replicated serving RTT, not base RTT, determines the loaded BDP");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000)
+            .Because("the latency cap wins without dropping below one base-RTT BDP");
     }
 
     [Test]
@@ -319,7 +320,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // Base RTT 1ms but the loaded serving RTT reads 20ms — that excess is queueing the
         // budget itself admitted. Unclamped, the floor would be 1.5 × 20ms = 30,000 bytes,
         // re-inflating the RTT it is derived from (the #2009 ratchet). The clamp bounds the
-        // floor at 1.5 × 2 × base RTT = 3ms; the 10ms target then governs.
+        // safety horizon at 1.5 × 2 × base RTT = 3ms, below the 10ms latency cap.
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
@@ -333,8 +334,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000)
-            .Because("queue-inflated serving RTT must not raise the floor it feeds back into");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_000)
+            .Because("queue-inflated serving RTT must not force the horizon to the target");
     }
 
     [Test]
@@ -355,9 +356,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         SetCapWithoutDecay(budget, 1_000_000, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(12_500)
-            .Because("probing exactly when the RTT floor dominates accelerated the ratchet; " +
-                "the probe step is uniform");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_750)
+            .Because("capacity probes apply uniform headroom to the target-bounded RTT horizon");
     }
 
     [Test]
@@ -370,10 +370,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(1.0));
 
         // Both samples measure 100,000 B/s. The later back-to-back 100ms service sample
-        // raises the loaded horizon — clamped to twice the retained 5ms base RTT, so the
-        // floor is 1.5 × 10ms — while the base RTT itself remains unchanged.
+        // raises the preferred safety horizon above the 10ms cap while the 5ms base RTT
+        // remains unchanged, so the latency target limits the budget to 10ms of rate.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]
@@ -398,10 +398,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 500, 0.005, T0);
         Ack(budget, 500, 0.005, T0 + Seconds(0.051));
 
-        // Expiring the minimum with a loaded sample starts a brief target-only drain,
+        // Expiring the minimum with a loaded sample starts a brief one-BDP drain,
         // rather than immediately accepting the 100ms queueing delay as base RTT.
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
 
         Ack(budget, 5_000, 0.050, T0 + Seconds(10.2));
         Ack(budget, 500, 0.005, T0 + Seconds(10.31));
@@ -411,7 +411,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // pipelined delivery credit flows through the delivered-counter delta rather than
         // a shrunken inter-ack interval. Normal operation restores the serving-RTT floor.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]
@@ -480,10 +480,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.1));
         Ack(budget, 5_000, 0.050, T0 + Seconds(10.16));
 
-        // The 100ms sample that starts the refresh keeps the target-only drain active.
+        // The 100ms sample that starts the refresh keeps the one-BDP drain active.
         // Sizing from the stale 5ms minimum would have ended after the 50ms floor and
         // accepted the still-loaded 50ms sample as base RTT, inflating this to 7,500.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
 
     [Test]
@@ -497,7 +497,9 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.Charge(11_000);
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
-        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.451))).IsFalse();
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp"))
+            .IsLessThanOrEqualTo(T0 + Seconds(10.45));
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.452))).IsTrue();
     }
 
     [Test]
@@ -507,14 +509,14 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 10_000, 0.100, T0);
         Ack(budget, 10_000, 0.100, T0 + Seconds(0.101));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
 
         Ack(budget, 20_000, 0.200, T0 + Seconds(10.2));
         await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
 
         SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(10.401));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(15_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
     }
 
     [Test]
@@ -529,7 +531,9 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.3))).IsTrue();
         await Assert.That(budget.IsOverBudget()).IsTrue();
-        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.401))).IsFalse();
+        await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(10.402))).IsTrue();
+        await Assert.That(GetField<long>(budget, "_minRttProbeUntilTimestamp"))
+            .IsLessThanOrEqualTo(T0 + Seconds(10.4));
     }
 
     [Test]
@@ -567,7 +571,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // the retained 5ms base RTT, but it does restore a serving-RTT safety horizon
         // (clamped to twice the base RTT).
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
     }
 
     [Test]
@@ -576,11 +580,11 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(3_000);
 
         Ack(budget, 1, 0.001, T0 + Seconds(11.0));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(1_000);
     }
 
     [Test]
@@ -589,10 +593,10 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
 
         EstablishRate(budget, bytesPerSecond: 100_000, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(100_000);
 
         Ack(budget, 100, 0.001, T0 + Seconds(11.0));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(100_000);
     }
 
     [Test]
@@ -602,7 +606,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 10, 0.0001, T0);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(100_000);
     }
 
     [Test]
@@ -643,7 +647,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // 1,000 bytes / 100ms request RTT = 10,000 B/s. The first request is enough to
         // establish rate; no preceding wall-clock ack timestamp is required.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(10_000);
     }
 
     [Test]
@@ -672,7 +676,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.100, T0);
         Ack(budget, 100, 0.100, T0 + Seconds(0.100));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(10_000);
     }
 
     [Test]
@@ -685,7 +689,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 1; i <= 23; i++)
             Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(1_000);
     }
 
     [Test]
@@ -700,7 +704,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 1; i <= 21; i++)
             Ack(budget, 100, 0.100, T0 + Seconds(i * 0.100), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThan(9_000)
             .Because("a two-second broker stall must not collapse the estimated pipe capacity");
     }
 
@@ -717,7 +721,7 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var second = 2; second <= 60; second += 2)
             Ack(budget, 100, 0.100, T0 + Seconds(second), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_500)
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThan(9_000)
             .Because("a transient one-minute rate dip must not self-ratchet a saturated producer");
     }
 
@@ -731,7 +735,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
         Ack(budget, 100, 0.100, T0 + Seconds(2.1), appLimitedAtSend: false);
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThan(9_000);
 
         Ack(budget, 100, 0.100, T0 + Seconds(3.0), appLimitedAtSend: true);
 
@@ -769,7 +773,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 1_000, 0.100, T0, appLimitedAtSend: false);
         Ack(budget, 100, 0.100, T0 + Seconds(2.1), appLimitedAtSend: false);
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(4_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsGreaterThan(9_000);
 
         Ack(budget, 100, 0.100, T0 + Seconds(4.3), appLimitedAtSend: true);
 
@@ -850,11 +854,11 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // Twenty fast acknowledgements cover only 500ms, so the 2-second maximum window
         // must retain the original 10,000 B/s observation.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(10_000);
 
-        Ack(budget, 10, 0.025, T0 + Seconds(2.1));
+        Ack(budget, 10, 0.025, T0 + Seconds(2.6));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(400);
     }
 
     [Test]
@@ -866,24 +870,24 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(375);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
@@ -1112,18 +1116,19 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task AdmissionPressureWithLatencyHeadroom_GrowsBudgetBeyondRateParity()
+    public async Task AdmissionPressureWithLatencyHeadroom_GrowsScaleWithinRttSafetyCap()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 32_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(10_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 
         // The drain estimate only ever measures traffic the gate admitted, so rate x target
         // is self-confirming at any throughput (#2008). Blocked demand with latency headroom
-        // must grow the budget past that parity so real capacity can be discovered.
+        // grows the target horizon so real capacity can be discovered. The RTT safety
+        // horizon remains the tighter cap on a low-latency link.
         var now = T0;
         for (var i = 0; i < 30; i++)
         {
@@ -1137,7 +1142,7 @@ public sealed class BrokerUnackedByteBudgetTests
         }
 
         await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(1.5);
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(15_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 
     [Test]
@@ -1163,7 +1168,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.LatencyBudgetScale).IsEqualTo(10.0).Within(0.000_001)
             .Because("a stale-high scale must stay within a short shrink-back window");
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(100_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
     }
 
     [Test]
@@ -1178,10 +1183,10 @@ public sealed class BrokerUnackedByteBudgetTests
         // One small response can arrive first after the larger budget is published.
         // It must not cancel the probe before other requests from the same RTT land.
         Ack(budget, 500, 0.100, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
         Ack(budget, 1_250, 0.100, T0 + Seconds(0.950));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(585);
     }
 
     [Test]
@@ -1196,7 +1201,8 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
+        budget.Release(5_100);
         await Assert.That(budget.IsOverBudget()).IsTrue()
             .Because("occupancy above the normal budget must reach the deadline-aware gate");
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse()
@@ -1220,7 +1226,7 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_minRttProbeUntilTimestamp", T0 + Seconds(0.050));
 
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.020))).IsTrue()
-            .Because("an active minimum-RTT probe must retain its target-only drain budget");
+            .Because("an active minimum-RTT probe must retain its one-BDP drain budget");
     }
 
     [Test]
@@ -1232,29 +1238,31 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
 
         // This request began before the probe opened at 800ms, so it cannot confirm
         // capacity under the larger admission budget even though it completes later.
         Ack(budget, 1_000, 0.200, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
 
         // First request wholly admitted under the probe starts three RTTs of measurement.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
 
         // Target horizon is longer than three RTTs, so measurement continues until 500ms
         // after the first wholly admitted response.
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(6_250);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
 
         Ack(budget, 1_000, 0.100, T0 + Seconds(1.500));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse();
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
     }
 
     [Test]
@@ -1341,17 +1349,19 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         Ack(budget, 1_250, 0.100, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(7_812);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(585);
+        var firstRungBudget = budget.BudgetBytes;
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(8_787);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(firstRungBudget);
+        var secondRungBudget = budget.BudgetBytes;
 
         // The probe averages three RTTs before ratcheting to the higher level.
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(secondRungBudget);
 
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(8_787);
+        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(secondRungBudget);
 
         // The ratcheted level gets another full-window average. Comparing average with
         // average lets the sustained 25% gain advance the next rung as well.
@@ -1363,7 +1373,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.800));
         Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
         Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_762);
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(secondRungBudget);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
     }
@@ -1392,7 +1402,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 100, 0.100, T0);
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(200)
-            .Because("minimum-RTT probes must publish a target-only budget that drains standing queueing");
+            .Because("minimum-RTT probes must publish a one-BDP budget that drains standing queueing");
 
         budget.ObserveWrittenUnackedBytes(20_000);
         Ack(budget, 100, 0.100, T0 + Seconds(0.101));
@@ -1417,7 +1427,7 @@ public sealed class BrokerUnackedByteBudgetTests
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
 
-        // 100,000 B/s drain at negligible RTT => rate budget 1,000 bytes. Feed the
+        // 100,000 B/s drain at negligible RTT => the configured 200-byte floor. Feed the
         // published budget back as observed occupancy each round — the exact feedback
         // shape that previously ratcheted the budget to its cap.
         Ack(budget, 100, 0.001, T0);
@@ -1427,8 +1437,8 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 100, 0.001, T0 + Seconds(i * 0.100));
         }
 
-        // Fixed point is the rate budget, not a multiple of it or the 1,000,000-byte cap.
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        // Fixed point is the floor, not a multiple of it or the 1,000,000-byte cap.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
     }
 
     [Test]
@@ -1601,7 +1611,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // took to arrive, not its own 5ms sojourn (which would read 20 MB/s).
         Ack(budget, 100_000, 0.005, T0 + Seconds(0.5), appLimitedAtSend: false);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(100_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(200_000);
     }
 
     [Test]
@@ -1615,7 +1625,7 @@ public sealed class BrokerUnackedByteBudgetTests
         // sample uses the request's own 5ms sojourn (20 MB/s, budget clamps to cap).
         Ack(budget, 100_000, 0.005, T0 + Seconds(5.0));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(20_000_000);
     }
 
     [Test]
@@ -1645,12 +1655,13 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
+        budget.Release(5_100);
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse();
         await Assert.That(budget.GetAdmissionRecheckDelayMilliseconds(T0 + Seconds(0.900)))
             .IsEqualTo(700);
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(1.601))).IsTrue();
 
-        budget.Release(5_500);
+        budget.Release(400);
     }
 
     [Test]
@@ -1661,7 +1672,7 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_000, 0.010, T0);
         Ack(budget, 1_000, 0.010, T0 + Seconds(1.0));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(50_000);
+        await Assert.That(budget.MaxRateBytesPerSecond).IsEqualTo(100_000);
     }
 
     [Test]
@@ -1674,7 +1685,7 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(6_400);
 
         // With a rate established, a cap below the computed budget clamps it...
-        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.001); // budget 1,500
+        EstablishRate(budget, bytesPerSecond: 3_000, rttSeconds: 0.5); // budget 1,500
         budget.SetCap(1_000, T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -220,7 +220,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
     }
 
     [Test]
-    public async Task BrokerBudgetFloor_UsesMeasuredTimeBudget_NotFixedBatchBytes()
+    public async Task BrokerBudgetHorizon_UsesMeasuredBdp_NotFixedBatchBytes()
     {
         await using var accumulator = new RecordAccumulator(
             CreateOptions(deliveryLatencyTargetMs: 10),
@@ -234,8 +234,8 @@ public sealed class ProducerDeliveryDiagnosticsTests
             now);
         budget.CompleteAckedPass(now);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000)
-            .Because("100 kB/s at a 10 ms target needs a 1 kB time-derived budget");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100)
+            .Because("100 kB/s at a 1 ms RTT needs a 100-byte measured BDP");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3585,6 +3585,33 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task DrainPendingAppends_BusyGuard_RecordsRetryRequest()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        var pool = new PendingAppendPool(1);
+        var op = CreatePendingAppend(accumulator, pool);
+        var queue = GetPrivateField<ConcurrentQueue<PendingAppend>>(accumulator, "_pendingAppends");
+
+        queue.Enqueue(op);
+        SetPrivateField(accumulator, "_draining", 1);
+        var requestVersion = GetPrivateField<long>(accumulator, "_pendingAppendDrainRequestVersion");
+
+        try
+        {
+            await Assert.That(accumulator.DrainPendingAppends()).IsFalse();
+            await Assert.That(GetPrivateField<long>(accumulator, "_pendingAppendDrainRequestVersion"))
+                .IsEqualTo(requestVersion + 1);
+        }
+        finally
+        {
+            SetPrivateField(accumulator, "_draining", 0);
+            queue.TryDequeue(out _);
+            if (op.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                op.ReturnToPoolAfterTryFail();
+        }
+    }
+
+    [Test]
     public async Task PendingAppend_AdmissionRecheckKeepsEarlierDeadline()
     {
         await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3612,6 +3612,64 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task DrainPendingAppends_CompetingWake_RescansReleasedBudget()
+    {
+        using var secondPartitionResolverEntered = new ManualResetEventSlim();
+        using var continueSecondPartitionResolver = new ManualResetEventSlim();
+        var secondPartitionResolverCalls = 0;
+        int ResolveLeaderId(string _, int partition)
+        {
+            if (partition == 1 && Interlocked.Increment(ref secondPartitionResolverCalls) == 1)
+            {
+                secondPartitionResolverEntered.Set();
+                if (!continueSecondPartitionResolver.Wait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("Timed out waiting to continue the partition 1 leader resolver.");
+            }
+
+            return partition;
+        }
+
+        var options = CreatePendingAppendTestOptions(unackedByteBudgetCapOverride: 1);
+        await using var accumulator = new RecordAccumulator(options, resolveLeaderId: ResolveLeaderId);
+        var pool = new PendingAppendPool(2);
+        var first = CreatePendingAppend(accumulator, pool, partition: 0, partitionCount: 2);
+        var second = CreatePendingAppend(accumulator, pool, partition: 1, partitionCount: 2);
+        var firstResult = new ValueTask<bool>((IValueTaskSource<bool>)first, first.Version).AsTask();
+        var queue = GetPrivateField<ConcurrentQueue<PendingAppend>>(accumulator, "_pendingAppends");
+        var firstBudget = accumulator.GetBrokerUnackedBudget(0)!;
+        var secondBudget = accumulator.GetBrokerUnackedBudget(1)!;
+        var firstCharge = firstBudget.BudgetBytes;
+        var secondCharge = secondBudget.BudgetBytes;
+        firstBudget.Charge(firstCharge);
+        secondBudget.Charge(secondCharge);
+        queue.Enqueue(first);
+        queue.Enqueue(second);
+
+        var ownerDrain = Task.Run(accumulator.DrainPendingAppends);
+        try
+        {
+            await Assert.That(secondPartitionResolverEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            firstBudget.Release(firstCharge);
+            await Assert.That(accumulator.DrainPendingAppends()).IsFalse();
+            continueSecondPartitionResolver.Set();
+
+            await Assert.That(await ownerDrain.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(await firstResult.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(second.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            continueSecondPartitionResolver.Set();
+            await ownerDrain.WaitAsync(TimeSpan.FromSeconds(5));
+            secondBudget.Release(secondCharge);
+            queue.TryDequeue(out _);
+            if (second.TryFail(new ObjectDisposedException(nameof(RecordAccumulator))))
+                second.ReturnToPoolAfterTryFail();
+        }
+    }
+
+    [Test]
     public async Task PendingAppend_AdmissionRecheckKeepsEarlierDeadline()
     {
         await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
@@ -3927,14 +3985,18 @@ public class RecordAccumulatorTests
         lockField!.SetValue(partitionDeque, Activator.CreateInstance(lockField.FieldType, [true]));
     }
 
-    private static PendingAppend CreatePendingAppend(RecordAccumulator accumulator, PendingAppendPool pool)
+    private static PendingAppend CreatePendingAppend(
+        RecordAccumulator accumulator,
+        PendingAppendPool pool,
+        int partition = 0,
+        int partitionCount = 1)
     {
         var now = Dekaf.MonotonicClock.GetMilliseconds();
         var op = pool.Rent();
         op.Initialize(
             "test-topic",
-            partition: 0,
-            partitionCount: 1,
+            partition,
+            partitionCount,
             timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             key: PooledMemory.Null,
             value: PooledMemory.Null,
@@ -3951,13 +4013,15 @@ public class RecordAccumulatorTests
         return op;
     }
 
-    private static ProducerOptions CreatePendingAppendTestOptions() => new()
+    private static ProducerOptions CreatePendingAppendTestOptions(
+        long? unackedByteBudgetCapOverride = null) => new()
     {
         BootstrapServers = new[] { "localhost:9092" },
         BufferMemory = 4096,
         BatchSize = 4096,
         LingerMs = 10,
-        MaxBlockMs = 30000
+        MaxBlockMs = 30000,
+        UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride
     };
 
     private static void InvokePendingAppendTimeout(PendingAppend op)


### PR DESCRIPTION
## Summary

- make the latency target cap the preferred RTT safety horizon instead of forcing a target-sized queue
- retain at least one measured BDP so high-RTT links remain throughput-safe
- preserve decay hysteresis, occupancy bounds, minimum-RTT drains, and capacity probes
- update public XML docs and controller tests for the new horizon semantics

Fixes #2108

## Verification

- `dotnet build Dekaf.sln --no-restore -c Release`: passed, 0 warnings
- net10 unit suite: 5544/5544 passed
- net8 budget state machine: 88/88 passed
- net8 diagnostics regression: 1/1 passed
- net8 full suite: 5436/5437 passed; unrelated `MetadataRerank_RequestTimeoutClearsMigrationFence` failed in untouched `BrokerSender.SumEncodedBytes`

A paired producer stress workflow will validate the required latency/throughput gate on this branch.