### PR TITLE
ci: add phased stress profiling

### DIFF
--- a/.github/scripts/test_stress_profile.py
+++ b/.github/scripts/test_stress_profile.py
@@ -1,0 +1,106 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "profile-stress-test.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "stress-tests.yml"
+
+
+class StressProfileScriptTests(unittest.TestCase):
+    def run_validation(self, windows):
+        command = (
+            f'PROFILE_VALIDATE_ONLY=true TRACE_WINDOWS="{windows}" '
+            "bash tools/profile-stress-test.sh "
+            "--duration 15 --scenario producer --client dekaf"
+        )
+        return subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            cwd=REPO_ROOT,
+            text=True,
+            check=False,
+        )
+
+    def test_accepts_sorted_windows_inside_measured_duration(self):
+        result = self.run_validation(
+            "60:30:healthy,330:30:pre-collapse,420:30:collapse,600:30:degraded"
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Valid profile", result.stdout)
+
+    def test_rejects_overlapping_windows(self):
+        result = self.run_validation("60:30:healthy,80:30:overlap")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("sorted and non-overlapping", result.stderr)
+
+    def test_rejects_window_after_measured_duration(self):
+        result = self.run_validation("895:30:too-late")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("ends after", result.stderr)
+
+    def test_rejects_duplicate_window_labels(self):
+        result = self.run_validation("60:30:same,120:30:same")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("Duplicate window label", result.stderr)
+
+    def test_uses_measured_marker_and_exact_pid_cleanup(self):
+        script = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn('grep -Eq "$TRACE_START_PATTERN"', script)
+        self.assertIn('dotnet-counters collect', script)
+        self.assertIn('dotnet-stack report --process-id "$STRESS_PID"', script)
+        self.assertIn('dotnet-trace collect', script)
+        self.assertIn('taskkill //F //PID "$STRESS_PID"', script)
+        self.assertNotIn("//IM", script)
+
+
+class StressProfileWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_exposes_reusable_profile_inputs(self):
+        for profile_input in (
+            "profile_mode:",
+            "profile_windows:",
+            "profile_counters:",
+            "profile_stacks:",
+        ):
+            self.assertIn(profile_input, self.workflow)
+
+    def test_profiles_only_one_explicit_dekaf_lane(self):
+        self.assertIn(
+            'if [ "$lane" = "all" ] || [ "$client" != "dekaf" ]',
+            self.workflow,
+        )
+        self.assertIn('.paired_samples = 1', self.workflow)
+        self.assertIn('.run_3conn = false', self.workflow)
+        self.assertIn('.artifact_suffix = "-profile"', self.workflow)
+
+    def test_installs_pinned_tools_only_for_profile_dispatch(self):
+        self.assertIn(
+            "if: github.event_name == 'workflow_dispatch' && github.event.inputs.profile_mode != 'off'",
+            self.workflow,
+        )
+        self.assertIn(
+            "dotnet tool install --global dotnet-counters --version 9.0.661903",
+            self.workflow,
+        )
+        self.assertIn(
+            "dotnet tool install --global dotnet-trace --version 9.0.661903",
+            self.workflow,
+        )
+
+    def test_keeps_target_and_profiler_affinity_separate(self):
+        self.assertIn('STRESS_CPUSET="$CLIENT_CPUS"', self.workflow)
+        self.assertIn('PROFILER_CPUSET="5"', self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -61,6 +61,31 @@ on:
           - lane-default
           - dekaf
           - confluent
+      profile_mode:
+        description: 'Attach phased diagnostics to one Dekaf lane (off for normal acceptance runs)'
+        required: false
+        type: choice
+        default: 'off'
+        options:
+          - 'off'
+          - cpu
+          - contention
+          - gc
+          - full
+      profile_windows:
+        description: 'Trace windows as measured-phase offset_seconds:duration_seconds:label'
+        required: false
+        default: '60:30:healthy,330:30:pre-collapse,420:30:collapse,600:30:degraded'
+      profile_counters:
+        description: 'Collect one-second System.Runtime counters across the measured phase'
+        required: false
+        type: boolean
+        default: true
+      profile_stacks:
+        description: 'Capture a managed stack snapshot at each trace window'
+        required: false
+        type: boolean
+        default: true
 
 # Scoped per lane+client so a cheap single-lane or single-client dispatch is not
 # queued for hours behind a full-matrix run; lanes execute on separate VMs and
@@ -91,6 +116,7 @@ jobs:
         env:
           LANE: ${{ github.event.inputs.lane }}
           CLIENT: ${{ github.event.inputs.client }}
+          PROFILE_MODE: ${{ github.event.inputs.profile_mode }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           # The UI enforces the required choice input, but API/CLI dispatches can
@@ -115,6 +141,21 @@ jobs:
               exit 1
               ;;
           esac
+
+          profile_mode="${PROFILE_MODE:-off}"
+          case "$profile_mode" in
+            off|cpu|contention|gc|full) ;;
+            *)
+              echo "::error::Unknown profile_mode '$profile_mode'. Valid values: off, cpu, contention, gc, full."
+              exit 1
+              ;;
+          esac
+          if [ "$profile_mode" != "off" ]; then
+            if [ "$lane" = "all" ] || [ "$client" != "dekaf" ]; then
+              echo "::error::Profiling requires one explicit lane and client=dekaf. It is diagnostic, not a comparison run."
+              exit 1
+            fi
+          fi
 
           # timeout_minutes rationale: at a 30-minute dispatch the paired_samples=2
           # lanes run four paired client durations plus one 3-connection duration
@@ -143,13 +184,19 @@ jobs:
           # sample — paired_samples exists to alternate client order, which is
           # meaningless for a single client — and the Dekaf-only 3-connection
           # pass survives only a dekaf override.
-          matrix=$(jq -c --arg lane "$lane" --arg client "$client" '
+          matrix=$(jq -c --arg lane "$lane" --arg client "$client" --arg profile_mode "$profile_mode" '
             {include: [ .[]
               | select($lane == "all" or .lane == $lane)
               | if $client != "" and .client == "all" then
                   .client = $client
                   | .paired_samples = 1
                   | if $client == "confluent" then .run_3conn = false | .artifact_suffix = "" else . end
+                else . end
+              | if $profile_mode != "off" then
+                  .client = "dekaf"
+                  | .paired_samples = 1
+                  | .run_3conn = false
+                  | .artifact_suffix = "-profile"
                 else . end
             ]}' lanes.json)
           count=$(echo "$matrix" | jq '.include | length')
@@ -161,8 +208,8 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           # Only an unmodified full matrix may publish docs/history: a client
           # override produces single-client rows that would wipe ratio columns.
-          echo "full_run=$([ "$lane" = "all" ] && [ -z "$client" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "Selected $count lane(s) for '$lane'${client:+ (client override: $client)}"
+          echo "full_run=$([ "$lane" = "all" ] && [ -z "$client" ] && [ "$profile_mode" = "off" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Selected $count lane(s) for '$lane'${client:+ (client override: $client)}${profile_mode:+ (profile: $profile_mode)}"
 
   # Run each scenario in parallel. Comparable clients run sequentially inside the
   # same job/VM so published ratios share hardware and noisy-neighbor conditions;
@@ -208,6 +255,12 @@ jobs:
         run: |
           dotnet tool install --global dotnet-stack --version 9.0.661903
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Install profiling diagnostics
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.profile_mode != 'off'
+        run: |
+          dotnet tool install --global dotnet-counters --version 9.0.661903
+          dotnet tool install --global dotnet-trace --version 9.0.661903
 
       - name: Build Stress Tests
         run: dotnet build tools/Dekaf.StressTests --configuration Release
@@ -271,6 +324,7 @@ jobs:
           STRESS_BROKER_CPUSET: ${{ env.BROKER_CPUS }}
           STRESS_BROKER_TMPFS: ${{ env.BROKER_TMPFS }}
           STRESS_BROKER_HEAP: ${{ env.BROKER_HEAP }}
+          PROFILE_MODE: ${{ github.event.inputs.profile_mode || 'off' }}
         run: |
           # Background disk monitor: samples every broker's log-dir usage so a tmpfs
           # fill (ingestion outpacing retention — the known broker-halt failure mode)
@@ -318,18 +372,37 @@ jobs:
 
             # Delivery diagnostics are always on in CI so a message-loss failure ships the
             # in-flight batch dump needed to debug it, instead of "Not captured".
-            taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- \
-              --duration ${{ github.event.inputs.duration_minutes || '15' }} \
-              --message-size ${{ matrix.message_size || github.event.inputs.message_size || '1000' }} \
-              --scenario ${{ matrix.scenario }} \
-              --client ${{ matrix.client }} \
-              --brokers ${{ matrix.brokers }} \
-              --connections-per-broker 1 \
-              --producer-delivery-diagnostics \
-              ${EXTRA_ARGS} \
-              --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
-              --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }} \
+            STRESS_ARGS=(
+              --duration ${{ github.event.inputs.duration_minutes || '15' }}
+              --message-size ${{ matrix.message_size || github.event.inputs.message_size || '1000' }}
+              --scenario ${{ matrix.scenario }}
+              --client ${{ matrix.client }}
+              --brokers ${{ matrix.brokers }}
+              --connections-per-broker 1
+              --producer-delivery-diagnostics
+              --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }}
+              --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }}
               --output ./results
