### PR TITLE
fix(producer): persist proven request depth

### DIFF
--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -194,6 +194,14 @@ internal static class DekafMetrics
         "Complete seal-to-ack delivery latency EWMA per broker.",
         static budget => budget.SealToAckLatencyEwmaMicros);
 
+    internal static readonly ObservableGauge<double> ProducerBrokerProvenPipelineRequestQuanta =
+        DekafDiagnostics.Meter.CreateObservableGauge(
+            "dekaf.producer.broker.proven_pipeline_request_quanta",
+            observeValues: () => ObserveProducers(static source => source.BudgetValues<double>(
+                static budget => budget.ProvenPipelineRequestQuanta)),
+            unit: "{request}",
+            description: "Persisted request-depth floor proven by capacity probes per broker.");
+
     internal static readonly ObservableGauge<double> ProducerBrokerLatencyBudgetScale =
         DekafDiagnostics.Meter.CreateObservableGauge(
             "dekaf.producer.broker.latency_budget_scale",

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -189,6 +189,11 @@ internal static class DekafMetrics
         "Seal-to-send queue latency EWMA per broker.",
         static budget => budget.DeliveryLatencyEwmaMicros);
 
+    internal static readonly ObservableGauge<long> ProducerBrokerSealToAckLatencyEwma = BudgetGauge(
+        "dekaf.producer.broker.seal_to_ack_latency_ewma", "us",
+        "Complete seal-to-ack delivery latency EWMA per broker.",
+        static budget => budget.SealToAckLatencyEwmaMicros);
+
     internal static readonly ObservableGauge<double> ProducerBrokerLatencyBudgetScale =
         DekafDiagnostics.Meter.CreateObservableGauge(
             "dekaf.producer.broker.latency_budget_scale",

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3400,7 +3400,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _totalMaxInFlightBytes = GetInFlightByteBudget(connectionCount);
         _unackedBudget?.SetCap(
             _options.UnackedByteBudgetCapOverride ?? _totalMaxInFlightBytes,
-            _getTimestamp());
+            _getTimestamp(),
+            connectionCount);
     }
 
     private static long SumEncodedBytes(List<PendingResponse> pendingResponses)

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -30,10 +30,11 @@ internal readonly record struct BrokerBudgetProbeEvent(
 /// so that producer queueing latency stays near <see cref="ProducerOptions.DeliveryLatencyTargetMs"/>
 /// instead of growing to the full <see cref="ProducerOptions.BufferMemory"/> reservoir.
 /// Under open-loop saturation, append-to-ack latency equals standing unacked bytes divided
-/// by the broker's drain rate; capping the standing bytes to
-/// <c>target × measured drain rate</c> caps the latency. The RTT safety horizon uses a
-/// periodically refreshed minimum RTT or the loaded serving RTT, capped by the latency target
-/// but never below one measured BDP so replicated service time still keeps the pipe full.
+/// by the broker's drain rate, plus serving RTT. Capping standing bytes to
+/// <c>(target - servingRtt) × measured drain rate</c> therefore caps end-to-end latency.
+/// The RTT safety horizon uses a periodically refreshed minimum RTT or loaded serving RTT,
+/// capped by the remaining latency horizon but never below one minimum-RTT BDP so replicated
+/// service time still keeps the pipe full.
 /// Raw round trips include the drain time of bytes the budget
 /// itself admitted ahead of the request, so RTT samples are queue-corrected at intake (raw
 /// RTT minus unacked-at-send over the measured max rate) before feeding the minimum and
@@ -1485,7 +1486,13 @@ internal sealed class BrokerUnackedByteBudget
                 : Math.Max(
                     RttSafetyMultiplier * loadAwareRttSeconds,
                     MinimumNormalHorizonSeconds);
-            var latencyCapSeconds = Math.Max(latencyGovernedTargetSeconds, minRttSeconds);
+            // DeliveryLatencyTarget covers the complete produce-to-ack journey. Reserve the
+            // measured serving RTT inside that horizon so persisted request depth cannot fill
+            // the target with standing flight and then add broker service time on top. Retain
+            // one minimum-RTT BDP when the configured target is shorter than path service time.
+            var latencyCapSeconds = Math.Max(
+                latencyGovernedTargetSeconds - loadAwareRttSeconds,
+                minRttSeconds);
             var horizonSeconds = _hasMinRttSample
                 ? Math.Min(rttSafetyHorizonSeconds, latencyCapSeconds)
                 : latencyGovernedTargetSeconds;
@@ -1502,8 +1509,9 @@ internal sealed class BrokerUnackedByteBudget
                 // the latency cap bounds it. General capacity discovery remains the job of
                 // the periodic 25% probes below — this floor only crosses coarse request
                 // granularity that a smaller byte probe cannot expose. Successful capacity
-                // probes persist higher proven quanta here; the latency cap still supplies
-                // the downward bound when that deeper flight starts queueing.
+                // probes persist higher proven quanta here; the latency cap, after reserving
+                // serving RTT, still supplies the downward bound when that deeper flight
+                // starts queueing.
                 var requestPipelineHorizonSeconds =
                     _provenPipelineRequestQuanta * _requestSizeEwmaBytes / effectiveMaxRate;
                 horizonSeconds = Math.Max(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -276,8 +276,8 @@ internal sealed class BrokerUnackedByteBudget
     private double _requestSizeEwmaBytes;
     // Capacity probes raise this per-connection request-depth floor only after proving that
     // larger flight increases delivery rate without inflating RTT or seal-to-ack latency. It
-    // survives an individual probe ending, but remains within the full wire ceiling. Sustained
-    // idle resets path evidence.
+    // survives an individual probe ending, but remains within the full wire ceiling. Actionable
+    // over-target latency decays stale evidence; sustained idle resets it.
     private double _provenPipelineRequestQuanta;
     private int _connectionCount;
     private bool _hasLoadedServingSample;
@@ -967,8 +967,24 @@ internal sealed class BrokerUnackedByteBudget
             _latencyBudgetScale * adjustment,
             MinimumLatencyBudgetScale,
             1.0));
+        DecayProvenPipelineRequestQuanta(adjustment);
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
         return sealToAckSeconds;
+    }
+
+    private void DecayProvenPipelineRequestQuanta(double adjustment)
+    {
+        var minimum = GetMinimumPipelineRequestQuanta();
+        if (adjustment >= 1.0 || _provenPipelineRequestQuanta <= minimum)
+            return;
+
+        // The scale is transient and recovers after the queue drains. Apply the same
+        // controller decrease to persistent proof so isolated false-positive probe rungs do
+        // not return as soon as the scale reaches one. This method is reached only after the
+        // sender-backlog/underfilled-wire actionability guard above.
+        Volatile.Write(
+            ref _provenPipelineRequestQuanta,
+            Math.Max(minimum, _provenPipelineRequestQuanta * adjustment));
     }
 
     private void UpdateAdmissionPressure()

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -1226,6 +1226,8 @@ internal sealed class BrokerUnackedByteBudget
         {
             if (nowTicks >= _capacityProbeDeadlineTimestamp)
             {
+                // This was only an untreated control window. No enlarged candidate budget
+                // opened, so a traffic-thinned baseline is not a capacity-probe failure.
                 CompleteCapacityProbeSession();
                 _nextProbeTimestamp = nowTicks + CapacityProbeCooldownTicks;
                 return;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -118,6 +118,11 @@ internal sealed class BrokerUnackedByteBudget
     /// the delivery-latency target with queueing delay.</summary>
     private const int MinimumPipelineRequestQuanta = 4;
 
+    /// <summary>Paired stress measurements bound one acknowledgement clock at six persisted
+    /// requests: deeper flight pins median delivery latency without adding useful throughput.
+    /// Parallel connections retain independent capacity discovery up to their wire limit.</summary>
+    private const int SingleConnectionMaximumPipelineRequestQuanta = 6;
+
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
     /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
@@ -1395,7 +1400,9 @@ internal sealed class BrokerUnackedByteBudget
     {
         var connectionCount = _connectionCount;
         var minimum = MinimumPipelineRequestQuanta * connectionCount;
-        var wireLimit = (double)CapBatchMultiplier * connectionCount;
+        var wireLimit = connectionCount == 1
+            ? SingleConnectionMaximumPipelineRequestQuanta
+            : (double)CapBatchMultiplier * connectionCount;
         return _requestSizeEwmaBytes > 0
             ? Math.Max(minimum, Math.Min(wireLimit, _capBytes / _requestSizeEwmaBytes))
             : wireLimit;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -199,9 +199,8 @@ internal sealed class BrokerUnackedByteBudget
     /// still converge when the path's base RTT has genuinely increased.</summary>
     private const double MinRttRefreshGrowthFactor = 1.25;
 
-    private const int ProbeIntervalRtts = 8;
-    // A capacity probe needs one RTT for the enlarged budget to reach the wire,
-    // then three wholly-probed RTTs to average before accepting or rejecting growth.
+    // A capacity probe needs one RTT for the enlarged budget to reach the wire, then at
+    // least three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
     /// <summary>Only probe when standing demand fills at least this fraction of the gate;
@@ -216,7 +215,13 @@ internal sealed class BrokerUnackedByteBudget
     /// latency cost. Comparing deltas avoids granting every rung a fresh fixed 10% latency
     /// allowance that compounds into standing queue as proof advances.</summary>
     private const double ProbeSealToAckEfficiencyTolerance = 1.10;
-    private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
+    private const int ProbeScheduleRtts = 8;
+    // Same-budget baseline/candidate windows must span scheduler and response clustering
+    // noise, and completed sessions must not turn that noise into thousands of upward votes.
+    private static readonly long MinimumCapacityProbeEvaluationTicks = Math.Max(
+        1,
+        Stopwatch.Frequency / 10);
+    private static readonly long CapacityProbeCooldownTicks = Stopwatch.Frequency;
     // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
     private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
     // Shorter loaded epochs are dominated by timer, scheduler, and burst quantization on common hosts.
@@ -251,8 +256,6 @@ internal sealed class BrokerUnackedByteBudget
     private readonly long _probeResponseHorizonTicks;
     private long _capBytes;
     private readonly double[] _rateBucketMaxValues = new double[WindowBucketCount];
-    private readonly double[] _rateBucketSums = new double[WindowBucketCount];
-    private readonly int[] _rateBucketSampleCounts = new int[WindowBucketCount];
     private readonly long[] _occupancyBucketMaxValues = new long[WindowBucketCount];
     // Per-request diagnostics: log2 histograms of acked request sizes and RTTs. Incremented
     // only by the owning send loop; snapshot copies use per-element volatile reads, so
@@ -266,13 +269,10 @@ internal sealed class BrokerUnackedByteBudget
     private long _admissionBlockedSinceTimestamp;
     private long _currentWindowBucket = long.MinValue;
     private double _windowMaxRate;
-    private double _windowRateSum;
-    private int _windowRateSampleCount;
     private double _retainedLoadedMaxRate;
     private long _windowMaxOccupancyBytes;
     private double _minRttSeconds;
     private double _servingRttEwmaSeconds;
-    private double _rawServingRttEwmaSeconds;
     private double _requestSizeEwmaBytes;
     // Capacity probes raise this per-connection request-depth floor only after proving that
     // larger flight increases delivery rate without inflating RTT or seal-to-ack latency. It
@@ -301,6 +301,7 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbePreProbeSealToAckSeconds;
     private int _capacityProbeRateSampleCount;
     private int _capacityProbeSealToAckSampleCount;
+    private bool _capacityProbeBaselineActive;
     private bool _capacityProbeActive;
     private long _capacityProbeSuccessCount;
     private long _capacityProbeFailureCount;
@@ -724,8 +725,13 @@ internal sealed class BrokerUnackedByteBudget
                 GetMinimumPipelineRequestQuanta(),
                 GetMaximumPipelineRequestQuanta()));
         CompleteExpiredMinRttProbe(nowTicks);
-        if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
-            DeactivateCapacityProbe(nowTicks);
+        if (nowTicks >= _capacityProbeDeadlineTimestamp)
+        {
+            if (_capacityProbeActive)
+                DeactivateCapacityProbe(nowTicks);
+            else if (_capacityProbeBaselineActive)
+                CompleteCapacityProbeSession();
+        }
         RecomputeBudget(nowTicks);
         if (!IsOverBudgetAt(nowTicks))
             RecordAdmissionAvailable(nowTicks);
@@ -793,13 +799,6 @@ internal sealed class BrokerUnackedByteBudget
             _servingRttEwmaSeconds = UpdateEwma(
                 _servingRttEwmaSeconds,
                 serviceRttSeconds,
-                ServingRttEwmaWeight);
-            // Raw (uncorrected) companion estimate for the capacity probe: probe samples are
-            // raw round trips, so their acceptance baseline must live in the same domain —
-            // a corrected baseline under standing load would reject every probe.
-            _rawServingRttEwmaSeconds = UpdateEwma(
-                _rawServingRttEwmaSeconds,
-                rttSeconds,
                 ServingRttEwmaWeight);
         }
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
@@ -1144,12 +1143,8 @@ internal sealed class BrokerUnackedByteBudget
         if (elapsed >= WindowBucketCount)
         {
             Array.Clear(_rateBucketMaxValues);
-            Array.Clear(_rateBucketSums);
-            Array.Clear(_rateBucketSampleCounts);
             Array.Clear(_occupancyBucketMaxValues);
             _windowMaxRate = 0;
-            _windowRateSum = 0;
-            _windowRateSampleCount = 0;
             _windowMaxOccupancyBytes = 0;
         }
         else
