### PR TITLE
feat(consumer)!: make consume-result Headers empty instead of null

### DIFF
--- a/docs/docs/consumer/basics.md
+++ b/docs/docs/consumer/basics.md
@@ -94,7 +94,7 @@ Each message gives you access to:
 | `Offset` | `long` | The offset within the partition |
 | `Timestamp` | `DateTimeOffset` | When the message was produced |
 | `TimestampType` | `TimestampType` | Whether timestamp is create time or log append time |
-| `Headers` | `IReadOnlyList<RecordHeader>?` | Optional message headers |
+| `Headers` | `IReadOnlyList<Header>` | Message headers (empty when the record has none; never null) |
 | `LeaderEpoch` | `int?` | The leader epoch (for exactly-once) |
 
 ## Consuming a Single Message

--- a/docs/docs/producer/headers.md
+++ b/docs/docs/producer/headers.md
@@ -102,17 +102,22 @@ When consuming messages, access headers from the `ConsumeResult`:
 ```csharp
 await foreach (var message in consumer.ConsumeAsync(ct))
 {
-    // Headers is IReadOnlyList<RecordHeader>
-    if (message.Headers != null)
+    // Headers is IReadOnlyList<Header> — empty (never null) when the record has no headers
+    foreach (var header in message.Headers)
     {
-        foreach (var header in message.Headers)
-        {
-            Console.WriteLine($"{header.Key}: {header.GetValueString()}");
-        }
+        Console.WriteLine($"{header.Key}: {header.GetValueAsString()}");
     }
 
-    // Or get a specific header
-    var traceId = message.Headers?.FirstOrDefault(h => h.Key == "trace-id")?.GetValueString();
+    // Or get a specific header (loop, not LINQ, to stay allocation-free)
+    string? traceId = null;
+    foreach (var header in message.Headers)
+    {
+        if (header.Key == "trace-id")
+        {
+            traceId = header.GetValueAsString();
+            break;
+        }
+    }
 }
 ```
 

--- a/src/Dekaf.Testing/InMemoryKafkaCluster.cs
+++ b/src/Dekaf.Testing/InMemoryKafkaCluster.cs
@@ -770,10 +770,10 @@ public sealed class InMemoryKafkaCluster
         return hash;
     }
 
