### PR TITLE
Centralize NuGet package versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Test Agent Lock Worktree Isolation
@@ -315,7 +315,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Install NativeAOT prerequisites
@@ -368,7 +368,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Install NativeAOT prerequisites
@@ -517,7 +517,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Install GitVersion

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,53 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <DekafPackageVersion Condition="'$(DekafPackageVersion)' == ''">1.4.0</DekafPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Apache.Avro" Version="1.12.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />
+    <PackageVersion Include="Dekaf" Version="$(DekafPackageVersion)" />
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.8.2" />
+    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
+    <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
+    <PackageVersion Include="ModularPipelines" Version="3.2.8" />
+    <PackageVersion Include="ModularPipelines.DotNet" Version="3.2.8" />
+    <PackageVersion Include="ModularPipelines.Git" Version="3.2.8" />
+    <PackageVersion Include="ModularPipelines.GitHub" Version="3.2.8" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageVersion Include="Polyfill" Version="11.0.1" />
+    <PackageVersion Include="SharpFuzz" Version="2.3.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.10" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.10" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.9" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.Toxiproxy" Version="4.13.0" />
+    <PackageVersion Include="ToxiproxyNetCore" Version="1.0.50" />
+    <PackageVersion Include="TUnit" Version="1.60.0" />
+    <PackageVersion Include="TUnit.Logging.Microsoft" Version="1.60.0" />
+    <PackageVersion Include="Verify.TUnit" Version="31.24.2" />
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.8" />
+  </ItemGroup>
+</Project>

--- a/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj
+++ b/samples/PackageSmoke/Dekaf.PackageSmoke.NetStandard20/Dekaf.PackageSmoke.NetStandard20.csproj
@@ -4,11 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <DekafPackageVersion Condition="'$(DekafPackageVersion)' == ''">1.4.0</DekafPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dekaf" Version="$(DekafPackageVersion)" />
+    <PackageReference Include="Dekaf" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Compression.Lz4/Dekaf.Compression.Lz4.csproj
+++ b/src/Dekaf.Compression.Lz4/Dekaf.Compression.Lz4.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Compression.Snappy/Dekaf.Compression.Snappy.csproj
+++ b/src/Dekaf.Compression.Snappy/Dekaf.Compression.Snappy.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Compression.Zstd/Dekaf.Compression.Zstd.csproj
+++ b/src/Dekaf.Compression.Zstd/Dekaf.Compression.Zstd.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
+    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
+++ b/src/Dekaf.Extensions.DependencyInjection/Dekaf.Extensions.DependencyInjection.csproj
@@ -18,11 +18,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Extensions.HealthChecks/Dekaf.Extensions.HealthChecks.csproj
+++ b/src/Dekaf.Extensions.HealthChecks/Dekaf.Extensions.HealthChecks.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Extensions.Hosting/Dekaf.Extensions.Hosting.csproj
+++ b/src/Dekaf.Extensions.Hosting/Dekaf.Extensions.Hosting.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
     <ProjectReference Include="..\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.OpenTelemetry/Dekaf.OpenTelemetry.csproj
+++ b/src/Dekaf.OpenTelemetry/Dekaf.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Api" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
+++ b/src/Dekaf.SchemaRegistry.Avro/Dekaf.SchemaRegistry.Avro.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.12.1" />
+    <PackageReference Include="Apache.Avro" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dekaf.SchemaRegistry.Protobuf/Dekaf.SchemaRegistry.Protobuf.csproj
+++ b/src/Dekaf.SchemaRegistry.Protobuf/Dekaf.SchemaRegistry.Protobuf.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+    <PackageReference Include="Google.Protobuf" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf.Testing/Dekaf.Testing.csproj
+++ b/src/Dekaf.Testing/Dekaf.Testing.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageReference Include="System.IO.Hashing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -40,11 +40,11 @@
 
   <!-- Compatibility dependencies for the package's netstandard2.0 asset. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
