### PR TITLE
feat: make stress profiling produce decision-ready bottleneck data

### DIFF
--- a/.github/scripts/stress_profile_summary.py
+++ b/.github/scripts/stress_profile_summary.py
@@ -1,0 +1,232 @@
+"""Turn raw stress-profile artifacts into a decision-ready markdown summary.
+
+Inputs (produced by tools/profile-stress-test.sh in --profile-dir):
+  profile-metadata.txt     key=value run metadata, including trace_windows and
+                           the measured_start/counters_start epochs.
+  runtime-counters.csv     1 Hz dotnet-counters output (System.Runtime + Dekaf).
+  <label>.topN-inclusive.txt  dotnet-trace topN report per trace window.
+
+Output: one markdown file with
+  1. per-window counter aggregates (mean/max per counter per window), and
+  2. window-to-window movement of topN inclusive CPU percentages,
+so bottleneck decisions come from tables instead of eyeballing raw artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+# Matches dotnet-trace PrintReportHelper rows: "12. Name(args)   45.67%   12.34%"
+# The name field is fixed-width (70) so 2+ spaces always precede the metrics.
+TOPN_ROW = re.compile(r"^\s*(\d+)\.\s+(?P<name>.*?)\s{2,}(?P<inclusive>\d+(?:\.\d+)?)%\s+(?P<exclusive>\d+(?:\.\d+)?)%")
+
+
+def parse_metadata(path):
+    metadata = {}
+    if not path.exists():
+        return metadata
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def parse_windows(spec):
+    windows = []
+    for part in spec.split(","):
+        pieces = part.split(":")
+        if len(pieces) != 3:
+            continue
+        offset, duration, label = pieces
+        windows.append((int(offset), int(duration), label))
+    return windows
+
+
+def load_counter_rows(path):
+    """Return (offset_seconds, provider, counter, type, value) per CSV row.
+
+    dotnet-counters timestamps are local-time and culture-formatted, so rows
+    are anchored by tick index instead: each distinct timestamp string is one
+    1 Hz refresh interval from the counters start.
+    """
+    rows = []
+    if not path.exists():
+        return rows
+    tick_by_stamp = {}
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, None)
+        if header is None:
+            return rows
+        for record in reader:
+            if len(record) < 5:
+                continue
+            stamp, provider, counter, counter_type, value = record[:5]
+            try:
+                numeric = float(value)
+            except ValueError:
+                continue
+            tick = tick_by_stamp.setdefault(stamp, len(tick_by_stamp))
+            rows.append((tick, provider, counter, counter_type, numeric))
+    return rows
+
+
+def summarize_counters(rows, windows, counter_skew_seconds):
+    """Aggregate counter values into mean/max per (counter, window)."""
+    aggregates = {}
+    for tick, provider, counter, counter_type, value in rows:
+        offset = tick + counter_skew_seconds
+        for start, duration, label in windows:
+            if start <= offset < start + duration:
+                key = (provider, counter, counter_type)
+                stats = aggregates.setdefault(key, {})
+                window_stats = stats.setdefault(label, [0, 0.0, float("-inf")])
+                window_stats[0] += 1
+                window_stats[1] += value
+                window_stats[2] = max(window_stats[2], value)
+                break
+    return aggregates
+
+
+def format_value(value):
+    if value != value:  # NaN
+        return "-"
+    magnitude = abs(value)
+    if magnitude >= 1_000_000_000:
+        return f"{value / 1_000_000_000:.2f}G"
+    if magnitude >= 1_000_000:
+        return f"{value / 1_000_000:.2f}M"
+    if magnitude >= 1_000:
+        return f"{value / 1_000:.2f}k"
+    if magnitude >= 1:
+        return f"{value:.2f}"
+    return f"{value:.4g}"
+
+
+def counter_table(aggregates, windows):
+    lines = []
+    labels = [label for _, _, label in windows]
+    if not aggregates:
+        lines.append("_No counter data captured._")
+        return lines
+    header = "| Counter | Type | " + " | ".join(f"{label} mean (max)" for label in labels) + " |"
+    lines.append(header)
+    lines.append("|" + "---|" * (2 + len(labels)))
+    for (provider, counter, counter_type) in sorted(aggregates):
+        stats = aggregates[(provider, counter, counter_type)]
+        cells = []
+        for label in labels:
+            if label in stats:
+                count, total, peak = stats[label]
+                cells.append(f"{format_value(total / count)} ({format_value(peak)})")
+            else:
+                cells.append("-")
+        lines.append(f"| {provider} / {counter} | {counter_type} | " + " | ".join(cells) + " |")
+    return lines
+
+
+def parse_topn(path):
+    """Return {function name: inclusive percent} for one topN report file."""
+    percents = {}
+    if not path.exists():
+        return percents
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = TOPN_ROW.match(line)
+        if not match:
+            continue
+        name = match.group("name").strip()
+        value = float(match.group("inclusive"))
+        # Fixed-width truncation can collide distinct methods; keep the larger.
+        percents[name] = max(value, percents.get(name, 0.0))
+    return percents
+
+
+def topn_movement_table(per_window, windows, limit=25):
+    lines = []
+    labels = [label for _, _, label in windows]
+    present = [label for label in labels if per_window.get(label)]
+    if len(present) < 2:
+        lines.append("_Fewer than two parseable topN reports; no movement to compare._")
+        return lines
+
+    methods = set()
+    for label in present:
+        methods.update(per_window[label])
+
+    def delta(method):
+        first = per_window[present[0]].get(method, 0.0)
+        last = per_window[present[-1]].get(method, 0.0)
+        return last - first
+
+    ranked = sorted(methods, key=lambda m: abs(delta(m)), reverse=True)[:limit]
+    header = "| Function (inclusive %) | " + " | ".join(present) + " | Δ last−first |"
+    lines.append(header)
+    lines.append("|" + "---|" * (2 + len(present)))
+    for method in ranked:
+        cells = []
+        for label in present:
+            value = per_window[label].get(method)
+            cells.append(f"{value:.2f}" if value is not None else "-")
+        lines.append(f"| `{method}` | " + " | ".join(cells) + f" | {delta(method):+.2f} |")
+    return lines
+
+
+def build_summary(profile_dir):
+    profile_dir = Path(profile_dir)
+    metadata = parse_metadata(profile_dir / "profile-metadata.txt")
+    windows = parse_windows(metadata.get("trace_windows", ""))
+
+    lines = ["# Stress Profile Summary", ""]
+    if metadata:
+        lines.append(f"- Profile: `{metadata.get('trace_profile', 'unknown')}`")
+        lines.append(f"- Windows: `{metadata.get('trace_windows', 'unknown')}`")
+        lines.append(f"- Stress args: `{metadata.get('stress_args', 'unknown')}`")
+        lines.append("")
+    if not windows:
+        lines.append("_No trace windows found in profile-metadata.txt; nothing to summarize._")
+        return "\n".join(lines) + "\n"
+
+    try:
+        counter_skew = int(metadata.get("counters_start_epoch", "")) - int(
+            metadata.get("measured_start_epoch", "")
+        )
+    except ValueError:
+        counter_skew = 0
+
+    lines.append("## Counter aggregates by window")
+    lines.append("")
+    rows = load_counter_rows(profile_dir / "runtime-counters.csv")
+    lines.extend(counter_table(summarize_counters(rows, windows, counter_skew), windows))
+    lines.append("")
+
+    lines.append("## Top-method movement across windows")
+    lines.append("")
+    per_window = {
+        label: parse_topn(profile_dir / f"{label}.topN-inclusive.txt")
+        for _, _, label in windows
+    }
+    lines.extend(topn_movement_table(per_window, windows))
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile-dir", required=True, help="Directory of profile artifacts")
+    parser.add_argument("--output", required=True, help="Markdown output path")
+    args = parser.parse_args(argv)
+
+    summary = build_summary(args.profile_dir)
+    output = Path(args.output)
+    output.write_text(summary, encoding="utf-8")
+    print(f"Wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_stress_profile.py
+++ b/.github/scripts/test_stress_profile.py
@@ -9,6 +9,10 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "stress-tests.yml"
 
 
 class StressProfileScriptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.script = SCRIPT.read_text(encoding="utf-8")
+
     def run_validation(self, windows):
         command = (
             f'PROFILE_VALIDATE_ONLY=true TRACE_WINDOWS="{windows}" '
@@ -49,8 +53,25 @@ class StressProfileScriptTests(unittest.TestCase):
         self.assertNotEqual(0, result.returncode)
         self.assertIn("Duplicate window label", result.stderr)
 
+    def test_rejects_invalid_stack_snapshot_count(self):
+        command = (
+            'PROFILE_VALIDATE_ONLY=true PROFILE_STACK_SNAPSHOTS=0 '
+            "bash tools/profile-stress-test.sh "
+            "--duration 15 --scenario producer --client dekaf"
+        )
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            cwd=REPO_ROOT,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("PROFILE_STACK_SNAPSHOTS", result.stderr)
+
     def test_uses_measured_marker_and_exact_pid_cleanup(self):
-        script = SCRIPT.read_text(encoding="utf-8")
+        script = self.script
 
         self.assertIn('grep -Eq "$TRACE_START_PATTERN"', script)
         self.assertIn('dotnet-counters collect', script)
@@ -58,6 +79,51 @@ class StressProfileScriptTests(unittest.TestCase):
         self.assertIn('dotnet-trace collect', script)
         self.assertIn('taskkill //F //PID "$STRESS_PID"', script)
         self.assertNotIn("//IM", script)
+
+    def test_collects_dekaf_meter_alongside_runtime_counters(self):
+        script = self.script
+
+        self.assertIn('PROFILE_COUNTER_PROVIDERS="${PROFILE_COUNTER_PROVIDERS:-System.Runtime,Dekaf}"', script)
+        self.assertIn('--counters "$PROFILE_COUNTER_PROVIDERS"', script)
+        self.assertIn('counters_start_epoch=', script)
+
+    def test_full_profile_is_verbose_and_includes_tpl_provider(self):
+        script = self.script
+
+        # Level 5 is load-bearing: GCAllocationTick is verbose-only, so a level-4
+        # "full" profile silently drops allocation-by-type data.
+        self.assertIn("0x000000000049C001:5", script)
+        self.assertIn("System.Threading.Tasks.TplEventSource:0x1C3:4", script)
+
+    def test_spreads_stack_snapshots_inside_traced_window(self):
+        script = self.script
+
+        self.assertIn('${label}.stacks.${snap}.txt', script)
+        self.assertIn("snapshot_gap", script)
+
+    def test_gcdump_is_opt_in_and_captured_after_the_trace(self):
+        script = self.script
+
+        self.assertIn('PROFILE_GCDUMP="${PROFILE_GCDUMP:-false}"', script)
+        self.assertIn("dotnet-gcdump collect", script)
+        # Ordering matters: the gcdump-induced blocking GC must not pollute the
+        # traced window, so collection happens after the trace wait completes.
+        self.assertLess(
+            script.index('wait "$trace_pid"'),
+            script.index("dotnet-gcdump collect"),
+        )
+
+    def test_generates_event_aggregation_and_summary(self):
+        script = self.script
+
+        # The analyzer is built once up front (fail-fast, no per-window MSBuild)
+        # and aggregation is gated on the providers actually carrying CLR events.
+        self.assertIn('ANALYZER_EXE=', script)
+        self.assertIn('dotnet build "$REPO_ROOT/tools/Dekaf.TraceAnalyzer"', script)
+        self.assertIn('*Microsoft-Windows-DotNETRuntime*', script)
+        self.assertIn('"$ANALYZER_EXE" "$trace_path"', script)
+        self.assertIn("stress_profile_summary.py", script)
+        self.assertIn("profile-summary.md", script)
 
 
 class StressProfileWorkflowTests(unittest.TestCase):
@@ -96,6 +162,24 @@ class StressProfileWorkflowTests(unittest.TestCase):
             "dotnet tool install --global dotnet-trace --version 9.0.661903",
             self.workflow,
         )
+        self.assertIn(
+            "dotnet tool install --global dotnet-gcdump --version 9.0.661903",
+            self.workflow,
+        )
+
+    def test_gcdump_capture_is_wired_for_gc_dispatches(self):
+        self.assertIn(
+            'PROFILE_GCDUMP="$([ "$PROFILE_MODE" = "gc" ] && echo true || echo false)"',
+            self.workflow,
+        )
+
+    def test_extra_args_stay_separate_argv_entries(self):
+        # A space-separated EXTRA_ARGS string appended as one quoted element
+        # reaches the client as a single unparseable argument; the array keeps
+        # multi-token additions safe on both the paired and 3conn paths.
+        self.assertIn("EXTRA_ARGS=()", self.workflow)
+        self.assertIn('STRESS_ARGS+=("${EXTRA_ARGS[@]}")', self.workflow)
+        self.assertIn('"${EXTRA_ARGS[@]}" \\', self.workflow)
 
     def test_keeps_target_and_profiler_affinity_separate(self):
         self.assertIn('STRESS_CPUSET="$CLIENT_CPUS"', self.workflow)

--- a/.github/scripts/test_stress_profile_summary.py
+++ b/.github/scripts/test_stress_profile_summary.py
@@ -1,0 +1,171 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from stress_profile_summary import (
+    build_summary,
+    load_counter_rows,
+    parse_topn,
+    summarize_counters,
+    topn_movement_table,
+)
+
+# Real shape from dotnet-trace PrintReportHelper: index + '. ' + name padded to
+# 70 chars + inclusive% in a 20-wide field left-padded by 4 + exclusive%.
+TOPN_SAMPLE = (
+    "Top 3 Functions (Inclusive)                                                  "
+    "Inclusive           Exclusive           \n"
+    " 1. BrokerSender.SendLoopAsync(class System.Threading.CancellationToken)   "
+    "    45.67%              12.34%              \n"
+    " 2. RecordAccumulator.Append(!0&,!1&)                                       "
+    "    30.5%               8%                  \n"
+    " 3. Missing Symbol                                                          "
+    "    10%                 10%                 \n"
+)
+
+COUNTERS_SAMPLE = (
+    "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment\n"
+    "07/15/2026 15:00:00,System.Runtime,CPU Usage (%),Metric,50\n"
+    "07/15/2026 15:00:00,Dekaf,dekaf.producer.buffer.used_bytes,Metric,1000\n"
+    "07/15/2026 15:00:01,System.Runtime,CPU Usage (%),Metric,70\n"
+    "07/15/2026 15:00:01,Dekaf,dekaf.producer.buffer.used_bytes,Metric,3000\n"
+    "07/15/2026 15:00:02,System.Runtime,CPU Usage (%),Metric,90\n"
+    "07/15/2026 15:00:02,Dekaf,dekaf.producer.buffer.used_bytes,Metric,5000\n"
+    "07/15/2026 15:00:03,System.Runtime,CPU Usage (%),Metric,10\n"
+)
+
+
+class TopNParsingTests(unittest.TestCase):
+    def parse(self, content):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "w.topN-inclusive.txt"
+            path.write_text(content, encoding="utf-8")
+            return parse_topn(path)
+
+    def test_parses_fixed_width_rows_and_skips_header(self):
+        percents = self.parse(TOPN_SAMPLE)
+
+        self.assertEqual(
+            45.67,
+            percents["BrokerSender.SendLoopAsync(class System.Threading.CancellationToken)"],
+        )
+        self.assertEqual(30.5, percents["RecordAccumulator.Append(!0&,!1&)"])
+        self.assertEqual(10.0, percents["Missing Symbol"])
+        self.assertEqual(3, len(percents))
+
+    def test_duplicate_truncated_names_keep_larger_percent(self):
+        content = (
+            " 1. Same.Name(x)                                                            "
+            "    40%                 5%                  \n"
+            " 2. Same.Name(x)                                                            "
+            "    15%                 5%                  \n"
+        )
+
+        self.assertEqual({"Same.Name(x)": 40.0}, self.parse(content))
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual({}, parse_topn(Path("does-not-exist.txt")))
+
+
+class CounterAggregationTests(unittest.TestCase):
+    def load_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "runtime-counters.csv"
+            path.write_text(COUNTERS_SAMPLE, encoding="utf-8")
+            return load_counter_rows(path)
+
+    def test_rows_are_anchored_by_timestamp_tick_index(self):
+        rows = self.load_rows()
+
+        ticks = sorted({row[0] for row in rows})
+        self.assertEqual([0, 1, 2, 3], ticks)
+
+    def test_window_aggregation_computes_mean_and_max(self):
+        rows = self.load_rows()
+        windows = [(0, 2, "healthy"), (2, 2, "collapse")]
+
+        aggregates = summarize_counters(rows, windows, counter_skew_seconds=0)
+
+        cpu = aggregates[("System.Runtime", "CPU Usage (%)", "Metric")]
+        count, total, peak = cpu["healthy"]
+        self.assertEqual(2, count)
+        self.assertEqual(60.0, total / count)
+        self.assertEqual(70.0, peak)
+        count, total, peak = cpu["collapse"]
+        self.assertEqual(50.0, total / count)
+        self.assertEqual(90.0, peak)
+
+    def test_counter_skew_shifts_rows_between_windows(self):
+        rows = self.load_rows()
+        windows = [(2, 2, "late")]
+
+        aggregates = summarize_counters(rows, windows, counter_skew_seconds=2)
+
+        cpu = aggregates[("System.Runtime", "CPU Usage (%)", "Metric")]
+        count, total, _ = cpu["late"]
+        self.assertEqual(2, count)
+        self.assertEqual(60.0, total / count)
+
+
+class MovementTableTests(unittest.TestCase):
+    def test_ranks_by_absolute_delta_between_first_and_last_window(self):
+        windows = [(0, 30, "healthy"), (60, 30, "collapse")]
+        per_window = {
+            "healthy": {"Stable.Method()": 20.0, "Collapsing.Method()": 5.0},
+            "collapse": {"Stable.Method()": 21.0, "Collapsing.Method()": 45.0},
+        }
+
+        lines = topn_movement_table(per_window, windows)
+
+        table = "\n".join(lines)
+        self.assertIn("Collapsing.Method()", table)
+        self.assertIn("+40.00", table)
+        collapsing_row = next(i for i, l in enumerate(lines) if "Collapsing" in l)
+        stable_row = next(i for i, l in enumerate(lines) if "Stable" in l)
+        self.assertLess(collapsing_row, stable_row)
+
+    def test_single_window_reports_nothing_to_compare(self):
+        windows = [(0, 30, "only")]
+        lines = topn_movement_table({"only": {"A.B()": 1.0}}, windows)
+
+        self.assertIn("Fewer than two parseable topN reports", "\n".join(lines))
+
+
+class BuildSummaryTests(unittest.TestCase):
+    def test_end_to_end_summary_contains_both_sections(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            profile_dir = Path(tmp)
+            (profile_dir / "profile-metadata.txt").write_text(
+                "trace_profile=gc\n"
+                "trace_windows=0:2:healthy,2:2:collapse\n"
+                "measured_start_epoch=100\n"
+                "counters_start_epoch=100\n"
+                "stress_args=--duration 15\n",
+                encoding="utf-8",
+            )
+            (profile_dir / "runtime-counters.csv").write_text(
+                COUNTERS_SAMPLE, encoding="utf-8"
+            )
+            (profile_dir / "healthy.topN-inclusive.txt").write_text(
+                TOPN_SAMPLE, encoding="utf-8"
+            )
+            (profile_dir / "collapse.topN-inclusive.txt").write_text(
+                TOPN_SAMPLE.replace("45.67%", "80.00%"), encoding="utf-8"
+            )
+
+            summary = build_summary(profile_dir)
+
+        self.assertIn("## Counter aggregates by window", summary)
+        self.assertIn("dekaf.producer.buffer.used_bytes", summary)
+        self.assertIn("## Top-method movement across windows", summary)
+        self.assertIn("BrokerSender.SendLoopAsync", summary)
+
+    def test_missing_metadata_degrades_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            summary = build_summary(tmp)
+
+        self.assertIn("nothing to summarize", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -77,7 +77,7 @@ on:
         required: false
         default: '60:30:healthy,330:30:pre-collapse,420:30:collapse,600:30:degraded'
       profile_counters:
-        description: 'Collect one-second System.Runtime counters across the measured phase'
+        description: 'Collect one-second System.Runtime + Dekaf meter counters across the measured phase'
         required: false
         type: boolean
         default: true
@@ -261,6 +261,11 @@ jobs:
         run: |
           dotnet tool install --global dotnet-counters --version 9.0.661903
           dotnet tool install --global dotnet-trace --version 9.0.661903
+          if [ "${{ github.event.inputs.profile_mode }}" = "gc" ]; then
+            # gc dispatches also capture per-window heap dumps (PROFILE_GCDUMP below);
+            # other modes never run gcdump, so skip the install cost.
+            dotnet tool install --global dotnet-gcdump --version 9.0.661903
+          fi
 
       - name: Build Stress Tests
         run: dotnet build tools/Dekaf.StressTests --configuration Release
@@ -353,9 +358,12 @@ jobs:
           cd tools/Dekaf.StressTests
           # Consumer fetch diagnostics are opt-in: they add Dekaf-only overhead inside the
           # measured window, so measurement runs keep them off and debug dispatches enable them.
-          EXTRA_ARGS=""
+          # An array so multi-token additions stay separate argv entries: appending a
+          # space-separated string as one quoted element would reach the client as a
+          # single unparseable argument.
+          EXTRA_ARGS=()
           if [ "${{ github.event.inputs.consumer_fetch_diagnostics }}" = "true" ]; then
-            EXTRA_ARGS="--consumer-fetch-diagnostics"
+            EXTRA_ARGS+=(--consumer-fetch-diagnostics)
           fi
           # Client pinned to its own cores: whichever client pushes more through the
           # same cores is genuinely faster, instead of both saturating the broker.
@@ -384,9 +392,7 @@ jobs:
               --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }}
               --output ./results
             )
-            if [ -n "$EXTRA_ARGS" ]; then
-              STRESS_ARGS+=("$EXTRA_ARGS")
-            fi
+            STRESS_ARGS+=("${EXTRA_ARGS[@]}")
 
             if [ "$PROFILE_MODE" != "off" ]; then
               # The stress process retains the normal client-core isolation. Attach
@@ -397,6 +403,7 @@ jobs:
               TRACE_WINDOWS="${{ github.event.inputs.profile_windows }}" \
               PROFILE_COUNTERS="${{ github.event.inputs.profile_counters }}" \
               PROFILE_STACKS="${{ github.event.inputs.profile_stacks }}" \
+              PROFILE_GCDUMP="$([ "$PROFILE_MODE" = "gc" ] && echo true || echo false)" \
               STRESS_CPUSET="$CLIENT_CPUS" \
               PROFILER_CPUSET="5" \
               bash ../../tools/profile-stress-test.sh "${STRESS_ARGS[@]}"
@@ -415,7 +422,7 @@ jobs:
               --brokers ${{ matrix.brokers }} \
               --connections-per-broker 3 \
               --producer-delivery-diagnostics \
-              ${EXTRA_ARGS} \
+              "${EXTRA_ARGS[@]}" \
               --roundtrip-messages ${{ github.event.inputs.roundtrip_messages || '250000' }} \
               --roundtrip-steady-seconds ${{ github.event.inputs.roundtrip_steady_seconds || matrix.roundtrip_steady_seconds || '60' }} \
               --output ./results

--- a/Dekaf.sln
+++ b/Dekaf.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.Tests.Aot.DependencyI
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.StressTests.Tests", "tools\Dekaf.StressTests.Tests\Dekaf.StressTests.Tests.csproj", "{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekaf.TraceAnalyzer", "tools\Dekaf.TraceAnalyzer\Dekaf.TraceAnalyzer.csproj", "{C36DE679-3D66-45B2-8887-121E4FCEB8CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -343,6 +345,18 @@ Global
 		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x64.Build.0 = Release|Any CPU
 		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x86.ActiveCfg = Release|Any CPU
 		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5}.Release|x86.Build.0 = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|x64.Build.0 = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Debug|x86.Build.0 = Debug|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|x64.ActiveCfg = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|x64.Build.0 = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|x86.ActiveCfg = Release|Any CPU
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -371,5 +385,6 @@ Global
 		{297DF785-1A36-4A2A-9335-B71EED7D1D26} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{439DB660-B5F9-4C6B-BB4B-9EB15AE144E8} = {B2C3D4E5-F6A7-8901-BCDE-F12345678901}
 		{F17E41FC-904D-4EC0-B2F8-E6158B8B75F5} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+		{C36DE679-3D66-45B2-8887-121E4FCEB8CE} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
     <PackageVersion Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
@@ -25,7 +26,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
     <PackageVersion Include="ModularPipelines" Version="3.2.8" />
     <PackageVersion Include="ModularPipelines.DotNet" Version="3.2.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.4" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
     <PackageVersion Include="ModularPipelines" Version="3.2.8" />
     <PackageVersion Include="ModularPipelines.DotNet" Version="3.2.8" />

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -262,13 +262,27 @@ internal static class DekafMetrics
         => DekafDiagnostics.Meter.CreateObservableGauge(
             name, () => ObserveProducers(source => source.SenderValues(selector)), unit, description);
 
+    // A source that throws (e.g. producer mid-disposal) is skipped rather than
+    // aborting the scrape for every other registered producer — the same
+    // isolation ObserveAllConsumerLag applies. Selectors are lazy iterators, so
+    // each source is materialized inside the guard to also cover enumeration.
     private static IEnumerable<Measurement<T>> ObserveProducers<T>(
         Func<ProducerStateSource, IEnumerable<Measurement<T>>> selector)
         where T : struct
     {
         foreach (var (source, _) in ProducerStateSources)
         {
-            foreach (var measurement in selector(source))
+            Measurement<T>[] measurements;
+            try
+            {
+                measurements = selector(source).ToArray();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var measurement in measurements)
             {
                 yield return measurement;
             }
@@ -280,7 +294,17 @@ internal static class DekafMetrics
     {
         foreach (var (source, _) in ProducerStateSources)
         {
-            yield return selector(source);
+            Measurement<long> measurement;
+            try
+            {
+                measurement = selector(source);
+            }
+            catch
+            {
+                continue;
+            }
+
+            yield return measurement;
         }
     }
 }

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
+using Dekaf.Producer;
 
 namespace Dekaf.Diagnostics;
 
@@ -131,6 +132,155 @@ internal static class DekafMetrics
             {
                 yield return measurement;
             }
+        }
+    }
+
+    // Producer internal controller state — same registry pattern as consumer lag.
+    // Diagnosing controller pathologies (budget stuck low, delivery-rate ratchet,
+    // connection scale-down inversion, buffer backpressure) requires this state as
+    // a live time series; throughput curves only show the symptom. Observable
+    // instruments are pull-based, so nothing here ever runs on the produce hot path
+    // and the closures below only execute when a metrics listener polls.
+
+    private static readonly ConcurrentDictionary<ProducerStateSource, byte> ProducerStateSources = new();
+
+    internal static readonly ObservableGauge<long> ProducerBufferUsedBytes = ProducerGauge(
+        "dekaf.producer.buffer.used_bytes", "By",
+        "Bytes currently reserved in the producer's BufferMemory.",
+        static source => source.BufferUsedBytes());
+
+    internal static readonly ObservableGauge<long> ProducerBufferLimitBytes = ProducerGauge(
+        "dekaf.producer.buffer.limit_bytes", "By",
+        "Configured producer BufferMemory limit.",
+        static source => source.BufferLimitBytes());
+
+    internal static readonly ObservableCounter<long> ProducerBufferPressureEvents =
+        DekafDiagnostics.Meter.CreateObservableCounter(
+            "dekaf.producer.buffer.pressure_events",
+            observeValues: () => ObserveProducers(static source => source.BufferPressureEvents()),
+            unit: "{event}",
+            description: "Times ProduceAsync entered the buffer-full slow path.");
+
+    // Per-broker budget stats: keep this selector set in sync with
+    // RecordAccumulator.CreateBrokerBudgetDiagnostic, which exports the same
+    // state into the opt-in delivery-diagnostics snapshot.
+    internal static readonly ObservableGauge<long> ProducerBrokerBudgetBytes = BudgetGauge(
+        "dekaf.producer.broker.budget_bytes", "By",
+        "Published unacked-byte admission budget per broker.",
+        static budget => budget.BudgetBytes);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerUnackedBytes = BudgetGauge(
+        "dekaf.producer.broker.unacked_bytes", "By",
+        "Standing unacked bytes charged against the broker budget.",
+        static budget => budget.UnackedBytes);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerMinRtt = BudgetGauge(
+        "dekaf.producer.broker.min_rtt", "us",
+        "Minimum-RTT window estimate driving the budget horizon.",
+        static budget => budget.MinimumRttMicros);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerMaxDeliveryRate = BudgetGauge(
+        "dekaf.producer.broker.max_delivery_rate", "By/s",
+        "Windowed-max delivery rate estimate per broker.",
+        static budget => budget.MaxRateBytesPerSecond);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerQueueLatencyEwma = BudgetGauge(
+        "dekaf.producer.broker.queue_latency_ewma", "us",
+        "Seal-to-send queue latency EWMA per broker.",
+        static budget => budget.DeliveryLatencyEwmaMicros);
+
+    internal static readonly ObservableGauge<double> ProducerBrokerLatencyBudgetScale =
+        DekafDiagnostics.Meter.CreateObservableGauge(
+            "dekaf.producer.broker.latency_budget_scale",
+            observeValues: () => ObserveProducers(static source => source.BudgetValues<double>(static budget => budget.LatencyBudgetScale)),
+            unit: "1",
+            description: "Latency-governed budget derating factor (1.0 = no derating).");
+
+    internal static readonly ObservableCounter<long> ProducerBrokerAdmissionBlocks = BudgetCounter(
+        "dekaf.producer.broker.admission_blocks", "{event}",
+        "Times the admission gate blocked a send on the broker budget.",
+        static budget => budget.AdmissionBlockEvents);
+
+    internal static readonly ObservableCounter<long> ProducerBrokerCapacityProbeSuccesses = BudgetCounter(
+        "dekaf.producer.broker.capacity_probe.successes", "{probe}",
+        "Capacity probes that raised the broker budget.",
+        static budget => budget.CapacityProbeSuccessCount);
+
+    internal static readonly ObservableCounter<long> ProducerBrokerCapacityProbeFailures = BudgetCounter(
+        "dekaf.producer.broker.capacity_probe.failures", "{probe}",
+        "Capacity probes that failed and restored the prior budget.",
+        static budget => budget.CapacityProbeFailureCount);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerConnections = SenderGauge(
+        "dekaf.producer.broker.connections", "{connection}",
+        "Current adaptive connection width per broker.",
+        static sender => sender.CurrentConnectionCount);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerInFlightBytes = SenderGauge(
+        "dekaf.producer.broker.in_flight_bytes", "By",
+        "Bytes written but not yet acknowledged per broker.",
+        static sender => sender.InFlightBytes);
+
+    internal static readonly ObservableGauge<long> ProducerBrokerInFlightRequests = SenderGauge(
+        "dekaf.producer.broker.in_flight_requests", "{request}",
+        "Produce requests awaiting a broker response.",
+        static sender => sender.InFlightRequestCount);
+
+    /// <summary>
+    /// Registers a producer's state source. Called from the <c>KafkaProducer</c> constructor.
+    /// </summary>
+    internal static void RegisterProducerState(ProducerStateSource source)
+    {
+        ProducerStateSources.TryAdd(source, 0);
+    }
+
+    /// <summary>
+    /// Unregisters a producer's state source. Called from <c>KafkaProducer.DisposeAsync</c>.
+    /// </summary>
+    internal static void UnregisterProducerState(ProducerStateSource source)
+    {
+        ProducerStateSources.TryRemove(source, out _);
+    }
+
+    private static ObservableGauge<long> ProducerGauge(
+        string name, string unit, string description, Func<ProducerStateSource, Measurement<long>> selector)
+        => DekafDiagnostics.Meter.CreateObservableGauge(
+            name, () => ObserveProducers(selector), unit, description);
+
+    private static ObservableGauge<long> BudgetGauge(
+        string name, string unit, string description, Func<BrokerUnackedByteBudget, long> selector)
+        => DekafDiagnostics.Meter.CreateObservableGauge(
+            name, () => ObserveProducers(source => source.BudgetValues(selector)), unit, description);
+
+    private static ObservableCounter<long> BudgetCounter(
+        string name, string unit, string description, Func<BrokerUnackedByteBudget, long> selector)
+        => DekafDiagnostics.Meter.CreateObservableCounter(
+            name, () => ObserveProducers(source => source.BudgetValues(selector)), unit, description);
+
+    private static ObservableGauge<long> SenderGauge(
+        string name, string unit, string description, Func<BrokerSender, long> selector)
+        => DekafDiagnostics.Meter.CreateObservableGauge(
+            name, () => ObserveProducers(source => source.SenderValues(selector)), unit, description);
+
+    private static IEnumerable<Measurement<T>> ObserveProducers<T>(
+        Func<ProducerStateSource, IEnumerable<Measurement<T>>> selector)
+        where T : struct
+    {
+        foreach (var (source, _) in ProducerStateSources)
+        {
+            foreach (var measurement in selector(source))
+            {
+                yield return measurement;
+            }
+        }
+    }
+
+    private static IEnumerable<Measurement<long>> ObserveProducers(
+        Func<ProducerStateSource, Measurement<long>> selector)
+    {
+        foreach (var (source, _) in ProducerStateSources)
+        {
+            yield return selector(source);
         }
     }
 }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -608,6 +608,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly long _maxInFlightBytesPerConnection;
     private readonly long[] _pendingResponseBytesByConnection;
 
+    // Diagnostic accessors for the producer state gauges (DekafMetrics), read from
+    // the metric-collection thread. _connectionCount is send-loop-owned with plain
+    // writes, so the gauge observes an eventually-consistent value — fine at 1 Hz.
+    internal int CurrentConnectionCount => Volatile.Read(ref _connectionCount);
+    internal int InFlightRequestCount => Volatile.Read(ref _totalPendingResponseCount);
+    internal long InFlightBytes => Interlocked.Read(ref _totalPendingResponseBytes);
+
     // Per-broker unacked-byte admission budget (owned by the accumulator, shared with the
     // producer's admission gate). This send loop is the single writer of its drain-rate
     // and minimum-RTT estimates (OnAcked) and cap (SetCap); null when the bound is disabled.

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Dekaf.Compression;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Internal;
 using Dekaf.Metadata;
@@ -67,6 +68,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     // channel and send loop. The per-broker in-flight semaphore enables pipelining across
     // different partitions. Ordering relies on broker idempotent producer support.
     private readonly ConcurrentDictionary<int, BrokerSender> _brokerSenders = new();
+
+    // Bridges internal controller state (buffer memory, broker budgets, connection
+    // scaling) to the "Dekaf" meter's observable gauges. Pull-based: costs nothing
+    // unless a metrics listener polls.
+    private readonly ProducerStateSource _stateSource;
 
 
     // Explicit initialization: users must call InitializeAsync() or use BuildAsync() before producing.
@@ -433,6 +439,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             TaskScheduler.Default).Unwrap();
         _accumulator.StartAppendWorkers(_senderCts.Token);
 
+        _stateSource = new ProducerStateSource(options.ClientId, _accumulator, _brokerSenders);
+        DekafMetrics.RegisterProducerState(_stateSource);
     }
 
     private static CompressionCodecRegistry CreateCompressionCodecRegistry(ProducerOptions options)
@@ -4011,6 +4019,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
+
+        DekafMetrics.UnregisterProducerState(_stateSource);
 
         if (_options.IsAutoTuned)
             _memoryBudget.UnregisterProducer(this);

--- a/src/Dekaf/Producer/ProducerStateSource.cs
+++ b/src/Dekaf/Producer/ProducerStateSource.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Per-producer bridge from internal controller state (buffer memory, per-broker
+/// delivery budgets, connection scaling, in-flight depth) to the "Dekaf" meter's
+/// observable instruments. Registered by the <c>KafkaProducer</c> constructor and
+/// unregistered on dispose via <see cref="DekafMetrics"/>.
+/// </summary>
+/// <remarks>
+/// Observable instruments are pull-based: these methods run only when a metrics
+/// listener polls (e.g. dotnet-counters at 1 Hz), never on the produce hot path.
+/// All reads go through the volatile-published accessors — the raw send-loop-owned
+/// estimator fields are single-writer and must not be read from here.
+/// </remarks>
+internal sealed class ProducerStateSource
+{
+    private readonly RecordAccumulator _accumulator;
+    private readonly ConcurrentDictionary<int, BrokerSender> _brokerSenders;
+    private readonly KeyValuePair<string, object?> _clientIdTag;
+
+    internal ProducerStateSource(
+        string? clientId,
+        RecordAccumulator accumulator,
+        ConcurrentDictionary<int, BrokerSender> brokerSenders)
+    {
+        _accumulator = accumulator;
+        _brokerSenders = brokerSenders;
+        _clientIdTag = new KeyValuePair<string, object?>(DekafDiagnostics.MessagingClientId, clientId);
+    }
+
+    internal Measurement<long> BufferUsedBytes()
+        => new(_accumulator.BufferedBytes, _clientIdTag);
+
+    internal Measurement<long> BufferLimitBytes()
+        => new((long)_accumulator.MaxBufferMemory, _clientIdTag);
+
+    internal Measurement<long> BufferPressureEvents()
+        => new(_accumulator.BufferPressureEvents, _clientIdTag);
+
+    internal IEnumerable<Measurement<T>> BudgetValues<T>(Func<BrokerUnackedByteBudget, T> selector)
+        where T : struct
+    {
+        foreach (var (brokerId, budget) in _accumulator.BrokerUnackedBudgets)
+        {
+            yield return new Measurement<T>(selector(budget), _clientIdTag, BrokerTag(brokerId));
+        }
+    }
+
+    internal IEnumerable<Measurement<long>> SenderValues(Func<BrokerSender, long> selector)
+    {
+        foreach (var (brokerId, sender) in _brokerSenders)
+        {
+            yield return new Measurement<long>(selector(sender), _clientIdTag, BrokerTag(brokerId));
+        }
+    }
+
+    private static KeyValuePair<string, object?> BrokerTag(int brokerId)
+        => new(DekafDiagnostics.MessagingKafkaBrokerId, brokerId);
+}

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1098,6 +1098,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <see cref="_unackedBudgetEnabled"/> is true.
     /// </summary>
     private readonly ConcurrentDictionary<int, BrokerUnackedByteBudget> _brokerUnackedBudgets = new();
+
+    // Enumerated by the producer state gauges (DekafMetrics) from the metric-collection
+    // thread; ConcurrentDictionary enumeration is lock-free and safe concurrently.
+    internal IEnumerable<KeyValuePair<int, BrokerUnackedByteBudget>> BrokerUnackedBudgets => _brokerUnackedBudgets;
     private readonly Func<string, int, int>? _resolveLeaderId;
     private readonly bool _unackedBudgetEnabled;
 
@@ -5456,6 +5460,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
     }
 
+    // Keep this stat set in sync with the per-broker budget gauges in
+    // DekafMetrics — both export the same BrokerUnackedByteBudget accessors.
     private static ProducerBrokerBudgetDiagnostic CreateBrokerBudgetDiagnostic(
         int brokerId,
         BrokerUnackedByteBudget budget,

--- a/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage for the per-broker producer state gauges: produces against
+/// a real broker and asserts the broker-tagged instruments report sane values,
+/// not just that the instrument names exist (unit tests cover the buffer gauges,
+/// but the per-broker dictionaries only populate with a live connection).
+/// </summary>
+[Category("ProducerStateGauges")]
+public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private static readonly string[] BrokerLongGauges =
+    [
+        "dekaf.producer.broker.budget_bytes",
+        "dekaf.producer.broker.unacked_bytes",
+        "dekaf.producer.broker.min_rtt",
+        "dekaf.producer.broker.max_delivery_rate",
+        "dekaf.producer.broker.queue_latency_ewma",
+        "dekaf.producer.broker.admission_blocks",
+        "dekaf.producer.broker.capacity_probe.successes",
+        "dekaf.producer.broker.capacity_probe.failures",
+        "dekaf.producer.broker.connections",
+        "dekaf.producer.broker.in_flight_bytes",
+        "dekaf.producer.broker.in_flight_requests",
+    ];
+
+    private sealed record BrokerSample(string Instrument, double Value, string? ClientId, object? BrokerId);
+
+    [Test]
+    public async Task BrokerGauges_AfterProducing_ReportBrokerTaggedMeasurements()
+    {
+        var clientId = $"state-gauge-{Guid.NewGuid():N}";
+        var samples = new List<BrokerSample>();
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                instrument.Name.StartsWith("dekaf.producer.broker.", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            RecordSample(samples, instrument.Name, measurement, tags));
+        listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            RecordSample(samples, instrument.Name, measurement, tags));
+        listener.Start();
+
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId(clientId)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        try
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Key = $"key-{i}",
+                    Value = $"value-{i}"
+                }, CancellationToken.None);
+            }
+
+            lock (samples)
+            {
+                samples.Clear();
+            }
+            listener.RecordObservableInstruments();
+
+            List<BrokerSample> observed;
+            lock (samples)
+            {
+                observed = samples.Where(sample => sample.ClientId == clientId).ToList();
+            }
+
+            foreach (var instrument in BrokerLongGauges)
+            {
+                var instrumentSamples = observed.Where(sample => sample.Instrument == instrument).ToList();
+                await Assert.That(instrumentSamples).IsNotEmpty()
+                    .Because($"{instrument} should report for a producer that has produced");
+                foreach (var sample in instrumentSamples)
+                {
+                    await Assert.That(sample.BrokerId).IsNotNull()
+                        .Because($"{instrument} measurements must carry the broker id tag");
+                    await Assert.That(sample.Value).IsGreaterThanOrEqualTo(0)
+                        .Because($"{instrument} must never report a negative value");
+                }
+            }
+
+            // Value sanity beyond presence: at least one live connection, a positive
+            // budget (cold start publishes the cap), and a derating factor in (0, 1].
+            var connections = observed.Where(s => s.Instrument == "dekaf.producer.broker.connections").ToList();
+            await Assert.That(connections.All(s => s.Value >= 1)).IsTrue()
+                .Because("an actively producing sender has at least one connection");
+
+            var budgets = observed.Where(s => s.Instrument == "dekaf.producer.broker.budget_bytes").ToList();
+            await Assert.That(budgets.All(s => s.Value > 0)).IsTrue()
+                .Because("the unacked-byte budget starts at its cap, never zero");
+
+            var scales = observed.Where(s => s.Instrument == "dekaf.producer.broker.latency_budget_scale").ToList();
+            await Assert.That(scales).IsNotEmpty();
+            await Assert.That(scales.All(s => s.Value > 0 && s.Value <= 1.0)).IsTrue()
+                .Because("the latency budget scale derates within (0, 1]");
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+
+        // Disposal must unregister the source: no measurements for this client id afterwards.
+        lock (samples)
+        {
+            samples.Clear();
+        }
+        listener.RecordObservableInstruments();
+        List<BrokerSample> postDispose;
+        lock (samples)
+        {
+            postDispose = samples.Where(sample => sample.ClientId == clientId).ToList();
+        }
+        await Assert.That(postDispose).IsEmpty()
+            .Because("a disposed producer must stop reporting gauge measurements");
+    }
+
+    private static void RecordSample(
+        List<BrokerSample> samples, string instrumentName, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        string? clientId = null;
+        object? brokerId = null;
+        foreach (var tag in tags)
+        {
+            if (tag.Key == DekafDiagnostics.MessagingClientId)
+                clientId = tag.Value as string;
+            else if (tag.Key == DekafDiagnostics.MessagingKafkaBrokerId)
+                brokerId = tag.Value;
+        }
+
+        lock (samples)
+        {
+            samples.Add(new BrokerSample(instrumentName, value, clientId, brokerId));
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -44,5 +44,22 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");
         await Assert.That(instrumentNames).Contains("messaging.consumer.fetch.duration");
         await Assert.That(instrumentNames).Contains("messaging.consumer.lag");
+
+        // Producer internal-state gauges (observable — published by listening alone)
+        await Assert.That(instrumentNames).Contains("dekaf.producer.buffer.used_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.buffer.limit_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.buffer.pressure_events");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.budget_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.unacked_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.min_rtt");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.max_delivery_rate");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.queue_latency_ewma");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.latency_budget_scale");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.admission_blocks");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.capacity_probe.successes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.capacity_probe.failures");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.connections");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.in_flight_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.broker.in_flight_requests");
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerStateGaugeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerStateGaugeTests.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+[NotInParallel("MeterListener")]
+public sealed class ProducerStateGaugeTests
+{
+    private const ulong BufferMemoryBytes = 64UL * 1024 * 1024;
+
+    private sealed record GaugeSample(long Value, string? ClientId);
+
+    private static MeterListener CreateListener(
+        string instrumentName, List<GaugeSample> samples)
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                instrument.Name == instrumentName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+        {
+            string? clientId = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == DekafDiagnostics.MessagingClientId)
+                    clientId = tag.Value as string;
+            }
+            samples.Add(new GaugeSample(measurement, clientId));
+        });
+        listener.Start();
+        return listener;
+    }
+
+    private static KafkaProducer<string, string> CreateProducer(string clientId)
+        => new(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ClientId = clientId,
+                BufferMemory = BufferMemoryBytes
+            },
+            Serializers.String,
+            Serializers.String);
+
+    [Test]
+    public async Task BufferLimitGauge_ReportsConfiguredBufferMemoryWithClientIdTag()
+    {
+        var clientId = $"gauge-test-{Guid.NewGuid():N}";
+        var samples = new List<GaugeSample>();
+        using var listener = CreateListener("dekaf.producer.buffer.limit_bytes", samples);
+
+        await using var producer = CreateProducer(clientId);
+        listener.RecordObservableInstruments();
+
+        var sample = samples.SingleOrDefault(s => s.ClientId == clientId);
+        await Assert.That(sample).IsNotNull();
+        await Assert.That(sample!.Value).IsEqualTo((long)BufferMemoryBytes);
+    }
+
+    [Test]
+    public async Task BufferUsedGauge_ReportsZeroForIdleProducer()
+    {
+        var clientId = $"gauge-test-{Guid.NewGuid():N}";
+        var samples = new List<GaugeSample>();
+        using var listener = CreateListener("dekaf.producer.buffer.used_bytes", samples);
+
+        await using var producer = CreateProducer(clientId);
+        listener.RecordObservableInstruments();
+
+        var sample = samples.SingleOrDefault(s => s.ClientId == clientId);
+        await Assert.That(sample).IsNotNull();
+        await Assert.That(sample!.Value).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DisposedProducer_StopsReportingGaugeMeasurements()
+    {
+        var clientId = $"gauge-test-{Guid.NewGuid():N}";
+        var samples = new List<GaugeSample>();
+        using var listener = CreateListener("dekaf.producer.buffer.limit_bytes", samples);
+
+        var producer = CreateProducer(clientId);
+        listener.RecordObservableInstruments();
+        await Assert.That(samples.Any(s => s.ClientId == clientId)).IsTrue();
+
+        await producer.DisposeAsync();
+        samples.Clear();
+        listener.RecordObservableInstruments();
+
+        await Assert.That(samples.Any(s => s.ClientId == clientId)).IsFalse();
+    }
+}

--- a/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
+++ b/tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dekaf.StressTests\Dekaf.StressTests.csproj" />
+    <ProjectReference Include="..\Dekaf.TraceAnalyzer\Dekaf.TraceAnalyzer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Dekaf.StressTests.Tests/TraceAnalyzer/RuntimeEventAggregatorTests.cs
+++ b/tools/Dekaf.StressTests.Tests/TraceAnalyzer/RuntimeEventAggregatorTests.cs
@@ -1,0 +1,91 @@
+using Dekaf.TraceAnalyzer;
+
+namespace Dekaf.StressTests.Tests.TraceAnalyzer;
+
+public class RuntimeEventAggregatorTests
+{
+    [Test]
+    public async Task Allocations_AreRankedBySampledBytes()
+    {
+        var aggregator = new RuntimeEventAggregator();
+        aggregator.AddAllocationTick("System.Byte[]", 100_000, isLargeObject: true);
+        aggregator.AddAllocationTick("System.String", 300_000, isLargeObject: false);
+        aggregator.AddAllocationTick("System.String", 300_000, isLargeObject: false);
+
+        var markdown = aggregator.RenderMarkdown();
+
+        var stringIndex = markdown.IndexOf("System.String", StringComparison.Ordinal);
+        var byteIndex = markdown.IndexOf("System.Byte[]", StringComparison.Ordinal);
+        await Assert.That(stringIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(stringIndex).IsLessThan(byteIndex);
+        await Assert.That(markdown).Contains("585.94 KB");
+        await Assert.That(markdown).Contains("| 1 |");
+    }
+
+    [Test]
+    public async Task Allocations_UnknownTypeNameFallsBackToPlaceholder()
+    {
+        var aggregator = new RuntimeEventAggregator();
+        aggregator.AddAllocationTick("", 1024, isLargeObject: false);
+
+        await Assert.That(aggregator.RenderMarkdown()).Contains("(unknown)");
+    }
+
+    [Test]
+    public async Task Contention_ReportsTotalsMaxAndRate()
+    {
+        var aggregator = new RuntimeEventAggregator();
+        aggregator.SetTraceDuration(10);
+        aggregator.AddContention(1.5);
+        aggregator.AddContention(4.5);
+
+        var markdown = aggregator.RenderMarkdown();
+
+        await Assert.That(markdown).Contains("2 events (0.2/s)");
+        await Assert.That(markdown).Contains("total wait 6.0ms");
+        await Assert.That(markdown).Contains("max 4.50ms");
+    }
+
+    [Test]
+    public async Task Gc_ReportsGenerationReasonAndPauseStats()
+    {
+        var aggregator = new RuntimeEventAggregator();
+        aggregator.AddGcStart(0, "AllocSmall");
+        aggregator.AddGcStart(2, "Induced");
+        aggregator.AddGcPause(3.0);
+        aggregator.AddGcPause(7.0);
+
+        var markdown = aggregator.RenderMarkdown();
+
+        await Assert.That(markdown).Contains("Gen0: 1");
+        await Assert.That(markdown).Contains("Gen2: 1");
+        await Assert.That(markdown).Contains("Reason AllocSmall: 1");
+        await Assert.That(markdown).Contains("Pauses: 2, total 10.0ms, max 7.00ms");
+    }
+
+    [Test]
+    public async Task ThreadPoolAndExceptions_ReportCountsByReasonAndType()
+    {
+        var aggregator = new RuntimeEventAggregator();
+        aggregator.AddThreadPoolAdjustment("Starvation");
+        aggregator.AddThreadPoolAdjustment("Starvation");
+        aggregator.AddException("System.TimeoutException");
+
+        var markdown = aggregator.RenderMarkdown();
+
+        await Assert.That(markdown).Contains("Starvation: 2");
+        await Assert.That(markdown).Contains("`System.TimeoutException`: 1");
+    }
+
+    [Test]
+    public async Task EmptyTrace_RendersExplicitNoDataNotes()
+    {
+        var markdown = new RuntimeEventAggregator().RenderMarkdown();
+
+        await Assert.That(markdown).Contains("No allocation tick events");
+        await Assert.That(markdown).Contains("No contention events");
+        await Assert.That(markdown).Contains("No GC events");
+        await Assert.That(markdown).Contains("No thread-pool adjustment events");
+        await Assert.That(markdown).Contains("No exception events");
+    }
+}

--- a/tools/Dekaf.TraceAnalyzer/Dekaf.TraceAnalyzer.csproj
+++ b/tools/Dekaf.TraceAnalyzer/Dekaf.TraceAnalyzer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+  </ItemGroup>
+
+</Project>

--- a/tools/Dekaf.TraceAnalyzer/Program.cs
+++ b/tools/Dekaf.TraceAnalyzer/Program.cs
@@ -1,0 +1,81 @@
+using Dekaf.TraceAnalyzer;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+
+// Aggregates the CLR events in a .nettrace file into a markdown summary
+// (allocations by type, contention, GC pauses, thread-pool adjustments,
+// exceptions). dotnet-trace report only analyzes CPU samples, so without this
+// the gc/contention/full stress profiles ship raw traces nobody has parsed.
+//
+// Usage: Dekaf.TraceAnalyzer <trace.nettrace> [--output <summary.md>]
+
+var (tracePath, outputPath) = args switch
+{
+    [var trace] => (trace, (string?)null),
+    [var trace, "--output", var path] => (trace, path),
+    _ => (null, null),
+};
+
+if (tracePath is null)
+{
+    Console.Error.WriteLine("Usage: Dekaf.TraceAnalyzer <trace.nettrace> [--output <summary.md>]");
+    return 2;
+}
+
+if (!File.Exists(tracePath))
+{
+    Console.Error.WriteLine($"Trace file not found: {tracePath}");
+    return 2;
+}
+
+var aggregator = new RuntimeEventAggregator();
+double suspendStartMs = -1;
+
+using (var source = new EventPipeEventSource(tracePath))
+{
+    source.Clr.GCAllocationTick += data => aggregator.AddAllocationTick(
+        data.TypeName, data.AllocationAmount64, data.AllocationKind == GCAllocationKind.Large);
+
+    source.Clr.ContentionStop += data => aggregator.AddContention(data.DurationNs / 1_000_000.0);
+
+    source.Clr.GCStart += data => aggregator.AddGcStart(data.Depth, data.Reason.ToString());
+
+    // GC pause = EE suspension to restart; pairs within one trace window.
+    // Filter to GC-caused suspensions so debugger/shutdown suspends don't count.
+    source.Clr.GCSuspendEEStart += data =>
+    {
+        if (data.Reason is GCSuspendEEReason.SuspendForGC or GCSuspendEEReason.SuspendForGCPrep)
+        {
+            suspendStartMs = data.TimeStampRelativeMSec;
+        }
+    };
+    source.Clr.GCRestartEEStop += data =>
+    {
+        if (suspendStartMs >= 0)
+        {
+            aggregator.AddGcPause(data.TimeStampRelativeMSec - suspendStartMs);
+            suspendStartMs = -1;
+        }
+    };
+
+    source.Clr.ThreadPoolWorkerThreadAdjustmentAdjustment += data =>
+        aggregator.AddThreadPoolAdjustment(data.Reason.ToString());
+
+    source.Clr.ExceptionStart += data => aggregator.AddException(data.ExceptionType);
+
+    source.Process();
+    aggregator.SetTraceDuration(source.SessionDuration.TotalSeconds);
+}
+
+var markdown = aggregator.RenderMarkdown();
+if (outputPath is null)
+{
+    Console.Write(markdown);
+}
+else
+{
+    File.WriteAllText(outputPath, markdown);
+    Console.WriteLine($"Wrote {outputPath}");
+}
+
+return 0;

--- a/tools/Dekaf.TraceAnalyzer/RuntimeEventAggregator.cs
+++ b/tools/Dekaf.TraceAnalyzer/RuntimeEventAggregator.cs
@@ -1,0 +1,234 @@
+using System.Text;
+
+namespace Dekaf.TraceAnalyzer;
+
+/// <summary>
+/// Aggregates CLR runtime events from one trace window into decision-ready
+/// tables: allocation by type, monitor contention, GC pauses, thread-pool
+/// adjustments, and exceptions. Pure accumulation — the EventPipe wiring in
+/// <c>Program</c> stays a thin adapter so this logic is unit-testable.
+/// </summary>
+public sealed class RuntimeEventAggregator
+{
+    private const int TopAllocationTypes = 30;
+
+    private sealed class AllocationStats
+    {
+        public long SampledBytes;
+        public long TickCount;
+        public long LargeObjectTicks;
+    }
+
+    private readonly Dictionary<string, AllocationStats> _allocationsByType = [];
+    private readonly Dictionary<string, long> _exceptionsByType = [];
+    private readonly Dictionary<string, long> _threadPoolAdjustmentsByReason = [];
+    private readonly Dictionary<int, long> _gcCountsByGeneration = [];
+    private readonly Dictionary<string, long> _gcCountsByReason = [];
+
+    private long _contentionCount;
+    private double _contentionTotalMs;
+    private double _contentionMaxMs;
+
+    private long _gcPauseCount;
+    private double _gcPauseTotalMs;
+    private double _gcPauseMaxMs;
+
+    private double _traceDurationSeconds;
+
+    public void AddAllocationTick(string typeName, long sampledBytes, bool isLargeObject)
+    {
+        var key = string.IsNullOrEmpty(typeName) ? "(unknown)" : typeName;
+        if (!_allocationsByType.TryGetValue(key, out var stats))
+        {
+            stats = new AllocationStats();
+            _allocationsByType[key] = stats;
+        }
+
+        stats.SampledBytes += sampledBytes;
+        stats.TickCount++;
+        if (isLargeObject)
+        {
+            stats.LargeObjectTicks++;
+        }
+    }
+
+    public void AddContention(double durationMs)
+    {
+        _contentionCount++;
+        _contentionTotalMs += durationMs;
+        _contentionMaxMs = Math.Max(_contentionMaxMs, durationMs);
+    }
+
+    public void AddGcStart(int generation, string reason)
+    {
+        _gcCountsByGeneration[generation] = _gcCountsByGeneration.GetValueOrDefault(generation) + 1;
+        _gcCountsByReason[reason] = _gcCountsByReason.GetValueOrDefault(reason) + 1;
+    }
+
+    public void AddGcPause(double pauseMs)
+    {
+        _gcPauseCount++;
+        _gcPauseTotalMs += pauseMs;
+        _gcPauseMaxMs = Math.Max(_gcPauseMaxMs, pauseMs);
+    }
+
+    public void AddThreadPoolAdjustment(string reason)
+        => _threadPoolAdjustmentsByReason[reason] =
+            _threadPoolAdjustmentsByReason.GetValueOrDefault(reason) + 1;
+
+    public void AddException(string exceptionType)
+        => _exceptionsByType[exceptionType] = _exceptionsByType.GetValueOrDefault(exceptionType) + 1;
+
+    public void SetTraceDuration(double seconds) => _traceDurationSeconds = seconds;
+
+    public string RenderMarkdown()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Runtime Event Summary");
+        builder.AppendLine();
+        if (_traceDurationSeconds > 0)
+        {
+            builder.AppendLine($"Trace duration: {_traceDurationSeconds:F1}s");
+            builder.AppendLine();
+        }
+
+        RenderAllocations(builder);
+        RenderContention(builder);
+        RenderGc(builder);
+        RenderThreadPool(builder);
+        RenderExceptions(builder);
+        return builder.ToString();
+    }
+
+    private void RenderAllocations(StringBuilder builder)
+    {
+        builder.AppendLine("## Allocations by type (GCAllocationTick, ~100KB sampling)");
+        builder.AppendLine();
+        if (_allocationsByType.Count == 0)
+        {
+            builder.AppendLine("_No allocation tick events (cpu profile, or level below verbose)._");
+            builder.AppendLine();
+            return;
+        }
+
+        builder.AppendLine("| Type | Sampled bytes | Ticks | LOH ticks | Sampled rate |");
+        builder.AppendLine("|---|---|---|---|---|");
+        foreach (var (type, stats) in _allocationsByType
+                     .OrderByDescending(pair => pair.Value.SampledBytes)
+                     .Take(TopAllocationTypes))
+        {
+            var rate = _traceDurationSeconds > 0
+                ? FormatBytes((long)(stats.SampledBytes / _traceDurationSeconds)) + "/s"
+                : "-";
+            builder.AppendLine(
+                $"| `{type}` | {FormatBytes(stats.SampledBytes)} | {stats.TickCount} | {stats.LargeObjectTicks} | {rate} |");
+        }
+
+        if (_allocationsByType.Count > TopAllocationTypes)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"_{_allocationsByType.Count - TopAllocationTypes} further types omitted._");
+        }
+
+        builder.AppendLine();
+    }
+
+    private void RenderContention(StringBuilder builder)
+    {
+        builder.AppendLine("## Monitor contention");
+        builder.AppendLine();
+        if (_contentionCount == 0)
+        {
+            builder.AppendLine("_No contention events._");
+        }
+        else
+        {
+            var perSecond = _traceDurationSeconds > 0
+                ? $"{_contentionCount / _traceDurationSeconds:F1}/s"
+                : "-";
+            builder.AppendLine(
+                $"{_contentionCount} events ({perSecond}), total wait {_contentionTotalMs:F1}ms, max {_contentionMaxMs:F2}ms.");
+        }
+
+        builder.AppendLine();
+    }
+
+    private void RenderGc(StringBuilder builder)
+    {
+        builder.AppendLine("## Garbage collection");
+        builder.AppendLine();
+        if (_gcCountsByGeneration.Count == 0 && _gcPauseCount == 0)
+        {
+            builder.AppendLine("_No GC events._");
+            builder.AppendLine();
+            return;
+        }
+
+        foreach (var (generation, count) in _gcCountsByGeneration.OrderBy(pair => pair.Key))
+        {
+            builder.AppendLine($"- Gen{generation}: {count}");
+        }
+
+        foreach (var (reason, count) in _gcCountsByReason.OrderByDescending(pair => pair.Value))
+        {
+            builder.AppendLine($"- Reason {reason}: {count}");
+        }
+
+        if (_gcPauseCount > 0)
+        {
+            builder.AppendLine(
+                $"- Pauses: {_gcPauseCount}, total {_gcPauseTotalMs:F1}ms, max {_gcPauseMaxMs:F2}ms");
+        }
+
+        builder.AppendLine();
+    }
+
+    private void RenderThreadPool(StringBuilder builder)
+    {
+        builder.AppendLine("## Thread-pool adjustments");
+        builder.AppendLine();
+        if (_threadPoolAdjustmentsByReason.Count == 0)
+        {
+            builder.AppendLine("_No thread-pool adjustment events (threading keyword not enabled)._");
+        }
+        else
+        {
+            foreach (var (reason, count) in _threadPoolAdjustmentsByReason.OrderByDescending(pair => pair.Value))
+            {
+                builder.AppendLine($"- {reason}: {count}");
+            }
+        }
+
+        builder.AppendLine();
+    }
+
+    private void RenderExceptions(StringBuilder builder)
+    {
+        builder.AppendLine("## Exceptions thrown");
+        builder.AppendLine();
+        if (_exceptionsByType.Count == 0)
+        {
+            builder.AppendLine("_No exception events._");
+        }
+        else
+        {
+            foreach (var (type, count) in _exceptionsByType.OrderByDescending(pair => pair.Value))
+            {
+                builder.AppendLine($"- `{type}`: {count}");
+            }
+        }
+
+        builder.AppendLine();
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        return bytes switch
+        {
+            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F2} GB",
+            >= 1_048_576 => $"{bytes / 1_048_576.0:F2} MB",
+            >= 1_024 => $"{bytes / 1_024.0:F2} KB",
+            _ => $"{bytes} B",
+        };
+    }
+}

--- a/tools/profile-stress-test.sh
+++ b/tools/profile-stress-test.sh
@@ -14,8 +14,15 @@
 #   TRACE_PROFILE         cpu (default), contention, gc, or full.
 #   TRACE_PROVIDERS       Explicit dotnet-trace providers; overrides profile.
 #   PROFILE_OUTPUT_DIR    Artifact directory (default: stress-profile).
-#   PROFILE_COUNTERS      Collect System.Runtime counters (default: true).
-#   PROFILE_STACKS        Capture a stack snapshot per window (default: true).
+#   PROFILE_COUNTERS      Collect runtime + Dekaf counters (default: true).
+#   PROFILE_COUNTER_PROVIDERS Counter providers/meters (default: System.Runtime,Dekaf).
+#   PROFILE_STACKS        Capture stack snapshots per window (default: true).
+#   PROFILE_STACK_SNAPSHOTS Snapshots spread across each window (default: 3),
+#                         so a stuck stack is distinguishable from a transient one.
+#   PROFILE_GCDUMP        Capture a managed heap dump after each window's trace
+#                         (default: false; induces a blocking GC on the target).
+#   PROFILE_SUMMARY       Generate profile-summary.md from counters and topN
+#                         reports after the run (default: true; needs python3).
 #   PROFILE_VALIDATE_ONLY Validate configuration without starting a test.
 #   PROFILE_START_TIMEOUT Seconds allowed for measured phase to start (default: 300).
 #   STRESS_CPUSET         Optional target process CPU affinity.
@@ -27,8 +34,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 STRESS_EXE="$REPO_ROOT/tools/Dekaf.StressTests/bin/Release/net10.0/Dekaf.StressTests"
+ANALYZER_EXE="$REPO_ROOT/tools/Dekaf.TraceAnalyzer/bin/Release/net10.0/Dekaf.TraceAnalyzer"
 if [[ "${OS:-}" == "Windows_NT" ]]; then
     STRESS_EXE="${STRESS_EXE}.exe"
+    ANALYZER_EXE="${ANALYZER_EXE}.exe"
 fi
 
 TRACE_WINDOWS="${TRACE_WINDOWS:-60:30:healthy,330:30:pre-collapse,420:30:collapse,600:30:degraded}"
@@ -36,7 +45,13 @@ TRACE_START_PATTERN="${TRACE_START_PATTERN:-Running .* stress test for}"
 TRACE_PROFILE="${TRACE_PROFILE:-cpu}"
 PROFILE_OUTPUT_DIR="${PROFILE_OUTPUT_DIR:-$REPO_ROOT/stress-profile}"
 PROFILE_COUNTERS="${PROFILE_COUNTERS:-true}"
+# "Dekaf" is the library's Meter: it publishes producer/consumer internals
+# (controller state, buffer usage) that System.Runtime cannot see.
+PROFILE_COUNTER_PROVIDERS="${PROFILE_COUNTER_PROVIDERS:-System.Runtime,Dekaf}"
 PROFILE_STACKS="${PROFILE_STACKS:-true}"
+PROFILE_STACK_SNAPSHOTS="${PROFILE_STACK_SNAPSHOTS:-3}"
+PROFILE_GCDUMP="${PROFILE_GCDUMP:-false}"
+PROFILE_SUMMARY="${PROFILE_SUMMARY:-true}"
 PROFILE_VALIDATE_ONLY="${PROFILE_VALIDATE_ONLY:-false}"
 PROFILE_START_TIMEOUT="${PROFILE_START_TIMEOUT:-300}"
 export KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS:-localhost:9092}"
@@ -72,13 +87,22 @@ case "$TRACE_PROFILE" in
         DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x0000000000480001:5,Microsoft-DotNETCore-SampleProfiler"
         ;;
     full)
-        DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000049C001:4,Microsoft-DotNETCore-SampleProfiler"
+        # Level 5 (verbose): GCAllocationTick is a verbose event, so level 4 would
+        # silently drop allocation-by-type data. TplEventSource (TaskTransfer|Tasks|
+        # TaskStops|TasksFlowActivityIds|AsyncMethod = 0x1C3) stitches async
+        # causality so await/wait time is attributable, not just CPU.
+        DEFAULT_TRACE_PROVIDERS="Microsoft-Windows-DotNETRuntime:0x000000000049C001:5,System.Threading.Tasks.TplEventSource:0x1C3:4,Microsoft-DotNETCore-SampleProfiler"
         ;;
     *)
         fail "Unknown TRACE_PROFILE '$TRACE_PROFILE'. Use cpu, contention, gc, or full."
         ;;
 esac
 TRACE_PROVIDERS="${TRACE_PROVIDERS:-$DEFAULT_TRACE_PROVIDERS}"
+# Post-run CLR-event aggregation only applies when the trace will actually
+# contain runtime events; derived from the final providers so an override
+# behaves the same as a named profile.
+COLLECT_RUNTIME_EVENTS=false
+[[ "$TRACE_PROVIDERS" == *Microsoft-Windows-DotNETRuntime* ]] && COLLECT_RUNTIME_EVENTS=true
 
 IFS=',' read -r -a WINDOW_SPECS <<< "$TRACE_WINDOWS"
 WINDOW_OFFSETS=()
@@ -120,8 +144,9 @@ is_positive_integer "$stress_duration_minutes" \
 (( previous_end <= 10#$stress_duration_minutes * 60 )) \
     || fail "Last trace window ends after the ${stress_duration_minutes}-minute measured phase."
 is_positive_integer "$PROFILE_START_TIMEOUT" || fail "PROFILE_START_TIMEOUT must be a positive integer."
+is_positive_integer "$PROFILE_STACK_SNAPSHOTS" || fail "PROFILE_STACK_SNAPSHOTS must be a positive integer."
 
-for toggle in PROFILE_COUNTERS PROFILE_STACKS PROFILE_VALIDATE_ONLY; do
+for toggle in PROFILE_COUNTERS PROFILE_STACKS PROFILE_GCDUMP PROFILE_SUMMARY PROFILE_VALIDATE_ONLY; do
     value="${!toggle}"
     [[ "$value" == "true" || "$value" == "false" ]] || fail "$toggle must be true or false."
 done
@@ -138,6 +163,9 @@ fi
 if [[ "$PROFILE_STACKS" == "true" ]]; then
     command -v dotnet-stack >/dev/null || fail "dotnet-stack not found."
 fi
+if [[ "$PROFILE_GCDUMP" == "true" ]]; then
+    command -v dotnet-gcdump >/dev/null || fail "dotnet-gcdump not found."
+fi
 if [[ -n "${STRESS_CPUSET:-}" || -n "${PROFILER_CPUSET:-}" ]]; then
     command -v taskset >/dev/null || fail "CPU affinity requested but taskset not found."
 fi
@@ -145,6 +173,13 @@ fi
 if [[ ! -f "$STRESS_EXE" ]]; then
     echo "Building stress tests in Release mode..."
     dotnet build "$REPO_ROOT/tools/Dekaf.StressTests" --configuration Release -q
+fi
+
+# Built up front so a broken analyzer fails fast instead of after the paid run,
+# and each window invokes the binary without re-paying MSBuild evaluation.
+if [[ "$COLLECT_RUNTIME_EVENTS" == "true" && ! -f "$ANALYZER_EXE" ]]; then
+    echo "Building trace analyzer in Release mode..."
+    dotnet build "$REPO_ROOT/tools/Dekaf.TraceAnalyzer" --configuration Release -q
 fi
 
 mkdir -p "$PROFILE_OUTPUT_DIR"
@@ -201,6 +236,8 @@ echo "Measured phase detected at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
     echo "trace_profile=$TRACE_PROFILE"
     echo "trace_providers=$TRACE_PROVIDERS"
     echo "trace_windows=$TRACE_WINDOWS"
+    echo "counter_providers=$PROFILE_COUNTER_PROVIDERS"
+    echo "stack_snapshots=$PROFILE_STACK_SNAPSHOTS"
     echo "stress_cpuset=${STRESS_CPUSET:-unrestricted}"
     echo "profiler_cpuset=${PROFILER_CPUSET:-unrestricted}"
     printf 'stress_args='
@@ -209,13 +246,16 @@ echo "Measured phase detected at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 } > "$METADATA"
 
 if [[ "$PROFILE_COUNTERS" == "true" ]]; then
-    echo "Starting System.Runtime counters..."
+    echo "Starting counters ($PROFILE_COUNTER_PROVIDERS)..."
+    # counters_start_epoch anchors CSV rows to measured-phase offsets in the
+    # post-run summary; the CSV's own timestamps are local-time and culture-bound.
+    echo "counters_start_epoch=$(date +%s)" >> "$METADATA"
     "${PROFILER_PREFIX[@]}" dotnet-counters collect \
         --process-id "$STRESS_PID" \
         --refresh-interval 1 \
         --format csv \
         --output "$PROFILE_OUTPUT_DIR/runtime-counters.csv" \
-        --counters System.Runtime \
+        --counters "$PROFILE_COUNTER_PROVIDERS" \
         > "$PROFILE_OUTPUT_DIR/runtime-counters.log" 2>&1 &
     COUNTERS_PID=$!
 fi
@@ -230,23 +270,47 @@ for ((i = 0; i < ${#WINDOW_LABELS[@]}; i++)); do
     done
 
     echo "Capturing '$label' at +${offset}s for ${duration}s..."
-    if [[ "$PROFILE_STACKS" == "true" ]]; then
-        if ! "${PROFILER_PREFIX[@]}" dotnet-stack report --process-id "$STRESS_PID" \
-            > "$PROFILE_OUTPUT_DIR/${label}.stacks.txt" 2>&1; then
-            echo "WARNING: stack capture failed for '$label'."
-            PROFILE_FAILED=1
-        fi
-    fi
-
+    # The trace runs in the background so stack snapshots land INSIDE the traced
+    # window (concurrent EventPipe sessions are supported). Snapshots are spread
+    # across the window: one identical stack in all of them means genuinely
+    # stuck, present in only one means transient.
     trace_path="$PROFILE_OUTPUT_DIR/${label}.nettrace"
-    if ! "${PROFILER_PREFIX[@]}" dotnet-trace collect \
+    "${PROFILER_PREFIX[@]}" dotnet-trace collect \
         --process-id "$STRESS_PID" \
         --output "$trace_path" \
         --providers "$TRACE_PROVIDERS" \
         --duration "$(format_duration "$duration")" \
-        > "$PROFILE_OUTPUT_DIR/${label}.collect.log" 2>&1; then
+        > "$PROFILE_OUTPUT_DIR/${label}.collect.log" 2>&1 &
+    trace_pid=$!
+
+    if [[ "$PROFILE_STACKS" == "true" ]]; then
+        snapshot_gap=$(( duration / (PROFILE_STACK_SNAPSHOTS + 1) ))
+        (( snapshot_gap > 0 )) || snapshot_gap=1
+        for ((snap = 1; snap <= PROFILE_STACK_SNAPSHOTS; snap++)); do
+            sleep "$snapshot_gap"
+            kill -0 "$STRESS_PID" 2>/dev/null || break
+            if ! "${PROFILER_PREFIX[@]}" dotnet-stack report --process-id "$STRESS_PID" \
+                > "$PROFILE_OUTPUT_DIR/${label}.stacks.${snap}.txt" 2>&1; then
+                echo "WARNING: stack snapshot $snap failed for '$label'."
+                PROFILE_FAILED=1
+            fi
+        done
+    fi
+
+    if ! wait "$trace_pid"; then
         echo "WARNING: trace capture failed for '$label'."
         PROFILE_FAILED=1
+    fi
+
+    # After the trace so the induced blocking GC never pollutes the window.
+    if [[ "$PROFILE_GCDUMP" == "true" ]]; then
+        if ! "${PROFILER_PREFIX[@]}" dotnet-gcdump collect \
+            --process-id "$STRESS_PID" \
+            --output "$PROFILE_OUTPUT_DIR/${label}.gcdump" \
+            > "$PROFILE_OUTPUT_DIR/${label}.gcdump.log" 2>&1; then
+            echo "WARNING: gcdump capture failed for '$label'."
+            PROFILE_FAILED=1
+        fi
     fi
 done
 
@@ -279,6 +343,34 @@ for label in "${WINDOW_LABELS[@]}"; do
         --output "$PROFILE_OUTPUT_DIR/${label}.speedscope.json" \
         > "$PROFILE_OUTPUT_DIR/${label}.convert.log" 2>&1 || true
 done
+
+# Runtime-event aggregation (alloc-by-type, contention, GC pauses, threadpool):
+# skipped when the providers carry no CLR events (the plain cpu profile).
+if [[ "$COLLECT_RUNTIME_EVENTS" == "true" ]]; then
+    for label in "${WINDOW_LABELS[@]}"; do
+        trace_path="$PROFILE_OUTPUT_DIR/${label}.nettrace"
+        [[ -f "$trace_path" ]] || continue
+        echo "Aggregating runtime events for '$label'..."
+        if ! "$ANALYZER_EXE" "$trace_path" --output "$PROFILE_OUTPUT_DIR/${label}.events.md" \
+            > "$PROFILE_OUTPUT_DIR/${label}.events.log" 2>&1; then
+            echo "WARNING: runtime-event aggregation failed for '$label' (see ${label}.events.log)."
+        fi
+    done
+fi
+
+# Decision-ready summary: per-window counter aggregates plus window-to-window
+# topN movement, so nobody has to eyeball a raw 900-row CSV against offsets.
+if [[ "$PROFILE_SUMMARY" == "true" ]]; then
+    if command -v python3 >/dev/null; then
+        if ! python3 "$REPO_ROOT/.github/scripts/stress_profile_summary.py" \
+            --profile-dir "$PROFILE_OUTPUT_DIR" \
+            --output "$PROFILE_OUTPUT_DIR/profile-summary.md"; then
+            echo "WARNING: profile summary generation failed."
+        fi
+    else
+        echo "WARNING: python3 not found; skipping profile-summary.md."
+    fi
+fi
 
 echo "Profile artifacts: $PROFILE_OUTPUT_DIR"
 if (( PROFILE_FAILED > 0 && STRESS_EXIT == 0 )); then


### PR DESCRIPTION
## Summary

Follow-up to #2150: profiled stress runs shipped raw artifacts that still required manual interpretation, and the captured data missed the state behind most recent perf regressions. This PR makes profiled dispatches produce concrete, decision-ready data.

### Library: producer internal-state gauges (the big one)
Most recent root causes (#2108 budget horizon, #1856 stuck-low budget equilibrium, #1796 scale-down inversion) were adaptive-controller pathologies invisible to CPU traces and System.Runtime counters — they were inferred indirectly from throughput curves across paid runs. 15 new observable instruments on the `Dekaf` meter expose that state directly, per broker (tagged `messaging.kafka.broker.id` + `messaging.client.id`):

| Area | Instruments |
|---|---|
| Budget/BBR | `broker.budget_bytes`, `broker.unacked_bytes`, `broker.min_rtt`, `broker.max_delivery_rate`, `broker.queue_latency_ewma`, `broker.latency_budget_scale`, `broker.admission_blocks`, `broker.capacity_probe.successes/.failures` |
| Connections/in-flight | `broker.connections`, `broker.in_flight_bytes`, `broker.in_flight_requests` |
| BufferMemory | `buffer.used_bytes`, `buffer.limit_bytes`, `buffer.pressure_events` |

All pull-based (`ObservableGauge`/`ObservableCounter`): zero cost unless a listener polls, zero produce-hot-path work, reads only volatile-published accessors. Registry mirrors the existing consumer-lag gauge pattern. `dotnet-counters` in profiled runs now collects `System.Runtime,Dekaf`, so controller state arrives as a 1 Hz time series.

### Trace capture fixes
- **`full` profile level 4 → 5**: `GCAllocationTick` is verbose-only — level 4 silently dropped allocation-by-type data. Also adds `TplEventSource:0x1C3` for async causality (await/wait attribution in PerfView).
- **3 stack snapshots per window**, spread inside the traced window (concurrent EventPipe sessions) — distinguishes stuck stacks from transient ones.
- **Opt-in per-window gcdump** (`PROFILE_GCDUMP`, auto-on for `gc` dispatches), captured after each window's trace so the induced blocking GC never pollutes it.

### Post-run analysis (new)
- **`tools/Dekaf.TraceAnalyzer`** (TraceEvent-based): `dotnet-trace report` only analyzes CPU samples, so gc/contention/full traces shipped raw with zero automated analysis. The analyzer aggregates each window into allocations-by-type (with LOH ticks and rates), contention totals, GC pause/generation/reason stats, threadpool adjustment reasons, and exception counts. Built once up front (fail-fast before the paid run), invoked as a binary per window.
- **`stress_profile_summary.py`**: emits `profile-summary.md` with a per-window counter mean/max table and a window-to-window topN inclusive-CPU movement table ranked by delta — the "what changed between healthy and collapse" question answered directly. The topN parser targets the pinned dotnet-trace version's verified row format.

### Workflow fixes
- **EXTRA_ARGS argv bug**: #2150 changed `${EXTRA_ARGS}` (word-split) to `STRESS_ARGS+=("$EXTRA_ARGS")` (single element). Harmless today (single-token flag) but the first multi-token addition would reach the client as one unparseable argument. Now a proper bash array on both paired and 3conn paths.
- gcdump tool installs only for `gc` dispatches; analyzer build ownership moved into the profile script (single owner, fail-fast, no per-window MSBuild).

## Validation
- Analyzer verified against a real 6s gc-profile trace of an allocation-churn app (alloc-by-type table, GC pause stats confirmed sane; non-GC EE suspensions filtered).
- topN row format verified against dotnet-trace `PrintReportHelper` source; parser unit-tested against that shape.
- 5591 unit tests, 33 stress-tool tests, 91 CI script tests pass. `/simplify` review applied (4 agents; factory-collapsed gauge declarations, generic observe helpers, providers-content aggregation gate).

## Follow-ups (not in this PR)
- Consolidate the three `FormatBytes` copies across `tools/` into a shared source file.
- Consider computing topN movement from speedscope JSON instead of scraping the report text (removes 70-char truncation collisions).