@@ -1162,11 +1157,7 @@ internal sealed class BrokerUnackedByteBudget
                 recomputeRate |= _windowMaxRate > 0 && _rateBucketMaxValues[slot] >= _windowMaxRate;
                 recomputeOccupancy |= _windowMaxOccupancyBytes > 0
                     && _occupancyBucketMaxValues[slot] >= _windowMaxOccupancyBytes;
-                _windowRateSum -= _rateBucketSums[slot];
-                _windowRateSampleCount -= _rateBucketSampleCounts[slot];
                 _rateBucketMaxValues[slot] = 0;
-                _rateBucketSums[slot] = 0;
-                _rateBucketSampleCounts[slot] = 0;
                 _occupancyBucketMaxValues[slot] = 0;
             }
 
@@ -1192,11 +1183,7 @@ internal sealed class BrokerUnackedByteBudget
     {
         var slot = (int)(_currentWindowBucket % WindowBucketCount);
         _rateBucketMaxValues[slot] = Math.Max(_rateBucketMaxValues[slot], bytesPerSecond);
-        _rateBucketSums[slot] += bytesPerSecond;
-        _rateBucketSampleCounts[slot]++;
         _windowMaxRate = Math.Max(_windowMaxRate, bytesPerSecond);
-        _windowRateSum += bytesPerSecond;
-        _windowRateSampleCount++;
         if (sustainedIdle)
             _retainedLoadedMaxRate = 0;
         else if (loadedSample)
@@ -1204,10 +1191,6 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     private double GetEffectiveMaxRate() => Math.Max(_windowMaxRate, _retainedLoadedMaxRate);
-
-    private double GetWindowAverageRate() => _windowRateSampleCount > 0
-        ? _windowRateSum / _windowRateSampleCount
-        : 0;
 
     private void AddOccupancySample(long bytes)
     {
@@ -1224,22 +1207,60 @@ internal sealed class BrokerUnackedByteBudget
         double sealToAckSeconds,
         long nowTicks)
     {
-        var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
+        var probeScheduleIntervalTicks = GetCapacityProbeScheduleIntervalTicks(rttTicks);
         var evaluationWindowTicks = Math.Max(
-            ProbeEvaluationRtts * rttTicks,
-            _probeResponseHorizonTicks);
+            MinimumCapacityProbeEvaluationTicks,
+            Math.Max(ProbeEvaluationRtts * rttTicks, _probeResponseHorizonTicks));
         var probeDurationTicks = Math.Max(
-            probeIntervalTicks,
+            probeScheduleIntervalTicks,
             rttTicks + evaluationWindowTicks);
         if (_nextProbeTimestamp == 0)
-            _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+            _nextProbeTimestamp = nowTicks + probeScheduleIntervalTicks;
+
+        if (_capacityProbeBaselineActive)
+        {
+            if (nowTicks >= _capacityProbeDeadlineTimestamp)
+            {
+                CompleteCapacityProbeSession();
+                _nextProbeTimestamp = nowTicks + CapacityProbeCooldownTicks;
+                return;
+            }
+
+            // Compare only work admitted after the control window began. This uses the
+            // same per-request rate, RTT, and seal-to-ack path as the candidate phase.
+            if (admissionTimestamp < _capacityProbeStartTimestamp)
+                return;
+
+            AddCapacityProbeSample(bytesPerSecond, rttSeconds, sealToAckSeconds);
+            if (!CapacityProbeEvaluationWindowElapsed(nowTicks, evaluationWindowTicks, rttTicks))
+                return;
+
+            _capacityProbeBaselineRate =
+                _capacityProbeRateSum / _capacityProbeRateSampleCount;
+            _capacityProbePreProbeRttSeconds =
+                _capacityProbeRttSumSeconds / _capacityProbeRateSampleCount;
+            _capacityProbePreProbeSealToAckSeconds = _capacityProbeSealToAckSampleCount > 0
+                ? _capacityProbeSealToAckSumSeconds / _capacityProbeSealToAckSampleCount
+                : 0;
+            _capacityProbeStartTimestamp = nowTicks;
+            ResetCapacityProbeSamples();
+            Volatile.Write(ref _capacityProbeBaselineActive, false);
+            Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
+            Volatile.Write(ref _capacityProbeActive, true);
+            RecordProbeEvent(
+                BrokerBudgetProbeType.Capacity,
+                BrokerBudgetProbeOutcome.Started,
+                nowTicks,
+                nowTicks);
+            return;
+        }
 
         if (_capacityProbeActive)
         {
             if (nowTicks >= _capacityProbeDeadlineTimestamp)
             {
                 DeactivateCapacityProbe(nowTicks);
-                _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+                _nextProbeTimestamp = nowTicks + CapacityProbeCooldownTicks;
                 return;
             }
 
@@ -1249,24 +1270,8 @@ internal sealed class BrokerUnackedByteBudget
             if (admissionTimestamp < _capacityProbeStartTimestamp)
                 return;
 
-            _capacityProbeRateSum += bytesPerSecond;
-            _capacityProbeRttSumSeconds += rttSeconds;
-            _capacityProbeRateSampleCount++;
-            if (sealToAckSeconds > 0)
-            {
-                _capacityProbeSealToAckSumSeconds += sealToAckSeconds;
-                _capacityProbeSealToAckSampleCount++;
-            }
-            if (_capacityProbeEvaluationDeadlineTimestamp == 0)
-            {
-                _capacityProbeEvaluationDeadlineTimestamp = nowTicks + evaluationWindowTicks;
-                Volatile.Write(
-                    ref _capacityProbeDeadlineTimestamp,
-                    Math.Max(_capacityProbeDeadlineTimestamp, nowTicks + evaluationWindowTicks));
-                return;
-            }
-
-            if (nowTicks < _capacityProbeEvaluationDeadlineTimestamp)
+            AddCapacityProbeSample(bytesPerSecond, rttSeconds, sealToAckSeconds);
+            if (!CapacityProbeEvaluationWindowElapsed(nowTicks, evaluationWindowTicks, rttTicks))
                 return;
 
             // Real headroom raises rate without buying proportionally more delivery latency.
@@ -1282,16 +1287,6 @@ internal sealed class BrokerUnackedByteBudget
                 && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold
                 && CapacityProbePreservedSealToAckEfficiency(averageRate))
             {
-                // Compare like with like across rungs. A single clustered-response peak is not
-                // a sustainable baseline and would make the next average-rate rung unwinnable.
-                _capacityProbeBaselineRate = averageRate;
-                _capacityProbePreProbeRttSeconds = averageRttSeconds;
-                if (_capacityProbeSealToAckSampleCount > 0)
-                {
-                    _capacityProbePreProbeSealToAckSeconds =
-                        _capacityProbeSealToAckSumSeconds
-                        / _capacityProbeSealToAckSampleCount;
-                }
                 Volatile.Write(
                     ref _provenPipelineRequestQuanta,
                     Math.Min(
@@ -1302,15 +1297,14 @@ internal sealed class BrokerUnackedByteBudget
                     BrokerBudgetProbeOutcome.Succeeded,
                     nowTicks,
                     _capacityProbeStartTimestamp);
-                _capacityProbeStartTimestamp = nowTicks;
-                ResetCapacityProbeSamples();
                 Interlocked.Increment(ref _capacityProbeSuccessCount);
-                Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
+                CompleteCapacityProbeSession();
+                _nextProbeTimestamp = nowTicks + CapacityProbeCooldownTicks;
             }
             else
             {
                 DeactivateCapacityProbe(nowTicks);
-                _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+                _nextProbeTimestamp = nowTicks + CapacityProbeCooldownTicks;
             }
 
             return;
@@ -1319,30 +1313,18 @@ internal sealed class BrokerUnackedByteBudget
         if (nowTicks < _nextProbeTimestamp)
             return;
 
-        if (nowTicks - _nextProbeTimestamp < probeIntervalTicks
+        if (nowTicks - _nextProbeTimestamp < probeScheduleIntervalTicks
             && HasCapacityProbeDemand())
         {
             _capacityProbeStartTimestamp = nowTicks;
-            _capacityProbeBaselineRate = GetWindowAverageRate();
-            // Raw-domain baseline to match the raw probe samples; the queue-corrected
-            // serving EWMA sits below loaded round trips and would fail every probe.
-            _capacityProbePreProbeRttSeconds = _rawServingRttEwmaSeconds > 0
-                ? _rawServingRttEwmaSeconds
-                : rttSeconds;
-            _capacityProbePreProbeSealToAckSeconds = _sealToAckEwmaSeconds;
             ResetCapacityProbeSamples();
             Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
-            Volatile.Write(ref _capacityProbeActive, true);
-            RecordProbeEvent(
-                BrokerBudgetProbeType.Capacity,
-                BrokerBudgetProbeOutcome.Started,
-                nowTicks,
-                nowTicks);
+            Volatile.Write(ref _capacityProbeBaselineActive, true);
         }
 
         // A schedule missed by a full interval represents producer idle time, not an
         // active-pipeline probe opportunity. Re-arm instead of probing on resume.
-        _nextProbeTimestamp = nowTicks + probeIntervalTicks;
+        _nextProbeTimestamp = nowTicks + probeScheduleIntervalTicks;
     }
 
     private bool HasCapacityProbeDemand()
@@ -1354,10 +1336,44 @@ internal sealed class BrokerUnackedByteBudget
         return Volatile.Read(ref _unackedBytes) >= minimumDemandBytes;
     }
 
-    private static long GetProbeIntervalTicks(long rttTicks)
-        => rttTicks >= MaxProbeIntervalTicks / ProbeIntervalRtts
-            ? MaxProbeIntervalTicks
-            : ProbeIntervalRtts * rttTicks;
+    private static long GetCapacityProbeScheduleIntervalTicks(long rttTicks)
+        => rttTicks >= CapacityProbeCooldownTicks / ProbeScheduleRtts
+            ? CapacityProbeCooldownTicks
+            : ProbeScheduleRtts * rttTicks;
+
+    private void AddCapacityProbeSample(
+        double bytesPerSecond,
+        double rttSeconds,
+        double sealToAckSeconds)
+    {
+        _capacityProbeRateSum += bytesPerSecond;
+        _capacityProbeRttSumSeconds += rttSeconds;
+        _capacityProbeRateSampleCount++;
+        if (sealToAckSeconds > 0)
+        {
+            _capacityProbeSealToAckSumSeconds += sealToAckSeconds;
+            _capacityProbeSealToAckSampleCount++;
+        }
+    }
+
+    private bool CapacityProbeEvaluationWindowElapsed(
+        long nowTicks,
+        long evaluationWindowTicks,
+        long rttTicks)
+    {
+        if (_capacityProbeEvaluationDeadlineTimestamp == 0)
+        {
+            _capacityProbeEvaluationDeadlineTimestamp = nowTicks + evaluationWindowTicks;
+            Volatile.Write(
+                ref _capacityProbeDeadlineTimestamp,
+                Math.Max(
+                    _capacityProbeDeadlineTimestamp,
+                    _capacityProbeEvaluationDeadlineTimestamp + rttTicks));
+            return false;
+        }
+
+        return nowTicks >= _capacityProbeEvaluationDeadlineTimestamp;
+    }
 
     private void ResetCapacityProbeSamples()
     {
@@ -1414,7 +1430,13 @@ internal sealed class BrokerUnackedByteBudget
                 _capacityProbeStartTimestamp);
         }
 
+        CompleteCapacityProbeSession();
+    }
+
+    private void CompleteCapacityProbeSession()
+    {
         ResetCapacityProbeSamples();
+        Volatile.Write(ref _capacityProbeBaselineActive, false);
         Volatile.Write(ref _capacityProbeActive, false);
         Volatile.Write(ref _capacityProbeDeadlineTimestamp, 0);
     }

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -118,11 +118,12 @@ internal sealed class BrokerUnackedByteBudget
     /// the delivery-latency target with queueing delay.</summary>
     private const int MinimumPipelineRequestQuanta = 4;
 
