### PR TITLE
fix(producer): make PendingResponse array return exactly-once; expose orphaned-reservation diagnostics

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -170,7 +170,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// at send start (before its first await) — the generations detect batch object
     /// recycling between send and response processing. Ownership of the rented
     /// <paramref name="BatchGenerations"/> and <paramref name="Batches"/> arrays transfers
-    /// to this PendingResponse; they are returned by <see cref="ReturnBatchesArray"/>.
+    /// to this PendingResponse; they are returned by <see cref="TryReturnBatchesArray"/>.
     /// </summary>
     private readonly record struct PendingResponse(
         PipelinedResponse<ProduceResponse> ResponseTask,
@@ -183,6 +183,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         BrokerUnackedByteBudget.DeliverySnapshot DeliverySnapshotAtSend)
     {
         /// <summary>
+        /// One-time-return claim for the rented arrays. Lives in a reference type because
+        /// PendingResponse is a struct copied by value (lists, locals, sweeps) — every copy
+        /// must observe the same claim, or two copies could each return the arrays and
+        /// poison <see cref="ArrayPool{T}.Shared"/> with a double-returned array (#2187:
+        /// a poisoned pool hands the same array to two renters, cross-contaminating requests).
+        /// </summary>
+        private ArrayReturnGuard ReturnGuard { get; } = new();
+
+        /// <summary>
         /// Returns true if the batch at index <paramref name="i"/> is the same incarnation
         /// that was present when this PendingResponse was created.
         /// </summary>
@@ -192,13 +201,27 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         /// <summary>
         /// Clears batch references and returns pooled arrays to <see cref="ArrayPool{T}.Shared"/>.
-        /// Must be called exactly once per PendingResponse entry — not idempotent due to struct copy semantics.
+        /// Only the first call (across all copies of this struct) returns the arrays; later
+        /// calls are no-ops that return false so the caller can log the breached
+        /// exactly-once cleanup contract instead of double-returning to the pool.
         /// </summary>
-        public void ReturnBatchesArray()
+        public bool TryReturnBatchesArray()
         {
+            if (!ReturnGuard.TryClaim())
+                return false;
+
             ArrayPool<int>.Shared.Return(BatchGenerations);
             ArrayPool<ReadyBatch>.Shared.Return(Batches, clearArray: true);
+            return true;
         }
+    }
+
+    /// <summary>Single-claim flag backing <see cref="PendingResponse.TryReturnBatchesArray"/>.</summary>
+    internal sealed class ArrayReturnGuard
+    {
+        private int _claimed;
+
+        public bool TryClaim() => Interlocked.Exchange(ref _claimed, 1) == 0;
     }
 
     private enum SendLoopEventType : byte
@@ -1992,7 +2015,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                     recoveredBatches, recoveredBatchSet);
                         }
                         pr.ResponseTask.Abandon();
-                        pr.ReturnBatchesArray();
+                        ReturnPendingResponseArrays(in pr);
                     }
                     Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
                     var removedBytes = SumEncodedBytes(pendingList);
@@ -2758,7 +2781,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         }
                     }
 
-                    pending.ReturnBatchesArray();
+                    ReturnPendingResponseArrays(in pending);
                     continue;
                 }
 
@@ -2847,7 +2870,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 if (response is ProduceResponse poolableResponse)
                     poolableResponse.Return();
 
-                pending.ReturnBatchesArray();
+                ReturnPendingResponseArrays(in pending);
             }
 
             // Compact: remove processed entries from the end
@@ -3148,7 +3171,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
 
                 pending.ResponseTask.Abandon();
-                pending.ReturnBatchesArray();
+                ReturnPendingResponseArrays(in pending);
             }
 
             // Remove all entries. Response tasks are orphaned — they'll eventually complete
