### PR TITLE
Fix consumer Gen2 collections under memory pressure

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1115,12 +1115,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,
-            ResponseBufferPool.Create(
-                CalculateMaximumFetchResponsePayloadBytes(options),
-                PoolSizing.ForConsumerResponseBuffers(
-                    options.BootstrapServers.Count,
-                    options.PrefetchPipelineDepth,
-                    options.MaxConnectionsPerBroker)),
+            CreateResponseBufferPool(options),
             telemetryMetricCollector: telemetryMetricCollector);
 
         var metadataManager = new MetadataManager(
@@ -1130,6 +1125,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             logger: loggerFactory?.CreateLogger<MetadataManager>());
 
         return (connectionPool, metadataManager, telemetryMetricCollector);
+    }
+
+    private static ResponseBufferPool CreateResponseBufferPool(ConsumerOptions options)
+    {
+        var responseBufferWorkingSet = PoolSizing.ForConsumerResponseBuffers(
+            options.BootstrapServers.Count,
+            options.PrefetchPipelineDepth,
+            options.MaxConnectionsPerBroker);
+        return ResponseBufferPool.Create(
+            CalculateMaximumFetchResponsePayloadBytes(options),
+            managedArraysPerBucket: responseBufferWorkingSet,
+            maxRetainedNativeBuffers: responseBufferWorkingSet);
     }
 
     internal static int CalculateMaximumFetchResponsePayloadBytes(ConsumerOptions options)

--- a/src/Dekaf/Internal/PoolSizing.cs
+++ b/src/Dekaf/Internal/PoolSizing.cs
@@ -23,8 +23,8 @@ internal static class PoolSizing
     private const int MaxValueTaskSources = 65536;
     private const int MinConsumerPrefetchBufferCapacity = 16;
     private const int MaxConsumerPrefetchBufferCapacity = 1024;
-    private const int MinConsumerResponseBuffersPerBucket = 16;
-    private const int MaxConsumerResponseBuffersPerBucket = 256;
+    private const int MinConsumerResponseBuffers = 16;
+    private const int MaxConsumerResponseBuffers = 256;
     private const int MinConsumerParsedRecordSlabsPerBucket = 16;
     private const int MaxConsumerParsedRecordSlabsPerBucket = 64;
 
@@ -168,6 +168,12 @@ internal static class PoolSizing
             MaxConsumerPrefetchBufferCapacity);
     }
 
+    /// <summary>
+    /// Returns the total response-buffer working set across brokers, pipeline slots, and
+    /// connections. The native response pool uses this as one global retention allowance
+    /// across capacity buckets so adaptive response sizes cannot multiply unmanaged memory.
+    /// The managed <see cref="ArrayPool{T}"/> uses the same depth independently per bucket.
+    /// </summary>
     internal static int ForConsumerResponseBuffers(
         int brokerCount,
         int prefetchPipelineDepth,
@@ -182,8 +188,8 @@ internal static class PoolSizing
 
         return ClampPoolDepth(
             liveResponseBuffers,
-            MinConsumerResponseBuffersPerBucket,
-            MaxConsumerResponseBuffersPerBucket);
+            MinConsumerResponseBuffers,
+            MaxConsumerResponseBuffers);
     }
 
     private static long CeilingDivide(long value, long divisor) =>

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3834,20 +3834,39 @@ internal sealed class ResponseBufferPool
     /// that don't have consumer-specific configuration.
     /// </summary>
     private const int DefaultMaxArraysPerBucket = 4;
-    internal static readonly ResponseBufferPool Default = new(DefaultMaxArrayLength, DefaultMaxArraysPerBucket);
+#if !NETSTANDARD2_0
+    private const long NativeMemoryPressureRefreshMilliseconds = 1_000;
+#endif
+    internal static readonly ResponseBufferPool Default = new(
+        DefaultMaxArrayLength,
+        DefaultMaxArraysPerBucket,
+        monitorNativeMemoryPressure: true);
     private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), ResponseBufferPool>
         s_sharedPools = new();
     private readonly ConcurrentDictionary<int, NativeBufferBucket> _nativeBuckets = new();
