### PR TITLE
Use coherent defaults for stress readiness producer

### DIFF
--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -300,7 +300,6 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                     .WithLoggerFactory(StressClientLogging.LoggerFactory)
                     .WithBootstrapServers(bootstrapServers)
                     .WithClientId("kafka-ready-check")
-                    .WithAcks(Producer.Acks.Leader)
                     .BuildAsync();
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Fixes #2132.

The readiness producer explicitly selected `Acks.Leader` while idempotence remained enabled by default, so each retry logged an override warning and then used Acks.All anyway. Remove the conflicting override and use the coherent idempotent defaults.

Validation: `dotnet build tools/Dekaf.StressTests/Dekaf.StressTests.csproj` — 0 warnings, 0 errors.