### PR TITLE
docs: use FireAsync for fire-and-forget

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ var metadata = await producer.ProduceAsync("my-topic", "key", "Hello, Kafka!");
 Console.WriteLine($"Sent to partition {metadata.Partition} at offset {metadata.Offset}");
 ```
 
-For high-throughput scenarios where you don't need to wait:
+For high-throughput scenarios where you don't need to wait for broker acknowledgment:
 
 ```csharp
-// Fire and forget - returns immediately
-producer.Produce("my-topic", "key", "value");
+// Fire-and-forget - waits only for local enqueue/backpressure
+await producer.FireAsync("my-topic", "key", "value");
 
 // Make sure everything's delivered before shutting down
 await producer.FlushAsync();
@@ -63,7 +63,7 @@ await using var producer = await Kafka.CreateProducer<string, string>()
 
 // No topic parameter needed
 await producer.ProduceAsync("order-123", orderJson);
-producer.Produce("order-456", orderJson);
+await producer.FireAsync("order-456", orderJson);
 ```
 
 You can also create multiple topic producers that share the same connection:

--- a/docs/docs/compression.md
+++ b/docs/docs/compression.md
@@ -197,7 +197,7 @@ var producer = await Kafka.CreateProducer<string, string>()
 // Send many messages
 for (int i = 0; i < 1_000_000; i++)
 {
-    producer.Produce("events", $"event-{i}", largeJsonPayload);
+    await producer.FireAsync("events", $"event-{i}", largeJsonPayload);
 }
 
 await producer.FlushAsync();

--- a/docs/docs/producer/batch-production.md
+++ b/docs/docs/producer/batch-production.md
@@ -157,13 +157,13 @@ foreach (var batch in allMessages.Chunk(1000))
 
 ### Combining with Fire-and-Forget
 
-For maximum throughput when you don't need results, combine `Produce()` with `FlushAsync()`:
+For maximum throughput when you don't need results, combine `FireAsync()` with `FlushAsync()`. Awaiting `FireAsync()` waits only for local enqueue and backpressure, not broker acknowledgment:
 
 ```csharp
-// Send all messages without waiting
+// Queue all messages without waiting for broker acknowledgment
 foreach (var msg in messages)
 {
-    producer.Produce("topic", msg.Key, msg.Value);
+    await producer.FireAsync("topic", msg.Key, msg.Value);
 }
 
 // Ensure all are delivered before continuing

--- a/docs/docs/producer/fire-and-forget.md
+++ b/docs/docs/producer/fire-and-forget.md
@@ -4,18 +4,9 @@ sidebar_position: 3
 
 # Fire-and-Forget Production
 
-For high-throughput scenarios where you don't need to wait for acknowledgment, Dekaf provides `FireAsync` methods. `FireAsync` means "enqueue this record and return once local backpressure has accepted it"; it does not wait for broker acknowledgment.
+For high-throughput scenarios where you don't need to wait for acknowledgment, Dekaf provides `FireAsync` methods. Each method returns a non-generic `ValueTask`. Awaiting it means "enqueue this record and return once local backpressure has accepted it"; it does not wait for broker acknowledgment.
 
 ## FireAsync vs ProduceAsync
-
-Before:
-
-```csharp
-// Old fire-and-forget syntax
-producer.Produce("my-topic", "key", "value");
-```
-
-After:
 
 ```csharp
 // Enqueues locally; does not wait for broker acknowledgment

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -106,9 +106,9 @@ var producer = await Kafka.CreateProducer<string, string>()
     .BuildAsync();
 
 // These will likely batch together in one partition
-producer.Produce("events", null, "event1");
-producer.Produce("events", null, "event2");
-producer.Produce("events", null, "event3");
+await producer.FireAsync("events", null, "event1");
+await producer.FireAsync("events", null, "event2");
+await producer.FireAsync("events", null, "event3");
 ```
 
 ```csharp

--- a/docs/docs/producer/topic-producer.md
+++ b/docs/docs/producer/topic-producer.md
@@ -103,19 +103,19 @@ var metadata = await producer.ProduceAsync(new TopicProducerMessage<string, stri
 });
 ```
 
-### Send (Fire-and-Forget)
+### FireAsync (Fire-and-Forget)
 
-Send without waiting for acknowledgment:
+Queue a message without waiting for broker acknowledgment. The returned `ValueTask` completes once local backpressure accepts the record:
 
 ```csharp
 // Basic fire-and-forget
-producer.Produce("key", "value");
+await producer.FireAsync("key", "value");
 
 // With headers
-producer.Produce("key", "value", headers);
+await producer.FireAsync("key", "value", headers);
 
 // With delivery callback
-producer.Produce("key", "value", (metadata, error) =>
+await producer.FireAsync("key", "value", (metadata, error) =>
 {
     if (error is not null)
         Console.WriteLine($"Failed: {error.Message}");


### PR DESCRIPTION
## Summary

- replace removed `Produce(...)` fire-and-forget examples with awaited `FireAsync(...)`
- document that `FireAsync` returns a non-generic `ValueTask`
- clarify that awaiting `FireAsync` covers local enqueue and backpressure, not broker acknowledgment

## Why

README and several guides still showed the old void-style producer API, contradicting the current public interfaces and dedicated fire-and-forget guidance.

## Validation

- `npm ci`
- `npm run build`
- `git diff --check`