-    /// <summary>Maximum low-RTT request floor persisted per active connection. Higher-RTT
-    /// bandwidth-delay products remain governed by the independent RTT safety horizon; this
-    /// bound only prevents capacity probes from turning request granularity into a full
-    /// 32-request-per-connection standing queue.</summary>
-    private const int MaximumPersistedPipelineRequestQuantaPerConnection = 8;
+    /// <summary>Additional persistent request headroom contributed by each active connection.
+    /// The aggregate proof ceiling is <c>connectionCount × (4 + 2 × connectionCount)</c>:
+    /// one connection stops at six requests before median latency pins at the target, while
+    /// wider senders can feed their independent acknowledgement clocks. The latency horizon
+    /// and byte cap still bound actual standing flight.</summary>
+    private const int PersistedPipelineHeadroomRequestQuantaPerConnection = 2;
 
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
@@ -1334,8 +1335,11 @@ internal sealed class BrokerUnackedByteBudget
 
     private double GetMaximumPipelineRequestQuanta()
     {
-        var minimum = GetMinimumPipelineRequestQuanta();
-        var persistentLimit = MaximumPersistedPipelineRequestQuantaPerConnection * _connectionCount;
+        var connectionCount = _connectionCount;
+        var minimum = MinimumPipelineRequestQuanta * connectionCount;
+        var requestQuantaPerConnection = MinimumPipelineRequestQuanta
+            + PersistedPipelineHeadroomRequestQuantaPerConnection * connectionCount;
+        var persistentLimit = requestQuantaPerConnection * connectionCount;
         return _requestSizeEwmaBytes > 0
             ? Math.Max(minimum, Math.Min(persistentLimit, _capBytes / _requestSizeEwmaBytes))
             : persistentLimit;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -118,6 +118,12 @@ internal sealed class BrokerUnackedByteBudget
     /// the delivery-latency target with queueing delay.</summary>
     private const int MinimumPipelineRequestQuanta = 4;
 
+    /// <summary>Maximum low-RTT request floor persisted per active connection. Higher-RTT
+    /// bandwidth-delay products remain governed by the independent RTT safety horizon; this
+    /// bound only prevents capacity probes from turning request granularity into a full
+    /// 32-request-per-connection standing queue.</summary>
+    private const int MaximumPersistedPipelineRequestQuantaPerConnection = 8;
+
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
     /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
@@ -270,11 +276,11 @@ internal sealed class BrokerUnackedByteBudget
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
     private double _requestSizeEwmaBytes;
-    // Capacity probes raise this request-depth floor only after proving that the larger
-    // flight increases delivery rate without inflating RTT. It survives an individual
-    // probe ending so normal admission does not fall back to the self-confirming four-
-    // request floor after every successful rung. Sustained idle resets path evidence.
-    private double _provenPipelineRequestQuanta = MinimumPipelineRequestQuanta;
+    // Capacity probes raise this per-connection request-depth floor only after proving that
+    // larger flight increases delivery rate without inflating RTT. It survives an individual
+    // probe ending, but remains below the full wire ceiling. Sustained idle resets path evidence.
+    private double _provenPipelineRequestQuanta;
+    private int _connectionCount;
     private bool _hasLoadedServingSample;
     private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
@@ -309,7 +315,8 @@ internal sealed class BrokerUnackedByteBudget
         long floorBytes,
         long initialCapBytes,
         double lingerSeconds = 0,
-        bool enableDiagnostics = false)
+        bool enableDiagnostics = false,
+        int initialConnectionCount = 1)
     {
         _targetSeconds = targetSeconds;
         _probeResponseHorizonTicks = Math.Max(
@@ -317,6 +324,8 @@ internal sealed class BrokerUnackedByteBudget
             (long)(Math.Max(0, targetSeconds + lingerSeconds) * Stopwatch.Frequency));
         _floorBytes = Math.Max(1, floorBytes);
         _capBytes = Math.Max(_floorBytes, initialCapBytes);
+        _connectionCount = Math.Max(1, initialConnectionCount);
+        _provenPipelineRequestQuanta = GetMinimumPipelineRequestQuanta();
         _lastNormalBudgetBytes = _capBytes;
         Volatile.Write(ref _budgetBytes, _capBytes);
         Volatile.Write(ref _budgetAfterMinRttProbeBytes, _capBytes);
@@ -693,8 +702,22 @@ internal sealed class BrokerUnackedByteBudget
     /// Called by the owning send loop at construction and on connection scale events.
     /// </summary>
     public void SetCap(long capBytes, long nowTicks)
+        => SetCap(capBytes, nowTicks, _connectionCount);
+
+    /// <summary>
+    /// Updates the ceiling and active routing width together, seeding or clamping the
+    /// low-RTT request floor before republishing the budget.
+    /// </summary>
+    public void SetCap(long capBytes, long nowTicks, int connectionCount)
     {
         _capBytes = Math.Max(_floorBytes, capBytes);
+        _connectionCount = Math.Max(1, connectionCount);
+        Volatile.Write(
+            ref _provenPipelineRequestQuanta,
+            Math.Clamp(
+                _provenPipelineRequestQuanta,
+                GetMinimumPipelineRequestQuanta(),
+                GetMaximumPipelineRequestQuanta()));
         CompleteExpiredMinRttProbe(nowTicks);
         if (_capacityProbeActive && nowTicks >= _capacityProbeDeadlineTimestamp)
             DeactivateCapacityProbe(nowTicks);
@@ -734,7 +757,7 @@ internal sealed class BrokerUnackedByteBudget
             _hasLoadedServingSample = false;
             Volatile.Write(
                 ref _provenPipelineRequestQuanta,
-                MinimumPipelineRequestQuanta);
+                GetMinimumPipelineRequestQuanta());
             _lastNormalBudgetBytes = _capBytes;
             _lastBudgetUpdateTimestamp = nowTicks;
         }
@@ -1306,10 +1329,17 @@ internal sealed class BrokerUnackedByteBudget
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }
 
+    private double GetMinimumPipelineRequestQuanta()
+        => MinimumPipelineRequestQuanta * _connectionCount;
+
     private double GetMaximumPipelineRequestQuanta()
-        => _requestSizeEwmaBytes > 0
-            ? Math.Max(MinimumPipelineRequestQuanta, _capBytes / _requestSizeEwmaBytes)
-            : MinimumPipelineRequestQuanta;
+    {
+        var minimum = GetMinimumPipelineRequestQuanta();
+        var persistentLimit = MaximumPersistedPipelineRequestQuantaPerConnection * _connectionCount;
+        return _requestSizeEwmaBytes > 0
+            ? Math.Max(minimum, Math.Min(persistentLimit, _capBytes / _requestSizeEwmaBytes))
+            : persistentLimit;
+    }
 
     private void DeactivateCapacityProbe(long nowTicks)
     {
@@ -1498,7 +1528,7 @@ internal sealed class BrokerUnackedByteBudget
                 : latencyGovernedTargetSeconds;
 
             var hasProvenAdditionalDepth =
-                _provenPipelineRequestQuanta > MinimumPipelineRequestQuanta;
+                _provenPipelineRequestQuanta > GetMinimumPipelineRequestQuanta();
             if (!minRttProbeActive
                 && _requestSizeEwmaBytes > 0
                 && (admissionPressureActive || hasProvenAdditionalDepth))

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -203,9 +203,9 @@ internal sealed class BrokerUnackedByteBudget
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
     /// <summary>Minimum fraction of added standing flight that must convert into delivered-rate
-    /// growth. A 25% budget treatment therefore needs at least 5% more rate. This preserves
-    /// useful capacity discovery while rejecting small scheduler/response-clustering wins.</summary>
-    private const double MinimumProbeThroughputElasticity = 0.20;
+    /// growth. A 25% budget treatment therefore needs at least 3% more rate. Settled control
+    /// windows reject smaller scheduler/response-clustering wins while preserving useful rungs.</summary>
+    private const double MinimumProbeThroughputElasticity = 0.12;
     private const double ProbeGrowthThreshold =
         1.0 + (ProbeBudgetMultiplier - 1.0) * MinimumProbeThroughputElasticity;
     /// <summary>Only probe when standing demand fills at least this fraction of the gate;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -269,6 +269,11 @@ internal sealed class BrokerUnackedByteBudget
     private double _servingRttEwmaSeconds;
     private double _rawServingRttEwmaSeconds;
     private double _requestSizeEwmaBytes;
+    // Capacity probes raise this request-depth floor only after proving that the larger
+    // flight increases delivery rate without inflating RTT. It survives an individual
+    // probe ending so normal admission does not fall back to the self-confirming four-
+    // request floor after every successful rung. Sustained idle resets path evidence.
+    private double _provenPipelineRequestQuanta = MinimumPipelineRequestQuanta;
     private bool _hasLoadedServingSample;
     private double _sealToAckEwmaSeconds;
     private double _minRttProbeMinimumSeconds;
@@ -350,6 +355,9 @@ internal sealed class BrokerUnackedByteBudget
     internal long CapacityProbeSuccessCount => Volatile.Read(ref _capacityProbeSuccessCount);
 
     internal long CapacityProbeFailureCount => Volatile.Read(ref _capacityProbeFailureCount);
+
+    internal double ProvenPipelineRequestQuanta =>
+        Volatile.Read(ref _provenPipelineRequestQuanta);
 
     /// <summary>EWMA of controllable seal-to-send queue latency. The diagnostic property
     /// retains its original name for compatibility.</summary>
@@ -723,6 +731,7 @@ internal sealed class BrokerUnackedByteBudget
         if (sustainedIdle)
         {
             _hasLoadedServingSample = false;
+            _provenPipelineRequestQuanta = MinimumPipelineRequestQuanta;
             _lastNormalBudgetBytes = _capBytes;
             _lastBudgetUpdateTimestamp = nowTicks;
         }
@@ -1220,6 +1229,9 @@ internal sealed class BrokerUnackedByteBudget
                 // a sustainable baseline and would make the next average-rate rung unwinnable.
                 _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
+                _provenPipelineRequestQuanta = Math.Min(
+                    GetMaximumPipelineRequestQuanta(),
+                    _provenPipelineRequestQuanta * ProbeBudgetMultiplier);
                 RecordProbeEvent(
                     BrokerBudgetProbeType.Capacity,
                     BrokerBudgetProbeOutcome.Succeeded,
@@ -1288,6 +1300,11 @@ internal sealed class BrokerUnackedByteBudget
         _capacityProbeRateSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
     }
+
+    private double GetMaximumPipelineRequestQuanta()
+        => _requestSizeEwmaBytes > 0
+            ? Math.Max(MinimumPipelineRequestQuanta, _capBytes / _requestSizeEwmaBytes)
+            : MinimumPipelineRequestQuanta;
 
     private void DeactivateCapacityProbe(long nowTicks)
     {
@@ -1469,16 +1486,22 @@ internal sealed class BrokerUnackedByteBudget
                 ? Math.Min(rttSafetyHorizonSeconds, latencyCapSeconds)
                 : latencyGovernedTargetSeconds;
 
-            if (!minRttProbeActive && admissionPressureActive && _requestSizeEwmaBytes > 0)
+            var hasProvenAdditionalDepth =
+                _provenPipelineRequestQuanta > MinimumPipelineRequestQuanta;
+            if (!minRttProbeActive
+                && _requestSizeEwmaBytes > 0
+                && (admissionPressureActive || hasProvenAdditionalDepth))
             {
                 // Admission is charged in batch/request-sized quanta, so a sub-request BDP
                 // cannot expose additional capacity even when the byte-rate estimator is
                 // accurate. Recent blocked demand enables a small acknowledgement pipeline;
                 // the latency cap bounds it. General capacity discovery remains the job of
                 // the periodic 25% probes below — this floor only crosses coarse request
-                // granularity that a smaller byte probe cannot expose.
+                // granularity that a smaller byte probe cannot expose. Successful capacity
+                // probes persist higher proven quanta here; the latency cap still supplies
+                // the downward bound when that deeper flight starts queueing.
                 var requestPipelineHorizonSeconds =
-                    MinimumPipelineRequestQuanta * _requestSizeEwmaBytes / effectiveMaxRate;
+                    _provenPipelineRequestQuanta * _requestSizeEwmaBytes / effectiveMaxRate;
                 horizonSeconds = Math.Max(
                     horizonSeconds,
                     Math.Min(requestPipelineHorizonSeconds, latencyCapSeconds));

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -731,7 +731,9 @@ internal sealed class BrokerUnackedByteBudget
         if (sustainedIdle)
         {
             _hasLoadedServingSample = false;
-            _provenPipelineRequestQuanta = MinimumPipelineRequestQuanta;
+            Volatile.Write(
+                ref _provenPipelineRequestQuanta,
+                MinimumPipelineRequestQuanta);
             _lastNormalBudgetBytes = _capBytes;
             _lastBudgetUpdateTimestamp = nowTicks;
         }
@@ -1229,9 +1231,11 @@ internal sealed class BrokerUnackedByteBudget
                 // a sustainable baseline and would make the next average-rate rung unwinnable.
                 _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
-                _provenPipelineRequestQuanta = Math.Min(
-                    GetMaximumPipelineRequestQuanta(),
-                    _provenPipelineRequestQuanta * ProbeBudgetMultiplier);
+                Volatile.Write(
+                    ref _provenPipelineRequestQuanta,
+                    Math.Min(
+                        GetMaximumPipelineRequestQuanta(),
+                        _provenPipelineRequestQuanta * ProbeBudgetMultiplier));
                 RecordProbeEvent(
                     BrokerBudgetProbeType.Capacity,
                     BrokerBudgetProbeOutcome.Succeeded,

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -102,7 +102,6 @@ internal sealed class BrokerUnackedByteBudget
     // minute and create a self-reinforcing rate/budget decay loop.
     private const double LoadedRateHalfLifeSeconds = 600.0;
     private const double OccupancySafetyMultiplier = 1.5;
-    private const double ProbeGrowthThreshold = 1.01;
     private const double DeliveryLatencyEwmaWeight = 0.125;
     private const double RequestSizeEwmaWeight = 0.125;
     private const double ServingRttEwmaWeight = 0.125;
@@ -203,6 +202,12 @@ internal sealed class BrokerUnackedByteBudget
     // least three wholly-probed RTTs to average before accepting or rejecting growth.
     private const int ProbeEvaluationRtts = 3;
     private const double ProbeBudgetMultiplier = 1.25;
+    /// <summary>Minimum fraction of added standing flight that must convert into delivered-rate
+    /// growth. A 25% budget treatment therefore needs at least 5% more rate. This preserves
+    /// useful capacity discovery while rejecting small scheduler/response-clustering wins.</summary>
+    private const double MinimumProbeThroughputElasticity = 0.20;
+    private const double ProbeGrowthThreshold =
+        1.0 + (ProbeBudgetMultiplier - 1.0) * MinimumProbeThroughputElasticity;
     /// <summary>Only probe when standing demand fills at least this fraction of the gate;
     /// enlarging a more-open gate cannot reveal additional delivery capacity.</summary>
     private const double CapacityProbeDemandFraction = 0.5;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -118,11 +118,6 @@ internal sealed class BrokerUnackedByteBudget
     /// the delivery-latency target with queueing delay.</summary>
     private const int MinimumPipelineRequestQuanta = 4;
 
-    /// <summary>Paired stress measurements bound one acknowledgement clock at six persisted
-    /// requests: deeper flight pins median delivery latency without adding useful throughput.
-    /// Parallel connections retain independent capacity discovery up to their wire limit.</summary>
-    private const int SingleConnectionMaximumPipelineRequestQuanta = 6;
-
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
     /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
@@ -217,9 +212,9 @@ internal sealed class BrokerUnackedByteBudget
     /// when queue is added, so a rate-only acceptance test converts every probe into budget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
-    /// <summary>Allowed noise when comparing rate growth with seal-to-ack latency growth.
-    /// A useful probe improves or preserves delivered bytes per second per second of latency;
-    /// a rung whose latency grows materially faster than its rate only added standing queue.</summary>
+    /// <summary>Allowed noise when comparing marginal rate gain with marginal seal-to-ack
+    /// latency cost. Comparing deltas avoids granting every rung a fresh fixed 10% latency
+    /// allowance that compounds into standing queue as proof advances.</summary>
     private const double ProbeSealToAckEfficiencyTolerance = 1.10;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
     // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
@@ -1390,7 +1385,8 @@ internal sealed class BrokerUnackedByteBudget
         var rateGrowth = averageRate / _capacityProbeBaselineRate;
         var sealToAckGrowth = averageSealToAckSeconds
             / _capacityProbePreProbeSealToAckSeconds;
-        return sealToAckGrowth <= rateGrowth * ProbeSealToAckEfficiencyTolerance;
+        return sealToAckGrowth - 1.0
+            <= (rateGrowth - 1.0) * ProbeSealToAckEfficiencyTolerance;
     }
 
     private double GetMinimumPipelineRequestQuanta()
@@ -1400,9 +1396,7 @@ internal sealed class BrokerUnackedByteBudget
     {
         var connectionCount = _connectionCount;
         var minimum = MinimumPipelineRequestQuanta * connectionCount;
-        var wireLimit = connectionCount == 1
-            ? SingleConnectionMaximumPipelineRequestQuanta
-            : (double)CapBatchMultiplier * connectionCount;
+        var wireLimit = (double)CapBatchMultiplier * connectionCount;
         return _requestSizeEwmaBytes > 0
             ? Math.Max(minimum, Math.Min(wireLimit, _capBytes / _requestSizeEwmaBytes))
             : wireLimit;

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -118,13 +118,6 @@ internal sealed class BrokerUnackedByteBudget
     /// the delivery-latency target with queueing delay.</summary>
     private const int MinimumPipelineRequestQuanta = 4;
 
-    /// <summary>Additional persistent request headroom contributed by each active connection.
-    /// The aggregate proof ceiling is <c>connectionCount × (4 + 2 × connectionCount)</c>:
-    /// one connection stops at six requests before median latency pins at the target, while
-    /// wider senders can feed their independent acknowledgement clocks. The latency horizon
-    /// and byte cap still bound actual standing flight.</summary>
-    private const int PersistedPipelineHeadroomRequestQuantaPerConnection = 2;
-
     /// <summary>
     /// The scale shrinks only while written-unacked occupancy demonstrates at least this
     /// fraction of the budget on the wire. Seal-to-send backlog with an underfilled wire
@@ -219,6 +212,10 @@ internal sealed class BrokerUnackedByteBudget
     /// when queue is added, so a rate-only acceptance test converts every probe into budget
     /// growth; requiring a flat RTT distinguishes real headroom from added queueing.</summary>
     private const double ProbeRttGrowthTolerance = 1.25;
+    /// <summary>Allowed noise when comparing rate growth with seal-to-ack latency growth.
+    /// A useful probe improves or preserves delivered bytes per second per second of latency;
+    /// a rung whose latency grows materially faster than its rate only added standing queue.</summary>
+    private const double ProbeSealToAckEfficiencyTolerance = 1.10;
     private static readonly long MaxProbeIntervalTicks = Stopwatch.Frequency;
     // An empty pipe refilled within this gap is a serialized loaded cycle, not application idle.
     private static readonly long MaximumSerializedRateCycleGapTicks = Math.Max(1, Stopwatch.Frequency / 500);
@@ -278,8 +275,9 @@ internal sealed class BrokerUnackedByteBudget
     private double _rawServingRttEwmaSeconds;
     private double _requestSizeEwmaBytes;
     // Capacity probes raise this per-connection request-depth floor only after proving that
-    // larger flight increases delivery rate without inflating RTT. It survives an individual
-    // probe ending, but remains below the full wire ceiling. Sustained idle resets path evidence.
+    // larger flight increases delivery rate without inflating RTT or seal-to-ack latency. It
+    // survives an individual probe ending, but remains within the full wire ceiling. Sustained
+    // idle resets path evidence.
     private double _provenPipelineRequestQuanta;
     private int _connectionCount;
     private bool _hasLoadedServingSample;
@@ -299,7 +297,10 @@ internal sealed class BrokerUnackedByteBudget
     private double _capacityProbeRateSum;
     private double _capacityProbeRttSumSeconds;
     private double _capacityProbePreProbeRttSeconds;
+    private double _capacityProbeSealToAckSumSeconds;
+    private double _capacityProbePreProbeSealToAckSeconds;
     private int _capacityProbeRateSampleCount;
+    private int _capacityProbeSealToAckSampleCount;
     private bool _capacityProbeActive;
     private long _capacityProbeSuccessCount;
     private long _capacityProbeFailureCount;
@@ -374,6 +375,9 @@ internal sealed class BrokerUnackedByteBudget
     /// retains its original name for compatibility.</summary>
     internal long DeliveryLatencyEwmaMicros =>
         (long)(Volatile.Read(ref _deliveryLatencyEwmaSeconds) * 1_000_000);
+
+    internal long SealToAckLatencyEwmaMicros =>
+        (long)(Volatile.Read(ref _sealToAckEwmaSeconds) * 1_000_000);
 
     internal double LatencyBudgetScale => Volatile.Read(ref _latencyBudgetScale);
 
@@ -799,7 +803,7 @@ internal sealed class BrokerUnackedByteBudget
                 ServingRttEwmaWeight);
         }
         Volatile.Write(ref _minimumRttMicros, (long)(_minRttSeconds * 1_000_000));
-        UpdateDeliveryLatency(
+        var sealToAckSeconds = UpdateDeliveryLatency(
             sendSnapshot.OldestBatchTimestamp,
             sendSnapshot.SendTimestamp,
             nowTicks);
@@ -858,6 +862,7 @@ internal sealed class BrokerUnackedByteBudget
                 : sendSnapshot.SendTimestamp,
             rttTicks,
             rttSeconds,
+            sealToAckSeconds,
             nowTicks);
     }
 
@@ -881,13 +886,13 @@ internal sealed class BrokerUnackedByteBudget
             RecordAdmissionAvailable(nowTicks);
     }
 
