### PR TITLE
Fix clean Correctness review detection

### DIFF
--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -204,6 +204,7 @@ function Get-ActionableReviewBodyReason {
         'genuine\s+improvement,\s+not\s+just\s+churn(?:[\s\S]*)?'
         'fix\s+is\s+scoped(?:\s+to\b[\s\S]*)?'
         '(?:[\s\S]*\b)?allocation[- ]free(?:[\s\S]*)?'
+        '(?:[\s\S]*\b)?verified\s+no\s+behavior\s+change(?:[\s\S]*)?'
     ) -join '|'
     $positiveCategoryVerdict =
         "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:[-*]\s*)?(?:$positiveVerdictAlternatives)\.?\s*$"

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -268,6 +268,22 @@ No issues to flag. This is a clean, well-tested, appropriately-scoped perf chang
         Blocks = $false
     },
     @{
+        Name = 'allows correctness verification bullets with global no-actionable verdict'
+        Body = @'
+## Review
+
+### Correctness
+- The new threshold defaults to the prior value, so existing call sites retain their behavior — verified no behavior change there.
+- Threshold conversion is correct and consistent with the existing recording path.
+
+### Tests
+- The regression test exercises the reproduced range.
+
+No actionable issues found.
+'@
+        Blocks = $false
+    },
+    @{
         Name = 'blocks api surface category defect despite no-issues verdict'
         Body = @'
 ## Review


### PR DESCRIPTION
Closes #2136.

## Summary
- accept category review sections containing an explicit `verified no behavior change` statement
- retain existing fail-closed defect-term checks
- add the exact PR #2134 review shape as a regression test

## Validation
- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1` (111 body cases, 4 stale review cases)
- `pwsh scripts/Assert-PrGreen.ps1 -Pr 2134` now passes review parsing and proceeds to the mergeability gate