### PR TITLE
Add steady-state producer round-trip measurement

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -13,6 +13,7 @@ SCENARIO_TITLES = {
     'producer-async-idempotent': 'Producer (Async, Idempotent)',
     'producer-transactional': 'Producer (Transactional EOS)',
     'producer-roundtrip': 'Producer → Consumer Round-Trip',
+    'producer-roundtrip-steady': 'Producer → Consumer Round-Trip Steady State',
     'consumer': 'Consumer',
     'consumer-batch': 'Consumer (Batch)',
     'consumer-raw': 'Consumer (Raw Bytes)',
@@ -315,6 +316,7 @@ def _latency_identity(result):
         result.get('messageSizeBytes'),
         _latency_consumer_seed_batch_size(result),
         _latency_roundtrip_messages(result),
+        result.get('roundTripSteadySeconds'),
         paired_order_identity(result),
     )
 
@@ -336,6 +338,8 @@ def _latency_consumer_seed_batch_size(result):
 
 
 def _latency_roundtrip_messages(result):
+    if result.get('roundTripSteadySeconds') is not None:
+        return None
     validation = result.get('roundTripValidation')
     if isinstance(validation, dict):
         return validation.get('expectedMessages', result.get('roundTripMessages'))

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -30,6 +30,7 @@ _IDENTITY_FIELDS = (
     "consumerSeedBatchSizeBytes",
     "consumerConnectionsPerBroker",
     "roundTripMessages",
+    "roundTripSteadySeconds",
     "pairedClientOrder",
     "pairedSampleCount",
 )
@@ -53,6 +54,8 @@ def _finite_number(value):
 
 
 def _roundtrip_messages(result):
+    if result.get("roundTripSteadySeconds") is not None:
+        return None
     validation = result.get("roundTripValidation")
     if isinstance(validation, dict):
         return validation.get("expectedMessages", result.get("roundTripMessages"))
@@ -92,6 +95,7 @@ def _identity(result):
         _consumer_seed_batch_size(result),
         _consumer_connections_per_broker(result),
         _roundtrip_messages(result),
+        result.get("roundTripSteadySeconds"),
         paired_order_identity(result),
     )
 
@@ -113,6 +117,7 @@ def _pair_identity(result):
         result.get("messageSizeBytes"),
         _consumer_seed_batch_size(result),
         _roundtrip_messages(result),
+        result.get("roundTripSteadySeconds"),
         paired_order_identity(result),
     )
 

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from stress_trend import (
     HISTORY_LIMIT,
+    _identity,
+    _pair_identity,
     emit_annotations,
     evaluate_and_update,
     format_markdown,
@@ -83,6 +85,25 @@ def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
 
 
 class StressTrendTests(unittest.TestCase):
+    def test_steady_roundtrip_identity_uses_window_not_dynamic_message_count(self):
+        dekaf = result(
+            scenario="producer-roundtrip-steady",
+            client="Dekaf",
+            roundTripSteadySeconds=60,
+            roundTripValidation={"expectedMessages": 8_000_000},
+        )
+        confluent = result(
+            scenario="producer-roundtrip-steady",
+            client="Confluent",
+            roundTripSteadySeconds=60,
+            roundTripValidation={"expectedMessages": 10_000_000},
+        )
+
+        self.assertNotEqual(_identity(dekaf), _identity(confluent))
+        self.assertEqual(_pair_identity(dekaf), _pair_identity(confluent))
+        self.assertIn(60, _pair_identity(dekaf))
+        self.assertNotIn(8_000_000, _pair_identity(dekaf))
+
     def test_paired_latency_threshold_breach_fails_without_history(self):
         confluent = result(
             client="Confluent",

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -17,6 +17,10 @@ on:
         description: 'Bounded message count for round-trip correctness scenario'
         required: false
         default: '250000'
+      roundtrip_steady_seconds:
+        description: 'Measured producer duration for steady-state round-trip scenario'
+        required: false
+        default: '60'
       consumer_fetch_diagnostics:
         description: 'Enable Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead to the measured window)'
         required: false
@@ -102,6 +106,15 @@ jobs:
             artifact_suffix: ""
             timeout_minutes: 90
             name: Producer → Consumer Round-Trip (Paired)
+          - scenario: producer-roundtrip-steady
+            client: all
+            brokers: 1
+            run_3conn: false
+            artifact_suffix: ""
+            message_size: 128
+            roundtrip_steady_seconds: 60
+            timeout_minutes: 90
+            name: Producer → Consumer Round-Trip Steady State (Paired)
           - scenario: consumer
             client: all
             brokers: 1
@@ -278,7 +291,7 @@ jobs:
             # in-flight batch dump needed to debug it, instead of "Not captured".
             taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
               --duration ${{ github.event.inputs.duration_minutes || '15' }} \
-              --message-size ${{ github.event.inputs.message_size || '1000' }} \
+              --message-size ${{ matrix.message_size || github.event.inputs.message_size || '1000' }} \
               --scenario ${{ matrix.scenario }} \
               --client ${{ matrix.client }} \
               --brokers ${{ matrix.brokers }} \
@@ -286,6 +299,7 @@ jobs:
               --producer-delivery-diagnostics \
               ${EXTRA_ARGS} \
               --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
+              --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }} \
               --output ./results
           done
 
