### PR TITLE
Time-bound metadata initialization to max.block.ms (Java parity)

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1273,7 +1273,9 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
-            ClientDnsLookup = _clientDnsLookup
+            ClientDnsLookup = _clientDnsLookup,
+            // Java parity: initial metadata blocks up to max.block.ms, retrying throughout.
+            InitTimeoutMs = options.MaxBlockMs
         };
 
         var producer = _clientInfrastructure is null

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Dekaf.Errors;
@@ -261,6 +262,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
             var initializationToken = linkedCts.Token;
             var backoffMs = _options.RetryBackoffMs;
+            var startedAt = Stopwatch.GetTimestamp();
 
             try
             {
@@ -280,8 +282,22 @@ public sealed partial class MetadataManager : IAsyncDisposable
                             throw;
                         }
 
+                        var elapsed = Stopwatch.GetElapsedTime(startedAt);
+                        var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
+                        if (remainingMs <= 0)
+                        {
+                            LogMetadataInitializationAbandoned(ex, attempt + 1);
+                            throw new KafkaTimeoutException(
+                                TimeoutKind.Metadata,
+                                elapsed,
+                                TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
+                                $"Failed to fetch initial metadata within {_options.InitTimeoutMs}ms. " +
+                                "Ensure the Kafka cluster is reachable and the bootstrap servers are correct.",
+                                ex);
+                        }
+
                         LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
-                        await Task.Delay(backoffMs, initializationToken).ConfigureAwait(false);
+                        await Task.Delay((int)Math.Min(backoffMs, remainingMs), initializationToken).ConfigureAwait(false);
                         backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
                     }
                 }
@@ -1264,19 +1280,29 @@ public sealed class MetadataOptions
 
     /// <summary>
     /// Initial retry backoff in milliseconds for metadata initialization.
-    /// Matches Java client's reconnect.backoff.ms. Default is 100ms.
+    /// Matches Java client's retry.backoff.ms. Default is 100ms.
     /// </summary>
     public int RetryBackoffMs { get; init; } = 100;
 
     /// <summary>
     /// Maximum retry backoff in milliseconds for metadata initialization.
-    /// Matches Java client's reconnect.backoff.max.ms. Default is 1000ms.
+    /// Matches Java client's retry.backoff.max.ms. Default is 1000ms.
     /// </summary>
     public int RetryBackoffMaxMs { get; init; } = 1000;
 
     /// <summary>
-    /// Maximum number of retries for initial metadata fetch.
-    /// Default is 3 (matching Kafka convention).
+    /// Total time budget in milliseconds for the initial metadata fetch. Initialization
+    /// keeps retrying retriable failures with exponential backoff until this deadline,
+    /// then throws <see cref="Errors.KafkaTimeoutException"/>. Matches the Java client,
+    /// where the first send blocks up to max.block.ms (60s) while metadata is fetched.
+    /// Default is 60000 (60 seconds). The producer maps its MaxBlockMs setting here.
     /// </summary>
-    public int MaxInitRetries { get; init; } = 3;
+    public int InitTimeoutMs { get; init; } = 60000;
+
+    /// <summary>
+    /// Optional cap on the number of retries for the initial metadata fetch. By default
+    /// initialization is bounded by <see cref="InitTimeoutMs"/> alone; set this to make
+    /// it give up after a fixed number of attempts instead, rethrowing the last failure.
+    /// </summary>
+    public int MaxInitRetries { get; init; } = int.MaxValue;
 }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3351,22 +3351,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             if (_initialized)
                 return;
 
