### PR TITLE
Trace producer admission stalls and probe windows

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -804,6 +804,74 @@ def format_producer_budget_timeline(results, title):
     return lines
 
 
+def format_budget_probe_timeline(results, title):
+    """Show bounded per-broker min-RTT and capacity probe state transitions."""
+    rows = [
+        (result, event)
+        for result in results
+        for event in (result.get('producerDeliveryDiagnostics') or {}).get('budgetProbeEvents') or []
+    ]
+    if not rows:
+        return []
+
+    rows.sort(key=lambda row: row[1].get('occurredAtUtc', ''))
+    displayed_rows = _sample_evenly(rows, MAX_TIMELINE_ROWS)
+    lines = [
+        f"## Producer Budget Probe Events - {title}",
+        "",
+        "| Client | UTC | Broker | Probe | Outcome | Duration | Budget / unacked |",
+        "|--------|-----|-------:|-------|---------|---------:|------------------|",
+    ]
+    for result, event in displayed_rows:
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {event.get('occurredAtUtc', '-')} | "
+            f"{event.get('brokerId', '-')} | {event.get('probeType', '-')} | "
+            f"{event.get('outcome', '-')} | {event.get('durationMilliseconds', 0):,}ms | "
+            f"{event.get('budgetBytes', 0) / 1_048_576:.1f} MiB / "
+            f"{event.get('unackedBytes', 0) / 1_048_576:.1f} MiB |"
+        )
+    omitted_rows = len(rows) - len(displayed_rows)
+    if omitted_rows > 0:
+        lines.append(
+            f"*{omitted_rows:,} probe event(s) omitted; rows sampled across the full timeline.*"
+        )
+    lines.append("")
+    return lines
+
+
+def format_admission_block_histogram(results, title):
+    """Show completed contiguous admission-block episodes by log2 duration."""
+    rows = []
+    for result in results:
+        diagnostics = result.get('producerDeliveryDiagnostics') or {}
+        for budget in diagnostics.get('brokerBudgets') or []:
+            for bucket, count in enumerate(budget.get('admissionBlockMicrosLog2Histogram') or []):
+                if count:
+                    rows.append((result, budget, bucket, count))
+    if not rows:
+        return []
+
+    lines = [
+        f"## Producer Admission Block Durations - {title}",
+        "",
+        "| Client | Broker | Duration bucket | Episodes |",
+        "|--------|-------:|-----------------|---------:|",
+    ]
+    for result, budget, bucket, count in rows:
+        lower_micros = 1 << bucket
+        duration = (
+            f"≥{lower_micros / 1000:.3f}ms"
+            if bucket == 23
+            else f"{lower_micros / 1000:.3f}–{(1 << (bucket + 1)) / 1000:.3f}ms"
+        )
+        lines.append(
+            f"| {result.get('client', 'Unknown')} | {budget.get('brokerId', '-')} | "
+            f"{duration} | {count:,} |"
+        )
+    lines.append("")
+    return lines
+
+
 def format_latency_outlier_timeline(results, title):
     """Correlate sampled delivery stalls with scaling, throughput, and GC."""
     rows = [
@@ -818,18 +886,28 @@ def format_latency_outlier_timeline(results, title):
     lines = [
         f"## Delivery Latency Outliers - {title}",
         "",
-        "| Client | Message | Started UTC | Latency | Correlated owner | Scale events in stall | Throughput interval | GC interval delta |",
-        "|--------|--------:|-------------|--------:|------------------|-----------------------|---------------------|-------------------|",
+        "| Client | Message | Started UTC | Latency | Correlated signal | Probe windows in stall | Scale events in stall | Throughput interval | GC interval delta |",
+        "|--------|--------:|-------------|--------:|------------------|------------------------|-----------------------|---------------------|-------------------|",
     ]
     for result, outlier in rows:
         started_at = _parse_timestamp(outlier.get('startedAtUtc'))
         completed_at = _parse_timestamp(outlier.get('completedAtUtc'))
         scale_events = []
-        for event in (result.get('producerDeliveryDiagnostics') or {}).get('connectionScaleEvents') or []:
+        diagnostics = result.get('producerDeliveryDiagnostics') or {}
+        for event in diagnostics.get('connectionScaleEvents') or []:
             occurred_at = _parse_timestamp(event.get('occurredAtUtc'))
             if started_at is not None and completed_at is not None and occurred_at is not None:
                 if started_at <= occurred_at <= completed_at:
                     scale_events.append(event)
+        probe_events = []
+        for event in diagnostics.get('budgetProbeEvents') or []:
+            occurred_at = _parse_timestamp(event.get('occurredAtUtc'))
+            if started_at is None or completed_at is None or occurred_at is None:
+                continue
+            duration_ms = event.get('durationMilliseconds', 0)
+            probe_started_at = occurred_at - timedelta(milliseconds=duration_ms)
+            if probe_started_at <= completed_at and occurred_at >= started_at:
+                probe_events.append(event)
 
         timestamped_samples = sorted(
             (
@@ -865,19 +943,25 @@ def format_latency_outlier_timeline(results, title):
             client_rate = (result.get('throughput') or {}).get('averageMessagesPerSecond', 0)
 
         if scale_events:
-            owner = 'connection transition'
+            signal = 'connection transition'
         elif gen2_delta > 0 or pause_delta_ms >= 10:
-            owner = 'GC pause'
+            signal = 'GC pause'
         elif completion is not None and completion.get('messagesPerSecond', 0) < client_rate * 0.5:
-            owner = 'throughput collapse'
+            signal = 'throughput collapse'
         else:
-            owner = 'broker/backlog (no scale or GC event)'
+            signal = 'broker/backlog (no scale or GC event)'
 
         scale_summary = '-'
         if scale_events:
             scale_summary = ', '.join(
                 f"{event.get('brokerId', '-')}:{event.get('oldConnectionCount', '-')}→{event.get('newConnectionCount', '-')}"
                 for event in scale_events
+            )
+        probe_summary = '-'
+        if probe_events:
+            probe_summary = ', '.join(
+                f"{event.get('brokerId', '-')}:{event.get('probeType', '-')}/{event.get('outcome', '-')}"
+                for event in probe_events
             )
         throughput_summary = '-'
         gc_summary = '-'
@@ -893,11 +977,15 @@ def format_latency_outlier_timeline(results, title):
         message_text = '-' if message_index is None else f"{message_index:,}"
         lines.append(
             f"| {result.get('client', 'Unknown')} | {message_text} | "
-            f"{outlier.get('startedAtUtc', '-')} | {latency_text} | {owner} | "
-            f"{scale_summary} | {throughput_summary} | {gc_summary} |"
+            f"{outlier.get('startedAtUtc', '-')} | {latency_text} | {signal} | "
+            f"{probe_summary} | {scale_summary} | {throughput_summary} | {gc_summary} |"
         )
 
-    lines.append("")
+    lines.extend([
+        "",
+        "*Probe overlap is temporal correlation only. Compare no-probe outliers, admission-block durations, GC, and throughput before attributing a stall.*",
+        "",
+    ])
     dropped = sum((result.get('latency') or {}).get('droppedOutlierSamples', 0) for result in results)
     if dropped > 0:
         lines.append(f"*{dropped:,} additional latency outlier sample(s) exceeded the bounded diagnostic capacity.*")
@@ -1103,6 +1191,8 @@ def generate_scenario_tables(results, include_ratio=False, include_callout=False
             output.extend(format_producer_request_diagnostics(scenario_results, title))
             output.extend(format_consumer_fetch_timeline(scenario_results, title))
             output.extend(format_producer_budget_timeline(scenario_results, title))
+            output.extend(format_budget_probe_timeline(scenario_results, title))
+            output.extend(format_admission_block_histogram(scenario_results, title))
             output.extend(format_latency_outlier_timeline(scenario_results, title))
             output.extend(format_transaction_verification(scenario_results))
             output.extend(format_roundtrip_validation_table(scenario_results))

--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -845,9 +845,11 @@ def format_admission_block_histogram(results, title):
     for result in results:
         diagnostics = result.get('producerDeliveryDiagnostics') or {}
         for budget in diagnostics.get('brokerBudgets') or []:
-            for bucket, count in enumerate(budget.get('admissionBlockMicrosLog2Histogram') or []):
+            histogram = budget.get('admissionBlockMicrosLog2Histogram') or []
+            top_bucket = len(histogram) - 1
+            for bucket, count in enumerate(histogram):
                 if count:
-                    rows.append((result, budget, bucket, count))
+                    rows.append((result, budget, bucket, top_bucket, count))
     if not rows:
         return []
 
@@ -857,11 +859,11 @@ def format_admission_block_histogram(results, title):
         "| Client | Broker | Duration bucket | Episodes |",
         "|--------|-------:|-----------------|---------:|",
     ]
-    for result, budget, bucket, count in rows:
+    for result, budget, bucket, top_bucket, count in rows:
         lower_micros = 1 << bucket
         duration = (
             f"≥{lower_micros / 1000:.3f}ms"
-            if bucket == 23
+            if bucket == top_bucket
             else f"{lower_micros / 1000:.3f}–{(1 << (bucket + 1)) / 1000:.3f}ms"
         )
         lines.append(

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -180,7 +180,7 @@ class StressReportTests(unittest.TestCase):
             }],
             "brokerBudgets": [{
                 "brokerId": 2,
-                "admissionBlockMicrosLog2Histogram": [0] * 12 + [3],
+                "admissionBlockMicrosLog2Histogram": [0] * 12 + [3] + [0] * 11,
             }],
         }
 
@@ -255,6 +255,20 @@ class StressReportTests(unittest.TestCase):
 
         self.assertIn("Probe overlap is temporal correlation only", report)
         self.assertIn("2:min-rtt/succeeded", report)
+
+    def test_admission_block_histogram_derives_top_bucket_from_data(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["producerDeliveryDiagnostics"] = {
+            "brokerBudgets": [{
+                "brokerId": 2,
+                "admissionBlockMicrosLog2Histogram": [0, 0, 0, 3],
+            }],
+        }
+
+        report = "\n".join(format_admission_block_histogram([value], "Producer"))
+
+        self.assertIn("≥0.008ms", report)
+        self.assertNotIn("0.008–0.016ms", report)
 
     def test_paired_latency_thresholds_flag_high_p99(self):
         confluent = stress_result("Confluent", effective_rate=1000)

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -1,6 +1,8 @@
 import unittest
 
 from stress_report import (
+    format_admission_block_histogram,
+    format_budget_probe_timeline,
     format_consumer_fetch_timeline,
     format_roundtrip_validation_table,
     format_connection_scale_timeline,
@@ -164,6 +166,33 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("3/2", report)
         self.assertIn("20.0s / 2,000 msg/s", report)
 
+    def test_probe_and_admission_diagnostics_are_reported(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["producerDeliveryDiagnostics"] = {
+            "budgetProbeEvents": [{
+                "occurredAtUtc": "2026-07-12T02:20:46+00:00",
+                "brokerId": 2,
+                "probeType": "min-rtt",
+                "outcome": "succeeded",
+                "durationMilliseconds": 51,
+                "budgetBytes": 4 * 1024 * 1024,
+                "unackedBytes": 3 * 1024 * 1024,
+            }],
+            "brokerBudgets": [{
+                "brokerId": 2,
+                "admissionBlockMicrosLog2Histogram": [0] * 12 + [3],
+            }],
+        }
+
+        probe_report = "\n".join(format_budget_probe_timeline([value], "Producer"))
+        admission_report = "\n".join(format_admission_block_histogram([value], "Producer"))
+
+        self.assertIn("min-rtt", probe_report)
+        self.assertIn("succeeded", probe_report)
+        self.assertIn("51ms", probe_report)
+        self.assertIn("4.096–8.192ms", admission_report)
+        self.assertIn("| 3 |", admission_report)
+
     def test_scenario_tables_surface_latency_outlier_diagnostics(self):
         value = stress_result("Dekaf", effective_rate=1400)
         value["scenario"] = "producer"
@@ -200,6 +229,32 @@ class StressReportTests(unittest.TestCase):
         self.assertIn("GC pause", report)
         self.assertIn("Gen2 +1 / pause +12.5ms", report)
         self.assertIn("2 additional latency outlier sample(s)", report)
+
+    def test_latency_outlier_correlates_overlapping_budget_probe_window(self):
+        value = stress_result("Dekaf", effective_rate=1400)
+        value["scenario"] = "producer"
+        value["latency"] = {
+            "outlierSamples": [{
+                "messageIndex": 42,
+                "startedAtUtc": "2026-07-12T02:20:44+00:00",
+                "completedAtUtc": "2026-07-12T02:20:46+00:00",
+                "latencyUs": 2_000_000,
+            }],
+        }
+        value["producerDeliveryDiagnostics"] = {
+            "budgetProbeEvents": [{
+                "occurredAtUtc": "2026-07-12T02:20:46+00:00",
+                "brokerId": 2,
+                "probeType": "min-rtt",
+                "outcome": "succeeded",
+                "durationMilliseconds": 2_000,
+            }],
+        }
+
+        report = "\n".join(generate_scenario_tables([value]))
+
+        self.assertIn("Probe overlap is temporal correlation only", report)
+        self.assertIn("2:min-rtt/succeeded", report)
 
     def test_paired_latency_thresholds_flag_high_p99(self):
         confluent = stress_result("Confluent", effective_rate=1000)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -492,8 +492,6 @@ internal sealed class BrokerUnackedByteBudget
             ? CopyHistogram(histogram)
             : [];
 
-    internal bool HasAdmissionBlockDiagnostics => _admissionBlockMicrosLog2Histogram is not null;
-
     internal BrokerBudgetProbeEvent[] CopyProbeEvents()
     {
         if (_minRttProbeEvents is null)
@@ -503,13 +501,27 @@ internal sealed class BrokerUnackedByteBudget
             return [.. _minRttProbeEvents, .. _capacityProbeEvents!];
     }
 
-    internal void ResetDiagnostics()
+    internal void ResetDiagnostics(long nowTicks = 0)
     {
         if (_admissionBlockMicrosLog2Histogram is { } histogram)
         {
             for (var i = 0; i < histogram.Length; i++)
                 Interlocked.Exchange(ref histogram[i], 0);
-            Volatile.Write(ref _admissionBlockedSinceTimestamp, 0);
+
+            if (nowTicks == 0)
+                nowTicks = Stopwatch.GetTimestamp();
+            while (true)
+            {
+                var startedAt = Volatile.Read(ref _admissionBlockedSinceTimestamp);
+                if (startedAt == 0
+                    || Interlocked.CompareExchange(
+                        ref _admissionBlockedSinceTimestamp,
+                        nowTicks,
+                        startedAt) == startedAt)
+                {
+                    break;
+                }
+            }
         }
 
         if (_minRttProbeEvents is not null)
@@ -627,7 +639,7 @@ internal sealed class BrokerUnackedByteBudget
         _ = Interlocked.CompareExchange(ref _admissionBlockedSinceTimestamp, nowTicks, 0);
     }
 
-    internal void RecordAdmissionAvailable(long nowTicks)
+    private void RecordAdmissionAvailable(long nowTicks)
     {
         var histogram = _admissionBlockMicrosLog2Histogram;
         if (histogram is null)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -4,6 +4,27 @@ using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
+internal enum BrokerBudgetProbeType
+{
+    MinimumRtt,
+    Capacity
+}
+
+internal enum BrokerBudgetProbeOutcome
+{
+    Started,
+    Succeeded,
+    Failed
+}
+
+internal readonly record struct BrokerBudgetProbeEvent(
+    BrokerBudgetProbeType ProbeType,
+    BrokerBudgetProbeOutcome Outcome,
+    DateTimeOffset OccurredAtUtc,
+    long DurationMilliseconds,
+    long BudgetBytes,
+    long UnackedBytes);
+
 /// <summary>
 /// Bounds the bytes a single broker may hold unacknowledged (sealed but not yet acked)
 /// so that producer queueing latency stays near <see cref="ProducerOptions.DeliveryLatencyTargetMs"/>
@@ -116,6 +137,9 @@ internal sealed class BrokerUnackedByteBudget
     /// 32 ms and above).
     /// </summary>
     private const int HistogramBucketCount = 16;
+    internal const int AdmissionBlockHistogramBucketCount = 24;
+    private const int MaxMinRttProbeDiagnosticEvents = 512;
+    private const int MaxCapacityProbeDiagnosticEvents = 4_096;
     private const int RequestSizeHistogramShift = 8;
 
     /// <summary>
@@ -228,6 +252,11 @@ internal sealed class BrokerUnackedByteBudget
     // readers may observe slightly stale counts (acceptable for diagnostics).
     private readonly long[] _requestSizeLog2Histogram = new long[HistogramBucketCount];
     private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
+    private readonly long[]? _admissionBlockMicrosLog2Histogram;
+    private readonly object? _probeDiagnosticsLock;
+    private readonly Queue<BrokerBudgetProbeEvent>? _minRttProbeEvents;
+    private readonly Queue<BrokerBudgetProbeEvent>? _capacityProbeEvents;
+    private long _admissionBlockedSinceTimestamp;
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
     private double _windowRateSum;
@@ -245,6 +274,7 @@ internal sealed class BrokerUnackedByteBudget
     // Written only by the send loop; acquire-read by appenders after _budgetBytes publishes
     // the matching precomputed post-probe budgets.
     private long _minRttProbeUntilTimestamp;
+    private long _minRttProbeStartedTimestamp;
     private long _nextProbeTimestamp;
     private long _capacityProbeStartTimestamp;
     private long _capacityProbeDeadlineTimestamp;
@@ -268,7 +298,8 @@ internal sealed class BrokerUnackedByteBudget
         double targetSeconds,
         long floorBytes,
         long initialCapBytes,
-        double lingerSeconds = 0)
+        double lingerSeconds = 0,
+        bool enableDiagnostics = false)
     {
         _targetSeconds = targetSeconds;
         _probeResponseHorizonTicks = Math.Max(
@@ -280,6 +311,13 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _budgetBytes, _capBytes);
         Volatile.Write(ref _budgetAfterMinRttProbeBytes, _capBytes);
         Volatile.Write(ref _probeBudgetAfterMinRttProbeBytes, _capBytes);
+        if (enableDiagnostics)
+        {
+            _admissionBlockMicrosLog2Histogram = new long[AdmissionBlockHistogramBucketCount];
+            _probeDiagnosticsLock = new object();
+            _minRttProbeEvents = new Queue<BrokerBudgetProbeEvent>();
+            _capacityProbeEvents = new Queue<BrokerBudgetProbeEvent>();
+        }
     }
 
     /// <summary>
@@ -449,6 +487,47 @@ internal sealed class BrokerUnackedByteBudget
     /// <summary>Diagnostics: log2 histogram of acked request round-trip times in microseconds.</summary>
     internal long[] CopyRequestRttMicrosHistogram() => CopyHistogram(_requestRttMicrosLog2Histogram);
 
+    internal long[] CopyAdmissionBlockMicrosHistogram() =>
+        _admissionBlockMicrosLog2Histogram is { } histogram
+            ? CopyHistogram(histogram)
+            : [];
+
+    internal BrokerBudgetProbeEvent[] CopyProbeEvents()
+    {
+        if (_minRttProbeEvents is null)
+            return [];
+
+        lock (_probeDiagnosticsLock!)
+            return [.. _minRttProbeEvents, .. _capacityProbeEvents!];
+    }
+
+    internal void ResetDiagnostics()
+    {
+        if (_admissionBlockMicrosLog2Histogram is { } histogram)
+        {
+            for (var i = 0; i < histogram.Length; i++)
+                Interlocked.Exchange(ref histogram[i], 0);
+            Volatile.Write(ref _admissionBlockedSinceTimestamp, 0);
+        }
+
+        if (_minRttProbeEvents is not null)
+        {
+            lock (_probeDiagnosticsLock!)
+            {
+                _minRttProbeEvents.Clear();
+                _capacityProbeEvents!.Clear();
+            }
+        }
+    }
+
+    internal long GetCurrentAdmissionBlockDurationMicros(long nowTicks)
+    {
+        var startedAt = Volatile.Read(ref _admissionBlockedSinceTimestamp);
+        return startedAt == 0 || nowTicks <= startedAt
+            ? 0
+            : (long)((nowTicks - startedAt) * 1_000_000.0 / Stopwatch.Frequency);
+    }
+
     private static long[] CopyHistogram(long[] source)
     {
         var copy = new long[source.Length];
@@ -535,8 +614,31 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void RecordAdmissionBlock()
-        => Interlocked.Increment(ref _admissionBlockEvents);
+    public void RecordAdmissionBlock(long nowTicks = 0)
+    {
+        Interlocked.Increment(ref _admissionBlockEvents);
+        if (_admissionBlockMicrosLog2Histogram is null)
+            return;
+
+        if (nowTicks == 0)
+            nowTicks = Stopwatch.GetTimestamp();
+        _ = Interlocked.CompareExchange(ref _admissionBlockedSinceTimestamp, nowTicks, 0);
+    }
+
+    internal void RecordAdmissionAvailable(long nowTicks)
+    {
+        var startedAt = Interlocked.Exchange(ref _admissionBlockedSinceTimestamp, 0);
+        if (_admissionBlockMicrosLog2Histogram is null || startedAt == 0 || nowTicks <= startedAt)
+            return;
+
+        var durationMicros = (ulong)Math.Max(
+            1,
+            (long)((nowTicks - startedAt) * 1_000_000.0 / Stopwatch.Frequency));
+        var bucket = Math.Min(
+            BitOperations.Log2(durationMicros),
+            AdmissionBlockHistogramBucketCount - 1);
+        Interlocked.Increment(ref _admissionBlockMicrosLog2Histogram[bucket]);
+    }
 
     /// <summary>
     /// Records broker bytes written and awaiting responses. Parallel connection sends may
@@ -564,8 +666,10 @@ internal sealed class BrokerUnackedByteBudget
         _capBytes = Math.Max(_floorBytes, capBytes);
         CompleteExpiredMinRttProbe(nowTicks);
         if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
-            DeactivateCapacityProbe();
+            DeactivateCapacityProbe(nowTicks);
         RecomputeBudget(nowTicks);
+        if (!IsOverBudgetAt(nowTicks))
+            RecordAdmissionAvailable(nowTicks);
     }
 
     /// <summary>
@@ -711,6 +815,8 @@ internal sealed class BrokerUnackedByteBudget
             AddOccupancySample(writtenUnackedPeak);
 
         RecomputeBudget(nowTicks);
+        if (!IsOverBudgetAt(nowTicks))
+            RecordAdmissionAvailable(nowTicks);
     }
 
     private void UpdateDeliveryLatency(
@@ -903,7 +1009,8 @@ internal sealed class BrokerUnackedByteBudget
 
     private void CompleteMinRttProbe(long nowTicks)
     {
-        if (_minRttProbeMinimumSeconds != double.MaxValue)
+        var succeeded = _minRttProbeMinimumSeconds != double.MaxValue;
+        if (succeeded)
         {
             _minRttSeconds = Math.Min(
                 _minRttProbeMinimumSeconds,
@@ -914,6 +1021,12 @@ internal sealed class BrokerUnackedByteBudget
         // freshness window. An idle gap is not a base-RTT measurement.
         _minRttTimestamp = nowTicks;
         _minRttProbeUntilTimestamp = 0;
+        RecordProbeEvent(
+            BrokerBudgetProbeType.MinimumRtt,
+            succeeded ? BrokerBudgetProbeOutcome.Succeeded : BrokerBudgetProbeOutcome.Failed,
+            nowTicks,
+            _minRttProbeStartedTimestamp);
+        _minRttProbeStartedTimestamp = 0;
     }
 
     private void StartMinRttProbe(long nowTicks, double observedRttSeconds)
@@ -925,6 +1038,12 @@ internal sealed class BrokerUnackedByteBudget
             MinRttProbeDurationTicks,
             MaxMinRttProbeDurationTicks);
         _minRttProbeUntilTimestamp = nowTicks + probeDurationTicks;
+        _minRttProbeStartedTimestamp = nowTicks;
+        RecordProbeEvent(
+            BrokerBudgetProbeType.MinimumRtt,
+            BrokerBudgetProbeOutcome.Started,
+            nowTicks,
+            nowTicks);
     }
 
     private void AdvanceWindow(long nowTicks)
@@ -1036,7 +1155,7 @@ internal sealed class BrokerUnackedByteBudget
         {
             if (nowTicks >= _capacityProbeDeadlineTimestamp)
             {
-                DeactivateCapacityProbe();
+                DeactivateCapacityProbe(nowTicks);
                 _nextProbeTimestamp = nowTicks + probeIntervalTicks;
                 return;
             }
@@ -1078,6 +1197,11 @@ internal sealed class BrokerUnackedByteBudget
                 // a sustainable baseline and would make the next average-rate rung unwinnable.
                 _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
+                RecordProbeEvent(
+                    BrokerBudgetProbeType.Capacity,
+                    BrokerBudgetProbeOutcome.Succeeded,
+                    nowTicks,
+                    _capacityProbeStartTimestamp);
                 _capacityProbeStartTimestamp = nowTicks;
                 ResetCapacityProbeSamples();
                 Interlocked.Increment(ref _capacityProbeSuccessCount);
@@ -1085,7 +1209,7 @@ internal sealed class BrokerUnackedByteBudget
             }
             else
             {
-                DeactivateCapacityProbe();
+                DeactivateCapacityProbe(nowTicks);
                 _nextProbeTimestamp = nowTicks + probeIntervalTicks;
             }
 
@@ -1108,6 +1232,11 @@ internal sealed class BrokerUnackedByteBudget
             ResetCapacityProbeSamples();
             Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             Volatile.Write(ref _capacityProbeActive, true);
+            RecordProbeEvent(
+                BrokerBudgetProbeType.Capacity,
+                BrokerBudgetProbeOutcome.Started,
+                nowTicks,
+                nowTicks);
         }
 
         // A schedule missed by a full interval represents producer idle time, not an
@@ -1137,14 +1266,54 @@ internal sealed class BrokerUnackedByteBudget
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }
 
-    private void DeactivateCapacityProbe()
+    private void DeactivateCapacityProbe(long nowTicks)
     {
         if (_capacityProbeActive)
+        {
             Interlocked.Increment(ref _capacityProbeFailureCount);
+            RecordProbeEvent(
+                BrokerBudgetProbeType.Capacity,
+                BrokerBudgetProbeOutcome.Failed,
+                nowTicks,
+                _capacityProbeStartTimestamp);
+        }
 
         ResetCapacityProbeSamples();
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
+    }
+
+    private void RecordProbeEvent(
+        BrokerBudgetProbeType probeType,
+        BrokerBudgetProbeOutcome outcome,
+        long nowTicks,
+        long startedAtTicks)
+    {
+        if (_minRttProbeEvents is null)
+            return;
+
+        var durationMilliseconds = startedAtTicks > 0 && nowTicks > startedAtTicks
+            ? (long)((nowTicks - startedAtTicks) * 1_000.0 / Stopwatch.Frequency)
+            : 0;
+        var diagnostic = new BrokerBudgetProbeEvent(
+            probeType,
+            outcome,
+            DateTimeOffset.UtcNow,
+            durationMilliseconds,
+            BudgetBytes,
+            UnackedBytes);
+        lock (_probeDiagnosticsLock!)
+        {
+            var events = probeType == BrokerBudgetProbeType.MinimumRtt
+                ? _minRttProbeEvents
+                : _capacityProbeEvents!;
+            var capacity = probeType == BrokerBudgetProbeType.MinimumRtt
+                ? MaxMinRttProbeDiagnosticEvents
+                : MaxCapacityProbeDiagnosticEvents;
+            if (events.Count >= capacity)
+                _ = events.Dequeue();
+            events.Enqueue(diagnostic);
+        }
     }
 
     private static double Max(double[] values)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -492,6 +492,8 @@ internal sealed class BrokerUnackedByteBudget
             ? CopyHistogram(histogram)
             : [];
 
+    internal bool HasAdmissionBlockDiagnostics => _admissionBlockMicrosLog2Histogram is not null;
+
     internal BrokerBudgetProbeEvent[] CopyProbeEvents()
     {
         if (_minRttProbeEvents is null)
@@ -627,8 +629,12 @@ internal sealed class BrokerUnackedByteBudget
 
     internal void RecordAdmissionAvailable(long nowTicks)
     {
+        var histogram = _admissionBlockMicrosLog2Histogram;
+        if (histogram is null)
+            return;
+
         var startedAt = Interlocked.Exchange(ref _admissionBlockedSinceTimestamp, 0);
-        if (_admissionBlockMicrosLog2Histogram is null || startedAt == 0 || nowTicks <= startedAt)
+        if (startedAt == 0 || nowTicks <= startedAt)
             return;
 
         var durationMicros = (ulong)Math.Max(
@@ -637,7 +643,7 @@ internal sealed class BrokerUnackedByteBudget
         var bucket = Math.Min(
             BitOperations.Log2(durationMicros),
             AdmissionBlockHistogramBucketCount - 1);
-        Interlocked.Increment(ref _admissionBlockMicrosLog2Histogram[bucket]);
+        Interlocked.Increment(ref histogram[bucket]);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -278,6 +278,7 @@ internal sealed class ProducerDeliveryDiagnosticsSnapshot
     public List<ProducerBatchDeliveryDiagnostic> Batches { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgets { get; init; } = [];
     public List<ProducerBrokerBudgetDiagnostic> BrokerBudgetSamples { get; init; } = [];
+    public List<ProducerBudgetProbeDiagnostic> BudgetProbeEvents { get; init; } = [];
     public List<ConnectionReapDiagnostic> ConnectionReapEvents { get; init; } = [];
     public List<ProducerConnectionScaleDiagnostic> ConnectionScaleEvents { get; init; } = [];
 }
@@ -328,6 +329,25 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     /// Populated only on live snapshots.
     /// </summary>
     public long[]? RequestRttMicrosLog2Histogram { get; init; }
+
+    /// <summary>Log2 histogram of completed contiguous admission-block intervals in
+    /// microseconds. Populated only on live snapshots.</summary>
+    public long[]? AdmissionBlockMicrosLog2Histogram { get; init; }
+
+    /// <summary>Age of the currently open admission-block interval, or zero when the
+    /// broker gate is presently admitting.</summary>
+    public long CurrentAdmissionBlockMicros { get; init; }
+}
+
+internal sealed class ProducerBudgetProbeDiagnostic
+{
+    public required DateTimeOffset OccurredAtUtc { get; init; }
+    public required int BrokerId { get; init; }
+    public required string ProbeType { get; init; }
+    public required string Outcome { get; init; }
+    public required long DurationMilliseconds { get; init; }
+    public required long BudgetBytes { get; init; }
+    public required long UnackedBytes { get; init; }
 }
 
 internal sealed class ProducerConnectionScaleDiagnostic

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4928,7 +4928,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
-            currentBudget.RecordAdmissionBlock();
+            currentBudget.RecordAdmissionBlock(nowTicks);
         return true;
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4902,29 +4902,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var currentBudget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
-        {
-            if (currentBudget?.HasAdmissionBlockDiagnostics == true)
-                currentBudget.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
-        }
 
         // A leader may have changed since this partition last sealed or routed a batch.
         // Resolve again before actually blocking so a stale, pressured old leader never
         // causes false backpressure. This lookup is confined to the already-cold path.
         currentBudget = ResolveAndCacheUnackedBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
-        {
-            if (currentBudget?.HasAdmissionBlockDiagnostics == true)
-                currentBudget.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
-        }
 
         var nowTicks = Stopwatch.GetTimestamp();
         if (!currentBudget.IsOverBudgetAt(nowTicks))
-        {
-            currentBudget.RecordAdmissionAvailable(nowTicks);
             return false;
-        }
 
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
@@ -5375,9 +5364,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             AdmissionBlockMicrosLog2Histogram = includeHistograms
             ? budget.CopyAdmissionBlockMicrosHistogram()
             : null,
-            CurrentAdmissionBlockMicros = includeHistograms
-            ? budget.GetCurrentAdmissionBlockDurationMicros(Stopwatch.GetTimestamp())
-            : 0
+            CurrentAdmissionBlockMicros = budget.GetCurrentAdmissionBlockDurationMicros(
+                Stopwatch.GetTimestamp())
         };
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4903,7 +4903,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var currentBudget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
         {
-            currentBudget?.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
+            if (currentBudget?.HasAdmissionBlockDiagnostics == true)
+                currentBudget.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
         }
 
@@ -4913,7 +4914,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         currentBudget = ResolveAndCacheUnackedBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
         {
-            currentBudget?.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
+            if (currentBudget?.HasAdmissionBlockDiagnostics == true)
+                currentBudget.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
         }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4843,7 +4843,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
             initialCapBytes: cap,
-            lingerSeconds: _options.LingerMs / 1000.0);
+            lingerSeconds: _options.LingerMs / 1000.0,
+            enableDiagnostics: _options.EnableDeliveryDiagnostics);
     }
 
     /// <summary>
