### PR TITLE
fix(producer): govern the latency users pay — admission-wait signal, conn-invariant window, slow-start exit, probe hygiene

### DIFF
--- a/src/Dekaf/Internal/InterlockedHelper.cs
+++ b/src/Dekaf/Internal/InterlockedHelper.cs
@@ -23,4 +23,21 @@ internal static class InterlockedHelper
         }
         while (Interlocked.CompareExchange(ref location, newValue, current) != current);
     }
+
+    /// <summary>
+    /// Atomically increases <paramref name="location"/> to at least <paramref name="newValue"/>.
+    /// If the current value is already greater than or equal to <paramref name="newValue"/>, this is a no-op.
+    /// Uses a CAS loop — safe for concurrent callers, never decreases.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RatchetUp(ref long location, long newValue)
+    {
+        long current;
+        do
+        {
+            current = Volatile.Read(ref location);
+            if (newValue <= current) return;
+        }
+        while (Interlocked.CompareExchange(ref location, newValue, current) != current);
+    }
 }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2289,11 +2289,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private static long MicrosecondsToStopwatchTicks(long microseconds) =>
         Math.Max(1, microseconds * Stopwatch.Frequency / 1_000_000);
 
-    internal static long GetOldestBatchSealTimestamp(ReadyBatch[] batches, int count)
+    /// <summary>
+    /// Origin timestamp for the governed delivery-delay sample of one request: the oldest
+    /// per-batch governed origin (seal, capped at the linger deadline when sealing stalled —
+    /// see <see cref="ReadyBatch.GovernedOriginTicks"/>).
+    /// </summary>
+    internal static long GetOldestBatchOriginTimestamp(ReadyBatch[] batches, int count)
     {
         var oldestBatchTimestamp = long.MaxValue;
         for (var i = 0; i < count; i++)
-            oldestBatchTimestamp = Math.Min(oldestBatchTimestamp, batches[i].StopwatchSealedTicks);
+            oldestBatchTimestamp = Math.Min(oldestBatchTimestamp, batches[i].GovernedOriginTicks);
 
         return oldestBatchTimestamp == long.MaxValue ? 0 : oldestBatchTimestamp;
     }
@@ -3644,7 +3649,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // RTT samples and disabled the budget's RTT safety floor. Including TCP write
                 // time biases individual RTT samples high, which the budget's minimum filter
                 // discards.
-                var oldestBatchTimestamp = GetOldestBatchSealTimestamp(batches, count);
+                var oldestBatchTimestamp = GetOldestBatchOriginTimestamp(batches, count);
                 var admissionGeneration = GetCommonAdmissionGeneration(batches, count);
 
                 var deliverySnapshotAtSend = _unackedBudget?.SnapshotDelivery(

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -70,7 +70,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _budgetBytes;
     private long _generation;
     private long _admissionBlockEvents;
-    private long _admissionWaitPeakTicks;
+    private long _admissionWaitTicks;
     private long _admissionBlockedSinceTimestamp;
     private long _pendingOutstandingPeakBytes;
     private long _minimumRttMicros;
@@ -255,14 +255,16 @@ internal sealed class BrokerUnackedByteBudget
 
     /// <summary>
     /// Records the wait a blocked append actually paid before it was admitted. The per-epoch
-    /// peak feeds the window controller's governed delay, so callers queueing outside the
-    /// window are visible to the same target the in-window pipeline is held to. Multi-writer;
-    /// slow path only (a wait was already paid).
+    /// sum feeds the window controller's governed delay as a load-scaled average, so callers
+    /// queueing outside the window are visible to the same target the in-window pipeline is
+    /// held to. A sum, not a peak: one outlier block must not swamp the paired-experiment
+    /// delay comparison the way a per-epoch maximum did (run 29552281754, A-B-A REGRESSION).
+    /// Multi-writer; slow path only (a wait was already paid).
     /// </summary>
     public void RecordAdmissionWait(long waitTicks)
     {
         if (waitTicks > 0)
-            InterlockedHelper.RatchetUp(ref _admissionWaitPeakTicks, waitTicks);
+            Interlocked.Add(ref _admissionWaitTicks, waitTicks);
     }
 
     /// <summary>
@@ -415,7 +417,7 @@ internal sealed class BrokerUnackedByteBudget
             AdmissionBlockEvents,
             outstandingPeak,
             nowTicks,
-            Interlocked.Exchange(ref _admissionWaitPeakTicks, 0));
+            Interlocked.Exchange(ref _admissionWaitTicks, 0));
         PublishDecision(decision, nowTicks);
         if (!IsOverBudget())
             RecordAdmissionAvailable(nowTicks);

--- a/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
+++ b/src/Dekaf/Producer/BrokerUnackedByteBudget.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Dekaf.Internal;
 
 namespace Dekaf.Producer;
 
@@ -69,6 +70,7 @@ internal sealed class BrokerUnackedByteBudget
     private long _budgetBytes;
     private long _generation;
     private long _admissionBlockEvents;
+    private long _admissionWaitPeakTicks;
     private long _admissionBlockedSinceTimestamp;
     private long _pendingOutstandingPeakBytes;
     private long _minimumRttMicros;
@@ -115,7 +117,7 @@ internal sealed class BrokerUnackedByteBudget
             latencyGovernorEnabled: coldStartBudgetBytes is not null && targetSeconds > 0);
         if (coldStartBudgetBytes is { } coldStartBudget)
         {
-            _coldStartBudgetBytes = Math.Clamp(coldStartBudget, floor, _controller.WindowBytes);
+            _ = ArmColdStartWave(coldStartBudget);
             _awaitingInitialAcknowledgement = true;
         }
         Publish(GetPublishedBudget(_controller.WindowBytes), _controller.Generation);
@@ -252,6 +254,18 @@ internal sealed class BrokerUnackedByteBudget
     }
 
     /// <summary>
+    /// Records the wait a blocked append actually paid before it was admitted. The per-epoch
+    /// peak feeds the window controller's governed delay, so callers queueing outside the
+    /// window are visible to the same target the in-window pipeline is held to. Multi-writer;
+    /// slow path only (a wait was already paid).
+    /// </summary>
+    public void RecordAdmissionWait(long waitTicks)
+    {
+        if (waitTicks > 0)
+            InterlockedHelper.RatchetUp(ref _admissionWaitPeakTicks, waitTicks);
+    }
+
+    /// <summary>
     /// Claims the right to force one partial batch into the broker pipeline. A claim is only
     /// needed when all charged bytes are held by open batches; an existing pipeline batch can
     /// already acknowledge bytes and wake blocked appenders without fragmenting every partition.
@@ -309,21 +323,8 @@ internal sealed class BrokerUnackedByteBudget
         Debug.Assert(remaining >= 0, "Broker pipeline batch count went negative.");
     }
 
-    public void ObserveWrittenUnackedBytes(long bytes)
-    {
-        var observed = Volatile.Read(ref _pendingOutstandingPeakBytes);
-        while (bytes > observed)
-        {
-            var prior = Interlocked.CompareExchange(
-                ref _pendingOutstandingPeakBytes,
-                bytes,
-                observed);
-            if (prior == observed)
-                return;
-
-            observed = prior;
-        }
-    }
+    public void ObserveWrittenUnackedBytes(long bytes) =>
+        InterlockedHelper.RatchetUp(ref _pendingOutstandingPeakBytes, bytes);
 
     public void SetCap(long capBytes, long nowTicks)
         => SetCap(capBytes, coldStartBudgetBytes: null, nowTicks);
