### PR TITLE
Capture sub-second producer latency stalls

### DIFF
--- a/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/LatencyTrackerTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Dekaf.StressTests.Metrics;
+using Dekaf.StressTests.Scenarios;
 
 namespace Dekaf.Tests.Unit.StressTests;
 
@@ -32,6 +33,20 @@ public sealed class LatencyTrackerTests
         var snapshot = tracker.GetSnapshot();
         await Assert.That(snapshot.OutlierSamples).IsEmpty();
         await Assert.That(snapshot.DroppedOutlierSamples).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DeliveryLatencyTracker_CapturesSubSecondOutlier()
+    {
+        var tracker = StressTestHelpers.CreateDeliveryLatencyTracker();
+
+        tracker.RecordTicks(Stopwatch.Frequency * 99 / 1_000, messageIndex: 41);
+        tracker.RecordTicks(Stopwatch.Frequency * 333 / 1_000, messageIndex: 42);
+
+        var snapshot = tracker.GetSnapshot();
+        await Assert.That(snapshot.OutlierSamples).Count().IsEqualTo(1);
+        await Assert.That(snapshot.OutlierSamples[0].MessageIndex).IsEqualTo(42);
+        await Assert.That(snapshot.OutlierSamples[0].LatencyUs).IsBetween(332_000, 334_000);
     }
 
     [Test]

--- a/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
@@ -12,13 +12,13 @@ namespace Dekaf.StressTests.Metrics;
 internal sealed class LatencyTracker
 {
     private const int MaxOutlierSamples = 256;
-    private static readonly long OutlierThresholdTicks = Stopwatch.Frequency;
 
     private readonly long[] _buckets;
     private readonly object _outlierLock = new();
     private readonly LatencyOutlierSample[] _outlierSamples = new LatencyOutlierSample[MaxOutlierSamples];
     private readonly double _bucketWidthUs;
     private readonly double _maxValueUs;
+    private readonly long _outlierThresholdTicks;
     private long _count;
     private long _overflowCount;
     private long _minTicks = long.MaxValue;
@@ -27,10 +27,17 @@ internal sealed class LatencyTracker
 
     /// <param name="maxValueMs">Upper bound of the histogram in milliseconds. Values above this are counted as overflow.</param>
     /// <param name="bucketWidthUs">Width of each bucket in microseconds. Smaller = higher resolution but more memory.</param>
-    public LatencyTracker(double maxValueMs = 5000, double bucketWidthUs = 10)
+    /// <param name="outlierThresholdMs">Minimum latency captured in the bounded diagnostic timeline.</param>
+    public LatencyTracker(
+        double maxValueMs = 5000,
+        double bucketWidthUs = 10,
+        double outlierThresholdMs = 1000)
     {
         _maxValueUs = maxValueMs * 1000.0;
         _bucketWidthUs = bucketWidthUs;
+        _outlierThresholdTicks = Math.Max(
+            1,
+            (long)(outlierThresholdMs / 1000.0 * Stopwatch.Frequency));
         _buckets = new long[(int)(_maxValueUs / bucketWidthUs)];
     }
 
@@ -40,7 +47,7 @@ internal sealed class LatencyTracker
         Interlocked.Increment(ref _count);
         UpdateMinMax(ticks);
 
-        if (ticks >= OutlierThresholdTicks)
+        if (ticks >= _outlierThresholdTicks)
         {
             RecordOutlier(ticks, messageIndex);
         }

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -64,9 +64,11 @@ internal static class StressTestHelpers
     /// Histogram for sampled delivery latency. The sample includes time queued in the
     /// client's send buffer, which under saturation is seconds deep — so the range must
     /// be much wider than the LatencyTracker default (coarser buckets keep it at ~2.4 MB).
+    /// Capture outliers from 100ms so the bounded timeline includes the multi-hundred-ms
+    /// stalls that producer diagnostics correlate against probes, GC, and throughput.
     /// </summary>
     internal static LatencyTracker CreateDeliveryLatencyTracker() =>
-        new(maxValueMs: 30_000, bucketWidthUs: 100);
+        new(maxValueMs: 30_000, bucketWidthUs: 100, outlierThresholdMs: 100);
 
     /// <summary>
     /// Queries the high watermark of each partition, giving the fixed end offsets that


### PR DESCRIPTION
## Summary
- make latency outlier sampling threshold configurable
- capture producer delivery stalls from 100 ms while preserving the 1-second default elsewhere
- regression-test the exact reproduced 333 ms spike range

## Evidence
Run 29405601673 reproduced 346.1 ms and 333.4 ms max delivery stalls, but captured zero outlier timestamps because `LatencyTracker` only sampled latencies at or above 1 second. That made the correlation timeline empty despite the new probe/admission diagnostics.

100 ms is above Confluent's observed <=96 ms max in #2109 and below Dekaf's reproduced multi-hundred-ms spikes, keeping the bounded 256-sample timeline focused.

## Test plan
- [x] TDD: new sub-second producer-delivery outlier test failed before implementation
- [x] net10 `LatencyTrackerTests`: 5/5
- [x] net10 `ConnectionScaleReportingTests`: 2/2
- [x] net10 build: 0 warnings/errors
- [x] net8 build: 0 warnings/errors

Refs #2109