@@ -293,7 +307,7 @@ jobs:
             echo "Running Dekaf 3-connection variant on the same VM"
             taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
               --duration ${{ github.event.inputs.duration_minutes || '15' }} \
-              --message-size ${{ github.event.inputs.message_size || '1000' }} \
+              --message-size ${{ matrix.message_size || github.event.inputs.message_size || '1000' }} \
               --scenario ${{ matrix.scenario }} \
               --client dekaf \
               --brokers ${{ matrix.brokers }} \
@@ -301,6 +315,7 @@ jobs:
               --producer-delivery-diagnostics \
               ${EXTRA_ARGS} \
               --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
+              --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }} \
               --output ./results
           fi
 

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -14,6 +14,54 @@ namespace Dekaf.Tests.Unit.Stress;
 public class RoundTripMessageCodecTests
 {
     [Test]
+    public async Task ScenarioRegistry_SeparatesColdStartAndSteadyStateRoundTrips()
+    {
+        var scenarios = Dekaf.StressTests.Program.CreateAllScenarios()
+            .Where(scenario => scenario.Name.StartsWith("producer-roundtrip", StringComparison.Ordinal))
+            .Select(scenario => (scenario.Name, scenario.Client))
+            .ToArray();
+
+        await Assert.That(scenarios).IsEquivalentTo(new[]
+        {
+            ("producer-roundtrip", "Dekaf"),
+            ("producer-roundtrip", "Confluent"),
+            ("producer-roundtrip-steady", "Dekaf"),
+            ("producer-roundtrip-steady", "Confluent")
+        });
+    }
+
+    [Test]
+    [Arguments(false, 249_999, 0, false)]
+    [Arguments(false, 250_000, 0, true)]
+    [Arguments(true, 1, 59_999, false)]
+    [Arguments(true, 1, 60_000, true)]
+    public async Task ProduceLimit_UsesMessageCountForColdStartAndDurationForSteadyState(
+        bool steadyState,
+        int messagesProduced,
+        int elapsedMilliseconds,
+        bool expected)
+    {
+        var options = new StressTestOptions
+        {
+            BootstrapServers = "unused",
+            Topic = "unused",
+            DurationMinutes = 15,
+            MessageSizeBytes = 128,
+            RoundTripMessages = 250_000,
+            RoundTripSteadySeconds = 60,
+            ProgressWatchdog = null!
+        };
+
+        var reached = RoundTripScenarioHelpers.HasReachedProduceLimit(
+            options,
+            steadyState,
+            messagesProduced,
+            TimeSpan.FromMilliseconds(elapsedMilliseconds));
+
+        await Assert.That(reached).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task ExpectedPartition_MatchesJavaMurmur2Vector()
     {
         await Assert.That(RoundTripMessageCodec.GetExpectedPartition("user-123", partitionCount: 10))

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -19,13 +19,14 @@ namespace Dekaf.StressTests;
 /// Options:
 ///   --duration &lt;minutes&gt;    Test duration in minutes (default: 15)
 ///   --message-size &lt;bytes&gt;  Message size in bytes (default: 1000)
-///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
+///   --scenario &lt;name&gt;       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, all (default: all)
 ///   --client &lt;name&gt;         Run specific client: dekaf, confluent, all (default: all)
 ///   --output &lt;path&gt;         Output directory for results (default: ./results)
 ///   --brokers &lt;count&gt;      Number of Kafka brokers (default: 1, use 3 for multi-broker)
 ///   --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
 ///   --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
 ///   --roundtrip-messages &lt;count&gt;  Bounded message count for producer-roundtrip (default: 250000)
+///   --roundtrip-steady-seconds &lt;seconds&gt;  Measured producer duration for producer-roundtrip-steady (default: 60)
 ///   report --input &lt;path&gt;   Generate report from existing results
 ///   fault [options]          Run fault-injection correctness suite
 ///
@@ -179,10 +180,11 @@ public static class Program
             replicationFactor,
             replayTopicConfigs).ConfigureAwait(false);
 
-        if (options.Scenario is "producer-roundtrip" or "all")
+        if (IsRoundTripScenario(options.Scenario) || options.Scenario == "all")
         {
             // Round-trip validation must consume every produced byte. Keep this topic
-            // retention-free, but cap its disk use with --roundtrip-messages.
+            // retention-free; the cold lane is message-bounded and the steady lane uses
+            // a compact payload plus a bounded measurement window to cap disk use.
             await kafka.CreateTopicAsync(roundTripTopic, options.Partitions, replicationFactor, new Dictionary<string, string>
             {
                 ["retention.ms"] = "-1",
@@ -208,7 +210,7 @@ public static class Program
                         $"Transactional topic was not created for {scenario.Client}.");
             }
 
-            if (scenario.Name.Equals("producer-roundtrip", StringComparison.OrdinalIgnoreCase))
+            if (IsRoundTripScenario(scenario.Name))
                 return roundTripTopic;
 
             return UsesProducerTopic(scenario.Name)
@@ -230,6 +232,7 @@ public static class Program
             BrokerCount = options.Brokers,
             ConnectionsPerBroker = connectionsPerBroker,
             RoundTripMessages = options.RoundTripMessages,
+            RoundTripSteadySeconds = options.RoundTripSteadySeconds,
             EnableProducerDeliveryDiagnostics = options.EnableProducerDeliveryDiagnostics,
             EnableConsumerFetchDiagnostics = options.EnableConsumerFetchDiagnostics,
             ProgressWatchdog = progressWatchdog,
@@ -385,6 +388,9 @@ public static class Program
     private static bool UsesProducerTopic(string scenarioName) =>
         scenarioName.StartsWith("producer", StringComparison.OrdinalIgnoreCase) ||
         scenarioName.Equals("soak", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsRoundTripScenario(string scenarioName) =>
+        scenarioName.StartsWith("producer-roundtrip", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Maximum consecutive seconds with zero client progress before the run is failed as
@@ -768,6 +774,8 @@ public static class Program
             new ConfluentTransactionalProducerStressTest(),
             new ProducerRoundTripStressTest(),
             new ConfluentProducerRoundTripStressTest(),
+            new ProducerRoundTripStressTest(steadyState: true),
+            new ConfluentProducerRoundTripStressTest(steadyState: true),
             new ConsumerStressTest(),
             new ConsumerBatchStressTest(),
             new ConsumerRawStressTest(),
@@ -915,6 +923,9 @@ public static class Program
                         throw new ArgumentException("--roundtrip-messages must be at least 1");
                     }
                     break;
+                case "--roundtrip-steady-seconds":
+                    options.RoundTripSteadySeconds = ParsePositiveInt(args[++i], "--roundtrip-steady-seconds");
+                    break;
                 case "--producer-delivery-diagnostics":
                     options.EnableProducerDeliveryDiagnostics = true;
                     break;
@@ -1020,7 +1031,7 @@ public static class Program
             Options:
               --duration <minutes>    Test duration in minutes (default: 15)
               --message-size <bytes>  Message size in bytes (default: 1000)
-              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
+              --scenario <name>       Run specific scenario: producer, producer-idempotent, producer-acks-all, producer-async, producer-async-idempotent, producer-transactional, producer-roundtrip, producer-roundtrip-steady, consumer, consumer-batch, consumer-raw, consumer-raw-batch, soak, all (default: all; all excludes soak)
               --client <name>         Run specific client: dekaf, confluent, all (default: all)
               --output <path>         Output directory for results (default: ./results)
               --partitions <count>    Number of topic partitions (default: 6)
@@ -1041,6 +1052,7 @@ public static class Program
               --max-loh-slope-mib-per-hour <n>          LOH growth limit (default: 4)
               --max-throughput-decay-percent-per-hour <n> Throughput decay limit (default: 5)
               --roundtrip-messages <count>  Bounded message count for producer-roundtrip (default: 250000)
+              --roundtrip-steady-seconds <seconds>  Measured producer duration for producer-roundtrip-steady (default: 60)
               report --input <path>   Generate report from existing results
 
             Fault injection:
@@ -1087,6 +1099,7 @@ public static class Program
         public int ConnectionsPerBroker { get; set; } = 1;
         public int SeedMessages { get; set; } = 2_000_000;
         public int RoundTripMessages { get; set; } = 250_000;
+        public int RoundTripSteadySeconds { get; set; } = 60;
         public bool EnableProducerDeliveryDiagnostics { get; set; }
         public bool EnableConsumerFetchDiagnostics { get; set; }
         public string FaultProfile { get; set; } = "all";

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -96,7 +96,6 @@ internal static class MarkdownReporter
     private static void GenerateThroughputTable(StringBuilder sb, string title, List<StressTestResult> results)
     {
         var messageSizes = results.Select(r => r.MessageSizeBytes).Distinct().ToList();
-        var durationMinutes = results.Select(r => r.DurationMinutes).Distinct().FirstOrDefault();
         var clientWidth = GetClientColumnWidth(results);
 
         foreach (var messageSize in messageSizes)
@@ -108,7 +107,12 @@ internal static class MarkdownReporter
             }
 
             var messageSizeKb = messageSize >= 1024 ? $"{messageSize / 1024.0:F1}KB" : $"{messageSize}B";
-            sb.AppendLine($"## {title} ({durationMinutes} minutes, {messageSizeKb} messages)");
+            var measurementWindow = sizeResults.Select(r => r.RoundTripSteadySeconds).FirstOrDefault() is { } seconds
+                ? $"{seconds}s measured producer window"
+                : sizeResults.All(r => r.IsMessageBounded)
+                    ? "message-bounded"
+                    : $"{sizeResults[0].DurationMinutes} minutes";
+            sb.AppendLine($"## {title} ({measurementWindow}, {messageSizeKb} messages)");
             sb.AppendLine();
             sb.AppendLine($"| {"Client".PadRight(clientWidth)} | CPU μs/msg | CPU μs/request | Messages/sec | Median msg/s | Drift | Slope %/min | MB/sec | Accepted msg/s | Errors | Standing cores | Comparison Ratio |");
             sb.AppendLine($"|{new string('-', clientWidth + 2)}|------------|----------------|--------------|--------------|-------|-------------|--------|----------------|--------|----------------|------------------|");
@@ -621,6 +625,7 @@ internal static class MarkdownReporter
         "producer-async-idempotent" => "Producer (Async, Idempotent) Throughput",
         "producer-transactional" => "Producer (Transactional EOS) Throughput",
         "producer-roundtrip" => "Producer → Consumer Round-Trip Throughput",
+        "producer-roundtrip-steady" => "Producer → Consumer Round-Trip Steady-State Throughput",
         "consumer" => "Consumer Throughput",
         "consumer-batch" => "Consumer (Batch) Throughput",
         "consumer-raw" => "Consumer (Raw Bytes) Throughput",
@@ -638,6 +643,7 @@ internal static class MarkdownReporter
         "producer-async-idempotent" => "Async (Idempotent)",
         "producer-transactional" => "Transactional EOS",
         "producer-roundtrip" => "Producer → Consumer Round-Trip",
+        "producer-roundtrip-steady" => "Producer → Consumer Round-Trip Steady State",
         "consumer" => "Consumer",
         "consumer-batch" => "Consumer (Batch)",
         "consumer-raw" => "Consumer (Raw Bytes)",

--- a/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
+++ b/tools/Dekaf.StressTests/Reporting/StressTestResult.cs
@@ -34,6 +34,7 @@ internal sealed class StressTestResult
     public ConsumerFetchDiagnosticsSnapshot? ConsumerFetchDiagnostics { get; init; }
     public RoundTripValidationSnapshot? RoundTripValidation { get; init; }
     public RoundTripPhaseSnapshot? RoundTripPhases { get; init; }
+    public int? RoundTripSteadySeconds { get; init; }
 
     /// <summary>
     /// Whether a fixed message count, rather than <see cref="DurationMinutes"/>, defines

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -28,6 +28,7 @@ internal sealed class StressTestOptions
     public int BrokerCount { get; init; } = 1;
     public int ConnectionsPerBroker { get; init; } = 1;
     public int RoundTripMessages { get; init; } = 250_000;
+    public int RoundTripSteadySeconds { get; init; } = 60;
     public bool EnableProducerDeliveryDiagnostics { get; init; }
 
     /// <summary>

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -12,7 +12,11 @@ namespace Dekaf.StressTests.Scenarios;
 
 internal sealed class ProducerRoundTripStressTest : IStressTestScenario
 {
-    public string Name => "producer-roundtrip";
+    private readonly bool _steadyState;
+
+    public ProducerRoundTripStressTest(bool steadyState = false) => _steadyState = steadyState;
+
+    public string Name => _steadyState ? "producer-roundtrip-steady" : "producer-roundtrip";
     public string Client => "Dekaf";
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
@@ -96,8 +100,14 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
         {
             produceTimeout.CancelAfter(RoundTripScenarioHelpers.GetTimeout(options));
 
-            Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Dekaf...");
-            for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+            Console.WriteLine(RoundTripScenarioHelpers.GetProduceDescription(options, _steadyState, "Dekaf"));
+            for (var ordinal = 0;
+                 !RoundTripScenarioHelpers.HasReachedProduceLimit(
+                     options,
+                     _steadyState,
+                     ordinal,
+                     produceTimer.Elapsed);
+                 ordinal++)
             {
                 if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
                         produceTimeout.IsCancellationRequested,
@@ -122,7 +132,11 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
 
                 if ((ordinal + 1) % 50_000 == 0)
                 {
-                    Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                    RoundTripScenarioHelpers.LogProduceProgress(
+                        options,
+                        _steadyState,
+                        ordinal + 1,
+                        produceTimer.Elapsed);
                 }
             }
 
@@ -195,7 +209,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
                 produceTimer.Elapsed,
                 validation.ConsumedMessages,
                 consumeTimer.Elapsed),
-            producerDiagnostics);
+            producerDiagnostics,
+            isMessageBounded: !_steadyState);
     }
 
     internal static DekafDeliveryErrorListener CreateDeliveryErrorListener(
@@ -265,7 +280,11 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
 
 internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 {
-    public string Name => "producer-roundtrip";
+    private readonly bool _steadyState;
+
+    public ConfluentProducerRoundTripStressTest(bool steadyState = false) => _steadyState = steadyState;
+
+    public string Name => _steadyState ? "producer-roundtrip-steady" : "producer-roundtrip";
     public string Client => "Confluent";
 
     public async Task<StressTestResult> RunAsync(StressTestOptions options, CancellationToken cancellationToken)
@@ -338,8 +357,14 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         // every message, CPU the Dekaf side (error-only MeterListener) never pays — the same
         // skew the acks-all scenario avoids (see ConfluentStressTestHelpers). Lost messages
         // still fail the run via the consume-side completion tracker + CRC validation.
-        Console.WriteLine($"  Producing {options.RoundTripMessages:N0} sequenced messages with Confluent.Kafka...");
-        for (var ordinal = 0; ordinal < options.RoundTripMessages; ordinal++)
+        Console.WriteLine(RoundTripScenarioHelpers.GetProduceDescription(options, _steadyState, "Confluent.Kafka"));
+        for (var ordinal = 0;
+             !RoundTripScenarioHelpers.HasReachedProduceLimit(
+                 options,
+                 _steadyState,
+                 ordinal,
+                 produceTimer.Elapsed);
+             ordinal++)
         {
             if (RoundTripScenarioHelpers.TryRecordProduceTimeout(
                     produceTimeout.IsCancellationRequested,
@@ -383,7 +408,11 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
             if ((ordinal + 1) % 50_000 == 0)
             {
-                Console.WriteLine($"  Produced {ordinal + 1:N0} / {options.RoundTripMessages:N0}");
+                RoundTripScenarioHelpers.LogProduceProgress(
+                    options,
+                    _steadyState,
+                    ordinal + 1,
+                    produceTimer.Elapsed);
                 await Task.Yield();
             }
         }
@@ -430,7 +459,8 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
                 produceTimer.Elapsed,
                 validation.ConsumedMessages,
                 consumeTimer.Elapsed),
-            producerDeliveryDiagnostics: null);
+            producerDeliveryDiagnostics: null,
+            isMessageBounded: !_steadyState);
     }
 
     private static bool ConsumeAndValidate(
@@ -492,7 +522,39 @@ internal static class RoundTripScenarioHelpers
     public static void ValidateOptions(StressTestOptions options)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.RoundTripMessages, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.RoundTripSteadySeconds, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MessageSizeBytes, RoundTripMessageCodec.MinimumPayloadSize);
+    }
+
+    public static bool HasReachedProduceLimit(
+        StressTestOptions options,
+        bool steadyState,
+        long messagesProduced,
+        TimeSpan elapsed) =>
+        steadyState
+            ? elapsed >= TimeSpan.FromSeconds(options.RoundTripSteadySeconds)
+            : messagesProduced >= options.RoundTripMessages;
+
+    public static string GetProduceDescription(StressTestOptions options, bool steadyState, string client) =>
+        steadyState
+            ? $"  Producing sequenced messages with {client} for {options.RoundTripSteadySeconds:N0}s..."
+            : $"  Producing {options.RoundTripMessages:N0} sequenced messages with {client}...";
+
+    public static void LogProduceProgress(
+        StressTestOptions options,
+        bool steadyState,
+        long messagesProduced,
+        TimeSpan elapsed)
+    {
+        if (steadyState)
+        {
+            Console.WriteLine(
+                $"  Produced {messagesProduced:N0}; elapsed {elapsed.TotalSeconds:N1}s / " +
+                $"{options.RoundTripSteadySeconds:N0}s");
+            return;
+        }
+
+        Console.WriteLine($"  Produced {messagesProduced:N0} / {options.RoundTripMessages:N0}");
     }
 
     public static TimeSpan GetTimeout(StressTestOptions options) =>
@@ -599,7 +661,8 @@ internal static class RoundTripScenarioHelpers
         long delivered,
         RoundTripValidationSnapshot validation,
         RoundTripPhaseSnapshot phases,
-        ProducerDeliveryDiagnosticsSnapshot? producerDeliveryDiagnostics) =>
+        ProducerDeliveryDiagnosticsSnapshot? producerDeliveryDiagnostics,
+        bool isMessageBounded = true) =>
         new()
         {
             Scenario = scenario,
@@ -614,9 +677,10 @@ internal static class RoundTripScenarioHelpers
             Latency = null,
             GcStats = gcStats.ToSnapshot(),
             CpuTimeSeconds = throughput.CpuTimeSeconds,
-            IsMessageBounded = true,
+            IsMessageBounded = isMessageBounded,
             RoundTripValidation = validation,
             RoundTripPhases = phases,
+            RoundTripSteadySeconds = isMessageBounded ? null : options.RoundTripSteadySeconds,
             ProducerDeliveryDiagnostics = producerDeliveryDiagnostics
         };
 


### PR DESCRIPTION
Closes #2110.

## Summary
- keep the existing 250k-message cold-start round-trip sprint
- add a distinct 60-second steady-state paired lane with a compact 128-byte payload
- record steady-window identity so variable produced counts still pair and trend correctly
- report message-bounded and measured-window semantics explicitly

## Validation
- solution build: 0 warnings, 0 errors
- unit tests net10.0: 5,549 passed
- unit tests net8.0: 5,437 passed
- round-trip focused tests: 28 passed
- stress report/trend Python tests: 59 passed
- workflow YAML parse: passed