-    private void UpdateDeliveryLatency(
+    private double UpdateDeliveryLatency(
         long oldestBatchTimestamp,
         long sendTimestamp,
         long nowTicks)
     {
-        if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp >= sendTimestamp)
-            return;
+        if (oldestBatchTimestamp <= 0 || oldestBatchTimestamp > sendTimestamp)
+            return 0;
 
         var sampleSeconds = (double)(sendTimestamp - oldestBatchTimestamp) / Stopwatch.Frequency;
         var latencyEstimate = UpdateEwma(
@@ -903,25 +908,26 @@ internal sealed class BrokerUnackedByteBudget
         // setpoint that suppressed fan-out (#1988). What remains — sender backlog plus
         // broker-side queueing — is exactly the delay the budget controls (#2008, #2009).
         var sealToAckSeconds = (double)(nowTicks - oldestBatchTimestamp) / Stopwatch.Frequency;
-        _sealToAckEwmaSeconds = UpdateEwma(
+        var sealToAckEstimate = UpdateEwma(
             _sealToAckEwmaSeconds,
             sealToAckSeconds,
             DeliveryLatencyEwmaWeight);
+        Volatile.Write(ref _sealToAckEwmaSeconds, sealToAckEstimate);
 
         if (_nextLatencyControlTimestamp == 0)
         {
             UpdateAdmissionPressure();
             _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
-            return;
+            return sealToAckSeconds;
         }
 
         if (nowTicks < _nextLatencyControlTimestamp)
-            return;
+            return sealToAckSeconds;
 
         UpdateAdmissionPressure();
 
         var baseRttSeconds = _hasMinRttSample ? _minRttSeconds : 0;
-        var brokerQueueSeconds = _sealToAckEwmaSeconds - baseRttSeconds;
+        var brokerQueueSeconds = sealToAckEstimate - baseRttSeconds;
         var controlLatencySeconds = Math.Max(latencyEstimate, brokerQueueSeconds);
         var targetRatio = _targetSeconds / controlLatencySeconds;
         double adjustment;
@@ -962,6 +968,7 @@ internal sealed class BrokerUnackedByteBudget
             MinimumLatencyBudgetScale,
             1.0));
         _nextLatencyControlTimestamp = nowTicks + LatencyControlIntervalTicks;
+        return sealToAckSeconds;
     }
 
     private void UpdateAdmissionPressure()
@@ -1198,6 +1205,7 @@ internal sealed class BrokerUnackedByteBudget
         long admissionTimestamp,
         long rttTicks,
         double rttSeconds,