@@ -4902,6 +4903,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var currentBudget = GetCachedAdmissionBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
         {
+            currentBudget?.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
         }
 
@@ -4910,11 +4912,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // causes false backpressure. This lookup is confined to the already-cold path.
         currentBudget = ResolveAndCacheUnackedBudget(partitionDeque, topic, partition);
         if (currentBudget is null || !currentBudget.IsOverBudget())
+        {
+            currentBudget?.RecordAdmissionAvailable(Stopwatch.GetTimestamp());
             return false;
+        }
 
         var nowTicks = Stopwatch.GetTimestamp();
         if (!currentBudget.IsOverBudgetAt(nowTicks))
+        {
+            currentBudget.RecordAdmissionAvailable(nowTicks);
             return false;
+        }
 
         recheckDelayMilliseconds = currentBudget.GetAdmissionRecheckDelayMilliseconds(nowTicks);
         if (recordBlockEvent)
@@ -5198,7 +5206,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         var capturedAtUtc = snapshot.CapturedAtUtc;
         foreach (var (brokerId, budget) in _brokerUnackedBudgets)
+        {
             snapshot.BrokerBudgets.Add(CreateBrokerBudgetDiagnostic(brokerId, budget, capturedAtUtc, includeHistograms: true));
+            foreach (var probeEvent in budget.CopyProbeEvents())
+            {
+                snapshot.BudgetProbeEvents.Add(new ProducerBudgetProbeDiagnostic
+                {
+                    OccurredAtUtc = probeEvent.OccurredAtUtc,
+                    BrokerId = brokerId,
+                    ProbeType = probeEvent.ProbeType == BrokerBudgetProbeType.MinimumRtt
+                        ? "min-rtt"
+                        : "capacity",
+                    Outcome = probeEvent.Outcome.ToString().ToLowerInvariant(),
+                    DurationMilliseconds = probeEvent.DurationMilliseconds,
+                    BudgetBytes = probeEvent.BudgetBytes,
+                    UnackedBytes = probeEvent.UnackedBytes
+                });
+            }
+        }
+
+        snapshot.BudgetProbeEvents.Sort(static (left, right) =>
+            left.OccurredAtUtc.CompareTo(right.OccurredAtUtc));
 
         lock (_deliveryDiagnosticsLock)
         {
@@ -5243,6 +5271,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             Interlocked.Exchange(ref counters.RequestCount, 0);
             Interlocked.Exchange(ref counters.RequestBytes, 0);
         }
