### PR TITLE
fix(tests): root-cause and fix BrokerSenderMuteOrderingTests 30s hangs (ArrayPool double-return poisoning)

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4851,6 +4851,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             LogBatchCleanupStepFailed(ex, _brokerId);
         }
 
+        // True when the loop finished (normally or faulted — its exit cleanup ran either way);
+        // false when the WaitAsync above timed out and the loop is still running.
+        var sendLoopExited = _sendLoopTask.IsCompleted;
+
         // A final send-loop iteration may have already detached a retirement drain after
         // clearing the raw connection fields. Wait for every such drain before inspecting
         // the remaining scale-down state.
@@ -4900,7 +4904,16 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         ClearMigratingPartitions();
 
         var totalPending = _totalPendingResponseCount;
-        if (totalPending > 0)
+        if (totalPending > 0 && !sendLoopExited)
+        {
+            // The send loop is still running and owns _pendingResponsesByConnection. Touching
+            // the lists here would race the loop's own exit cleanup and return the same rented
+            // arrays to ArrayPool.Shared twice — duplicate pool entries later hand one array to
+            // two concurrent requests, pairing responses with the wrong batches (#2187). The
+            // loop's exit path fails these batches and returns the arrays when it completes.
+            LogSkippingPendingResponseCleanup(_brokerId, totalPending);
+        }
+        else if (totalPending > 0)
         {
             LogFailingPendingResponses(_brokerId, totalPending);
 
@@ -5645,6 +5658,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] failing {RemainingCount} pending responses during disposal")]
     private partial void LogFailingPendingResponses(int brokerId, int remainingCount);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] send loop still running after disposal wait; leaving {RemainingCount} pending responses to its exit cleanup")]
+    private partial void LogSkippingPendingResponseCleanup(int brokerId, int remainingCount);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] non-fatal exception during batch cleanup step (suppressed)")]
     private partial void LogBatchCleanupStepFailed(Exception exception, int brokerId);

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -89,6 +89,17 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
         return true;
     }
 
+    /// <summary>
+    /// Number of topic entries regardless of whether the request was populated through
+    /// <see cref="TopicData"/> or the internal scratch arrays. Pairs with
+    /// <see cref="GetTopicEntry"/>; exists so tests can observe scratch-built requests
+    /// without reflecting into private fields.
+    /// </summary>
+    internal int TopicEntryCount => _topicDataScratch is not null ? _topicDataScratchCount : TopicData.Count;
+
+    internal ProduceRequestTopicData GetTopicEntry(int index) =>
+        _topicDataScratch is { } topicDataScratch ? topicDataScratch[index] : TopicData[index];
+
     public void Write(ref KafkaProtocolWriter writer, short version)
     {
         writer.WriteCompactNullableString(TransactionalId);
@@ -146,6 +157,19 @@ public sealed class ProduceRequestTopicData
         _partitionDataScratchStart = 0;
         _partitionDataScratchCount = 0;
     }