@@ -3680,7 +3703,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 for (var i = 0; i < count; i++)
                 {
                     var batch = batches[i];
-                    if (!batch.IsCurrentIncarnation(generations[i]))
+                    // A null slot means the array was corrupted by another owner (pool
+                    // poisoning) — an NRE here would skip the memory release of every
+                    // remaining batch in this request, permanently orphaning their
+                    // BufferMemory reservations and starving all future appends.
+                    if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
                     {
                         LogStaleBatchInSendSkipped(_instanceId, _brokerId);
                         batches[i] = null!;
@@ -3856,7 +3883,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         finally
         {
             // The generations snapshot transfers to PendingResponse along with the batches
-            // array; ReturnBatchesArray returns both. On every other path it is owned here.
+            // array; TryReturnBatchesArray returns both. On every other path it is owned here.
             if (!pendingResponseAdded)
             {
                 responseTask.Abandon();
@@ -4812,6 +4839,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         _accumulator.OnBatchExitsPipeline(batch);
     }
 
+    /// <summary>
+    /// Sole path for returning a PendingResponse's rented arrays. A duplicate call means two
+    /// cleanup paths both believed they owned the entry (e.g., a stale entry re-processed after
+    /// an exception escaped before list compaction) — previously a silent ArrayPool.Shared
+    /// double-return that poisoned the pool process-wide (#2187, #2195).
+    /// </summary>
+    private void ReturnPendingResponseArrays(in PendingResponse pending)
+    {
+        if (!pending.TryReturnBatchesArray())
+            LogPendingResponseArraysAlreadyReturned(_instanceId, _brokerId);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
@@ -4933,7 +4972,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     }
 
                     pr.ResponseTask.Abandon();
-                    pr.ReturnBatchesArray();
+                    ReturnPendingResponseArrays(in pr);
                 }
 
                 Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
@@ -5583,6 +5622,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "BrokerSender[{BrokerId}] send loop failed")]
     private partial void LogSendLoopFailed(Exception ex, int brokerId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BS#{InstanceId}[broker {BrokerId}] PendingResponse arrays already returned — duplicate cleanup suppressed (would have double-returned to ArrayPool, #2187)")]
+    private partial void LogPendingResponseArraysAlreadyReturned(int instanceId, int brokerId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] send loop exited unexpectedly — redelivering surviving batches to a replacement sender")]
     private partial void LogSendLoopExitRedelivery(int brokerId);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -172,7 +172,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// <paramref name="BatchGenerations"/> and <paramref name="Batches"/> arrays transfers
     /// to this PendingResponse; they are returned by <see cref="TryReturnBatchesArray"/>.
     /// </summary>
-    private readonly record struct PendingResponse(
+    internal readonly record struct PendingResponse(
         PipelinedResponse<ProduceResponse> ResponseTask,
         ReadyBatch[] Batches,
         int[] BatchGenerations,
@@ -3633,7 +3633,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     for (var i = 0; i < count; i++)
                     {
                         var batch = batches[i];
-                        if (!batch.IsCurrentIncarnation(generations[i]))
+                        // Null slot = array corrupted by another owner (pool poisoning); an NRE
+                        // here would skip the completion of every remaining batch in this request.
+                        if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
                         {
                             LogStaleBatchInSendSkipped(_instanceId, _brokerId);
                             batches[i] = null!;

--- a/src/Dekaf/Producer/PendingAppend.cs
+++ b/src/Dekaf/Producer/PendingAppend.cs
@@ -258,10 +258,7 @@ internal sealed class PendingAppend : IValueTaskSource<bool>
             TimeoutKind.MaxBlock,
             elapsed,
             configured,
-            $"Failed to allocate buffer within max.block.ms ({accumulator.MaxBlockMsOption}ms). " +
-            $"Requested {_recordSize} bytes, current usage: {accumulator.BufferedBytes}/{accumulator.MaxBufferMemory} bytes. " +
-            $"Producer is generating messages faster than the network can send them. " +
-            $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
+            accumulator.BuildBufferTimeoutMessage(_recordSize));
 
         if (TryFail(exception))
             accumulator.DrainPendingAppendsIfHead(this);

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -4329,6 +4329,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal int MaxBlockMsOption => _options.MaxBlockMs;
 
     /// <summary>
+    /// Batches currently handed to broker senders. Exposed for <see cref="PendingAppend"/>
+    /// timeout diagnostics: a full buffer with zero in-flight and zero unsealed batches means
+    /// reservations were orphaned (a refund leak), not that the network is slow.
+    /// </summary>
+    internal long InFlightBatchCount => Volatile.Read(ref _inFlightBatchCount);
+
+    /// <summary>Open (not yet sealed) batches. See <see cref="InFlightBatchCount"/>.</summary>
+    internal int UnsealedBatchCount => Volatile.Read(ref _unsealedBatchCount);
+
+    /// <summary>
     /// Atomically updates the maximum buffer memory limit. Used by the global
     /// memory budget for dynamic rebalancing.
     /// Growing the limit signals waiting producers so they re-check immediately.
@@ -4530,11 +4540,22 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             TimeoutKind.MaxBlock,
             elapsed,
             configured,
-            $"Failed to allocate buffer within max.block.ms ({_options.MaxBlockMs}ms). " +
-            $"Requested {recordSize} bytes, current usage: {Volatile.Read(ref _bufferedBytes)}/{(ulong)Volatile.Read(ref _maxBufferMemory)} bytes. " +
-            $"Producer is generating messages faster than the network can send them. " +
-            $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.");
+            BuildBufferTimeoutMessage(recordSize));
     }
+
+    /// <summary>
+    /// Builds the buffer-allocation timeout message from live accumulator state. Shared with
+    /// <see cref="PendingAppend"/> so both timeout sites report identical diagnostics.
+    /// In-flight/unsealed counts distinguish genuine backpressure (batches in the pipeline
+    /// still hold memory) from orphaned reservations (buffer full with nothing in flight —
+    /// a refund leak, run 29594249742).
+    /// </summary>
+    internal string BuildBufferTimeoutMessage(int recordSize) =>
+        $"Failed to allocate buffer within max.block.ms ({_options.MaxBlockMs}ms). " +
+        $"Requested {recordSize} bytes, current usage: {BufferedBytes}/{MaxBufferMemory} bytes, " +
+        $"in-flight batches: {InFlightBatchCount}, unsealed batches: {UnsealedBatchCount}. " +
+        $"Producer is generating messages faster than the network can send them. " +
+        $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.";
 
     /// <summary>
     /// Releases reserved buffer memory when a batch is completed/sent.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -75,26 +75,6 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
         return (pool, connection);
     }
 
-    private static ReadyBatch CreateTestBatch(
-        ValueTaskSourcePool<RecordMetadata> pool,
-        string topic, int partition, int messageCount = 1)
-    {
-        var batch = new ReadyBatch();
-        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(messageCount);
-        for (var i = 0; i < messageCount; i++)
-            sources[i] = pool.Rent();
-
-        batch.Initialize(
-            new TopicPartition(topic, partition),
-            new RecordBatch { Records = Array.Empty<Record>() },
-            sources,
-            messageCount,
-            dataSize: 100);
-
-        batch.TrySetMemoryReleased();
-        return batch;
-    }
-
     private static Task WaitForDiagAsync(
         ReadyBatch batch,
         char marker,
@@ -106,29 +86,6 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             () => $"Batch did not reach '{marker}': {batch.DiagTrace}",
             cancellationToken,
             pollInterval: TimeSpan.FromMilliseconds(1));
-
-    private static ProduceResponse CreateSuccessResponse(string topic, int partition, long baseOffset) =>
-        new()
-        {
-            TopicCount = 1,
-            Responses =
-            [
-                new ProduceResponseTopicData
-                {
-                    Name = topic,
-                    PartitionCount = 1,
-                    PartitionResponses =
-                    [
-                        new ProduceResponsePartitionData
-                        {
-                            Index = partition,
-                            ErrorCode = ErrorCode.None,
-                            BaseOffset = baseOffset
-                        }
-                    ]
-                }
-            ]
-        };
 
     private static ProduceResponse CreateRetriableErrorResponse(string topic, int partition) =>
         new()

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -637,36 +637,6 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         return (pool, scaleRequested);
     }
 