@@ -333,17 +334,21 @@ internal sealed class BrokerUnackedByteBudget
         _ = nowTicks;
         var decision = _controller.SetCap(capBytes);
         if (_awaitingInitialAcknowledgement && coldStartBudgetBytes is { } coldStartBudget)
-        {
-            // The pre-ack window must be able to carry one wave at the new routing width,
-            // otherwise the slow start's pessimistic floor would shrink the wave the cold
-            // gate itself intends to admit.
-            decision = _controller.NoteColdStartWave(coldStartBudget);
-            _coldStartBudgetBytes = Math.Clamp(
-                coldStartBudget,
-                _floorBytes,
-                decision.WindowBytes);
-        }
+            decision = ArmColdStartWave(coldStartBudget);
         Publish(GetPublishedBudget(decision.WindowBytes), decision.Generation);
+    }
+
+    /// <summary>
+    /// Raises the pre-ack window to carry one cold-start wave at the current routing width
+    /// and clamps the pre-ack budget to it. The wave spans all connections while the
+    /// slow-start entry is denominated in single-connection quanta, so without this the
+    /// slow start's pessimistic floor would shrink the wave the cold gate intends to admit.
+    /// </summary>
+    private BrokerWindowDecision ArmColdStartWave(long coldStartBudget)
+    {
+        var decision = _controller.NoteColdStartWave(coldStartBudget);
+        _coldStartBudgetBytes = Math.Clamp(coldStartBudget, _floorBytes, decision.WindowBytes);
+        return decision;
     }
 
     internal DeliverySnapshot SnapshotDelivery(
@@ -409,7 +414,8 @@ internal sealed class BrokerUnackedByteBudget
         var decision = _controller.CompleteInterval(
             AdmissionBlockEvents,
             outstandingPeak,
-            nowTicks);
+            nowTicks,
+            Interlocked.Exchange(ref _admissionWaitPeakTicks, 0));
         PublishDecision(decision, nowTicks);
         if (!IsOverBudget())
             RecordAdmissionAvailable(nowTicks);