+
+    /// <summary>
+    /// Number of partition entries regardless of whether the topic was populated through
+    /// <see cref="PartitionData"/> or the internal scratch arrays. Pairs with
+    /// <see cref="GetPartitionEntry"/>; exists so tests can observe scratch-built requests
+    /// without reflecting into private fields.
+    /// </summary>
+    internal int PartitionEntryCount => _partitionDataScratch is not null ? _partitionDataScratchCount : PartitionData.Count;
+
+    internal ProduceRequestPartitionData GetPartitionEntry(int index) =>
+        _partitionDataScratch is { } partitionDataScratch
+            ? partitionDataScratch[_partitionDataScratchStart + index]
+            : PartitionData[index];
 
     internal bool TryGetSinglePartition(out ProduceRequestPartitionData partition)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -24,6 +24,10 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class BrokerSenderMuteOrderingTests
 {
+    // Well below the 30s TUnit timeout so a stalled wait fails with a state dump instead of
+    // an opaque test-level timeout, while still generous for loaded CI runners.
+    private static readonly TimeSpan DiagnosticWaitTimeout = TimeSpan.FromSeconds(15);
+
     private static readonly MethodInfo CoalesceBatchMethod = typeof(BrokerSender).GetMethod(
         "CoalesceBatch",
         BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -55,26 +59,44 @@ public sealed class BrokerSenderMuteOrderingTests
             LingerMs = 0
         };
 
-    private static (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
+    private ScriptedProduceResponses? _scriptedResponses;
+
+    private (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
         Action? onSend = null)
     {
-        var connection = new TestKafkaConnection();
+        var connection = new TestKafkaConnection { CaptureProduceRequests = true };
+        var scripted = new ScriptedProduceResponses(responseQueue, onSend);
+        _scriptedResponses = scripted;
 
-        Task<ProduceResponse> DequeueResponse()
-        {
-            var task = responseQueue.Dequeue().Task;
-            onSend?.Invoke();
-            return task;
-        }
-
-        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(DequeueResponse());
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(connection);
 
         return (pool, connection);
+    }
+
+    /// <summary>
+    /// Links the test's cancellation token to the mock connection script so an unscripted
+    /// (extra) send aborts every in-test wait immediately instead of hanging until the
+    /// 30s test timeout with no diagnosis (#2187).
+    /// </summary>
+    private CancellationToken GuardUnscriptedSends(CancellationToken testToken) =>
+        _scriptedResponses!.Guard(testToken);
+
+    [After(Test)]
+    public void FailTestOnUnscriptedSend()
+    {
+        var scripted = _scriptedResponses;
+        _scriptedResponses = null;
+        if (scripted is null)
+            return;
+
+        scripted.Dispose();
+        if (scripted.UnscriptedSendFailure is { } failure)
+            throw failure;
     }
 
     private static ReadyBatch CreateTestBatch(
@@ -97,21 +119,32 @@ public sealed class BrokerSenderMuteOrderingTests
         return batch;
     }
 
-    private static async Task WaitForDiagAsync(
-        ReadyBatch batch,
-        char marker,
+    private static async Task WaitUntilAsync(
+        Func<bool> condition,
         TimeSpan timeout,
+        Func<string> timeoutMessage,
         CancellationToken cancellationToken)
     {
         var deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
-        while (!batch.DiagTrace.Contains(marker))
+        while (!condition())
         {
             if (Stopwatch.GetTimestamp() >= deadline)
-                throw new TimeoutException($"Batch did not reach '{marker}': {batch.DiagTrace}");
+                throw new TimeoutException(timeoutMessage());
 
             await Task.Delay(1, cancellationToken);
         }
     }
+
+    private static Task WaitForDiagAsync(
+        ReadyBatch batch,
+        char marker,
+        TimeSpan timeout,
+        CancellationToken cancellationToken) =>
+        WaitUntilAsync(
+            () => batch.DiagTrace.Contains(marker),
+            timeout,
+            () => $"Batch did not reach '{marker}': {batch.DiagTrace}",
+            cancellationToken);
 
     private static ProduceResponse CreateSuccessResponse(string topic, int partition, long baseOffset) =>
         new()
@@ -377,6 +410,7 @@ public sealed class BrokerSenderMuteOrderingTests
         var (pool, connection) = CreateMockConnection(responseQueue);
         pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(connection);
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(
             maxInFlight: 2,
             enableIdempotence: false,
@@ -449,6 +483,7 @@ public sealed class BrokerSenderMuteOrderingTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var (pool, connection) = CreateMockConnection(new Queue<TaskCompletionSource<ProduceResponse>>([response]));
         pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(connection);
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: false, connectionsPerBroker: 2);
         var accumulator = new RecordAccumulator(options);
         await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
@@ -492,9 +527,14 @@ public sealed class BrokerSenderMuteOrderingTests
     {
         var timedOutResponse = new TaskCompletionSource<ProduceResponse>(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([timedOutResponse]);
+        // Second scripted response: the wake batch enqueued below may dispatch a send after
+        // the timeout sweep; script its response so the send is not an unscripted extra.
+        var wakeResponse = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([timedOutResponse, wakeResponse]);
         var (pool, connection) = CreateMockConnection(responseQueue);
         pool.GetConnectionByIndexAsync(1, Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(connection);
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: false,
             deliveryTimeoutMs: 1, requestTimeoutMs: 10_000, connectionsPerBroker: 2);
         var accumulator = new RecordAccumulator(options);
@@ -521,23 +561,29 @@ public sealed class BrokerSenderMuteOrderingTests
                     "RefreshPartitionRouting", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .Invoke(sender, null);
 
-            var migratingCount = (int)typeof(BrokerSender).GetMethod(
-                    "GetMigratingPartitionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .Invoke(sender, null)!;
+            var getMigratingCount = typeof(BrokerSender).GetMethod(
+                "GetMigratingPartitionCount", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var migratingCount = (int)getMigratingCount.Invoke(sender, null)!;
             await Assert.That(migratingCount).IsEqualTo(1);
 
             await Task.Delay(20, ct);
             Volatile.Write(
                 ref testTimestamp,
                 Stopwatch.GetTimestamp() + (20 * Stopwatch.Frequency));
-            typeof(BrokerSender).GetMethod(
-                    "HandleTimedOutRequests", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .Invoke(sender, [CreateCarryOver(), ct]);
 
-            migratingCount = (int)typeof(BrokerSender).GetMethod(
-                    "GetMigratingPartitionCount", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .Invoke(sender, null)!;
-            await Assert.That(migratingCount).IsEqualTo(0);
+            // Wake the send loop with an unrelated-topic batch so the loop's OWN iteration runs
+            // the request-timeout sweep. Never invoke HandleTimedOutRequests reflectively from
+            // the test thread: it is send-loop-owned, and a concurrent test-thread invocation
+            // races the live loop's walk of the same pending-response list, double-returning its
+            // pooled arrays into the process-wide ArrayPool. Later tests then rent the same
+            // array for two in-flight requests and complete the wrong batch (#2187).
+            sender.Enqueue(CreateTestBatch(vtPool, "wake-topic", partition: 0));
+
+            await WaitUntilAsync(
+                () => (int)getMigratingCount.Invoke(sender, null)! == 0,
+                DiagnosticWaitTimeout,
+                () => "The send loop's request-timeout sweep did not clear the migration fence",
+                ct);
 
             await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
                 .Because("timeout removal leaves no old request that can justify a migration fence");
@@ -545,6 +591,7 @@ public sealed class BrokerSenderMuteOrderingTests
         finally
         {
             timedOutResponse.TrySetResult(CreateSuccessResponse(topicPartition.Topic, topicPartition.Partition, 100));
+            wakeResponse.TrySetResult(CreateSuccessResponse("wake-topic", partition: 0, baseOffset: 100));
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
@@ -664,7 +711,8 @@ public sealed class BrokerSenderMuteOrderingTests
             .Select(_ => new TaskCompletionSource<ProduceResponse>())
             .ToArray();
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>(responses);
-        var (pool, _) = CreateMockConnection(responseQueue);
+        var (pool, connection) = CreateMockConnection(responseQueue);
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: false);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -692,21 +740,50 @@ public sealed class BrokerSenderMuteOrderingTests
         try
         {
             var firstBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
+            ReadyBatch? secondBatch = null;
+
+            string Diagnose()
+            {
+                string acks;
+                lock (acknowledgedOffsets)
+                    acks = string.Join(',', acknowledgedOffsets);
+                string captured;
+                lock (connection.CapturedProduceRequests)
+                {
+                    captured = string.Join(" ; ", connection.CapturedProduceRequests.Select((c, i) =>
+                        $"send{i}: {c.Info}refs=[{string.Join(',', c.RecordBatches.Select(rb =>
+                            ReferenceEquals(rb, firstBatch.RecordBatch) ? "first"
+                            : ReferenceEquals(rb, secondBatch?.RecordBatch) ? "second"
+                            : "OTHER"))}]"));
+                }
+
+                return $"sends={sendLogger.SendCount}, afterWriteCalls={Volatile.Read(ref connection.SendPipelinedAfterWriteCalls)}, " +
+                    $"queuedResponses={responseQueue.Count}, acks=[{acks}], " +
+                    $"muted={accumulator.IsMuted(firstBatch.TopicPartition)}, " +
+                    $"first={firstBatch.DiagTrace}/pooled={firstBatch.IsReturnedToPool}/gen={firstBatch.Generation}, " +
+                    $"second={secondBatch?.DiagTrace}/pooled={secondBatch?.IsReturnedToPool}/gen={secondBatch?.Generation}, " +
+                    $"{captured}\n  " +
+                    sendLogger.DumpEvents();
+            }
+
             sender.Enqueue(firstBatch);
-            sendLogger.WaitForSend(0, ct);
+            if (!sendLogger.TryWaitForSend(0, DiagnosticWaitTimeout, ct))
+                throw new TimeoutException($"Send 1 never happened: {Diagnose()}");
 
             await Assert.That(accumulator.IsMuted(firstBatch.TopicPartition)).IsFalse();
 
-            var secondBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
+            secondBatch = CreateTestBatch(vtPool, "test-topic", partition: 0);
             sender.Enqueue(secondBatch);
 
-            sendLogger.WaitForSend(1, ct);
+            if (!sendLogger.TryWaitForSend(1, DiagnosticWaitTimeout, ct))
+                throw new TimeoutException($"Send 2 never happened: {Diagnose()}");
             await Assert.That(sendLogger.SendCount).IsEqualTo(2);
 
             responses[0].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 100));
             responses[1].SetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 101));
 
-            allAcknowledged.Wait(ct);
+            if (!allAcknowledged.Wait(DiagnosticWaitTimeout, ct))
+                throw new TimeoutException($"Acknowledgements never arrived: {Diagnose()}");
             await Assert.That(acknowledgedOffsets).IsEquivalentTo([100L, 101L]);
         }
         finally
@@ -729,6 +806,7 @@ public sealed class BrokerSenderMuteOrderingTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>([response]);
         var (pool, _) = CreateMockConnection(responseQueue);
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: false);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1098,6 +1176,7 @@ public sealed class BrokerSenderMuteOrderingTests
 
         var requestSent = new TaskCompletionSource();
         var (pool, _) = CreateMockConnection(responseQueue, onSend: () => requestSent.TrySetResult());
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(retryBackoffMs: 10_000, retryBackoffMaxMs: 10_000);
         var accumulator = new RecordAccumulator(options);
         var metadataManager = new MetadataManager(pool, options.BootstrapServers);
@@ -1194,6 +1273,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1292,6 +1372,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1325,14 +1406,18 @@ public sealed class BrokerSenderMuteOrderingTests
             // Wait for send 1 (coalesced A+B)
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
-            // p0 gets retriable error, p1 succeeds
+            // Enqueue batch C (p1) while send 1 is still in flight, BEFORE releasing the
+            // response. Enqueuing after the response completes races the send loop: the p0
+            // retry can dispatch alone before C's channel event is drained, splitting send 2
+            // into two sends and breaking the script. With C already in the channel when the
+            // loop wakes, the same iteration drains it and coalesces it with the retry.
+            var batchC = CreateTestBatch(vtPool, "test-topic", 1);
+            sender.Enqueue(batchC);
+
+            // p0 gets retriable error, p1 succeeds; C proceeds (p1 is not muted)
             tcs1.SetResult(CreateMultiPartitionResponse("test-topic",
                 (0, ErrorCode.NotLeaderOrFollower, -1),
                 (1, ErrorCode.None, 200)));
-
-            // Enqueue batch C (p1) — should NOT be blocked (p1 is not muted)
-            var batchC = CreateTestBatch(vtPool, "test-topic", 1);
-            sender.Enqueue(batchC);
 
             // Wait for send 2 (batch A retry + batch C coalesced — both partitions)
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -1387,6 +1472,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1475,6 +1561,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1561,6 +1648,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1651,6 +1739,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1683,14 +1772,18 @@ public sealed class BrokerSenderMuteOrderingTests
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
-            // p0 fails, p1 succeeds → p0 muted
+            // Enqueue C (p1) while send 1 is still in flight, BEFORE releasing the response.
+            // Enqueuing after the response completes races the send loop: the p0 retry can
+            // dispatch alone before C's channel event is drained, splitting send 2 into two
+            // sends and breaking the script. With C already in the channel when the loop wakes,
+            // the same iteration drains it and coalesces it with the retry.
+            var batchC = CreateTestBatch(vtPool, "test-topic", 1);
+            sender.Enqueue(batchC);
+
+            // p0 fails, p1 succeeds → p0 muted; C proceeds (p1 is not muted)
             tcs1.SetResult(CreateMultiPartitionResponse("test-topic",
                 (0, ErrorCode.NotLeaderOrFollower, -1),
                 (1, ErrorCode.None, 200)));
-
-            // Enqueue C (p1) — p1 is NOT muted, should proceed
-            var batchC = CreateTestBatch(vtPool, "test-topic", 1);
-            sender.Enqueue(batchC);
 
             // Send 2: A retry (p0) + C (p1) coalesced
             await sendSignals[1].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
@@ -1742,6 +1835,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (index < sendSignals.Length)
                 sendSignals[index].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1879,6 +1973,7 @@ public sealed class BrokerSenderMuteOrderingTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        ct = GuardUnscriptedSends(ct);
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1998,7 +2093,9 @@ public sealed class BrokerSenderMuteOrderingTests
     private sealed class PipelinedSendLogger : ILogger, IDisposable
     {
         private readonly ManualResetEventSlim[] _sendSignals;
+        private readonly System.Collections.Concurrent.ConcurrentQueue<string> _events = new();
         private int _sendCount;
+        private int _eventCount;
 
         public PipelinedSendLogger(int expectedSends)
         {
@@ -2009,6 +2106,8 @@ public sealed class BrokerSenderMuteOrderingTests
 
         public int SendCount => Volatile.Read(ref _sendCount);
 
+        public string DumpEvents() => string.Join("\n  ", _events);
+
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public void Dispose()
@@ -2018,9 +2117,12 @@ public sealed class BrokerSenderMuteOrderingTests
         }
 
         public void WaitForSend(int index, CancellationToken cancellationToken) =>
-            _sendSignals[index].Wait(cancellationToken);
+            TryWaitForSend(index, Timeout.InfiniteTimeSpan, cancellationToken);
 
-        public bool IsEnabled(LogLevel logLevel) => logLevel == LogLevel.Debug;
+        public bool TryWaitForSend(int index, TimeSpan timeout, CancellationToken cancellationToken) =>
+            _sendSignals[index].Wait(timeout, cancellationToken);
+
+        public bool IsEnabled(LogLevel logLevel) => true;
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -2029,6 +2131,12 @@ public sealed class BrokerSenderMuteOrderingTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            // Bounded capture: a runaway sender loop (the failure mode this diagnoses) must not
+            // balloon the queue — or keep paying for message formatting — while the test waits
+            // out its timeout.
+            if (Interlocked.Increment(ref _eventCount) <= 200)
+                _events.Enqueue($"{eventId.Name}: {formatter(state, exception)}{(exception is null ? "" : $" [{exception.GetType().Name}: {exception.Message}]")}");
+
             if (eventId.Name != "LogPipelinedSend")
                 return;
 
@@ -2037,4 +2145,5 @@ public sealed class BrokerSenderMuteOrderingTests
                 _sendSignals[index].Set();
         }
     }
+
 }

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -22,7 +22,7 @@ namespace Dekaf.Tests.Unit.Producer;
 /// - FinalizeCoalescedRetries clears mute state only when batch actually sends
 /// - Carry-over ordering preserves retry-before-normal invariant
 /// </summary>