+    private int _retainedNativeBufferCount;
+    private int _highNativeMemoryPressure;
+#if !NETSTANDARD2_0
+    private long _nextNativeMemoryPressureRefresh;
+    private readonly bool _monitorNativeMemoryPressure;
+#endif
 
     internal ArrayPool<byte> Pool { get; }
     internal int MaxArrayLength { get; }
     internal int MaxArraysPerBucket { get; }
+    internal int RetainedNativeBufferCount => Volatile.Read(ref _retainedNativeBufferCount);
 
-    internal ResponseBufferPool(int maxArrayLength, int maxArraysPerBucket = DefaultMaxArraysPerBucket)
+    internal ResponseBufferPool(
+        int maxArrayLength,
+        int maxArraysPerBucket = DefaultMaxArraysPerBucket,
+        bool monitorNativeMemoryPressure = false)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxArraysPerBucket);
         MaxArrayLength = maxArrayLength;
         MaxArraysPerBucket = maxArraysPerBucket;
+#if !NETSTANDARD2_0
+        _monitorNativeMemoryPressure = monitorNativeMemoryPressure;
+#endif
         Pool = ArrayPool<byte>.Create(
             maxArrayLength: maxArrayLength,
             maxArraysPerBucket: maxArraysPerBucket);
@@ -3869,7 +3888,8 @@ internal sealed class ResponseBufferPool
                 (maxArrayLength, maxArraysPerBucket),
                 static configuration => new ResponseBufferPool(
                     configuration.MaxArrayLength,
-                    configuration.MaxArraysPerBucket));
+                    configuration.MaxArraysPerBucket,
+                    monitorNativeMemoryPressure: true));
     }
 
     internal static int ComputeMaxArrayLength(int fetchMaxBytes)
@@ -3894,19 +3914,89 @@ internal sealed class ResponseBufferPool
         var capacity = RoundUpToPowerOfTwo(minimumLength);
         var bucket = _nativeBuckets.GetOrAdd(
             capacity,
-            static (size, retention) => new NativeBufferBucket(size, retention),
-            MaxArraysPerBucket);
-        return NativeResponseBuffer.Rent(this, bucket.Rent(), capacity);
+            static _ => new NativeBufferBucket());
+        if (bucket.TryRent(out var pointer))
+        {
+            Interlocked.Decrement(ref _retainedNativeBufferCount);
+            return NativeResponseBuffer.Rent(this, pointer, capacity);
+        }
+
+        return NativeResponseBuffer.Rent(this, Marshal.AllocHGlobal(capacity), capacity);
     }
 
     internal void ReturnNative(IntPtr pointer, int capacity)
     {
+#if !NETSTANDARD2_0
+        RefreshNativeMemoryPressure();
+#endif
+        if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
+        {
+            Marshal.FreeHGlobal(pointer);
+            return;
+        }
+
+        if (Interlocked.Increment(ref _retainedNativeBufferCount) > MaxArraysPerBucket)
+        {
+            Interlocked.Decrement(ref _retainedNativeBufferCount);
+            Marshal.FreeHGlobal(pointer);
+            return;
+        }
+
         var bucket = _nativeBuckets.GetOrAdd(
             capacity,
-            static (size, retention) => new NativeBufferBucket(size, retention),
-            MaxArraysPerBucket);
+            static _ => new NativeBufferBucket());
         bucket.Return(pointer);
+
+        // Pressure can begin after the first check but before this buffer is published.
+        if (Volatile.Read(ref _highNativeMemoryPressure) != 0)
+            TrimNativeBuffers();
     }
