### PR TITLE
Restore producer budget pressure growth

### DIFF
--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -103,24 +103,19 @@ internal sealed class BrokerUnackedByteBudget
     private const double OccupancySafetyMultiplier = 1.5;
     private const double ProbeGrowthThreshold = 1.01;
     private const double DeliveryLatencyEwmaWeight = 0.125;
+    private const double RequestSizeEwmaWeight = 0.125;
     private const double ServingRttEwmaWeight = 0.125;
     private const double MinimumLatencyBudgetScale = 0.10;
-
-    /// <summary>
-    /// Upper bound on the latency budget scale. Above 1.0 the scale is the budget's only
-    /// unconditional upward force (#2008): the drain-rate estimate is measured from traffic
-    /// the admission gate itself admitted, so <c>rate × target</c> is self-confirming at any
-    /// throughput level — without headroom above parity the budget can never discover broker
-    /// or sender capacity beyond whatever it happens to be admitting. The controller grows
-    /// the scale only while admission is blocking (proof of demand) and measured delivery
-    /// latency sits below target, and growth decelerates as latency approaches target. The
-    /// bound keeps a stale-high scale's overshoot window short: shrinking back to parity
-    /// from here takes ~8 control intervals (~0.8 s).
-    /// </summary>
-    private const double MaximumLatencyBudgetScale = 10.0;
     private const double MinimumLatencyAdjustmentFactor = 0.75;
     private const double MaximumLatencyAdjustmentFactor = 1.05;
     private const double MaximumBudgetDecayPerSecond = 0.10;
+
+    /// <summary>Minimum number of average encoded requests retained under proven demand.
+    /// A byte BDP smaller than one or two request quanta serializes the acknowledgement clock,
+    /// making its reduced delivery rate self-confirming. Four request quanta mirror BBR's
+    /// minimum flight: enough to tolerate request and scheduler granularity without filling
+    /// the delivery-latency target with queueing delay.</summary>
+    private const int MinimumPipelineRequestQuanta = 4;
 
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
@@ -178,6 +173,12 @@ internal sealed class BrokerUnackedByteBudget
     /// and ratchet the budget down to the floor.</summary>
     private const double RttSafetyMultiplier = 1.5;
     private const double MinRttProbeSafetyMultiplier = 1.0;
+
+    /// <summary>Minimum neutral safety horizon on low-latency links. Sub-millisecond
+    /// RTT samples describe an empty pipe but do not leave enough byte admission depth to
+    /// start a saturated sender's request pipeline. The request-quantum floor supplies the
+    /// remaining granularity only under proven demand; minimum-RTT probes bypass both.</summary>
+    private const double MinimumNormalHorizonSeconds = 0.001;
 
     /// <summary>Ceiling on the loaded serving RTT as a multiple of the queue-drained minimum
     /// RTT. The serving EWMA includes queueing delay the budget itself admitted, so letting
@@ -267,6 +268,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
+    private double _requestSizeEwmaBytes;
     private bool _hasLoadedServingSample;
     private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
@@ -290,6 +292,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _capacityProbeFailureCount;
     private double _deliveryLatencyEwmaSeconds;
     private double _latencyBudgetScale = 1.0;
+    private bool _admissionPressureActive;
     private long _nextLatencyControlTimestamp;
     private long _lastLatencyControlAdmissionBlockEvents;
     private long _lastNormalBudgetBytes;
@@ -747,17 +750,17 @@ internal sealed class BrokerUnackedByteBudget
             naturalMinRttSample: sendSnapshot.AppLimited && !sustainedIdle);
         if (loadedServingSample && !minRttProbeActive)
         {
-            _servingRttEwmaSeconds = _servingRttEwmaSeconds == 0
-                ? serviceRttSeconds
-                : _servingRttEwmaSeconds
-                    + ServingRttEwmaWeight * (serviceRttSeconds - _servingRttEwmaSeconds);
+            _servingRttEwmaSeconds = UpdateEwma(
+                _servingRttEwmaSeconds,
+                serviceRttSeconds,
+                ServingRttEwmaWeight);
             // Raw (uncorrected) companion estimate for the capacity probe: probe samples are
             // raw round trips, so their acceptance baseline must live in the same domain —
             // a corrected baseline under standing load would reject every probe.
-            _rawServingRttEwmaSeconds = _rawServingRttEwmaSeconds == 0
-                ? rttSeconds
-                : _rawServingRttEwmaSeconds
-                    + ServingRttEwmaWeight * (rttSeconds - _rawServingRttEwmaSeconds);
+            _rawServingRttEwmaSeconds = UpdateEwma(
+                _rawServingRttEwmaSeconds,
+                rttSeconds,
+                ServingRttEwmaWeight);
         }
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
         UpdateDeliveryLatency(
@@ -765,6 +768,10 @@ internal sealed class BrokerUnackedByteBudget
             sendSnapshot.SendTimestamp,
             nowTicks);
 