-public sealed class BrokerSenderMuteOrderingTests
+public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixture
 {
     // Well below the 30s TUnit timeout so a stalled wait fails with a state dump instead of
     // an opaque test-level timeout, while still generous for loaded CI runners.
@@ -59,15 +59,12 @@ public sealed class BrokerSenderMuteOrderingTests
             LingerMs = 0
         };
 
-    private ScriptedProduceResponses? _scriptedResponses;
-
     private (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
         Action? onSend = null)
     {
         var connection = new TestKafkaConnection { CaptureProduceRequests = true };
-        var scripted = new ScriptedProduceResponses(responseQueue, onSend);
-        _scriptedResponses = scripted;
+        var scripted = RegisterScript(responseQueue, onSend);
 
         connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
 
@@ -76,27 +73,6 @@ public sealed class BrokerSenderMuteOrderingTests
             .Returns(connection);
 
         return (pool, connection);
-    }
-
-    /// <summary>
-    /// Links the test's cancellation token to the mock connection script so an unscripted
-    /// (extra) send aborts every in-test wait immediately instead of hanging until the
-    /// 30s test timeout with no diagnosis (#2187).
-    /// </summary>
-    private CancellationToken GuardUnscriptedSends(CancellationToken testToken) =>
-        _scriptedResponses!.Guard(testToken);
-
-    [After(Test)]
-    public void FailTestOnUnscriptedSend()
-    {
-        var scripted = _scriptedResponses;
-        _scriptedResponses = null;
-        if (scripted is null)
-            return;
-
-        scripted.Dispose();
-        if (scripted.UnscriptedSendFailure is { } failure)
-            throw failure;
     }
 
     private static ReadyBatch CreateTestBatch(
@@ -119,32 +95,17 @@ public sealed class BrokerSenderMuteOrderingTests
         return batch;
     }
 