+
+    internal int TrimNativeBuffers()
+    {
+        var released = 0;
+        foreach (var bucket in _nativeBuckets.Values)
+            released += bucket.Trim();
+
+        if (released > 0)
+            Interlocked.Add(ref _retainedNativeBufferCount, -released);
+        return released;
+    }
+
+    internal static bool IsHighMemoryLoad(long memoryLoadBytes, long highMemoryLoadThresholdBytes)
+        => highMemoryLoadThresholdBytes > 0 && memoryLoadBytes >= highMemoryLoadThresholdBytes;
+
+    internal void UpdateNativeMemoryPressure(long memoryLoadBytes, long highMemoryLoadThresholdBytes)
+    {
+        var isHigh = IsHighMemoryLoad(memoryLoadBytes, highMemoryLoadThresholdBytes);
+        var wasHigh = Interlocked.Exchange(ref _highNativeMemoryPressure, isHigh ? 1 : 0) != 0;
+        if (isHigh && !wasHigh)
+            TrimNativeBuffers();
+    }
+
+#if !NETSTANDARD2_0
+    private void RefreshNativeMemoryPressure()
+    {
+        if (!_monitorNativeMemoryPressure)
+            return;
+
+        var now = Environment.TickCount64;
+        var nextRefresh = Volatile.Read(ref _nextNativeMemoryPressureRefresh);
+        if (now < nextRefresh
+            || Interlocked.CompareExchange(
+                ref _nextNativeMemoryPressureRefresh,
+                now + NativeMemoryPressureRefreshMilliseconds,
+                nextRefresh) != nextRefresh)
+        {
+            return;
+        }
+
+        var memoryInfo = GC.GetGCMemoryInfo();
+        UpdateNativeMemoryPressure(
+            memoryInfo.MemoryLoadBytes,
+            memoryInfo.HighMemoryLoadThresholdBytes);
+    }
+#endif
 
     private static int RoundUpToPowerOfTwo(int value)
     {
@@ -3923,32 +4013,24 @@ internal sealed class ResponseBufferPool
         return (int)rounded;
     }
 
-    private sealed class NativeBufferBucket(int capacity, int maxRetained)
+    private sealed class NativeBufferBucket
     {
         private readonly ConcurrentStack<IntPtr> _buffers = new();
-        private int _retained;
 
-        internal IntPtr Rent()
+        internal bool TryRent(out IntPtr pointer) => _buffers.TryPop(out pointer);
+
+        internal void Return(IntPtr pointer) => _buffers.Push(pointer);
+
+        internal int Trim()
         {
-            if (_buffers.TryPop(out var pointer))
+            var released = 0;
+            while (_buffers.TryPop(out var pointer))
             {
-                Interlocked.Decrement(ref _retained);
-                return pointer;
+                Marshal.FreeHGlobal(pointer);
+                released++;
             }
 
-            return Marshal.AllocHGlobal(capacity);
-        }
-
-        internal void Return(IntPtr pointer)
-        {
-            if (Interlocked.Increment(ref _retained) <= maxRetained)
-            {
-                _buffers.Push(pointer);
-                return;
-            }
-
-            Interlocked.Decrement(ref _retained);
-            Marshal.FreeHGlobal(pointer);
+            return released;
         }
     }
 }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3833,15 +3833,18 @@ internal sealed class ResponseBufferPool
     /// Default shared instance used by producers, admin clients, and connections
     /// that don't have consumer-specific configuration.
     /// </summary>
-    private const int DefaultMaxArraysPerBucket = 4;
+    private const int DefaultManagedArraysPerBucket = 4;
 #if !NETSTANDARD2_0
     private const long NativeMemoryPressureRefreshMilliseconds = 1_000;
 #endif
     internal static readonly ResponseBufferPool Default = new(
         DefaultMaxArrayLength,
-        DefaultMaxArraysPerBucket,
+        DefaultManagedArraysPerBucket,
+        maxRetainedNativeBuffers: DefaultManagedArraysPerBucket,
         monitorNativeMemoryPressure: true);
-    private static readonly ConcurrentDictionary<(int MaxArrayLength, int MaxArraysPerBucket), ResponseBufferPool>
+    private static readonly ConcurrentDictionary<
+        (int MaxArrayLength, int ManagedArraysPerBucket, int MaxRetainedNativeBuffers),
+        ResponseBufferPool>
         s_sharedPools = new();
     private readonly ConcurrentDictionary<int, NativeBufferBucket> _nativeBuckets = new();
     private int _retainedNativeBufferCount;