+        _requestSizeEwmaBytes = UpdateEwma(
+            _requestSizeEwmaBytes,
+            ackedBytes,
+            RequestSizeEwmaWeight);
         RecordRequestHistograms(ackedBytes, rttSeconds);
 
         // Keep two delivery-rate axes. The request axis attributes immediate delivery credit
@@ -847,10 +854,10 @@ internal sealed class BrokerUnackedByteBudget
             return;
 
         var sampleSeconds = (double)(sendTimestamp - oldestBatchTimestamp) / Stopwatch.Frequency;
-        var latencyEstimate = _deliveryLatencyEwmaSeconds == 0
-            ? sampleSeconds
-            : _deliveryLatencyEwmaSeconds
-                + DeliveryLatencyEwmaWeight * (sampleSeconds - _deliveryLatencyEwmaSeconds);
+        var latencyEstimate = UpdateEwma(
+            _deliveryLatencyEwmaSeconds,
+            sampleSeconds,
+            DeliveryLatencyEwmaWeight);
         Volatile.Write(ref _deliveryLatencyEwmaSeconds, latencyEstimate);
 
         // Measured seal-to-ack is the delivery latency users experience from the moment a
@@ -860,24 +867,22 @@ internal sealed class BrokerUnackedByteBudget
         // setpoint that suppressed fan-out (#1988). What remains — sender backlog plus
         // broker-side queueing — is exactly the delay the budget controls (#2008, #2009).
         var sealToAckSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
-        _sealToAckEwmaSeconds = _sealToAckEwmaSeconds == 0
-            ? sealToAckSeconds
-            : _sealToAckEwmaSeconds
-                + DeliveryLatencyEwmaWeight * (sealToAckSeconds - _sealToAckEwmaSeconds);
+        _sealToAckEwmaSeconds = UpdateEwma(
+            _sealToAckEwmaSeconds,
+            sealToAckSeconds,
+            DeliveryLatencyEwmaWeight);
 
         if (_nextLatencyControlTimestamp == 0)
         {
+            UpdateAdmissionPressure();
             _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
-            _lastLatencyControlAdmissionBlockEvents = AdmissionBlockEvents;
             return;
         }
 
         if (nowTicks < _nextLatencyControlTimestamp)
             return;
 
-        var admissionBlockEvents = AdmissionBlockEvents;
-        var admissionWasBlocked = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
-        _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
+        UpdateAdmissionPressure();
 
         var baseRttSeconds = _hasMinRttSample ? _minRttSeconds : 0;
         var brokerQueueSeconds = _sealToAckEwmaSeconds - baseRttSeconds;
@@ -900,21 +905,13 @@ internal sealed class BrokerUnackedByteBudget
                 ? Math.Max(MinimumLatencyAdjustmentFactor, targetRatio)
                 : 1.0;
         }