-    /// <summary>
-    /// Creates a minimal ReadyBatch suitable for send loop testing.
-    /// Sets MemoryReleased=true to skip accumulator memory tracking.
-    /// </summary>
-    private static ReadyBatch CreateTestBatch(
-        ValueTaskSourcePool<RecordMetadata> pool,
-        string topic, int partition, int messageCount = 1,
-        bool markMemoryReleased = true, int dataSize = 100)
-    {
-        var batch = new ReadyBatch();
-        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(messageCount);
-        for (var i = 0; i < messageCount; i++)
-            sources[i] = pool.Rent();
-
-        batch.Initialize(
-            new TopicPartition(topic, partition),
-            new RecordBatch { Records = Array.Empty<Record>() },
-            sources,
-            messageCount,
-            dataSize: dataSize);
-
-        if (markMemoryReleased)
-        {
-            // Skip accumulator memory tracking in tests
-            batch.TrySetMemoryReleased();
-        }
-
-        return batch;
-    }
-
     private static (ReadyBatch Batch, Task<RecordMetadata> Delivery) CreateTestBatchWithDelivery(
         ValueTaskSourcePool<RecordMetadata> pool,
         string topic,
@@ -686,34 +656,6 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         batch.TrySetMemoryReleased();
         return (batch, delivery);
     }