+        foreach (var budget in _brokerUnackedBudgets.Values)
+            budget.ResetDiagnostics();
     }
 
     private sealed class ProducerRequestDiagnosticCounters
@@ -5326,21 +5356,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         BrokerUnackedByteBudget budget,
         DateTimeOffset capturedAtUtc,
         bool includeHistograms) => new()
-    {
-        CapturedAtUtc = capturedAtUtc,
-        BrokerId = brokerId,
-        BudgetBytes = budget.BudgetBytes,
-        UnackedBytes = budget.UnackedBytes,
-        MinRttMicros = budget.MinimumRttMicros,
-        MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
-        AdmissionBlockCount = budget.AdmissionBlockEvents,
-        CapacityProbeSuccessCount = budget.CapacityProbeSuccessCount,
-        CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
-        DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
-        LatencyBudgetScale = budget.LatencyBudgetScale,
-        RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
-        RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null
-    };
+        {
+            CapturedAtUtc = capturedAtUtc,
+            BrokerId = brokerId,
+            BudgetBytes = budget.BudgetBytes,
+            UnackedBytes = budget.UnackedBytes,
+            MinRttMicros = budget.MinimumRttMicros,
+            MaxRateBytesPerSec = budget.MaxRateBytesPerSecond,
+            AdmissionBlockCount = budget.AdmissionBlockEvents,
+            CapacityProbeSuccessCount = budget.CapacityProbeSuccessCount,
+            CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
+            DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
+            LatencyBudgetScale = budget.LatencyBudgetScale,
+            RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
+            RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null,
+            AdmissionBlockMicrosLog2Histogram = includeHistograms
+            ? budget.CopyAdmissionBlockMicrosHistogram()
+            : null,
+            CurrentAdmissionBlockMicros = includeHistograms
+            ? budget.GetCurrentAdmissionBlockDurationMicros(Stopwatch.GetTimestamp())
+            : 0
+        };
 
     /// <summary>
     /// Sweeps the in-flight batch list for batches whose delivery timeout has expired

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1867,7 +1867,7 @@ public sealed class BrokerUnackedByteBudgetTests
 
         budget.RecordAdmissionBlock(T0);
         budget.RecordAdmissionBlock(T0 + Seconds(0.002));