-    private static IReadOnlyList<Header>? CopyHeaders(IReadOnlyList<Header>? headers)
+    private static IReadOnlyList<Header> CopyHeaders(IReadOnlyList<Header>? headers)
     {
         if (headers is null || headers.Count == 0)
-            return null;
+            return Array.Empty<Header>();
 
         var copy = new Header[headers.Count];
         for (var i = 0; i < headers.Count; i++)

--- a/src/Dekaf.Testing/InMemoryRecord.cs
+++ b/src/Dekaf.Testing/InMemoryRecord.cs
@@ -14,7 +14,7 @@ public sealed record InMemoryRecord
     public required bool IsKeyNull { get; init; }
     public required byte[] Value { get; init; }
     public required bool IsValueNull { get; init; }
-    public IReadOnlyList<Header>? Headers { get; init; }
+    public IReadOnlyList<Header> Headers { get; init; } = Array.Empty<Header>();
     public required long TimestampMs { get; init; }
     public DateTimeOffset Timestamp => DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs);
 }

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
@@ -38,23 +38,21 @@ public static class DeadLetterHeaders
         int failureCount,
         bool includeException)
     {
-        var originalCount = result.Headers?.Count ?? 0;
+        // Hoisted: each Headers access on the readonly struct constructs a new lazy wrapper.
+        var originalHeaders = result.Headers;
         var dlqHeaderCount = includeException ? 7 : 5;
-        var headers = new Headers(originalCount + dlqHeaderCount);
+        var headers = new Headers(originalHeaders.Count + dlqHeaderCount);
 
         // Preserve original headers first
-        if (result.Headers is not null)
+        foreach (var header in originalHeaders)
         {
-            foreach (var header in result.Headers)
-            {
-                headers.Add(header);
-            }
+            headers.Add(header);
         }
 
         // Source metadata
-        var sourceTopic = RetryTopicHeaders.GetSourceTopic(result.Headers) ?? result.Topic;
-        var sourcePartition = RetryTopicHeaders.GetSourcePartition(result.Headers) ?? result.Partition;
-        var sourceOffset = RetryTopicHeaders.GetSourceOffset(result.Headers) ?? result.Offset;
+        var sourceTopic = RetryTopicHeaders.GetSourceTopic(originalHeaders) ?? result.Topic;
+        var sourcePartition = RetryTopicHeaders.GetSourcePartition(originalHeaders) ?? result.Partition;
+        var sourceOffset = RetryTopicHeaders.GetSourceOffset(originalHeaders) ?? result.Offset;
         headers.Add(SourceTopicKey, sourceTopic);
         headers.Add(SourcePartitionKey, DeadLetterHeaderFormatting.FormatInt(sourcePartition));
         headers.Add(SourceOffsetKey, DeadLetterHeaderFormatting.FormatLong(sourceOffset));

--- a/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/RetryTopicHeaders.cs
@@ -33,19 +33,17 @@ public static class RetryTopicHeaders
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(failureCount);
         RetryTopicOptions.ValidateDelay(delay);
 
-        var sourceTopic = GetSourceTopic(result.Headers) ?? result.Topic;
-        var sourcePartition = GetSourcePartition(result.Headers) ?? result.Partition;
-        var sourceOffset = GetSourceOffset(result.Headers) ?? result.Offset;
-        var originalCount = result.Headers?.Count ?? 0;
-        var headers = new Headers(originalCount + 6);
+        // Hoisted: each Headers access on the readonly struct constructs a new lazy wrapper.
+        var originalHeaders = result.Headers;
+        var sourceTopic = GetSourceTopic(originalHeaders) ?? result.Topic;
+        var sourcePartition = GetSourcePartition(originalHeaders) ?? result.Partition;
+        var sourceOffset = GetSourceOffset(originalHeaders) ?? result.Offset;
+        var headers = new Headers(originalHeaders.Count + 6);
 
-        if (result.Headers is not null)
+        foreach (var header in originalHeaders)
         {
-            foreach (var header in result.Headers)
-            {
-                if (!IsRetryHeader(header.Key))
-                    headers.Add(header);
-            }
+            if (!IsRetryHeader(header.Key))
+                headers.Add(header);
         }
 
         headers.Add(SourceTopicKey, sourceTopic);

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -564,12 +564,12 @@ public readonly struct ConsumeResult<TKey, TValue>
     public TValue Value { get; }
 
     /// <summary>
-    /// The message headers. Returns null if no headers.
+    /// The message headers. Empty if the record has no headers; never null.
     /// Header arrays from consumed record batches are copied lazily on first access; if a
     /// result is retained beyond the consume loop, access this property before the owning
     /// fetch batch is disposed to keep a safe snapshot.
     /// </summary>
-    public IReadOnlyList<Header>? Headers => _headers ?? LazyConsumeHeaders.Create(
+    public IReadOnlyList<Header> Headers => _headers ?? LazyConsumeHeaders.Create(
         _pooledHeaders,
         _pooledHeaderCount,
         _headerOwner,

--- a/src/Dekaf/Consumer/LazyConsumeHeaders.cs
+++ b/src/Dekaf/Consumer/LazyConsumeHeaders.cs
@@ -23,14 +23,14 @@ internal sealed class LazyConsumeHeaders : IReadOnlyList<Header>
         _generation = generation;
     }
 
-    internal static IReadOnlyList<Header>? Create(
+    internal static IReadOnlyList<Header> Create(
         Header[]? pooledHeaders,
         int count,
         PendingFetchData? owner,
         int generation)
     {
         if (pooledHeaders is null || count == 0)
-            return null;
+            return Array.Empty<Header>();
 
         if (owner is null)
             throw new ObjectDisposedException(nameof(Headers), StaleHeadersMessage);

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -765,7 +765,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         ? default!
                         : _valueDeserializer.Deserialize(record.Value, t_serializationContext);
 
-                    Header[]? headers = null;
+                    var headers = Array.Empty<Header>();
                     if (record.Headers is not null && record.HeaderCount > 0)
                     {
                         headers = new Header[record.HeaderCount];

--- a/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumeResult.cs
@@ -35,9 +35,9 @@ public sealed class ShareConsumeResult<TKey, TValue>
     public required TValue Value { get; init; }
 
     /// <summary>
-    /// The message headers, or null if no headers.
+    /// The message headers. Empty if the record has no headers; never null.
     /// </summary>
-    public IReadOnlyList<Header>? Headers { get; init; }
+    public IReadOnlyList<Header> Headers { get; init; } = Array.Empty<Header>();
 
     /// <summary>
     /// The message timestamp as raw Unix milliseconds since epoch.

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -397,9 +397,8 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         // Assert
         await Assert.That(result).IsNotNull();
         var r = result!.Value;
-        await Assert.That(r.Headers).IsNotNull();
         // >= 2 because TUnit's ActivityListener may inject a traceparent header
-        await Assert.That(r.Headers!.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(r.Headers.Count).IsGreaterThanOrEqualTo(2);
 
         var header1 = r.Headers.FirstOrDefault(h => h.Key == "header1");
         await Assert.That(header1.Key).IsNotNull();

--- a/tests/Dekaf.Tests.Integration/HeaderRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/HeaderRoundTripTests.cs
@@ -43,9 +43,8 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
         // >= 2 because TUnit's ActivityListener may inject a traceparent header
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(2);
 
         var contentType = result.Value.Headers.First(h => h.Key == "content-type");
         await Assert.That(Encoding.UTF8.GetString(contentType.Value.Span)).IsEqualTo("application/json");
@@ -90,7 +89,7 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        var allTags = result!.Value.Headers!.Where(h => h.Key == "tag").ToList();
+        var allTags = result!.Value.Headers.Where(h => h.Key == "tag").ToList();
         await Assert.That(allTags.Count).IsEqualTo(3);
         await Assert.That(Encoding.UTF8.GetString(allTags[0].Value.Span)).IsEqualTo("value1");
         await Assert.That(Encoding.UTF8.GetString(allTags[1].Value.Span)).IsEqualTo("value2");
@@ -132,10 +131,10 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        var nullHeader = result!.Value.Headers!.First(h => h.Key == "null-header");
+        var nullHeader = result!.Value.Headers.First(h => h.Key == "null-header");
         await Assert.That(nullHeader.IsValueNull).IsTrue();
 
-        var normalHeader = result.Value.Headers!.First(h => h.Key == "normal-header");
+        var normalHeader = result.Value.Headers.First(h => h.Key == "normal-header");
         await Assert.That(Encoding.UTF8.GetString(normalHeader.Value.Span)).IsEqualTo("has-value");
     }
 
@@ -173,7 +172,7 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        var emptyHeader = result!.Value.Headers!.First(h => h.Key == "empty-header");
+        var emptyHeader = result!.Value.Headers.First(h => h.Key == "empty-header");
         await Assert.That(emptyHeader.IsValueNull).IsFalse();
         await Assert.That(emptyHeader.Value.Length).IsEqualTo(0);
     }
@@ -212,7 +211,7 @@ public class HeaderRoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        var unicodeHeader = result!.Value.Headers!.First(h => h.Key == "unicode");
+        var unicodeHeader = result!.Value.Headers.First(h => h.Key == "unicode");
         await Assert.That(Encoding.UTF8.GetString(unicodeHeader.Value.Span)).IsEqualTo("日本語テスト");
     }
 }

--- a/tests/Dekaf.Tests.Integration/LargeMessageTests.cs
+++ b/tests/Dekaf.Tests.Integration/LargeMessageTests.cs
@@ -169,8 +169,7 @@ public class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrationTest(
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         // Verify the 64KB header
         var largeHeader = result.Value.Headers.First(h => h.Key == "large-header");
@@ -233,8 +232,7 @@ public class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrationTest(
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(headerCount);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(headerCount);
         await Assert.That(result.Value.Value).IsEqualTo("value-with-many-headers");
 
         // Verify each header value matches (look up by key to tolerate injected tracing headers)
@@ -443,8 +441,7 @@ public class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrationTest(
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Value.Value).IsEqualTo(largeValue);
-        await Assert.That(result.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(4);
+        await Assert.That(result.Value.Headers.Count).IsGreaterThanOrEqualTo(4);
 
         for (var i = 0; i < 4; i++)
         {

--- a/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
+++ b/tests/Dekaf.Tests.Integration/NewConsumerProtocolTests.cs
@@ -677,8 +677,7 @@ public class NewConsumerProtocolTests(KafkaTestContainer kafka) : KafkaIntegrati
 
         await Assert.That(result).IsNotNull();
         var r = result!.Value;
-        await Assert.That(r.Headers).IsNotNull();
         // >= 2 because TUnit's ActivityListener may inject a traceparent header
-        await Assert.That(r.Headers!.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(r.Headers.Count).IsGreaterThanOrEqualTo(2);
     }
 }

--- a/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
@@ -291,8 +291,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         // Assert
         await Assert.That(result).IsNotNull();
         var r = result!.Value;
-        await Assert.That(r.Headers).IsNotNull();
-        await Assert.That(r.Headers!.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(r.Headers.Count).IsGreaterThanOrEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/RealWorld/CompressionRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/CompressionRoundTripTests.cs
@@ -174,8 +174,7 @@ public sealed class CompressionRoundTripTests(KafkaTestContainer kafka) : KafkaI
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         var contentType = result.Value.Headers.First(h => h.Key == "content-type");
         await Assert.That(contentType.GetValueAsString()).IsEqualTo("application/json");

--- a/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ConvenienceApiTests.cs
@@ -268,8 +268,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(1);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(1);
     }
 
     [Test]
@@ -499,7 +498,7 @@ public sealed class ConvenienceApiTests(KafkaTestContainer kafka) : KafkaIntegra
 
         await Assert.That(result).IsNotNull();
 
-        var consumedHeaders = result!.Value.Headers!;
+        var consumedHeaders = result!.Value.Headers;
         // content-type, version, optional, notempty = 4 headers (absent and empty should be filtered)
         // Count may be higher due to injected tracing headers (e.g. traceparent)
         await Assert.That(consumedHeaders.Count).IsGreaterThanOrEqualTo(4);

--- a/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
@@ -479,10 +479,10 @@ public sealed class CrossClientInteropTests(KafkaTestContainer kafka) : KafkaInt
         await AssertBytesAsync(actual.Value, expected.Value);
 
         var actualHeaders = actual.Headers;
-        await Assert.That(actualHeaders?.Count ?? 0).IsEqualTo(expected.Headers.Count);
+        await Assert.That(actualHeaders.Count).IsEqualTo(expected.Headers.Count);
         for (var i = 0; i < expected.Headers.Count; i++)
         {
-            await Assert.That(actualHeaders![i].Key).IsEqualTo(expected.Headers[i].Key);
+            await Assert.That(actualHeaders[i].Key).IsEqualTo(expected.Headers[i].Key);
             await AssertBytesAsync(actualHeaders[i].GetValueAsArray(), expected.Headers[i].Value);
         }
     }

--- a/tests/Dekaf.Tests.Integration/RealWorld/EventPipelineTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/EventPipelineTests.cs
@@ -101,9 +101,8 @@ public sealed class EventPipelineTests(KafkaTestContainer kafka) : KafkaIntegrat
         {
             await Assert.That(msg.Value).Contains("processedAt");
             await Assert.That(msg.Value).Contains("original");
-            await Assert.That(msg.Headers).IsNotNull();
 
-            var sourceHeader = msg.Headers!.First(h => h.Key == "source-topic");
+            var sourceHeader = msg.Headers.First(h => h.Key == "source-topic");
             await Assert.That(sourceHeader.GetValueAsString()).IsEqualTo(inputTopic);
         }
     }
@@ -209,9 +208,8 @@ public sealed class EventPipelineTests(KafkaTestContainer kafka) : KafkaIntegrat
         foreach (var msg in dlqMessages)
         {
             await Assert.That(msg.Value).StartsWith("INVALID");
-            await Assert.That(msg.Headers).IsNotNull();
 
-            var errorReason = msg.Headers!.First(h => h.Key == "error-reason");
+            var errorReason = msg.Headers.First(h => h.Key == "error-reason");
             await Assert.That(errorReason.GetValueAsString()).IsEqualTo("Message failed validation");
         }
     }
@@ -256,7 +254,7 @@ public sealed class EventPipelineTests(KafkaTestContainer kafka) : KafkaIntegrat
         await Assert.That(stage1Msg).IsNotNull();
 
         // Forward with additional headers
-        var enrichedHeaders = new Headers(stage1Msg!.Value.Headers!);
+        var enrichedHeaders = new Headers(stage1Msg!.Value.Headers);
         enrichedHeaders.Add("processed-by", "stage-2-enrichment");
         enrichedHeaders.Add("stage", "enrichment");
 
@@ -281,7 +279,7 @@ public sealed class EventPipelineTests(KafkaTestContainer kafka) : KafkaIntegrat
         var stage2Msg = await stage2Consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cts2.Token);
         await Assert.That(stage2Msg).IsNotNull();
 
-        var finalHeaders = new Headers(stage2Msg!.Value.Headers!);
+        var finalHeaders = new Headers(stage2Msg!.Value.Headers);
         finalHeaders.Add("processed-by", "stage-3-output");
         finalHeaders.Add("stage", "output");
 
@@ -306,7 +304,7 @@ public sealed class EventPipelineTests(KafkaTestContainer kafka) : KafkaIntegrat
         var finalMsg = await finalConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cts3.Token);
         await Assert.That(finalMsg).IsNotNull();
 