-
-    /// <summary>
-    /// Creates a ProduceResponse with success for the given topic/partition.
-    /// </summary>
-    private static ProduceResponse CreateSuccessResponse(
-        string topic, int partition, long baseOffset, int throttleTimeMs = 0) =>
-        new()
-        {
-            ThrottleTimeMs = throttleTimeMs,
-            TopicCount = 1,
-            Responses =
-            [
-                new ProduceResponseTopicData
-                {
-                    Name = topic,
-                    PartitionCount = 1,
-                    PartitionResponses =
-                    [
-                        new ProduceResponsePartitionData
-                        {
-                            Index = partition,
-                            ErrorCode = ErrorCode.None,
-                            BaseOffset = baseOffset
-                        }
-                    ]
-                }
-            ]
-        };
 
     private static ProduceResponse CreateErrorResponse(string topic, int partition, ErrorCode errorCode) =>
         new()
@@ -790,53 +732,6 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                 }
             ]
         };
-
-    /// <summary>
-    /// Creates a BrokerSender with standard test defaults, reducing constructor boilerplate.
-    /// </summary>
-    private static BrokerSender CreateSender(
-        IConnectionPool pool,
-        ProducerOptions options,
-        RecordAccumulator accumulator,
-        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
-        MetadataManager? metadataManager = null,
-        Action<ReadyBatch, int>? rerouteBatch = null,
-        Action<int>? onBrokerThrottle = null,
-        Func<long>? getTimestamp = null,
-        Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
-        Action? onBlockedBucketRequeued = null,
-        Action? onPipelinedResponseAcquired = null,
-        Action? onWaveCoalesceStarted = null,
-        BrokerUnackedByteBudget? unackedBudget = null,
-        int produceApiVersion = 9,
-        bool isTransactional = false,
-        bool usesTransactionV2 = false,
-        Func<ReadyBatch[], int, Action<Exception?>, HashSet<TopicPartition>, HashSet<TopicPartition>,
-            TransactionPartitionEnrollmentResult>?
-            tryEnsurePartitionsInTransaction = null) =>
-        new(
-            brokerId: 1, pool,
-            metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
-            accumulator, options,
-            new CompressionCodecRegistry(),
-            inflightTracker: new PartitionInflightTracker(),
-            getProduceApiVersion: () => produceApiVersion,
-            setProduceApiVersion: _ => { },
-            isTransactional: () => isTransactional,
-            tryEnsurePartitionsInTransaction: tryEnsurePartitionsInTransaction,
-            bumpEpoch: null,
-            getCurrentEpoch: null,
-            rerouteBatch,
-            onAcknowledgement: onAcknowledgement,
-            logger: null,
-            onBrokerThrottle: onBrokerThrottle,
-            getTimestamp: getTimestamp,
-            delayForThrottle: delayForThrottle,
-            onBlockedBucketRequeued: onBlockedBucketRequeued,
-            unackedBudget: unackedBudget,
-            usesTransactionV2: () => usesTransactionV2,
-            onPipelinedResponseAcquired: onPipelinedResponseAcquired,
-            onWaveCoalesceStarted: onWaveCoalesceStarted);
 
     private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