-        budget.RecordAdmissionAvailable(T0 + Seconds(0.008));
+        budget.CompleteAckedPass(T0 + Seconds(0.008));
 
         var histogram = budget.CopyAdmissionBlockMicrosHistogram();
 
@@ -1886,10 +1886,32 @@ public sealed class BrokerUnackedByteBudgetTests
             initialCapBytes: 3_200);
         SetField(budget, "_admissionBlockedSinceTimestamp", T0);
 
-        budget.RecordAdmissionAvailable(T0 + Seconds(0.008));
+        budget.CompleteAckedPass(T0 + Seconds(0.008));
 
-        await Assert.That(budget.HasAdmissionBlockDiagnostics).IsFalse();
+        await Assert.That(budget.CopyAdmissionBlockMicrosHistogram()).IsEmpty();
         await Assert.That(GetField<long>(budget, "_admissionBlockedSinceTimestamp")).IsEqualTo(T0);
+    }
+
+    [Test]
+    public async Task AdmissionBlockDiagnostics_ResetPreservesOpenEpisodeFromBoundary()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200,
+            enableDiagnostics: true);
+
+        budget.RecordAdmissionBlock(T0);
+        budget.ResetDiagnostics(T0 + Seconds(0.005));
+
+        await Assert.That(budget.GetCurrentAdmissionBlockDurationMicros(T0 + Seconds(0.013)))
+            .IsEqualTo(8_000).Within(1);
+
+        budget.CompleteAckedPass(T0 + Seconds(0.013));
+        var histogram = budget.CopyAdmissionBlockMicrosHistogram();
+
+        await Assert.That(histogram.Sum()).IsEqualTo(1);
+        await Assert.That(histogram[12]).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -860,7 +860,11 @@ public sealed class BrokerUnackedByteBudgetTests
     [Test]
     public async Task PeriodicProbe_CollectsThreeRtts_ThenRevertsWithoutRateGain()
     {
-        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000,
+            enableDiagnostics: true);
         budget.Charge(5_000);
 
         for (var i = 0; i <= 8; i++)
