### PR TITLE
Reduce transactional response continuation hops

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -105,6 +105,13 @@ public interface IKafkaConnection : IAsyncDisposable
 
 internal interface IKafkaPipelinedWriteCompletionConnection
 {
+    /// <summary>
+    /// Sends a pipelined request and returns its response handle after the socket write completes.
+    /// </summary>
+    /// <remarks>
+    /// Response completion runs inline on the receive-dispatch path. Code awaiting the returned
+    /// response must remain bounded and non-blocking until its next asynchronous yield.
+    /// </remarks>
     ValueTask<PipelinedResponse<TResponse>> SendPipelinedAfterWriteAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -723,11 +723,14 @@ public sealed partial class KafkaConnection :
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
+        // The pipelined wrapper performs bounded internal parsing, then only signals the
+        // sender. Resume it in the receive dispatch frame to avoid a ThreadPool round trip.
         pending.Initialize(
             responseHeaderVersion,
             cancellationToken,
             registerCancellation: false,
-            checkCrcs: request is FetchRequest { CheckCrcs: true });
+            checkCrcs: request is FetchRequest { CheckCrcs: true },
+            runContinuationsAsynchronously: false);
         try
         {
             AddPendingRequest(correlationId, pending);
@@ -4272,11 +4275,13 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         short responseHeaderVersion,
         CancellationToken cancellationToken,
         bool registerCancellation = true,
-        bool checkCrcs = false)
+        bool checkCrcs = false,
+        bool runContinuationsAsynchronously = true)
     {
         _responseHeaderVersion = responseHeaderVersion;
         _cancellationToken = cancellationToken;
         _checkCrcs = checkCrcs;
+        _core.RunContinuationsAsynchronously = runContinuationsAsynchronously;
         _state = CreateState(_core.Version, StatePending);
 
         // Register for cancellation if the token can be cancelled

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -505,7 +505,7 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
-    public async Task PipelinedResponse_ContinuationRunsInlineInCompletionFrame(
+    public async Task PipelinedResponse_ContinuationRunsInlineInReceiveDispatch(
         CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
@@ -528,14 +528,16 @@ public sealed class KafkaConnectionTests
             var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
             var completion = new TaskCompletionSource<ApiVersionsResponse>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
-            var ranInCompletionFrame = false;
+            var ranInReceiveDispatch = false;
             response.UnsafeOnCompleted(() =>
             {
-                ranInCompletionFrame = new StackTrace().GetFrames().Any(
-                    static frame => frame.GetMethod()?.Name == "CompletePendingResponse"
-                        && frame.GetMethod()?.DeclaringType?.Name.StartsWith(
-                            "PooledPipelinedResponse",
-                            StringComparison.Ordinal) == true);
+                var frames = new StackTrace().GetFrames();
+                ranInReceiveDispatch = frames.Any(
+                        static frame => frame.GetMethod()?.Name == "CompletePendingResponse"
+                            && frame.GetMethod()?.DeclaringType?.Name.StartsWith(
+                                "PooledPipelinedResponse",
+                                StringComparison.Ordinal) == true)
+                    && frames.Any(static frame => frame.GetMethod()?.Name == "DispatchResponse");
 
                 try
                 {
@@ -552,7 +554,7 @@ public sealed class KafkaConnectionTests
                 cancellationToken);
             var parsed = await completion.Task.WaitAsync(cancellationToken);
 
-            await Assert.That(ranInCompletionFrame).IsTrue();
+            await Assert.That(ranInReceiveDispatch).IsTrue();
             await Assert.That(parsed.ErrorCode).IsEqualTo(ErrorCode.None);
         }
         finally

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -851,15 +851,16 @@ public class PooledPendingRequestTests
     }
 
     [Test]
-    public async Task RunContinuationsAsynchronously_SurvivesResetAndReuse()
+    public async Task RunContinuationsAsynchronously_IsRestoredAfterInlineUse()
     {
-        // Regression test: RunContinuationsAsynchronously must remain true after
-        // Reset() and pool reuse. If it reverts to false, response continuations
-        // run inline on the receive loop thread, causing deadlocks when
-        // Send() → .GetAwaiter().GetResult() blocks that thread.
+        // Pipelined requests opt into inline internal continuations. A later direct request
+        // reusing the source must restore asynchronous application continuations.
         var pool = new PendingRequestPool();
         var request = pool.Rent();
-        request.Initialize(responseHeaderVersion: 0, CancellationToken.None);
+        request.Initialize(
+            responseHeaderVersion: 0,
+            CancellationToken.None,
+            runContinuationsAsynchronously: false);
 
         // Complete, reset, reuse — simulates pool lifecycle
         var testData = new byte[] { 0, 0, 0, 1, 10 };


### PR DESCRIPTION
Fixes #2111

## Root cause

Profiling showed transactional CPU dominated by ThreadPool wake/park churn. #2114 addresses the fixed 1 ms linger timer; this change removes a separate per-response dispatch: `PooledPendingRequest` forced `PooledPipelinedResponse.CompletePendingResponse` onto another worker even though that continuation performs only bounded internal parsing and sender signaling.

## Change

- configure pipelined pending requests for inline internal continuation
- keep direct request/application continuations asynchronous by default
- restore the continuation mode on every pooled-source initialization
- assert the pipelined completion stays inside the receive-dispatch frame and direct reuse returns to async mode

User transactional continuations remain governed by `InlineTransactionCompletions`; this change does not run arbitrary application code on the receive loop.

## Validation

- local 3-broker, one-minute transactional A/B on the same host:
  - CPU: 1184.48 → 953.95 μs/msg (-19.5%)
  - accepted throughput: 51.57 → 62.76 msg/s (+21.7%)
  - allocation: 892.73 → 825.43 B/msg (-7.5%)
  - both runs: zero shortfall, duplicates, aborted-record leaks, or verification errors
- net10 unit tests: 5544 passed
- net8 unit tests: 5437 passed
- solution build: 0 warnings, 0 errors