@@ -1,12 +1,8 @@
 using System.Buffers;
-using System.Reflection;
-using Dekaf.Compression;
-using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
-using Dekaf.Protocol.Records;
 
 using NSubstitute;
 
@@ -25,10 +21,6 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponseFixture
 {
     private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
-
-    private static readonly Type PendingResponseType = typeof(BrokerSender).GetNestedType(
-        "PendingResponse",
-        BindingFlags.NonPublic)!;
 
     [Test]
     public async Task ArrayReturnGuard_FirstClaimWins_SecondIsRefused()
@@ -59,25 +51,22 @@ public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponse
     [Test]
     public async Task PendingResponse_TryReturnBatchesArray_SecondCallIsNoOp()
     {
-        // Construct a standalone PendingResponse (never attached to a live sender — reflective
-        // calls into running send loops are forbidden, see #2187) and verify the exactly-once
-        // return contract that all five cleanup paths rely on.
-        var batches = ArrayPool<ReadyBatch>.Shared.Rent(1);
-        var generations = ArrayPool<int>.Shared.Rent(1);
-        var pending = Activator.CreateInstance(
-            PendingResponseType,
-            default(PipelinedResponse<ProduceResponse>),
-            batches,
-            generations,
-            0,
-            0L,
-            0L,
-            0L,
-            default(BrokerUnackedByteBudget.DeliverySnapshot))!;
-        var tryReturn = PendingResponseType.GetMethod("TryReturnBatchesArray")!;
+        // Standalone struct, never attached to a live sender. The claim lives in the
+        // reference-typed guard, so it is shared across every by-value copy — the second
+        // call must no-op even from a different copy.
+        var pending = new BrokerSender.PendingResponse(
+            default,
+            ArrayPool<ReadyBatch>.Shared.Rent(1),
+            ArrayPool<int>.Shared.Rent(1),
+            Count: 0,
+            EncodedBytes: 0,
+            DataBytes: 0,
+            RequestStartTime: 0,
+            default);
+        var copy = pending;
 
-        var first = (bool)tryReturn.Invoke(pending, null)!;
-        var second = (bool)tryReturn.Invoke(pending, null)!;
+        var first = pending.TryReturnBatchesArray();
+        var second = copy.TryReturnBatchesArray();
 
         await Assert.That(first).IsTrue();
         await Assert.That(second).IsFalse();

--- a/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingResponseArrayOwnershipTests.cs
@@ -1,0 +1,158 @@
+using System.Buffers;
+using System.Reflection;
+using Dekaf.Compression;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for the one-time-return ownership of PendingResponse's rented arrays and the
+/// buffer-memory release invariant of the send pipeline.
+///
+/// Background (CI run 29594249742): a double return of a PendingResponse batches/generations
+/// array poisons ArrayPool.Shared process-wide — the pool hands the same array to two renters,
+/// letting one request's cleanup corrupt another's slots. The corrupted request then skips its
+/// post-write memory release, permanently orphaning BufferMemory reservations: appends block
+/// until max.block.ms with the buffer "full" while nothing is in flight.
+/// </summary>
+public sealed class PendingResponseArrayOwnershipTests : ScriptedProduceResponseFixture
+{
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+
+    private static readonly Type PendingResponseType = typeof(BrokerSender).GetNestedType(
+        "PendingResponse",
+        BindingFlags.NonPublic)!;
+
+    [Test]
+    public async Task ArrayReturnGuard_FirstClaimWins_SecondIsRefused()
+    {
+        var guard = new BrokerSender.ArrayReturnGuard();
+
+        await Assert.That(guard.TryClaim()).IsTrue();
+        await Assert.That(guard.TryClaim()).IsFalse();
+        await Assert.That(guard.TryClaim()).IsFalse();
+    }
+
+    [Test]
+    public async Task ArrayReturnGuard_ConcurrentClaims_ExactlyOneWins()
+    {
+        var guard = new BrokerSender.ArrayReturnGuard();
+        var winners = 0;
+        var tasks = Enumerable.Range(0, 16).Select(_ => Task.Run(() =>
+        {
+            if (guard.TryClaim())
+                Interlocked.Increment(ref winners);
+        }));
+
+        await Task.WhenAll(tasks);
+
+        await Assert.That(winners).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PendingResponse_TryReturnBatchesArray_SecondCallIsNoOp()
+    {
+        // Construct a standalone PendingResponse (never attached to a live sender — reflective
+        // calls into running send loops are forbidden, see #2187) and verify the exactly-once
+        // return contract that all five cleanup paths rely on.
+        var batches = ArrayPool<ReadyBatch>.Shared.Rent(1);
+        var generations = ArrayPool<int>.Shared.Rent(1);
+        var pending = Activator.CreateInstance(
+            PendingResponseType,
+            default(PipelinedResponse<ProduceResponse>),
+            batches,
+            generations,
+            0,
+            0L,
+            0L,
+            0L,
+            default(BrokerUnackedByteBudget.DeliverySnapshot))!;
+        var tryReturn = PendingResponseType.GetMethod("TryReturnBatchesArray")!;
+
+        var first = (bool)tryReturn.Invoke(pending, null)!;
+        var second = (bool)tryReturn.Invoke(pending, null)!;
+
+        await Assert.That(first).IsTrue();
+        await Assert.That(second).IsFalse();
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task BufferMemory_AckedWaves_AlwaysReleaseReservations(
+        CancellationToken cancellationToken)
+    {
+        // Leak invariant: after every delivered wave the accumulator's buffered-byte counter
+        // must return to zero. In run 29594249742 a delivered wave's reservations were never
+        // released, so all subsequent appends starved for the full max.block.ms.
+        const int waves = 20;
+        const int dataSize = 100;
+        var topic = "test-topic";
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        for (var i = 0; i < waves; i++)
+        {
+            var response = new TaskCompletionSource<ProduceResponse>();
+            response.SetResult(CreateSuccessResponse(topic, partition: 0, baseOffset: i));
+            responseQueue.Enqueue(response);
+        }
+
+        var connection = new TestKafkaConnection();
+        var scripted = RegisterScript(responseQueue);
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            Acks = Acks.Leader,
+            EnableIdempotence = false,
+            RetryBackoffMs = 0,
+            RetryBackoffMaxMs = 0,
+            LingerMs = 0
+        };
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acked = 0;
+        var sender = CreateSender(pool, options, accumulator,
+            (_, _, _, _, _) => Interlocked.Increment(ref acked));
+        var guarded = GuardUnscriptedSends(cancellationToken);
+
+        try
+        {
+            for (var wave = 0; wave < waves; wave++)
+            {
+                await Assert.That(accumulator.TryReserveMemory(dataSize)).IsTrue();
+                sender.Enqueue(CreateTestBatch(
+                    valueTaskSourcePool, topic, partition: 0,
+                    markMemoryReleased: false, dataSize: dataSize));
+
+                var expectedAcks = wave + 1;
+                await TestWait.UntilAsync(
+                    () => Volatile.Read(ref acked) == expectedAcks
+                        && accumulator.BufferedBytes == 0,
+                    WaitTimeout,
+                    () => $"Wave {expectedAcks}: acked={Volatile.Read(ref acked)}, " +
+                        $"bufferedBytes={accumulator.BufferedBytes} (expected 0 — orphaned reservation)",
+                    guarded,
+                    pollInterval: TimeSpan.FromMilliseconds(1));
+            }
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -1,4 +1,11 @@
+using System.Buffers;
+using Dekaf.Compression;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Tests.Unit.Producer;
 
@@ -154,4 +161,111 @@ public abstract class ScriptedProduceResponseFixture
         if (failure is not null)
             throw failure;
     }
+
+    /// <summary>
+    /// Creates a minimal ReadyBatch suitable for send loop testing.
+    /// Sets MemoryReleased=true by default to skip accumulator memory tracking; pass
+    /// markMemoryReleased: false for tests that exercise real buffer-memory accounting
+    /// (the caller must then reserve dataSize bytes on the accumulator first).
+    /// </summary>
+    private protected static ReadyBatch CreateTestBatch(
+        ValueTaskSourcePool<RecordMetadata> pool,
+        string topic, int partition, int messageCount = 1,
+        bool markMemoryReleased = true, int dataSize = 100)
+    {
+        var batch = new ReadyBatch();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(messageCount);
+        for (var i = 0; i < messageCount; i++)
+            sources[i] = pool.Rent();
+
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            messageCount,
+            dataSize: dataSize);
+
+        if (markMemoryReleased)
+        {
+            // Skip accumulator memory tracking in tests
+            batch.TrySetMemoryReleased();
+        }
+
+        return batch;
+    }
+
+    /// <summary>
+    /// Creates a ProduceResponse with success for the given topic/partition.
+    /// </summary>
+    private protected static ProduceResponse CreateSuccessResponse(
+        string topic, int partition, long baseOffset, int throttleTimeMs = 0) =>
+        new()
+        {
+            ThrottleTimeMs = throttleTimeMs,
+            TopicCount = 1,
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = topic,
+                    PartitionCount = 1,
+                    PartitionResponses =
+                    [
+                        new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = ErrorCode.None,
+                            BaseOffset = baseOffset
+                        }
+                    ]
+                }
+            ]
+        };
+
+    /// <summary>
+    /// Creates a BrokerSender with standard test defaults, reducing constructor boilerplate.
+    /// </summary>
+    private protected static BrokerSender CreateSender(
+        IConnectionPool pool,
+        ProducerOptions options,
+        RecordAccumulator accumulator,
+        Action<TopicPartition, long, DateTimeOffset, int, Exception?> onAcknowledgement,
+        MetadataManager? metadataManager = null,
+        Action<ReadyBatch, int>? rerouteBatch = null,
+        Action<int>? onBrokerThrottle = null,
+        Func<long>? getTimestamp = null,
+        Func<int, CancellationToken, ValueTask>? delayForThrottle = null,
+        Action? onBlockedBucketRequeued = null,
+        Action? onPipelinedResponseAcquired = null,
+        Action? onWaveCoalesceStarted = null,
+        BrokerUnackedByteBudget? unackedBudget = null,
+        int produceApiVersion = 9,
+        bool isTransactional = false,
+        bool usesTransactionV2 = false,
+        Func<ReadyBatch[], int, Action<Exception?>, HashSet<TopicPartition>, HashSet<TopicPartition>,
+            TransactionPartitionEnrollmentResult>?
+            tryEnsurePartitionsInTransaction = null) =>
+        new(
+            brokerId: 1, pool,
+            metadataManager ?? new MetadataManager(pool, options.BootstrapServers),
+            accumulator, options,
+            new CompressionCodecRegistry(),
+            inflightTracker: new PartitionInflightTracker(),
+            getProduceApiVersion: () => produceApiVersion,
+            setProduceApiVersion: _ => { },
+            isTransactional: () => isTransactional,
+            tryEnsurePartitionsInTransaction: tryEnsurePartitionsInTransaction,
+            bumpEpoch: null,
+            getCurrentEpoch: null,
+            rerouteBatch,
+            onAcknowledgement: onAcknowledgement,
+            logger: null,
+            onBrokerThrottle: onBrokerThrottle,
+            getTimestamp: getTimestamp,
+            delayForThrottle: delayForThrottle,
+            onBlockedBucketRequeued: onBlockedBucketRequeued,
+            unackedBudget: unackedBudget,
+            usesTransactionV2: () => usesTransactionV2,
+            onPipelinedResponseAcquired: onPipelinedResponseAcquired,
+            onWaveCoalesceStarted: onWaveCoalesceStarted);
 }