@@ -886,6 +890,14 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo(5_000);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        var capacityEvents = budget.CopyProbeEvents()
+            .Where(probeEvent => probeEvent.ProbeType == BrokerBudgetProbeType.Capacity)
+            .ToArray();
+        await Assert.That(capacityEvents.Select(probeEvent => probeEvent.Outcome)).IsEquivalentTo(new[]
+        {
+            BrokerBudgetProbeOutcome.Started,
+            BrokerBudgetProbeOutcome.Failed
+        });
     }
 
     [Test]
@@ -1842,5 +1854,47 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.RecordAdmissionBlock();
 
         await Assert.That(budget.AdmissionBlockEvents).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AdmissionBlockDiagnostics_RecordContiguousBlockedDuration()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200,
+            enableDiagnostics: true);
+
+        budget.RecordAdmissionBlock(T0);
+        budget.RecordAdmissionBlock(T0 + Seconds(0.002));
+        budget.RecordAdmissionAvailable(T0 + Seconds(0.008));
+
+        var histogram = budget.CopyAdmissionBlockMicrosHistogram();
+
+        await Assert.That(histogram.Sum()).IsEqualTo(1);
+        await Assert.That(histogram[12]).IsEqualTo(1)
+            .Because("8,000 microseconds belongs to log2 bucket 12");
+        await Assert.That(budget.GetCurrentAdmissionBlockDurationMicros(T0 + Seconds(1))).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task MinimumRttProbeDiagnostics_RecordWindowBoundaries()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000,
+            enableDiagnostics: true);
+
+        Ack(budget, 500, 0.005, T0);
+        Ack(budget, 500, 0.005, T0 + Seconds(0.051));
+
+        var events = budget.CopyProbeEvents();
+
+        await Assert.That(events).Count().IsEqualTo(2);
+        await Assert.That(events[0].ProbeType).IsEqualTo(BrokerBudgetProbeType.MinimumRtt);
+        await Assert.That(events[0].Outcome).IsEqualTo(BrokerBudgetProbeOutcome.Started);
+        await Assert.That(events[1].Outcome).IsEqualTo(BrokerBudgetProbeOutcome.Succeeded);
+        await Assert.That(events[1].DurationMilliseconds).IsEqualTo(50);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1878,6 +1878,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task AdmissionBlockDiagnostics_DisabledDoesNotTouchTrackingState()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+        SetField(budget, "_admissionBlockedSinceTimestamp", T0);
+
+        budget.RecordAdmissionAvailable(T0 + Seconds(0.008));
+
+        await Assert.That(budget.HasAdmissionBlockDiagnostics).IsFalse();
+        await Assert.That(GetField<long>(budget, "_admissionBlockedSinceTimestamp")).IsEqualTo(T0);
+    }
+
+    [Test]
     public async Task MinimumRttProbeDiagnostics_RecordWindowBoundaries()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1895,6 +1910,6 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(events[0].ProbeType).IsEqualTo(BrokerBudgetProbeType.MinimumRtt);
         await Assert.That(events[0].Outcome).IsEqualTo(BrokerBudgetProbeOutcome.Started);
         await Assert.That(events[1].Outcome).IsEqualTo(BrokerBudgetProbeOutcome.Succeeded);
