### PR TITLE
Preserve pending-append drain wakes

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2000,17 +2000,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </returns>
     internal bool DrainPendingAppends()
     {
-        if (_pendingAppends.IsEmpty)
+        // The active owner temporarily moves every candidate out of the concurrent queue
+        // while it evaluates admission. An empty queue is therefore conclusive only when
+        // no drainer owns that private snapshot.
+        if (_pendingAppends.IsEmpty && Volatile.Read(ref _draining) == 0)
             return true;
 
-        // Only one thread drains at a time. Record the missed entry so the owner rescans
-        // after publishing the guard as free; a bool is insufficient because an older owner
-        // could consume a newer owner's wake in the handoff window.
+        // Publish the request before competing for ownership. If the current owner releases
+        // between these operations, this caller takes over; otherwise that owner observes the
+        // version change and rescans. Publishing after a failed CAS leaves a handoff window
+        // where both callers can miss the wake.
+        Interlocked.Increment(ref _pendingAppendDrainRequestVersion);
         if (Interlocked.CompareExchange(ref _draining, 1, 0) != 0)
-        {
-            Interlocked.Increment(ref _pendingAppendDrainRequestVersion);
             return false;
-        }
 
         Interlocked.Increment(ref _pendingAppendDrainEntryCount);
         var ownsDrainGuard = true;

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3612,6 +3612,26 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    public async Task DrainPendingAppends_EmptyQueueWithBusyGuard_RecordsRetryRequest()
+    {
+        await using var accumulator = new RecordAccumulator(CreatePendingAppendTestOptions());
+        SetPrivateField(accumulator, "_draining", 1);
+        var requestVersion = GetPrivateField<long>(accumulator, "_pendingAppendDrainRequestVersion");
+
+        try
+        {
+            await Assert.That(accumulator.DrainPendingAppends()).IsFalse()
+                .Because("the active drainer may hold a blocked candidate outside the queue");
+            await Assert.That(GetPrivateField<long>(accumulator, "_pendingAppendDrainRequestVersion"))
+                .IsEqualTo(requestVersion + 1);
+        }
+        finally
+        {
+            SetPrivateField(accumulator, "_draining", 0);
+        }
+    }
+
+    [Test]
     public async Task DrainPendingAppends_CompetingWake_RescansReleasedBudget()
     {
         using var secondPartitionResolverEntered = new ManualResetEventSlim();


### PR DESCRIPTION
Fixes #2146.

A drainer temporarily removes every pending append from the concurrent queue while evaluating broker admission. During that window, a concurrent buffer/budget release could observe an empty queue and return before recording its retry request. If the owner had already observed the old blocked state, it then requeued the append and exited with no future wake; the append remained parked until `max.block.ms`.

This publishes the retry request before competing for drain ownership. If the prior owner is still active it observes the version change; if it hands off concurrently, the caller acquires the guard and drains. The empty-queue fast return now applies only when no owner holds a private scan.

Validation:
- `RecordAccumulatorTests`: 93/93 on net10.0
- `RecordAccumulatorTests`: 93/93 on net8.0
- focused drain-handoff tests: 3/3 on net10.0 and net8.0
- builds: 0 warnings, 0 errors