+        double sealToAckSeconds,
         long nowTicks)
     {
         var probeIntervalTicks = GetProbeIntervalTicks(rttTicks);
@@ -1228,6 +1236,11 @@ internal sealed class BrokerUnackedByteBudget
             _capacityProbeRateSum += bytesPerSecond;
             _capacityProbeRttSumSeconds += rttSeconds;
             _capacityProbeRateSampleCount++;
+            if (sealToAckSeconds > 0)
+            {
+                _capacityProbeSealToAckSumSeconds += sealToAckSeconds;
+                _capacityProbeSealToAckSampleCount++;
+            }
             if (_capacityProbeEvaluationDeadlineTimestamp == 0)
             {
                 _capacityProbeEvaluationDeadlineTimestamp = nowTicks + evaluationWindowTicks;
@@ -1240,22 +1253,29 @@ internal sealed class BrokerUnackedByteBudget
             if (nowTicks < _capacityProbeEvaluationDeadlineTimestamp)
                 return;
 
-            // Real headroom shows as rate-up with a flat round trip. A saturated broker also
-            // shows rate-not-down when the probe adds queue, so a rate-only test would accept
-            // every probe under load and ratchet the budget into standing latency. The rate
-            // gate stays primary; the RTT guard (raw-domain baseline vs raw probe samples,
-            // <= 0 only when reflection-seeded in tests) catches the queue-dominated regime
-            // where round trips inflate well past the tolerance.
+            // Real headroom raises rate without buying proportionally more delivery latency.
+            // A saturated broker can keep raw request RTT flat while the sender backlog grows,
+            // so rate plus RTT alone ratchets persistent proof into standing latency. Compare
+            // complete seal-to-ack growth with rate growth as well; <= 0 baselines only occur
+            // when old callers or reflection-seeded tests cannot supply a batch timestamp.
             var averageRate = _capacityProbeRateSum / _capacityProbeRateSampleCount;
             var averageRttSeconds = _capacityProbeRttSumSeconds / _capacityProbeRateSampleCount;
             var rttHeld = _capacityProbePreProbeRttSeconds <= 0
                 || averageRttSeconds <= _capacityProbePreProbeRttSeconds * ProbeRttGrowthTolerance;
-            if (rttHeld && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold)
+            if (rttHeld
+                && averageRate > _capacityProbeBaselineRate * ProbeGrowthThreshold
+                && CapacityProbePreservedSealToAckEfficiency(averageRate))
             {
                 // Compare like with like across rungs. A single clustered-response peak is not
                 // a sustainable baseline and would make the next average-rate rung unwinnable.
                 _capacityProbeBaselineRate = averageRate;
                 _capacityProbePreProbeRttSeconds = averageRttSeconds;
+                if (_capacityProbeSealToAckSampleCount > 0)
+                {
+                    _capacityProbePreProbeSealToAckSeconds =
+                        _capacityProbeSealToAckSumSeconds
+                        / _capacityProbeSealToAckSampleCount;
+                }
                 Volatile.Write(
                     ref _provenPipelineRequestQuanta,
                     Math.Min(
@@ -1293,6 +1313,7 @@ internal sealed class BrokerUnackedByteBudget
             _capacityProbePreProbeRttSeconds = _rawServingRttEwmaSeconds > 0
                 ? _rawServingRttEwmaSeconds
                 : rttSeconds;
+            _capacityProbePreProbeSealToAckSeconds = _sealToAckEwmaSeconds;
             ResetCapacityProbeSamples();
             Volatile.Write(ref _capacityProbeDeadlineTimestamp, nowTicks + probeDurationTicks);
             Volatile.Write(ref _capacityProbeActive, true);
@@ -1326,8 +1347,29 @@ internal sealed class BrokerUnackedByteBudget
     {
         _capacityProbeRateSum = 0;
         _capacityProbeRttSumSeconds = 0;
+        _capacityProbeSealToAckSumSeconds = 0;
         _capacityProbeRateSampleCount = 0;
+        _capacityProbeSealToAckSampleCount = 0;
         _capacityProbeEvaluationDeadlineTimestamp = 0;
+    }
+
+    private bool CapacityProbePreservedSealToAckEfficiency(double averageRate)
+    {
+        if (_capacityProbeSealToAckSampleCount == 0)
+            return true;
+
+        var averageSealToAckSeconds = _capacityProbeSealToAckSumSeconds
+            / _capacityProbeSealToAckSampleCount;
+        if (averageSealToAckSeconds > _targetSeconds)
+            return false;
+
+        if (_capacityProbePreProbeSealToAckSeconds <= 0 || _capacityProbeBaselineRate <= 0)
+            return true;
+
+        var rateGrowth = averageRate / _capacityProbeBaselineRate;
+        var sealToAckGrowth = averageSealToAckSeconds
+            / _capacityProbePreProbeSealToAckSeconds;
+        return sealToAckGrowth <= rateGrowth * ProbeSealToAckEfficiencyTolerance;
     }
 
     private double GetMinimumPipelineRequestQuanta()
@@ -1337,12 +1379,10 @@ internal sealed class BrokerUnackedByteBudget
     {
         var connectionCount = _connectionCount;
         var minimum = MinimumPipelineRequestQuanta * connectionCount;
-        var requestQuantaPerConnection = MinimumPipelineRequestQuanta
-            + PersistedPipelineHeadroomRequestQuantaPerConnection * connectionCount;
-        var persistentLimit = requestQuantaPerConnection * connectionCount;
+        var wireLimit = (double)CapBatchMultiplier * connectionCount;
         return _requestSizeEwmaBytes > 0
-            ? Math.Max(minimum, Math.Min(persistentLimit, _capBytes / _requestSizeEwmaBytes))
-            : persistentLimit;
+            ? Math.Max(minimum, Math.Min(wireLimit, _capBytes / _requestSizeEwmaBytes))
+            : wireLimit;
     }
 
     private void DeactivateCapacityProbe(long nowTicks)

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -317,6 +317,9 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     /// <summary>Controllable seal-to-send queue-latency EWMA. Name retained for diagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }
+    // Optional for backward compatibility with persisted stress results captured before
+    // capacity probes used the complete seal-to-ack latency signal.
+    public long SealToAckLatencyEwmaMicros { get; init; }
     public required double LatencyBudgetScale { get; init; }
 
     /// <summary>

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -311,6 +311,9 @@ internal sealed class ProducerBrokerBudgetDiagnostic
     // probe outcomes were added; missing JSON values naturally deserialize as zero.
     public long CapacityProbeSuccessCount { get; init; }
     public long CapacityProbeFailureCount { get; init; }
+    // Optional for backward compatibility with persisted stress results captured before
+    // successful capacity probes could persist their proven request depth.
+    public double ProvenPipelineRequestQuanta { get; init; }
     /// <summary>Controllable seal-to-send queue-latency EWMA. Name retained for diagnostic
     /// output compatibility.</summary>
     public required long DeliveryLatencyEwmaMicros { get; init; }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5477,6 +5477,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             AdmissionBlockCount = budget.AdmissionBlockEvents,
             CapacityProbeSuccessCount = budget.CapacityProbeSuccessCount,
             CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
+            ProvenPipelineRequestQuanta = budget.ProvenPipelineRequestQuanta,
             DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
             LatencyBudgetScale = budget.LatencyBudgetScale,
             RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5480,6 +5480,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             CapacityProbeFailureCount = budget.CapacityProbeFailureCount,
             ProvenPipelineRequestQuanta = budget.ProvenPipelineRequestQuanta,
             DeliveryLatencyEwmaMicros = budget.DeliveryLatencyEwmaMicros,
+            SealToAckLatencyEwmaMicros = budget.SealToAckLatencyEwmaMicros,
             LatencyBudgetScale = budget.LatencyBudgetScale,
             RequestSizeLog2Histogram = includeHistograms ? budget.CopyRequestSizeHistogram() : null,
             RequestRttMicrosLog2Histogram = includeHistograms ? budget.CopyRequestRttMicrosHistogram() : null,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4962,7 +4962,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             floorBytes: 1,
             initialCapBytes: cap,
             lingerSeconds: _options.LingerMs / 1000.0,
-            enableDiagnostics: _options.EnableDeliveryDiagnostics);
+            enableDiagnostics: _options.EnableDeliveryDiagnostics,
+            initialConnectionCount: _options.ConnectionsPerBroker);
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace Dekaf.Tests.Integration;
 [Category("ProducerStateGauges")]
 public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
-    private static readonly string[] BrokerLongGauges =
+    private static readonly string[] BrokerGauges =
     [
         "dekaf.producer.broker.budget_bytes",
         "dekaf.producer.broker.unacked_bytes",
@@ -21,6 +21,7 @@ public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka)
         "dekaf.producer.broker.max_delivery_rate",
         "dekaf.producer.broker.queue_latency_ewma",
         "dekaf.producer.broker.seal_to_ack_latency_ewma",
+        "dekaf.producer.broker.proven_pipeline_request_quanta",
         "dekaf.producer.broker.admission_blocks",
         "dekaf.producer.broker.capacity_probe.successes",
         "dekaf.producer.broker.capacity_probe.failures",
@@ -83,7 +84,7 @@ public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka)
                 observed = samples.Where(sample => sample.ClientId == clientId).ToList();
             }
 
-            foreach (var instrument in BrokerLongGauges)
+            foreach (var instrument in BrokerGauges)
             {
                 var instrumentSamples = observed.Where(sample => sample.Instrument == instrument).ToList();
                 await Assert.That(instrumentSamples).IsNotEmpty()
@@ -106,6 +107,12 @@ public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka)
             var budgets = observed.Where(s => s.Instrument == "dekaf.producer.broker.budget_bytes").ToList();
             await Assert.That(budgets.All(s => s.Value > 0)).IsTrue()
                 .Because("the unacked-byte budget starts at its cap, never zero");
+
+            var provenDepth = observed
+                .Where(s => s.Instrument == "dekaf.producer.broker.proven_pipeline_request_quanta")
+                .ToList();
+            await Assert.That(provenDepth.All(s => s.Value >= 4)).IsTrue()
+                .Because("live proven depth starts at the four-request-per-connection floor");
 
             var scales = observed.Where(s => s.Instrument == "dekaf.producer.broker.latency_budget_scale").ToList();
             await Assert.That(scales).IsNotEmpty();

--- a/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
@@ -20,6 +20,7 @@ public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka)
         "dekaf.producer.broker.min_rtt",
         "dekaf.producer.broker.max_delivery_rate",
         "dekaf.producer.broker.queue_latency_ewma",
+        "dekaf.producer.broker.seal_to_ack_latency_ewma",
         "dekaf.producer.broker.admission_blocks",
         "dekaf.producer.broker.capacity_probe.successes",
         "dekaf.producer.broker.capacity_probe.failures",

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -54,6 +54,7 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.min_rtt");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.max_delivery_rate");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.queue_latency_ewma");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.seal_to_ack_latency_ewma");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.latency_budget_scale");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.admission_blocks");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.capacity_probe.successes");

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -55,6 +55,7 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.max_delivery_rate");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.queue_latency_ewma");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.seal_to_ack_latency_ewma");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.proven_pipeline_request_quanta");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.latency_budget_scale");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.admission_blocks");
         await Assert.That(instrumentNames).Contains("dekaf.producer.broker.capacity_probe.successes");

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -980,6 +980,71 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_SuccessPersistsProvenRequestDepthAfterProbeEnds()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", 42_000.0);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(5.0).Within(0.000_001);
+
+        SetField(budget, "_capacityProbeActive", false);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", 0L);
+        SetField(budget, "_minRttProbeUntilTimestamp", 0L);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.0001);
+        SetField(budget, "_servingRttEwmaSeconds", 0.0001);
+        SetField(budget, "_hasLoadedServingSample", true);
+        SetField(budget, "_windowMaxRate", 1_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_requestSizeEwmaBytes", 1_000.0);
+        SetField(budget, "_admissionPressureActive", false);
+        SetField(budget, "_latencyBudgetScale", 1.0);
+
+        SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(0.301));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(5_000)
+            .Because("a successful five-request rung must become the normal budget, not a transient probe only");
+
+        SetField(budget, "_latencyBudgetScale", 0.25);
+        SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(0.302));
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_500)
+            .Because("latency pressure must still bound previously proven request depth");
+    }
+
+    [Test]
+    public async Task ProvenRequestDepth_ResetsAfterSustainedIdle()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        Ack(budget, 1_000, 0.001, T0);
+        SetField(budget, "_provenPipelineRequestQuanta", 10.0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(100));
+
+        var sendTimestamp = T0 + Seconds(3.0);
+        var snapshot = budget.SnapshotDelivery(sendTimestamp, appLimited: true);
+        Ack(budget, 1_000, 0.001, sendTimestamp + Seconds(0.001), snapshot);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(4.0)
+            .Because("capacity proven before a sustained idle gap is stale path evidence");
+    }
+
+    [Test]
     public async Task BudgetDecay_IsRateLimitedWithoutAdmissionBlocks()
     {
         var budget = BrokerUnackedByteBudget.BoundBudgetDecay(
@@ -1460,6 +1525,9 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsGreaterThan(secondRungBudget);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(6.25).Within(0.000_001)
+            .Because("each flat-RTT rate-gain rung must become normal admission depth");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -909,26 +909,23 @@ public sealed class BrokerUnackedByteBudgetTests
         for (var i = 0; i <= 8; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
+        await Assert.That(budget.BudgetBytes).IsEqualTo(375);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeBaselineActive")).IsTrue();
+
+        for (var i = 9; i <= 14; i++)
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
         await Assert.That(budget.BudgetBytes).IsEqualTo(468);
 
-        Ack(budget, 1_000, 0.100, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
-
-        Ack(budget, 1_000, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
-
-        Ack(budget, 1_000, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
-
-        Ack(budget, 1_000, 0.100, T0 + Seconds(1.200));
-        Ack(budget, 1_000, 0.100, T0 + Seconds(1.300));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(468);
-
-        Ack(budget, 1_000, 0.100, T0 + Seconds(1.400));
+        for (var i = 15; i <= 20; i++)
+            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(375);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(GetField<long>(budget, "_nextProbeTimestamp") - (T0 + Seconds(2.000)))
+            .IsGreaterThanOrEqualTo(Seconds(1.0));
         var capacityEvents = budget.CopyProbeEvents()
             .Where(probeEvent => probeEvent.ProbeType == BrokerBudgetProbeType.Capacity)
             .ToArray();
@@ -951,6 +948,40 @@ public sealed class BrokerUnackedByteBudgetTests
 
         var nextProbeTimestamp = GetField<long>(budget, "_nextProbeTimestamp");
         await Assert.That(nextProbeTimestamp - T0).IsLessThanOrEqualTo(Seconds(1.0));
+    }
+
+    [Test]
+    public async Task PeriodicProbe_MeasuresSettledBaselineBeforeOpeningCandidateBudget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        Ack(budget, 1_000, 0.008, T0);
+        budget.Charge(20_000);
+
+        var probeStart = T0 + Seconds(0.064);
+        SetField(budget, "_nextProbeTimestamp", probeStart);
+        Ack(budget, 1_000, 0.008, probeStart);
+
+        var normalBudget = GetField<long>(budget, "_budgetAfterMinRttProbeBytes");
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("the first phase must observe the current budget before changing the treatment");
+        await Assert.That(GetField<bool>(budget, "_capacityProbeBaselineActive")).IsTrue();
+        await Assert.That(budget.BudgetBytes).IsEqualTo(normalBudget);
+
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.073));
+        await Assert.That(GetField<int>(budget, "_capacityProbeRateSampleCount")).IsEqualTo(1);
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.123));
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.174));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeBaselineActive")).IsFalse();
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
+            .IsEqualTo(125_000.0).Within(0.001)
+            .Because("baseline and candidate must use the same per-request delivery-rate domain");
+        await Assert.That(budget.BudgetBytes).IsGreaterThan(normalBudget)
+            .Because("only the candidate phase may publish the enlarged budget");
     }
 
     [Test]
@@ -978,7 +1009,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_SuccessCarriesAverageRateToNextRung_NotSinglePeak()
+    public async Task PeriodicProbe_SuccessClosesSessionBeforeAnotherRung()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.5,
@@ -994,9 +1025,14 @@ public sealed class BrokerUnackedByteBudgetTests
 
         Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