-        var headers = finalMsg!.Value.Headers!;
+        var headers = finalMsg!.Value.Headers;
         await Assert.That(headers.Where(h => h.Key == "stage").Count()).IsEqualTo(3);
         await Assert.That(headers.Where(h => h.Key == "processed-by").Count()).IsEqualTo(2);
         await Assert.That(headers.FirstOrDefault(h => h.Key == "correlation-id").Key).IsNotNull();

--- a/tests/Dekaf.Tests.Integration/RealWorld/InterceptorTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/InterceptorTests.cs
@@ -47,9 +47,7 @@ public sealed class InterceptorTests(KafkaTestContainer kafka) : KafkaIntegratio
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-
-        var traceHeader = result.Value.Headers!.First(h => h.Key == "trace-id");
+        var traceHeader = result!.Value.Headers.First(h => h.Key == "trace-id");
         await Assert.That(traceHeader.GetValueAsString()).IsNotNull();
     }
 
@@ -117,7 +115,7 @@ public sealed class InterceptorTests(KafkaTestContainer kafka) : KafkaIntegratio
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        var headers = result!.Value.Headers!.Where(h => h.Key == "interceptor-order").ToList();
+        var headers = result!.Value.Headers.Where(h => h.Key == "interceptor-order").ToList();
         await Assert.That(headers).Count().IsEqualTo(2);
     }
 