-    private static async Task WaitUntilAsync(
-        Func<bool> condition,
-        TimeSpan timeout,
-        Func<string> timeoutMessage,
-        CancellationToken cancellationToken)
-    {
-        var deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
-        while (!condition())
-        {
-            if (Stopwatch.GetTimestamp() >= deadline)
-                throw new TimeoutException(timeoutMessage());
-
-            await Task.Delay(1, cancellationToken);
-        }
-    }
-
     private static Task WaitForDiagAsync(
         ReadyBatch batch,
         char marker,
         TimeSpan timeout,
         CancellationToken cancellationToken) =>
-        WaitUntilAsync(
+        TestWait.UntilAsync(
             () => batch.DiagTrace.Contains(marker),
             timeout,
             () => $"Batch did not reach '{marker}': {batch.DiagTrace}",
-            cancellationToken);
+            cancellationToken,
+            pollInterval: TimeSpan.FromMilliseconds(1));
 
     private static ProduceResponse CreateSuccessResponse(string topic, int partition, long baseOffset) =>
         new()
@@ -579,11 +540,12 @@ public sealed class BrokerSenderMuteOrderingTests
             // array for two in-flight requests and complete the wrong batch (#2187).
             sender.Enqueue(CreateTestBatch(vtPool, "wake-topic", partition: 0));
 
-            await WaitUntilAsync(
+            await TestWait.UntilAsync(
                 () => (int)getMigratingCount.Invoke(sender, null)! == 0,
                 DiagnosticWaitTimeout,
                 () => "The send loop's request-timeout sweep did not clear the migration fence",
-                ct);
+                ct,
+                pollInterval: TimeSpan.FromMilliseconds(1));
 
             await Assert.That((int)getConnection.Invoke(sender, [topicPartition])!).IsEqualTo(1)
                 .Because("timeout removal leaves no old request that can justify a migration fence");

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -581,27 +581,41 @@ public sealed class BrokerSenderSendLoopTests
             TransactionalId = transactionalId
         };
 
+    private readonly List<ScriptedProduceResponses> _scriptedResponses = [];
+
+    [After(Test)]
+    public void FailTestOnUnscriptedSend()
+    {
+        InvalidOperationException? failure = null;
+        foreach (var scripted in _scriptedResponses)
+        {
+            scripted.Dispose();
+            failure ??= scripted.UnscriptedSendFailure;
+        }
+
+        _scriptedResponses.Clear();
+        if (failure is not null)
+            throw failure;
+    }
+
     /// <summary>
     /// Creates a mock connection pool that returns a controllable mock connection.
     /// The mock connection queues response tasks so each SendPipelinedAfterWriteAsync call
-    /// returns the next TaskCompletionSource's task from the queue.
+    /// returns the next TaskCompletionSource's task from the queue. An unscripted (extra)
+    /// send parks the sender and fails the test with a named diagnostic instead of feeding
+    /// BrokerSender's retry loop forever (#2187).
     /// The optional onSend callback fires each time SendPipelinedAfterWriteAsync is called,
     /// enabling deterministic synchronization without Task.Delay.
     /// </summary>
-    private static (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
+    private (IConnectionPool pool, TestKafkaConnection connection) CreateMockConnection(
         Queue<TaskCompletionSource<ProduceResponse>> responseQueue,
         Action? onSend = null)
     {
         var connection = new TestKafkaConnection();
+        var scripted = new ScriptedProduceResponses(responseQueue, onSend);
+        _scriptedResponses.Add(scripted);
 
-        Task<ProduceResponse> DequeueResponse()
-        {
-            var task = responseQueue.Dequeue().Task;
-            onSend?.Invoke();
-            return task;
-        }
-
-        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(DequeueResponse());
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
 
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -3041,15 +3055,15 @@ public sealed class BrokerSenderSendLoopTests
             new TaskCompletionSource()
         };
         var sendCount = 0;
+        var scripted0 = new ScriptedProduceResponses(responseQueue, () =>
+        {
+            var index = Interlocked.Increment(ref sendCount) - 1;
+            sendSignals[index].TrySetResult();
+        });
+        _scriptedResponses.Add(scripted0);
         var connection0 = new TestKafkaConnection
         {
-            SendProducePipelinedAfterWrite = () =>
-            {
-                var response = responseQueue.Dequeue().Task;
-                var index = Interlocked.Increment(ref sendCount) - 1;
-                sendSignals[index].TrySetResult();
-                return new ValueTask<Task<ProduceResponse>>(response);
-            }
+            SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted0.Dequeue())
         };
         var connection1 = new TestKafkaConnection();
         var pool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -26,7 +26,7 @@ namespace Dekaf.Tests.Unit.Producer;
 /// These tests use controllable mock connections to verify send loop timing behavior.
 /// Synchronization uses deterministic TCS signals from mock callbacks, not Task.Delay.
 /// </summary>
-public sealed class BrokerSenderSendLoopTests
+public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 {
     [Test]
     public async Task DeliveryLatencyOrigin_SealWithinLinger_UsesSealNotCreation()
@@ -583,36 +583,6 @@ public sealed class BrokerSenderSendLoopTests
             TransactionalId = transactionalId
         };
 
-    private readonly List<ScriptedProduceResponses> _scriptedResponses = [];
-
-    /// <summary>
-    /// Links the test's cancellation token to every mock connection script created so far,
-    /// so an unscripted (extra) send aborts in-test waits immediately instead of hanging
-    /// until the test timeout (#2187).
-    /// </summary>
-    private CancellationToken GuardUnscriptedSends(CancellationToken testToken)
-    {
-        var guarded = testToken;
-        foreach (var scripted in _scriptedResponses)
-            guarded = scripted.Guard(guarded);
-        return guarded;
-    }
-
-    [After(Test)]
-    public void FailTestOnUnscriptedSend()
-    {
-        InvalidOperationException? failure = null;
-        foreach (var scripted in _scriptedResponses)
-        {
-            scripted.Dispose();
-            failure ??= scripted.UnscriptedSendFailure;
-        }
-
-        _scriptedResponses.Clear();
-        if (failure is not null)
-            throw failure;
-    }
-
     /// <summary>
     /// Creates a mock connection pool that returns a controllable mock connection.
     /// The mock connection queues response tasks so each SendPipelinedAfterWriteAsync call
@@ -627,8 +597,7 @@ public sealed class BrokerSenderSendLoopTests
         Action? onSend = null)
     {
         var connection = new TestKafkaConnection();
-        var scripted = new ScriptedProduceResponses(responseQueue, onSend);
-        _scriptedResponses.Add(scripted);
+        var scripted = RegisterScript(responseQueue, onSend);
 
         connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
 
@@ -3089,12 +3058,11 @@ public sealed class BrokerSenderSendLoopTests
             new TaskCompletionSource()
         };
         var sendCount = 0;