-        await Assert.That(events[1].DurationMilliseconds).IsEqualTo(50);
+        await Assert.That(events[1].DurationMilliseconds).IsBetween(50, 51);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -186,7 +186,9 @@ public sealed class ProducerDeliveryDiagnosticsTests
             resolveLeaderId: static (_, _) => 7);
         var budget = accumulator.GetBrokerUnackedBudget(7)!;
         budget.Charge(600);
-        budget.RecordAdmissionBlock();
+        var blockStartedAt = Stopwatch.GetTimestamp();
+        budget.RecordAdmissionBlock(blockStartedAt);
+        budget.RecordAdmissionAvailable(blockStartedAt + Stopwatch.Frequency * 8 / 1_000);
         var ackTimestamp = Stopwatch.GetTimestamp();
         budget.OnAcked(
             1_000,
@@ -211,12 +213,20 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
         await Assert.That(current.RequestRttMicrosLog2Histogram!.Sum()).IsEqualTo(1);
+        await Assert.That(current.AdmissionBlockMicrosLog2Histogram).IsNotNull();
+        await Assert.That(current.AdmissionBlockMicrosLog2Histogram!.Sum()).IsEqualTo(1);
+        await Assert.That(current.AdmissionBlockMicrosLog2Histogram[12]).IsEqualTo(1);
+        await Assert.That(current.CurrentAdmissionBlockMicros).IsEqualTo(0);
+        await Assert.That(snapshot.BudgetProbeEvents).Count().IsEqualTo(1);
+        await Assert.That(snapshot.BudgetProbeEvents[0].ProbeType).IsEqualTo("min-rtt");
+        await Assert.That(snapshot.BudgetProbeEvents[0].Outcome).IsEqualTo("started");
         await Assert.That(sample.BrokerId).IsEqualTo(7);
         await Assert.That(sample.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(sample.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");
+        await Assert.That(sample.AdmissionBlockMicrosLog2Histogram).IsNull();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -188,7 +188,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         budget.Charge(600);
         var blockStartedAt = Stopwatch.GetTimestamp();
         budget.RecordAdmissionBlock(blockStartedAt);
-        budget.RecordAdmissionAvailable(blockStartedAt + Stopwatch.Frequency * 8 / 1_000);
+        budget.CompleteAckedPass(blockStartedAt + Stopwatch.Frequency * 8 / 1_000);
         var ackTimestamp = Stopwatch.GetTimestamp();
         budget.OnAcked(
             1_000,
@@ -226,6 +226,22 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");
+        await Assert.That(sample.AdmissionBlockMicrosLog2Histogram).IsNull();
+    }
+
+    [Test]
+    public async Task BrokerBudgetPeriodicSample_CapturesOpenAdmissionBlockDuration()
+    {
+        await using var accumulator = new RecordAccumulator(
+            CreateOptions(enableDeliveryDiagnostics: true, deliveryLatencyTargetMs: 10),
+            resolveLeaderId: static (_, _) => 7);
+        var budget = accumulator.GetBrokerUnackedBudget(7)!;
+        budget.RecordAdmissionBlock(Stopwatch.GetTimestamp() - Stopwatch.Frequency / 1_000);
+
+        accumulator.RecordBrokerBudgetDiagnosticSample();
+        var sample = accumulator.GetDeliveryDiagnosticsSnapshot().BrokerBudgetSamples.Single();
+
+        await Assert.That(sample.CurrentAdmissionBlockMicros).IsGreaterThan(0);
         await Assert.That(sample.AdmissionBlockMicrosLog2Histogram).IsNull();
     }
 

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -248,6 +248,39 @@ public sealed class ConnectionScaleReportingTests
                         SendLoopPressureDelta = 340
                     }
                 ],
+                BudgetProbeEvents =
+                [
+                    new ProducerBudgetProbeDiagnostic
+                    {
+                        OccurredAtUtc = startedAt.AddSeconds(6),
+                        BrokerId = 1,
+                        ProbeType = "min-rtt",
+                        Outcome = "succeeded",
+                        DurationMilliseconds = 2_000,
+                        BudgetBytes = 8 * 1024 * 1024,
+                        UnackedBytes = 6 * 1024 * 1024
+                    }
+                ],
+                BrokerBudgets =
+                [
+                    new ProducerBrokerBudgetDiagnostic
+                    {
+                        CapturedAtUtc = startedAt.AddMinutes(15),
+                        BrokerId = 1,
+                        BudgetBytes = 8 * 1024 * 1024,
+                        UnackedBytes = 0,
+                        MinRttMicros = 800,
+                        MaxRateBytesPerSec = 750_000_000,
+                        AdmissionBlockCount = 12,
+                        DeliveryLatencyEwmaMicros = 2_500,
+                        LatencyBudgetScale = 1.0,
+                        AdmissionBlockMicrosLog2Histogram =
+                        [
+                            0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 3
+                        ]
+                    }
+                ],
                 BrokerBudgetSamples =
                 [
                     new ProducerBrokerBudgetDiagnostic
@@ -290,9 +323,14 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("8.0 MiB");
         await Assert.That(markdown).Contains("750.0 MB/s");
         await Assert.That(markdown).Contains("3/2");
+        await Assert.That(markdown).Contains("Producer Budget Probe Events - Fire-and-Forget");
+        await Assert.That(markdown).Contains("min-rtt");
+        await Assert.That(markdown).Contains("Producer Admission Block Durations - Fire-and-Forget");
+        await Assert.That(markdown).Contains("4.096–8.192ms");
         await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
         await Assert.That(markdown).Contains("42");
-        await Assert.That(markdown).Contains("connection transition");
+        await Assert.That(markdown).Contains("Probe overlap is temporal correlation only");
+        await Assert.That(markdown).Contains("1:min-rtt/succeeded");
         await Assert.That(markdown).Contains("Gen2 +1 / pause +12.5ms");
         await Assert.That(markdown).Contains("43");
         await Assert.That(markdown).Contains("GC pause");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -343,5 +343,11 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(json).Contains("\"averageRequestBytes\": 262144");
         await Assert.That(json).Contains("\"coalesceWidthHistogram\"");
         await Assert.That(json).Contains("\"requestCount\": 2000");
+
+        result.ProducerDeliveryDiagnostics.BudgetProbeEvents.Clear();
+        var markdownWithoutProbeEvents = MarkdownReporter.Generate(results);
+
+        await Assert.That(markdownWithoutProbeEvents).DoesNotContain("Producer Budget Probe Events");
+        await Assert.That(markdownWithoutProbeEvents).Contains("Producer Admission Block Durations");
     }
 }

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -277,8 +277,22 @@ public sealed class ConnectionScaleReportingTests
                         AdmissionBlockMicrosLog2Histogram =
                         [
                             0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 0, 3
+                            0, 0, 0, 0, 3, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0
                         ]