### PR DESCRIPTION
Fixes #2199.

## Root cause

Release-gate run [29594249742](https://github.com/thomhurst/Dekaf/actions/runs/29594249742) (AOT/4.3.1 produce lane): `BufferFull_ProduceBlocks_UntilBatchSent` timed out after the full 120s `max.block.ms` with live usage 65508/65536. The attempt-1 artifact's trace spans show a fully delivered first wave (~59 messages, sent + acked + `ProduceAsync` resolved successfully in 4.5ms) whose BufferMemory reservations were **never refunded** — zero admissions for 120s, then an instant graceful dispose (nothing left in flight). Full evidence trail and static-analysis elimination in #2199.

The surviving mechanism is cross-request array aliasing after an `ArrayPool.Shared` double return of a `PendingResponse` batches/generations array (#2187 family; production windows tracked in #2195). `ReturnBatchesArray` was documented "must be called exactly once — not idempotent" yet had five call sites; e.g. an exception escaping `ProcessCompletedResponses` between the return and list compaction leaves the returned entry queued for re-processing and a second return.

## Changes

- **Exactly-once array return**: `PendingResponse` carries a per-request `ArrayReturnGuard` (reference type — the struct is copied by value, every copy must share the claim). All five cleanup paths funnel through `ReturnPendingResponseArrays`; the first call returns the arrays, later calls no-op and log a Warning. This kills the double-return → pool-poisoning family at the source and provides the telemetry to find any path that actually double-fires.
- **Release-loop robustness**: the post-write memory-release loop skips null slots (matching the sibling catch handlers' `batch is null ||` idiom) instead of NRE-ing past the remaining batches' releases — previously one corrupted slot orphaned every subsequent batch's reservation in the request.
- **Diagnosable timeouts**: buffer-allocation timeout messages now include in-flight and unsealed batch counts via a shared `BuildBufferTimeoutMessage` (both throw sites stay in sync). The observed failure would have read `in-flight batches: 0, unsealed batches: 0` — an immediate refund-leak signature instead of "network too slow".

## Tests

- `ArrayReturnGuard` claim semantics: first-wins, 16-way concurrent exactly-one-winner.
- `PendingResponse.TryReturnBatchesArray` cross-copy no-op contract (standalone instance — no reflective calls into live senders, per the #2187 lesson).
- Leak invariant: 20 acked waves through the scripted send loop, asserting `BufferedBytes` returns to 0 after every wave.
- Shared test helpers (`CreateTestBatch`/`CreateSuccessResponse`/`CreateSender`) hoisted into `ScriptedProduceResponseFixture`; 7 duplicate copies deleted across the sibling fixtures.

## Verification

- Unit suite: 5591/5591 (new tests looped 5x for stability).
- Backpressure integration category: 9/9 against a real broker via Docker — includes the originally failing test.
- Perf: the guard adds one small allocation + one `Interlocked.Exchange` per **request** (per batch group, not per message) — within the project's per-batch allocation budget; no stress lane needed.

## Explicitly out of scope (tracked in #2199)

Single-ownership consolidation of the five cleanup lifecycle paths and the return-then-compact ordering in `ProcessCompletedResponses` — the Warning log added here is the instrument for finding any real double-cleanup path before that refactor.

Also (named per review): a stale re-processed entry would re-fire its entry-level side effects that run before the array return — `_unackedBudget.OnAcked`/`NotePartialDeliverySuccess` and the user-facing `_onAcknowledgement` interceptor callback — which sit outside the per-batch incarnation guard. Tracked as an explicit item in #2199.
