### PR TITLE
Pass A-B-A metrics decisively when the candidate beats both controls

### DIFF
--- a/.github/scripts/stress_aba.py
+++ b/.github/scripts/stress_aba.py
@@ -175,15 +175,26 @@ def _metric_status(
             worse_than_both = candidate < min(baseline_a, baseline_a2) * (
                 1 - tolerance_percent / 100
             )
+            better_than_both = candidate >= max(baseline_a, baseline_a2)
             adverse = delta_percent < -tolerance_percent
         else:
             worse_than_both = candidate > max(baseline_a, baseline_a2) * (
                 1 + tolerance_percent / 100
             )
+            better_than_both = candidate <= min(baseline_a, baseline_a2)
             adverse = delta_percent > tolerance_percent
 
+        # Symmetric decisiveness overrides for noisy controls: a candidate worse than both
+        # bracketing controls by more than the tolerance is a regression no matter how far
+        # apart the controls sit, and a candidate at least as good as the better control
+        # cannot have regressed under any reading of the data — control drift only matters
+        # for candidates the controls actually bracket (run 29525842754: the candidate beat
+        # both controls on p99 yet was ruled inconclusive because the controls disagreed
+        # with each other by 12%).
         if worse_than_both:
             status = "regression"
+        elif better_than_both:
+            status = "pass"
         elif control_drift_percent > max_control_drift_percent:
             status = "inconclusive"
         elif adverse:

--- a/.github/scripts/test_stress_aba.py
+++ b/.github/scripts/test_stress_aba.py
@@ -105,6 +105,32 @@ class StressAbaComparisonTests(unittest.TestCase):
         self.assertEqual("inconclusive", throughput["status"])
         self.assertAlmostEqual(20.0, throughput["controlDriftPercent"])
 
+    def test_candidate_beating_both_noisy_controls_passes(self):
+        # Run 29525842754: candidate p99 (14.85ms) was better than both controls
+        # (17.25 / 15.25ms), yet 12.3% control drift ruled the metric inconclusive.
+        # A candidate at least as good as the better control cannot have regressed.
+        comparison = compare(
+            result(p99=17.25),
+            result(p99=14.85),
+            result(p99=15.25),
+        )
+
+        self.assertEqual("pass", comparison["verdict"])
+        p99 = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "p99"
+        )
+        self.assertEqual("pass", p99["status"])
+        self.assertGreater(p99["controlDriftPercent"], 10.0)
+
+    def test_bracketed_candidate_with_noisy_controls_stays_inconclusive(self):
+        comparison = compare(result(p99=13.0), result(p99=15.0), result(p99=17.0))
+
+        self.assertEqual("inconclusive", comparison["verdict"])
+        p99 = next(
+            metric for metric in comparison["metrics"] if metric["key"] == "p99"
+        )
+        self.assertEqual("inconclusive", p99["status"])
+
     def test_decisive_regression_overrides_noisy_controls(self):
         comparison = compare(result(100), result(70), result(130))
 


### PR DESCRIPTION
Runner noise between the two same-SHA control passes can exceed the 10% drift limit on microsecond-scale latency metrics, blocking verdicts even when the candidate is unambiguously fine. Producer-1b run [29525842754](https://github.com/thomhurst/Dekaf/actions/runs/29525842754) was ruled INCONCLUSIVE on p99 control drift (17.25 vs 15.25ms, 12.3%) while the candidate (14.85ms) beat both controls outright.

The comparison already treats worse-than-both-by-tolerance as decisive regression regardless of drift; this adds the symmetric dual — at least as good as the better control is a decisive pass regardless of drift. Bracketed candidates under disagreeing controls remain inconclusive (genuinely unresolvable).

Replays of all three PR #2149 A-B-A runs pin the behavior in tests:
- run 29513570135 (real intra-run collapse): still **REGRESSION**
- run 29518014693 (candidate p50 bracketed by drifting controls): still **INCONCLUSIVE**
- run 29525842754 (candidate beat both controls everywhere): **PASS**