-        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
-            .IsEqualTo(18_000.0).Within(0.001)
-            .Because("the next probe rung must compare average rate with average rate");
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("a successful sample must not chain another +25% treatment without a settled baseline");
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(5.0).Within(0.000_001);
+        await Assert.That(GetField<long>(budget, "_nextProbeTimestamp") - (T0 + Seconds(0.300)))
+            .IsGreaterThanOrEqualTo(Seconds(1.0))
+            .Because("scheduler bursts must not become thousands of independent probe votes");
     }
 
     [Test]
@@ -1525,7 +1561,7 @@ public sealed class BrokerUnackedByteBudgetTests
             .Because("one base-RTT BDP remains when serving time consumes most of the end-to-end target");
         budget.Charge(20_000);
 
-        for (var i = 1; i <= 8; i++)
+        for (var i = 1; i <= 22; i++)
             Ack(budget, 8_000, 0.008, T0 + Seconds(i * 0.008));
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
@@ -1533,11 +1569,13 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.BudgetBytes).IsEqualTo((long)(normalBudget * 1.25))
             .Because("the periodic probe must explore 25% beyond an RTT-dominant target cap");
 
-        for (var i = 9; i <= 12; i++)
+        for (var i = 23; i <= 36; i++)
             Ack(budget, 10_000, 0.008, T0 + Seconds(i * 0.008));
 
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1)
             .Because("flat-RTT rate gain above the target cap must remain discoverable");
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse()
+            .Because("the next rung requires a newly settled baseline");
     }
 
     [Test]
@@ -1546,8 +1584,15 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
 
-        for (var i = 0; i <= 8; i++)
+        for (var i = 0; i <= 7; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbePreProbeRttSeconds", 0.100);
+        SetField(budget, "_capacityProbeStartTimestamp", T0 + Seconds(0.800));
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.600));
+        SetField(budget, "_capacityProbeActive", true);
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.800));
 
         // One small response can arrive first after the larger budget is published.
         // It must not cancel the probe before other requests from the same RTT land.
@@ -1567,8 +1612,13 @@ public sealed class BrokerUnackedByteBudgetTests
             initialCapBytes: 1_000_000);
         budget.Charge(5_500);
 
-        for (var i = 0; i <= 8; i++)
+        for (var i = 0; i <= 7; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        SetField(budget, "_capacityProbeStartTimestamp", T0 + Seconds(0.800));
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.600));
+        SetField(budget, "_capacityProbeActive", true);
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.800));
 
         await Assert.That(budget.BudgetBytes).IsEqualTo(468);
         budget.Release(5_100);
@@ -1604,8 +1654,14 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
 
-        for (var i = 0; i <= 8; i++)
+        for (var i = 0; i <= 7; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0 + Seconds(0.800));
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(2.000));
+        SetField(budget, "_capacityProbeActive", true);
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.800));
 
         await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
@@ -1654,6 +1710,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_BaselineRejectsBatchAdmittedBeforeControlWindow()
+    {
+        var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeBaselineActive", true);
+
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: T0 + Seconds(0.010),
+            appLimited: true,
+            oldestBatchTimestamp: T0 - Seconds(0.010));
+        Ack(budget, 200, 0.001, T0 + Seconds(0.011), snapshot);
+
+        await Assert.That(GetField<int>(budget, "_capacityProbeRateSampleCount")).IsEqualTo(0)
+            .Because("the control window must exclude the same pre-phase admissions as the treatment window");
+    }
+
+    [Test]
     public async Task PeriodicProbe_EvaluationWindowCoversTargetHorizonAndLinger()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1674,23 +1748,28 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 20, 0.001, now, snapshot);
 
         var evaluationDeadline = GetField<long>(budget, "_capacityProbeEvaluationDeadlineTimestamp");
-        await Assert.That(evaluationDeadline - now).IsGreaterThanOrEqualTo(Seconds(0.015))
-            .Because("probe-added admissions need a full target horizon plus linger to affect delivery rate");
+        await Assert.That(evaluationDeadline - now).IsGreaterThanOrEqualTo(Seconds(0.100))
+            .Because("probe-added admissions need a scheduler-noise-resistant observation horizon");
     }
 
     [Test]
-    public async Task PeriodicProbe_UsesWindowAverageBaseline_NotDecayingRetainedPeak()
+    public async Task PeriodicProbe_BaselineIgnoresDifferentDomainRollingRateWindow()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.010, floorBytes: 200, initialCapBytes: 1_000_000);
-        Ack(budget, 10, 0.001, T0);
-        budget.Charge(100);
-        SetField(budget, "_retainedLoadedMaxRate", 100_000.0);
-        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.008));
+        Ack(budget, 1_000, 0.008, T0);
+        budget.Charge(20_000);
+        SetField(budget, "_windowMaxRate", 10_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 10_000_000.0);
+        SetField(budget, "_nextProbeTimestamp", T0 + Seconds(0.064));
 
-        Ack(budget, 10, 0.001, T0 + Seconds(0.008));
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.064));
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.073));
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.123));
+        Ack(budget, 1_000, 0.008, T0 + Seconds(0.174));
 
-        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate")).IsEqualTo(10_000.0)
-            .Because("a stale retained peak must not make every recovery probe impossible");
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
+            .IsEqualTo(125_000.0).Within(0.001)
+            .Because("the control and treatment windows must use identical measurements");
     }
 
     [Test]
@@ -1709,45 +1788,36 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RatchetsWhileRateAndRttProveCapacity()
+    public async Task PeriodicProbe_NextRungRequiresFreshSettledBaseline()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0, 42_000);
 
-        for (var i = 0; i <= 8; i++)
-            Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(5.0).Within(0.000_001);
 
-        Ack(budget, 1_250, 0.100, T0 + Seconds(0.900));
-        await Assert.That(budget.BudgetBytes).IsEqualTo(585);
-        var firstRungBudget = budget.BudgetBytes;
+        Ack(budget, 1_250, 0.100, T0 + Seconds(1.300));
+        await Assert.That(GetField<bool>(budget, "_capacityProbeBaselineActive")).IsTrue();
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse();
 
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.000));
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(firstRungBudget);
-        var secondRungBudget = budget.BudgetBytes;
+        for (var i = 14; i <= 19; i++)
+            Ack(budget, 1_250, 0.100, T0 + Seconds(i * 0.100));
 
-        // The probe averages three RTTs before ratcheting to the higher level.
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.100));
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(secondRungBudget);
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsTrue();
+        await Assert.That(GetField<double>(budget, "_capacityProbeBaselineRate"))
+            .IsEqualTo(12_500.0).Within(0.001);
 
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.200));
-        await Assert.That(budget.BudgetBytes).IsGreaterThanOrEqualTo(secondRungBudget);
+        for (var i = 20; i <= 25; i++)
+            Ack(budget, 1_563, 0.100, T0 + Seconds(i * 0.100));
 
-        // The ratcheted level gets another full-window average. Comparing average with
-        // average lets the sustained 25% gain advance the next rung as well.
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.300));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.400));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.500));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.600));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.700));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.800));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(1.900));
-        Ack(budget, 1_562, 0.100, T0 + Seconds(2.000));
-        await Assert.That(budget.BudgetBytes).IsGreaterThan(secondRungBudget);
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
             .IsEqualTo(6.25).Within(0.000_001)
-            .Because("two sustained 25% gains persist when no delivery-latency sample is available");
+            .Because("two independently baselined 25% gains remain discoverable");
     }
 
     [Test]
@@ -2024,8 +2094,13 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_500);
 
-        for (var i = 0; i <= 8; i++)
+        for (var i = 0; i <= 7; i++)
             Ack(budget, 1_000, 0.100, T0 + Seconds(i * 0.100));
+
+        SetField(budget, "_capacityProbeStartTimestamp", T0 + Seconds(0.800));
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.600));
+        SetField(budget, "_capacityProbeActive", true);
+        CompleteAckedPassWithoutDecay(budget, T0 + Seconds(0.800));
 
         budget.Release(5_100);
         await Assert.That(budget.IsOverBudgetAt(T0 + Seconds(0.900))).IsFalse();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1111,15 +1111,33 @@ public sealed class BrokerUnackedByteBudgetTests
             targetSeconds: 0.5,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
-        SeedCapacityProbeEvaluation(budget, 10_000, 0, 20_800);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0, 20_400);
 
-        Ack(budget, 1_040, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+        Ack(budget, 1_020, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
             .IsEqualTo(4.0).Within(0.000_001)
-            .Because("4% more rate does not justify 25% more standing flight");
+            .Because("2% more rate does not justify 25% more standing flight");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_AcceptsUsefulElasticityRateGainWhenLatencyIsFlat()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0, 20_620);
+
+        Ack(budget, 1_031, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(5.0).Within(0.000_001)
+            .Because("3.1% more rate is useful capacity when delivery latency stays flat");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1023,6 +1023,29 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_RejectsSmallRateGainWithLargerMarginalLatencyCost()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0.100, 20_400);
+
+        var now = T0 + Seconds(0.300);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.100),
+            appLimited: false,
+            oldestBatchTimestamp: now - Seconds(0.108));
+        Ack(budget, 1_020, 0.100, now, snapshot);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(4.0).Within(0.000_001)
+            .Because("2% more rate cannot justify 8% more latency");
+    }
+
+    [Test]
     public async Task PeriodicProbe_PersistsRateGainWhenSealToAckEfficiencyImproves()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1136,7 +1159,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task ProvenRequestDepth_UsesSingleConnectionCeilingAndParallelWireCap()
+    public async Task ProvenRequestDepth_IsSeededByConnectionWidthAndBoundedByWireCap()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1151,8 +1174,8 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.SetCap(32_000_000, T0, connectionCount: 1);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0)
-            .Because("paired stress evidence bounds one connection below target-pinned queue depth");
+            .IsEqualTo(32.0)
+            .Because("marginal delivery efficiency, not a fixed width heuristic, bounds persistence below the wire cap");
 
         SetField(budget, "_provenPipelineRequestQuanta", 4.0);
         budget.SetCap(96_000_000, T0, connectionCount: 3);
@@ -1170,7 +1193,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_SingleConnectionProofStopsAtMeasuredLatencyCeiling()
+    public async Task PeriodicProbe_ProofIsNotStoppedByWidthHeuristic()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1189,8 +1212,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0)
-            .Because("successful probe noise must not recreate the measured one-connection latency regression");
+            .IsEqualTo(7.5)
+            .Because("the measured delivery signal, not a fixed single-connection ceiling, must stop proof growth");
     }
 
     [Test]
@@ -1686,7 +1709,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RatchetsToSingleConnectionCeilingWhileRateAndRttProveCapacity()
+    public async Task PeriodicProbe_RatchetsWhileRateAndRttProveCapacity()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
@@ -1723,8 +1746,8 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0).Within(0.000_001)
-            .Because("rate and RTT evidence may reach but not exceed the measured one-connection ceiling");
+            .IsEqualTo(6.25).Within(0.000_001)
+            .Because("two sustained 25% gains persist when no delivery-latency sample is available");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1031,7 +1031,8 @@ public sealed class BrokerUnackedByteBudgetTests
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
-            initialCapBytes: 1_000_000);
+            initialCapBytes: 1_000_000,
+            initialConnectionCount: 3);
         SetField(budget, "_hasMinRttSample", true);
         SetField(budget, "_minRttSeconds", 0.001);
         SetField(budget, "_servingRttEwmaSeconds", 0.002);
@@ -1049,7 +1050,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task ProvenRequestDepth_IsSeededAndBoundedOnConnectionScale()
+    public async Task ProvenRequestDepth_IsSeededAndBoundedByConnectionWidth()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1059,29 +1060,36 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
             .IsEqualTo(4.0);
 
-        budget.SetCap(96_000_000, T0, connectionCount: 3);
-
-        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(12.0)
-            .Because("each active connection needs its own four-request acknowledgement pipeline");
-
         SetField(budget, "_provenPipelineRequestQuanta", 96.0);
         SetField(budget, "_requestSizeEwmaBytes", 1_000_000.0);
         budget.SetCap(32_000_000, T0, connectionCount: 1);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(8.0)
-            .Because("stale low-RTT proof must not retain the full wire ceiling after scale-down");
+            .IsEqualTo(6.0)
+            .Because("one connection needs two proven quanta above the four-request acknowledgement floor");
+
+        budget.SetCap(96_000_000, T0, connectionCount: 3);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(12.0)
+            .Because("scale-up must seed four acknowledgement-clock requests per connection");
+
+        SetField(budget, "_provenPipelineRequestQuanta", 96.0);
+        budget.SetCap(96_000_000, T0, connectionCount: 3);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(30.0)
+            .Because("three connections need more aggregate proof than the old 24-request limit");
     }
 
     [Test]
-    public async Task PeriodicProbe_ProvenRequestDepthStopsAtLowRttPerConnectionLimit()
+    public async Task PeriodicProbe_ProvenRequestDepthStopsAtWidthAwareLimit()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 32_000_000);
-        SetField(budget, "_provenPipelineRequestQuanta", 8.0);
+        SetField(budget, "_provenPipelineRequestQuanta", 6.0);
         SetField(budget, "_requestSizeEwmaBytes", 1_000_000.0);
         SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
         SetField(budget, "_capacityProbeStartTimestamp", T0);