@@ -362,8 +360,8 @@ public sealed class InterceptorTests(KafkaTestContainer kafka) : KafkaIntegratio
 
         public ConsumeResult<string, string> OnConsume(ConsumeResult<string, string> result)
         {
-            var traceHeader = result.Headers?.FirstOrDefault(h => h.Key == "trace-id");
-            if (traceHeader is { } header && !header.IsValueNull)
+            var header = result.Headers.FirstOrDefault(h => h.Key == "trace-id");
+            if (header.Key is not null && !header.IsValueNull)
             {
                 _seenTraceIds.Add(header.GetValueAsString()!);
             }

--- a/tests/Dekaf.Tests.Integration/RealWorld/LargeMessageTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/LargeMessageTests.cs
@@ -56,8 +56,7 @@ public sealed class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrati
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(50);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(50);
 
         // Verify each header
         for (var i = 0; i < 50; i++)
@@ -111,8 +110,7 @@ public sealed class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrati
 
         // Assert
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        var header = result.Value.Headers!.First(h => h.Key == "large-header");
+        var header = result!.Value.Headers.First(h => h.Key == "large-header");
         await Assert.That(Encoding.UTF8.GetString(header.Value.Span)).IsEqualTo(largeHeaderValue);
     }
 
@@ -263,9 +261,8 @@ public sealed class LargeMessageTests(KafkaTestContainer kafka) : KafkaIntegrati
         var r = result!.Value;
         await Assert.That(r.Key).IsEqualTo(unicodeKey);
         await Assert.That(r.Value).IsEqualTo(unicodeValue);
