### PR TITLE
ci(stress): require single-lane selection on manual dispatch

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -462,17 +462,19 @@ def allocated_per_message(result):
 
 
 def find_confluent_baseline(results):
-    """Find Confluent throughput as a baseline for ratio calculations."""
+    """Find Confluent throughput as a baseline for ratio calculations.
+
+    Returns None when no Confluent rows exist (Dekaf-only scenarios and
+    single-client dispatches) so the ratio column renders '-' instead of a
+    self-referential ratio that reads as a Confluent comparison.
+    """
     confluent_results = [
         result for result in results
         if result.get('client', '').lower() == 'confluent'
     ]
-    if confluent_results:
-        rate = aggregate_client_rate(confluent_results)
-        if rate is not None:
-            return rate
+    if not confluent_results:
         return None
-    return min((comparison_rate(r) or 1 for r in results), default=1)
+    return aggregate_client_rate(confluent_results)
 
 
 def throughput_sort_key(result):

--- a/.github/scripts/test_stress_report.py
+++ b/.github/scripts/test_stress_report.py
@@ -383,6 +383,24 @@ class StressReportTests(unittest.TestCase):
         self.assertTrue(rows[0].startswith("| Dekaf"))
         self.assertIn("| 2.00x |", rows[0])
 
+    def test_throughput_table_single_client_shows_no_ratio(self):
+        # Dekaf-only scenarios and single-client dispatches have no Confluent
+        # baseline; a self-referential ratio would read as a Confluent comparison.
+        lines = format_throughput_table(
+            [
+                stress_result("Dekaf", effective_rate=2000, median_rate=1800),
+                stress_result("Dekaf (3conn)", effective_rate=2400, median_rate=2200),
+            ],
+            "Producer Throughput",
+            include_ratio=True,
+        )
+
+        rows = [line for line in lines if line.startswith("| Dekaf")]
+
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertTrue(row.endswith("| - |"), row)
+
     def test_throughput_table_aggregates_order_balanced_samples(self):
         dekaf_first = stress_result("Dekaf", effective_rate=1_440_000)
         dekaf_first["pairedClientOrder"] = "dekaf-first"

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -14,6 +15,12 @@ from stress_trend import (
     format_markdown,
     main,
 )
+
+
+def stress_workflow_text():
+    return (
+        Path(__file__).parent.parent / "workflows" / "stress-tests.yml"
+    ).read_text(encoding="utf-8")
 
 
 def result(messages_per_second=1000.0, cpu_micros_per_message=2.0, **overrides):
@@ -906,9 +913,7 @@ class StressTrendTests(unittest.TestCase):
             self.assertFalse(github_output_path.exists())
 
     def test_workflow_creates_merged_results_before_searching_for_results(self):