@@ -470,7 +476,7 @@ internal sealed class BrokerUnackedByteBudget
         Volatile.Write(ref _maxRateBytesPerSecond, _controller.MaximumGoodputBytesPerSecond);
         Volatile.Write(
             ref _deliveryLatencyEwmaMicros,
-            _controller.ControlledDelayEwmaTicks * 1_000_000 / Stopwatch.Frequency);
+            _controller.GovernedDelayEwmaTicks * 1_000_000 / Stopwatch.Frequency);
         Volatile.Write(ref _latencyBudgetScale, _controller.WindowScale);
         Volatile.Write(ref _capacityProbeSuccessCount, _controller.CapacityProbeSuccessCount);
         Volatile.Write(ref _capacityProbeFailureCount, _controller.CapacityProbeFailureCount);

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -34,14 +34,19 @@ internal readonly record struct BrokerWindowDecision(
 /// size. Each doubling follows a fully acknowledged response pass, so the broker has always
 /// drained the previous window within one round trip before more is admitted; the first
 /// acknowledgement can no longer release the whole optimistic window as one unmeasured
-/// burst into a cold broker (#2109).</item>
-/// <item>While the controlled-delay EWMA exceeds the delivery-latency target, probes are
-/// biased downward: up-probes are withheld, down-probes may explore beneath the normal
-/// pipeline floor, and each successful goodput-preserving descent schedules the next probe
-/// early. Every step remains a B-A-B experiment whose goodput guard reverts harmful
-/// shrinks, so topologies whose knee sits high keep their window and only pay a treatment
-/// slice per cycle, while topologies with a low knee descend out of standing queueing
-/// delay the target forbids.</item>
+/// burst into a cold broker (#2109). Doubling also stops early when the delay EWMA is over
+/// target and grew materially since the previous doubling — queueing the opening itself
+/// manufactured must not compound, while ambient window-independent delay keeps the
+/// opening unrestricted.</item>
+/// <item>While the governed-delay EWMA (post-seal pipeline delay plus observed
+/// admission-block wait) exceeds the delivery-latency target, probes are biased downward:
+/// up-probes are withheld, down-probes may explore beneath the normal pipeline floor, and
+/// each successful goodput-preserving descent schedules the next probe early. Every step
+/// remains a B-A-B experiment whose goodput guard reverts harmful shrinks, so topologies
+/// whose knee sits high keep their window and only pay a treatment slice per cycle, while
+/// topologies with a low knee descend out of standing queueing delay the target forbids.
+/// Consecutive failed experiments back the probe schedule off exponentially, bounding the
+/// standing-queue tax probes charge to a saturated broker.</item>
 /// </list>
 /// </summary>
 internal sealed class BrokerWindowController
@@ -103,6 +108,19 @@ internal sealed class BrokerWindowController
     private const double DeepDescentDelayGainFactor = 0.90;
     private const double DelayGrowthTolerance = 1.25;
     private const double EwmaWeight = 0.125;
+    // Slow start stops doubling only when the delay EWMA is over target AND grew by at least
+    // this factor since the previous doubling. Ambient delay that does not respond to the
+    // window (a slow broker, a long link) must not strangle the opening window — only
+    // queueing the doubling itself manufactured may end it early.
+    private const double SlowStartDelayGrowthFactor = 1.5;
+    // Consecutive failed experiments double the probe interval up to this shift (8x, ~4min):
+    // each failure means the broker is already at its knee, so re-running the same 15s
+    // experiment every cycle only injects periodic queueing the target forbids.
+    private const int MaximumProbeBackoffShift = 3;
+    // An up-probe treatment whose epoch delay blows past both twice the target and twice the
+    // delay observed at probe entry cannot pass the final delay veto; aborting immediately
+    // stops charging the remaining treatment epochs of standing queue to live traffic.
+    private const double UpProbeAbortDelayFactor = 2.0;
 
     private static readonly long ControlIntervalTicks = Math.Max(1, Stopwatch.Frequency / 2);
     private static readonly long MinimumRttRefreshTicks = 60 * Stopwatch.Frequency;
@@ -127,12 +145,16 @@ internal sealed class BrokerWindowController
     private bool _epochLoaded;
 
     private double _controlledDelayEwmaTicks;
+    private double _admissionWaitEwmaTicks;
+    private double _slowStartLastDelayEwmaTicks;
+    private long _epochAdmissionWaitPeakTicks;
     private double _maximumGoodputBytesPerSecond;
     private long _minimumRttTicks;
     private long _lastAdmissionBlockEvents;
 
     private int _epochsUntilProbe = ProbeIntervalEpochs;
     private bool _probeDownNext = true;
+    private int _consecutiveProbeFailures;
     private long _probeBaselineWindow;
     private long _probeCandidateWindow;
     private CapacityProbeStage _probeStage;
@@ -140,6 +162,7 @@ internal sealed class BrokerWindowController
     private double _probeTreatmentBeforeDelayTicks;
     private double _probeBaselineGoodput;
     private double _probeBaselineDelayTicks;
+    private double _probeEntryDelayTicks;
     private int _probeEvaluationCount;
     private int _probeSettleEpochsRemaining;
     private int _unqualifiedProbeEpochs;
@@ -172,14 +195,20 @@ internal sealed class BrokerWindowController
     internal BrokerWindowPhase Phase => _phase;
     internal long MinimumRttTicks => _minimumRttTicks;
     internal long MaximumGoodputBytesPerSecond => (long)_maximumGoodputBytesPerSecond;
-    internal long ControlledDelayEwmaTicks => (long)_controlledDelayEwmaTicks;
+    internal long GovernedDelayEwmaTicks => (long)GovernedDelayEwma;
     internal long RequestQuantumBytes => _requestQuantumBytes;
     internal double WindowScale => _capBytes == 0 ? 1 : (double)_windowBytes / _capBytes;
     internal long CapacityProbeSuccessCount { get; private set; }
     internal long CapacityProbeFailureCount { get; private set; }
 
+    /// <summary>The delay the governor regulates against the target: post-seal pipeline delay
+    /// plus the admission-block wait blocked appends actually paid. Without the admission
+    /// component, a window that is exactly the bottleneck reads as on-target while callers
+    /// queue outside it (run 29541359283: 120k-711k blocks/broker invisible to descent).</summary>
+    private double GovernedDelayEwma => _controlledDelayEwmaTicks + _admissionWaitEwmaTicks;
+
     private bool DelayOverTarget =>
-        _latencyGovernorEnabled && _controlledDelayEwmaTicks > _targetDelayTicks;
+        _latencyGovernorEnabled && GovernedDelayEwma > _targetDelayTicks;
 
     internal BrokerWindowDecision SetCap(long capBytes)
     {
@@ -251,8 +280,13 @@ internal sealed class BrokerWindowController
     internal BrokerWindowDecision CompleteInterval(
         long admissionBlockEvents,
         long observedOutstandingBytes,
-        long nowTicks)
+        long nowTicks,
+        long admissionWaitPeakTicks)
     {
+        _epochAdmissionWaitPeakTicks = Math.Max(
+            _epochAdmissionWaitPeakTicks,
+            admissionWaitPeakTicks);
+
         // Called once per response pass that carried at least one full acknowledgement, so
         // each doubling follows a proven drain of the previous window within one round trip.
         if (_slowStartActive)
@@ -275,9 +309,14 @@ internal sealed class BrokerWindowController
 
         var generationQualified = _epochCurrentGenerationBytes > 0
             && _epochCurrentGenerationBytes >= _epochBytes / 2 + _epochBytes % 2;
-        var controlledDelayTicks = generationQualified
+        // The epoch's governed delay adds the worst admission-block wait observed this epoch:
+        // an experiment that merely moves queueing from inside the window to blocked callers
+        // shows no delay gain and is rejected, while one that removes standing queue passes.
+        var epochAdmissionWaitTicks = _epochAdmissionWaitPeakTicks;
+        _admissionWaitEwmaTicks = UpdateEwma(_admissionWaitEwmaTicks, epochAdmissionWaitTicks);
+        var controlledDelayTicks = (generationQualified
             ? _epochCurrentGenerationDelayByteTicks / _epochCurrentGenerationBytes
-            : _controlledDelayEwmaTicks;
+            : _controlledDelayEwmaTicks) + epochAdmissionWaitTicks;
         var admissionPressure = admissionBlockEvents != _lastAdmissionBlockEvents;
         // Occupancy is a demand signal, not a floor. A floor would make the lower-window
         // treatment impossible to test; the 99% goodput guard below reverts a harmful probe
@@ -318,6 +357,21 @@ internal sealed class BrokerWindowController
 
     private void AdvanceSlowStart()
     {
+        // Stop doubling when the delay EWMA is over target AND has grown materially since the
+        // previous doubling: the previous window already manufactured standing queue, so the
+        // next doubling would only deepen it (run 29541359283: slow start reached the 3conn
+        // optimistic window in ~1s with a 403ms delay EWMA). Ambient over-target delay with no
+        // growth keeps doubling — a window-independent delay must not strangle the opening.
+        var governedDelay = GovernedDelayEwma;
+        if (_slowStartLastDelayEwmaTicks > 0
+            && governedDelay > _targetDelayTicks
+            && governedDelay > _slowStartLastDelayEwmaTicks * SlowStartDelayGrowthFactor)
+        {
+            _slowStartActive = false;
+            return;
+        }
+
+        _slowStartLastDelayEwmaTicks = governedDelay;
         var optimisticWindow = OptimisticWindowBytes;
         SetWindow(Math.Min(SaturatingMultiply(_windowBytes, 2), optimisticWindow));
         if (_windowBytes >= optimisticWindow)
@@ -391,6 +445,7 @@ internal sealed class BrokerWindowController
         _probeStage = CapacityProbeStage.TreatmentBefore;
         _unqualifiedProbeEpochs = 0;
         ResetProbeExperiment();
+        _probeEntryDelayTicks = GovernedDelayEwma;
         _probeSettleEpochsRemaining = ProbeSettleEpochs;
         SetWindow(_probeCandidateWindow);
 
@@ -407,6 +462,17 @@ internal sealed class BrokerWindowController
         {
             _probeSettleEpochsRemaining--;
             return CurrentDecision();
+        }
+
+        // An up-probe treatment whose delay has clearly blown through both the target and the
+        // entry delay can no longer pass the final delay veto: abort now instead of holding
+        // the inflated window for the remaining treatment and baseline epochs.
+        if (_phase == BrokerWindowPhase.ProbeUp
+            && _probeStage != CapacityProbeStage.Baseline
+            && controlledDelayTicks > UpProbeAbortDelayFactor
+                * Math.Max(_targetDelayTicks, _probeEntryDelayTicks))
+        {
+            return CompleteCapacityProbe(succeeded: false);
         }
 
         var requiredEpochs = _probeStage == CapacityProbeStage.Baseline
@@ -456,9 +522,9 @@ internal sealed class BrokerWindowController
             : DownProbeGoodputThreshold;
         var deepDescent = !probingUp
             && _probeCandidateWindow < QuantaFloorBytes(MinimumPipelineQuanta);
-        // Seal-to-send plus network queueing omits pre-seal admission and batch-fill time, so
-        // it cannot veto a lower window. It remains a conservative guard against growing a
-        // window that raises the delay component the controller can observe.
+        // The governed delay includes the epoch's worst admission-block wait, so a descent
+        // that only converts in-window queueing into blocked callers shows no delay gain and
+        // fails deep descent, while growth that manufactures queueing trips the delay veto.
         var succeeded = treatmentGoodput >= _probeBaselineGoodput * goodputThreshold
             && (!probingUp || treatmentDelayTicks <= delayLimit)
             && (!deepDescent
@@ -477,10 +543,14 @@ internal sealed class BrokerWindowController
         if (succeeded)
         {
             CapacityProbeSuccessCount++;
+            _consecutiveProbeFailures = 0;
         }
         else
         {
             CapacityProbeFailureCount++;
+            _consecutiveProbeFailures = Math.Min(
+                _consecutiveProbeFailures + 1,
+                MaximumProbeBackoffShift);
             SetWindow(_probeBaselineWindow);
         }
 
@@ -490,12 +560,15 @@ internal sealed class BrokerWindowController
         _probeDownNext = probingUp ? !succeeded : succeeded;
         // A goodput-preserving descent earns an early retry only while the experiment's own
         // baseline delay missed the target — the instantaneous EWMA flickers on bursts and
-        // over-accelerated the walk (run 29513570135).
+        // over-accelerated the walk (run 29513570135). Consecutive failures back the schedule
+        // off exponentially: a broker already at its knee proved the current window right,
+        // and re-running the same experiment every cycle spent 32-42% of broker time inside
+        // probes on run 29541359283.
         _epochsUntilProbe = !probingUp
             && succeeded
             && _probeBaselineDelayTicks > _targetDelayTicks
             ? AcceleratedDescentIntervalEpochs
-            : ProbeIntervalEpochs;
+            : ProbeIntervalEpochs << _consecutiveProbeFailures;
         _unqualifiedProbeEpochs = 0;
         ResetProbeExperiment();
         return CurrentDecision(
@@ -627,6 +700,7 @@ internal sealed class BrokerWindowController
         _epochBytes = 0;
         _epochCurrentGenerationBytes = 0;
         _epochCurrentGenerationDelayByteTicks = 0;
+        _epochAdmissionWaitPeakTicks = 0;
         _epochLoaded = false;
     }
 

--- a/src/Dekaf/Producer/BrokerWindowController.cs
+++ b/src/Dekaf/Producer/BrokerWindowController.cs
@@ -45,8 +45,9 @@ internal readonly record struct BrokerWindowDecision(
 /// remains a B-A-B experiment whose goodput guard reverts harmful shrinks, so topologies
 /// whose knee sits high keep their window and only pay a treatment slice per cycle, while
 /// topologies with a low knee descend out of standing queueing delay the target forbids.
-/// Consecutive failed experiments back the probe schedule off exponentially, bounding the
-/// standing-queue tax probes charge to a saturated broker.</item>
+/// Consecutive failed experiments back the probe schedule off exponentially while delay is
+/// on target, bounding the standing-queue tax probes charge to a broker at its knee without
+/// throttling the descent search while the target is missed.</item>
 /// </list>
 /// </summary>
 internal sealed class BrokerWindowController
@@ -113,9 +114,11 @@ internal sealed class BrokerWindowController
     // window (a slow broker, a long link) must not strangle the opening window — only
     // queueing the doubling itself manufactured may end it early.
     private const double SlowStartDelayGrowthFactor = 1.5;
-    // Consecutive failed experiments double the probe interval up to this shift (8x, ~4min):
-    // each failure means the broker is already at its knee, so re-running the same 15s
-    // experiment every cycle only injects periodic queueing the target forbids.
+    // Consecutive failed experiments double the probe interval up to this shift (8x, ~4min),
+    // but only while delay is on target: each on-target failure means the broker is already
+    // at its knee, so re-running the same 15s experiment every cycle only injects periodic
+    // queueing. While the target is missed, failed experiments are the escape search and run
+    // at the normal cadence.
     private const int MaximumProbeBackoffShift = 3;
     // An up-probe treatment whose epoch delay blows past both twice the target and twice the
     // delay observed at probe entry cannot pass the final delay veto; aborting immediately
@@ -147,7 +150,7 @@ internal sealed class BrokerWindowController
     private double _controlledDelayEwmaTicks;
     private double _admissionWaitEwmaTicks;
     private double _slowStartLastDelayEwmaTicks;
-    private long _epochAdmissionWaitPeakTicks;
+    private long _epochAdmissionWaitTicks;
     private double _maximumGoodputBytesPerSecond;
     private long _minimumRttTicks;
     private long _lastAdmissionBlockEvents;
@@ -281,11 +284,9 @@ internal sealed class BrokerWindowController
         long admissionBlockEvents,
         long observedOutstandingBytes,
         long nowTicks,
-        long admissionWaitPeakTicks)
+        long admissionWaitTicks)
     {
-        _epochAdmissionWaitPeakTicks = Math.Max(
-            _epochAdmissionWaitPeakTicks,
-            admissionWaitPeakTicks);
+        _epochAdmissionWaitTicks = SaturatingAdd(_epochAdmissionWaitTicks, admissionWaitTicks);
 
         // Called once per response pass that carried at least one full acknowledgement, so
         // each doubling follows a proven drain of the previous window within one round trip.
@@ -309,14 +310,20 @@ internal sealed class BrokerWindowController
 
         var generationQualified = _epochCurrentGenerationBytes > 0
             && _epochCurrentGenerationBytes >= _epochBytes / 2 + _epochBytes % 2;
-        // The epoch's governed delay adds the worst admission-block wait observed this epoch:
-        // an experiment that merely moves queueing from inside the window to blocked callers
-        // shows no delay gain and is rejected, while one that removes standing queue passes.
-        var epochAdmissionWaitTicks = _epochAdmissionWaitPeakTicks;
-        _admissionWaitEwmaTicks = UpdateEwma(_admissionWaitEwmaTicks, epochAdmissionWaitTicks);
+        // The epoch's governed delay adds the admission-block wait scaled to the epoch's
+        // load: the summed waits spread over one request quantum of traffic, i.e. the average
+        // admission delay a full request's worth of bytes paid. An experiment that merely
+        // moves queueing from inside the window to blocked callers shows no delay gain and is
+        // rejected, while one that removes standing queue passes. A load-scaled sum, not the
+        // epoch peak — a single outlier block swamped the paired delay comparison and vetoed
+        // legitimate descents (run 29552281754, A-B-A REGRESSION).
+        var epochAdmissionDelayTicks = (double)_epochAdmissionWaitTicks
+            * _requestQuantumBytes
+            / Math.Max(_epochBytes, _requestQuantumBytes);
+        _admissionWaitEwmaTicks = UpdateEwma(_admissionWaitEwmaTicks, epochAdmissionDelayTicks);
         var controlledDelayTicks = (generationQualified
             ? _epochCurrentGenerationDelayByteTicks / _epochCurrentGenerationBytes
-            : _controlledDelayEwmaTicks) + epochAdmissionWaitTicks;
+            : _controlledDelayEwmaTicks) + epochAdmissionDelayTicks;
         var admissionPressure = admissionBlockEvents != _lastAdmissionBlockEvents;
         // Occupancy is a demand signal, not a floor. A floor would make the lower-window
         // treatment impossible to test; the 99% goodput guard below reverts a harmful probe
@@ -561,14 +568,18 @@ internal sealed class BrokerWindowController
         // A goodput-preserving descent earns an early retry only while the experiment's own
         // baseline delay missed the target — the instantaneous EWMA flickers on bursts and
         // over-accelerated the walk (run 29513570135). Consecutive failures back the schedule
-        // off exponentially: a broker already at its knee proved the current window right,
-        // and re-running the same experiment every cycle spent 32-42% of broker time inside
-        // probes on run 29541359283.
+        // off exponentially, but only while delay is on target: at the knee, re-running the
+        // same experiment every cycle spent 32-42% of broker time inside probes (run
+        // 29541359283), yet while the target is missed the failed experiments ARE the search
+        // for a way out, and throttling them froze the window at the slow-start ceiling for
+        // most of a run (run 29552281754, A-B-A REGRESSION).
         _epochsUntilProbe = !probingUp
             && succeeded
             && _probeBaselineDelayTicks > _targetDelayTicks
             ? AcceleratedDescentIntervalEpochs
-            : ProbeIntervalEpochs << _consecutiveProbeFailures;
+            : DelayOverTarget
+                ? ProbeIntervalEpochs
+                : ProbeIntervalEpochs << _consecutiveProbeFailures;
         _unqualifiedProbeEpochs = 0;
         ResetProbeExperiment();
         return CurrentDecision(
@@ -700,7 +711,7 @@ internal sealed class BrokerWindowController
         _epochBytes = 0;
         _epochCurrentGenerationBytes = 0;
         _epochCurrentGenerationDelayByteTicks = 0;
-        _epochAdmissionWaitPeakTicks = 0;
+        _epochAdmissionWaitTicks = 0;
         _epochLoaded = false;
     }
 

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -84,6 +84,10 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
     internal Action<RecordMetadata, Exception?>? Callback => _callback;
     internal int RecordSize => _recordSize;
 
+    /// <summary>Monotonic milliseconds when the originating append started blocking; the
+    /// drain uses this to report the admission wait actually paid.</summary>
+    internal long StartTicks => _startTicks;
+
     public PendingAppend()
     {
         _core.RunContinuationsAsynchronously = true;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2139,6 +2139,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         continue;
                     }
 
+                    RecordAdmissionWaitForDrainedAppend(op, drainable.AdmissionReservation);
+
                     try
                     {
                         var result = AppendAfterReservation(
@@ -2215,6 +2217,27 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         DrainPendingAppends();
+    }
+
+    /// <summary>
+    /// Feeds the wait a drained slow-path append actually paid into its broker budget's
+    /// governed delay. Without this the window controller cannot see latency spent queueing
+    /// outside the window, and a window that is exactly the bottleneck reads as on-target
+    /// while callers block against it. The wait deliberately includes buffer-memory blocks,
+    /// not just window rejections: from the leader's governed-delay perspective any slow-path
+    /// wait is delay the caller paid, and the probe guards (goodput + delay-gain) prevent a
+    /// non-window cause from driving descent that buys nothing. Slow path only.
+    /// </summary>
+    private void RecordAdmissionWaitForDrainedAppend(
+        PendingAppend operation,
+        in AdmissionReservation reservation)
+    {
+        var budget = reservation.Budget;
+        if (budget is null && reservation.Deque is { } deque)
+            budget = GetCachedAdmissionBudget(deque, operation.Topic, operation.Partition);
+
+        var waitMilliseconds = MonotonicClock.GetMilliseconds() - operation.StartTicks;
+        budget?.RecordAdmissionWait(waitMilliseconds * Stopwatch.Frequency / 1_000);
     }
 
     /// <summary>
@@ -5119,13 +5142,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // adaptive window by ack-clocked doubling (slow start) instead of in one unlearned
         // step. Explicit cap overrides retain their existing controller semantics for tests
         // and advanced callers.
+        //
+        // The controller quantum is one batch regardless of connection count: connections are
+        // parallelism for draining the window, not license for more standing bytes. Scaling
+        // the quantum by routing width multiplied every floor and the slow-start ceiling by
+        // the connection count, which tripled standing queue at 3 connections per broker and
+        // put the descent floor itself above the delivery-latency target (run 29541359283).
+        // Only the cap and the pre-ack cold-start wave span the full routing width.
         return new BrokerUnackedByteBudget(
             _options.DeliveryLatencyTargetMs / 1000.0,
             floorBytes: 1,
             initialCapBytes: cap,
             lingerSeconds: _options.LingerMs / 1000.0,
             enableDiagnostics: _options.EnableDeliveryDiagnostics,
-            initialRequestBytes: requestWaveBytes,
+            initialRequestBytes: _options.BatchSize,
             coldStartBudgetBytes: _options.UnackedByteBudgetCapOverride is null
                 && _options.Acks != Acks.None
                 ? requestWaveBytes
@@ -7388,7 +7418,8 @@ internal sealed class PartitionBatch
                 _callbackCount,
                 _arrayReuseQueue,
                 _recordCount,
-                _createdStopwatchTimestamp);
+                _createdStopwatchTimestamp,
+                _options.LingerMs * Stopwatch.Frequency / 1_000);
 
             if (_admissionBudget is { } admissionBudget)
             {
@@ -8050,6 +8081,15 @@ internal sealed class ReadyBatch
     internal long StopwatchSealedTicks { get; private set; }
 
     /// <summary>
+    /// Origin for the governed delivery-delay sample: the seal, or the linger deadline when
+    /// sealing stalled past it. Configured linger is the caller's chosen batching delay and
+    /// must not read as queueing, but a batch held open beyond its linger (admission-flush
+    /// stalls, drain starvation) is delay the user pays that seal-to-send alone cannot see.
+    /// Fixed at seal time so retries keep their original origin.
+    /// </summary>
+    internal long GovernedOriginTicks { get; private set; }
+
+    /// <summary>
     /// Age of this ready batch in milliseconds since sealing (or since last reenqueue).
     /// </summary>
     internal int AgeMs => (int)((Stopwatch.GetTimestamp() - _createdTimestamp) * 1000 / Stopwatch.Frequency);
@@ -8192,7 +8232,8 @@ internal sealed class ReadyBatch
         int callbackCount = 0,
         BatchArrayReuseQueue? arrayReuseQueue = null,
         int recordCount = 0,
-        long createdStopwatchTimestamp = 0)
+        long createdStopwatchTimestamp = 0,
+        long lingerTicks = 0)
     {
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
@@ -8241,6 +8282,9 @@ internal sealed class ReadyBatch
         StopwatchCreatedTicks = createdStopwatchTimestamp > 0
             ? createdStopwatchTimestamp
             : StopwatchSealedTicks;
+        GovernedOriginTicks = Math.Min(
+            StopwatchSealedTicks,
+            StopwatchCreatedTicks + lingerTicks);
         _createdTimestamp = StopwatchSealedTicks;
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -29,16 +29,66 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class BrokerSenderSendLoopTests
 {
     [Test]
-    public async Task DeliveryLatencyTimestamp_HighThroughputLinger_UsesSealNotCreation()
+    public async Task DeliveryLatencyOrigin_SealWithinLinger_UsesSealNotCreation()
+    {
+        // Sealing within the configured linger: the origin stays the seal, so opted-in
+        // batching delay never reads as queueing to the window governor.
+        var readyBatch = CreateReadyBatchSealedAfter(
+            creationAgeTicks: Stopwatch.Frequency / 10,
+            lingerMs: 200);
+
+        try
+        {
+            var originTimestamp = BrokerSender.GetOldestBatchOriginTimestamp([readyBatch], 1);
+
+            await Assert.That(readyBatch.GovernedOriginTicks)
+                .IsEqualTo(readyBatch.StopwatchSealedTicks);
+            await Assert.That(originTimestamp).IsEqualTo(readyBatch.StopwatchSealedTicks);
+        }
+        finally
+        {
+            readyBatch.TrySetMemoryReleased();
+            readyBatch.Fail(new InvalidOperationException("test cleanup"));
+        }
+    }
+
+    [Test]
+    public async Task DeliveryLatencyOrigin_SealStalledPastLinger_UsesLingerDeadline()
+    {
+        // Sealing stalled past the linger deadline (admission-flush stall, drain starvation):
+        // the overrun is delay the caller pays, so the origin becomes the linger deadline
+        // rather than the late seal that would hide it from the window governor.
+        const int lingerMs = 10;
+        var readyBatch = CreateReadyBatchSealedAfter(
+            creationAgeTicks: Stopwatch.Frequency / 10,
+            lingerMs);
+        var lingerTicks = lingerMs * Stopwatch.Frequency / 1_000;
+
+        try
+        {
+            var originTimestamp = BrokerSender.GetOldestBatchOriginTimestamp([readyBatch], 1);
+
+            await Assert.That(originTimestamp)
+                .IsEqualTo(readyBatch.StopwatchCreatedTicks + lingerTicks);
+            await Assert.That(originTimestamp).IsLessThan(readyBatch.StopwatchSealedTicks);
+        }
+        finally
+        {
+            readyBatch.TrySetMemoryReleased();
+            readyBatch.Fail(new InvalidOperationException("test cleanup"));
+        }
+    }
+
+    private static ReadyBatch CreateReadyBatchSealedAfter(long creationAgeTicks, int lingerMs)
     {
         var options = new ProducerOptions
         {
             BootstrapServers = ["localhost:9092"],
-            LingerMs = 100,
+            LingerMs = lingerMs,
             DeliveryLatencyTargetMs = 10
         };
         var partitionBatch = new PartitionBatch(new TopicPartition("test-topic", 0), options);
-        var simulatedCreationTimestamp = Stopwatch.GetTimestamp() - Stopwatch.Frequency / 10;
+        var simulatedCreationTimestamp = Stopwatch.GetTimestamp() - creationAgeTicks;
         typeof(PartitionBatch)
             .GetField("_createdStopwatchTimestamp", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(partitionBatch, simulatedCreationTimestamp);
@@ -53,23 +103,10 @@ public sealed class BrokerSenderSendLoopTests
             completionSource: null,
             callback: null,
             estimatedSize: 1);
-        var readyBatch = partitionBatch.Complete()!;
+        if (!appendResult.Success)
+            throw new InvalidOperationException("Test batch append failed.");
 
-        try
-        {
-            var deliveryTimestamp = BrokerSender.GetOldestBatchSealTimestamp([readyBatch], 1);
-
-            await Assert.That(appendResult.Success).IsTrue();
-            await Assert.That(readyBatch.StopwatchCreatedTicks).IsEqualTo(simulatedCreationTimestamp);
-            await Assert.That(deliveryTimestamp).IsEqualTo(readyBatch.StopwatchSealedTicks);
-            await Assert.That(deliveryTimestamp - readyBatch.StopwatchCreatedTicks)
-                .IsGreaterThanOrEqualTo(Stopwatch.Frequency / 20);
-        }
-        finally
-        {
-            readyBatch.TrySetMemoryReleased();
-            readyBatch.Fail(new InvalidOperationException("test cleanup"));
-        }
+        return partitionBatch.Complete()!;
     }
 
     private sealed class TrackingPipelinedResponseSource : IPipelinedResponseSource<ProduceResponse>

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -277,7 +277,7 @@ public sealed class BrokerUnackedByteBudgetTests
                 admissionBlocks,
                 controller.WindowBytes,
                 now,
-                admissionWaitPeakTicks: Seconds(0.00006) * controller.WindowBytes);
+                admissionWaitTicks: Seconds(0.00006) * controller.WindowBytes);
         }
 
         await Assert.That(controller.WindowBytes).IsEqualTo(200);
@@ -317,6 +317,37 @@ public sealed class BrokerUnackedByteBudgetTests
 
         await Assert.That(epochsToSecondProbe).IsGreaterThanOrEqualTo(120);
         await Assert.That(epochsToThirdProbe).IsGreaterThanOrEqualTo(240);
+    }
+
+    [Test]
+    public async Task OverTargetProbeFailures_DoNotBackOffTheSchedule()
+    {
+        var controller = CreateController(latencyGovernorEnabled: true);
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(0, 0, now, 0);
+
+        // Window-independent 50ms delay keeps the target missed forever; sub-floor descents
+        // repeatedly fail their delay-gain requirement.
+        for (var i = 0; i < 4_000 && controller.CapacityProbeFailureCount < 2; i++)
+        {
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.050);
+        }
+        await Assert.That(controller.CapacityProbeFailureCount).IsGreaterThanOrEqualTo(2);
+
+        // While the target is missed, failed experiments are the escape search: the next one
+        // must arrive on the normal schedule, not a 4x/8x backed-off one (run 29552281754
+        // froze the window at the slow-start ceiling for most of a run this way).
+        var epochsToNextProbe = CountEpochsUntilProbe(
+            controller,
+            ref now,
+            ref admissionBlocks,
+            sealToSendSeconds: 0.050);
+        await Assert.That(epochsToNextProbe).IsLessThanOrEqualTo(100);
     }
 
     [Test]