+            )
+            if [ -n "$EXTRA_ARGS" ]; then
+              STRESS_ARGS+=("$EXTRA_ARGS")
+            fi
+
+            if [ "$PROFILE_MODE" != "off" ]; then
+              # The stress process retains the normal client-core isolation. Attach
+              # tools use one broker core; profiling runs diagnose within-run change
+              # and are intentionally excluded from acceptance/trend publication.
+              PROFILE_OUTPUT_DIR="$PWD/results/profiling" \
+              TRACE_PROFILE="$PROFILE_MODE" \
+              TRACE_WINDOWS="${{ github.event.inputs.profile_windows }}" \
+              PROFILE_COUNTERS="${{ github.event.inputs.profile_counters }}" \
+              PROFILE_STACKS="${{ github.event.inputs.profile_stacks }}" \
+              STRESS_CPUSET="$CLIENT_CPUS" \
+              PROFILER_CPUSET="5" \
+              bash ../../tools/profile-stress-test.sh "${STRESS_ARGS[@]}"
+            else
+              taskset -c ${CLIENT_CPUS} dotnet run --configuration Release --no-build -- "${STRESS_ARGS[@]}"
+            fi
           done
 
           if [ "${{ matrix.run_3conn }}" = "true" ]; then

--- a/tools/profile-stress-test.sh
+++ b/tools/profile-stress-test.sh
@@ -1,223 +1,287 @@
 #!/usr/bin/env bash