-        workflow = (
-            Path(__file__).parent.parent / "workflows" / "stress-tests.yml"
-        ).read_text(encoding="utf-8")
+        workflow = stress_workflow_text()
         step = workflow[
             workflow.index("      - name: Detect Performance Trends"):
             workflow.index("      - name: Upload Merged Results")
@@ -919,9 +924,7 @@ class StressTrendTests(unittest.TestCase):
         self.assertLess(create_directory, find_result)
 
     def test_workflow_regression_gate_consumes_all_failure_kinds(self):
-        workflow = (
-            Path(__file__).parent.parent / "workflows" / "stress-tests.yml"
-        ).read_text(encoding="utf-8")
+        workflow = stress_workflow_text()
 
         self.assertIn(
             "regression_failure: ${{ steps.stress-trends.outputs.should_fail }}",
@@ -932,10 +935,31 @@ class StressTrendTests(unittest.TestCase):
             workflow,
         )
 
+    def test_workflow_lane_options_match_selectable_lanes(self):
+        # The workflow_dispatch 'lane' choice list and the lanes.json matrix in
+        # the select-lanes job are maintained by hand in two places; an option
+        # without a lane dispatches a run that fails, and a lane without an
+        # option cannot be dispatched individually.
+        workflow = stress_workflow_text()
+
+        heredoc = re.search(
+            r"cat > lanes\.json << 'EOF'\n(?P<body>.*?)\n\s*EOF\n",
+            workflow,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(heredoc)
+        lanes = json.loads(heredoc.group("body"))
+        lane_ids = [lane["lane"] for lane in lanes]
+        self.assertEqual(len(lane_ids), len(set(lane_ids)))
+
+        options_block = workflow[
+            workflow.index("        options:"):workflow.index("      duration_minutes:")
+        ]
+        options = re.findall(r"^\s+- (\S+)$", options_block, re.MULTILINE)
+        self.assertEqual(options, lane_ids + ["all"])
+
     def test_history_merge_uses_admin_token(self):
-        workflow = (
-            Path(__file__).parent.parent / "workflows" / "stress-tests.yml"
-        ).read_text(encoding="utf-8")
+        workflow = stress_workflow_text()
         step = workflow[
             workflow.index("      - name: Auto-merge Pull Request"):
             workflow.index("  regression-gate:")

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -1,5 +1,5 @@
 name: Stress Tests
-run-name: Stress Tests (${{ github.event.inputs.lane || 'all' }})
+run-name: Stress Tests (${{ github.event.inputs.lane || 'all' }}${{ github.event.inputs.client != 'lane-default' && github.event.inputs.client && format(' / {0} only', github.event.inputs.client) || '' }})
 
 on:
   schedule:
@@ -49,12 +49,25 @@ on:
         description: 'Enable Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead to the measured window)'
         required: false
         default: 'false'
+      # Keep this choice input below duration_minutes: the options-sync test in
+      # .github/scripts/test_stress_trend.py slices the workflow text from the
+      # first 'options:' to 'duration_minutes:' to read the lane list.
+      client:
+        description: 'Client override for paired lanes: dekaf/confluent runs only that client (single sample, no ratio, results not published). Dekaf-only lanes ignore this.'
+        required: false
+        type: choice
+        default: lane-default
+        options:
+          - lane-default
+          - dekaf
+          - confluent
 
-# Scoped per lane so a cheap single-lane dispatch is not queued for hours behind
-# a full-matrix run; lanes execute on separate VMs and share no mutable state
-# (docs/history publishing only happens on full runs).
+# Scoped per lane+client so a cheap single-lane or single-client dispatch is not
+# queued for hours behind a full-matrix run; lanes execute on separate VMs and
+# share no mutable state (docs/history publishing only happens on unmodified
+# full runs, which all fall in the stress-tests-all-lane-default group).
 concurrency:
-  group: stress-tests-${{ github.event.inputs.lane || 'all' }}
+  group: stress-tests-${{ github.event.inputs.lane || 'all' }}-${{ github.event.inputs.client || 'lane-default' }}
   cancel-in-progress: false
 
 env:
@@ -77,6 +90,7 @@ jobs:
         id: select
         env:
           LANE: ${{ github.event.inputs.lane }}
+          CLIENT: ${{ github.event.inputs.client }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           # The UI enforces the required choice input, but API/CLI dispatches can
@@ -88,6 +102,19 @@ jobs:
             exit 1
           fi
           lane="${LANE:-all}"
+
+          # Client override: empty means the lane's own paired behavior. Validate
+          # here (choice is UI-enforced only) so a bad value fails on this free
+          # runner, not on a paid one.
+          client="$CLIENT"
+          [ "$client" = "lane-default" ] && client=""
+          case "$client" in
+            ""|dekaf|confluent) ;;
+            *)
+              echo "::error::Unknown client '$client'. Valid values: lane-default, dekaf, confluent."
+              exit 1
+              ;;
+          esac
 
           # timeout_minutes rationale: at a 30-minute dispatch the paired_samples=2
           # lanes run four paired client durations plus one 3-connection duration
@@ -111,8 +138,20 @@ jobs:
           ]
           EOF
 
-          matrix=$(jq -c --arg lane "$lane" \
-            '{include: [ .[] | select($lane == "all" or .lane == $lane) ]}' lanes.json)
+          # A client override applies only to paired lanes (client == "all"):
+          # Dekaf-only lanes keep their client. Overridden lanes drop to one
+          # sample — paired_samples exists to alternate client order, which is
+          # meaningless for a single client — and the Dekaf-only 3-connection
+          # pass survives only a dekaf override.
+          matrix=$(jq -c --arg lane "$lane" --arg client "$client" '
+            {include: [ .[]
+              | select($lane == "all" or .lane == $lane)
+              | if $client != "" and .client == "all" then
+                  .client = $client
+                  | .paired_samples = 1
+                  | if $client == "confluent" then .run_3conn = false | .artifact_suffix = "" else . end
+                else . end
+            ]}' lanes.json)
           count=$(echo "$matrix" | jq '.include | length')
           if [ "$count" -eq 0 ]; then
             echo "::error::Unknown lane '$lane'. Valid lanes: all $(jq -r '[.[].lane] | join(" ")' lanes.json)"
@@ -120,8 +159,10 @@ jobs:
           fi
 
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-          echo "full_run=$([ "$lane" = "all" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "Selected $count lane(s) for '$lane'"
+          # Only an unmodified full matrix may publish docs/history: a client
+          # override produces single-client rows that would wipe ratio columns.
+          echo "full_run=$([ "$lane" = "all" ] && [ -z "$client" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Selected $count lane(s) for '$lane'${client:+ (client override: $client)}"
 
   # Run each scenario in parallel. Comparable clients run sequentially inside the
   # same job/VM so published ratios share hardware and noisy-neighbor conditions;
@@ -514,9 +555,10 @@ jobs:
     runs-on: ubuntu-latest
     # stress-test success is required: a failed scenario (e.g. broker died mid-run)
     # must block the docs update rather than publish a partial or invalid table.
-    # Single-lane dispatches never publish: the docs page and trend history are
-    # regenerated from this run's results alone, so a partial run would drop every
-    # other lane's rows. Read single-lane data from the run summary and artifacts.
+    # Partial dispatches (single lane, or a client override) never publish: the
+    # docs page and trend history are regenerated from this run's results alone,
+    # so a partial run would drop other lanes' rows or the ratio columns. Read
+    # partial-run data from the run summary and artifacts.
     if: github.ref == 'refs/heads/main' && needs.select-lanes.outputs.full_run == 'true' && needs.stress-test.result == 'success' && needs.generate-summary.result == 'success'
 
     permissions:
@@ -648,9 +690,10 @@ jobs:
     needs: [stress-test, generate-summary, publish-to-docs]
     runs-on: ubuntu-latest
     # Wait for the docs PR so valid regression observations are persisted before
-    # the workflow reports the repeated regression. Single-lane dispatches skip
-    # publish-to-docs and therefore this gate too: their observations are never
-    # persisted to history, so consecutive-regression tracking would be spurious.
+    # the workflow reports the repeated regression. Partial dispatches (single
+    # lane or client override) skip publish-to-docs and therefore this gate too:
+    # their observations are never persisted to history, so consecutive-regression
+    # tracking would be spurious.
     if: >-
       always() &&
       needs.stress-test.result == 'success' &&

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -1,10 +1,34 @@
 name: Stress Tests
+run-name: Stress Tests (${{ github.event.inputs.lane || 'all' }})
 
 on:
   schedule:
     - cron: '0 2 * * 0'  # Weekly Sunday 2 AM UTC
   workflow_dispatch:
     inputs:
+      # Required so every manual dispatch makes an explicit cost decision: each
+      # lane is its own paid 8-core runner job (up to 3 hours), so pick the single
+      # lane whose data you need and use "all" only when the full comparison
+      # matrix is required. Scheduled runs always run the full matrix.
+      lane:
+        description: 'Stress lane to run (one paid runner job per lane; "all" runs the full matrix)'
+        required: true
+        type: choice
+        options:
+          - producer-1b
+          - producer-3b
+          - producer-idempotent-1b
+          - producer-idempotent-3b
+          - producer-acks-all-1b
+          - producer-acks-all-3b
+          - producer-transactional-3b
+          - producer-roundtrip-1b
+          - producer-roundtrip-steady-1b
+          - consumer-1b
+          - consumer-batch-1b
+          - consumer-raw-1b
+          - consumer-raw-batch-1b
+          - all
       duration_minutes:
         description: 'Test duration in minutes'
         required: false
@@ -26,8 +50,11 @@ on:
         required: false
         default: 'false'
 
+# Scoped per lane so a cheap single-lane dispatch is not queued for hours behind
+# a full-matrix run; lanes execute on separate VMs and share no mutable state
+# (docs/history publishing only happens on full runs).
 concurrency:
-  group: stress-tests
+  group: stress-tests-${{ github.event.inputs.lane || 'all' }}
   cancel-in-progress: false
 
 env:
@@ -35,114 +62,75 @@ env:
   Deterministic: true
 
 jobs:
+  # Resolves the lane input to the matrix that actually runs, on a free runner,
+  # before any paid 8-core runner spins up. Keep the lane list here in sync with
+  # the workflow_dispatch choice options above (enforced by
+  # test_workflow_lane_options_match_selectable_lanes in .github/scripts).
+  select-lanes:
+    name: Select Lanes
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      full_run: ${{ steps.select.outputs.full_run }}
+    steps:
+      - name: Select lanes for this run
+        id: select
+        env:
+          LANE: ${{ github.event.inputs.lane }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # The UI enforces the required choice input, but API/CLI dispatches can
+          # omit it; fail fast here rather than defaulting a manual run to the
+          # full (expensive) matrix. Scheduled runs have no inputs and always run
+          # the full matrix.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -z "$LANE" ]; then
+            echo "::error::Missing required 'lane' input. Pass -f lane=<lane> (single paid-runner job) or -f lane=all for the full matrix."
+            exit 1
+          fi
+          lane="${LANE:-all}"
+
+          # timeout_minutes rationale: at a 30-minute dispatch the paired_samples=2
+          # lanes run four paired client durations plus one 3-connection duration
+          # (180 min); acks-all 1-broker runs four measured durations (150 min);
+          # all lanes leave setup/publish headroom.
+          cat > lanes.json << 'EOF'
+          [
+            {"lane": "producer-1b", "scenario": "producer", "client": "all", "brokers": 1, "paired_samples": 2, "run_3conn": true, "artifact_suffix": "-with-3conn", "timeout_minutes": 180, "name": "Producer (Paired)"},
+            {"lane": "producer-3b", "scenario": "producer", "client": "all", "brokers": 3, "run_3conn": true, "artifact_suffix": "-with-3conn", "timeout_minutes": 150, "name": "Producer (Paired, 3 Brokers)"},
+            {"lane": "producer-idempotent-1b", "scenario": "producer-idempotent", "client": "all", "brokers": 1, "paired_samples": 2, "run_3conn": true, "artifact_suffix": "-with-3conn", "timeout_minutes": 180, "name": "Producer Idempotent (Paired)"},
+            {"lane": "producer-idempotent-3b", "scenario": "producer-idempotent", "client": "all", "brokers": 3, "run_3conn": true, "artifact_suffix": "-with-3conn", "timeout_minutes": 150, "name": "Producer Idempotent (Paired, 3 Brokers)"},
+            {"lane": "producer-acks-all-1b", "scenario": "producer-acks-all", "client": "all", "brokers": 1, "paired_samples": 2, "timeout_minutes": 150, "name": "Producer Acks All (Paired)"},
+            {"lane": "producer-acks-all-3b", "scenario": "producer-acks-all", "client": "all", "brokers": 3, "timeout_minutes": 120, "name": "Producer Acks All (Paired, 3 Brokers)"},
+            {"lane": "producer-transactional-3b", "scenario": "producer-transactional", "client": "all", "brokers": 3, "timeout_minutes": 150, "name": "Transactional EOS (Paired, 3 Brokers)"},
+            {"lane": "producer-roundtrip-1b", "scenario": "producer-roundtrip", "client": "all", "brokers": 1, "timeout_minutes": 90, "name": "Producer → Consumer Round-Trip (Paired)"},
+            {"lane": "producer-roundtrip-steady-1b", "scenario": "producer-roundtrip-steady", "client": "all", "brokers": 1, "message_size": 128, "roundtrip_steady_seconds": 60, "timeout_minutes": 90, "name": "Producer → Consumer Round-Trip Steady State (Paired)"},
+            {"lane": "consumer-1b", "scenario": "consumer", "client": "all", "brokers": 1, "timeout_minutes": 90, "name": "Consumer (Paired)"},
+            {"lane": "consumer-batch-1b", "scenario": "consumer-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Batch"},
+            {"lane": "consumer-raw-1b", "scenario": "consumer-raw", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw"},
+            {"lane": "consumer-raw-batch-1b", "scenario": "consumer-raw-batch", "client": "dekaf", "brokers": 1, "timeout_minutes": 60, "name": "Dekaf Consumer Raw Batch"}
+          ]
+          EOF
+
+          matrix=$(jq -c --arg lane "$lane" \
+            '{include: [ .[] | select($lane == "all" or .lane == $lane) ]}' lanes.json)
+          count=$(echo "$matrix" | jq '.include | length')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Unknown lane '$lane'. Valid lanes: all $(jq -r '[.[].lane] | join(" ")' lanes.json)"
+            exit 1
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "full_run=$([ "$lane" = "all" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Selected $count lane(s) for '$lane'"
+
   # Run each scenario in parallel. Comparable clients run sequentially inside the
   # same job/VM so published ratios share hardware and noisy-neighbor conditions;
   # 1-broker producer acceptance lanes repeat in both client orders.
   stress-test:
+    needs: select-lanes
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - scenario: producer
-            client: all
-            brokers: 1
-            paired_samples: 2
-            run_3conn: true
-            artifact_suffix: -with-3conn
-            # At a 30-minute dispatch this runs four paired client durations plus
-            # one 3-connection duration; leave setup/publish headroom as well.
-            timeout_minutes: 180
-            name: Producer (Paired)
-          - scenario: producer
-            client: all
-            brokers: 3
-            run_3conn: true
-            artifact_suffix: -with-3conn
-            timeout_minutes: 150
-            name: Producer (Paired, 3 Brokers)
-          - scenario: producer-idempotent
-            client: all
-            brokers: 1
-            paired_samples: 2
-            run_3conn: true
-            artifact_suffix: -with-3conn
-            # Same five measured durations as the fire-and-forget lane.
-            timeout_minutes: 180
-            name: Producer Idempotent (Paired)
-          - scenario: producer-idempotent
-            client: all
-            brokers: 3
-            run_3conn: true
-            artifact_suffix: -with-3conn
-            timeout_minutes: 150
-            name: Producer Idempotent (Paired, 3 Brokers)
-          - scenario: producer-acks-all
-            client: all
-            brokers: 1
-            paired_samples: 2
-            run_3conn: false
-            artifact_suffix: ""
-            # Four measured durations need 120 minutes at a 30-minute dispatch.
-            timeout_minutes: 150
-            name: Producer Acks All (Paired)
-          - scenario: producer-acks-all
-            client: all
-            brokers: 3
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 120
-            name: Producer Acks All (Paired, 3 Brokers)
-          - scenario: producer-transactional
-            client: all
-            brokers: 3
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 150
-            name: Transactional EOS (Paired, 3 Brokers)
-          - scenario: producer-roundtrip
-            client: all
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 90
-            name: Producer → Consumer Round-Trip (Paired)
-          - scenario: producer-roundtrip-steady
-            client: all
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            message_size: 128
-            roundtrip_steady_seconds: 60
-            timeout_minutes: 90
-            name: Producer → Consumer Round-Trip Steady State (Paired)
-          - scenario: consumer
-            client: all
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 90
-            name: Consumer (Paired)
-          - scenario: consumer-batch
-            client: dekaf
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 60
-            name: Dekaf Consumer Batch
-          - scenario: consumer-raw
-            client: dekaf
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 60
-            name: Dekaf Consumer Raw
-          - scenario: consumer-raw-batch
-            client: dekaf
-            brokers: 1
-            run_3conn: false
-            artifact_suffix: ""
-            timeout_minutes: 60
-            name: Dekaf Consumer Raw Batch
+      matrix: ${{ fromJson(needs.select-lanes.outputs.matrix) }}
 
     name: ${{ matrix.name }}
     # 8 vCPUs, split so the client under test is the measured bottleneck:
@@ -522,11 +510,14 @@ jobs:
 
   publish-to-docs:
     name: Publish Stress Test Results to Documentation
-    needs: [stress-test, generate-summary]
+    needs: [select-lanes, stress-test, generate-summary]
     runs-on: ubuntu-latest
     # stress-test success is required: a failed scenario (e.g. broker died mid-run)
     # must block the docs update rather than publish a partial or invalid table.
-    if: github.ref == 'refs/heads/main' && needs.stress-test.result == 'success' && needs.generate-summary.result == 'success'
+    # Single-lane dispatches never publish: the docs page and trend history are
+    # regenerated from this run's results alone, so a partial run would drop every
+    # other lane's rows. Read single-lane data from the run summary and artifacts.
+    if: github.ref == 'refs/heads/main' && needs.select-lanes.outputs.full_run == 'true' && needs.stress-test.result == 'success' && needs.generate-summary.result == 'success'
 
     permissions:
       contents: write
@@ -657,7 +648,9 @@ jobs:
     needs: [stress-test, generate-summary, publish-to-docs]
     runs-on: ubuntu-latest
     # Wait for the docs PR so valid regression observations are persisted before
-    # the workflow reports the repeated regression.
+    # the workflow reports the repeated regression. Single-lane dispatches skip
+    # publish-to-docs and therefore this gate too: their observations are never
+    # persisted to history, so consecutive-regression tracking would be spurious.
     if: >-
       always() &&
       needs.stress-test.result == 'success' &&


### PR DESCRIPTION
## Problem

Agents gathering stress data dispatch the workflow and get the full 13-job matrix — each lane is a paid 8-core `ubicloud-standard-8` job running up to 3 hours. Most investigations need exactly one lane, and often only one client's data.

## Change

Manual dispatch now **requires** a `lane` choice input, with an optional `client` override:

```
gh workflow run stress-tests.yml -f lane=producer-acks-all-3b                  # one lane, paired as usual
gh workflow run stress-tests.yml -f lane=producer-1b -f client=dekaf          # one lane, Dekaf only
gh workflow run stress-tests.yml -f lane=all                                   # full matrix, unchanged behavior
```

Lanes: `producer-1b/3b`, `producer-idempotent-1b/3b`, `producer-acks-all-1b/3b`, `producer-transactional-3b`, `producer-roundtrip-1b`, `producer-roundtrip-steady-1b`, `consumer-1b`, `consumer-batch-1b`, `consumer-raw-1b`, `consumer-raw-batch-1b`, `all`. The weekly schedule still runs everything.

## How

- **`select-lanes` job** (free `ubuntu-latest`, no checkout) resolves the inputs to a dynamic `fromJson` matrix. Needed because the `matrix` context is unavailable in job-level `if`, so lanes can't be filtered on the static matrix without spinning up paid runners just to skip.
- **Fail-fast guards**: GitHub only enforces `required: true` and choice values in the UI; API/CLI dispatches that omit `lane` or pass a bad `client` fail in `select-lanes` with instructions, before any paid runner starts — instead of silently defaulting to the expensive full matrix.
- **Client override** (`dekaf`/`confluent`, default `lane-default`) applies only to paired lanes: the lane runs a single sample of just that client (paired ordering is meaningless for one client), and the Dekaf-only 3-connection pass survives only a `dekaf` override. Dekaf-only consumer lanes ignore it. Resolved entirely in `select-lanes`, so the paid-runner job is untouched.
- **Partial dispatches (single lane or client override) skip `publish-to-docs` and the regression gate.** The docs page and trend history are regenerated wholesale from the run's results, so a partial run would wipe other lanes' rows or the ratio columns, and unpersisted observations would make consecutive-regression tracking spurious. Read partial-run data from the run summary and artifacts. Full runs (`lane=all`, no override / schedule) publish exactly as before.
- **Per-lane+client concurrency group** so a 15-minute dispatch is not queued behind a 3-hour full run; lanes share no mutable state since only unmodified full runs publish.
- **Clean single-client summary tables**: with no Confluent rows, the ratio baseline used to fall back to the slowest row in the table, printing self-referential values under the "Comparison Ratio" header (also affected Dekaf-only consumer lanes in full runs). It now returns `None` and those cells render `-`. Docs tables are unaffected — they never include the ratio column.
- **Drift guard**: the lane list is hand-maintained in two places (choice options + lanes.json in `select-lanes`); `test_workflow_lane_options_match_selectable_lanes` asserts they match exactly.

Matrix lane definitions are field-for-field identical to the old static include list; paid-runner jobs gain zero steps and zero seconds.

## Testing

- `python -m unittest test_stress_report test_stress_trend`: 61 tests pass (includes new lane/options sync test and single-client ratio-column test).
- Workflow YAML and embedded lanes JSON validated by parse.
- jq lane+client transform exercised locally with jq 1.7.1 for: `all`, single lane, unknown lane (0 matches → error), `dekaf` and `confluent` overrides on paired/3conn/Dekaf-only lanes, and `all`+`dekaf`.