@@ -1094,8 +1102,33 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(8.0)
-            .Because("persistent low-RTT flight stays below the 32-request wire ceiling");
+            .IsEqualTo(6.0)
+            .Because("single-connection proof must stop below the latency-pinning eight-request depth");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_ThreeConnectionProofGrowsPastSingleWidthLimit()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 96_000_000,
+            initialConnectionCount: 3);
+        SetField(budget, "_provenPipelineRequestQuanta", 24.0);
+        SetField(budget, "_requestSizeEwmaBytes", 1_000_000.0);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", 42_000.0);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(30.0)
+            .Because("successful three-connection probing must escape the 24-request throughput ceiling");
     }
 
     [Test]
@@ -1563,7 +1596,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RatchetsWhileWhollyProbedRateRises()
+    public async Task PeriodicProbe_RatchetsUntilWidthAwareProofLimit()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
@@ -1600,8 +1633,8 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.25).Within(0.000_001)
-            .Because("each flat-RTT rate-gain rung must become normal admission depth");
+            .IsEqualTo(6.0).Within(0.000_001)
+            .Because("flat-RTT gains persist until the single-connection latency bound is reached");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1136,7 +1136,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task ProvenRequestDepth_IsSeededByConnectionWidthAndBoundedByWireCap()
+    public async Task ProvenRequestDepth_UsesSingleConnectionCeilingAndParallelWireCap()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1151,8 +1151,8 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.SetCap(32_000_000, T0, connectionCount: 1);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(32.0)
-            .Because("latency-aware probe evidence, not a width heuristic, bounds persistence below the wire cap");
+            .IsEqualTo(6.0)
+            .Because("paired stress evidence bounds one connection below target-pinned queue depth");
 
         SetField(budget, "_provenPipelineRequestQuanta", 4.0);
         budget.SetCap(96_000_000, T0, connectionCount: 3);
@@ -1170,7 +1170,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_ProofIsNotStoppedByWidthHeuristic()
+    public async Task PeriodicProbe_SingleConnectionProofStopsAtMeasuredLatencyCeiling()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1189,8 +1189,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(7.5)
-            .Because("the measured delivery signal, not a fixed single-connection ceiling, must stop proof growth");
+            .IsEqualTo(6.0)
+            .Because("successful probe noise must not recreate the measured one-connection latency regression");
     }
 
     [Test]
@@ -1686,7 +1686,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RatchetsWhileRateAndRttProveCapacity()
+    public async Task PeriodicProbe_RatchetsToSingleConnectionCeilingWhileRateAndRttProveCapacity()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
@@ -1723,8 +1723,8 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.25).Within(0.000_001)
-            .Because("two sustained 25% gains persist when no delivery-latency sample is available");
+            .IsEqualTo(6.0).Within(0.000_001)
+            .Because("rate and RTT evidence may reach but not exceed the measured one-connection ceiling");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1049,6 +1049,56 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task ProvenRequestDepth_IsSeededAndBoundedOnConnectionScale()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(4.0);
+
+        budget.SetCap(96_000_000, T0, connectionCount: 3);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(12.0)
+            .Because("each active connection needs its own four-request acknowledgement pipeline");
+
+        SetField(budget, "_provenPipelineRequestQuanta", 96.0);
+        SetField(budget, "_requestSizeEwmaBytes", 1_000_000.0);
+        budget.SetCap(32_000_000, T0, connectionCount: 1);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(8.0)
+            .Because("stale low-RTT proof must not retain the full wire ceiling after scale-down");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_ProvenRequestDepthStopsAtLowRttPerConnectionLimit()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 32_000_000);
+        SetField(budget, "_provenPipelineRequestQuanta", 8.0);
+        SetField(budget, "_requestSizeEwmaBytes", 1_000_000.0);
+        SetField(budget, "_capacityProbeBaselineRate", 10_000.0);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", 42_000.0);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+
+        Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(8.0)
+            .Because("persistent low-RTT flight stays below the 32-request wire ceiling");
+    }
+
+    [Test]
     public async Task ProvenRequestDepth_ResetsAfterSustainedIdle()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -134,13 +134,14 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task DeliveryLatencyAboveTarget_ReducesRateBudget()
+    public async Task DeliveryLatencyAboveTarget_ReducesRateBudgetAndProof()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        SetField(budget, "_provenPipelineRequestQuanta", 32.0);
 
         var now = T0;
         for (var i = 0; i < 6; i++)
@@ -157,6 +158,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsEqualTo(19_000).Within(10);
         await Assert.That(budget.LatencyBudgetScale).IsLessThan(0.25);
+        await Assert.That(budget.ProvenPipelineRequestQuanta).IsLessThan(8.0)
+            .Because("actionable over-target queueing must revoke stale probe proof, not only derate it transiently");
         await Assert.That(budget.BudgetBytes).IsLessThan(2_500);
     }
 
@@ -1373,13 +1376,14 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task SendLoopBacklog_WithoutWireOccupancy_DoesNotShrinkScale()
+    public async Task SendLoopBacklog_WithoutWireOccupancy_DoesNotShrinkScaleOrProof()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
             floorBytes: 200,
             initialCapBytes: 1_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.001);
+        SetField(budget, "_provenPipelineRequestQuanta", 8.0);
 
         // 19ms of seal-to-send backlog with an empty wire: the send loop, not broker
         // admission, is the bottleneck. Shrinking would starve the sender below capacity.
@@ -1396,6 +1400,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001)
             .Because("sender backlog with an underfilled wire is not actionable by admission");
+        await Assert.That(budget.ProvenPipelineRequestQuanta).IsEqualTo(8.0).Within(0.000_001)
+            .Because("non-actionable sender backlog must not revoke proven broker capacity");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -951,6 +951,29 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_BaselineTimeoutDoesNotReportCandidateFailure()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000,
+            enableDiagnostics: true);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeBaselineActive", true);
+
+        Ack(budget, 1_000, 0.100, T0 + Seconds(0.300));
+
+        await Assert.That(GetField<bool>(budget, "_capacityProbeBaselineActive")).IsFalse();
+        await Assert.That(GetField<bool>(budget, "_capacityProbeActive")).IsFalse();
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0)
+            .Because("the enlarged candidate budget never opened");
+        await Assert.That(budget.CopyProbeEvents()
+                .Where(probeEvent => probeEvent.ProbeType == BrokerBudgetProbeType.Capacity))
+            .IsEmpty();
+    }
+
+    [Test]
     public async Task PeriodicProbe_MeasuresSettledBaselineBeforeOpeningCandidateBudget()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -82,6 +82,22 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, (long)(bytesPerSecond * rttSeconds), rttSeconds, T0);
     }
 
+    private static void SeedCapacityProbeEvaluation(
+        BrokerUnackedByteBudget budget,
+        double baselineRate,
+        double baselineSealToAckSeconds,
+        double accumulatedRate)
+    {
+        SetField(budget, "_capacityProbeBaselineRate", baselineRate);
+        SetField(budget, "_capacityProbePreProbeSealToAckSeconds", baselineSealToAckSeconds);
+        SetField(budget, "_capacityProbeStartTimestamp", T0);
+        SetField(budget, "_capacityProbeDeadlineTimestamp", T0 + Seconds(1.0));
+        SetField(budget, "_capacityProbeEvaluationDeadlineTimestamp", T0 + Seconds(0.200));
+        SetField(budget, "_capacityProbeRateSum", accumulatedRate);
+        SetField(budget, "_capacityProbeRateSampleCount", 2);
+        SetField(budget, "_capacityProbeActive", true);
+    }
+
     [Test]
     public async Task Budget_BeforeFirstRateSample_EqualsCap()
     {
@@ -981,6 +997,73 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_RejectsRateGainThatCostsSealToAckEfficiency()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0.100, 42_000);
+
+        var now = T0 + Seconds(0.300);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.100),
+            appLimited: false,
+            oldestBatchTimestamp: now - Seconds(0.250));
+        Ack(budget, 1_200, 0.100, now, snapshot);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(4.0).Within(0.000_001)
+            .Because("a throughput gain that buys proportionally more seal-to-ack latency is queue, not capacity");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_PersistsRateGainWhenSealToAckEfficiencyImproves()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0.100, 42_000);
+
+        var now = T0 + Seconds(0.300);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.100),
+            appLimited: false,
+            oldestBatchTimestamp: now - Seconds(0.150));
+        Ack(budget, 1_200, 0.100, now, snapshot);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(1);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(5.0).Within(0.000_001)
+            .Because("higher delivery rate with better rate-to-latency efficiency is usable capacity");
+    }
+
+    [Test]
+    public async Task PeriodicProbe_RejectsDeliveryLatencyAboveConfiguredTarget()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.200,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0, 78_000);
+
+        var now = T0 + Seconds(0.300);
+        var snapshot = budget.SnapshotDelivery(
+            sendTimestamp: now - Seconds(0.250),
+            appLimited: false,
+            oldestBatchTimestamp: now - Seconds(0.250));
+        Ack(budget, 600, 0.250, now, snapshot);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1)
+            .Because("rate growth cannot persist a rung whose complete delivery latency exceeds the target");
+    }
+
+    [Test]
     public async Task PeriodicProbe_SuccessPersistsProvenRequestDepthAfterProbeEnds()
     {
         var budget = new BrokerUnackedByteBudget(
@@ -1050,7 +1133,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task ProvenRequestDepth_IsSeededAndBoundedByConnectionWidth()
+    public async Task ProvenRequestDepth_IsSeededByConnectionWidthAndBoundedByWireCap()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1065,9 +1148,10 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.SetCap(32_000_000, T0, connectionCount: 1);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0)
-            .Because("one connection needs two proven quanta above the four-request acknowledgement floor");
+            .IsEqualTo(32.0)
+            .Because("latency-aware probe evidence, not a width heuristic, bounds persistence below the wire cap");
 
+        SetField(budget, "_provenPipelineRequestQuanta", 4.0);
         budget.SetCap(96_000_000, T0, connectionCount: 3);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
@@ -1078,12 +1162,12 @@ public sealed class BrokerUnackedByteBudgetTests
         budget.SetCap(96_000_000, T0, connectionCount: 3);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(30.0)
-            .Because("three connections need more aggregate proof than the old 24-request limit");
+            .IsEqualTo(96.0)
+            .Because("three connections retain at most their full aggregate wire depth");
     }
 
     [Test]
-    public async Task PeriodicProbe_ProvenRequestDepthStopsAtWidthAwareLimit()
+    public async Task PeriodicProbe_ProofIsNotStoppedByWidthHeuristic()
     {
         var budget = new BrokerUnackedByteBudget(
             targetSeconds: 0.010,
@@ -1102,8 +1186,8 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 1_200, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
 
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0)
-            .Because("single-connection proof must stop below the latency-pinning eight-request depth");
+            .IsEqualTo(7.5)
+            .Because("the measured delivery signal, not a fixed single-connection ceiling, must stop proof growth");
     }
 
     [Test]
@@ -1596,7 +1680,7 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
-    public async Task PeriodicProbe_RatchetsUntilWidthAwareProofLimit()
+    public async Task PeriodicProbe_RatchetsWhileRateAndRttProveCapacity()
     {
         var budget = new BrokerUnackedByteBudget(targetSeconds: 0.5, floorBytes: 200, initialCapBytes: 1_000_000);
         budget.Charge(5_000);
@@ -1633,8 +1717,8 @@ public sealed class BrokerUnackedByteBudgetTests
         await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(2);
         await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
-            .IsEqualTo(6.0).Within(0.000_001)
-            .Because("flat-RTT gains persist until the single-connection latency bound is reached");
+            .IsEqualTo(6.25).Within(0.000_001)
+            .Because("two sustained 25% gains persist when no delivery-latency sample is available");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -1082,6 +1082,24 @@ public sealed class BrokerUnackedByteBudgetTests
     }
 
     [Test]
+    public async Task PeriodicProbe_RejectsLowElasticityRateGainEvenWhenLatencyIsFlat()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.5,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SeedCapacityProbeEvaluation(budget, 10_000, 0, 20_800);
+
+        Ack(budget, 1_040, 0.100, T0 + Seconds(0.300), appLimitedAtSend: false);
+
+        await Assert.That(budget.CapacityProbeSuccessCount).IsEqualTo(0);
+        await Assert.That(budget.CapacityProbeFailureCount).IsEqualTo(1);
+        await Assert.That(GetField<double>(budget, "_provenPipelineRequestQuanta"))
+            .IsEqualTo(4.0).Within(0.000_001)
+            .Because("4% more rate does not justify 25% more standing flight");
+    }
+
+    [Test]
     public async Task PeriodicProbe_PersistsRateGainWhenSealToAckEfficiencyImproves()
     {
         var budget = new BrokerUnackedByteBudget(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -224,8 +224,8 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(budget.DeliveryLatencyEwmaMicros).IsLessThan(6_000);
         await Assert.That(budget.LatencyBudgetScale).IsGreaterThan(reducedScale);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(3_225)
-            .Because("blocked demand restores a request pipeline only within the current latency cap");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_225)
+            .Because("blocked demand restores a request pipeline only within the remaining end-to-end latency cap");
     }
 
     [Test]