+                    },
+                    new ProducerBrokerBudgetDiagnostic
+                    {
+                        CapturedAtUtc = startedAt.AddMinutes(15),
+                        BrokerId = 2,
+                        BudgetBytes = 1,
+                        UnackedBytes = 0,
+                        MinRttMicros = 1,
+                        MaxRateBytesPerSec = 1,
+                        AdmissionBlockCount = 1,
+                        DeliveryLatencyEwmaMicros = 1,
+                        LatencyBudgetScale = 1,
+                        AdmissionBlockMicrosLog2Histogram = [0, 0, 0, 1]
                     }
                 ],
                 BrokerBudgetSamples =
@@ -327,6 +341,7 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("min-rtt");
         await Assert.That(markdown).Contains("Producer Admission Block Durations - Fire-and-Forget");
         await Assert.That(markdown).Contains("4.096–8.192ms");
+        await Assert.That(markdown).Contains("≥0.008ms");
         await Assert.That(markdown).Contains("Delivery Latency Outliers - Fire-and-Forget");
         await Assert.That(markdown).Contains("42");
         await Assert.That(markdown).Contains("Probe overlap is temporal correlation only");

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -635,6 +635,23 @@ public static class Program
             $"      capturedAtUtc={snapshot.CapturedAtUtc:O} " +
             $"inFlight={snapshot.InFlightBatchCount:N0} batches={snapshot.Batches.Count:N0}");
 
+        foreach (var budget in snapshot.BrokerBudgets)
+        {
+            var completedBlocks = budget.AdmissionBlockMicrosLog2Histogram?.Sum() ?? 0;
+            Console.WriteLine(
+                $"      broker={budget.BrokerId} admissionBlockEpisodes={completedBlocks:N0} " +
+                $"currentAdmissionBlock={budget.CurrentAdmissionBlockMicros / 1_000.0:F3}ms");
+        }
+
+        foreach (var probeEvent in snapshot.BudgetProbeEvents.TakeLast(32))
+        {
+            Console.WriteLine(
+                $"      probe={probeEvent.ProbeType}/{probeEvent.Outcome} " +
+                $"broker={probeEvent.BrokerId} at={probeEvent.OccurredAtUtc:O} " +
+                $"duration={probeEvent.DurationMilliseconds:N0}ms " +
+                $"budget={probeEvent.BudgetBytes:N0} unacked={probeEvent.UnackedBytes:N0}");
+        }
+
         if (snapshot.Batches.Count == 0)
         {
             Console.WriteLine("      No live in-flight batches remained when diagnostics were captured.");

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -346,8 +346,15 @@ internal static class MarkdownReporter
     {
         var rows = results
             .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BrokerBudgets ?? [])
-                .SelectMany(budget => (budget.AdmissionBlockMicrosLog2Histogram ?? [])
-                    .Select((count, bucket) => (Result: result, Budget: budget, Count: count, Bucket: bucket))))
+                .Select(budget => (
+                    Budget: budget,
+                    Histogram: budget.AdmissionBlockMicrosLog2Histogram ?? []))
+                .SelectMany(row => row.Histogram.Select((count, bucket) => (
+                    Result: result,
+                    row.Budget,
+                    Count: count,
+                    Bucket: bucket,
+                    TopBucket: row.Histogram.Length - 1))))
             .Where(row => row.Count > 0)
             .ToList();
         if (rows.Count == 0)