@@ -1182,11 +1213,16 @@ public sealed class BrokerUnackedByteBudgetTests
     private static int CountEpochsUntilProbe(
         BrokerWindowController controller,
         ref long now,
-        ref long admissionBlocks)
+        ref long admissionBlocks,
+        double sealToSendSeconds = 0)
     {
         for (var i = 1; i <= 1_000; i++)
         {
-            _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
+            _ = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: sealToSendSeconds);
             if (controller.Phase != BrokerWindowPhase.Steady)
                 return i;
         }
@@ -1239,6 +1275,6 @@ public sealed class BrokerUnackedByteBudgetTests
             admissionBlocks,
             observedOutstandingBytes ?? controller.WindowBytes,
             now,
-            admissionWaitPeakTicks: 0);
+            admissionWaitTicks: 0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerUnackedByteBudgetTests.cs
@@ -106,7 +106,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController(latencyGovernorEnabled: true);
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         // Controllable delay proportional to the window (12ms at the descent floor, 96ms at
         // the optimistic window) against a 10ms target: every descent step demonstrably buys
@@ -156,7 +156,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController(latencyGovernorEnabled: true);
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         // Delay is over target but window-independent (a fixed 50ms): shrinking below the
         // legacy floor cannot help, so every sub-floor experiment fails its delay-gain