@@ -385,10 +385,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(1.0));
 
         // Both samples measure 100,000 B/s. The later back-to-back 100ms service sample
-        // raises the preferred safety horizon above the 10ms cap while the 5ms base RTT
-        // remains unchanged, so the latency target limits the budget to 10ms of rate.
+        // raises the preferred safety horizon above the 10ms end-to-end cap while the 5ms
+        // base RTT remains unchanged, leaving one base-RTT BDP as standing flight.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
 
     [Test]
@@ -424,9 +424,10 @@ public sealed class BrokerUnackedByteBudgetTests
 
         // The final 10,000-byte request measures its own 100ms sojourn (100,000 B/s);
         // pipelined delivery credit flows through the delivered-counter delta rather than
-        // a shrunken inter-ack interval. Normal operation restores the serving-RTT floor.
+        // a shrunken inter-ack interval. Normal operation retains one base-RTT BDP after
+        // reserving serving time inside the end-to-end target.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
 
     [Test]
@@ -583,10 +584,10 @@ public sealed class BrokerUnackedByteBudgetTests
         Ack(budget, 10_000, 0.100, T0 + Seconds(10.25));
 
         // No ack landed inside the 100ms drain. The late loaded sample must not replace
-        // the retained 5ms base RTT, but it does restore a serving-RTT safety horizon
-        // (clamped to twice the base RTT).
+        // the retained 5ms base RTT. Serving time consumes the end-to-end target, so normal
+        // operation retains one base-RTT BDP rather than adding another target-sized flight.
         await Assert.That(budget.MinimumRttMicros).IsEqualTo(5_000);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000);
+        await Assert.That(budget.BudgetBytes).IsEqualTo(500);
     }
 
     [Test]
@@ -1020,8 +1021,31 @@ public sealed class BrokerUnackedByteBudgetTests
         SetField(budget, "_latencyBudgetScale", 0.25);
         SetCapWithoutDecay(budget, 1_000_000, T0 + Seconds(0.302));
 
-        await Assert.That(budget.BudgetBytes).IsEqualTo(2_500)
-            .Because("latency pressure must still bound previously proven request depth");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(2_400)
+            .Because("latency pressure and serving RTT must still bound previously proven request depth");
+    }
+
+    [Test]
+    public async Task ProvenRequestDepth_ReservesServingRttWithinLatencyCap()
+    {
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 200,
+            initialCapBytes: 1_000_000);
+        SetField(budget, "_hasMinRttSample", true);
+        SetField(budget, "_minRttSeconds", 0.001);
+        SetField(budget, "_servingRttEwmaSeconds", 0.002);
+        SetField(budget, "_hasLoadedServingSample", true);
+        SetField(budget, "_windowMaxRate", 1_000_000.0);
+        SetField(budget, "_retainedLoadedMaxRate", 1_000_000.0);
+        SetField(budget, "_requestSizeEwmaBytes", 1_000.0);
+        SetField(budget, "_provenPipelineRequestQuanta", 32.0);
+        SetField(budget, "_latencyBudgetScale", 1.0);
+
+        SetCapWithoutDecay(budget, 1_000_000, T0);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(8_000)
+            .Because("the configured horizon includes serving RTT; only the remainder may become standing flight");
     }
 
     [Test]
@@ -1260,8 +1284,8 @@ public sealed class BrokerUnackedByteBudgetTests
         }
 
         await Assert.That(budget.LatencyBudgetScale).IsEqualTo(1.0).Within(0.000_001);
-        await Assert.That(budget.BudgetBytes).IsEqualTo(2_000)
-            .Because("request granularity must not turn the configured latency target back into a floor");
+        await Assert.That(budget.BudgetBytes).IsEqualTo(1_000)
+            .Because("request granularity must not add standing flight on top of serving RTT");
     }
 
     [Test]
@@ -1301,8 +1325,8 @@ public sealed class BrokerUnackedByteBudgetTests
             floorBytes: 200,
             initialCapBytes: 1_000_000);
         EstablishRate(budget, bytesPerSecond: 1_000_000, rttSeconds: 0.008);
-        await Assert.That(GetField<long>(budget, "_budgetAfterMinRttProbeBytes")).IsEqualTo(10_000)
-            .Because("the latency target binds below the 1.5x RTT safety horizon");
+        await Assert.That(GetField<long>(budget, "_budgetAfterMinRttProbeBytes")).IsEqualTo(8_000)
+            .Because("one base-RTT BDP remains when serving time consumes most of the end-to-end target");
         budget.Charge(20_000);
 
         for (var i = 1; i <= 8; i++)

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -192,7 +192,10 @@ public sealed class ProducerDeliveryDiagnosticsTests
         var ackTimestamp = Stopwatch.GetTimestamp();
         budget.OnAcked(
             1_000,
-            budget.SnapshotDelivery(ackTimestamp - Stopwatch.Frequency / 1_000, appLimited: true),
+            budget.SnapshotDelivery(
+                ackTimestamp - Stopwatch.Frequency / 1_000,
+                appLimited: true,
+                oldestBatchTimestamp: ackTimestamp - Stopwatch.Frequency * 2 / 1_000),
             ackTimestamp);
         budget.CompleteAckedPass(ackTimestamp);
 
@@ -210,6 +213,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(current.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(current.ProvenPipelineRequestQuanta).IsEqualTo(4.0);
+        await Assert.That(current.SealToAckLatencyEwmaMicros).IsEqualTo(2_000).Within(10);
         await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
@@ -225,6 +229,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(sample.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(sample.CapacityProbeFailureCount).IsEqualTo(0);
         await Assert.That(sample.ProvenPipelineRequestQuanta).IsEqualTo(4.0);
+        await Assert.That(sample.SealToAckLatencyEwmaMicros).IsEqualTo(2_000).Within(10);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerDeliveryDiagnosticsTests.cs
@@ -209,6 +209,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(current.AdmissionBlockCount).IsEqualTo(1);
         await Assert.That(current.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(current.CapacityProbeFailureCount).IsEqualTo(0);
+        await Assert.That(current.ProvenPipelineRequestQuanta).IsEqualTo(4.0);
         await Assert.That(current.RequestSizeLog2Histogram).IsNotNull();
         await Assert.That(current.RequestSizeLog2Histogram!.Sum()).IsEqualTo(1);
         await Assert.That(current.RequestRttMicrosLog2Histogram).IsNotNull();
@@ -223,6 +224,7 @@ public sealed class ProducerDeliveryDiagnosticsTests
         await Assert.That(sample.BrokerId).IsEqualTo(7);
         await Assert.That(sample.CapacityProbeSuccessCount).IsEqualTo(0);
         await Assert.That(sample.CapacityProbeFailureCount).IsEqualTo(0);
+        await Assert.That(sample.ProvenPipelineRequestQuanta).IsEqualTo(4.0);
         await Assert.That(sample.CapturedAtUtc).IsLessThanOrEqualTo(snapshot.CapturedAtUtc);
         await Assert.That(sample.RequestSizeLog2Histogram).IsNull()
             .Because("periodic samples omit histograms to keep the 4096-entry ring compact");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -309,7 +309,8 @@ public sealed class ConnectionScaleReportingTests
                         DeliveryLatencyEwmaMicros = 2_500,
                         LatencyBudgetScale = 1.0,
                         CapacityProbeSuccessCount = 3,
-                        CapacityProbeFailureCount = 2
+                        CapacityProbeFailureCount = 2,
+                        ProvenPipelineRequestQuanta = 5.0
                     }
                 ]
             }
@@ -337,6 +338,8 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("8.0 MiB");
         await Assert.That(markdown).Contains("750.0 MB/s");
         await Assert.That(markdown).Contains("3/2");
+        await Assert.That(markdown).Contains("Proven request depth");
+        await Assert.That(markdown).Contains("| 5.00 | 750.0 MB/s |");
         await Assert.That(markdown).Contains("Producer Budget Probe Events - Fire-and-Forget");
         await Assert.That(markdown).Contains("min-rtt");
         await Assert.That(markdown).Contains("Producer Admission Block Durations - Fire-and-Forget");

--- a/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/ConnectionScaleReportingTests.cs
@@ -310,7 +310,8 @@ public sealed class ConnectionScaleReportingTests
                         LatencyBudgetScale = 1.0,
                         CapacityProbeSuccessCount = 3,
                         CapacityProbeFailureCount = 2,
-                        ProvenPipelineRequestQuanta = 5.0
+                        ProvenPipelineRequestQuanta = 5.0,
+                        SealToAckLatencyEwmaMicros = 4_250
                     }
                 ]
             }
@@ -339,7 +340,8 @@ public sealed class ConnectionScaleReportingTests
         await Assert.That(markdown).Contains("750.0 MB/s");
         await Assert.That(markdown).Contains("3/2");
         await Assert.That(markdown).Contains("Proven request depth");
-        await Assert.That(markdown).Contains("| 5.00 | 750.0 MB/s |");
+        await Assert.That(markdown).Contains("Seal-to-ack EWMA");
+        await Assert.That(markdown).Contains("| 5.00 | 4.25 ms | 750.0 MB/s |");
         await Assert.That(markdown).Contains("Producer Budget Probe Events - Fire-and-Forget");
         await Assert.That(markdown).Contains("min-rtt");
         await Assert.That(markdown).Contains("Producer Admission Block Durations - Fire-and-Forget");

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -285,8 +285,8 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## Producer Budget Timeline - {label}");
         sb.AppendLine();
-        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
-        sb.AppendLine("|--------|------------|-------:|------------------|---------:|----------------------:|-----------------:|---------------------------|");
+        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Proven request depth | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
+        sb.AppendLine("|--------|------------|-------:|------------------|---------------------:|---------:|----------------------:|-----------------:|---------------------------|");
         foreach (var row in displayedRows)
         {
             var nearest = row.Result.Throughput.IntervalSamples
@@ -297,6 +297,7 @@ internal static class MarkdownReporter
             sb.AppendLine(
                 $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss.fff} | {row.Sample.BrokerId} | " +
                 $"{row.Sample.BudgetBytes / 1_048_576.0:F1} MiB / {row.Sample.UnackedBytes / 1_048_576.0:F1} MiB | " +
+                $"{row.Sample.ProvenPipelineRequestQuanta:F2} | " +
                 $"{row.Sample.MaxRateBytesPerSec / 1_000_000.0:F1} MB/s | " +
                 $"{row.Sample.CapacityProbeSuccessCount:N0}/{row.Sample.CapacityProbeFailureCount:N0} | " +
                 $"{row.Sample.AdmissionBlockCount:N0} | {throughput} |");

--- a/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
+++ b/tools/Dekaf.StressTests/Reporting/MarkdownReporter.cs
@@ -285,8 +285,8 @@ internal static class MarkdownReporter
 
         sb.AppendLine($"## Producer Budget Timeline - {label}");
         sb.AppendLine();
-        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Proven request depth | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
-        sb.AppendLine("|--------|------------|-------:|------------------|---------------------:|---------:|----------------------:|-----------------:|---------------------------|");
+        sb.AppendLine("| Client | Sample UTC | Broker | Budget / unacked | Proven request depth | Seal-to-ack EWMA | Max rate | Probe success/failure | Admission blocks | Nearest throughput sample |");
+        sb.AppendLine("|--------|------------|-------:|------------------|---------------------:|-----------------:|---------:|----------------------:|-----------------:|---------------------------|");
         foreach (var row in displayedRows)
         {
             var nearest = row.Result.Throughput.IntervalSamples
@@ -298,6 +298,7 @@ internal static class MarkdownReporter
                 $"| {row.Result.Client} | {row.Sample.CapturedAtUtc:HH:mm:ss.fff} | {row.Sample.BrokerId} | " +
                 $"{row.Sample.BudgetBytes / 1_048_576.0:F1} MiB / {row.Sample.UnackedBytes / 1_048_576.0:F1} MiB | " +
                 $"{row.Sample.ProvenPipelineRequestQuanta:F2} | " +
+                $"{row.Sample.SealToAckLatencyEwmaMicros / 1_000.0:F2} ms | " +
                 $"{row.Sample.MaxRateBytesPerSec / 1_000_000.0:F1} MB/s | " +
                 $"{row.Sample.CapacityProbeSuccessCount:N0}/{row.Sample.CapacityProbeFailureCount:N0} | " +
                 $"{row.Sample.AdmissionBlockCount:N0} | {throughput} |");


### PR DESCRIPTION
## Summary
- persist request depth proven by flat-RTT capacity-probe rate gains
- keep proven depth bounded by the latency controller and broker cap
- reset stale path evidence after sustained idle
- expose proven request depth in producer stress diagnostics

## Root cause
Profile run 29421976165 showed only 1.03/2 client cores used, negligible allocation/GC pressure, but 170,871 admission blocks at a 3.7-4.8 MiB budget. #2128's successful 25% probes were transient: normal admission always returned to four ~1 MiB requests, making the gate self-confirming below broker/client capacity.

## Validation
- 97/97 BrokerUnackedByteBudget tests (net10.0)
- 1039/1039 producer tests (net10.0)
- 1039/1039 producer tests (net8.0)
- 19/19 producer delivery diagnostics tests
- 2/2 stress reporting tests
- Release build: 0 warnings/errors

Closes #2108
