### PR TITLE
Fix worktree-backed merge cleanup ordering

### DIFF
--- a/.agents/skills/issue-pr-loop/SKILL.md
+++ b/.agents/skills/issue-pr-loop/SKILL.md
@@ -279,7 +279,7 @@ Do not rely on branch protection being present, current, or configured for every
 
 The guard enforces only the **mechanical** MERGE signals. The judgment-only signals from the MERGE row — approval (or repo-does-not-gate), zero unaddressed comments, and a bot CI cycle since your last fix push — are still yours to confirm before you run it; a passing guard is necessary, not sufficient.
 
-Merge with the single command `scripts/Merge-Pr.ps1 -Pr <n>`. It runs the gate, merges only if the gate passes, then removes that PR's isolated worktree — atomically, so the worktree cannot be left behind:
+Merge with the single command `scripts/Merge-Pr.ps1 -Pr <n>`. It runs the gate, merges only if the gate passes, then performs best-effort cleanup of that PR's isolated worktree and head branches:
 
 ```powershell
 pwsh scripts/Merge-Pr.ps1 -Pr <n>
@@ -289,7 +289,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 ```
 
-`Merge-Pr.ps1` internally: (1) calls the pure `Assert-PrGreen.ps1` gate (re-fetches fresh state; exits 0 only when OPEN + `MERGEABLE` + `CLEAN` + every check terminal-and-passing + no unresolved threads); (2) on exit 0, runs `gh pr merge <n> --squash --delete-branch`; (3) finds the worktree by the PR's head branch and removes it, **preserving it untouched if it has uncommitted tracked changes**. The gate remains a separate read-only predicate — do not fold merging into it; `Merge-Pr.ps1` composes it.
+`Merge-Pr.ps1` internally: (1) calls the pure `Assert-PrGreen.ps1` gate (re-fetches fresh state; exits 0 only when OPEN + `MERGEABLE` + `CLEAN` + every check terminal-and-passing + no unresolved threads); (2) on exit 0, runs `gh pr merge <n> --squash` without asking `gh` to delete a branch that may still be checked out; (3) finds and removes the clean worktree by the PR's head branch; (4) only after the worktree is gone, deletes the remote and local head branches. If the worktree has uncommitted tracked changes, it and both branches are preserved. Once the merge succeeds, later cleanup failures warn and still exit 0 — never retry an already-completed merge because cleanup was incomplete. The gate remains a separate read-only predicate — do not fold merging into it; `Merge-Pr.ps1` composes it.
 
 Hard rules — no exceptions:
 
@@ -298,7 +298,7 @@ Hard rules — no exceptions:
 3. **Any non-terminal check (`QUEUED`/`IN_PROGRESS`/`PENDING`/`WAITING`) means the PR is not mergeable this iteration.** Skip it; the next iteration's survey re-checks it for free. Do not wait, poll, or auto-merge.
 4. **`Merge-Pr.ps1` exiting non-zero is the correct outcome, not an obstacle.** It means the gate denied or the merge failed — nothing was destroyed. Advance to the next item; never retry the merge or work around the gate.
 
-Worktree cleanup is now part of `Merge-Pr.ps1` — it removes the merged PR's isolated worktree automatically, preserving it untouched if it has uncommitted tracked changes (untracked build artifacts are cleared). You do **not** run a separate removal step after merge.
+Worktree and branch cleanup are part of `Merge-Pr.ps1`. It removes a clean merged-PR worktree before deleting its remote/local head branches. If tracked changes exist, it preserves the worktree and both branches (untracked build artifacts are cleared). Post-merge cleanup failures are warnings because the merge cannot safely be retried. You do **not** run a separate removal step after merge.
 
 **Per-iteration safety-net sweep.** Once per loop iteration, run `pwsh scripts/Remove-MergedWorktrees.ps1`. It reaps any worktree whose branch has a **merged PR** — including PRs squash-merged by another agent or a human, which `Merge-Pr.ps1` never saw. Detection is via GitHub's merged-PR head branches (`gh pr list --state merged`), the only signal that survives squash/rebase (the branch tip is not an ancestor of `main`, so ancestry checks miss it). It is squash-safe, skips branches with an open PR, skips detached worktrees, and preserves dirty worktrees. A `[gone]` branch is deliberately **not** treated as merged — that also happens to closed-unmerged PRs.
 

--- a/scripts/Merge-Pr.ps1
+++ b/scripts/Merge-Pr.ps1
@@ -1,8 +1,9 @@
 # Merge-Pr.ps1
 # One-command, fail-closed merge for the issue-pr-loop skill:
 #   1. runs the pure gate  Assert-PrGreen.ps1  (read-only; exits 0 only when green)
-#   2. merges with  gh pr merge --squash --delete-branch  (only if the gate passed)
-#   3. removes the PR's isolated worktree so it cannot accumulate on disk
+#   2. merges with  gh pr merge --squash  (only if the gate passed)
+#   3. removes the PR's isolated worktree
+#   4. deletes the merged local and remote head branches
 #
 # Cleanup is *part of* the merge command — an agent cannot merge and then forget
 # to remove the worktree, because it is the same call. This is the durable fix for