-            var startedAt = Stopwatch.GetTimestamp();
-            try
-            {
-                await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
-                var elapsed = Stopwatch.GetElapsedTime(startedAt);
-                throw new KafkaTimeoutException(
-                    TimeoutKind.Metadata,
-                    elapsed,
-                    configured,
-                    $"Failed to fetch initial metadata within max.block.ms ({_options.MaxBlockMs}ms). " +
-                    $"Ensure the Kafka cluster is reachable and the bootstrap servers are correct.");
-            }
+            // The metadata manager time-bounds initialization itself (InitTimeoutMs, mapped
+            // from MaxBlockMs by the builder) and throws KafkaTimeoutException on expiry.
+            await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
 
             if (_options.EnableIdempotence && _options.TransactionalId is null && !_idempotentInitialized)
             {

--- a/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Producer;
 
@@ -65,11 +66,11 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
     public async Task MaxBlock_ExceededWaitingForMetadata_ErrorPropagated()
     {
         // Arrange & Act - Resolve the invalid bootstrap server deterministically so metadata lookup will fail.
-        // BuildAsync() eagerly initializes and connects, so an unreachable broker
-        // should cause initialization to fail quickly rather than hanging indefinitely.
+        // BuildAsync() eagerly initializes, retrying metadata until MaxBlock expires
+        // (Java max.block.ms parity), then surfaces a timeout rather than hanging.
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        var exception = await Assert.ThrowsAsync<KafkaTimeoutException>(async () =>
         {
             await using var producer = await Kafka.CreateProducer<string, string>()
                 .WithBootstrapServers("invalid-host-that-does-not-exist:9092")
@@ -82,9 +83,12 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
 
         sw.Stop();
 
-        // The error should propagate within a reasonable time frame.
-        // The injected resolver avoids depending on the host DNS timeout.
+        // The timeout should identify the metadata phase and carry the underlying
+        // failure. The injected resolver avoids depending on the host DNS timeout.
         // The key invariant is that the error does NOT hang indefinitely.
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(sw.Elapsed.TotalSeconds).IsGreaterThanOrEqualTo(2);
         await Assert.That(sw.Elapsed.TotalSeconds).IsLessThan(30);
     }
 

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Reflection;
 using Dekaf.Errors;
@@ -319,7 +320,7 @@ public class MetadataManagerTests
     }
 
     [Test]
-    public async Task InitializeAsync_DefaultRetries_LogEarlyDebugAndTerminalWarning()
+    public async Task InitializeAsync_AttemptCapped_LogEarlyDebugAndTerminalWarning()
     {
         var pool = CreateFailingConnectionPool();
         var logger = new CapturingLogger<MetadataManager>();
@@ -329,6 +330,7 @@ public class MetadataManagerTests
             new MetadataOptions
             {
                 EnableBackgroundRefresh = false,
+                MaxInitRetries = 3,
                 RetryBackoffMs = 0,
                 RetryBackoffMaxMs = 0
             },
@@ -348,6 +350,38 @@ public class MetadataManagerTests
         await Assert.That(logger.Entries.Any(entry =>
             entry.Level == LogLevel.Warning &&
             entry.Message.Contains("failed after 4 attempts", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task InitializeAsync_DefaultRetries_TimeBounded_ThrowsKafkaTimeoutException()
+    {
+        var pool = CreateFailingConnectionPool();
+        var logger = new CapturingLogger<MetadataManager>();
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 100,
+                RetryBackoffMs = 10,
+                RetryBackoffMaxMs = 20
+            },
+            logger);
+
+        var startedAt = Stopwatch.GetTimestamp();
+        var act = () => manager.InitializeAsync().AsTask();
+        var exception = await Assert.That(act).Throws<KafkaTimeoutException>();
+        var elapsed = Stopwatch.GetElapsedTime(startedAt);
+
+        // Retries until the time budget is exhausted, then surfaces a timeout
+        // carrying the last underlying failure.
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(100));
+        await Assert.That(logger.Entries.Any(entry =>
+            entry.Level == LogLevel.Warning &&
+            entry.Message.Contains("Metadata initialization failed after", StringComparison.Ordinal))).IsTrue();
     }
 
     [Test]

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -144,6 +144,7 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
                     .WithEnvironment("KAFKA_MIN_INSYNC_REPLICAS", minInSyncReplicas.ToString())
                     .WithEnvironment("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
                     .WithEnvironment("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                    .WithWaitStrategy(KafkaEnvironment.BrokerServingWaitStrategy())
                     .Build();
 
                 brokers.Add(broker);

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -19,6 +19,14 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
     internal const string KafkaImage = "apache/kafka:4.3.1";
     internal static ConsensusProtocol SingleBrokerConsensusProtocol { get; } = ConsensusProtocol.KRaft;
 
+    // Raw ContainerBuilder has no Kafka-aware readiness check, so "started" would
+    // otherwise mean only "container running" — brokers still forming the KRaft quorum
+    // reset incoming connections, and ready-check clients log metadata-initialization
+    // failures. RECOVERY→RUNNING is the broker-unfenced transition: the broker is
+    // registered and serving. Shared by every raw-builder broker container here.
+    internal static IWaitForContainerOS BrokerServingWaitStrategy()
+        => Wait.ForUnixContainer().UntilMessageIsLogged(".*Transitioning from RECOVERY to RUNNING.*");
+
     // Testcontainers.Kafka emits a trailing comma in KAFKA_ADVERTISED_LISTENERS
     // when no extra listener is configured. Kafka 4.2+ rejects that empty value.
     private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
@@ -244,7 +252,8 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                 .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", Math.Min(brokerCount, 3).ToString())
                 // Explicit log dir so the optional tmpfs mount target always matches
                 .WithEnvironment("KAFKA_LOG_DIRS", KafkaLogDir)
-                .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts);
+                .WithEnvironment("KAFKA_HEAP_OPTS", BrokerHeapOpts)
+                .WithWaitStrategy(BrokerServingWaitStrategy());
 
             foreach (var (key, value) in RetentionConfig)
             {
@@ -300,6 +309,10 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
                     .WithLoggerFactory(StressClientLogging.LoggerFactory)
                     .WithBootstrapServers(bootstrapServers)
                     .WithClientId("kafka-ready-check")
+                    // Keep the probe granular: initialization blocks up to MaxBlock
+                    // (default 60s) retrying internally, but this loop supplies its own
+                    // retry cadence and per-attempt logging.
+                    .WithMaxBlock(TimeSpan.FromSeconds(5))
                     .BuildAsync();
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Problem

Producer stress startup logged scary failures while brokers were still booting ([run 29522448948](https://github.com/thomhurst/Dekaf/actions/runs/29522448948/job/87702550710)):

```
Warning  Dekaf.Metadata.MetadataManager  Metadata initialization failed after 4 attempts
System.InvalidOperationException: Failed to refresh metadata from any broker
 ---> System.Net.Sockets.SocketException (104): Connection reset by peer
```

Two root causes:

1. **Harness**: the multi-broker and fault-injection cluster paths build raw `ContainerBuilder`s with **no wait strategy** — Testcontainers "ready" meant only "container running". Brokers still forming the KRaft quorum accept TCP then reset, so the ready-check probe's `BuildAsync` failed and logged warnings until the outer poll loop succeeded. (The single-broker path was never affected — `KafkaBuilder` ships a Kafka-aware wait.)
2. **Library**: initial metadata fetch gave up after 4 attempts (~1.25s total: 100→200→400ms backoff). The Java client never fail-fasts here — the first send blocks up to `max.block.ms` (60s) retrying metadata throughout.

## Changes

### Library — Java-parity blocking init
- New `MetadataOptions.InitTimeoutMs` (default 60000) time-bounds `MetadataManager.InitializeAsync`: retriable failures retry with the existing exponential backoff, the final delay is clamped to the remaining budget, and expiry throws `KafkaTimeoutException(TimeoutKind.Metadata, elapsed, configured, …)` with the last underlying failure as `InnerException`. Fatal errors (auth etc.) still throw immediately.
- `MaxInitRetries` becomes an opt-in attempt cap (default `int.MaxValue`); attempt-capped behavior is unchanged when set explicitly.
- Producer builder maps `WithMaxBlock`/`MaxBlockMs` → `InitTimeoutMs`. Consumer/share-consumer/admin keep the 60s default (Java `default.api.timeout.ms` parity). DI path inherits via the builder.
- Removed the producer's now-dead `OperationCanceledException` → `KafkaTimeoutException` translation — the manager owns init-timeout semantics.
- Doc fix: `RetryBackoffMs`/`RetryBackoffMaxMs` match Java `retry.backoff.ms`/`retry.backoff.max.ms` (not `reconnect.backoff.ms`).

### Stress harness — real readiness gates
- Both raw-builder cluster paths now share `KafkaEnvironment.BrokerServingWaitStrategy()`: wait for the `RECOVERY→RUNNING` (broker unfenced) log transition, same pattern the integration tests already use. Containers report ready only when actually serving.
- The ready-check probe pins `WithMaxBlock(5s)` so its own 1s-cadence poll loop stays authoritative.

## Verification
- Full unit suite: 5543/5543 green (12.7s — confirms no test now blocks on the 60s default).
- New unit test: time budget exhaustion → `KafkaTimeoutException` with inner failure; existing attempt-cap escalation tests updated to pin `MaxInitRetries`.
- End-to-end (local Docker): `BuildAsync` started with **no broker**; broker container started at t=5s; init completed at t=8.5s and produced offset 0. Unreachable bootstrap + `WithMaxBlock(3s)` → `KafkaTimeoutException` at ~4.2s (deadline is checked after a failed attempt, so overshoot is bounded by one connect attempt).
- 3-broker stress startup with the wait strategy: `Waiting for Kafka to be ready...` → `Kafka is ready` first probe, zero metadata warnings.

## Known limitation (pre-existing, documented not fixed)
Producers attached to a shared `KafkaClient` infrastructure use the client's shared `MetadataManager` (60s default) — a per-producer `WithMaxBlock` does not bound init there. Honoring it would need a per-call deadline parameter on `InitializeAsync`; left for a follow-up.