### PR TITLE
Reduce metadata bootstrap log noise

### DIFF
--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -31,6 +31,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
     private volatile bool _initialized;
+    private volatile bool _hasSuccessfulRefresh;
+    private int _initializationAttempt;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
     private readonly object _backgroundRefreshGate = new();
@@ -43,6 +45,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     // but the broker always sends the ApiVersions response with header v0 regardless of version.
     // Using a named constant prevents silent breakage if LowestSupportedVersion is bumped later.
     private const short ApiVersionsBootstrapVersion = 3;
+    private const int BootstrapWarningAttempt = 6;
 
     // Rebootstrap recovery state
     private readonly List<string> _originalBootstrapHostnames;
@@ -263,13 +266,20 @@ public sealed partial class MetadataManager : IAsyncDisposable
             {
                 for (var attempt = 0; ; attempt++)
                 {
+                    Volatile.Write(ref _initializationAttempt, attempt + 1);
                     try
                     {
                         await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
                         break;
                     }
-                    catch (Exception ex) when (!IsFatalMetadataError(ex) && attempt < _options.MaxInitRetries && !initializationToken.IsCancellationRequested)
+                    catch (Exception ex) when (!IsFatalMetadataError(ex) && !initializationToken.IsCancellationRequested)
                     {
+                        if (attempt >= _options.MaxInitRetries)
+                        {
+                            LogMetadataInitializationAbandoned(ex, attempt + 1);
+                            throw;
+                        }
+
                         LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
                         await Task.Delay(backoffMs, initializationToken).ConfigureAwait(false);
                         backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
@@ -279,6 +289,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
             catch (OperationCanceledException) when (_disposalCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
             {
                 throw new ObjectDisposedException(nameof(MetadataManager));
+            }
+            finally
+            {
+                Volatile.Write(ref _initializationAttempt, 0);
             }
 
             if (Volatile.Read(ref _disposed) != 0)
@@ -620,6 +634,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     if (rebootstrapped)
                     {
                         ResetAllBrokersUnavailableTimestamp();
+                        _hasSuccessfulRefresh = true;
                         return;
                     }
                     // Rebootstrap failed — fall through and apply the original response as best-effort fallback
@@ -642,6 +657,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 // Success - reset the rebootstrap timer
                 ResetAllBrokersUnavailableTimestamp();
+                _hasSuccessfulRefresh = true;
 
                 return;
             }
@@ -662,6 +678,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
             var rebootstrapped = await TryRebootstrapAsync(topics, cancellationToken).ConfigureAwait(false);
             if (rebootstrapped)
             {
+                _hasSuccessfulRefresh = true;
                 return;
             }
         }
@@ -1093,17 +1110,59 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     #region Logging
 
+    private bool ShouldWarnAboutMetadataFailure()
+        => _hasSuccessfulRefresh || Volatile.Read(ref _initializationAttempt) >= BootstrapWarningAttempt;
+
+    private void LogMetadataInitializationFailed(Exception ex, int attempt, int backoffMs)
+    {
+        if (ShouldWarnAboutMetadataFailure())
+            LogMetadataInitializationFailedWarning(ex, attempt, backoffMs);
+        else
+            LogMetadataInitializationFailedDebug(ex, attempt, backoffMs);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Metadata initialization attempt {Attempt} failed, retrying in {BackoffMs}ms")]
+    private partial void LogMetadataInitializationFailedDebug(Exception ex, int attempt, int backoffMs);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Metadata initialization attempt {Attempt} failed, retrying in {BackoffMs}ms")]
-    private partial void LogMetadataInitializationFailed(Exception ex, int attempt, int backoffMs);
+    private partial void LogMetadataInitializationFailedWarning(Exception ex, int attempt, int backoffMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Metadata initialization failed after {AttemptCount} attempts")]
+    private partial void LogMetadataInitializationAbandoned(Exception ex, int attemptCount);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Refreshed metadata: {BrokerCount} brokers, {TopicCount} topics")]
     private partial void LogMetadataRefreshed(int brokerCount, int topicCount);
 
+    private void LogMetadataRefreshFailed(Exception ex, string host, int port)
+    {
+        if (ShouldWarnAboutMetadataFailure())
+            LogMetadataRefreshFailedWarning(ex, host, port);
+        else
+            LogMetadataRefreshFailedDebug(ex, host, port);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to refresh metadata from {Host}:{Port}")]
+    private partial void LogMetadataRefreshFailedDebug(Exception ex, string host, int port);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to refresh metadata from {Host}:{Port}")]
-    private partial void LogMetadataRefreshFailed(Exception ex, string host, int port);
+    private partial void LogMetadataRefreshFailedWarning(Exception ex, string host, int port);
+
+    private void LogAllBrokersUnavailable(int triggerMs)
+    {
+        // This signal is emitted once per outage episode, so an initialization-attempt
+        // threshold cannot escalate it later. A terminal initialization warning covers a
+        // persistent bootstrap outage; after successful operation, a new outage is warning.
+        if (_hasSuccessfulRefresh)
+            LogAllBrokersUnavailableWarning(triggerMs);
+        else
+            LogAllBrokersUnavailableDebug(triggerMs);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "All known brokers are unavailable. Rebootstrap will trigger after {TriggerMs}ms")]
+    private partial void LogAllBrokersUnavailableDebug(int triggerMs);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "All known brokers are unavailable. Rebootstrap will trigger after {TriggerMs}ms")]
-    private partial void LogAllBrokersUnavailable(int triggerMs);
+    private partial void LogAllBrokersUnavailableWarning(int triggerMs);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Rebootstrap not yet triggered. Elapsed: {ElapsedMs}ms, Trigger: {TriggerMs}ms")]
     private partial void LogRebootstrapNotYetTriggered(long elapsedMs, int triggerMs);

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -1,9 +1,11 @@
+using System.Net.Sockets;
 using System.Reflection;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace Dekaf.Tests.Unit.Metadata;
@@ -317,6 +319,144 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task InitializeAsync_DefaultRetries_LogEarlyDebugAndTerminalWarning()
+    {
+        var pool = CreateFailingConnectionPool();
+        var logger = new CapturingLogger<MetadataManager>();
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            },
+            logger);
+
+        var act = () => manager.InitializeAsync().AsTask();
+        await Assert.That(act).Throws<InvalidOperationException>();
+
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            var expectedMessage = $"attempt {attempt} failed";
+            await Assert.That(logger.Entries.Any(entry =>
+                entry.Level == LogLevel.Debug &&
+                entry.Message.Contains(expectedMessage, StringComparison.Ordinal))).IsTrue();
+        }
+
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("failed after 4 attempts", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task InitializeAsync_SixthBootstrapFailure_LogsWarning()
+    {
+        var pool = CreateFailingConnectionPool();
+        var logger = new CapturingLogger<MetadataManager>();
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                MaxInitRetries = 6,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            },
+            logger);
+
+        var act = () => manager.InitializeAsync().AsTask();
+        await Assert.That(act).Throws<InvalidOperationException>();
+
+        for (var attempt = 1; attempt <= 5; attempt++)
+        {
+            var expectedMessage = $"attempt {attempt} failed";
+            await Assert.That(logger.Entries.Any(entry =>
+                entry.Level == LogLevel.Debug &&
+                entry.Message.Contains(expectedMessage, StringComparison.Ordinal))).IsTrue();
+        }
+
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("attempt 6 failed", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task FirstBootstrapOutage_RemainsDebugRegardlessOfAttemptCounter()
+    {
+        var logger = new CapturingLogger<MetadataManager>();
+        await using var manager = new MetadataManager(
+            CreateFailingConnectionPool(),
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                MetadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap
+            },
+            logger);
+        SetInstanceField(manager, "_initializationAttempt", 6);
+
+        var rebootstrapped = await manager.TryRebootstrapAsync(null, CancellationToken.None);
+
+        await Assert.That(rebootstrapped).IsFalse();
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Debug &&
+            entry.Message.Contains("All known brokers are unavailable", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("All known brokers are unavailable", StringComparison.Ordinal))).IsFalse();
+    }
+
+    [Test]
+    public async Task RefreshMetadataAsync_AfterSuccessfulRefreshFailure_LogsWarning()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        var failConnections = false;
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => failConnections
+                ? ValueTask.FromException<IKafkaConnection>(new SocketException())
+                : new ValueTask<IKafkaConnection>(connection));
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<ApiVersionsResponse>(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<MetadataResponse>(CreateMetadataResponse((1, "localhost", 9092))));
+        var logger = new CapturingLogger<MetadataManager>();
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false },
+            logger);
+        await manager.InitializeAsync();
+        failConnections = true;
+
+        var act = () => manager.RefreshMetadataAsync().AsTask();
+        await Assert.That(act).Throws<InvalidOperationException>();
+
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("Failed to refresh metadata", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
     public async Task InitializeAsync_DisposeDuringRefresh_DoesNotStartBackgroundRefresh()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -516,6 +656,14 @@ public class MetadataManagerTests
         field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
     }
 
+    private static IConnectionPool CreateFailingConnectionPool()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(new SocketException()));
+        return pool;
+    }
+
     private static bool IsFatalMetadataError(MetadataManager metadataManager, Exception exception)
     {
         var method = typeof(MetadataManager)
@@ -647,4 +795,36 @@ public class MetadataManagerTests
         void IRetirableKafkaConnection.BeginRetirement() { }
         void IRetirableKafkaConnection.CompleteRetirement() { }
     }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        private readonly object _gate = new();
+        private readonly List<LogEntry> _entries = [];
+
+        public IReadOnlyList<LogEntry> Entries
+        {
+            get
+            {
+                lock (_gate)
+                    return _entries.ToArray();
+            }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (_gate)
+                _entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
 }


### PR DESCRIPTION
Closes #2129.

## Summary
- log metadata initialization, per-broker refresh, and initial rebootstrap diagnostics at Debug for attempts 1-5
- escalate attempt 6+ to Warning
- preserve Warning severity after the first successful metadata refresh

## Validation
- TDD: early-bootstrap severity regression failed before implementation
- MetadataManagerTests: 19/19 on net8.0 and 19/19 on net10.0
- coverage includes early bootstrap, sixth-attempt escalation, and a real successful refresh followed by failure