-    <PackageReference Include="Polyfill" Version="11.0.1" PrivateAssets="all" />
-    <PackageReference Include="System.IO.Pipelines" Version="10.0.10" />
-    <PackageReference Include="System.Text.Json" Version="10.0.9" />
-    <PackageReference Include="System.Threading.Channels" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
+    <PackageReference Include="System.IO.Pipelines" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Threading.Channels" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj
+++ b/tests/Dekaf.Tests.Aot.DependencyInjection/Dekaf.Tests.Aot.DependencyInjection.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.OpenTelemetry\Dekaf.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Testing\Dekaf.Testing.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -24,16 +24,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.12.1" />
-    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.82.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="TUnit" Version="1.60.0" />
-    <PackageReference Include="TUnit.Logging.Microsoft" Version="1.60.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.Toxiproxy" Version="4.13.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
+    <PackageReference Include="Apache.Avro" />
+    <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="TUnit.Logging.Microsoft" />
+    <PackageReference Include="Testcontainers.Kafka" />
+    <PackageReference Include="Testcontainers.Toxiproxy" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
+++ b/tests/Dekaf.Tests.Mutation.Producer/Dekaf.Tests.Mutation.Producer.csproj
@@ -41,8 +41,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="NSubstitute" Version="6.0.0" />
-    <PackageReference Include="TUnit" Version="1.60.0" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="TUnit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Mutation.Protocol/Dekaf.Tests.Mutation.Protocol.csproj
+++ b/tests/Dekaf.Tests.Mutation.Protocol/Dekaf.Tests.Mutation.Protocol.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dekaf\Dekaf.csproj" />
-    <PackageReference Include="TUnit" Version="1.60.0" />
+    <PackageReference Include="TUnit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
+++ b/tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj
@@ -30,14 +30,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
-    <PackageReference Include="NSubstitute" Version="6.0.0" />
-    <PackageReference Include="TUnit" Version="1.60.0" />
-    <PackageReference Include="Verify.TUnit" Version="31.24.2" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="Verify.TUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
+    <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Testcontainers.Kafka" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dekaf.Fuzzing/Dekaf.Fuzzing.csproj
+++ b/tools/Dekaf.Fuzzing/Dekaf.Fuzzing.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpFuzz" Version="2.3.0" />
+    <PackageReference Include="SharpFuzz" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dekaf.Pipeline/Dekaf.Pipeline.csproj
+++ b/tools/Dekaf.Pipeline/Dekaf.Pipeline.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="6.8.2">
+    <PackageReference Include="GitVersion.MsBuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ModularPipelines" Version="3.2.8" />
-    <PackageReference Include="ModularPipelines.Git" Version="3.2.8" />
-    <PackageReference Include="ModularPipelines.DotNet" Version="3.2.8" />
-    <PackageReference Include="ModularPipelines.GitHub" Version="3.2.8" />
-    <PackageReference Include="System.CommandLine" Version="2.0.10" />
+    <PackageReference Include="ModularPipelines" />
+    <PackageReference Include="ModularPipelines.Git" />
+    <PackageReference Include="ModularPipelines.DotNet" />
+    <PackageReference Include="ModularPipelines.GitHub" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
 </Project>

--- a/tools/Dekaf.Profiling/Dekaf.Profiling.csproj
+++ b/tools/Dekaf.Profiling/Dekaf.Profiling.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
+    <PackageReference Include="Testcontainers.Kafka" />
   </ItemGroup>
 
 </Project>

--- a/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
+++ b/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
-    <PackageReference Include="TUnit" Version="1.60.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="TUnit" />
   </ItemGroup>
 
 </Project>

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -28,11 +28,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.15.0" />
-    <PackageReference Include="Testcontainers" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.Kafka" Version="4.13.0" />
-    <PackageReference Include="Testcontainers.Toxiproxy" Version="4.13.0" />
-    <PackageReference Include="ToxiproxyNetCore" Version="1.0.50" />
+    <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.Kafka" />
+    <PackageReference Include="Testcontainers.Toxiproxy" />
+    <PackageReference Include="ToxiproxyNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- enable NuGet Central Package Management with a root `Directory.Packages.props`
- move all 44 package versions out of 64 project references without changing resolved versions
- preserve the configurable package-smoke version and include the central file in CI NuGet cache keys

## Why

Package versions were repeated across project files, making dependency updates harder to review and keep aligned. Central package management provides one version source while projects retain only package usage and reference metadata.

## Impact

No package versions change. Future dependency updates can be made in one file, and CI cache invalidation now follows central version changes.

## Validation

- restored all 28 projects, including projects outside `Dekaf.sln`
- `dotnet build Dekaf.sln --configuration Release --no-restore`
- `dotnet pack Dekaf.sln --configuration Release --no-restore --no-build`
- audited 64 baseline/current references and 44 central packages with zero mapping errors
- net10.0 unit run: 5,573 passed; one timing timeout passed on isolated rerun
- net8.0 unit run: 5,461 passed; one timing timeout passed on isolated rerun
- stress unit tests: 27 passed
