### PR TITLE
Stabilize contended integration tests

### DIFF
--- a/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace Dekaf.Tests.Integration.RealWorld;
 [Category("Backpressure")]
 public sealed class BackpressureIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
-    [Test]
+    [Test, NotInParallel]
     public async Task BufferFull_ProduceBlocks_UntilBatchSent()
     {
         // Arrange - very small buffer to trigger backpressure quickly
@@ -23,6 +23,7 @@ public sealed class BackpressureIntegrationTests(KafkaTestContainer kafka) : Kaf
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithClientId("test-producer-buffer-blocks")
             .WithBufferMemory(65536) // 64KB buffer
+            .WithMaxBlock(TimeSpan.FromMinutes(2))
             .WithLinger(TimeSpan.FromMilliseconds(5))
             .WithIdempotence(false)
             .WithAcks(Acks.Leader)

--- a/tests/Dekaf.Tests.Integration/RealWorld/BackpressureTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/BackpressureTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration.RealWorld;
 [Category("Backpressure")]
 public sealed class BackpressureTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
-    [Test]
+    [Test, NotInParallel]
     public async Task Producer_SmallBufferMemory_AllMessagesDelivered()
     {
         // Arrange - use small buffer memory (1MB) to force backpressure

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
@@ -44,7 +44,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             .BuildAsync();
 
         // Start consuming in background (default offset is Latest, so produce after consumer joins)
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         ConsumeResult<string, string>? received = null;
         var consumeTask = Task.Run(async () =>
         {
@@ -55,10 +55,12 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
             }
         });
 
-        // Wait for consumer to be assigned partitions before producing
+        // Assignment is published before the default Latest offsets are resolved. Wait for
+        // positions too, otherwise producing here can race offset initialization and be skipped.
         await WaitForConditionAsync(
-            () => consumer.Assignment.Count > 0,
-            TimeSpan.FromSeconds(20));
+            () => consumer.Assignment.Count > 0
+                  && consumer.Assignment.All(partition => consumer.GetPosition(partition) is not null),
+            TimeSpan.FromSeconds(30));
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)


### PR DESCRIPTION
## Summary

- isolate the two broker-saturating backpressure tests from other integration tests sharing the Kafka fixture
- give the 64 KB buffer test a two-minute `MaxBlock` budget so it tests eventual draining instead of the default timeout
- wait for default `Latest` consumer positions to initialize before producing, eliminating the assignment/offset-resolution race

## Root cause

Attempts 1 and 2 of run https://github.com/thomhurst/Dekaf/actions/runs/29558105204 retained their failed logs after the successful rerun. The failures were contention- and timing-dependent:

- `BufferFull_ProduceBlocks_UntilBatchSent` exhausted `MaxBlockMs` twice in NativeAOT while sharing the broker with other backpressure tests.
- `Producer_SmallBufferMemory_AllMessagesDelivered` hit the five-minute test timeout on net8.0 and net10.0 under the same shared-broker saturation.
- `ConsumerBuilder_SubscribeTo_ConsumesSuccessfully` produced after assignment was published but before the default `Latest` position had resolved, allowing the record to be skipped.

## Validation

- `dotnet format` on all three changed files
- Backpressure category: net8.0 / Kafka 4.0.2 — 9/9 passed
- Backpressure category: net10.0 / Kafka 4.1.2 — 9/9 passed
- Consumer category: net8.0 / Kafka 4.2.1 — 119/119 passed
- targeted consumer test: 5 consecutive passes on net8.0 / Kafka 4.2.1