### PR TITLE
Lease metadata connections through bootstrap requests

### DIFF
--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -591,8 +591,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
         {
             try
             {
-                var connection = await _connectionPool.GetConnectionAsync(host, port, cancellationToken)
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(host, port, cancellationToken)
                     .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 // Negotiate API version if not already done
                 if (_metadataApiVersion < 0)
@@ -727,8 +728,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
         {
             try
             {
-                var connection = await _connectionPool.GetConnectionAsync(host, port, cancellationToken)
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(host, port, cancellationToken)
                     .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
 
                 // Re-negotiate API versions with new broker
                 await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Networking/KafkaConnectionLease.cs
+++ b/src/Dekaf/Networking/KafkaConnectionLease.cs
@@ -48,6 +48,24 @@ internal static class ConnectionPoolLeaseExtensions
         }
     }
 
+    public static async ValueTask<KafkaConnectionLease> LeaseConnectionAsync(
+        this IConnectionPool connectionPool,
+        string host,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var connection = await connectionPool.GetConnectionAsync(host, port, cancellationToken)
+                .ConfigureAwait(false);
+            if (KafkaConnectionLease.TryAcquire(connection, out var lease))
+                return lease;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(LeaseRetryDelay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
     public static async ValueTask<KafkaConnectionLease> LeaseConnectionByIndexAsync(
         this IConnectionPool connectionPool,
         int brokerId,

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -298,6 +298,25 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task InitializeAsync_HoldsConnectionLeaseAcrossNegotiationAndMetadataRequest()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = new LeaseTrackingConnection();
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+
+        await manager.InitializeAsync();
+
+        await Assert.That(connection.AllRequestsLeased).IsTrue();
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task InitializeAsync_DisposeDuringRefresh_DoesNotStartBackgroundRefresh()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -540,5 +559,92 @@ public class MetadataManagerTests
             ?? throw new InvalidOperationException($"{name} field not found");
 
         field.SetValue(instance, value);
+    }
+
+    private sealed class LeaseTrackingConnection : IKafkaConnection, IRetirableKafkaConnection
+    {
+        private int _leaseCount;
+
+        public int BrokerId => -1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public bool AllRequestsLeased { get; private set; } = true;
+        public int LeaseCount => Volatile.Read(ref _leaseCount);
+        int IRetirableKafkaConnection.ActiveOperationCount => 0;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            AllRequestsLeased &= LeaseCount == 1;
+            object response = request switch
+            {
+                ApiVersionsRequest => new ApiVersionsResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    ApiKeys =
+                    [
+                        new ApiVersion(
+                            ApiKey.Metadata,
+                            MetadataRequest.LowestSupportedVersion,
+                            MetadataRequest.HighestSupportedVersion)
+                    ]
+                },
+                MetadataRequest => CreateMetadataResponse((1, "localhost", 9092)),
+                _ => throw new NotSupportedException()
+            };
+
+            return ValueTask.FromResult((TResponse)response);
+        }
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => ValueTask.FromException(new NotSupportedException());
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => ValueTask.FromException(new NotSupportedException());
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => Task.FromException<TResponse>(new NotSupportedException());
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => Task.FromException<TResponse>(new NotSupportedException());
+
+        bool IRetirableKafkaConnection.TryAcquireLease()
+        {
+            Interlocked.Increment(ref _leaseCount);
+            return true;
+        }
+
+        void IRetirableKafkaConnection.ReleaseLease() => Interlocked.Decrement(ref _leaseCount);
+        void IRetirableKafkaConnection.BeginRetirement() { }
+        void IRetirableKafkaConnection.CompleteRetirement() { }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionLeaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionLeaseTests.cs
@@ -41,4 +41,28 @@ public sealed class KafkaConnectionLeaseTests
 
         await Assert.That(lease.Connection).IsSameReferenceAs(connection);
     }
+
+    [Test]
+    public async Task LeaseConnectionByEndpoint_RetiredSelection_RetriesAndReleasesLease()
+    {
+        await using var retiredConnection = new KafkaConnection("localhost", 9092);
+        await using var activeConnection = new KafkaConnection("localhost", 9093);
+        ((IRetirableKafkaConnection)retiredConnection).BeginRetirement();
+        var pool = Substitute.For<IConnectionPool>();
+        var selectionCount = 0;
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult<IKafkaConnection>(
+                Interlocked.Increment(ref selectionCount) == 1
+                    ? retiredConnection
+                    : activeConnection));
+
+        using (var lease = await pool.LeaseConnectionAsync("localhost", 9092, CancellationToken.None))
+        {
+            await Assert.That(lease.Connection).IsSameReferenceAs(activeConnection);
+            await Assert.That(((IRetirableKafkaConnection)activeConnection).LeaseCount).IsEqualTo(1);
+        }
+
+        _ = pool.Received(2).GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>());
+        await Assert.That(((IRetirableKafkaConnection)activeConnection).LeaseCount).IsEqualTo(0);
+    }
 }


### PR DESCRIPTION
Closes #2131.

## Summary
- add endpoint-based `KafkaConnectionLease` acquisition that retries retired selections
- hold one lease across ApiVersions negotiation and metadata fetch
- apply the same protection during rebootstrap

This closes the selection-to-send race without a racy post-selection state check: idle retirement cannot begin while metadata owns the lease.

## Validation
- TDD: endpoint lease overload was absent before implementation
- KafkaConnectionLeaseTests + MetadataManagerTests: 20/20 on net8.0 and 20/20 on net10.0
- test connection verifies both bootstrap requests execute with lease count exactly one and release afterward