### PR TITLE
Govern producer broker window with delay-biased probes and ack-clocked slow start

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -20,8 +20,17 @@ class Metric:
     unit: str
     higher_is_better: bool
     gated: bool = True
+    floor: bool = False
 
 
+# Steady/peak is a shape statistic: it normalizes a run's settled throughput by that same
+# run's best interval. Comparing it A-vs-B penalizes a candidate whose adaptive window
+# intentionally front-loads throughput while it settles — run 29518014693's candidate beat
+# both controls on delivered throughput yet "failed" stability solely because its own early
+# peak was higher — and its control spread has been observed near 5%, wider than the adverse
+# tolerance. It is therefore gated against the harness's own absolute steady-state floor,
+# which still rejects genuine intra-run collapse (run 29513570135's 0.745 breaches it) and
+# marks the comparison inconclusive when a control itself is unstable.
 METRICS = (
     Metric("throughput", "Delivered throughput", "msg/s", True),
     Metric("medianThroughput", "Median interval throughput", "msg/s", True),
@@ -30,10 +39,12 @@ METRICS = (
     Metric("p99", "Latency p99", "ms", False),
     Metric("cpu", "CPU", "us/msg", False),
     Metric("alloc", "Allocation", "B/msg", False),
-    Metric("stability", "Steady/peak ratio", "ratio", True),
+    Metric("stability", "Steady/peak ratio", "ratio", True, floor=True),
     Metric("max", "Latency max", "ms", False, gated=False),
     Metric("averageRequest", "Average request", "KiB", True, gated=False),
 )
+
+DEFAULT_STABILITY_FLOOR = 0.85
 
 
 def _finite_number(value):
@@ -128,6 +139,18 @@ def _delivery_mismatch(result):
     return delivered is not None and accepted is not None and delivered != accepted
 
 
+def _stability_breached(result):
+    breached = result.get("steadyStatePeakThresholdBreached")
+    if isinstance(breached, bool):
+        return breached
+
+    ratio = result.get("steadyStatePeakRatio")
+    threshold = result.get("steadyStatePeakRatioThreshold")
+    if not _finite_number(threshold):
+        threshold = DEFAULT_STABILITY_FLOOR
+    return _finite_number(ratio) and ratio < threshold
+
+
 def _metric_status(
     metric,
     baseline_a,
@@ -135,6 +158,7 @@ def _metric_status(
     baseline_a2,
     tolerance_percent,
     max_control_drift_percent,
+    floor_status=None,
 ):
     baseline_mean = (baseline_a + baseline_a2) / 2
     if baseline_mean == 0:
@@ -144,6 +168,8 @@ def _metric_status(
     control_drift_percent = 100 * abs(baseline_a2 - baseline_a) / abs(baseline_mean)
     if not metric.gated:
         status = "recorded"
+    elif metric.floor:
+        status = floor_status
     else:
         if metric.higher_is_better:
             worse_than_both = candidate < min(baseline_a, baseline_a2) * (
@@ -205,6 +231,12 @@ def compare(
     baseline_a = _measurements(baseline_a_result)
     candidate = _measurements(candidate_result)
     baseline_a2 = _measurements(baseline_a2_result)
+    if _stability_breached(candidate_result):
+        stability_status = "regression"
+    elif _stability_breached(baseline_a_result) or _stability_breached(baseline_a2_result):
+        stability_status = "inconclusive"
+    else:
+        stability_status = "pass"
     metrics = [
         _metric_status(
             metric,
@@ -213,6 +245,7 @@ def compare(
             baseline_a2[metric.key],
             tolerance_percent,
             max_control_drift_percent,
+            floor_status=stability_status if metric.floor else None,
         )
         for metric in METRICS
     ]

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -51,6 +51,8 @@ def result(
         "cpuMicrosPerMessage": cpu,
         "allocatedBytesPerMessage": allocation,
         "steadyStatePeakRatio": stability,
+        "steadyStatePeakRatioThreshold": 0.85,
+        "steadyStatePeakThresholdBreached": stability < 0.85,
         "throughput": {
             "totalMessages": total_messages,
             "totalErrors": errors,
@@ -111,6 +113,58 @@ class StressAbaComparisonTests(unittest.TestCase):
             metric for metric in comparison["metrics"] if metric["key"] == "throughput"
         )
         self.assertEqual("regression", throughput["status"])
+
+    def test_stability_gates_on_absolute_floor_not_shape_comparison(self):
+        # Run 29518014693: candidate beat both controls on throughput yet its
+        # steady/peak shape sat >3% under the control mean purely because its
+        # adaptive window front-loaded throughput. The floor gate accepts it.
+        comparison = compare(
+            result(throughput=1172, stability=0.951),
+            result(throughput=1211, stability=0.888, cpu=0.78),
+            result(throughput=1185, stability=0.906),
+        )
+
+        self.assertEqual("pass", comparison["verdict"])
+        stability = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "stability"
+        )
+        self.assertEqual("pass", stability["status"])
+
+    def test_candidate_stability_floor_breach_forces_regression(self):
+        # Run 29513570135: genuine intra-run throughput collapse (0.745) must
+        # still reject the candidate.
+        comparison = compare(
+            result(stability=0.994),
+            result(stability=0.745),
+            result(stability=0.996),
+        )
+
+        self.assertEqual("regression", comparison["verdict"])
+        stability = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "stability"
+        )
+        self.assertEqual("regression", stability["status"])
+
+    def test_unstable_control_marks_stability_inconclusive(self):
+        comparison = compare(
+            result(stability=0.70),
+            result(stability=0.95),
+            result(stability=0.95),
+        )
+
+        self.assertEqual("inconclusive", comparison["verdict"])
+        stability = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "stability"
+        )
+        self.assertEqual("inconclusive", stability["status"])
+
+    def test_stability_floor_falls_back_to_ratio_when_flag_missing(self):
+        candidate = result(stability=0.74)
+        del candidate["steadyStatePeakThresholdBreached"]
+
+        comparison = compare(result(), candidate, result())
+
+        self.assertEqual("regression", comparison["verdict"])
 
     def test_candidate_errors_force_regression(self):
         comparison = compare(result(), result(errors=1), result())

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -365,7 +365,7 @@ Soft target for per-broker queueing latency (append to broker acknowledgement):
 .WithDeliveryLatencyTarget(TimeSpan.Zero)                 // disable the bound
 ```
 
-Default: 10ms. The producer bounds each broker's unacknowledged bytes to a preferred measured bandwidth-delay-product safety horizon, capped by `target × measured ack throughput` but never below one measured bandwidth-delay product. This avoids standing queueing under sustained overload (bufferbloat) without making throughput window-limited. When a broker exceeds its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Until the first drain measurement the bound sits at its ceiling, so short-lived producers are unaffected. Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to restore pre-bound behavior.
+Default: 10ms. Before a broker's first successful acknowledgement, the producer admits one configured batch per current connection. This prevents an unsampled startup burst from filling the full pipeline. The adaptive controller then starts from a wider request window and probes up and down for the smallest whole-request window that preserves acknowledged goodput without increasing controllable queueing delay. `Acks.None` keeps the normal controller window because no acknowledgement can end the startup phase. When a broker reaches its budget, produce calls block exactly like `BufferMemory` exhaustion (subject to `WithMaxBlock` and cancellation). Raise the target if you prefer deeper buffering over latency; set `TimeSpan.Zero` to disable the bound.
 
 ### WithSocketSendBufferBytes / WithSocketReceiveBufferBytes
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2760,6 +2760,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var response = task.GetResult();
                 ObserveBrokerThrottle(response.ThrottleTimeMs);
                 var allPartitionsSucceeded = true;
+                var anyPartitionSucceeded = false;
                 ProduceResponsePartitionData? directResponse = null;
                 // Reuse caller-provided dictionary to avoid per-response allocation.
                 // The dictionary is cleared after use in ProcessResponseBatches.
@@ -2776,6 +2777,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var partitionResponse = response.Responses[0].PartitionResponses[0];
                     directResponse = partitionResponse;
                     allPartitionsSucceeded = partitionResponse.ErrorCode == ErrorCode.None;
+                    anyPartitionSucceeded = allPartitionsSucceeded;
                 }
                 else
                 {
@@ -2786,6 +2788,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         {
                             if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
                                 allPartitionsSucceeded = false;
+                            else
+                                anyPartitionSucceeded = true;
                             responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
                             responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] =
                                 topicResp.PartitionResponses[p];
@@ -2803,6 +2807,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         pending.DeliverySnapshotAtSend,
                         lastAckTimestamp);
                     anyAckedThisPass = true;
+                }
+                else if (anyPartitionSucceeded && _unackedBudget is { } partiallyAckedBudget)
+                {
+                    // Mixed responses carry no cleanly attributable request timing, so they
+                    // feed no window sample — but a delivered partition still proves the
+                    // broker drains data, which must end the cold-start clamp.
+                    partiallyAckedBudget.NotePartialDeliverySuccess();
                 }
 
                 // Diagnostic: log response content and expected batches for mismatch diagnosis

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3408,14 +3408,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     /// <summary>
     /// Recomputes the written-unacked pipeline ceiling for the given routing width and
-    /// republishes the admission budget's cap in lockstep. Every path that changes
-    /// <c>_connectionCount</c> must go through this so the two ceilings never desync.
+    /// republishes the admission cap and pre-ack request wave in lockstep. Every path that
+    /// changes <c>_connectionCount</c> must go through this so the ceilings never desync.
     /// </summary>
     private void UpdateInFlightByteBudget(int connectionCount)
     {
         _totalMaxInFlightBytes = GetInFlightByteBudget(connectionCount);
         _unackedBudget?.SetCap(
             _options.UnackedByteBudgetCapOverride ?? _totalMaxInFlightBytes,
+            _options.UnackedByteBudgetCapOverride is null
+                && _options.Acks != Acks.None
+                ? BrokerUnackedByteBudget.ComputeColdStartBudget(
+                    _options.BatchSize,
+                    connectionCount)
+                : null,
             _getTimestamp());
     }
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -82,6 +82,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _nextAdmissionFlushClaim;
     private long _probeStartedTimestamp;
     private double _latencyBudgetScale = 1;
+    private long _latencyCeilingBytes;
 
     // Single-writer state. Production supplies one request wave here; the first successful
     // acknowledgement permanently hands admission back to the adaptive window controller.
@@ -104,11 +105,15 @@ internal sealed class BrokerUnackedByteBudget
         if (initialRequestBytes <= 0)
             initialRequestBytes = Math.Clamp(64 * 1024, floor, cap);
 
+        // The latency ceiling shares the cold-start gate's arming condition (no explicit cap
+        // override, acknowledgements exist to measure) plus a positive latency target: with
+        // no target there is no delay budget to convert measured drain into a byte bound.
         _controller = new BrokerWindowController(
             targetSeconds,
             floor,
             cap,
-            initialRequestBytes);
+            initialRequestBytes,
+            latencyCeilingEnabled: coldStartBudgetBytes is not null && targetSeconds > 0);
         if (coldStartBudgetBytes is { } coldStartBudget)
         {
             _coldStartBudgetBytes = Math.Clamp(coldStartBudget, floor, _controller.WindowBytes);
@@ -143,6 +148,7 @@ internal sealed class BrokerUnackedByteBudget
     internal long PipelineBatchCount => Volatile.Read(ref _pipelineBatchCount);
     internal long DeliveryLatencyEwmaMicros => Volatile.Read(ref _deliveryLatencyEwmaMicros);
     internal double LatencyBudgetScale => Volatile.Read(ref _latencyBudgetScale);
+    internal long LatencyCeilingBytes => Volatile.Read(ref _latencyCeilingBytes);
 
     /// <summary>
     /// Atomically reserves logical bytes. One reservation larger than the current window may
@@ -330,6 +336,10 @@ internal sealed class BrokerUnackedByteBudget
         var decision = _controller.SetCap(capBytes);
         if (_awaitingInitialAcknowledgement && coldStartBudgetBytes is { } coldStartBudget)
         {
+            // The pre-ack window must be able to carry one wave at the new routing width,
+            // otherwise the ceiling's pessimistic start would shrink the wave the cold gate
+            // itself intends to admit.
+            decision = _controller.NoteColdStartWave(coldStartBudget);
             _coldStartBudgetBytes = Math.Clamp(
                 coldStartBudget,
                 _floorBytes,
@@ -371,12 +381,26 @@ internal sealed class BrokerUnackedByteBudget
             sendSnapshot.AppLimited,
             sendSnapshot.AdmissionGeneration,
             nowTicks);
-        if (_awaitingInitialAcknowledgement)
-        {
-            _awaitingInitialAcknowledgement = false;
-            Publish(_controller.WindowBytes, _controller.Generation);
-        }
+        EndColdStartGate();
         RecordRequestHistograms(ackedBytes, rttTicks);
+    }
+
+    /// <summary>
+    /// Ends the cold-start phase when a response delivered at least one partition but not all
+    /// of them. <see cref="OnAcked"/> only runs for fully successful responses, so without
+    /// this a broker whose first responses carry one churning partition (for example
+    /// NotLeaderOrFollower during startup elections) would stay clamped to a single request
+    /// wave despite demonstrably draining data. Single-writer: owning send loop only.
+    /// </summary>
+    public void NotePartialDeliverySuccess() => EndColdStartGate();
+
+    private void EndColdStartGate()
+    {
+        if (!_awaitingInitialAcknowledgement)
+            return;
+
+        _awaitingInitialAcknowledgement = false;
+        Publish(_controller.WindowBytes, _controller.Generation);
     }
 
     public void CompleteAckedPass(long nowTicks)
@@ -450,6 +474,7 @@ internal sealed class BrokerUnackedByteBudget
             ref _deliveryLatencyEwmaMicros,
             _controller.ControlledDelayEwmaTicks * 1_000_000 / Stopwatch.Frequency);
         Volatile.Write(ref _latencyBudgetScale, _controller.WindowScale);
+        Volatile.Write(ref _latencyCeilingBytes, _controller.LatencyCeilingBytes);
         Volatile.Write(ref _capacityProbeSuccessCount, _controller.CapacityProbeSuccessCount);
         Volatile.Write(ref _capacityProbeFailureCount, _controller.CapacityProbeFailureCount);
 

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -58,6 +58,7 @@ internal sealed class BrokerUnackedByteBudget
     private const int MaxProbeDiagnosticEvents = 4_096;
 
     private readonly BrokerWindowController _controller;
+    private readonly long _floorBytes;
     private readonly long[] _requestSizeLog2Histogram = new long[HistogramBucketCount];
     private readonly long[] _requestRttMicrosLog2Histogram = new long[HistogramBucketCount];
     private readonly long[]? _admissionBlockMicrosLog2Histogram;
@@ -82,16 +83,23 @@ internal sealed class BrokerUnackedByteBudget
     private long _probeStartedTimestamp;
     private double _latencyBudgetScale = 1;
 
+    // Single-writer state. Production supplies one request wave here; the first successful
+    // acknowledgement permanently hands admission back to the adaptive window controller.
+    private long _coldStartBudgetBytes;
+    private bool _awaitingInitialAcknowledgement;
+
     public BrokerUnackedByteBudget(
         double targetSeconds,
         long floorBytes,
         long initialCapBytes,
         double lingerSeconds = 0,
         bool enableDiagnostics = false,
-        long initialRequestBytes = 0)
+        long initialRequestBytes = 0,
+        long? coldStartBudgetBytes = null)
     {
         _ = lingerSeconds;
         var floor = Math.Max(1, floorBytes);
+        _floorBytes = floor;
         var cap = Math.Max(floor, initialCapBytes);
         if (initialRequestBytes <= 0)
             initialRequestBytes = Math.Clamp(64 * 1024, floor, cap);
@@ -101,7 +109,12 @@ internal sealed class BrokerUnackedByteBudget
             floor,
             cap,
             initialRequestBytes);
-        Publish(_controller.WindowBytes, _controller.Generation);
+        if (coldStartBudgetBytes is { } coldStartBudget)
+        {
+            _coldStartBudgetBytes = Math.Clamp(coldStartBudget, floor, _controller.WindowBytes);
+            _awaitingInitialAcknowledgement = true;
+        }
+        Publish(GetPublishedBudget(_controller.WindowBytes), _controller.Generation);
 
         if (enableDiagnostics)
         {
@@ -112,7 +125,10 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     internal static long ComputeCap(int batchSize, int connectionCount) =>
-        (long)Math.Max(1, batchSize) * CapBatchMultiplier * Math.Max(1, connectionCount);
+        ComputeBudget(batchSize, connectionCount, CapBatchMultiplier);
+
+    internal static long ComputeColdStartBudget(int batchSize, int connectionCount) =>
+        ComputeBudget(batchSize, connectionCount, batchMultiplier: 1);
 
     internal long UnackedBytes => Volatile.Read(ref _unackedBytes);
     internal long BudgetBytes => Volatile.Read(ref _budgetBytes);
@@ -306,10 +322,20 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     public void SetCap(long capBytes, long nowTicks)
+        => SetCap(capBytes, coldStartBudgetBytes: null, nowTicks);
+
+    public void SetCap(long capBytes, long? coldStartBudgetBytes, long nowTicks)
     {
         _ = nowTicks;
         var decision = _controller.SetCap(capBytes);
-        Publish(decision.WindowBytes, decision.Generation);
+        if (_awaitingInitialAcknowledgement && coldStartBudgetBytes is { } coldStartBudget)
+        {
+            _coldStartBudgetBytes = Math.Clamp(
+                coldStartBudget,
+                _floorBytes,
+                decision.WindowBytes);
+        }
+        Publish(GetPublishedBudget(decision.WindowBytes), decision.Generation);
     }
 
     internal DeliverySnapshot SnapshotDelivery(
@@ -345,6 +371,11 @@ internal sealed class BrokerUnackedByteBudget
             sendSnapshot.AppLimited,
             sendSnapshot.AdmissionGeneration,
             nowTicks);
+        if (_awaitingInitialAcknowledgement)
+        {
+            _awaitingInitialAcknowledgement = false;
+            Publish(_controller.WindowBytes, _controller.Generation);
+        }
         RecordRequestHistograms(ackedBytes, rttTicks);
     }
 
@@ -410,7 +441,7 @@ internal sealed class BrokerUnackedByteBudget
 
     private void PublishDecision(BrokerWindowDecision decision, long nowTicks)
     {
-        Publish(decision.WindowBytes, decision.Generation);
+        Publish(GetPublishedBudget(decision.WindowBytes), decision.Generation);
         Volatile.Write(
             ref _minimumRttMicros,
             _controller.MinimumRttTicks * 1_000_000 / Stopwatch.Frequency);
@@ -431,6 +462,23 @@ internal sealed class BrokerUnackedByteBudget
     {
         Volatile.Write(ref _budgetBytes, budgetBytes);
         Volatile.Write(ref _generation, generation);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long GetPublishedBudget(long controllerWindowBytes) =>
+        _awaitingInitialAcknowledgement
+            ? Math.Min(_coldStartBudgetBytes, controllerWindowBytes)
+            : controllerWindowBytes;
+
+    private static long ComputeBudget(
+        int batchSize,
+        int connectionCount,
+        int batchMultiplier)
+    {
+        var requestWaveBytes = (long)Math.Max(1, batchSize) * Math.Max(1, connectionCount);
+        return requestWaveBytes > long.MaxValue / batchMultiplier
+            ? long.MaxValue
+            : requestWaveBytes * batchMultiplier;
     }
 
     private void RecordProbeEvent(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -335,8 +335,8 @@ internal sealed class BrokerUnackedByteBudget
         if (_awaitingInitialAcknowledgement && coldStartBudgetBytes is { } coldStartBudget)
         {
             // The pre-ack window must be able to carry one wave at the new routing width,
-            // otherwise the ceiling's pessimistic start would shrink the wave the cold gate
-            // itself intends to admit.
+            // otherwise the slow start's pessimistic floor would shrink the wave the cold
+            // gate itself intends to admit.
             decision = _controller.NoteColdStartWave(coldStartBudget);
             _coldStartBudgetBytes = Math.Clamp(
                 coldStartBudget,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -82,7 +82,6 @@ internal sealed class BrokerUnackedByteBudget
     private long _nextAdmissionFlushClaim;
     private long _probeStartedTimestamp;
     private double _latencyBudgetScale = 1;
-    private long _latencyCeilingBytes;
 
     // Single-writer state. Production supplies one request wave here; the first successful
     // acknowledgement permanently hands admission back to the adaptive window controller.
@@ -105,15 +104,15 @@ internal sealed class BrokerUnackedByteBudget
         if (initialRequestBytes <= 0)
             initialRequestBytes = Math.Clamp(64 * 1024, floor, cap);
 
-        // The latency ceiling shares the cold-start gate's arming condition (no explicit cap
-        // override, acknowledgements exist to measure) plus a positive latency target: with
-        // no target there is no delay budget to convert measured drain into a byte bound.
+        // The latency governor shares the cold-start gate's arming condition (no explicit cap
+        // override, acknowledgements exist to pace the slow start) plus a positive latency
+        // target: with no target there is no delay budget for the descent bias to enforce.
         _controller = new BrokerWindowController(
             targetSeconds,
             floor,
             cap,
             initialRequestBytes,
-            latencyCeilingEnabled: coldStartBudgetBytes is not null && targetSeconds > 0);
+            latencyGovernorEnabled: coldStartBudgetBytes is not null && targetSeconds > 0);
         if (coldStartBudgetBytes is { } coldStartBudget)
         {
             _coldStartBudgetBytes = Math.Clamp(coldStartBudget, floor, _controller.WindowBytes);
@@ -148,7 +147,6 @@ internal sealed class BrokerUnackedByteBudget
     internal long PipelineBatchCount => Volatile.Read(ref _pipelineBatchCount);
     internal long DeliveryLatencyEwmaMicros => Volatile.Read(ref _deliveryLatencyEwmaMicros);
     internal double LatencyBudgetScale => Volatile.Read(ref _latencyBudgetScale);
-    internal long LatencyCeilingBytes => Volatile.Read(ref _latencyCeilingBytes);
 
     /// <summary>
     /// Atomically reserves logical bytes. One reservation larger than the current window may
@@ -474,7 +472,6 @@ internal sealed class BrokerUnackedByteBudget
             ref _deliveryLatencyEwmaMicros,
             _controller.ControlledDelayEwmaTicks * 1_000_000 / Stopwatch.Frequency);
         Volatile.Write(ref _latencyBudgetScale, _controller.WindowScale);
-        Volatile.Write(ref _latencyCeilingBytes, _controller.LatencyCeilingBytes);
         Volatile.Write(ref _capacityProbeSuccessCount, _controller.CapacityProbeSuccessCount);
         Volatile.Write(ref _capacityProbeFailureCount, _controller.CapacityProbeFailureCount);
 

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -152,10 +152,7 @@ internal sealed class BrokerWindowController
         // (explicit cap override, Acks.None) keeps the optimistic start unchanged.
         _windowBytes = _slowStartActive
             ? MinimumWindowBytes
-            : Math.Clamp(
-                SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
-                MinimumWindowBytes,
-                _capBytes);
+            : Math.Max(MinimumWindowBytes, OptimisticWindowBytes);
     }
 
     internal long WindowBytes => _windowBytes;
@@ -307,13 +304,15 @@ internal sealed class BrokerWindowController
 
     private void AdvanceSlowStart()
     {
-        var optimisticWindow = Math.Min(
-            SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
-            _capBytes);
+        var optimisticWindow = OptimisticWindowBytes;
         SetWindow(Math.Min(SaturatingMultiply(_windowBytes, 2), optimisticWindow));
         if (_windowBytes >= optimisticWindow)
             _slowStartActive = false;
     }
+
+    private long OptimisticWindowBytes => Math.Min(
+        SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
+        _capBytes);
 
     private BrokerWindowDecision UpdateSteady(bool demand)
     {
@@ -358,12 +357,8 @@ internal sealed class BrokerWindowController
     /// <summary>Lowest window a down-probe may propose. The legacy eight-quantum floor holds
     /// while latency is on target; descent below it is justified only by a missed target,
     /// and even then each step must pass the paired goodput guard.</summary>
-    private long ProbeFloorBytes(bool descentBias) => Math.Clamp(
-        SaturatingMultiply(
-            _requestQuantumBytes,
-            descentBias ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta),
-        _floorBytes,
-        _capBytes);
+    private long ProbeFloorBytes(bool descentBias) => QuantaFloorBytes(
+        descentBias ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta);
 
     private BrokerWindowDecision StartCapacityProbe(
         BrokerWindowPhase phase,
@@ -591,10 +586,12 @@ internal sealed class BrokerWindowController
     /// <summary>Hard lower bound on any window value. Governor-enabled controllers may hold
     /// descent-floor windows reached while over target; probe policy (not this bound)
     /// decides when descent below the legacy floor is permitted.</summary>
-    private long MinimumWindowBytes => Math.Clamp(
-        SaturatingMultiply(
-            _requestQuantumBytes,
-            _latencyGovernorEnabled ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta),
+    private long MinimumWindowBytes => QuantaFloorBytes(
+        _latencyGovernorEnabled ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private long QuantaFloorBytes(int quanta) => Math.Clamp(
+        SaturatingMultiply(_requestQuantumBytes, quanta),
         _floorBytes,
         _capBytes);
 

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -26,12 +26,23 @@ internal readonly record struct BrokerWindowDecision(
 /// Pure, allocation-free knee-seeking byte-window controller. Its quantum is the configured
 /// batch capacity and never changes with fragmented request sizes. It searches for the
 /// smallest whole-quantum window that preserves broker goodput.
-/// When the latency ceiling is enabled, every window value is additionally bounded by
-/// <c>delivery-latency target × windowed-maximum measured goodput</c>: standing unacked
-/// bytes divided by drain rate is the queueing delay each delivery wears, so goodput probes
-/// may only explore beneath the target's worth of measured drain. The same bound, fed by an
-/// ack-clocked cumulative rate before the first control epoch completes, paces the
-/// cold-start window open instead of releasing the optimistic initial size in one step.
+/// With the latency governor enabled, two behaviors change — both expressed through the
+/// existing goodput-guarded paired experiments rather than a separate control law, so no
+/// self-measured estimate can strangle or inflate the window:
+/// <list type="bullet">
+/// <item>Cold start opens by ack-clocked doubling from two quanta to the optimistic initial
+/// size. Each doubling follows a fully acknowledged response pass, so the broker has always
+/// drained the previous window within one round trip before more is admitted; the first
+/// acknowledgement can no longer release the whole optimistic window as one unmeasured
+/// burst into a cold broker (#2109).</item>
+/// <item>While the controlled-delay EWMA exceeds the delivery-latency target, probes are
+/// biased downward: up-probes are withheld, down-probes may explore beneath the normal
+/// pipeline floor, and each successful goodput-preserving descent schedules the next probe
+/// early. Every step remains a B-A-B experiment whose goodput guard reverts harmful
+/// shrinks, so topologies whose knee sits high keep their window and only pay a treatment
+/// slice per cycle, while topologies with a low knee descend out of standing queueing
+/// delay the target forbids.</item>
+/// </list>
 /// </summary>
 internal sealed class BrokerWindowController
 {
@@ -44,47 +55,31 @@ internal sealed class BrokerWindowController
 
     private const int SizeBucketCount = 16;
     private const int SizeBucketShift = 8;
-    // Two quanta keep the acknowledgement clock pipelined (one request on the wire while the
-    // next seals) without encoding any topology's knee into the floor. The knee itself is
-    // discovered by paired probes underneath the latency ceiling: an eight-quantum floor
-    // matched a one-broker drain rate but forced ~3x the delivery-latency target of standing
-    // queue per broker on three-broker topologies (#2109). Applies only while the latency
-    // ceiling is armed — probing below the old floor is safe only with the ceiling's
-    // rate-derived bound above it.
-    private const int MinimumPipelineQuanta = 2;
-    // Ceiling-disabled controllers (explicit cap override, Acks.None) keep the original
-    // eight-quantum floor: for them the down-probe goodput guard is the only other
-    // protection against walking a fast pipe below its knee, so their semantics are
-    // deliberately unchanged.
-    private const int UnceiledMinimumPipelineQuanta = 8;
+    // The control run sustained its knee at roughly seven full requests. One extra quantum
+    // absorbs response/scheduler granularity without allowing fragmented requests to redefine
+    // the floor. Descent below this floor is allowed only while the controlled-delay EWMA
+    // exceeds the delivery-latency target (see LatencyDescentPipelineQuanta).
+    private const int MinimumPipelineQuanta = 8;
+    // Deep-descent floor while over the latency target: two quanta keep the acknowledgement
+    // clock pipelined (one request on the wire while the next seals). The eight-quantum
+    // floor encoded a one-broker knee and forced ~3x the delivery-latency target of standing
+    // queue per broker on three-broker topologies (#2109); the goodput guard, not a fixed
+    // constant, decides how far each topology can actually descend.
+    private const int LatencyDescentPipelineQuanta = 2;
     // Open partition batches also hold bounded lease slack, so start above the expected knee
     // and search downward. This avoids throughput-biased learning from a starved startup.
-    // With the latency ceiling enabled the optimistic start is additionally bounded by
-    // measured drain rate, so it cannot flood a cold broker.
     private const int InitialRequestQuanta = 16;
-    // The latency ceiling tracks the maximum epoch goodput over this many completed control
-    // epochs (~30s of loaded time). A windowed maximum ignores transient dips without letting
-    // a stale one-time peak size the window forever.
-    private const int GoodputRingEpochs = 60;
-    // Serving-time floor on the ceiling's horizon, in multiples of the best request-sized
-    // round trip. Growth out of a clamped window has gain = multiplier x best/average round
-    // trip; jittery environments run averages near twice the best, so a multiplier of two
-    // sat at gain ~1.0 and froze (observed locally as an 84% throughput collapse at the
-    // window floor). Three keeps the gain above one at 2:1 jitter while staying under the
-    // 10ms latency target wherever request round trips are a few milliseconds.
-    private const int ServingHorizonRttMultiplier = 3;
-    // Escape valve for environments whose jitter beats the multiplier: a ceiling that binds
-    // under demand while goodput persists below this fraction of the windowed maximum is
-    // strangling the pipe, not saving latency.
-    private const double CeilingStrangleGoodputFraction = 0.75;
-    // One violating epoch can be a broker hiccup; two consecutive epochs (~1s) is a regime.
-    private const int CeilingStrangleEpochsBeforeEscape = 2;
     // Treatments are deliberately sparse and settled: frequent sub-second window changes
     // caused self-inflicted admission stalls that looked like congestion. Each experiment is
     // a B-A-B sandwich (3s candidate, 6s baseline, 3s candidate after a 1s washout at each
     // transition), which cancels a linear runner trend instead of comparing one temporal
     // slice with one 1.5-second vote.
     private const int ProbeIntervalEpochs = 60;
+    // While over the latency target, a successful goodput-preserving descent re-probes after
+    // this many epochs (~3s) instead of the full interval, so escaping standing queueing
+    // delay takes tens of seconds rather than many minutes. A failed descent proves the
+    // current window earns its goodput and falls back to the sparse schedule.
+    private const int AcceleratedDescentIntervalEpochs = 6;
     private const int ProbeSettleEpochs = 2;
     private const int OuterProbeEvaluationEpochs = 6;
     private const int BaselineProbeEvaluationEpochs = 12;
@@ -104,22 +99,15 @@ internal sealed class BrokerWindowController
     private readonly long _floorBytes;
     private readonly long _requestQuantumBytes;
     private readonly long _targetDelayTicks;
-    private readonly bool _latencyCeilingEnabled;
+    private readonly bool _latencyGovernorEnabled;
     private readonly long[] _minimumRttBySizeTicks = new long[SizeBucketCount];
     private readonly long[] _minimumRttTimestamps = new long[SizeBucketCount];
-    private readonly double[] _epochGoodputRing = new double[GoodputRingEpochs];
 
     private long _capBytes;
     private long _windowBytes;
     private long _generation = 1;
     private BrokerWindowPhase _phase = BrokerWindowPhase.Steady;
-    private long _latencyCeilingBytes = long.MaxValue;
-    private int _epochGoodputIndex;
-    private bool _coldStartRampComplete;
-    private long _rampStartTimestamp;
-    private long _rampAckedBytes;
-    private long _ceilingEscapeFloorBytes;
-    private int _ceilingStrangleEpochs;
+    private bool _slowStartActive;
 
     private long _epochStartedAt;
     private long _epochBytes;
@@ -152,22 +140,22 @@ internal sealed class BrokerWindowController
         long floorBytes,
         long capBytes,
         long initialRequestBytes,
-        bool latencyCeilingEnabled = false)
+        bool latencyGovernorEnabled = false)
     {
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, capBytes);
         _targetDelayTicks = Math.Max(1, (long)(targetSeconds * Stopwatch.Frequency));
         _requestQuantumBytes = Math.Max(_floorBytes, initialRequestBytes);
-        _latencyCeilingEnabled = latencyCeilingEnabled;
-        // Ceiling-enabled controllers start pessimistic: the window opens as the cold-start
-        // ramp measures the broker's actual drain rate, so the first acknowledgement cannot
-        // release an unlearned multi-quantum burst into a cold broker (#2109).
-        if (latencyCeilingEnabled)
-            _latencyCeilingBytes = MinimumWindowBytes;
-        _windowBytes = Math.Clamp(
-            SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
-            MinimumWindowBytes,
-            EffectiveCapBytes);
+        _latencyGovernorEnabled = latencyGovernorEnabled;
+        _slowStartActive = latencyGovernorEnabled;
+        // Governor-enabled controllers slow-start from the descent floor; everything else
+        // (explicit cap override, Acks.None) keeps the optimistic start unchanged.
+        _windowBytes = _slowStartActive
+            ? MinimumWindowBytes
+            : Math.Clamp(
+                SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
+                MinimumWindowBytes,
+                _capBytes);
     }
 
     internal long WindowBytes => _windowBytes;
@@ -177,15 +165,40 @@ internal sealed class BrokerWindowController
     internal long MaximumGoodputBytesPerSecond => (long)_maximumGoodputBytesPerSecond;
     internal long ControlledDelayEwmaTicks => (long)_controlledDelayEwmaTicks;
     internal long RequestQuantumBytes => _requestQuantumBytes;
-    internal long LatencyCeilingBytes => _latencyCeilingEnabled ? _latencyCeilingBytes : 0;
     internal double WindowScale => _capBytes == 0 ? 1 : (double)_windowBytes / _capBytes;
     internal long CapacityProbeSuccessCount { get; private set; }
     internal long CapacityProbeFailureCount { get; private set; }
 
+    private bool DelayOverTarget =>
+        _latencyGovernorEnabled && _controlledDelayEwmaTicks > _targetDelayTicks;
+
     internal BrokerWindowDecision SetCap(long capBytes)
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
-        ApplyEffectiveCap();
+        if (_windowBytes > _capBytes)
+        {
+            _windowBytes = _capBytes;
+            _generation++;
+        }
+        if (_probeBaselineWindow > _capBytes)
+            _probeBaselineWindow = _capBytes;
+        if (_probeCandidateWindow > _capBytes)
+            _probeCandidateWindow = _capBytes;
+
+        return CurrentDecision();
+    }
+
+    /// <summary>
+    /// Keeps the pre-acknowledgement window large enough for one request wave at the current
+    /// routing width. Connection scale-up before the first acknowledgement grows the wave
+    /// beyond the slow-start floor; the wave is still an unmeasured burst the cold-start
+    /// gate itself bounds, so admitting it does not reintroduce the flood.
+    /// </summary>
+    internal BrokerWindowDecision NoteColdStartWave(long waveBytes)
+    {
+        if (_slowStartActive)
+            SetWindow(Math.Max(_windowBytes, waveBytes));
+
         return CurrentDecision();
     }
 
@@ -209,11 +222,6 @@ internal sealed class BrokerWindowController
 
         UpdateMinimumRtt(logicalBytes, rttTicks, nowTicks);
 
-        // After the RTT update so this acknowledgement's round trip already informs the
-        // ceiling's serving-time horizon.
-        if (_latencyCeilingEnabled && !_coldStartRampComplete)
-            AdvanceColdStartRamp(logicalBytes, rttTicks, nowTicks);
-
         var controlledDelayTicks = Math.Max(0, sealToSendTicks)
             + Math.Max(0, rttTicks - GetMinimumRtt(logicalBytes));
         _controlledDelayEwmaTicks = UpdateEwma(
@@ -236,6 +244,11 @@ internal sealed class BrokerWindowController
         long observedOutstandingBytes,
         long nowTicks)
     {
+        // Called once per response pass that carried at least one full acknowledgement, so
+        // each doubling follows a proven drain of the previous window within one round trip.
+        if (_slowStartActive)
+            AdvanceSlowStart();
+
         if (_epochStartedAt == 0)
         {
             _epochStartedAt = nowTicks;
@@ -270,9 +283,6 @@ internal sealed class BrokerWindowController
         if (goodput <= 0)
             return CurrentDecision();
 
-        if (_latencyCeilingEnabled)
-            CompleteLatencyCeilingEpoch(goodput, demand);
-
         if (!generationQualified)
         {
             if (_phase == BrokerWindowPhase.Steady
@@ -295,6 +305,16 @@ internal sealed class BrokerWindowController
         };
     }
 
+    private void AdvanceSlowStart()
+    {
+        var optimisticWindow = Math.Min(
+            SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
+            _capBytes);
+        SetWindow(Math.Min(SaturatingMultiply(_windowBytes, 2), optimisticWindow));
+        if (_windowBytes >= optimisticWindow)
+            _slowStartActive = false;
+    }
+
     private BrokerWindowDecision UpdateSteady(bool demand)
     {
         if (!demand)
@@ -303,11 +323,20 @@ internal sealed class BrokerWindowController
         if (--_epochsUntilProbe > 0)
             return CurrentDecision();
 
-        if (_probeDownNext && _windowBytes > MinimumWindowBytes)
-            return StartDownProbe();
+        var descentBias = DelayOverTarget;
+        if ((_probeDownNext || descentBias) && _windowBytes > ProbeFloorBytes(descentBias))
+            return StartDownProbe(descentBias);
+
+        if (descentBias)
+        {
+            // At the descent floor while still over target: growing would stack queueing on
+            // an already-missed target, so hold and re-check on the next cycle.
+            _epochsUntilProbe = ProbeIntervalEpochs;
+            return CurrentDecision();
+        }
 
         var requestedWindow = Math.Min(
-            EffectiveCapBytes,
+            _capBytes,
             Math.Max(
                 _windowBytes + _requestQuantumBytes,
                 (long)Math.Ceiling(_windowBytes * UpProbeMultiplier)));
@@ -316,15 +345,25 @@ internal sealed class BrokerWindowController
             requestedWindow);
     }
 
-    private BrokerWindowDecision StartDownProbe()
+    private BrokerWindowDecision StartDownProbe(bool descentBias)
     {
         var requestedWindow = Math.Max(
-            MinimumWindowBytes,
+            ProbeFloorBytes(descentBias),
             (long)Math.Floor(_windowBytes * DownProbeMultiplier));
         return StartCapacityProbe(
             BrokerWindowPhase.ProbeDown,
             requestedWindow);
     }
+
+    /// <summary>Lowest window a down-probe may propose. The legacy eight-quantum floor holds
+    /// while latency is on target; descent below it is justified only by a missed target,
+    /// and even then each step must pass the paired goodput guard.</summary>
+    private long ProbeFloorBytes(bool descentBias) => Math.Clamp(
+        SaturatingMultiply(
+            _requestQuantumBytes,
+            descentBias ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta),
+        _floorBytes,
+        _capBytes);
 
     private BrokerWindowDecision StartCapacityProbe(
         BrokerWindowPhase phase,
@@ -432,7 +471,11 @@ internal sealed class BrokerWindowController
         // Continue walking in a direction while it wins. A failed treatment reverses the
         // next probe, converging on the knee instead of oscillating unconditionally.
         _probeDownNext = probingUp ? !succeeded : succeeded;
-        _epochsUntilProbe = ProbeIntervalEpochs;
+        // A goodput-preserving descent while over the latency target earns an early retry;
+        // anything else returns to the sparse schedule.
+        _epochsUntilProbe = !probingUp && succeeded && DelayOverTarget
+            ? AcceleratedDescentIntervalEpochs
+            : ProbeIntervalEpochs;
         _unqualifiedProbeEpochs = 0;
         ResetProbeExperiment();
         return CurrentDecision(
@@ -535,7 +578,7 @@ internal sealed class BrokerWindowController
     private long NormalizeWindow(long requestedBytes)
     {
         var minimum = MinimumWindowBytes;
-        var next = Math.Clamp(requestedBytes, minimum, EffectiveCapBytes);
+        var next = Math.Clamp(requestedBytes, minimum, _capBytes);
         if (next > minimum && _requestQuantumBytes > 1)
         {
             next = next / _requestQuantumBytes * _requestQuantumBytes;
@@ -545,182 +588,15 @@ internal sealed class BrokerWindowController
         return next;
     }
 
-    /// <summary>Quantum floor for the window. Every latency-ceiling write clamps the ceiling
-    /// to at least this value, so the effective cap never undercuts it.</summary>
+    /// <summary>Hard lower bound on any window value. Governor-enabled controllers may hold
+    /// descent-floor windows reached while over target; probe policy (not this bound)
+    /// decides when descent below the legacy floor is permitted.</summary>
     private long MinimumWindowBytes => Math.Clamp(
         SaturatingMultiply(
             _requestQuantumBytes,
-            _latencyCeilingEnabled ? MinimumPipelineQuanta : UnceiledMinimumPipelineQuanta),
+            _latencyGovernorEnabled ? LatencyDescentPipelineQuanta : MinimumPipelineQuanta),
         _floorBytes,
         _capBytes);
-
-    /// <summary>Cap actually available to the window: the routing-width byte ceiling bounded
-    /// by the latency ceiling (delivery-latency target × windowed-maximum measured goodput).
-    /// Under open-loop saturation, standing unacked bytes divided by drain rate is the
-    /// queueing delay every delivery wears, so no goodput-probed window may hold more than
-    /// the target's worth of measured drain. Goodput cannot be inflated by self-queueing
-    /// (unlike an RTT horizon), so this bound has no positive-feedback ratchet.</summary>
-    private long EffectiveCapBytes => Math.Min(_capBytes, _latencyCeilingBytes);
-
-    /// <summary>Clamps the window and any in-flight probe bookkeeping to the current
-    /// effective cap after the cap or the latency ceiling moves.</summary>
-    private void ApplyEffectiveCap()
-    {
-        var effectiveCap = EffectiveCapBytes;
-        if (_windowBytes > effectiveCap)
-        {
-            _windowBytes = effectiveCap;
-            _generation++;
-        }
-        if (_probeBaselineWindow > effectiveCap)
-            _probeBaselineWindow = effectiveCap;
-        if (_probeCandidateWindow > effectiveCap)
-            _probeCandidateWindow = effectiveCap;
-    }
-
-    /// <summary>
-    /// Keeps the pre-acknowledgement window large enough for one request wave at the current
-    /// routing width. Connection scale-up before the first acknowledgement grows the wave
-    /// beyond the pessimistic two-quantum start; the wave is still an unmeasured burst the
-    /// cold-start gate itself bounds, so admitting it does not reintroduce the flood.
-    /// No-op once any acknowledgement has been measured — the ramp owns the ceiling then.
-    /// </summary>
-    internal BrokerWindowDecision NoteColdStartWave(long waveBytes)
-    {
-        // _rampAckedBytes == 0 also implies the ramp has not completed: completing requires
-        // a control epoch with goodput, which requires an acknowledgement the ramp counted.
-        if (_latencyCeilingEnabled && _rampAckedBytes == 0)
-            TryRaiseColdStartCeiling(Math.Min(waveBytes, _capBytes));
-
-        return CurrentDecision();
-    }
-
-    /// <summary>
-    /// Cold-start ramp: before the first completed control epoch, the ceiling grows with the
-    /// cumulative acknowledged drain rate and the window follows it toward the optimistic
-    /// initial size. Ack-clocked and rate-proportional — a fast broker opens the window
-    /// within a few round trips, a cold broker admits only what it has demonstrably drained.
-    /// Single-writer (owning send loop), so plain field updates suffice.
-    /// </summary>
-    private void AdvanceColdStartRamp(long logicalBytes, long rttTicks, long nowTicks)
-    {
-        if (_rampStartTimestamp == 0)
-            _rampStartTimestamp = nowTicks - rttTicks;
-        _rampAckedBytes = SaturatingAdd(_rampAckedBytes, logicalBytes);
-        var elapsedTicks = Math.Max(1, nowTicks - _rampStartTimestamp);
-        var rateBytesPerSecond = _rampAckedBytes * (double)Stopwatch.Frequency / elapsedTicks;
-        TryRaiseColdStartCeiling(ComputeCeilingBytes(rateBytesPerSecond));
-    }
-
-    /// <summary>Raises the cold-start ceiling and re-seeks the optimistic initial window
-    /// underneath it. Raise-only: pre-epoch estimates may only open the window further.</summary>
-    private void TryRaiseColdStartCeiling(long ceilingBytes)
-    {
-        if (ceilingBytes <= _latencyCeilingBytes)
-            return;
-
-        _latencyCeilingBytes = ceilingBytes;
-        SetWindow(SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta));
-    }
-
-    /// <summary>Feeds one completed epoch's goodput into the windowed-maximum ring and
-    /// re-derives the latency ceiling. Ends the cold-start ramp: epoch goodput is measured
-    /// over a full control interval and supersedes the ramp's cumulative estimate.
-    /// A window sitting on the ceiling follows it back up when measured goodput recovers —
-    /// the raise carries the same rate-times-target justification as the clamp, so recovery
-    /// from a transient dip does not wait for the probe schedule. Windows the probe walk
-    /// placed below the ceiling are deliberate and stay put.</summary>
-    private void CompleteLatencyCeilingEpoch(double goodputBytesPerSecond, bool demand)
-    {
-        _coldStartRampComplete = true;
-        _epochGoodputRing[_epochGoodputIndex] = goodputBytesPerSecond;
-        _epochGoodputIndex = (_epochGoodputIndex + 1) % GoodputRingEpochs;
-
-        var windowedMax = 0.0;
-        for (var i = 0; i < _epochGoodputRing.Length; i++)
-            windowedMax = Math.Max(windowedMax, _epochGoodputRing[i]);
-
-        var previousEffectiveCap = EffectiveCapBytes;
-        UpdateCeilingEscapeFloor(goodputBytesPerSecond, windowedMax, demand, previousEffectiveCap);
-        _latencyCeilingBytes = Math.Max(
-            ComputeCeilingBytes(windowedMax),
-            _ceilingEscapeFloorBytes);
-        if (_phase == BrokerWindowPhase.Steady
-            && _windowBytes >= previousEffectiveCap
-            && EffectiveCapBytes > previousEffectiveCap)
-        {
-            SetWindow(EffectiveCapBytes);
-        }
-        else
-        {
-            ApplyEffectiveCap();
-        }
-    }
-
-    /// <summary>
-    /// Goodput-preservation escape valve: a ceiling that binds under demand while goodput
-    /// persists well below the windowed maximum is strangling the pipe — the clamp itself
-    /// suppresses the measurement that would justify a wider window. Doubling the ceiling's
-    /// floor (monotone within a run) restores throughput within an epoch or two; a latency
-    /// clamp is never worth a goodput regression. One violating epoch is ignored as a
-    /// possible broker hiccup so a transient stall cannot permanently widen the floor.
-    /// </summary>
-    private void UpdateCeilingEscapeFloor(
-        double goodputBytesPerSecond,
-        double windowedMaxGoodput,
-        bool demand,
-        long previousEffectiveCap)
-    {
-        var ceilingBinding = _latencyCeilingBytes < _capBytes
-            && _windowBytes >= previousEffectiveCap;
-        if (!ceilingBinding
-            || !demand
-            || goodputBytesPerSecond >= CeilingStrangleGoodputFraction * windowedMaxGoodput)
-        {
-            _ceilingStrangleEpochs = 0;
-            return;
-        }
-
-        if (++_ceilingStrangleEpochs < CeilingStrangleEpochsBeforeEscape)
-            return;
-
-        _ceilingStrangleEpochs = 0;
-        _ceilingEscapeFloorBytes = Math.Min(
-            Math.Max(SaturatingMultiply(previousEffectiveCap, 2), _ceilingEscapeFloorBytes),
-            _capBytes);
-    }
-
-    private long ComputeCeilingBytes(double rateBytesPerSecond)
-    {
-        // The delivery-latency target is an aspiration; a few request-sized round trips are
-        // physics. When a full request's best-case round trip exceeds the target, a
-        // target-only horizon demands fewer standing bytes than the pipe needs to stay
-        // full, goodput is then measured at the strangled window, and the lower measurement
-        // justifies an even lower ceiling — a self-confirming collapse (observed as an 84%
-        // local throughput loss). Flooring the horizon at a small multiple of the
-        // request-quantum-sized minimum RTT keeps requests pipelined, so measured goodput
-        // reflects drain capacity and the ceiling's growth feedback stays above unity even
-        // when average round trips run well above the best case (see
-        // ServingHorizonRttMultiplier).
-        var horizonTicks = Math.Max(
-            _targetDelayTicks,
-            SaturatingMultiply(QuantumMinimumRttTicks, ServingHorizonRttMultiplier));
-        var targetBytes = rateBytesPerSecond * horizonTicks / Stopwatch.Frequency;
-        return (long)Math.Clamp(targetBytes, MinimumWindowBytes, _capBytes);
-    }
-
-    /// <summary>Best observed round trip for request-quantum-sized transfers, falling back
-    /// to the global minimum until that size bucket has a sample. The global minimum comes
-    /// from small early requests and can undercut a full request's service time by orders
-    /// of magnitude, which is exactly the gap that strangles the ceiling's horizon.</summary>
-    private long QuantumMinimumRttTicks
-    {
-        get
-        {
-            var bucketMinimum = _minimumRttBySizeTicks[GetSizeBucket(_requestQuantumBytes)];
-            return bucketMinimum != 0 ? bucketMinimum : _minimumRttTicks;
-        }
-    }
 
     private void ResetEpoch(long nowTicks)
     {

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -26,6 +26,12 @@ internal readonly record struct BrokerWindowDecision(
 /// Pure, allocation-free knee-seeking byte-window controller. Its quantum is the configured
 /// batch capacity and never changes with fragmented request sizes. It searches for the
 /// smallest whole-quantum window that preserves broker goodput.
+/// When the latency ceiling is enabled, every window value is additionally bounded by
+/// <c>delivery-latency target × windowed-maximum measured goodput</c>: standing unacked
+/// bytes divided by drain rate is the queueing delay each delivery wears, so goodput probes
+/// may only explore beneath the target's worth of measured drain. The same bound, fed by an
+/// ack-clocked cumulative rate before the first control epoch completes, paces the
+/// cold-start window open instead of releasing the optimistic initial size in one step.
 /// </summary>
 internal sealed class BrokerWindowController
 {
@@ -38,13 +44,28 @@ internal sealed class BrokerWindowController
 
     private const int SizeBucketCount = 16;
     private const int SizeBucketShift = 8;
-    // The control run sustained its knee at roughly seven full requests. One extra quantum
-    // absorbs response/scheduler granularity without allowing fragmented requests to redefine
-    // the floor.
-    private const int MinimumPipelineQuanta = 8;
+    // Two quanta keep the acknowledgement clock pipelined (one request on the wire while the
+    // next seals) without encoding any topology's knee into the floor. The knee itself is
+    // discovered by paired probes underneath the latency ceiling: an eight-quantum floor
+    // matched a one-broker drain rate but forced ~3x the delivery-latency target of standing
+    // queue per broker on three-broker topologies (#2109). Applies only while the latency
+    // ceiling is armed — probing below the old floor is safe only with the ceiling's
+    // rate-derived bound above it.
+    private const int MinimumPipelineQuanta = 2;
+    // Ceiling-disabled controllers (explicit cap override, Acks.None) keep the original
+    // eight-quantum floor: for them the down-probe goodput guard is the only other
+    // protection against walking a fast pipe below its knee, so their semantics are
+    // deliberately unchanged.
+    private const int UnceiledMinimumPipelineQuanta = 8;
     // Open partition batches also hold bounded lease slack, so start above the expected knee
     // and search downward. This avoids throughput-biased learning from a starved startup.
+    // With the latency ceiling enabled the optimistic start is additionally bounded by
+    // measured drain rate, so it cannot flood a cold broker.
     private const int InitialRequestQuanta = 16;
+    // The latency ceiling tracks the maximum epoch goodput over this many completed control
+    // epochs (~30s of loaded time). A windowed maximum ignores transient dips without letting
+    // a stale one-time peak size the window forever.
+    private const int GoodputRingEpochs = 60;
     // Treatments are deliberately sparse and settled: frequent sub-second window changes
     // caused self-inflicted admission stalls that looked like congestion. Each experiment is
     // a B-A-B sandwich (3s candidate, 6s baseline, 3s candidate after a 1s washout at each
@@ -70,13 +91,20 @@ internal sealed class BrokerWindowController
     private readonly long _floorBytes;
     private readonly long _requestQuantumBytes;
     private readonly long _targetDelayTicks;
+    private readonly bool _latencyCeilingEnabled;
     private readonly long[] _minimumRttBySizeTicks = new long[SizeBucketCount];
     private readonly long[] _minimumRttTimestamps = new long[SizeBucketCount];
+    private readonly double[] _epochGoodputRing = new double[GoodputRingEpochs];
 
     private long _capBytes;
     private long _windowBytes;
     private long _generation = 1;
     private BrokerWindowPhase _phase = BrokerWindowPhase.Steady;
+    private long _latencyCeilingBytes = long.MaxValue;
+    private int _epochGoodputIndex;
+    private bool _coldStartRampComplete;
+    private long _rampStartTimestamp;
+    private long _rampAckedBytes;
 
     private long _epochStartedAt;
     private long _epochBytes;
@@ -108,16 +136,23 @@ internal sealed class BrokerWindowController
         double targetSeconds,
         long floorBytes,
         long capBytes,
-        long initialRequestBytes)
+        long initialRequestBytes,
+        bool latencyCeilingEnabled = false)
     {
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, capBytes);
         _targetDelayTicks = Math.Max(1, (long)(targetSeconds * Stopwatch.Frequency));
         _requestQuantumBytes = Math.Max(_floorBytes, initialRequestBytes);
+        _latencyCeilingEnabled = latencyCeilingEnabled;
+        // Ceiling-enabled controllers start pessimistic: the window opens as the cold-start
+        // ramp measures the broker's actual drain rate, so the first acknowledgement cannot
+        // release an unlearned multi-quantum burst into a cold broker (#2109).
+        if (latencyCeilingEnabled)
+            _latencyCeilingBytes = MinimumWindowBytes;
         _windowBytes = Math.Clamp(
             SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta),
             MinimumWindowBytes,
-            _capBytes);
+            EffectiveCapBytes);
     }
 
     internal long WindowBytes => _windowBytes;
@@ -127,6 +162,7 @@ internal sealed class BrokerWindowController
     internal long MaximumGoodputBytesPerSecond => (long)_maximumGoodputBytesPerSecond;
     internal long ControlledDelayEwmaTicks => (long)_controlledDelayEwmaTicks;
     internal long RequestQuantumBytes => _requestQuantumBytes;
+    internal long LatencyCeilingBytes => _latencyCeilingEnabled ? _latencyCeilingBytes : 0;
     internal double WindowScale => _capBytes == 0 ? 1 : (double)_windowBytes / _capBytes;
     internal long CapacityProbeSuccessCount { get; private set; }
     internal long CapacityProbeFailureCount { get; private set; }
@@ -134,16 +170,7 @@ internal sealed class BrokerWindowController
     internal BrokerWindowDecision SetCap(long capBytes)
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
-        if (_windowBytes > _capBytes)
-        {
-            _windowBytes = _capBytes;
-            _generation++;
-        }
-        if (_probeBaselineWindow > _capBytes)
-            _probeBaselineWindow = _capBytes;
-        if (_probeCandidateWindow > _capBytes)
-            _probeCandidateWindow = _capBytes;
-
+        ApplyEffectiveCap();
         return CurrentDecision();
     }
 
@@ -164,6 +191,9 @@ internal sealed class BrokerWindowController
 
         if (_epochStartedAt == 0)
             _epochStartedAt = nowTicks;
+
+        if (_latencyCeilingEnabled && !_coldStartRampComplete)
+            AdvanceColdStartRamp(logicalBytes, rttTicks, nowTicks);
 
         UpdateMinimumRtt(logicalBytes, rttTicks, nowTicks);
 
@@ -223,6 +253,9 @@ internal sealed class BrokerWindowController
         if (goodput <= 0)
             return CurrentDecision();
 
+        if (_latencyCeilingEnabled)
+            CompleteLatencyCeilingEpoch(goodput);
+
         if (!generationQualified)
         {
             if (_phase == BrokerWindowPhase.Steady
@@ -257,7 +290,7 @@ internal sealed class BrokerWindowController
             return StartDownProbe();
 
         var requestedWindow = Math.Min(
-            _capBytes,
+            EffectiveCapBytes,
             Math.Max(
                 _windowBytes + _requestQuantumBytes,
                 (long)Math.Ceiling(_windowBytes * UpProbeMultiplier)));
@@ -485,7 +518,7 @@ internal sealed class BrokerWindowController
     private long NormalizeWindow(long requestedBytes)
     {
         var minimum = MinimumWindowBytes;
-        var next = Math.Clamp(requestedBytes, minimum, _capBytes);
+        var next = Math.Clamp(requestedBytes, minimum, EffectiveCapBytes);
         if (next > minimum && _requestQuantumBytes > 1)
         {
             next = next / _requestQuantumBytes * _requestQuantumBytes;
@@ -495,10 +528,120 @@ internal sealed class BrokerWindowController
         return next;
     }
 
+    /// <summary>Quantum floor for the window. Every latency-ceiling write clamps the ceiling
+    /// to at least this value, so the effective cap never undercuts it.</summary>
     private long MinimumWindowBytes => Math.Clamp(
-        SaturatingMultiply(_requestQuantumBytes, MinimumPipelineQuanta),
+        SaturatingMultiply(
+            _requestQuantumBytes,
+            _latencyCeilingEnabled ? MinimumPipelineQuanta : UnceiledMinimumPipelineQuanta),
         _floorBytes,
         _capBytes);
+
+    /// <summary>Cap actually available to the window: the routing-width byte ceiling bounded
+    /// by the latency ceiling (delivery-latency target × windowed-maximum measured goodput).
+    /// Under open-loop saturation, standing unacked bytes divided by drain rate is the
+    /// queueing delay every delivery wears, so no goodput-probed window may hold more than
+    /// the target's worth of measured drain. Goodput cannot be inflated by self-queueing
+    /// (unlike an RTT horizon), so this bound has no positive-feedback ratchet.</summary>
+    private long EffectiveCapBytes => Math.Min(_capBytes, _latencyCeilingBytes);
+
+    /// <summary>Clamps the window and any in-flight probe bookkeeping to the current
+    /// effective cap after the cap or the latency ceiling moves.</summary>
+    private void ApplyEffectiveCap()
+    {
+        var effectiveCap = EffectiveCapBytes;
+        if (_windowBytes > effectiveCap)
+        {
+            _windowBytes = effectiveCap;
+            _generation++;
+        }
+        if (_probeBaselineWindow > effectiveCap)
+            _probeBaselineWindow = effectiveCap;
+        if (_probeCandidateWindow > effectiveCap)
+            _probeCandidateWindow = effectiveCap;
+    }
+
+    /// <summary>
+    /// Keeps the pre-acknowledgement window large enough for one request wave at the current
+    /// routing width. Connection scale-up before the first acknowledgement grows the wave
+    /// beyond the pessimistic two-quantum start; the wave is still an unmeasured burst the
+    /// cold-start gate itself bounds, so admitting it does not reintroduce the flood.
+    /// No-op once any acknowledgement has been measured — the ramp owns the ceiling then.
+    /// </summary>
+    internal BrokerWindowDecision NoteColdStartWave(long waveBytes)
+    {
+        // _rampAckedBytes == 0 also implies the ramp has not completed: completing requires
+        // a control epoch with goodput, which requires an acknowledgement the ramp counted.
+        if (_latencyCeilingEnabled && _rampAckedBytes == 0)
+            TryRaiseColdStartCeiling(Math.Min(waveBytes, _capBytes));
+
+        return CurrentDecision();
+    }
+
+    /// <summary>
+    /// Cold-start ramp: before the first completed control epoch, the ceiling grows with the
+    /// cumulative acknowledged drain rate and the window follows it toward the optimistic
+    /// initial size. Ack-clocked and rate-proportional — a fast broker opens the window
+    /// within a few round trips, a cold broker admits only what it has demonstrably drained.
+    /// Single-writer (owning send loop), so plain field updates suffice.
+    /// </summary>
+    private void AdvanceColdStartRamp(long logicalBytes, long rttTicks, long nowTicks)
+    {
+        if (_rampStartTimestamp == 0)
+            _rampStartTimestamp = nowTicks - rttTicks;
+        _rampAckedBytes = SaturatingAdd(_rampAckedBytes, logicalBytes);
+        var elapsedTicks = Math.Max(1, nowTicks - _rampStartTimestamp);
+        var rateBytesPerSecond = _rampAckedBytes * (double)Stopwatch.Frequency / elapsedTicks;
+        TryRaiseColdStartCeiling(ComputeCeilingBytes(rateBytesPerSecond));
+    }
+
+    /// <summary>Raises the cold-start ceiling and re-seeks the optimistic initial window
+    /// underneath it. Raise-only: pre-epoch estimates may only open the window further.</summary>
+    private void TryRaiseColdStartCeiling(long ceilingBytes)
+    {
+        if (ceilingBytes <= _latencyCeilingBytes)
+            return;
+
+        _latencyCeilingBytes = ceilingBytes;
+        SetWindow(SaturatingMultiply(_requestQuantumBytes, InitialRequestQuanta));
+    }
+
+    /// <summary>Feeds one completed epoch's goodput into the windowed-maximum ring and
+    /// re-derives the latency ceiling. Ends the cold-start ramp: epoch goodput is measured
+    /// over a full control interval and supersedes the ramp's cumulative estimate.
+    /// A window sitting on the ceiling follows it back up when measured goodput recovers —
+    /// the raise carries the same rate-times-target justification as the clamp, so recovery
+    /// from a transient dip does not wait for the probe schedule. Windows the probe walk
+    /// placed below the ceiling are deliberate and stay put.</summary>
+    private void CompleteLatencyCeilingEpoch(double goodputBytesPerSecond)
+    {
+        _coldStartRampComplete = true;
+        _epochGoodputRing[_epochGoodputIndex] = goodputBytesPerSecond;
+        _epochGoodputIndex = (_epochGoodputIndex + 1) % GoodputRingEpochs;
+
+        var windowedMax = 0.0;
+        for (var i = 0; i < _epochGoodputRing.Length; i++)
+            windowedMax = Math.Max(windowedMax, _epochGoodputRing[i]);
+
+        var previousEffectiveCap = EffectiveCapBytes;
+        _latencyCeilingBytes = ComputeCeilingBytes(windowedMax);
+        if (_phase == BrokerWindowPhase.Steady
+            && _windowBytes >= previousEffectiveCap
+            && EffectiveCapBytes > previousEffectiveCap)
+        {
+            SetWindow(EffectiveCapBytes);
+        }
+        else
+        {
+            ApplyEffectiveCap();
+        }
+    }
+
+    private long ComputeCeilingBytes(double rateBytesPerSecond)
+    {
+        var targetBytes = rateBytesPerSecond * _targetDelayTicks / Stopwatch.Frequency;
+        return (long)Math.Clamp(targetBytes, MinimumWindowBytes, _capBytes);
+    }
 
     private void ResetEpoch(long nowTicks)
     {

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -66,6 +66,19 @@ internal sealed class BrokerWindowController
     // epochs (~30s of loaded time). A windowed maximum ignores transient dips without letting
     // a stale one-time peak size the window forever.
     private const int GoodputRingEpochs = 60;
+    // Serving-time floor on the ceiling's horizon, in multiples of the best request-sized
+    // round trip. Growth out of a clamped window has gain = multiplier x best/average round
+    // trip; jittery environments run averages near twice the best, so a multiplier of two
+    // sat at gain ~1.0 and froze (observed locally as an 84% throughput collapse at the
+    // window floor). Three keeps the gain above one at 2:1 jitter while staying under the
+    // 10ms latency target wherever request round trips are a few milliseconds.
+    private const int ServingHorizonRttMultiplier = 3;
+    // Escape valve for environments whose jitter beats the multiplier: a ceiling that binds
+    // under demand while goodput persists below this fraction of the windowed maximum is
+    // strangling the pipe, not saving latency.
+    private const double CeilingStrangleGoodputFraction = 0.75;
+    // One violating epoch can be a broker hiccup; two consecutive epochs (~1s) is a regime.
+    private const int CeilingStrangleEpochsBeforeEscape = 2;
     // Treatments are deliberately sparse and settled: frequent sub-second window changes
     // caused self-inflicted admission stalls that looked like congestion. Each experiment is
     // a B-A-B sandwich (3s candidate, 6s baseline, 3s candidate after a 1s washout at each
@@ -105,6 +118,8 @@ internal sealed class BrokerWindowController
     private bool _coldStartRampComplete;
     private long _rampStartTimestamp;
     private long _rampAckedBytes;
+    private long _ceilingEscapeFloorBytes;
+    private int _ceilingStrangleEpochs;
 
     private long _epochStartedAt;
     private long _epochBytes;
@@ -256,7 +271,7 @@ internal sealed class BrokerWindowController
             return CurrentDecision();
 
         if (_latencyCeilingEnabled)
-            CompleteLatencyCeilingEpoch(goodput);
+            CompleteLatencyCeilingEpoch(goodput, demand);
 
         if (!generationQualified)
         {
@@ -615,7 +630,7 @@ internal sealed class BrokerWindowController
     /// the raise carries the same rate-times-target justification as the clamp, so recovery
     /// from a transient dip does not wait for the probe schedule. Windows the probe walk
     /// placed below the ceiling are deliberate and stay put.</summary>
-    private void CompleteLatencyCeilingEpoch(double goodputBytesPerSecond)
+    private void CompleteLatencyCeilingEpoch(double goodputBytesPerSecond, bool demand)
     {
         _coldStartRampComplete = true;
         _epochGoodputRing[_epochGoodputIndex] = goodputBytesPerSecond;
@@ -626,7 +641,10 @@ internal sealed class BrokerWindowController
             windowedMax = Math.Max(windowedMax, _epochGoodputRing[i]);
 
         var previousEffectiveCap = EffectiveCapBytes;
-        _latencyCeilingBytes = ComputeCeilingBytes(windowedMax);
+        UpdateCeilingEscapeFloor(goodputBytesPerSecond, windowedMax, demand, previousEffectiveCap);
+        _latencyCeilingBytes = Math.Max(
+            ComputeCeilingBytes(windowedMax),
+            _ceilingEscapeFloorBytes);
         if (_phase == BrokerWindowPhase.Steady
             && _windowBytes >= previousEffectiveCap
             && EffectiveCapBytes > previousEffectiveCap)
@@ -639,19 +657,54 @@ internal sealed class BrokerWindowController
         }
     }
 
+    /// <summary>
+    /// Goodput-preservation escape valve: a ceiling that binds under demand while goodput
+    /// persists well below the windowed maximum is strangling the pipe — the clamp itself
+    /// suppresses the measurement that would justify a wider window. Doubling the ceiling's
+    /// floor (monotone within a run) restores throughput within an epoch or two; a latency
+    /// clamp is never worth a goodput regression. One violating epoch is ignored as a
+    /// possible broker hiccup so a transient stall cannot permanently widen the floor.
+    /// </summary>
+    private void UpdateCeilingEscapeFloor(
+        double goodputBytesPerSecond,
+        double windowedMaxGoodput,
+        bool demand,
+        long previousEffectiveCap)
+    {
+        var ceilingBinding = _latencyCeilingBytes < _capBytes
+            && _windowBytes >= previousEffectiveCap;
+        if (!ceilingBinding
+            || !demand
+            || goodputBytesPerSecond >= CeilingStrangleGoodputFraction * windowedMaxGoodput)
+        {
+            _ceilingStrangleEpochs = 0;
+            return;
+        }
+
+        if (++_ceilingStrangleEpochs < CeilingStrangleEpochsBeforeEscape)
+            return;
+
+        _ceilingStrangleEpochs = 0;
+        _ceilingEscapeFloorBytes = Math.Min(
+            Math.Max(SaturatingMultiply(previousEffectiveCap, 2), _ceilingEscapeFloorBytes),
+            _capBytes);
+    }
+
     private long ComputeCeilingBytes(double rateBytesPerSecond)
     {
-        // The delivery-latency target is an aspiration; two request-sized round trips are
+        // The delivery-latency target is an aspiration; a few request-sized round trips are
         // physics. When a full request's best-case round trip exceeds the target, a
         // target-only horizon demands fewer standing bytes than the pipe needs to stay
         // full, goodput is then measured at the strangled window, and the lower measurement
         // justifies an even lower ceiling — a self-confirming collapse (observed as an 84%
-        // local throughput loss). Flooring the horizon at twice the request-quantum-sized
-        // minimum RTT keeps one request serving while the next seals, so measured goodput
-        // reflects drain capacity and the ceiling's growth feedback stays above unity.
+        // local throughput loss). Flooring the horizon at a small multiple of the
+        // request-quantum-sized minimum RTT keeps requests pipelined, so measured goodput
+        // reflects drain capacity and the ceiling's growth feedback stays above unity even
+        // when average round trips run well above the best case (see
+        // ServingHorizonRttMultiplier).
         var horizonTicks = Math.Max(
             _targetDelayTicks,
-            SaturatingMultiply(QuantumMinimumRttTicks, 2));
+            SaturatingMultiply(QuantumMinimumRttTicks, ServingHorizonRttMultiplier));
         var targetBytes = rateBytesPerSecond * horizonTicks / Stopwatch.Frequency;
         return (long)Math.Clamp(targetBytes, MinimumWindowBytes, _capBytes);
     }

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -89,7 +89,18 @@ internal sealed class BrokerWindowController
     private const double UpProbeMultiplier = 1.125;
     private const double DownProbeMultiplier = 0.875;
     private const double UpProbeGoodputThreshold = 1.03;
+    // When the experiment itself observed admission blocking, demand is provably clipped by
+    // the window and "not worse" goodput suffices to grow it — the +3% bar exists to stop
+    // speculative bufferbloat, not to trap an over-shrunk window: down-probes pass on noise
+    // at 0.99 while up-probes never pass on noise at 1.03, and that asymmetry compounds into
+    // a run-long throughput ratchet (observed as steady/peak 0.745 on run 29513570135).
+    // The delay-growth veto below still guards against queue-building growth.
+    private const double BlockedUpProbeGoodputThreshold = 1.00;
     private const double DownProbeGoodputThreshold = 0.99;
+    // Descent below the legacy floor must demonstrably buy latency, not merely avoid hurting
+    // goodput: sub-floor windows trade admission headroom for queueing delay, so a paired
+    // experiment that shows no delay gain has no business shrinking further.
+    private const double DeepDescentDelayGainFactor = 0.90;
     private const double DelayGrowthTolerance = 1.25;
     private const double EwmaWeight = 0.125;
 
@@ -134,6 +145,7 @@ internal sealed class BrokerWindowController
     private int _unqualifiedProbeEpochs;
     private double _probeGoodputTotal;
     private double _probeDelayTotalTicks;
+    private bool _probeSawAdmissionPressure;
 
     internal BrokerWindowController(
         double targetSeconds,
@@ -273,6 +285,8 @@ internal sealed class BrokerWindowController
         var occupancyPressure = observedOutstandingBytes
             >= _windowBytes - _windowBytes / 4;
         var demand = admissionPressure || occupancyPressure || _epochLoaded;
+        if (_phase != BrokerWindowPhase.Steady && admissionPressure)
+            _probeSawAdmissionPressure = true;
 
         _lastAdmissionBlockEvents = admissionBlockEvents;
         ResetEpoch(nowTicks);
@@ -436,13 +450,21 @@ internal sealed class BrokerWindowController
             _targetDelayTicks,
             _probeBaselineDelayTicks * DelayGrowthTolerance);
         var goodputThreshold = probingUp
-            ? UpProbeGoodputThreshold
+            ? _probeSawAdmissionPressure
+                ? BlockedUpProbeGoodputThreshold
+                : UpProbeGoodputThreshold
             : DownProbeGoodputThreshold;
+        var deepDescent = !probingUp
+            && _probeCandidateWindow < QuantaFloorBytes(MinimumPipelineQuanta);
         // Seal-to-send plus network queueing omits pre-seal admission and batch-fill time, so
         // it cannot veto a lower window. It remains a conservative guard against growing a
         // window that raises the delay component the controller can observe.
         var succeeded = treatmentGoodput >= _probeBaselineGoodput * goodputThreshold
-            && (!probingUp || treatmentDelayTicks <= delayLimit);
+            && (!probingUp || treatmentDelayTicks <= delayLimit)
+            && (!deepDescent
+                || (_probeBaselineDelayTicks > _targetDelayTicks
+                    && treatmentDelayTicks
+                        <= _probeBaselineDelayTicks * DeepDescentDelayGainFactor));
         return CompleteCapacityProbe(succeeded);
     }
 
@@ -466,9 +488,12 @@ internal sealed class BrokerWindowController
         // Continue walking in a direction while it wins. A failed treatment reverses the
         // next probe, converging on the knee instead of oscillating unconditionally.
         _probeDownNext = probingUp ? !succeeded : succeeded;
-        // A goodput-preserving descent while over the latency target earns an early retry;
-        // anything else returns to the sparse schedule.
-        _epochsUntilProbe = !probingUp && succeeded && DelayOverTarget
+        // A goodput-preserving descent earns an early retry only while the experiment's own
+        // baseline delay missed the target — the instantaneous EWMA flickers on bursts and
+        // over-accelerated the walk (run 29513570135).
+        _epochsUntilProbe = !probingUp
+            && succeeded
+            && _probeBaselineDelayTicks > _targetDelayTicks
             ? AcceleratedDescentIntervalEpochs
             : ProbeIntervalEpochs;
         _unqualifiedProbeEpochs = 0;
@@ -492,6 +517,7 @@ internal sealed class BrokerWindowController
         _probeBaselineGoodput = 0;
         _probeBaselineDelayTicks = 0;
         _probeSettleEpochsRemaining = 0;
+        _probeSawAdmissionPressure = false;
         ResetProbeEvaluation();
     }
 

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -192,10 +192,12 @@ internal sealed class BrokerWindowController
         if (_epochStartedAt == 0)
             _epochStartedAt = nowTicks;
 
+        UpdateMinimumRtt(logicalBytes, rttTicks, nowTicks);
+
+        // After the RTT update so this acknowledgement's round trip already informs the
+        // ceiling's serving-time horizon.
         if (_latencyCeilingEnabled && !_coldStartRampComplete)
             AdvanceColdStartRamp(logicalBytes, rttTicks, nowTicks);
-
-        UpdateMinimumRtt(logicalBytes, rttTicks, nowTicks);
 
         var controlledDelayTicks = Math.Max(0, sealToSendTicks)
             + Math.Max(0, rttTicks - GetMinimumRtt(logicalBytes));
@@ -639,8 +641,32 @@ internal sealed class BrokerWindowController
 
     private long ComputeCeilingBytes(double rateBytesPerSecond)
     {
-        var targetBytes = rateBytesPerSecond * _targetDelayTicks / Stopwatch.Frequency;
+        // The delivery-latency target is an aspiration; two request-sized round trips are
+        // physics. When a full request's best-case round trip exceeds the target, a
+        // target-only horizon demands fewer standing bytes than the pipe needs to stay
+        // full, goodput is then measured at the strangled window, and the lower measurement
+        // justifies an even lower ceiling — a self-confirming collapse (observed as an 84%
+        // local throughput loss). Flooring the horizon at twice the request-quantum-sized
+        // minimum RTT keeps one request serving while the next seals, so measured goodput
+        // reflects drain capacity and the ceiling's growth feedback stays above unity.
+        var horizonTicks = Math.Max(
+            _targetDelayTicks,
+            SaturatingMultiply(QuantumMinimumRttTicks, 2));
+        var targetBytes = rateBytesPerSecond * horizonTicks / Stopwatch.Frequency;
         return (long)Math.Clamp(targetBytes, MinimumWindowBytes, _capBytes);
+    }
+
+    /// <summary>Best observed round trip for request-quantum-sized transfers, falling back
+    /// to the global minimum until that size bucket has a sample. The global minimum comes
+    /// from small early requests and can undercut a full request's service time by orders
+    /// of magnitude, which is exactly the gap that strangles the ceiling's horizon.</summary>
+    private long QuantumMinimumRttTicks
+    {
+        get
+        {
+            var bucketMinimum = _minimumRttBySizeTicks[GetSizeBucket(_requestQuantumBytes)];
+            return bucketMinimum != 0 ? bucketMinimum : _minimumRttTicks;
+        }
     }
 
     private void ResetEpoch(long nowTicks)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -315,6 +315,9 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }
     public required double LatencyBudgetScale { get; init; }
+    /// <summary>Latency ceiling (delivery-latency target × windowed-maximum measured
+    /// goodput) bounding the window, or 0 when the ceiling is disabled.</summary>
+    public long LatencyCeilingBytes { get; init; }
 
     /// <summary>
     /// Log2 histogram of acked produce-request payload sizes; bucket semantics are defined

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -315,9 +315,6 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }
     public required double LatencyBudgetScale { get; init; }
-    /// <summary>Latency ceiling (delivery-latency target × windowed-maximum measured
-    /// goodput) bounding the window, or 0 when the ceiling is disabled.</summary>
-    public long LatencyCeilingBytes { get; init; }
 
     /// <summary>
     /// Log2 histogram of acked produce-request payload sizes; bucket semantics are defined

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -151,9 +151,10 @@ public sealed class ProducerOptions
     /// <see cref="MaxBlockMs"/> and cancellation).
     /// Before the first successful broker acknowledgement, admission is limited to one
     /// configured batch per current connection; acknowledgements then open the adaptive
-    /// window at the measured drain rate, and the window is thereafter bounded by this
-    /// target multiplied by the maximum goodput observed over the recent control epochs, so
-    /// standing queueing delay cannot exceed the target's worth of measured drain.
+    /// window by doubling once per fully acknowledged response pass. While the controller's
+    /// measured queueing delay exceeds this target, window growth is withheld and
+    /// goodput-guarded shrink experiments run preferentially, so standing queueing delay
+    /// converges toward the target wherever the broker's drain capacity allows it.
     /// <see cref="Acks.None"/> keeps the normal controller window because no acknowledgement
     /// can end the startup phase.
     /// Set to 0 to disable the bound entirely. Default: 10.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -150,7 +150,10 @@ public sealed class ProducerOptions
     /// full, admission blocks like <see cref="BufferMemory"/> exhaustion (subject to
     /// <see cref="MaxBlockMs"/> and cancellation).
     /// Before the first successful broker acknowledgement, admission is limited to one
-    /// configured batch per current connection; the adaptive window then takes over.
+    /// configured batch per current connection; acknowledgements then open the adaptive
+    /// window at the measured drain rate, and the window is thereafter bounded by this
+    /// target multiplied by the maximum goodput observed over the recent control epochs, so
+    /// standing queueing delay cannot exceed the target's worth of measured drain.
     /// <see cref="Acks.None"/> keeps the normal controller window because no acknowledgement
     /// can end the startup phase.
     /// Set to 0 to disable the bound entirely. Default: 10.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -149,6 +149,10 @@ public sealed class ProducerOptions
     /// entering a batch, so concurrent partitions cannot overshoot it. When the window is
     /// full, admission blocks like <see cref="BufferMemory"/> exhaustion (subject to
     /// <see cref="MaxBlockMs"/> and cancellation).
+    /// Before the first successful broker acknowledgement, admission is limited to one
+    /// configured batch per current connection; the adaptive window then takes over.
+    /// <see cref="Acks.None"/> keeps the normal controller window because no acknowledgement
+    /// can end the startup phase.
     /// Set to 0 to disable the bound entirely. Default: 10.
     /// </summary>
     public int DeliveryLatencyTargetMs

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5116,9 +5116,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _options.BatchSize,
             _options.ConnectionsPerBroker);
         // Bound only the unsampled startup burst. Acknowledgements then open the controller's
-        // adaptive window at the measured drain rate (the latency-ceiling ramp) instead of in
-        // one unlearned step. Explicit cap overrides retain their existing controller
-        // semantics for tests and advanced callers.
+        // adaptive window by ack-clocked doubling (slow start) instead of in one unlearned
+        // step. Explicit cap overrides retain their existing controller semantics for tests
+        // and advanced callers.
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
@@ -5780,7 +5780,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
             DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
             LatencyBudgetScale = budget.LatencyBudgetScale,
-            LatencyCeilingBytes = budget.LatencyCeilingBytes,
             RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
             RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null,
             AdmissionBlockMicrosLog2Histogram = includeHistograms

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5112,15 +5112,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         var cap = _options.UnackedByteBudgetCapOverride
             ?? BrokerUnackedByteBudget.ComputeCap(_options.BatchSize, _options.ConnectionsPerBroker);
-        // The controller starts with enough fixed batch quanta for both open partition batches
-        // and broker flight, then searches downward for the smallest window preserving goodput.
+        var requestWaveBytes = BrokerUnackedByteBudget.ComputeColdStartBudget(
+            _options.BatchSize,
+            _options.ConnectionsPerBroker);
+        // Bound only the unsampled startup burst. The first successful acknowledgement hands
+        // admission to the controller's wider adaptive window. Explicit cap overrides retain
+        // their existing controller semantics for tests and advanced callers.
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
             initialCapBytes: cap,
             lingerSeconds: _options.LingerMs / 1000.0,
             enableDiagnostics: _options.EnableDeliveryDiagnostics,
-            initialRequestBytes: (long)_options.BatchSize * Math.Max(1, _options.ConnectionsPerBroker));
+            initialRequestBytes: requestWaveBytes,
+            coldStartBudgetBytes: _options.UnackedByteBudgetCapOverride is null
+                && _options.Acks != Acks.None
+                ? requestWaveBytes
+                : null);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5115,9 +5115,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var requestWaveBytes = BrokerUnackedByteBudget.ComputeColdStartBudget(
             _options.BatchSize,
             _options.ConnectionsPerBroker);
-        // Bound only the unsampled startup burst. The first successful acknowledgement hands
-        // admission to the controller's wider adaptive window. Explicit cap overrides retain
-        // their existing controller semantics for tests and advanced callers.
+        // Bound only the unsampled startup burst. Acknowledgements then open the controller's
+        // adaptive window at the measured drain rate (the latency-ceiling ramp) instead of in
+        // one unlearned step. Explicit cap overrides retain their existing controller
+        // semantics for tests and advanced callers.
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
@@ -5779,6 +5780,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
             DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
             LatencyBudgetScale = budget.LatencyBudgetScale,
+            LatencyCeilingBytes = budget.LatencyCeilingBytes,
             RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
             RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null,
             AdmissionBlockMicrosLog2Histogram = includeHistograms

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedAdmissionTests.cs
@@ -18,7 +18,9 @@ public sealed class BrokerUnackedAdmissionTests
         long? capOverride,
         int deliveryLatencyTargetMs = 10,
         int maxBlockMs = 60_000,
-        int batchSize = 50) => new()
+        int batchSize = 50,
+        int connectionsPerBroker = 1,
+        Acks acks = Acks.Leader) => new()
         {
             BootstrapServers = ["localhost:9092"],
             ClientId = "test-producer",
@@ -27,9 +29,62 @@ public sealed class BrokerUnackedAdmissionTests
             LingerMs = 60_000, // No linger-driven seals: rotation on full batches only.
             MaxBlockMs = maxBlockMs,
             DeliveryLatencyTargetMs = deliveryLatencyTargetMs,
-            UnackedByteBudgetCapOverride = capOverride
+            UnackedByteBudgetCapOverride = capOverride,
+            ConnectionsPerBroker = connectionsPerBroker,
+            Acks = acks
         };
 
+    [Test]
+    public async Task ColdStartAdmission_UsesOneBatchPerConfiguredConnection()
+    {
+        const int batchSize = 1_024;
+        const int connectionsPerBroker = 3;
+        var options = CreateOptions(
+            capOverride: null,
+            batchSize: batchSize,
+            connectionsPerBroker: connectionsPerBroker);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) => LeaderNodeId);
+
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(batchSize * connectionsPerBroker);
+    }
+
+    [Test]
+    public async Task ColdStartAdmission_ExplicitCapOverrideKeepsControllerWindow()
+    {
+        const int capOverride = 10_000;
+        var options = CreateOptions(
+            capOverride,
+            batchSize: 1_024,
+            connectionsPerBroker: 3);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) => LeaderNodeId);
+
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(capOverride);
+    }
+
+    [Test]
+    public async Task ColdStartAdmission_AcksNoneKeepsControllerWindow()
+    {
+        const int batchSize = 1_024;
+        var options = CreateOptions(
+            capOverride: null,
+            batchSize: batchSize,
+            acks: Acks.None);
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: (_, _) => LeaderNodeId);
+
+        var budget = accumulator.GetBrokerUnackedBudget(LeaderNodeId)!;
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(batchSize * 16);
+    }
 
     /// <summary>
     /// Appends empty-payload records until at least one batch has been sealed (batch rotation
@@ -92,7 +147,9 @@ public sealed class BrokerUnackedAdmissionTests
     [Test]
     public async Task Seal_ChargesLeaderBudget_AndBatchExitReleases()
     {
-        var options = CreateOptions(capOverride: null);
+        // Keep enough initial controller credit to cover multiple sealed batches so this test
+        // protects cumulative accounting instead of stopping after the first cold-start seal.
+        var options = CreateOptions(capOverride: 10_000);
         var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
         var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
 
@@ -106,7 +163,7 @@ public sealed class BrokerUnackedAdmissionTests
             await Assert.That(budget!.UnackedBytes).IsGreaterThan(0);
 
             var batches = DrainSealedBatches(accumulator, metadataManager);
-            await Assert.That(batches.Count).IsGreaterThan(0);
+            await Assert.That(batches.Count).IsGreaterThanOrEqualTo(2);
 
             var chargedBytes = batches.Sum(b => (long)b.DataSize);
             await Assert.That(budget.UnackedBytes).IsEqualTo(chargedBytes);
@@ -489,7 +546,7 @@ public sealed class BrokerUnackedAdmissionTests
     [Test]
     public async Task LeaderChange_ChargesSubsequentSeals_ToNewBrokerBudget()
     {
-        var options = CreateOptions(capOverride: null);
+        var options = CreateOptions(capOverride: 10_000);
         var currentLeader = 1;
         var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => currentLeader);
 
@@ -598,7 +655,7 @@ public sealed class BrokerUnackedAdmissionTests
     [Test]
     public async Task Reroute_TransfersExistingBatchCharge_ToNewBrokerBudget()
     {
-        var options = CreateOptions(capOverride: null);
+        var options = CreateOptions(capOverride: 10_000);
         var accumulator = new RecordAccumulator(options, resolveLeaderId: (_, _) => LeaderNodeId);
         var metadataManager = AccumulatorTestHelpers.CreateMetadataManager("test-topic", 1, LeaderNodeId);
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -108,20 +108,20 @@ public sealed class BrokerUnackedByteBudgetTests
         var admissionBlocks = 0L;
         _ = controller.CompleteInterval(admissionBlocks, 0, now);
 
-        // Sustained 50ms of controllable delay against a 10ms target biases every probe
-        // downward; each goodput-preserving descent re-probes early, so the walk reaches
-        // the two-quantum descent floor instead of parking at the legacy eight-quantum one.
+        // Controllable delay proportional to the window (12ms at the descent floor, 96ms at
+        // the optimistic window) against a 10ms target: every descent step demonstrably buys
+        // latency, so the biased walk reaches the two-quantum floor instead of parking at
+        // the legacy eight-quantum one.
         for (var i = 0; i < 2_000 && controller.WindowBytes > 200; i++)
         {
             _ = DriveControllerEpoch(
                 controller,
                 ref now,
                 ref admissionBlocks,
-                sealToSendSeconds: 0.050);
+                sealToSendSeconds: 0.00006 * controller.WindowBytes);
         }
 
         await Assert.That(controller.WindowBytes).IsEqualTo(200);
-        await Assert.That(controller.CapacityProbeFailureCount).IsEqualTo(0);
 
         // Let the experiment that reached the floor finish before pinning the schedule.
         for (var i = 0; i < 100 && controller.Phase != BrokerWindowPhase.Steady; i++)
@@ -130,7 +130,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 controller,
                 ref now,
                 ref admissionBlocks,
-                sealToSendSeconds: 0.050);
+                sealToSendSeconds: 0.00006 * controller.WindowBytes);
         }
 
         // At the floor and still over target: growth is withheld, so no further experiment
@@ -142,12 +142,35 @@ public sealed class BrokerUnackedByteBudgetTests
                 controller,
                 ref now,
                 ref admissionBlocks,
-                sealToSendSeconds: 0.050);
+                sealToSendSeconds: 0.00006 * controller.WindowBytes);
         }
 
         await Assert.That(controller.WindowBytes).IsEqualTo(200);
         await Assert.That(controller.Phase).IsEqualTo(BrokerWindowPhase.Steady);
         await Assert.That(controller.CapacityProbeSuccessCount).IsEqualTo(successes);
+    }
+
+    [Test]
+    public async Task DeepDescent_RequiresDemonstratedDelayGain()
+    {
+        var controller = CreateController(latencyGovernorEnabled: true);
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+
+        // Delay is over target but window-independent (a fixed 50ms): shrinking below the
+        // legacy floor cannot help, so every sub-floor experiment fails its delay-gain
+        // requirement and the window holds at the legacy floor.
+        for (var i = 0; i < 2_000; i++)
+        {
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.050);
+        }
+
+        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
     }
 
     [Test]
@@ -164,6 +187,23 @@ public sealed class BrokerUnackedByteBudgetTests
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
 
         await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
+    }
+
+    [Test]
+    public async Task BlockedDemand_RecoversWindowWithoutGoodputGain()
+    {
+        var controller = CreateController();
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+
+        // Flat goodput walks the window down to the legacy floor; sustained admission
+        // blocking then lets up-probes pass at "not worse" goodput, so the window recovers
+        // instead of staying trapped under the +3% growth bar it can never clear on noise.
+        for (var i = 0; i < 5_000; i++)
+            _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
+
+        await Assert.That(controller.WindowBytes).IsGreaterThan(1_600);
     }
 
     [Test]
@@ -562,11 +602,15 @@ public sealed class BrokerUnackedByteBudgetTests
             ref now,
             ref admissionBlocks);
 
+        // No admission blocking during the experiment: unblocked flat goodput must not buy
+        // a larger window (blocked demand relaxes this bar — see
+        // BlockedDemand_RecoversWindowWithoutGoodputGain).
         var decision = CompleteActiveProbe(
             controller,
             baselineWindow,
             ref now,
-            ref admissionBlocks);
+            ref admissionBlocks,
+            recordAdmissionBlock: false);
 
         await Assert.That(decision.ProbeOutcome).IsEqualTo(BrokerBudgetProbeOutcome.Failed);
         await Assert.That(controller.WindowBytes).IsEqualTo(baselineWindow);
@@ -654,7 +698,8 @@ public sealed class BrokerUnackedByteBudgetTests
                 controller,
                 ref now,
                 ref admissionBlocks,
-                logicalBytes: 100 + epoch++);
+                logicalBytes: 100 + epoch++,
+                recordAdmissionBlock: false);
         }
 
         await Assert.That(decision.ProbeOutcome).IsEqualTo(BrokerBudgetProbeOutcome.Failed);
@@ -942,7 +987,8 @@ public sealed class BrokerUnackedByteBudgetTests
         long candidateLogicalBytes = 100,
         long baselineLogicalBytes = 100,
         double candidateSealToSendSeconds = 0,
-        double baselineSealToSendSeconds = 0)
+        double baselineSealToSendSeconds = 0,
+        bool recordAdmissionBlock = true)
     {
         BrokerWindowDecision decision = default;
         for (var i = 0; i < 100 && controller.Phase != BrokerWindowPhase.Steady; i++)
@@ -955,7 +1001,8 @@ public sealed class BrokerUnackedByteBudgetTests
                 logicalBytes: candidateActive ? candidateLogicalBytes : baselineLogicalBytes,
                 sealToSendSeconds: candidateActive
                     ? candidateSealToSendSeconds
-                    : baselineSealToSendSeconds);
+                    : baselineSealToSendSeconds,
+                recordAdmissionBlock: recordAdmissionBlock);
         }
 
         if (controller.Phase != BrokerWindowPhase.Steady)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -25,37 +25,41 @@ public sealed class BrokerUnackedByteBudgetTests
     [Test]
     public async Task ColdStartAdmission_UsesOneRequestWaveUntilFirstAcknowledgement()
     {
-        var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.010,
-            floorBytes: 1,
-            initialCapBytes: 10_000,
-            initialRequestBytes: 100,
-            coldStartBudgetBytes: 100);
+        var budget = CreateColdStartBudget();
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(100);
         await Assert.That(budget.TryReserve(100, out _)).IsTrue();
         await Assert.That(budget.TryReserve(1, out _)).IsFalse();
 
+        // First ack: 100 bytes drained in 1ms = 100 KB/s; the 10ms target admits ten
+        // milliseconds of that drain (1,000 bytes), not the full optimistic initial window.
         var now = T0 + Seconds(0.001);
         budget.OnAcked(
             ackedBytes: 100,
             budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
             now);
 
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.TryReserve(900, out _)).IsTrue();
+        await Assert.That(budget.TryReserve(1, out _)).IsFalse();
+        budget.Release(1_000);
+
+        // Second ack raises the cumulative measured rate; the ramp opens the window further
+        // until the optimistic sixteen-quantum start stops being the binding bound.
+        var later = now + Seconds(0.001);
+        budget.OnAcked(
+            ackedBytes: 1_000,
+            budget.SnapshotDelivery(later - Seconds(0.001), appLimited: false),
+            later);
+        budget.CompleteAckedPass(later);
+
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
-        await Assert.That(budget.TryReserve(1_500, out _)).IsTrue();
-        budget.Release(1_600);
     }
 
     [Test]
     public async Task ColdStartAdmission_TracksCurrentConnectionWidthBeforeFirstAck()
     {
-        var budget = new BrokerUnackedByteBudget(
-            targetSeconds: 0.010,
-            floorBytes: 1,
-            initialCapBytes: 10_000,
-            initialRequestBytes: 100,
-            coldStartBudgetBytes: 100);
+        var budget = CreateColdStartBudget();
 
         budget.SetCap(capBytes: 30_000, coldStartBudgetBytes: 300, nowTicks: T0);
         await Assert.That(budget.BudgetBytes).IsEqualTo(300);
@@ -71,6 +75,108 @@ public sealed class BrokerUnackedByteBudgetTests
             .IsEqualTo(3_000);
         await Assert.That(BrokerUnackedByteBudget.ComputeCap(1_000, 3))
             .IsEqualTo(96_000);
+    }
+
+    [Test]
+    public async Task NotePartialDeliverySuccess_EndsColdStartClampWithoutRateSample()
+    {
+        var budget = CreateColdStartBudget();
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100);
+
+        budget.NotePartialDeliverySuccess();
+
+        // No rate was measured, so the window opens only to the pessimistic two-quantum
+        // start — but admission is no longer serialized on one request wave per round trip.
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+
+        budget.NotePartialDeliverySuccess();
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+
+        // The ramp still owns subsequent growth once a clean acknowledgement is measured.
+        var now = T0 + Seconds(0.001);
+        budget.OnAcked(
+            ackedBytes: 100,
+            budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
+            now);
+        budget.CompleteAckedPass(now);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+    }
+
+    [Test]
+    public async Task LatencyCeiling_ClampsWindowWhenMeasuredGoodputFallsBelowTarget()
+    {
+        var budget = CreateColdStartBudget();
+        var now = FlipColdStartGateWithFastAck(budget);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        var generation = budget.CurrentGeneration;
+
+        // One completed control epoch at ~5.9 KB/s: ten milliseconds of that drain rounds
+        // far below the two-quantum floor, so the window clamps to the floor.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+        await Assert.That(budget.CurrentGeneration).IsGreaterThan(generation);
+    }
+
+    [Test]
+    public async Task LatencyCeiling_RestoresCeilingBoundWindowWhenGoodputRecovers()
+    {
+        var budget = CreateColdStartBudget();
+        var now = FlipColdStartGateWithFastAck(budget);
+
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+
+        // A recovered epoch (~980 KB/s) re-raises the ceiling; the ceiling-bound window
+        // follows it without waiting for the probe schedule.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 500_000, rttSeconds: 0.001);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(9_800);
+    }
+
+    [Test]
+    public async Task LatencyCeiling_SuppressesProbesWhileBindingAtTheFloor()
+    {
+        var budget = CreateColdStartBudget();
+        var now = FlipColdStartGateWithFastAck(budget);
+
+        // Sustained ~200 B/s goodput pins the ceiling at the floor: no up-probe candidate
+        // can differ from the baseline, so the schedule never launches an experiment.
+        for (var i = 0; i < 100; i++)
+        {
+            now += Seconds(0.510);
+            DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
+        }
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+        await Assert.That(budget.Phase).IsEqualTo(BrokerWindowPhase.Steady);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
+    }
+
+    private static BrokerUnackedByteBudget CreateColdStartBudget() =>
+        new(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100,
+            coldStartBudgetBytes: 100);
+
+    /// <summary>Ends the cold-start phase with a 2 MB/s first acknowledgement, whose
+    /// target-scaled ceiling (20 KB, capped to 10 KB) leaves the sixteen-quantum optimistic
+    /// window as the binding bound — the pre-ceiling handoff behavior.</summary>
+    private static long FlipColdStartGateWithFastAck(BrokerUnackedByteBudget budget)
+    {
+        var now = T0 + Seconds(0.001);
+        budget.OnAcked(
+            ackedBytes: 2_000,
+            budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
+            now);
+        return now;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -139,23 +139,34 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task LatencyCeiling_SuppressesProbesWhileBindingAtTheFloor()
+    public async Task LatencyCeiling_EscapesWhenClampPersistentlyCostsGoodput()
     {
         var budget = CreateColdStartBudget();
         var now = FlipColdStartGateWithFastAck(budget);
 
-        // Sustained ~200 B/s goodput pins the ceiling at the floor: no up-probe candidate
-        // can differ from the baseline, so the schedule never launches an experiment.
-        for (var i = 0; i < 100; i++)
-        {
-            now += Seconds(0.510);
-            DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
-        }
-
+        // First epoch measures ~5.9 KB/s: ten milliseconds of that drain clamps the window
+        // to the floor while the windowed maximum remembers the higher rate.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(200);
-        await Assert.That(budget.Phase).IsEqualTo(BrokerWindowPhase.Steady);
-        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
-        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
+
+        // One strangled epoch could be a broker hiccup — the clamp holds.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
+
+        // A second consecutive strangled epoch proves the clamp is suppressing goodput,
+        // not saving latency: the escape valve doubles the ceiling's floor.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(400);
+
+        // Persistent strangulation keeps doubling toward the cap.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(800);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -158,6 +158,29 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task LatencyCeiling_FloorsHorizonAtRequestServingTimeWhenTargetUnreachable()
+    {
+        var budget = CreateColdStartBudget();
+
+        // The first full acknowledgement takes 50ms — five times the 10ms target. The
+        // horizon floors at two serving round trips (100ms), so the ceiling admits 100ms of
+        // the measured 40 KB/s drain (4,000 bytes) and the optimistic 1,600-byte window
+        // stands, instead of a target-only horizon (400 bytes) strangling admission at the
+        // floor and re-measuring goodput through its own clamp.
+        var now = T0 + Seconds(0.050);
+        budget.OnAcked(
+            ackedBytes: 2_000,
+            budget.SnapshotDelivery(now - Seconds(0.050), appLimited: false),
+            now);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+
+        // The completed-epoch path honors the same serving-time floor.
+        now += Seconds(0.510);
+        DriveBudgetEpoch(budget, now, logicalBytes: 100_000, rttSeconds: 0.050);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+    }
+
     private static BrokerUnackedByteBudget CreateColdStartBudget() =>
         new(
             targetSeconds: 0.010,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -23,6 +23,57 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task ColdStartAdmission_UsesOneRequestWaveUntilFirstAcknowledgement()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100,
+            coldStartBudgetBytes: 100);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100);
+        await Assert.That(budget.TryReserve(100, out _)).IsTrue();
+        await Assert.That(budget.TryReserve(1, out _)).IsFalse();
+
+        var now = T0 + Seconds(0.001);
+        budget.OnAcked(
+            ackedBytes: 100,
+            budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
+            now);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        await Assert.That(budget.TryReserve(1_500, out _)).IsTrue();
+        budget.Release(1_600);
+    }
+
+    [Test]
+    public async Task ColdStartAdmission_TracksCurrentConnectionWidthBeforeFirstAck()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100,
+            coldStartBudgetBytes: 100);
+
+        budget.SetCap(capBytes: 30_000, coldStartBudgetBytes: 300, nowTicks: T0);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(300);
+
+        budget.SetCap(capBytes: 10_000, coldStartBudgetBytes: 100, nowTicks: T0);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task ColdStartBudget_UsesSharedBatchAndConnectionFormula()
+    {
+        await Assert.That(BrokerUnackedByteBudget.ComputeColdStartBudget(1_000, 3))
+            .IsEqualTo(3_000);
+        await Assert.That(BrokerUnackedByteBudget.ComputeCap(1_000, 3))
+            .IsEqualTo(96_000);
+    }
+
+    [Test]
     public async Task TryReserve_AtomicallyEnforcesWindow()
     {
         var budget = CreateBudget(capBytes: 10_000, initialRequestBytes: 100);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -103,7 +103,7 @@ public sealed class BrokerUnackedByteBudgetTests
     [Test]
     public async Task DelayOverTarget_DescendsBelowLegacyFloorThenWithholdsGrowth()
     {
-        var controller = CreateGovernorController();
+        var controller = CreateController(latencyGovernorEnabled: true);
         var now = T0;
         var admissionBlocks = 0L;
         _ = controller.CompleteInterval(admissionBlocks, 0, now);
@@ -153,7 +153,7 @@ public sealed class BrokerUnackedByteBudgetTests
     [Test]
     public async Task DelayUnderTarget_KeepsLegacyFloor()
     {
-        var controller = CreateGovernorController();
+        var controller = CreateController(latencyGovernorEnabled: true);
         var now = T0;
         var admissionBlocks = 0L;
         _ = controller.CompleteInterval(admissionBlocks, 0, now);
@@ -167,30 +167,14 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task SlowStart_DoublesOnlyWhileGovernorEnabled()
+    public async Task InitialWindow_SlowStartsFromFloorOnlyWhileGovernorEnabled()
     {
-        var governed = CreateGovernorController();
+        var governed = CreateController(latencyGovernorEnabled: true);
         await Assert.That(governed.WindowBytes).IsEqualTo(200);
 
         var legacy = CreateController();
         await Assert.That(legacy.WindowBytes).IsEqualTo(1_600);
     }
-
-    private static BrokerUnackedByteBudget CreateColdStartBudget() =>
-        new(
-            targetSeconds: 0.010,
-            floorBytes: 1,
-            initialCapBytes: 10_000,
-            initialRequestBytes: 100,
-            coldStartBudgetBytes: 100);
-
-    private static BrokerWindowController CreateGovernorController() =>
-        new(
-            targetSeconds: 0.010,
-            floorBytes: 1,
-            capBytes: 10_000,
-            initialRequestBytes: 100,
-            latencyGovernorEnabled: true);
 
     [Test]
     public async Task TryReserve_AtomicallyEnforcesWindow()
@@ -888,8 +872,21 @@ public sealed class BrokerUnackedByteBudgetTests
             initialCapBytes: capBytes,
             initialRequestBytes: initialRequestBytes);
 
-    private static BrokerWindowController CreateController() =>
-        new(targetSeconds: 0.010, floorBytes: 1, capBytes: 10_000, initialRequestBytes: 100);
+    private static BrokerWindowController CreateController(bool latencyGovernorEnabled = false) =>
+        new(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            capBytes: 10_000,
+            initialRequestBytes: 100,
+            latencyGovernorEnabled: latencyGovernorEnabled);
+
+    private static BrokerUnackedByteBudget CreateColdStartBudget() =>
+        new(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100,
+            coldStartBudgetBytes: 100);
 
     private static void DriveBudgetEpoch(
         BrokerUnackedByteBudget budget,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -31,29 +31,26 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.TryReserve(100, out _)).IsTrue();
         await Assert.That(budget.TryReserve(1, out _)).IsFalse();
 
-        // First ack: 100 bytes drained in 1ms = 100 KB/s; the 10ms target admits ten
-        // milliseconds of that drain (1,000 bytes), not the full optimistic initial window.
+        // The first acknowledgement ends the gate at the slow-start window, not the full
+        // optimistic initial size — a cold broker never receives one unmeasured burst.
         var now = T0 + Seconds(0.001);
         budget.OnAcked(
             ackedBytes: 100,
             budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
             now);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
-        await Assert.That(budget.TryReserve(900, out _)).IsTrue();
-        await Assert.That(budget.TryReserve(1, out _)).IsFalse();
-        budget.Release(1_000);
-
-        // Second ack raises the cumulative measured rate; the ramp opens the window further
-        // until the optimistic sixteen-quantum start stops being the binding bound.
-        var later = now + Seconds(0.001);
-        budget.OnAcked(
-            ackedBytes: 1_000,
-            budget.SnapshotDelivery(later - Seconds(0.001), appLimited: false),
-            later);
-        budget.CompleteAckedPass(later);
-
+        // Each fully acknowledged response pass doubles the window toward the optimistic
+        // sixteen-quantum start, then the doubling stops.
+        budget.CompleteAckedPass(now);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(400);
+        budget.CompleteAckedPass(now);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(800);
+        budget.CompleteAckedPass(now);
         await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        budget.CompleteAckedPass(now);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        budget.Release(100);
     }
 
     [Test]
@@ -92,7 +89,7 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.NotePartialDeliverySuccess();
         await Assert.That(budget.BudgetBytes).IsEqualTo(200);
 
-        // The ramp still owns subsequent growth once a clean acknowledgement is measured.
+        // Slow start still owns subsequent growth once clean acknowledged passes complete.
         var now = T0 + Seconds(0.001);
         budget.OnAcked(
             ackedBytes: 100,
@@ -100,96 +97,83 @@ public sealed class BrokerUnackedByteBudgetTests
             now);
         budget.CompleteAckedPass(now);
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
-    }
-
-    [Test]
-    public async Task LatencyCeiling_ClampsWindowWhenMeasuredGoodputFallsBelowTarget()
-    {
-        var budget = CreateColdStartBudget();
-        var now = FlipColdStartGateWithFastAck(budget);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
-        var generation = budget.CurrentGeneration;
-
-        // One completed control epoch at ~5.9 KB/s: ten milliseconds of that drain rounds
-        // far below the two-quantum floor, so the window clamps to the floor.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
-
-        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
-        await Assert.That(budget.CurrentGeneration).IsGreaterThan(generation);
-    }
-
-    [Test]
-    public async Task LatencyCeiling_RestoresCeilingBoundWindowWhenGoodputRecovers()
-    {
-        var budget = CreateColdStartBudget();
-        var now = FlipColdStartGateWithFastAck(budget);
-
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
-
-        // A recovered epoch (~980 KB/s) re-raises the ceiling; the ceiling-bound window
-        // follows it without waiting for the probe schedule.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 500_000, rttSeconds: 0.001);
-
-        await Assert.That(budget.BudgetBytes).IsEqualTo(9_800);
-    }
-
-    [Test]
-    public async Task LatencyCeiling_EscapesWhenClampPersistentlyCostsGoodput()
-    {
-        var budget = CreateColdStartBudget();
-        var now = FlipColdStartGateWithFastAck(budget);
-
-        // First epoch measures ~5.9 KB/s: ten milliseconds of that drain clamps the window
-        // to the floor while the windowed maximum remembers the higher rate.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 1_000, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
-
-        // One strangled epoch could be a broker hiccup — the clamp holds.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(200);
-
-        // A second consecutive strangled epoch proves the clamp is suppressing goodput,
-        // not saving latency: the escape valve doubles the ceiling's floor.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
         await Assert.That(budget.BudgetBytes).IsEqualTo(400);
-
-        // Persistent strangulation keeps doubling toward the cap.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 100, rttSeconds: 0.001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(800);
     }
 
     [Test]
-    public async Task LatencyCeiling_FloorsHorizonAtRequestServingTimeWhenTargetUnreachable()
+    public async Task DelayOverTarget_DescendsBelowLegacyFloorThenWithholdsGrowth()
     {
-        var budget = CreateColdStartBudget();
+        var controller = CreateGovernorController();
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now);
 
-        // The first full acknowledgement takes 50ms — five times the 10ms target. The
-        // horizon floors at two serving round trips (100ms), so the ceiling admits 100ms of
-        // the measured 40 KB/s drain (4,000 bytes) and the optimistic 1,600-byte window
-        // stands, instead of a target-only horizon (400 bytes) strangling admission at the
-        // floor and re-measuring goodput through its own clamp.
-        var now = T0 + Seconds(0.050);
-        budget.OnAcked(
-            ackedBytes: 2_000,
-            budget.SnapshotDelivery(now - Seconds(0.050), appLimited: false),
-            now);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        // Sustained 50ms of controllable delay against a 10ms target biases every probe
+        // downward; each goodput-preserving descent re-probes early, so the walk reaches
+        // the two-quantum descent floor instead of parking at the legacy eight-quantum one.
+        for (var i = 0; i < 2_000 && controller.WindowBytes > 200; i++)
+        {
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.050);
+        }
 
-        // The completed-epoch path honors the same serving-time floor.
-        now += Seconds(0.510);
-        DriveBudgetEpoch(budget, now, logicalBytes: 100_000, rttSeconds: 0.050);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_600);
+        await Assert.That(controller.WindowBytes).IsEqualTo(200);
+        await Assert.That(controller.CapacityProbeFailureCount).IsEqualTo(0);
+
+        // Let the experiment that reached the floor finish before pinning the schedule.
+        for (var i = 0; i < 100 && controller.Phase != BrokerWindowPhase.Steady; i++)
+        {
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.050);
+        }
+
+        // At the floor and still over target: growth is withheld, so no further experiment
+        // starts in either direction.
+        var successes = controller.CapacityProbeSuccessCount;
+        for (var i = 0; i < 100; i++)
+        {
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.050);
+        }
+
+        await Assert.That(controller.WindowBytes).IsEqualTo(200);
+        await Assert.That(controller.Phase).IsEqualTo(BrokerWindowPhase.Steady);
+        await Assert.That(controller.CapacityProbeSuccessCount).IsEqualTo(successes);
+    }
+
+    [Test]
+    public async Task DelayUnderTarget_KeepsLegacyFloor()
+    {
+        var controller = CreateGovernorController();
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+
+        // On-target delay keeps the legacy eight-quantum floor: the governor's deep descent
+        // is justified only by a missed latency target.
+        for (var i = 0; i < 1_000; i++)
+            _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
+
+        await Assert.That(controller.WindowBytes).IsGreaterThanOrEqualTo(800);
+    }
+
+    [Test]
+    public async Task SlowStart_DoublesOnlyWhileGovernorEnabled()
+    {
+        var governed = CreateGovernorController();
+        await Assert.That(governed.WindowBytes).IsEqualTo(200);
+
+        var legacy = CreateController();
+        await Assert.That(legacy.WindowBytes).IsEqualTo(1_600);
     }
 
     private static BrokerUnackedByteBudget CreateColdStartBudget() =>
@@ -200,18 +184,13 @@ public sealed class BrokerUnackedByteBudgetTests
             initialRequestBytes: 100,
             coldStartBudgetBytes: 100);
 
-    /// <summary>Ends the cold-start phase with a 2 MB/s first acknowledgement, whose
-    /// target-scaled ceiling (20 KB, capped to 10 KB) leaves the sixteen-quantum optimistic
-    /// window as the binding bound — the pre-ceiling handoff behavior.</summary>
-    private static long FlipColdStartGateWithFastAck(BrokerUnackedByteBudget budget)
-    {
-        var now = T0 + Seconds(0.001);
-        budget.OnAcked(
-            ackedBytes: 2_000,
-            budget.SnapshotDelivery(now - Seconds(0.001), appLimited: false),
-            now);
-        return now;
-    }
+    private static BrokerWindowController CreateGovernorController() =>
+        new(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            capBytes: 10_000,
+            initialRequestBytes: 100,
+            latencyGovernorEnabled: true);
 
     [Test]
     public async Task TryReserve_AtomicallyEnforcesWindow()

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -231,7 +231,9 @@ public class KafkaProducerFastPathTests
             LingerMs = 10,
             RequestTimeoutMs = 500,
             DeliveryTimeoutMs = 1000,
-            CloseTimeoutMs = 1000
+            CloseTimeoutMs = 1000,
+            // Background senders are stopped; direct batch completion does not produce acks.
+            DeliveryLatencyTargetMs = 0
         };
 
         await using var producer = new KafkaProducer<string, string>(
@@ -286,6 +288,8 @@ public class KafkaProducerFastPathTests
             RequestTimeoutMs = 500,
             DeliveryTimeoutMs = 1000,
             CloseTimeoutMs = 1000,
+            // Background senders are stopped; this test buffers several batches without acks.
+            DeliveryLatencyTargetMs = 0,
             EnableAdaptivePartitioning = false
         };
 

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -5,17 +5,21 @@ namespace Dekaf.Tests.Unit.Producer;
 
 public sealed class ProducerDeliveryDiagnosticsTests
 {
+    private const int TestBatchSize = 60;
+
     private static ProducerOptions CreateOptions(
         bool enableDeliveryDiagnostics = false,
-        int deliveryLatencyTargetMs = 0) => new()
+        int deliveryLatencyTargetMs = 0,
+        long? unackedByteBudgetCapOverride = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
             ClientId = "diagnostics-test",
             BufferMemory = ulong.MaxValue,
-            BatchSize = 60,
+            BatchSize = TestBatchSize,
             LingerMs = 10_000,
             EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
-            DeliveryLatencyTargetMs = deliveryLatencyTargetMs
+            DeliveryLatencyTargetMs = deliveryLatencyTargetMs,
+            UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride
         };
 
     [Test]
@@ -180,7 +184,10 @@ public sealed class ProducerDeliveryDiagnosticsTests
     {
         var options = CreateOptions(
             enableDeliveryDiagnostics: true,
-            deliveryLatencyTargetMs: 10);
+            deliveryLatencyTargetMs: 10,
+            unackedByteBudgetCapOverride: BrokerUnackedByteBudget.ComputeCap(
+                TestBatchSize,
+                connectionCount: 1));
         await using var accumulator = new RecordAccumulator(
             options,
             resolveLeaderId: static (_, _) => 7);
@@ -221,7 +228,8 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.RequestRttMicrosLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.AdmissionBlockMicrosLog2Histogram).IsNotNull();
         await Assert.That(current.AdmissionBlockMicrosLog2Histogram!.Sum()).IsEqualTo(1);
-        await Assert.That(current.AdmissionBlockMicrosLog2Histogram[12]).IsEqualTo(1);
+        await Assert.That(current.AdmissionBlockMicrosLog2Histogram.Skip(12).Sum()).IsEqualTo(1)
+            .Because("the synthetic block began eight milliseconds earlier; scheduling may extend it");
         await Assert.That(current.CurrentAdmissionBlockMicros).IsEqualTo(0);
         await Assert.That(snapshot.BudgetProbeEvents).IsEmpty();
         await Assert.That(sample.BrokerId).IsEqualTo(7);
@@ -253,7 +261,11 @@ public sealed class ProducerDeliveryDiagnosticsTests
     public async Task BrokerWindow_DoesNotTreatOneRttAsSustainableGoodput()
     {
         await using var accumulator = new RecordAccumulator(
-            CreateOptions(deliveryLatencyTargetMs: 10),
+            CreateOptions(
+                deliveryLatencyTargetMs: 10,
+                unackedByteBudgetCapOverride: BrokerUnackedByteBudget.ComputeCap(
+                    TestBatchSize,
+                    connectionCount: 1)),
             resolveLeaderId: static (_, _) => 7);
         var budget = accumulator.GetBrokerUnackedBudget(7)!;
         var now = Stopwatch.GetTimestamp();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -290,7 +290,9 @@ public class RecordAccumulatorTests
             ClientId = "test-producer",
             BufferMemory = ulong.MaxValue,
             BatchSize = 1_000,
-            LingerMs = 5_000
+            LingerMs = 5_000,
+            // This test injects admission pressure explicitly after opening two partitions.
+            UnackedByteBudgetCapOverride = 10_000
         };
         await using var accumulator = new RecordAccumulator(
             options,


### PR DESCRIPTION
Fixes #2109.

## What this does

The broker window controller gets a **latency governor** (armed whenever the unacked-byte budget is active: no explicit cap override, acks enabled, positive `DeliveryLatencyTargetMs`):

- **Cold start opens by ack-clocked slow start.** Admission is limited to one request wave until the first successful acknowledgement (including partial-success responses — a churning partition no longer clamps a draining broker), then the window doubles once per fully acknowledged response pass from two quanta up to the optimistic sixteen. Each doubling follows a proven drain, so a cold broker never receives the previous one-step 16-quanta flood that caused the multi-hundred-ms startup stalls.
- **While the controlled-delay EWMA exceeds the latency target, probes bias downward.** Up-probes are withheld; down-probes may explore beneath the legacy eight-quantum floor (to two quanta) but only if their own paired experiment demonstrates a ≥10% delay reduction with goodput held; a successful descent re-probes after ~3s instead of ~30s. Every step remains a goodput-guarded B-A-B experiment, so topologies whose knee sits high keep their window.
- **Blocked windows can recover.** Up-probes accept at 1.00× goodput (instead of 1.03×) when the experiment observed admission blocking — blocked demand is direct evidence of under-provisioning, and the delay-growth veto still prevents bufferbloat. This removes the down-passes-on-noise / up-never-passes asymmetry that could ratchet throughput down over a run.

Explicit cap overrides and `Acks.None` keep their existing semantics (optimistic start, eight-quantum floor, sparse schedule).

Also included: the exact-SHA A-B-A stability gate now judges steady/peak against the harness's absolute floor rather than A-vs-B shape comparison (a candidate that front-loads throughput while settling was being penalized for its own early peak; genuine intra-run collapse still rejects, and an unstable control marks the comparison inconclusive).

## Why the design looks like this

Three earlier iterations derived a window ceiling from `target × measured goodput` (then with serving-time horizons, then with an escape valve). All three failed local A-B-A validation the same fundamental way: **any bound fed by goodput measured at its own window is self-referential** — the clamp suppresses the measurement that would justify lifting it. The shipped design expresses the latency objective purely through the existing paired-experiment machinery, which is Pareto-safe by construction.

## Evidence

Exact-SHA A-B-A runs, baseline `d15e2a6c` → candidate → baseline on one VM:

**producer-3b (run [29522448948](https://github.com/thomhurst/Dekaf/actions/runs/29522448948)) — PASS:**

| Metric | Baselines | Candidate | Δ vs mean |
|---|---|---|---|
| Throughput | 1,159k / 1,145k | **1,203k** | **+4.45%** |
| p95 / p99 | 33.3–34.6 / 53.8–55.6 ms | **30.9 / 51.4 ms** | **−9.0% / −6.0%** |
| CPU | 1.106–1.117 µs/msg | **1.027** | **−7.7%** |
| Allocation | 1.044–1.144 B/msg | 1.040 | −4.9% |
| Steady/peak | 0.902–0.970 | **0.977** | +4.4% |

**producer-1b (run [29525842754](https://github.com/thomhurst/Dekaf/actions/runs/29525842754)) — candidate beat both controls on every metric; formally INCONCLUSIVE solely because the two d15 controls disagreed by 12.3% on p99 between themselves. Accepted by maintainer decision:**

| Metric | Baselines | Candidate |
|---|---|---|
| Throughput | 1,552k / 1,535k | **1,578k (+2.24%)** |
| CPU | 0.927 / 0.903 µs/msg | **0.900** |
| p95 / p99 | 10.7–11.4 / 15.3–17.3 ms | **11.0 / 14.9 ms** |
| Max | 68 / 90 ms | **53 ms** |

An earlier candidate run on a slow VM class showed the latency effect at full size (p95 29.2ms vs 47.6/32.5 baselines, −27%) — and a d15 control in that same run reproduced #2109 with a 654ms max stall.

Zero errors and exact accepted==delivered in every pass of every run. Local tmpfs A-B-A: parity with d15 (~99% throughput, equal CPU/latency; descent correctly refuses where the local knee is high).

## Notes for the record

- The historical 3b CPU number (1.03 µs/msg) was largely an idle-time artifact: the pre-#2158 budget had collapsed to 25–61KB and kept the admission gate closed ~1/3 of wall time (1.264 cores × 0.664 unblocked fraction = 0.838 cores exactly). The candidate now beats that number anyway (1.027 on 3b at +45% more throughput than that era).
- Rare >100ms startup-tail samples are reduced (halved on the fast-VM run; max 167ms vs a 654ms baseline stall on the slow-VM run) but not fully eliminated; the remaining exposure is the pre-descent window in the first minutes. Follow-up candidates: faster initial descent, or the standing-burn send-loop work.
- Follow-ups tracked separately: standing spin/poll burn (~1.26 cores whenever unblocked — also the 1b >1.5M lever), `GetOrAdd` double-`BrokerSender` construction race, zero-measure-ack gate-flip skip, outlier tracker timestamps for dropped samples, two pre-existing load-sensitive flaky unit tests (`Revoke_WhenCommitExceedsRebalanceTimeout_Continues`, `SendLoop_CoalescedSendFailure_RefreshesMetadataOncePerTopic` — reproduce on clean d15).