-        else if (admissionWasBlocked)
-        {
-            // The budget's only unconditional upward force: blocked demand with measured
-            // latency below target grows the scale past rate parity, breaking the
-            // self-confirming rate x target equilibrium (#2008). Growth decelerates as
-            // latency approaches target (adjustment -> 1 as targetRatio -> 1).
-            adjustment = Math.Min(MaximumLatencyAdjustmentFactor, targetRatio);
-        }
         else if (_latencyBudgetScale < 1.0)
         {
             // A transient queue can legitimately derate the budget, but once measured
             // latency is back below target the controller must return to its neutral scale.
             // Requiring another admission block here makes the derating self-sealing: the
             // smaller budget removes the pressure event that would restore it. Recovery
-            // without pressure stops at 1.0; only the branch above may probe past parity.
+            // without pressure stops at the neutral 1.0 scale.
             adjustment = Math.Min(
                 MaximumLatencyAdjustmentFactor,
                 1.0 / _latencyBudgetScale);
@@ -927,8 +924,15 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _latencyBudgetScale, Math.Clamp(
             _latencyBudgetScale * adjustment,
             MinimumLatencyBudgetScale,
-            MaximumLatencyBudgetScale));
+            1.0));
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
+    }
+
+    private void UpdateAdmissionPressure()
+    {
+        var admissionBlockEvents = AdmissionBlockEvents;
+        _admissionPressureActive = admissionBlockEvents > _lastLatencyControlAdmissionBlockEvents;
+        _lastLatencyControlAdmissionBlockEvents = admissionBlockEvents;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1344,6 +1348,10 @@ internal sealed class BrokerUnackedByteBudget
         return maximum;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double UpdateEwma(double current, double sample, double weight)
+        => current == 0 ? sample : current + weight * (sample - current);
+
     private static long Max(long[] values)
     {
         var maximum = 0L;
@@ -1356,17 +1364,20 @@ internal sealed class BrokerUnackedByteBudget
     private void RecomputeBudget(long nowTicks)
     {
         var minRttProbeActive = _minRttProbeUntilTimestamp != 0;
+        var admissionPressureActive = _admissionPressureActive;
         var postProbeMinRttSeconds = _minRttSeconds;
         if (minRttProbeActive && _minRttProbeMinimumSeconds != double.MaxValue)
             postProbeMinRttSeconds = _minRttProbeMinimumSeconds;
         var computedNormalBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: false,
+            admissionPressureActive,
             postProbeMinRttSeconds);
         var normalBudget = ApplyNormalBudgetDecayHysteresis(computedNormalBudget, nowTicks);
         var probeBudget = ComputeBudget(
             minRttProbeActive: false,
             capacityProbeActive: true,
+            admissionPressureActive,
             postProbeMinRttSeconds);
         probeBudget = Math.Max(normalBudget, probeBudget);
         Volatile.Write(ref _budgetAfterMinRttProbeBytes, normalBudget);
@@ -1378,6 +1389,7 @@ internal sealed class BrokerUnackedByteBudget
             budget = ComputeBudget(
                 minRttProbeActive: true,
                 capacityProbeActive: false,
+                admissionPressureActive,
                 _minRttSeconds);
         }
         else
@@ -1424,6 +1436,7 @@ internal sealed class BrokerUnackedByteBudget
     private long ComputeBudget(
         bool minRttProbeActive,
         bool capacityProbeActive,
+        bool admissionPressureActive,
         double minRttSeconds)
     {
         long budget;
@@ -1448,11 +1461,29 @@ internal sealed class BrokerUnackedByteBudget
                 : minRttSeconds;
             var rttSafetyHorizonSeconds = minRttProbeActive
                 ? MinRttProbeSafetyMultiplier * minRttSeconds
-                : RttSafetyMultiplier * loadAwareRttSeconds;
+                : Math.Max(
+                    RttSafetyMultiplier * loadAwareRttSeconds,
+                    MinimumNormalHorizonSeconds);
             var latencyCapSeconds = Math.Max(latencyGovernedTargetSeconds, minRttSeconds);
             var horizonSeconds = _hasMinRttSample
                 ? Math.Min(rttSafetyHorizonSeconds, latencyCapSeconds)
                 : latencyGovernedTargetSeconds;
+
+            if (!minRttProbeActive && admissionPressureActive && _requestSizeEwmaBytes > 0)
+            {
+                // Admission is charged in batch/request-sized quanta, so a sub-request BDP
+                // cannot expose additional capacity even when the byte-rate estimator is
+                // accurate. Recent blocked demand enables a small acknowledgement pipeline;
+                // the latency cap bounds it. General capacity discovery remains the job of
+                // the periodic 25% probes below — this floor only crosses coarse request
+                // granularity that a smaller byte probe cannot expose.
+                var requestPipelineHorizonSeconds =
+                    MinimumPipelineRequestQuanta * _requestSizeEwmaBytes / effectiveMaxRate;
+                horizonSeconds = Math.Max(
+                    horizonSeconds,
+                    Math.Min(requestPipelineHorizonSeconds, latencyCapSeconds));
+            }
+
             rateBudgetBytes = effectiveMaxRate * horizonSeconds;
             var estimatedBytes = rateBudgetBytes;
             if (capacityProbeActive && !minRttProbeActive)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -103,6 +103,21 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task LowRttBudget_UsesMinimumNormalHorizon()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 3_200);
+
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.0001);
+        Ack(budget, 100, 0.0001, T0 + Seconds(0.051));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000)
+            .Because("an empty-pipe RTT must not make the admission horizon too shallow to discover capacity");
+    }
+
+    [Test]
     public async Task DeliveryLatencyAboveTarget_ReducesRateBudget()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -209,8 +224,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
         await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(reducedScale);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500)
-            .Because("latency-scale recovery cannot grow the budget beyond its RTT safety horizon");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(3_225)
+            .Because("blocked demand restores a request pipeline only within the current latency cap");
     }
 
     [Test]