-        var scripted0 = new ScriptedProduceResponses(responseQueue, () =>
+        var scripted0 = RegisterScript(responseQueue, () =>
         {
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
-        _scriptedResponses.Add(scripted0);
         cancellationToken = GuardUnscriptedSends(cancellationToken);
         var connection0 = new TestKafkaConnection
         {

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -425,6 +425,7 @@ public sealed class BrokerSenderSendLoopTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var responses = new Queue<TaskCompletionSource<ProduceResponse>>([pendingResponse]);
         var (pool, _) = CreateMockConnection(responses);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 2, enableIdempotence: true, lingerMs: 0);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
@@ -497,6 +498,7 @@ public sealed class BrokerSenderSendLoopTests
         var responses = new Queue<TaskCompletionSource<ProduceResponse>>(
             [firstResponse, secondResponse]);
         var (pool, connection) = CreateMockConnection(responses);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             acks: Acks.All,
             maxInFlight: 5,
@@ -582,6 +584,19 @@ public sealed class BrokerSenderSendLoopTests
         };
 
     private readonly List<ScriptedProduceResponses> _scriptedResponses = [];
+
+    /// <summary>
+    /// Links the test's cancellation token to every mock connection script created so far,
+    /// so an unscripted (extra) send aborts in-test waits immediately instead of hanging
+    /// until the test timeout (#2187).
+    /// </summary>
+    private CancellationToken GuardUnscriptedSends(CancellationToken testToken)
+    {
+        var guarded = testToken;
+        foreach (var scripted in _scriptedResponses)
+            guarded = scripted.Guard(guarded);
+        return guarded;
+    }
 
     [After(Test)]
     public void FailTestOnUnscriptedSend()
@@ -881,6 +896,7 @@ public sealed class BrokerSenderSendLoopTests
         {
             sends[Interlocked.Increment(ref sendCount) - 1].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             retryBackoffMs: 0,
             retryBackoffMaxMs: 0,
@@ -1022,6 +1038,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 5);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1077,6 +1094,7 @@ public sealed class BrokerSenderSendLoopTests
             if (index < sendSignals.Length)
                 sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 2, transactionalId: "test-transaction");
         var accumulator = new RecordAccumulator(options);
         var valueTaskPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1257,6 +1275,7 @@ public sealed class BrokerSenderSendLoopTests
         var responses = new Queue<TaskCompletionSource<ProduceResponse>>([response]);
         var sendStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var (connectionPool, _) = CreateMockConnection(responses, sendStarted.SetResult);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(transactionalId: "test-transaction");
         var accumulator = new RecordAccumulator(options);
         var valueTaskPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1349,6 +1368,7 @@ public sealed class BrokerSenderSendLoopTests
         var sendCount = 0;
         var (connectionPool, _) = CreateMockConnection(responses, () =>
             sendSignals[Interlocked.Increment(ref sendCount) - 1].TrySetResult());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             retryBackoffMs: 0,
             retryBackoffMaxMs: 0,
@@ -1434,6 +1454,7 @@ public sealed class BrokerSenderSendLoopTests
             if (index < sends.Length)
                 sends[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 5,
             retryBackoffMs: 0,
@@ -1503,6 +1524,7 @@ public sealed class BrokerSenderSendLoopTests
         {
             sends[Interlocked.Increment(ref sendCount) - 1].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 5,
             retryBackoffMs: 0,
@@ -1617,6 +1639,7 @@ public sealed class BrokerSenderSendLoopTests
 
         var requestSent = new TaskCompletionSource();
         var (pool, _) = CreateMockConnection(responseQueue, onSend: () => requestSent.TrySetResult());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1670,6 +1693,7 @@ public sealed class BrokerSenderSendLoopTests
 
         var requestSent = new TaskCompletionSource();
         var (pool, _) = CreateMockConnection(responseQueue, onSend: () => requestSent.TrySetResult());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1772,6 +1796,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1841,6 +1866,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 100,
             enableAdaptiveConnections: false,
@@ -1892,6 +1918,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 100,
             connectionsPerBroker: 2,
@@ -1948,6 +1975,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 100,
             connectionsPerBroker: 2,
@@ -2015,6 +2043,7 @@ public sealed class BrokerSenderSendLoopTests
                 Interlocked.Exchange(ref staleBatch!._returnedToPool, 1);
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(
             maxInFlight: 100,
             enableAdaptiveConnections: false,
@@ -2070,6 +2099,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -2499,6 +2529,7 @@ public sealed class BrokerSenderSendLoopTests
             if (Interlocked.Increment(ref sendCount) >= 1)
                 allSent.TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 5);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -2733,6 +2764,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 1, retryBackoffMs: 0, retryBackoffMaxMs: 0);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -2876,6 +2908,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 2);
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -2965,6 +2998,7 @@ public sealed class BrokerSenderSendLoopTests
             if (idx < sendSignals.Length)
                 sendSignals[idx].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
 
         // Short request timeout (1s) so HandleTimedOutRequests fires quickly.
         // Delivery timeout also 1s so the batch is permanently failed rather than retried.
@@ -3061,6 +3095,7 @@ public sealed class BrokerSenderSendLoopTests
             sendSignals[index].TrySetResult();
         });
         _scriptedResponses.Add(scripted0);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var connection0 = new TestKafkaConnection
         {
             SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted0.Dequeue())
@@ -3154,6 +3189,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
 
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
@@ -3228,6 +3264,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
 
         var options = CreateOptions(maxInFlight: 1);
         var accumulator = new RecordAccumulator(options);
@@ -3295,6 +3332,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
 
         var options = CreateOptions(maxInFlight: 1, deliveryTimeoutMs: deliveryTimeoutMs);
         var accumulator = new RecordAccumulator(options);
@@ -3403,6 +3441,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
 
         // One successful request must feed logical bytes and request RTT into the budget.
         var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
@@ -3455,6 +3494,7 @@ public sealed class BrokerSenderSendLoopTests
         // (microseconds), disabling the budget's RTT safety floor (#1941). The pre-write
         // anchor includes the write time, so the observed minimum cannot undercut it.
         var (pool, connection) = CreateMockConnection(new Queue<TaskCompletionSource<ProduceResponse>>());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var responseSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         connection.SendProducePipelinedAfterWrite = async () =>
         {
@@ -3501,6 +3541,7 @@ public sealed class BrokerSenderSendLoopTests
         };
         var (pool, _) = CreateMockConnection(
             new Queue<TaskCompletionSource<ProduceResponse>>(responses));
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 2, unackedByteBudgetCapOverride: 1_000_000);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
@@ -3580,6 +3621,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 1, unackedByteBudgetCapOverride: 1_000_000);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
@@ -3630,6 +3672,7 @@ public sealed class BrokerSenderSendLoopTests
             var index = Interlocked.Increment(ref sendCount) - 1;
             sendSignals[index].TrySetResult();
         });
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions(maxInFlight: 1, retryBackoffMs: 0,
             unackedByteBudgetCapOverride: 1_000_000);
         var accumulator = new RecordAccumulator(options);

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -85,16 +85,15 @@ internal sealed class ScriptedProduceResponses : IDisposable
 
         // Cancel asynchronously: a synchronous Cancel would resume guarded test waits inline
         // on this sender-loop thread, and a resumed continuation may join this same thread