@@ -179,7 +179,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController(latencyGovernorEnabled: true);
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         // On-target delay keeps the legacy eight-quantum floor: the governor's deep descent
         // is justified only by a missed latency target.
@@ -195,7 +195,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         // Flat goodput walks the window down to the legacy floor; sustained admission
         // blocking then lets up-probes pass at "not worse" goodput, so the window recovers
@@ -204,6 +204,172 @@ public sealed class BrokerUnackedByteBudgetTests
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
 
         await Assert.That(controller.WindowBytes).IsGreaterThan(1_600);
+    }
+
+    [Test]
+    public async Task SlowStart_StopsDoublingWhenDelayGrowsOverTarget()
+    {
+        var controller = CreateController(latencyGovernorEnabled: true);
+        var now = T0;
+
+        // First pass: on-target delay records the baseline and doubles (200 -> 400).
+        for (var i = 0; i < 8; i++)
+        {
+            controller.RecordAcknowledgement(
+                100, Seconds(0.001), Seconds(0.003), false, controller.Generation, now);
+        }
+        _ = controller.CompleteInterval(0, 0, now, 0);
+        await Assert.That(controller.WindowBytes).IsEqualTo(400);
+
+        // Second pass: the doubling manufactured queueing (delay over target and well past
+        // 1.5x the recorded baseline) — slow start ends without doubling again.
+        for (var i = 0; i < 8; i++)
+        {
+            controller.RecordAcknowledgement(
+                100, Seconds(0.001), Seconds(0.020), false, controller.Generation, now);
+        }
+        _ = controller.CompleteInterval(0, 0, now, 0);
+        await Assert.That(controller.WindowBytes).IsEqualTo(400);
+
+        // Slow start stays ended: further passes no longer double.
+        _ = controller.CompleteInterval(0, 0, now, 0);
+        await Assert.That(controller.WindowBytes).IsEqualTo(400);
+    }
+
+    [Test]
+    public async Task SlowStart_AmbientOverTargetDelayKeepsDoubling()
+    {
+        var controller = CreateController(latencyGovernorEnabled: true);
+        var now = T0;
+
+        // A fixed 50ms delay that does not respond to the window (slow broker, long link)
+        // is over target from the first acknowledgement but shows no growth between
+        // doublings — it must not strangle the opening window.
+        for (var pass = 0; pass < 4; pass++)
+        {
+            controller.RecordAcknowledgement(
+                100, Seconds(0.001), Seconds(0.050), false, controller.Generation, now);
+            _ = controller.CompleteInterval(0, 0, now, 0);
+        }
+
+        await Assert.That(controller.WindowBytes).IsEqualTo(1_600);
+    }
+
+    [Test]
+    public async Task AdmissionWait_AloneDrivesDescentBelowLegacyFloor()
+    {
+        var controller = CreateController(latencyGovernorEnabled: true);
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
+
+        // The in-window pipeline reads as idle (no post-seal delay, RTT at minimum) while
+        // blocked appends pay a wait proportional to the window. Only the admission-wait
+        // channel can justify descent here; before it fed the governed delay this exact
+        // shape parked at the legacy floor with callers queueing outside the window.
+        for (var i = 0; i < 2_000 && controller.WindowBytes > 200; i++)
+        {
+            now += Seconds(0.510);
+            admissionBlocks++;
+            controller.RecordAcknowledgement(
+                100, Seconds(0.001), 0, false, controller.Generation, now);
+            _ = controller.CompleteInterval(
+                admissionBlocks,
+                controller.WindowBytes,
+                now,
+                admissionWaitPeakTicks: Seconds(0.00006) * controller.WindowBytes);
+        }
+
+        await Assert.That(controller.WindowBytes).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task AdmissionWait_SurfacesInPublishedDeliveryLatencyEwma()
+    {
+        var budget = CreateBudget(capBytes: 10_000, initialRequestBytes: 100);
+        budget.CompleteAckedPass(T0);
+
+        budget.RecordAdmissionWait(Seconds(0.050));
+        DriveBudgetEpoch(budget, T0 + Seconds(0.510), 100, 0.001);
+
+        await Assert.That(budget.DeliveryLatencyEwmaMicros).IsGreaterThan(40_000);
+    }
+
+    [Test]
+    public async Task ProbeFailures_BackOffTheProbeSchedule()
+    {
+        var controller = CreateController();
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
+
+        // Two consecutive failed experiments: each doubles the wait before the next probe.
+        FailNextDownProbe(controller, ref now, ref admissionBlocks);
+        var baselineWindow = controller.WindowBytes;
+        var epochsToSecondProbe = CountEpochsUntilProbe(controller, ref now, ref admissionBlocks);
+        _ = CompleteActiveProbe(
+            controller,
+            baselineWindow,
+            ref now,
+            ref admissionBlocks,
+            candidateLogicalBytes: 50);
+        var epochsToThirdProbe = CountEpochsUntilProbe(controller, ref now, ref admissionBlocks);
+
+        await Assert.That(epochsToSecondProbe).IsGreaterThanOrEqualTo(120);
+        await Assert.That(epochsToThirdProbe).IsGreaterThanOrEqualTo(240);
+    }
+
+    [Test]
+    public async Task UpProbeTreatment_AbortsEarlyOnDelayBlowThrough()
+    {
+        var controller = CreateController();
+        var now = T0;
+        var admissionBlocks = 0L;
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
+
+        FailNextDownProbe(controller, ref now, ref admissionBlocks);
+        var baselineWindow = controller.WindowBytes;
+        StartNextProbe(
+            controller,
+            BrokerWindowPhase.ProbeUp,
+            ref now,
+            ref admissionBlocks);
+
+        // The treatment blows through twice the target and twice the entry delay: the
+        // experiment cannot pass the final delay veto, so it aborts on the first qualified
+        // treatment epoch instead of holding the inflated window for the full sandwich.
+        BrokerWindowDecision decision = default;
+        for (var i = 0; i < 3 && controller.Phase != BrokerWindowPhase.Steady; i++)
+        {
+            decision = DriveControllerEpoch(
+                controller,
+                ref now,
+                ref admissionBlocks,
+                sealToSendSeconds: 0.200);
+        }
+
+        await Assert.That(decision.ProbeOutcome).IsEqualTo(BrokerBudgetProbeOutcome.Failed);
+        await Assert.That(controller.Phase).IsEqualTo(BrokerWindowPhase.Steady);
+        await Assert.That(controller.WindowBytes).IsEqualTo(baselineWindow);
+    }
+
+    [Test]
+    public async Task ColdStartWave_WiderThanSlowStartEntry_RaisesPreAckWindow()
+    {
+        // Three connections per broker produce a cold-start wave of three single-connection
+        // quanta; the pre-ack window must carry the whole wave even though slow start now
+        // enters at two quanta of one connection.
+        var budget = new BrokerUnackedByteBudget(
+            targetSeconds: 0.010,
+            floorBytes: 1,
+            initialCapBytes: 10_000,
+            initialRequestBytes: 100,
+            coldStartBudgetBytes: 300);
+
+        await Assert.That(budget.BudgetBytes).IsEqualTo(300);
+        await Assert.That(budget.TryReserve(300, out _)).IsTrue();
+        await Assert.That(budget.TryReserve(1, out _)).IsFalse();
+        budget.Release(300);
     }
 
     [Test]
@@ -372,7 +538,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var now = T0;
         var admissionBlocks = 0L;
         var initialWindow = controller.WindowBytes;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         for (var i = 0; i < 100; i++)
         {
@@ -395,7 +561,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         for (var i = 0; i < 100 && controller.Phase == BrokerWindowPhase.Steady; i++)
         {
@@ -417,7 +583,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         for (var i = 0; i < 100 && controller.Phase == BrokerWindowPhase.Steady; i++)
         {
@@ -438,7 +604,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         for (var i = 0; i < 100 && controller.Phase == BrokerWindowPhase.Steady; i++)
         {
@@ -476,7 +642,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         ReachSteady(controller, ref now, ref admissionBlocks);
 
         var baselineWindow = controller.WindowBytes;
@@ -507,7 +673,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         var baselineWindow = controller.WindowBytes;
 
         StartNextProbe(
@@ -534,7 +700,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         var baselineWindow = controller.WindowBytes;
 
         StartNextProbe(
@@ -560,7 +726,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         var baselineWindow = controller.WindowBytes;
 
         StartNextProbe(
@@ -591,7 +757,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         ReachSteady(controller, ref now, ref admissionBlocks);
 
         FailNextDownProbe(controller, ref now, ref admissionBlocks);
@@ -623,7 +789,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         FailNextDownProbe(controller, ref now, ref admissionBlocks);
         var baselineWindow = controller.WindowBytes;
@@ -652,7 +818,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         FailNextDownProbe(controller, ref now, ref admissionBlocks);
         var baselineWindow = controller.WindowBytes;
@@ -680,7 +846,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
 
         FailNextDownProbe(controller, ref now, ref admissionBlocks);
         var baselineWindow = controller.WindowBytes;
@@ -712,7 +878,7 @@ public sealed class BrokerUnackedByteBudgetTests
         var controller = CreateController();
         var now = T0;
         var admissionBlocks = 0L;
-        _ = controller.CompleteInterval(admissionBlocks, 0, now);
+        _ = controller.CompleteInterval(admissionBlocks, 0, now, 0);
         _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks, rttSeconds: 0.001);
         for (var i = 0; i < 1_000; i++)
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks, rttSeconds: 0.050);
@@ -969,7 +1135,9 @@ public sealed class BrokerUnackedByteBudgetTests
         ref long now,
         ref long admissionBlocks)
     {
-        for (var i = 0; i < 100 && controller.Phase == BrokerWindowPhase.Steady; i++)
+        // Consecutive probe failures back the schedule off exponentially (up to 8x the
+        // 60-epoch interval), so allow the longest backed-off wait before giving up.
+        for (var i = 0; i < 600 && controller.Phase == BrokerWindowPhase.Steady; i++)
             _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
 
         if (controller.Phase != expectedPhase)
@@ -1009,6 +1177,21 @@ public sealed class BrokerUnackedByteBudgetTests
             throw new InvalidOperationException("Capacity probe did not complete.");
 
         return decision;
+    }
+
+    private static int CountEpochsUntilProbe(
+        BrokerWindowController controller,
+        ref long now,
+        ref long admissionBlocks)
+    {
+        for (var i = 1; i <= 1_000; i++)
+        {
+            _ = DriveControllerEpoch(controller, ref now, ref admissionBlocks);
+            if (controller.Phase != BrokerWindowPhase.Steady)
+                return i;
+        }
+
+        throw new InvalidOperationException("No probe started within 1,000 epochs.");
     }
 
     private static void FailNextDownProbe(
@@ -1055,6 +1238,7 @@ public sealed class BrokerUnackedByteBudgetTests
         return controller.CompleteInterval(
             admissionBlocks,
             observedOutstandingBytes ?? controller.WindowBytes,
-            now);
+            now,
+            admissionWaitPeakTicks: 0);
     }
 }

--- a/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
+++ b/tools/Dekaf.StressTests/Metrics/LatencyTracker.cs
@@ -73,11 +73,13 @@ internal sealed class LatencyTracker
     {
         lock (_outlierLock)
         {
-            var slot = _outlierCount++;
+            // Reservoir sampling (Algorithm R): every outlier over the whole run has an equal
+            // chance of being kept. First-N capture saturated within minute 0 of stress runs
+            // and left the remaining tail invisible (run 29541359283).
+            var seen = _outlierCount++;
+            var slot = seen < MaxOutlierSamples ? seen : Random.Shared.NextInt64(seen + 1);
             if ((ulong)slot >= MaxOutlierSamples)
-            {
                 return;
-            }
 
             var completedAt = DateTimeOffset.UtcNow;
             var latency = Stopwatch.GetElapsedTime(0, ticks);
@@ -187,6 +189,9 @@ internal sealed class LatencyTracker
 
             droppedOutlierSamples = Math.Max(0, _outlierCount - MaxOutlierSamples);
         }
+
+        // The reservoir keeps samples in replacement order; report them chronologically.
+        outlierSamples.Sort(static (a, b) => a.StartedAtUtc.CompareTo(b.StartedAtUtc));
 
         return new LatencySnapshot
         {


### PR DESCRIPTION
## Problem

Weekly full run [29541359283](https://github.com/thomhurst/Dekaf/actions/runs/29541359283) failed every 3-broker latency gate while all 1-broker lanes passed:

| Lane | p95/target (≤3.00) | p50/Confluent (≤2.00) | p99/Confluent (≤2.00) |
|---|---|---|---|
| producer acks-all 3b | **3.83** | **2.12** | 1.33 |
| producer idempotent 3b | **3.23** | **2.24** | **2.30** |
| producer 3conn 3b | **6.55** | – | – |
| producer idempotent 3conn 3b | **11.63** (p95 116ms, max 792ms) | – | – |

Diagnostics + code map traced all four breaches to the window governor's **inputs**, not its control law:

1. **The governed delay excluded admission-block wait and fill stalls.** 120k–711k blocked appends per broker (typ. 1–4ms, up to 65ms) were invisible to descent; `DelayOverTarget` read on-target while callers queued outside the window, so deep descent below the 8-quantum legacy floor never unlocked (its precondition is baseline delay over target). Result: 17–25ms standing queue against a 10ms target at 3-broker per-broker drain rates.
2. **Every window level scaled with `ConnectionsPerBroker`** (quantum = BatchSize×conns). 3conn tripled the floors, the optimistic slow-start target (48MB), and the cap (96MB) — the deep-descent floor itself (6MB ≈ 13ms of drain) sat **above the target**, making the gate mathematically unreachable.
3. **Slow start doubled to the optimistic window unconditionally** — observed 403ms delay EWMA at t≈1s on 3conn; every captured latency outlier (100–792ms) sat in minute 0.
4. **Capacity probes consumed 32–42% of broker time** (15s B-A-B every ~45s) with ~50% failure; each failed experiment charged 15s of extra standing queue to live traffic.

## Changes

- **Admission-wait signal (cause 1):** drained slow-path appends feed the wait they actually paid into their broker budget (CAS-max per-epoch peak via a new `InterlockedHelper.RatchetUp(ref long, long)`); the controller folds it into a governed-delay EWMA used by `DelayOverTarget`, probe evaluation, and the published `DeliveryLatencyEwmaMicros`. A descent that merely converts in-window queueing into blocked callers now shows no delay gain and reverts; one that removes standing queue passes.
- **Seal-origin clamp (cause 1):** per-batch governed origin = `min(seal, created + linger)`, fixed at seal time on `ReadyBatch.GovernedOriginTicks`. Opted-in linger never reads as queueing; a seal stalled past its linger deadline does.
- **Connection-invariant quantum (cause 2):** controller quantum is one batch regardless of connection count; only the cap and the pre-ack cold-start wave span routing width (ctor + `SetCap` share `ArmColdStartWave`). 3conn floors drop 6MB→2MB, optimistic 48MB→16MB, descent granularity 3MB→1MB.
- **Slow-start delay exit (cause 3):** doubling stops when the governed delay is over target **and** grew ≥1.5× since the previous doubling. Ambient window-independent delay (slow broker, long link) keeps doubling — no self-strangulation, per the #2109 lesson.
- **Probe hygiene (cause 4):** consecutive failures back the probe interval off exponentially (60→120→240→480 epochs); an up-probe treatment aborts the moment its epoch delay can no longer pass the final delay veto.
- **Diagnostics:** stress `LatencyTracker` outlier capture is now reservoir sampling (Algorithm R) — run 29541359283's first-256 capture saturated in minute 0 and blinded the remaining 14 minutes.

Deliberately **not** done: no `budget = target × rate` formula ceiling (three documented failures); window movement stays exclusively inside goodput-guarded B-A-B experiments. #2118/#2148 wake and drain invariants untouched.

## Validation

- Unit suite: **5564/5564** (new coverage: slow-start delay exit + ambient-delay non-exit, admission-wait-driven deep descent, admission wait surfacing in the published EWMA, probe backoff spacing, up-probe early abort, cold-start wave vs single-connection quantum, seal-vs-linger-deadline origin).
- Producer integration (real broker, Testcontainers): **77/77**, twice (pre- and post-simplify).
- `/simplify` run: 4-angle review applied (shared `RatchetUp`, seal-time origin move, `ArmColdStartWave` extraction, required admission-wait parameter, reservoir flattening); efficiency review confirmed nothing new on per-message hot paths and no allocations.

## Stress acceptance (before merge)

Per CLAUDE.md rules 7/8: dispatch **one lane** — `producer-idempotent` 3-broker (worst breaches: 3.23/2.24/2.30) — cheap shape, 15 min, `baseline_sha` = current main head for the A-B-A Pareto gate. Protected metrics: throughput ratios and CPU/msg must hold; the win must show in p50/p95 vs target and vs Confluent same-run ratios. 1-broker lanes pass today and must not regress (expected inert there: signal additions only bias descent when delay is genuinely over target).