-        await Assert.That(r.Headers).IsNotNull();
 
-        var header = r.Headers!.First(h => h.Key == "unicode-header");
+        var header = r.Headers.First(h => h.Key == "unicode-header");
         await Assert.That(Encoding.UTF8.GetString(header.Value.Span)).IsEqualTo(unicodeHeaderValue);
     }
 }

--- a/tests/Dekaf.Tests.Integration/RealWorld/Lz4CompressionRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/Lz4CompressionRoundTripTests.cs
@@ -273,8 +273,7 @@ public sealed class Lz4CompressionRoundTripTests(KafkaTestContainer kafka) : Kaf
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         var contentType = result.Value.Headers.First(h => h.Key == "content-type");
         await Assert.That(contentType.GetValueAsString()).IsEqualTo("application/json");

--- a/tests/Dekaf.Tests.Integration/RealWorld/SnappyCompressionRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/SnappyCompressionRoundTripTests.cs
@@ -273,8 +273,7 @@ public sealed class SnappyCompressionRoundTripTests(KafkaTestContainer kafka) : 
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         var contentType = result.Value.Headers.First(h => h.Key == "content-type");
         await Assert.That(contentType.GetValueAsString()).IsEqualTo("application/json");

--- a/tests/Dekaf.Tests.Integration/RealWorld/TombstoneAndNullValueTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/TombstoneAndNullValueTests.cs
@@ -191,9 +191,8 @@ public sealed class TombstoneAndNullValueTests(KafkaTestContainer kafka) : Kafka
 
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Value.Value).IsNull();
-        await Assert.That(result.Value.Headers).IsNotNull();
         // >= 2 because TUnit's ActivityListener may inject a traceparent header
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(result.Value.Headers.Count).IsGreaterThanOrEqualTo(2);
 
         var reason = result.Value.Headers.First(h => h.Key == "reason");
         await Assert.That(reason.GetValueAsString()).IsEqualTo("deleted");