@@ -38,7 +39,7 @@ function Fail([string]$msg) { [Console]::Error.WriteLine("MERGE ABORTED #${Pr} -
 & pwsh (Join-Path $PSScriptRoot 'Assert-PrGreen.ps1') -Pr $Pr @repoArgs
 if ($LASTEXITCODE -ne 0) { Fail "Assert-PrGreen denied (exit $LASTEXITCODE). Not merging." }
 
-# Resolve the head branch BEFORE merging (--delete-branch removes it server-side).
+# Resolve the head branch before merging so post-merge cleanup can remove it.
 $headRef = gh pr view $Pr @repoArgs --json headRefName --jq '.headRefName' 2>$null
 if ($LASTEXITCODE -ne 0 -or -not $headRef) { Fail "could not resolve head branch (exit $LASTEXITCODE)" }
 $headRef = $headRef.Trim()
@@ -49,7 +50,7 @@ $mainRepo = ((git worktree list --porcelain) | Where-Object { $_ -like 'worktree
     Select-Object -First 1) -replace '^worktree ', ''
 
 # --- 2. Merge. -----------------------------------------------------------------
-gh pr merge $Pr @repoArgs --squash --delete-branch
+gh pr merge $Pr @repoArgs --squash
 if ($LASTEXITCODE -ne 0) { Fail "gh pr merge failed (exit $LASTEXITCODE). Worktree untouched." }
 Write-Host "Merged #${Pr} ($headRef)."
 
@@ -66,8 +67,35 @@ if (-not $Worktree) {
 if (-not $Worktree) {
     Write-Host "No isolated worktree found for branch '$headRef' (nothing to remove)."
     git -C $mainRepo worktree prune
-    exit 0
+} else {
+    Remove-MergedWorktree -Repo $mainRepo -Worktree $Worktree -Label "#${Pr}"
+
+    # A dirty worktree is intentionally preserved. Its local and remote branches are
+    # also preserved so uncommitted work retains an upstream recovery point.
+    if (Test-Path -LiteralPath $Worktree) {
+        Write-Host "Preserving branches for worktree #${Pr}: $Worktree"
+        exit 0
+    }
 }
 
-Remove-MergedWorktree -Repo $mainRepo -Worktree $Worktree -Label "#${Pr}"
+# Branch cleanup happens only after the checked-out worktree is gone. Cleanup is
+# best-effort: the PR is already merged, so failures must not be reported as a
+# merge abort or invite a dangerous retry of the merge operation.
+$remoteRef = "refs/heads/$headRef"
+git -C $mainRepo ls-remote --exit-code origin $remoteRef 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    git -C $mainRepo push origin --delete $headRef 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "WARNING: merged #${Pr}, but could not delete remote branch '$headRef'"
+    }
+}
+
+git -C $mainRepo show-ref --verify --quiet "refs/heads/$headRef"
+if ($LASTEXITCODE -eq 0) {
+    git -C $mainRepo branch -D -- $headRef 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "WARNING: merged #${Pr}, but could not delete local branch '$headRef'"
+    }
+}
+
 exit 0

--- a/scripts/Test-MergePr.ps1
+++ b/scripts/Test-MergePr.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Merge-Pr.ps1'
+$script = Get-Content -LiteralPath $scriptPath -Raw
+
+$mergeMatch = [regex]::Match($script, '(?m)^gh pr merge .*$', 'IgnoreCase')
+if (-not $mergeMatch.Success) {
+    throw 'Merge-Pr.ps1 must invoke gh pr merge.'
+}
+
+if ($mergeMatch.Value -match '--delete-branch') {
+    throw 'gh pr merge must not delete a branch before its worktree is removed.'
+}
+
+$cleanupIndex = $script.IndexOf('Remove-MergedWorktree', $mergeMatch.Index)
+$remoteDeleteIndex = $script.IndexOf('push origin --delete', $mergeMatch.Index)
+$localDeleteIndex = $script.IndexOf('branch -D', $mergeMatch.Index)
+
+if ($cleanupIndex -lt 0) {
+    throw 'Merged worktree cleanup is missing.'
+}
+
+if ($remoteDeleteIndex -lt 0 -or $localDeleteIndex -lt 0) {
+    throw 'Post-merge remote/local branch cleanup is missing.'
+}
+
+if ($cleanupIndex -gt $remoteDeleteIndex -or $cleanupIndex -gt $localDeleteIndex) {
+    throw 'The worktree must be removed before deleting its local or remote branch.'
+}
+
+$mergedConfirmationIndex = $script.IndexOf('Write-Host "Merged', $mergeMatch.Index)
+if ($mergedConfirmationIndex -lt 0) {
+    throw 'Successful merge confirmation is missing.'
+}
+
+$postMergeScript = $script.Substring($mergedConfirmationIndex)
+if ($postMergeScript -match '(?m)^\s*Fail\s+') {
+    throw 'Post-merge cleanup must warn rather than report that the merge was aborted.'
+}
+
+Write-Output 'OK Merge-Pr command ordering and post-merge failure semantics passed.'


### PR DESCRIPTION
Closes #2140.

## Summary
- stop passing `--delete-branch` before the checked-out worktree is removed
- after a confirmed merge, remove the clean worktree, then delete remote/local head branches
- preserve dirty worktrees and both branches
- treat post-merge cleanup failures as warnings, never a false `MERGE ABORTED`

## Validation
- TDD: regression test failed on the old `--delete-branch` ordering
- `pwsh scripts/Test-MergePr.ps1`
- PowerShell parse validation
- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1` (111 body cases, 4 stale review cases)