@@ -3853,23 +3856,28 @@ internal sealed class ResponseBufferPool
 
     internal ArrayPool<byte> Pool { get; }
     internal int MaxArrayLength { get; }
-    internal int MaxArraysPerBucket { get; }
+    internal int ManagedArraysPerBucket { get; }
+    internal int MaxRetainedNativeBuffers { get; }
     internal int RetainedNativeBufferCount => Volatile.Read(ref _retainedNativeBufferCount);
 
     internal ResponseBufferPool(
         int maxArrayLength,
-        int maxArraysPerBucket = DefaultMaxArraysPerBucket,
+        int managedArraysPerBucket = DefaultManagedArraysPerBucket,
+        int? maxRetainedNativeBuffers = null,
         bool monitorNativeMemoryPressure = false)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxArraysPerBucket);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(managedArraysPerBucket);
+        var nativeRetentionLimit = maxRetainedNativeBuffers ?? managedArraysPerBucket;
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(nativeRetentionLimit);
         MaxArrayLength = maxArrayLength;
-        MaxArraysPerBucket = maxArraysPerBucket;
+        ManagedArraysPerBucket = managedArraysPerBucket;
+        MaxRetainedNativeBuffers = nativeRetentionLimit;
 #if !NETSTANDARD2_0
         _monitorNativeMemoryPressure = monitorNativeMemoryPressure;
 #endif
         Pool = ArrayPool<byte>.Create(
             maxArrayLength: maxArrayLength,
-            maxArraysPerBucket: maxArraysPerBucket);
+            maxArraysPerBucket: managedArraysPerBucket);
     }
 
     /// <summary>
@@ -3879,16 +3887,21 @@ internal sealed class ResponseBufferPool
     /// </summary>
     internal static ResponseBufferPool Create(
         int fetchMaxBytes,
-        int maxArraysPerBucket = DefaultMaxArraysPerBucket)
+        int managedArraysPerBucket = DefaultManagedArraysPerBucket,
+        int? maxRetainedNativeBuffers = null)
     {
         var maxArrayLength = ComputeMaxArrayLength(fetchMaxBytes);
-        return maxArrayLength == DefaultMaxArrayLength && maxArraysPerBucket == DefaultMaxArraysPerBucket
+        var nativeRetentionLimit = maxRetainedNativeBuffers ?? managedArraysPerBucket;
+        return maxArrayLength == DefaultMaxArrayLength
+            && managedArraysPerBucket == DefaultManagedArraysPerBucket
+            && nativeRetentionLimit == DefaultManagedArraysPerBucket
             ? Default
             : s_sharedPools.GetOrAdd(
-                (maxArrayLength, maxArraysPerBucket),
+                (maxArrayLength, managedArraysPerBucket, nativeRetentionLimit),
                 static configuration => new ResponseBufferPool(
                     configuration.MaxArrayLength,
-                    configuration.MaxArraysPerBucket,
+                    configuration.ManagedArraysPerBucket,
+                    configuration.MaxRetainedNativeBuffers,
                     monitorNativeMemoryPressure: true));
     }
 
@@ -3935,7 +3948,7 @@ internal sealed class ResponseBufferPool
             return;
         }
 