--- a/tests/Dekaf.Tests.Integration/RealWorld/ZstdCompressionRoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/ZstdCompressionRoundTripTests.cs
@@ -176,8 +176,7 @@ public sealed class ZstdCompressionRoundTripTests(KafkaTestContainer kafka) : Ka
         var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Value.Headers).IsNotNull();
-        await Assert.That(result.Value.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(result!.Value.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         var contentType = result.Value.Headers.First(h => h.Key == "content-type");
         await Assert.That(contentType.GetValueAsString()).IsEqualTo("application/json");

--- a/tests/Dekaf.Tests.Integration/RoundTripTests.cs
+++ b/tests/Dekaf.Tests.Integration/RoundTripTests.cs
@@ -99,8 +99,7 @@ public class RoundTripTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kaf
         // Assert
         await Assert.That(consumed).IsNotNull();
         var c = consumed!.Value;
-        await Assert.That(c.Headers).IsNotNull();
-        await Assert.That(c.Headers!.Count).IsGreaterThanOrEqualTo(3);
+        await Assert.That(c.Headers.Count).IsGreaterThanOrEqualTo(3);
 
         var correlationId = c.Headers.FirstOrDefault(h => h.Key == "correlationId");
         await Assert.That(correlationId.Key).IsNotNull();

--- a/tests/Dekaf.Tests.Integration/TopicProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/TopicProducerTests.cs
@@ -152,7 +152,6 @@ public class TopicProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         {
             await Assert.That(msg.Key).IsEqualTo("key1");
             await Assert.That(msg.Value).IsEqualTo("value1");
-            await Assert.That(msg.Headers).IsNotNull();
             break;
         }
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeResultTests.cs
@@ -59,7 +59,9 @@ public class ConsumeResultTests
         await Assert.That(result.Partition).IsEqualTo(2);
         await Assert.That(result.Offset).IsEqualTo(500);
         await Assert.That(result.TimestampType).IsEqualTo(TimestampType.NotAvailable);
-        await Assert.That(result.Headers).IsNull();
+        await Assert.That(result.Headers).IsEmpty();
+        // Zero-header results must not allocate: the getter returns the Array.Empty singleton.
+        await Assert.That(ReferenceEquals(result.Headers, Array.Empty<Header>())).IsTrue();
         await Assert.That(result.LeaderEpoch).IsNull();
     }
 
@@ -184,7 +186,7 @@ public class ConsumeResultTests
         pending.EagerParseAll();
         pending.MoveNext();
 
-        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration)!;
+        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration);
         var header = headers[0];
 
         pooledHeaders[0] = new Header("changed", "def"u8.ToArray());