@@ -360,7 +367,7 @@ internal static class MarkdownReporter
         foreach (var row in rows)
         {
             var lowerMicros = 1L << row.Bucket;
-            var upperMicros = row.Bucket == BrokerUnackedByteBudget.AdmissionBlockHistogramBucketCount - 1
+            var upperMicros = row.Bucket == row.TopBucket
                 ? (long?)null
                 : 1L << (row.Bucket + 1);
             var bucket = upperMicros is { } upper

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Dekaf.Producer;
 using Dekaf.StressTests.Metrics;
 
 namespace Dekaf.StressTests.Reporting;
@@ -299,6 +300,80 @@ internal static class MarkdownReporter
         if (omittedRows > 0)
             sb.AppendLine($"*{omittedRows:N0} budget sample(s) omitted; rows sampled across the full timeline.*");
         sb.AppendLine();
+
+        GenerateBudgetProbeTimeline(sb, results, label);
+        GenerateAdmissionBlockHistogram(sb, results, label);
+    }
+
+    private static void GenerateBudgetProbeTimeline(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BudgetProbeEvents ?? [])
+                .Select(probeEvent => (Result: result, Event: probeEvent)))
+            .OrderBy(row => row.Event.OccurredAtUtc)
+            .ToList();
+        if (rows.Count == 0)
+        {
+            GenerateBudgetProbeTimeline(sb, results, label);
+            GenerateAdmissionBlockHistogram(sb, results, label);
+            return;
+        }
+
+        var displayedRows = SampleEvenly(rows, MaxTimelineRows);
+        sb.AppendLine($"## Producer Budget Probe Events - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | UTC | Broker | Probe | Outcome | Duration | Budget / unacked |");
+        sb.AppendLine("|--------|-----|-------:|-------|---------|---------:|------------------|");
+        foreach (var row in displayedRows)
+        {
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Event.OccurredAtUtc:HH:mm:ss.fff} | " +
+                $"{row.Event.BrokerId} | {row.Event.ProbeType} | {row.Event.Outcome} | " +
+                $"{row.Event.DurationMilliseconds:N0}ms | " +
+                $"{row.Event.BudgetBytes / 1_048_576.0:F1} MiB / " +
+                $"{row.Event.UnackedBytes / 1_048_576.0:F1} MiB |");
+        }
+
+        var omitted = rows.Count - displayedRows.Count;
+        if (omitted > 0)
+            sb.AppendLine($"*{omitted:N0} probe event(s) omitted; rows sampled across the full timeline.*");
+        sb.AppendLine();
+    }
+
+    private static void GenerateAdmissionBlockHistogram(
+        StringBuilder sb,
+        List<StressTestResult> results,
+        string label)
+    {
+        var rows = results
+            .SelectMany(result => (result.ProducerDeliveryDiagnostics?.BrokerBudgets ?? [])
+                .SelectMany(budget => (budget.AdmissionBlockMicrosLog2Histogram ?? [])
+                    .Select((count, bucket) => (Result: result, Budget: budget, Count: count, Bucket: bucket))))
+            .Where(row => row.Count > 0)
+            .ToList();
+        if (rows.Count == 0)
+            return;
+
+        sb.AppendLine($"## Producer Admission Block Durations - {label}");
+        sb.AppendLine();
+        sb.AppendLine("| Client | Broker | Duration bucket | Episodes |");
+        sb.AppendLine("|--------|-------:|-----------------|---------:|");
+        foreach (var row in rows)
+        {
+            var lowerMicros = 1L << row.Bucket;
+            var upperMicros = row.Bucket == BrokerUnackedByteBudget.AdmissionBlockHistogramBucketCount - 1
+                ? (long?)null
+                : 1L << (row.Bucket + 1);
+            var bucket = upperMicros is { } upper
+                ? $"{lowerMicros / 1_000.0:F3}–{upper / 1_000.0:F3}ms"
+                : $"≥{lowerMicros / 1_000.0:F3}ms";
+            sb.AppendLine(
+                $"| {row.Result.Client} | {row.Budget.BrokerId} | {bucket} | {row.Count:N0} |");
+        }
+        sb.AppendLine();
     }
 
     private static void GenerateConsumerFetchTimeline(
@@ -374,14 +449,17 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## Delivery Latency Outliers - {label}");
         sb.AppendLine();
-        sb.AppendLine("| Client | Message | Started UTC | Latency | Correlated owner | Scale events in stall | Throughput interval | GC interval delta |");
-        sb.AppendLine("|--------|--------:|-------------|--------:|------------------|-----------------------|---------------------|-------------------|");
+        sb.AppendLine("| Client | Message | Started UTC | Latency | Correlated signal | Probe windows in stall | Scale events in stall | Throughput interval | GC interval delta |");
+        sb.AppendLine("|--------|--------:|-------------|--------:|------------------|------------------------|-----------------------|---------------------|-------------------|");
         foreach (var row in rows)
         {
             var scaleEvents = (row.Result.ProducerDeliveryDiagnostics?.ConnectionScaleEvents ?? [])
                 .Where(scaleEvent =>
                     scaleEvent.OccurredAtUtc >= row.Sample.StartedAtUtc &&
                     scaleEvent.OccurredAtUtc <= row.Sample.CompletedAtUtc)
+                .ToList();
+            var probeEvents = (row.Result.ProducerDeliveryDiagnostics?.BudgetProbeEvents ?? [])
+                .Where(probeEvent => ProbeOverlaps(probeEvent, row.Sample))
                 .ToList();
             var samples = row.Result.Throughput.IntervalSamples;
             var throughputSample = samples.FirstOrDefault(sample => sample.CapturedAtUtc >= row.Sample.CompletedAtUtc)
@@ -393,7 +471,7 @@ internal static class MarkdownReporter
             var pauseDeltaMs = throughputSample is null
                 ? 0
                 : Math.Max(0, throughputSample.GcPauseDurationMs - (baselineSample?.GcPauseDurationMs ?? 0));
-            var owner = ClassifyLatencyOutlier(
+            var signal = ClassifyLatencyOutlier(
                 scaleEvents.Count,
                 gen2Delta,
                 pauseDeltaMs,
@@ -403,6 +481,10 @@ internal static class MarkdownReporter
                 ? "-"
                 : string.Join(", ", scaleEvents.Select(scaleEvent =>
                     $"{scaleEvent.BrokerId}:{scaleEvent.OldConnectionCount}→{scaleEvent.NewConnectionCount}"));
+            var probeSummary = probeEvents.Count == 0
+                ? "-"
+                : string.Join(", ", probeEvents.Select(probeEvent =>
+                    $"{probeEvent.BrokerId}:{probeEvent.ProbeType}/{probeEvent.Outcome}"));
             var throughputSummary = throughputSample is null
                 ? "-"
                 : $"{throughputSample.ElapsedSeconds:F1}s / {throughputSample.MessagesPerSecond:N0} msg/s";
@@ -413,10 +495,12 @@ internal static class MarkdownReporter
 
             sb.AppendLine(
                 $"| {row.Result.Client} | {messageIndex} | {row.Sample.StartedAtUtc:HH:mm:ss.fff} | " +
-                $"{FormatLatencyUs(row.Sample.LatencyUs).Trim()} | {owner} | {scaleSummary} | " +
+                $"{FormatLatencyUs(row.Sample.LatencyUs).Trim()} | {signal} | {probeSummary} | {scaleSummary} | " +
                 $"{throughputSummary} | {gcSummary} |");
         }
 
+        sb.AppendLine();
+        sb.AppendLine("*Probe overlap is temporal correlation only. Compare no-probe outliers, admission-block durations, GC, and throughput before attributing a stall.*");
         sb.AppendLine();
         var dropped = results.Sum(result => result.Latency?.DroppedOutlierSamples ?? 0);
         if (dropped > 0)
@@ -444,6 +528,17 @@ internal static class MarkdownReporter
         }
 
         return "broker/backlog (no scale or GC event)";
+    }
+
+    private static bool ProbeOverlaps(
+        ProducerBudgetProbeDiagnostic probeEvent,
+        LatencyOutlierSample outlier)
+    {
+        var probeEnd = probeEvent.OccurredAtUtc;
+        var probeStart = probeEvent.DurationMilliseconds > 0
+            ? probeEnd - TimeSpan.FromMilliseconds(probeEvent.DurationMilliseconds)
+            : probeEnd;
+        return probeStart <= outlier.CompletedAtUtc && probeEnd >= outlier.StartedAtUtc;
     }
 
     private static void GenerateLatencyTable(StringBuilder sb, List<StressTestResult> results, string title = "Latency Percentiles")

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -316,11 +316,7 @@ internal static class MarkdownReporter
             .OrderBy(row => row.Event.OccurredAtUtc)
             .ToList();
         if (rows.Count == 0)
-        {
-            GenerateBudgetProbeTimeline(sb, results, label);
-            GenerateAdmissionBlockHistogram(sb, results, label);
             return;
-        }
 
         var displayedRows = SampleEvenly(rows, MaxTimelineRows);
         sb.AppendLine($"## Producer Budget Probe Events - {label}");


### PR DESCRIPTION
## Summary
- add bounded min-RTT and capacity-probe event windows to producer delivery diagnostics
- record contiguous broker admission-block durations in a log2 histogram
- correlate sampled latency outliers with probe windows, connection transitions, throughput, and GC in both stress reporters
- mark probe overlap as temporal correlation only

## Evidence
A local 1-minute 3-broker idempotent run emitted 176 probe events and 1,198 admission-block episodes. Most sampled late outliers overlapped frequent capacity probes, but large no-probe outliers also occurred; this PR therefore adds the missing visibility without claiming a causal fix.

## Validation
- `dotnet build Dekaf.sln -c Release --no-restore` (0 warnings/errors)
- net10 unit suite: 5,546 passed
- net8 unit suite: 5,439 passed
- Python stress-report suite: 26 passed
- local 3-broker producer diagnostic run: 3,752,942 delivered, 0 errors

Refs #2109