-        if (Interlocked.Increment(ref _retainedNativeBufferCount) > MaxArraysPerBucket)
+        if (Interlocked.Increment(ref _retainedNativeBufferCount) > MaxRetainedNativeBuffers)
         {
             Interlocked.Decrement(ref _retainedNativeBufferCount);
             Marshal.FreeHGlobal(pointer);
@@ -3977,6 +3990,8 @@ internal sealed class ResponseBufferPool
 #if !NETSTANDARD2_0
     private void RefreshNativeMemoryPressure()
     {
+        // Sampling is demand-driven to avoid one background timer per shared pool. An idle
+        // pool remains bounded by MaxRetainedNativeBuffers and trims on its next return.
         if (!_monitorNativeMemoryPressure)
             return;
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
@@ -86,11 +86,13 @@ public sealed class ConsumerResponseBufferSizingTests
         var connectionPool = GetField<ConnectionPool>(consumer, "_connectionPool");
         var responsePool = GetField<ResponseBufferPool>(connectionPool, "_responseBufferPool");
 
-        await Assert.That(responsePool.MaxArraysPerBucket).IsEqualTo(
-            PoolSizing.ForConsumerResponseBuffers(
-                options.BootstrapServers.Count,
-                options.PrefetchPipelineDepth,
-                options.MaxConnectionsPerBroker));
+        var expectedWorkingSet = PoolSizing.ForConsumerResponseBuffers(
+            options.BootstrapServers.Count,
+            options.PrefetchPipelineDepth,
+            options.MaxConnectionsPerBroker);
+
+        await Assert.That(responsePool.ManagedArraysPerBucket).IsEqualTo(expectedWorkingSet);
+        await Assert.That(responsePool.MaxRetainedNativeBuffers).IsEqualTo(expectedWorkingSet);
     }
 
     private static T GetField<T>(object target, string name) =>

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -135,6 +135,72 @@ public class ResponseBufferPoolTests
     }
 
     [Test]
+    public async Task NativePool_BoundsRetentionAcrossSizeBuckets()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes * 2);
+
+        first.Return();
+        second.Return();
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(1)
+            .Because("the pipeline working-set allowance is global, not per size bucket");
+    }
+
+    [Test]
+    public async Task NativePool_TrimReleasesAllDormantBuffers()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 4);
+        var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes * 2);
+        first.Return();
+        second.Return();
+
+        var released = pool.TrimNativeBuffers();
+
+        await Assert.That(released).IsEqualTo(2);
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(89, 90, false)]
+    [Arguments(90, 90, true)]
+    [Arguments(91, 90, true)]
+    [Arguments(1, 0, false)]
+    public async Task NativePool_HighMemoryLoadUsesRuntimeThreshold(
+        long memoryLoadBytes,
+        long highMemoryLoadThresholdBytes,
+        bool expected)
+    {
+        await Assert.That(ResponseBufferPool.IsHighMemoryLoad(
+                memoryLoadBytes,
+                highMemoryLoadThresholdBytes))
+            .IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task NativePool_MemoryPressureTrimsAndSuspendsRetention()
+    {
+        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 2);
+        var dormant = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        dormant.Return();
+
+        pool.UpdateNativeMemoryPressure(memoryLoadBytes: 90, highMemoryLoadThresholdBytes: 90);
+
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
+        var underPressure = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        underPressure.Return();
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(0);
+
+        pool.UpdateNativeMemoryPressure(memoryLoadBytes: 89, highMemoryLoadThresholdBytes: 90);
+        var recovered = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
+        recovered.Return();
+        await Assert.That(pool.RetainedNativeBufferCount).IsEqualTo(1);
+        pool.TrimNativeBuffers();
+    }
+
+    [Test]
     public async Task NativeBuffer_TransferOwnershipReturnsBufferOnce()
     {
         var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseBufferPoolTests.cs
@@ -120,7 +120,7 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativePool_ReusesReturnedLargeBuffer()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 1);
         var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         var address = first.Address;
         first.GetSpan()[0] = 42;
@@ -137,7 +137,10 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativePool_BoundsRetentionAcrossSizeBuckets()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var pool = new ResponseBufferPool(
+            1024 * 1024,
+            managedArraysPerBucket: 4,
+            maxRetainedNativeBuffers: 1);
         var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes * 2);
 
@@ -151,7 +154,7 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativePool_TrimReleasesAllDormantBuffers()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 4);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 4);
         var first = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         var second = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes * 2);
         first.Return();
@@ -182,7 +185,7 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativePool_MemoryPressureTrimsAndSuspendsRetention()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 2);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 2);
         var dormant = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         dormant.Return();
 
@@ -203,7 +206,7 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativeBuffer_TransferOwnershipReturnsBufferOnce()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 1);
         var native = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         var address = native.Address;
         native.GetSpan()[0] = 99;