-# Profile Dekaf stress tests using dotnet trace (attach mode).
+# Capture comparable diagnostics at named offsets from a stress test's measured
+# phase. The target runs normally; diagnostic tools attach to its exact PID.
 #
-# This script starts the stress test as a normal process, waits for it to
-# begin producing, then attaches dotnet-trace for a fixed sample window.
-# Attaching separately avoids the massive overhead of launching through
-# dotnet trace, which can make a 2-minute test take 30+ minutes.
-#
-# Usage:
-#   ./tools/profile-stress-test.sh [options]
-#
-# Options (passed through to Dekaf.StressTests):
-#   --duration <minutes>     Stress test duration (default: 5)
-#   --scenario <name>        producer|consumer|all (default: producer)
-#   --client <name>          dekaf|confluent|all (default: dekaf)
-#   --message-size <bytes>   Message size (default: 1000)
+# Example:
+#   TRACE_WINDOWS='60:30:healthy,420:30:collapse,600:30:degraded' \
+#   STRESS_CPUSET='6,7' PROFILER_CPUSET='5' \
+#   bash ./tools/profile-stress-test.sh --duration 15 --scenario producer --client dekaf
 #
 # Environment:
-#   TRACE_DURATION           Trace sample window in seconds (default: 180)
-#   TRACE_SETTLE_TIME        Seconds to wait before attaching (default: 45)
-#   KAFKA_BOOTSTRAP_SERVERS  External Kafka address (default: localhost:9092)
-#   TRACE_OUTPUT             Output .nettrace file path
-#   TRACE_PROVIDERS          dotnet-trace --providers value
-#                            (default: Microsoft-DotNETCore-SampleProfiler)
-#   TRACE_PROFILE            Preset profile: cpu (default), contention, gc, full
-#                            Overridden by TRACE_PROVIDERS if set explicitly.
-#   WAIT_FOR_EXIT            If "true", wait for stress test to finish and show
-#                            its throughput output (default: true)
+#   TRACE_WINDOWS         Comma-separated offset:duration:label windows.
+#                         Offsets are seconds from measured-phase start.
+#   TRACE_START_PATTERN   Extended regex identifying measured-phase start.
+#   TRACE_PROFILE         cpu (default), contention, gc, or full.
+#   TRACE_PROVIDERS       Explicit dotnet-trace providers; overrides profile.
+#   PROFILE_OUTPUT_DIR    Artifact directory (default: stress-profile).
+#   PROFILE_COUNTERS      Collect System.Runtime counters (default: true).
+#   PROFILE_STACKS        Capture a stack snapshot per window (default: true).
+#   PROFILE_VALIDATE_ONLY Validate configuration without starting a test.
+#   PROFILE_START_TIMEOUT Seconds allowed for measured phase to start (default: 300).
+#   STRESS_CPUSET         Optional target process CPU affinity.
+#   PROFILER_CPUSET       Optional diagnostics process CPU affinity.
+#   KAFKA_BOOTSTRAP_SERVERS External Kafka address (default: localhost:9092).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-STRESS_EXE="$REPO_ROOT/tools/Dekaf.StressTests/bin/Release/net10.0/Dekaf.StressTests.exe"
+STRESS_EXE="$REPO_ROOT/tools/Dekaf.StressTests/bin/Release/net10.0/Dekaf.StressTests"
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+    STRESS_EXE="${STRESS_EXE}.exe"
+fi
 