-        // (sender.DisposeAsync in the test's finally).
-        try
-        {
-            _ = guardCts?.CancelAsync();
-        }
-        catch (ObjectDisposedException)
-        {
-            // The After(Test) hook already tore the guard down; the recorded
-            // failure still fails the test.
-        }
+        // (sender.DisposeAsync in the test's finally). If Dispose raced ahead and the source
+        // is already disposed, CancelAsync surfaces ObjectDisposedException through its
+        // returned task rather than synchronously — observe the fault so it cannot become
+        // an unobserved-task exception; the recorded failure still fails the test.
+        guardCts?.CancelAsync().ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
         return _unscriptedSendResponse.Task;
     }
@@ -106,5 +105,53 @@ internal sealed class ScriptedProduceResponses : IDisposable
             _guardCts?.Dispose();
             _guardCts = null;
         }
+    }
+}
+
+/// <summary>
+/// Base fixture for test classes that script produce responses through
+/// <see cref="ScriptedProduceResponses"/>: registers every script the test creates, links
+/// them into the test's cancellation token via <see cref="GuardUnscriptedSends"/>, and
+/// fails the test after it finishes if any unscripted send was recorded.
+/// </summary>
+public abstract class ScriptedProduceResponseFixture
+{
+    private readonly List<ScriptedProduceResponses> _scriptedResponses = [];
+
+    private protected ScriptedProduceResponses RegisterScript(
+        Queue<TaskCompletionSource<ProduceResponse>> responses,
+        Action? onSend = null)
+    {
+        var scripted = new ScriptedProduceResponses(responses, onSend);
+        _scriptedResponses.Add(scripted);
+        return scripted;
+    }
+
+    /// <summary>
+    /// Links the test's cancellation token to every script registered so far, so an
+    /// unscripted (extra) send aborts in-test waits immediately instead of hanging
+    /// until the test timeout (#2187).
+    /// </summary>
+    protected CancellationToken GuardUnscriptedSends(CancellationToken testToken)
+    {
+        var guarded = testToken;
+        foreach (var scripted in _scriptedResponses)
+            guarded = scripted.Guard(guarded);
+        return guarded;
+    }
+
+    [After(Test)]
+    public void FailTestOnUnscriptedSend()
+    {
+        InvalidOperationException? failure = null;
+        foreach (var scripted in _scriptedResponses)
+        {
+            scripted.Dispose();
+            failure ??= scripted.UnscriptedSendFailure;
+        }
+
+        _scriptedResponses.Clear();
+        if (failure is not null)
+            throw failure;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -1,0 +1,110 @@
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Scripts a fixed set of produce responses for a <see cref="TestKafkaConnection"/> and converts
+/// any unscripted (extra) send into an immediate, diagnosable failure. Previously an exhausted
+/// script threw <c>InvalidOperationException("Queue empty.")</c> from <c>Queue.Dequeue</c>, which
+/// <c>BrokerSender.SendCoalescedAsync</c> treats as a retriable connection failure — with the
+/// zero retry backoff these tests configure, the sender retried against the exhausted script
+/// forever and the test died as an opaque 30s timeout (#2187). An unscripted send now records
+/// a diagnostic (rethrow it from an <c>[After(Test)]</c> hook), cancels the token issued by
+/// <see cref="Guard"/> so in-test waits abort instantly, and parks the sender on a response
+/// that never completes so no retry loop can start.
+/// </summary>
+internal sealed class ScriptedProduceResponses : IDisposable
+{
+    private readonly Queue<TaskCompletionSource<ProduceResponse>> _responses;
+    private readonly Action? _onSend;
+    private readonly TaskCompletionSource<ProduceResponse> _unscriptedSendResponse = new();
+    // object, not System.Threading.Lock: this project also targets net8.0.
+    private readonly object _lock = new();
+    private CancellationTokenSource? _guardCts;
+    private int _dequeuedCount;
+    private volatile InvalidOperationException? _unscriptedSendFailure;
+
+    public ScriptedProduceResponses(
+        Queue<TaskCompletionSource<ProduceResponse>> responses,
+        Action? onSend)
+    {
+        _responses = responses;
+        _onSend = onSend;
+    }
+
+    public InvalidOperationException? UnscriptedSendFailure => _unscriptedSendFailure;
+
+    /// <summary>
+    /// Links the test's cancellation token to this script so an unscripted send aborts every
+    /// in-test wait immediately instead of hanging until the test timeout.
+    /// </summary>
+    public CancellationToken Guard(CancellationToken testToken)
+    {
+        CancellationTokenSource guardCts;
+        bool alreadyFailed;
+        lock (_lock)
+        {
+            guardCts = CancellationTokenSource.CreateLinkedTokenSource(testToken);
+            _guardCts = guardCts;
+            alreadyFailed = _unscriptedSendFailure is not null;
+        }
+
+        if (alreadyFailed)
+            guardCts.Cancel();
+        return guardCts.Token;
+    }
+
+    public Task<ProduceResponse> Dequeue()
+    {
+        TaskCompletionSource<ProduceResponse>? scripted = null;
+        CancellationTokenSource? guardCts = null;
+        lock (_lock)
+        {
+            if (_responses.Count > 0)
+            {
+                scripted = _responses.Dequeue();
+                _dequeuedCount++;
+            }
+            else
+            {
+                // Capture the sender-side stack: it names the code path that produced the
+                // extra send, which is the input the underlying-race investigation needs.
+                _unscriptedSendFailure ??= new InvalidOperationException(
+                    $"Unscripted send: all {_dequeuedCount} scripted produce responses were " +
+                    "already consumed when the sender issued another send. Sender stack: " +
+                    Environment.StackTrace);
+                guardCts = _guardCts;
+            }
+        }
+
+        if (scripted is not null)
+        {
+            _onSend?.Invoke();
+            return scripted.Task;
+        }
+
+        // Cancel asynchronously: a synchronous Cancel would resume guarded test waits inline
+        // on this sender-loop thread, and a resumed continuation may join this same thread
+        // (sender.DisposeAsync in the test's finally).
+        try
+        {
+            _ = guardCts?.CancelAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The After(Test) hook already tore the guard down; the recorded
+            // failure still fails the test.
+        }
+
+        return _unscriptedSendResponse.Task;
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            _guardCts?.Dispose();
+            _guardCts = null;
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -162,12 +162,17 @@ internal sealed class TestKafkaConnection :
         {
             var recordBatches = new List<object>();
             var info = new System.Text.StringBuilder();
-            foreach (var (topicName, partition) in EnumeratePartitions(produceRequest))
+            for (var t = 0; t < produceRequest.TopicEntryCount; t++)
             {
-                foreach (var recordBatch in partition.Records)
+                var topic = produceRequest.GetTopicEntry(t);
+                for (var p = 0; p < topic.PartitionEntryCount; p++)
                 {
-                    recordBatches.Add(recordBatch);
-                    info.Append($"{topicName}-{partition.Index}(seq={recordBatch.BaseSequence}) ");
+                    var partition = topic.GetPartitionEntry(p);
+                    foreach (var recordBatch in partition.Records)
+                    {
+                        recordBatches.Add(recordBatch);
+                        info.Append($"{topic.Name}-{partition.Index}(seq={recordBatch.BaseSequence}) ");
+                    }
                 }
             }
 
@@ -202,66 +207,4 @@ internal sealed class TestKafkaConnection :
     private static async Task<TResponse> CastResponseTask<TResponse>(Task<ProduceResponse> responseTask)
         where TResponse : IKafkaResponse
         => (TResponse)(IKafkaResponse)await responseTask.ConfigureAwait(false);
-
-    // BrokerSender populates produce requests through internal scratch arrays that the public
-    // TopicData/PartitionData properties never expose; read them reflectively so the capture
-    // also sees coalesced multi-batch requests.
-    private static readonly System.Reflection.FieldInfo TopicDataScratchField =
-        typeof(ProduceRequest).GetField("_topicDataScratch",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-
-    private static readonly System.Reflection.FieldInfo TopicDataScratchCountField =
-        typeof(ProduceRequest).GetField("_topicDataScratchCount",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-
-    private static readonly System.Reflection.FieldInfo PartitionDataScratchField =
-        typeof(ProduceRequestTopicData).GetField("_partitionDataScratch",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-
-    private static readonly System.Reflection.FieldInfo PartitionDataScratchStartField =
-        typeof(ProduceRequestTopicData).GetField("_partitionDataScratchStart",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-
-    private static readonly System.Reflection.FieldInfo PartitionDataScratchCountField =
-        typeof(ProduceRequestTopicData).GetField("_partitionDataScratchCount",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-
-    private static IEnumerable<(string TopicName, ProduceRequestPartitionData Partition)> EnumeratePartitions(
-        ProduceRequest request)
-    {
-        if (TopicDataScratchField.GetValue(request) is ProduceRequestTopicData[] topicScratch)
-        {
-            var topicCount = (int)TopicDataScratchCountField.GetValue(request)!;
-            for (var t = 0; t < topicCount; t++)
-            {
-                foreach (var partition in EnumerateTopicPartitions(topicScratch[t]))
-                    yield return (topicScratch[t].Name, partition);
-            }
-        }
-        else
-        {
-            foreach (var topic in request.TopicData)
-            {
-                foreach (var partition in EnumerateTopicPartitions(topic))
-                    yield return (topic.Name, partition);
-            }
-        }
-    }
-
-    private static IEnumerable<ProduceRequestPartitionData> EnumerateTopicPartitions(
-        ProduceRequestTopicData topic)
-    {
-        if (PartitionDataScratchField.GetValue(topic) is ProduceRequestPartitionData[] partitionScratch)
-        {
-            var start = (int)PartitionDataScratchStartField.GetValue(topic)!;
-            var count = (int)PartitionDataScratchCountField.GetValue(topic)!;
-            for (var p = 0; p < count; p++)
-                yield return partitionScratch[start + p];
-        }
-        else
-        {
-            foreach (var partition in topic.PartitionData)
-                yield return partition;
-        }
-    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TestKafkaConnection.cs
@@ -32,6 +32,19 @@ internal sealed class TestKafkaConnection :
     public TaskCompletionSource DisposeStarted { get; } = new(
         TaskCreationOptions.RunContinuationsAsynchronously);
 
+    /// <summary>
+    /// Opt-in switch for <see cref="CapturedProduceRequests"/>. Off by default so the many
+    /// suites sharing this double don't pay per-send capture cost for diagnostics they never read.
+    /// </summary>
+    public bool CaptureProduceRequests { get; set; }
+
+    /// <summary>
+    /// Snapshot of every pipelined produce request's record batches, captured at write time
+    /// (the sender's scratch request structures are cleared after each send, so the request
+    /// object itself cannot be inspected later). Lock the list to read it.
+    /// </summary>
+    public List<(string Info, IReadOnlyList<object> RecordBatches)> CapturedProduceRequests { get; } = [];
+
     public Func<ValueTask<Task<ProduceResponse>>>? SendProducePipelinedAfterWrite { get; set; }
     public IPipelinedResponseSource<ProduceResponse>? PipelinedResponseSource { get; set; }
     public Func<ValueTask>? SendProduceFireAndForgetWithCallerTimeout { get; set; }
@@ -145,6 +158,23 @@ internal sealed class TestKafkaConnection :
     {
         Interlocked.Increment(ref SendPipelinedAfterWriteCalls);
 
+        if (CaptureProduceRequests && request is ProduceRequest produceRequest)
+        {
+            var recordBatches = new List<object>();
+            var info = new System.Text.StringBuilder();
+            foreach (var (topicName, partition) in EnumeratePartitions(produceRequest))
+            {
+                foreach (var recordBatch in partition.Records)
+                {
+                    recordBatches.Add(recordBatch);
+                    info.Append($"{topicName}-{partition.Index}(seq={recordBatch.BaseSequence}) ");
+                }
+            }
+
+            lock (CapturedProduceRequests)
+                CapturedProduceRequests.Add((info.ToString(), recordBatches));
+        }
+
         if (PipelinedResponseSource is not null)
         {
             var source = (IPipelinedResponseSource<TResponse>)(object)PipelinedResponseSource;
@@ -172,4 +202,66 @@ internal sealed class TestKafkaConnection :
     private static async Task<TResponse> CastResponseTask<TResponse>(Task<ProduceResponse> responseTask)
         where TResponse : IKafkaResponse
         => (TResponse)(IKafkaResponse)await responseTask.ConfigureAwait(false);
+
+    // BrokerSender populates produce requests through internal scratch arrays that the public
+    // TopicData/PartitionData properties never expose; read them reflectively so the capture
+    // also sees coalesced multi-batch requests.
+    private static readonly System.Reflection.FieldInfo TopicDataScratchField =
+        typeof(ProduceRequest).GetField("_topicDataScratch",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+    private static readonly System.Reflection.FieldInfo TopicDataScratchCountField =
+        typeof(ProduceRequest).GetField("_topicDataScratchCount",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+    private static readonly System.Reflection.FieldInfo PartitionDataScratchField =
+        typeof(ProduceRequestTopicData).GetField("_partitionDataScratch",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+    private static readonly System.Reflection.FieldInfo PartitionDataScratchStartField =
+        typeof(ProduceRequestTopicData).GetField("_partitionDataScratchStart",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+    private static readonly System.Reflection.FieldInfo PartitionDataScratchCountField =
+        typeof(ProduceRequestTopicData).GetField("_partitionDataScratchCount",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+    private static IEnumerable<(string TopicName, ProduceRequestPartitionData Partition)> EnumeratePartitions(
+        ProduceRequest request)
+    {
+        if (TopicDataScratchField.GetValue(request) is ProduceRequestTopicData[] topicScratch)
+        {
+            var topicCount = (int)TopicDataScratchCountField.GetValue(request)!;
+            for (var t = 0; t < topicCount; t++)
+            {
+                foreach (var partition in EnumerateTopicPartitions(topicScratch[t]))
+                    yield return (topicScratch[t].Name, partition);
+            }
+        }
+        else
+        {
+            foreach (var topic in request.TopicData)
+            {
+                foreach (var partition in EnumerateTopicPartitions(topic))
+                    yield return (topic.Name, partition);
+            }
+        }
+    }
+
+    private static IEnumerable<ProduceRequestPartitionData> EnumerateTopicPartitions(
+        ProduceRequestTopicData topic)
+    {
+        if (PartitionDataScratchField.GetValue(topic) is ProduceRequestPartitionData[] partitionScratch)
+        {
+            var start = (int)PartitionDataScratchStartField.GetValue(topic)!;
+            var count = (int)PartitionDataScratchCountField.GetValue(topic)!;
+            for (var p = 0; p < count; p++)
+                yield return partitionScratch[start + p];
+        }
+        else
+        {
+            foreach (var partition in topic.PartitionData)
+                yield return partition;
+        }
+    }
 }

--- a/tests/Dekaf.Tests.Unit/TestWait.cs
+++ b/tests/Dekaf.Tests.Unit/TestWait.cs
@@ -21,6 +21,25 @@ internal static class TestWait
 
     public static async Task UntilAsync(
         Func<bool> condition,
+        TimeSpan timeout,
+        Func<string> timeoutMessage,
+        CancellationToken cancellationToken,
+        TimeSpan? pollInterval = null)
+    {
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        var delay = pollInterval ?? TimeSpan.FromMilliseconds(10);
+
+        while (!condition())
+        {
+            if (Environment.TickCount64 >= deadline)
+                throw new TimeoutException(timeoutMessage());
+
+            await Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    public static async Task UntilAsync(
+        Func<bool> condition,
         CancellationToken cancellationToken,
         TimeSpan? pollInterval = null)
     {


### PR DESCRIPTION
Fixes #2187.

## What was actually wrong

#2187 diagnosed the symptom (mock throws `Queue empty.` → `SendCoalescedAsync` retries forever → opaque 30s hang) but not the mechanism that produced the extra/missing sends. Stress-looping the class under load (3 concurrent 25-run lanes, ~15/75 failing) with new instrumentation pinned it down:

**`MetadataRerank_RequestTimeoutClearsMigrationFence` invoked the send-loop-owned `HandleTimedOutRequests` reflectively from the test thread while the sender loop was live.** Both threads walk the same pending-response list and call `PendingResponse.ReturnBatchesArray()` on the same entry, so the rented `ReadyBatch[]`/`int[]` arrays are returned to the process-global `ArrayPool<T>.Shared` **twice**. Duplicate pool references persist for the rest of the test process. A later test that pipelines two requests (`NonIdempotentProducer_MultipleInFlight_...`, `InFlightWait_...` — exactly the tests seen hanging) then rents **the same array for both in-flight `PendingResponse`s**:

- processing response #1 reads the aliased array and completes the *other* request's batch (captured in a failing run: send #1 = firstBatch, send #2 = secondBatch, ack for offset 100 delivered to secondBatch, `second.pooled=True`, `first` orphaned with trace `CSGW`);
- `ReturnBatchesArray(clearArray: true)` then nulls the shared slots, so response #2 logs `expected []` and its ack is swallowed;
- the orphaned batch either leaves the test waiting for an ack that never comes (30s hang) or gets retried against the exhausted mock script (`Queue empty.` storm from the issue's dump — the other victim mode).

## Fixes

**Test (root cause):** the racy test now advances the injected timestamp and wakes the send loop with an unrelated-topic batch so the loop's *own* iteration runs the request-timeout sweep, then polls `GetMigratingPartitionCount`. Loop-owned methods are never invoked reflectively on a live sender.

**Product hardening (same hazard class):** `DisposeCoreAsync` waits up to 5s for the send loop; previously, on timeout it proceeded to fail pending responses and return their arrays while the still-running loop's exit cleanup would return them again. The cleanup is now gated on the loop actually having completed (its own exit path fails the batches and returns the arrays when it exits); a warning is logged instead.

**Fail-fast harness (issue's primary ask):** a new shared `ScriptedProduceResponses` (adopted by both `BrokerSenderMuteOrderingTests` and `BrokerSenderSendLoopTests`, which carried an identical copy of the hang-prone raw-`Dequeue` mock) replaces the raw scripted queue. An unscripted (extra) send:
- records a diagnostic naming the consumed script count plus the sender-side stack,
- cancels a guard token linked into every in-test wait (`ct = GuardUnscriptedSends(ct)`), aborting the test instantly,
- parks the sender on a never-completing response (no retriable-exception storm, no reconnect NREs),
- and an `[After(Test)]` hook rethrows the diagnostic so the failure names the extra send.

Validated by sabotage: scripting 1 response where 2 sends occur now fails in ~130-240ms with `Unscripted send: all 1 scripted produce responses were already consumed...` instead of a 30s opaque timeout.

**Deterministic coalescing scripts:** `MutedPartitionHeldBack_...` and `RetriableError_OnOnePartition_...` enqueued batch C *after* releasing the response, racing the loop: the retry could dispatch alone before C's channel event drained, splitting send 2 and producing a genuinely unscripted third send under load (caught by the new harness in 243ms). C is now enqueued while send 1 is still in flight.

**Diagnostics kept for the next investigation:** bounded event capture in `PipelinedSendLogger` (`DumpEvents`), opt-in produce-request snapshots in `TestKafkaConnection` (`CaptureProduceRequests` / `CapturedProduceRequests` — captured at write time via the request's internal scratch arrays, because the reusable scratch request is cleared after each send), and bounded waits with a full state dump in `NonIdempotentProducer_MultipleInFlight_...`.

## Validation

- Stress: 3 concurrent lanes x 30 class runs (net8.0, Release): **90/90 pass** (baseline before fixes: ~15/75 failing with 30s hangs). Post-cleanup re-run: mute class 50/50 + send-loop class 12/12 under mutual load.
- Full unit suite: net10.0 5565/5565, net8.0 5439/5439. (One unrelated pre-existing full-suite-only consumer flake observed once — `Revoke_WhenCommitExceedsRebalanceTimeout_Continues`, 0/6 solo repro — tracked separately.)
- Harness fail-fast exercised via deliberate sabotage (see above), then reverted.

## Follow-ups (not in this PR)

Two more double-return windows exist on exception paths and deserve their own hardening pass: a mid-pass exception in `ProcessCompletedResponses` between `ReturnBatchesArray()` and the compaction `RemoveRange` leaves returned entries in the list for the loop-exit cleanup to re-return; the loop-exit cleanup itself has the same partial-failure shape. Both are unreachable without an exception escaping paths that are already per-batch guarded, so they are noted rather than changed here.