@@ -1128,7 +1143,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task AdmissionPressureWithLatencyHeadroom_GrowsScaleWithinRttSafetyCap()
+    public async Task AdmissionPressureWithLatencyHeadroom_ProvidesMinimumRequestPipeline()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1137,10 +1152,10 @@ public sealed class BrokerUnackedByteBudgetTests
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
 
-        // The drain estimate only ever measures traffic the gate admitted, so rate x target
-        // is self-confirming at any throughput (#2008). Blocked demand with latency headroom
-        // grows the target horizon so real capacity can be discovered. The RTT safety
-        // horizon remains the tighter cap on a low-latency link.
+        // The drain estimate only ever measures traffic the gate admitted, so a low-RTT
+        // budget smaller than a few request quanta is self-confirming at low throughput.
+        // Blocked demand provides a minimum request pipeline without filling the latency
+        // target with queueing delay.
         var now = T0;
         for (var i = 0; i < 30; i++)
         {
@@ -1153,15 +1168,16 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
 
-        await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(1.5);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(4_000)
+            .Because("four full request quanta keep the acknowledgement clock running without a target-sized queue");
     }
 
     [Test]
-    public async Task LatencyBudgetScale_IsBoundedAboveByCeiling()
+    public async Task MinimumRequestPipeline_IsBoundedByLatencyTarget()
     {
         var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.010,
+            targetSeconds: 0.002,
             floorBytes: 200,
             initialCapBytes: 32_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
@@ -1178,9 +1194,65 @@ public sealed class BrokerUnackedByteBudgetTests
             Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
         }
 
-        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(10.0).Within(0.000_001)
-            .Because("a stale-high scale must stay within a short shrink-back window");
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500);
+        await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_000)
+            .Because("request granularity must not turn the configured latency target back into a floor");
+    }
+
+    [Test]
+    public async Task MinimumRequestPipeline_ExpiresWithoutRecentAdmissionPressure()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+
+        var now = T0 + Seconds(0.110);
+        budget.RecordAdmissionBlock();
+        var snapshot = budget.SnapshotDelivery(
+            now - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: now - Seconds(0.002));
+        Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(4_000);
+
+        now += Seconds(0.110);
+        snapshot = budget.SnapshotDelivery(
+            now - Seconds(0.001),
+            appLimited: true,
+            oldestBatchTimestamp: now - Seconds(0.002));
+        Ack(budget, 1_000, rttSeconds: 0, now, snapshotAtSend: snapshot);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_500)
+            .Because("one historical admission block must not retain the request floor forever");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RttDominantTarget_ExploresCapacityAboveTargetCap()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.008);
+        await Assert.That(GetField<long>(budget, "_budgetAfterMinRttProbeBytes")).IsEqualTo(10_000)
+            .Because("the latency target binds below the 1.5x RTT safety horizon");
+        budget.Charge(20_000);
+
+        for (var i = 1; i <= 8; i++)
+            Ack(budget, 8_000, 0.008, T0 + Seconds(i * 0.008));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
+        var normalBudget = GetField<long>(budget, "_budgetAfterMinRttProbeBytes");
+        await Assert.That(budget.BudgetBytes).IsEqualTo((long)(normalBudget * 1.25))
+            .Because("the periodic probe must explore 25% beyond an RTT-dominant target cap");
+
+        for (var i = 9; i <= 12; i++)
+            Ack(budget, 10_000, 0.008, T0 + Seconds(i * 0.008));
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1)
+            .Because("flat-RTT rate gain above the target cap must remain discoverable");
     }
 
     [Test]


### PR DESCRIPTION
Fixes #2108.

The RTT-safety cap added in #2119 exposed request granularity: on this lane each produce request averages ~1.03 MB, while the 1 ms low-RTT budget admitted only about one full request. That serialized the acknowledgement clock and made the reduced delivered-rate estimate self-confirming.

This revision keeps the RTT/latency horizon as a hard cap and removes pressure growth above neutral. During recent admission pressure it instead retains four EWMA-sized encoded request quanta, capped by the active latency target. The floor expires after a quiet 100 ms control interval; normal decay hysteresis prevents a loaded pipeline collapsing before pressure can reassert. Minimum-RTT probes bypass the floor, while periodic 25% capacity probes remain able to explore above an RTT-dominant target cap.

Validation:
- `BrokerUnackedByteBudgetTests`: 95/95 on net10.0
- `BrokerUnackedByteBudgetTests`: 95/95 on net8.0
- regression coverage proves an RTT-dominant 10 KB target cap still publishes a 1.25x probe and accepts flat-RTT rate gain
- builds: 0 warnings, 0 errors

Final acceptance will use only the required lane (`producer-1b`) and required comparative clients (Dekaf + Confluent).