-# Defaults
-TRACE_DURATION="${TRACE_DURATION:-180}"
-TRACE_SETTLE_TIME="${TRACE_SETTLE_TIME:-45}"
+TRACE_WINDOWS="${TRACE_WINDOWS:-60:30:healthy,330:30:pre-collapse,420:30:collapse,600:30:degraded}"
+TRACE_START_PATTERN="${TRACE_START_PATTERN:-Running .* stress test for}"
 TRACE_PROFILE="${TRACE_PROFILE:-cpu}"
-WAIT_FOR_EXIT="${WAIT_FOR_EXIT:-true}"
-TRACE_OUTPUT="${TRACE_OUTPUT:-$REPO_ROOT/stress_profile.nettrace}"
+PROFILE_OUTPUT_DIR="${PROFILE_OUTPUT_DIR:-$REPO_ROOT/stress-profile}"
+PROFILE_COUNTERS="${PROFILE_COUNTERS:-true}"
+PROFILE_STACKS="${PROFILE_STACKS:-true}"
+PROFILE_VALIDATE_ONLY="${PROFILE_VALIDATE_ONLY:-false}"
+PROFILE_START_TIMEOUT="${PROFILE_START_TIMEOUT:-300}"
 export KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}"
 
-# --- Provider presets ---
-# Use TRACE_PROVIDERS env var to override, otherwise select by TRACE_PROFILE.
-if [ -z "${TRACE_PROVIDERS:-}" ]; then
-    case "$TRACE_PROFILE" in
-        cpu)
-            TRACE_PROVIDERS="Microsoft-DotNETCore-SampleProfiler"
-            ;;
-        contention)
-            # ContentionKeyword (0x4000) + ThreadingKeyword (0x10000) + GC (0x1) + ExceptionKeyword (0x8000)
-            TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000001C001:4,Microsoft-DotNETCore-SampleProfiler"
-            ;;
-        gc)
-            # GCKeyword (0x1) + GCHeapSurvivalAndMovement (0x400000) + Type (0x80000)
-            TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x0000000000480001:5,Microsoft-DotNETCore-SampleProfiler"
-            ;;
-        full)
-            # CPU + Contention + GC + Threading + Exceptions
-            TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000049C001:4,Microsoft-DotNETCore-SampleProfiler"
-            ;;
-        *)
-            echo "ERROR: Unknown TRACE_PROFILE '$TRACE_PROFILE'. Use: cpu, contention, gc, full"
-            exit 1
-            ;;
-    esac
-fi
-
-# Pass remaining args to stress test (defaults if none given)
-STRESS_ARGS=("$@")
-if [ ${#STRESS_ARGS[@]} -eq 0 ]; then
-    STRESS_ARGS=(--duration 5 --scenario producer --client dekaf --message-size 1000)
-fi
-
-# --- Preflight checks ---
-
-if ! command -v dotnet-trace &>/dev/null && ! dotnet tool list -g 2>/dev/null | grep -q dotnet-trace; then
-    echo "ERROR: dotnet-trace not found. Install with: dotnet tool install -g dotnet-trace"
+fail() {
+    echo "ERROR: $*" >&2
     exit 1
+}
+
+is_positive_integer() {
+    [[ "$1" =~ ^[0-9]+$ ]] && (( 10#$1 > 0 ))
+}
+
+is_nonnegative_integer() {
+    [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+format_duration() {
+    local total="$1"
+    printf '%02d:%02d:%02d:%02d' \
+        "$((total / 86400))" "$(((total % 86400) / 3600))" \
+        "$(((total % 3600) / 60))" "$((total % 60))"
+}
+
+case "$TRACE_PROFILE" in
+    cpu)
+        DEFAULT_TRACE_PROVIDERS="Microsoft-DotNETCore-SampleProfiler"
+        ;;
+    contention)
+        DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000001C001:4,Microsoft-DotNETCore-SampleProfiler"
+        ;;
+    gc)
+        DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x0000000000480001:5,Microsoft-DotNETCore-SampleProfiler"
+        ;;
+    full)
+        DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000049C001:4,Microsoft-DotNETCore-SampleProfiler"
+        ;;
+    *)
+        fail "Unknown TRACE_PROFILE '$TRACE_PROFILE'. Use cpu, contention, gc, or full."
+        ;;
+esac
+TRACE_PROVIDERS="${TRACE_PROVIDERS:-$DEFAULT_TRACE_PROVIDERS}"
+
+IFS=',' read -r -a WINDOW_SPECS <<< "$TRACE_WINDOWS"
+WINDOW_OFFSETS=()
+WINDOW_DURATIONS=()
+WINDOW_LABELS=()
+declare -A SEEN_WINDOW_LABELS=()
+previous_end=0
+for spec in "${WINDOW_SPECS[@]}"; do
+    IFS=':' read -r offset duration label extra <<< "$spec"
+    [[ -n "${offset:-}" && -n "${duration:-}" && -n "${label:-}" && -z "${extra:-}" ]] \
+        || fail "Invalid trace window '$spec'; expected offset:duration:label."
+    is_nonnegative_integer "$offset" || fail "Window offset must be a non-negative integer: '$spec'."
+    is_positive_integer "$duration" || fail "Window duration must be a positive integer: '$spec'."
+    [[ "$label" =~ ^[A-Za-z0-9._-]+$ ]] || fail "Unsafe window label '$label'."
+    [[ -z "${SEEN_WINDOW_LABELS[$label]:-}" ]] || fail "Duplicate window label '$label'."
+    (( 10#$offset >= previous_end )) || fail "Trace windows must be sorted and non-overlapping: '$spec'."
+    WINDOW_OFFSETS+=("$((10#$offset))")
+    WINDOW_DURATIONS+=("$((10#$duration))")
+    WINDOW_LABELS+=("$label")
+    SEEN_WINDOW_LABELS[$label]=1
+    previous_end=$((10#$offset + 10#$duration))
+done
+(( ${#WINDOW_LABELS[@]} > 0 )) || fail "TRACE_WINDOWS must contain at least one window."
+
+STRESS_ARGS=("$@")
+if (( ${#STRESS_ARGS[@]} == 0 )); then
+    STRESS_ARGS=(--duration 15 --scenario producer --client dekaf --message-size 1000)
 fi
 
-if [ ! -f "$STRESS_EXE" ]; then
+stress_duration_minutes=""
+for ((i = 0; i < ${#STRESS_ARGS[@]}; i++)); do
+    if [[ "${STRESS_ARGS[$i]}" == "--duration" && $((i + 1)) -lt ${#STRESS_ARGS[@]} ]]; then
+        stress_duration_minutes="${STRESS_ARGS[$((i + 1))]}"
+        break
+    fi
+done
+is_positive_integer "$stress_duration_minutes" \
+    || fail "Stress arguments must contain '--duration <positive integer minutes>'."
+(( previous_end <= 10#$stress_duration_minutes * 60 )) \
+    || fail "Last trace window ends after the ${stress_duration_minutes}-minute measured phase."
+is_positive_integer "$PROFILE_START_TIMEOUT" || fail "PROFILE_START_TIMEOUT must be a positive integer."
+
+for toggle in PROFILE_COUNTERS PROFILE_STACKS PROFILE_VALIDATE_ONLY; do
+    value="${!toggle}"
+    [[ "$value" == "true" || "$value" == "false" ]] || fail "$toggle must be true or false."
+done
+
+if [[ "$PROFILE_VALIDATE_ONLY" == "true" ]]; then
+    echo "Valid profile: $TRACE_PROFILE; measured duration: ${stress_duration_minutes}m; windows: $TRACE_WINDOWS"
+    exit 0
+fi
+
+command -v dotnet-trace >/dev/null || fail "dotnet-trace not found."
+if [[ "$PROFILE_COUNTERS" == "true" ]]; then
+    command -v dotnet-counters >/dev/null || fail "dotnet-counters not found."
+fi
+if [[ "$PROFILE_STACKS" == "true" ]]; then
+    command -v dotnet-stack >/dev/null || fail "dotnet-stack not found."
+fi
+if [[ -n "${STRESS_CPUSET:-}" || -n "${PROFILER_CPUSET:-}" ]]; then
+    command -v taskset >/dev/null || fail "CPU affinity requested but taskset not found."
+fi
+
+if [[ ! -f "$STRESS_EXE" ]]; then
     echo "Building stress tests in Release mode..."
     dotnet build "$REPO_ROOT/tools/Dekaf.StressTests" --configuration Release -q
 fi
 
-# --- Start stress test ---
+mkdir -p "$PROFILE_OUTPUT_DIR"
+STRESS_LOG="$PROFILE_OUTPUT_DIR/stress-output.log"
+METADATA="$PROFILE_OUTPUT_DIR/profile-metadata.txt"
+: > "$STRESS_LOG"
 
-STRESS_LOG=$(mktemp)
+STRESS_PREFIX=()
+PROFILER_PREFIX=()
+[[ -n "${STRESS_CPUSET:-}" ]] && STRESS_PREFIX=(taskset -c "$STRESS_CPUSET")
+[[ -n "${PROFILER_CPUSET:-}" ]] && PROFILER_PREFIX=(taskset -c "$PROFILER_CPUSET")
 
-echo "Starting stress test: ${STRESS_ARGS[*]}"
-echo "Profile: $TRACE_PROFILE | Settle: ${TRACE_SETTLE_TIME}s | Trace: ${TRACE_DURATION}s"
-echo ""
-
-"$STRESS_EXE" "${STRESS_ARGS[@]}" > >(tee "$STRESS_LOG") 2>&1 &
-BASH_PID=$!
-
+STRESS_PID=0
+COUNTERS_PID=0
+PROFILE_FAILED=0
 cleanup() {
     local exit_code=$?
-    echo ""
-    echo "Cleaning up..."
-    kill "$BASH_PID" 2>/dev/null || true
-    wait "$BASH_PID" 2>/dev/null || true
-    # Also kill the Windows process if it's still running
-    taskkill //F //IM "Dekaf.StressTests.exe" >/dev/null 2>&1 || true
-    rm -f "$STRESS_LOG" 2>/dev/null || true
-    exit $exit_code
-}
-trap cleanup EXIT
-
-# On Windows/Git Bash, $! gives a bash PID, but dotnet trace needs the Windows PID.
-# Wait briefly for the process to start, then find the real PID.
-sleep 3
-if command -v tasklist &>/dev/null; then
-    STRESS_PID=$(tasklist 2>/dev/null | grep "Dekaf.StressTests" | awk '{print $2}' | head -1)
-else
-    STRESS_PID=$BASH_PID
-fi
-
-if [ -z "$STRESS_PID" ]; then
-    echo "ERROR: Could not find Dekaf.StressTests.exe process."
-    exit 1
-fi
-
-echo "Stress test PID: $STRESS_PID"
-echo "Waiting ${TRACE_SETTLE_TIME}s for warmup..."
-sleep "$TRACE_SETTLE_TIME"
-
-# Verify process is still alive
-if command -v tasklist &>/dev/null; then
-    if ! tasklist 2>/dev/null | grep -q "Dekaf.StressTests"; then
-        echo "ERROR: Stress test exited before trace could attach."
-        echo ""
-        echo "=== Stress test output ==="
-        cat "$STRESS_LOG"
-        exit 1
+    trap - EXIT INT TERM
+    if (( COUNTERS_PID > 0 )); then
+        kill -INT "$COUNTERS_PID" 2>/dev/null || true
+        wait "$COUNTERS_PID" 2>/dev/null || true
     fi
-elif ! kill -0 "$STRESS_PID" 2>/dev/null; then
-    echo "ERROR: Stress test exited before trace could attach."
-    echo ""
-    echo "=== Stress test output ==="
-    cat "$STRESS_LOG"
+    if (( STRESS_PID > 0 )); then
+        kill "$STRESS_PID" 2>/dev/null || true
+        wait "$STRESS_PID" 2>/dev/null || true
+        if [[ "${OS:-}" == "Windows_NT" ]]; then
+            taskkill //F //PID "$STRESS_PID" >/dev/null 2>&1 || true
+        fi
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting stress test: ${STRESS_ARGS[*]}"
+echo "Profile: $TRACE_PROFILE | windows: $TRACE_WINDOWS"
+"${STRESS_PREFIX[@]}" "$STRESS_EXE" "${STRESS_ARGS[@]}" > >(tee "$STRESS_LOG") 2>&1 &
+STRESS_PID=$!
+echo "Stress test PID: $STRESS_PID"
+
+start_waited=0
+until grep -Eq "$TRACE_START_PATTERN" "$STRESS_LOG"; do
+    kill -0 "$STRESS_PID" 2>/dev/null || fail "Stress test exited before measured phase started."
+    (( start_waited < 10#$PROFILE_START_TIMEOUT )) \
+        || fail "Measured phase marker not seen after ${PROFILE_START_TIMEOUT}s: $TRACE_START_PATTERN"
+    sleep 1
+    ((start_waited += 1))
+done
+MEASURED_START_EPOCH=$(date +%s)
+echo "Measured phase detected at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+{
+    echo "stress_pid=$STRESS_PID"
+    echo "measured_start_epoch=$MEASURED_START_EPOCH"
+    echo "trace_profile=$TRACE_PROFILE"
+    echo "trace_providers=$TRACE_PROVIDERS"
+    echo "trace_windows=$TRACE_WINDOWS"
+    echo "stress_cpuset=${STRESS_CPUSET:-unrestricted}"
+    echo "profiler_cpuset=${PROFILER_CPUSET:-unrestricted}"
+    printf 'stress_args='
+    printf '%q ' "${STRESS_ARGS[@]}"
+    echo
+} > "$METADATA"
+
+if [[ "$PROFILE_COUNTERS" == "true" ]]; then
+    echo "Starting System.Runtime counters..."
+    "${PROFILER_PREFIX[@]}" dotnet-counters collect \
+        --process-id "$STRESS_PID" \
+        --refresh-interval 1 \
+        --format csv \
+        --output "$PROFILE_OUTPUT_DIR/runtime-counters.csv" \
+        --counters System.Runtime \
+        > "$PROFILE_OUTPUT_DIR/runtime-counters.log" 2>&1 &
+    COUNTERS_PID=$!
+fi
+
+for ((i = 0; i < ${#WINDOW_LABELS[@]}; i++)); do
+    offset="${WINDOW_OFFSETS[$i]}"
+    duration="${WINDOW_DURATIONS[$i]}"
+    label="${WINDOW_LABELS[$i]}"
+    while (( $(date +%s) - MEASURED_START_EPOCH < offset )); do
+        kill -0 "$STRESS_PID" 2>/dev/null || fail "Stress test exited before '$label' window."
+        sleep 1
+    done
+
+    echo "Capturing '$label' at +${offset}s for ${duration}s..."
+    if [[ "$PROFILE_STACKS" == "true" ]]; then
+        if ! "${PROFILER_PREFIX[@]}" dotnet-stack report --process-id "$STRESS_PID" \
+            > "$PROFILE_OUTPUT_DIR/${label}.stacks.txt" 2>&1; then
+            echo "WARNING: stack capture failed for '$label'."
+            PROFILE_FAILED=1
+        fi
+    fi
+
+    trace_path="$PROFILE_OUTPUT_DIR/${label}.nettrace"
+    if ! "${PROFILER_PREFIX[@]}" dotnet-trace collect \
+        --process-id "$STRESS_PID" \
+        --output "$trace_path" \
+        --providers "$TRACE_PROVIDERS" \
+        --duration "$(format_duration "$duration")" \
+        > "$PROFILE_OUTPUT_DIR/${label}.collect.log" 2>&1; then
+        echo "WARNING: trace capture failed for '$label'."
+        PROFILE_FAILED=1
+    fi
+done
+
+set +e
+wait "$STRESS_PID"
+STRESS_EXIT=$?
+set -e
+STRESS_PID=0
+
+if (( COUNTERS_PID > 0 )); then
+    kill -INT "$COUNTERS_PID" 2>/dev/null || true
+    wait "$COUNTERS_PID" 2>/dev/null || true
+    COUNTERS_PID=0
+    if [[ ! -s "$PROFILE_OUTPUT_DIR/runtime-counters.csv" ]]; then
+        echo "WARNING: runtime counter capture produced no data."
+        PROFILE_FAILED=1
+    fi
+fi
+
+# Analyze only after the measurement ends, so report/convert CPU cannot perturb it.
+for label in "${WINDOW_LABELS[@]}"; do
+    trace_path="$PROFILE_OUTPUT_DIR/${label}.nettrace"
+    [[ -f "$trace_path" ]] || continue
+    echo "Analyzing '$label'..."
+    "${PROFILER_PREFIX[@]}" dotnet-trace report "$trace_path" topN -n 50 \
+        > "$PROFILE_OUTPUT_DIR/${label}.topN-exclusive.txt" 2>&1 || true
+    "${PROFILER_PREFIX[@]}" dotnet-trace report "$trace_path" topN --inclusive -n 50 \
+        > "$PROFILE_OUTPUT_DIR/${label}.topN-inclusive.txt" 2>&1 || true
+    "${PROFILER_PREFIX[@]}" dotnet-trace convert "$trace_path" --format Speedscope \
+        --output "$PROFILE_OUTPUT_DIR/${label}.speedscope.json" \
+        > "$PROFILE_OUTPUT_DIR/${label}.convert.log" 2>&1 || true
+done
+
+echo "Profile artifacts: $PROFILE_OUTPUT_DIR"
+if (( PROFILE_FAILED > 0 && STRESS_EXIT == 0 )); then
     exit 1
 fi
-
-# --- Attach trace ---
-
-echo "Attaching dotnet-trace for ${TRACE_DURATION}s (profile: $TRACE_PROFILE)..."
-echo "Providers: $TRACE_PROVIDERS"
-echo "Output: $TRACE_OUTPUT"
-echo ""
-
-# dotnet trace --duration uses HH:MM:SS format
-HOURS=$((TRACE_DURATION / 3600))
-MINS=$(( (TRACE_DURATION % 3600) / 60 ))
-SECS=$((TRACE_DURATION % 60))
-DURATION_FMT=$(printf '%02d:%02d:%02d' "$HOURS" "$MINS" "$SECS")
-
-if ! dotnet trace collect \
-    --process-id "$STRESS_PID" \
-    --output "$TRACE_OUTPUT" \
-    --providers "$TRACE_PROVIDERS" \
-    --duration "$DURATION_FMT" \
-    2>&1; then
-    echo "WARNING: dotnet trace collect failed (process may have exited during collection)"
-fi
-
-echo ""
-echo "Trace complete: $TRACE_OUTPUT"
-echo ""
-
-# --- Wait for stress test to finish (captures throughput output) ---
-
-if [ "$WAIT_FOR_EXIT" = "true" ]; then
-    echo "Waiting for stress test to finish..."
-    # Disable exit-on-error for wait since the process may have been killed
-    set +e
-    wait "$BASH_PID" 2>/dev/null
-    STRESS_EXIT=$?
-    set -e
-
-    # Reset BASH_PID so cleanup doesn't try to kill again
-    BASH_PID=0
-
-    echo ""
-    echo "============================================"
-    echo "=== Stress Test Results ==="
-    echo "============================================"
-    # Show the throughput/results portion of the output (skip container startup noise)
-    grep -E '(msg/sec|MB/sec|messages|throughput|Total|Average|Median|P99|P95|p50|p95|p99|percentile|Duration|Results|===|Completed|Progress|GC|Gen[012]|Allocated|Ratio|Client|Flushing|Resources)' "$STRESS_LOG" 2>/dev/null || cat "$STRESS_LOG"
-    echo ""
-fi
-
-# --- Trace Report ---
-
-echo "============================================"
-echo "=== Trace Analysis ==="
-echo "============================================"
-echo ""
-
-echo "--- Top 30 methods by exclusive CPU time ---"
-dotnet trace report "$TRACE_OUTPUT" topN -n 30 2>&1 || echo "(report failed — trace may be too short)"
-
-echo ""
-echo "--- Top 30 methods by inclusive CPU time ---"
-dotnet trace report "$TRACE_OUTPUT" topN --inclusive -n 30 2>&1 || echo "(report failed)"
-
-echo ""
-
-# --- Speedscope conversion ---
-
-SPEEDSCOPE_OUTPUT="${TRACE_OUTPUT%.nettrace}.speedscope.json"
-echo "Converting to Speedscope format..."
-if dotnet trace convert "$TRACE_OUTPUT" --format Speedscope --output "$SPEEDSCOPE_OUTPUT" 2>&1; then
-    echo "Speedscope file: $SPEEDSCOPE_OUTPUT"
-    echo "Open in https://www.speedscope.app/"
-else
-    echo "(Speedscope conversion failed)"
-fi
-
-echo ""
-echo "Done."
+exit "$STRESS_EXIT"


### PR DESCRIPTION
## Summary
- anchor diagnostics to the measured stress phase, not process launch
- collect continuous System.Runtime counters plus named dotnet-trace/dotnet-stack windows
- restrict profiling to one explicit Dekaf lane and exclude diagnostic runs from published acceptance trends
- preserve client CPU isolation and pin attach tools separately

## Validation
- bash -n tools/profile-stress-test.sh
- python -m unittest discover -s .github/scripts -p 'test_stress_*.py' (73 tests)
- workflow YAML parse

Supports diagnosis of #2108