@@ -206,7 +208,7 @@ public class ConsumeResultTests
         pending.EagerParseAll();
         pending.MoveNext();
 
-        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration)!;
+        var headers = LazyConsumeHeaders.Create(pooledHeaders, 1, pending, pending.HeaderGeneration);
         pending.Dispose();
 
         _ = headers.Count;
@@ -241,7 +243,7 @@ public class ConsumeResultTests
             keyDeserializer: null,
             valueDeserializer: null);
 
-        var headers = result.Headers!;
+        var headers = result.Headers;
         var first = headers[0];
         pooledHeaders[0] = new Header("changed", "def"u8.ToArray());
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -50,7 +50,7 @@ public sealed class InMemoryKafkaClusterTests
         await Assert.That(result.Value.Offset).IsEqualTo(0);
         await Assert.That(result.Value.Key).IsEqualTo("order-1");
         await Assert.That(result.Value.Value).IsEqualTo("created");
-        await Assert.That(result.Value.Headers!.Single().GetValueAsString()).IsEqualTo("abc");
+        await Assert.That(result.Value.Headers.Single().GetValueAsString()).IsEqualTo("abc");
         await Assert.That(result.Value.TimestampMs).IsEqualTo(1234);
     }
 


### PR DESCRIPTION
## Summary
- `ConsumeResult<TKey,TValue>.Headers`, `ShareConsumeResult.Headers`, and `Dekaf.Testing`''s `InMemoryRecord.Headers` are now non-nullable `IReadOnlyList<Header>` — empty (the cached `Array.Empty<Header>()` singleton) when a record has no headers, never null.
- Kafka semantics: the per-record header count on the wire is a plain varint >= 0 — there is no null/empty distinction for the header *collection* (only key/value and individual header *values* have a -1 sentinel). Null vs empty was purely an implementation artifact.
- Alloc-free: the zero-header getter path returns a static singleton (a field load, same cost as returning null). A new unit-test assertion checks reference-equality with `Array.Empty<Header>()`.
- Producer-side inputs (`ProducerMessage.Headers` etc.) deliberately stay nullable — null-as-input is a convenience and the produce path already treats null and empty identically. Protocol `Record.Headers` stays a nullable pooled array internally.
- DLQ/retry `Build` methods hoist `result.Headers` into a local: each access on the readonly struct constructed a new `LazyConsumeHeaders` wrapper.
- Tests: removed now-dead `!` suppressions, vacuous `IsNotNull` assertions, and `?.` null-shaping on consumer-result headers (producer/protocol-side nullable sites left untouched).
- Docs: consumer-side snippet in `producer/headers.md` dropped its null check and now compiles against the real API (`Header`/`GetValueAsString` — the old snippet used nonexistent `RecordHeader`/`GetValueString` and an invalid `?.` on the struct); `consumer/basics.md` property table updated.

Not binary-breaking; user code doing `!= null` still compiles (the check just becomes always-true).

## Test plan
- [x] Full unit suite: 5565/5565 pass
- [x] Integration (local Docker broker): HeaderRoundTripTests, ConvenienceApiTests, EventPipelineTests, InterceptorTests, CrossClientInteropTests — 38/38 pass
- [x] Solution builds with 0 warnings