@@ -222,7 +225,7 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task NativeBuffer_SlicedMemoryCopyPreservesOffset()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 1);
         var native = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         native.GetSpan().Clear();
         var source = new byte[] { 10, 20, 30, 40 };
@@ -351,12 +354,25 @@ public class ResponseBufferPoolTests
     [Test]
     public async Task Create_DifferentRetentionDepths_UseDifferentSharedPools()
     {
-        var shallow = ResponseBufferPool.Create(20 * 1024 * 1024, maxArraysPerBucket: 4);
-        var consumer = ResponseBufferPool.Create(20 * 1024 * 1024, maxArraysPerBucket: 16);
+        var shallow = ResponseBufferPool.Create(
+            20 * 1024 * 1024,
+            managedArraysPerBucket: 4,
+            maxRetainedNativeBuffers: 4);
+        var consumer = ResponseBufferPool.Create(
+            20 * 1024 * 1024,
+            managedArraysPerBucket: 16,
+            maxRetainedNativeBuffers: 16);
+        var nativeShallow = ResponseBufferPool.Create(
+            20 * 1024 * 1024,
+            managedArraysPerBucket: 16,
+            maxRetainedNativeBuffers: 4);
 
         await Assert.That(shallow).IsNotSameReferenceAs(consumer);
-        await Assert.That(shallow.MaxArraysPerBucket).IsEqualTo(4);
-        await Assert.That(consumer.MaxArraysPerBucket).IsEqualTo(16);
+        await Assert.That(nativeShallow).IsNotSameReferenceAs(consumer);
+        await Assert.That(shallow.ManagedArraysPerBucket).IsEqualTo(4);
+        await Assert.That(consumer.ManagedArraysPerBucket).IsEqualTo(16);
+        await Assert.That(nativeShallow.ManagedArraysPerBucket).IsEqualTo(16);
+        await Assert.That(nativeShallow.MaxRetainedNativeBuffers).IsEqualTo(4);
         await Assert.That(ResponseBufferPool.Create(20 * 1024 * 1024, 16))
             .IsSameReferenceAs(consumer);
     }

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -185,7 +185,7 @@ public sealed class ResponseFrameReaderTests
     [Test]
     public async Task ReadFrameAsync_EofMidNativeFrame_ReturnsBufferToPool()
     {
-        var pool = new ResponseBufferPool(1024 * 1024, maxArraysPerBucket: 1);
+        var pool = new ResponseBufferPool(1024 * 1024, managedArraysPerBucket: 1);
         var seeded = pool.RentNative(ResponseBufferPool.NativeMemoryThresholdBytes);
         var address = seeded.Address;
         seeded.Return();


### PR DESCRIPTION
Fixes #2112

## Root cause

Live-heap and EventPipe GC profiling showed value strings dying in Gen0 and only ~9 MB retained in Gen2. Full collections were `InducedLowMemory`, not large managed allocations. The native response pool retained dormant unmanaged buffers independently in every adaptive capacity bucket and never trimmed them under process memory pressure.

## Change

- bound native response-buffer retention globally across capacity buckets, using the total consumer pipeline working set
- keep the native global allowance distinct from the managed ArrayPool per-bucket depth
- sample runtime memory load at most once per second on native returns (demand-driven: quiet pools stay bounded and trim on their next return, avoiding a timer per shared pool)
- trim dormant native buffers and suspend retention while runtime high-memory pressure is active
- preserve `netstandard2.0` compatibility where memory-load telemetry is unavailable
- cover cross-bucket bounds, trimming, thresholds, pressure transitions, and recovery

## Validation

- `dotnet build Dekaf.sln -c Release --no-restore`: 0 warnings, 0 errors
- net10 unit tests: 5551 passed
- net8 unit tests: 5444 passed
- focused response-pool tests: 29 passed
- one-minute local consumer stress under high host memory load: Gen2 reduced from 3 baseline to 2; allocation unchanged at 1.98 KB/msg; 71,911 msg/s
