### PR TITLE
Stabilize revoke timeout test

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4272,10 +4272,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(_options.RebalanceTimeoutMs);
 
+        await CommitRevokedOffsetsWithTimeoutAsync(partitions, cancellationToken, timeout.Token)
+            .ConfigureAwait(false);
+    }
+
+    private async ValueTask CommitRevokedOffsetsWithTimeoutAsync(
+        IReadOnlyList<TopicPartition> partitions,
+        CancellationToken cancellationToken,
+        CancellationToken commitCancellationToken)
+    {
         try
         {
             var revoked = partitions.ToHashSet();
-            if (await CommitStoredOffsetsAsync(revoked, timeout.Token).ConfigureAwait(false))
+            if (await CommitStoredOffsetsAsync(revoked, commitCancellationToken).ConfigureAwait(false))
                 LogCommittedRevokedOffsets();
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -380,27 +380,33 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
-    [Timeout(5_000)]
-    public async Task Revoke_WhenCommitExceedsRebalanceTimeout_Continues(
-        CancellationToken cancellationToken)
+    public async Task Revoke_WhenCommitExceedsRebalanceTimeout_Continues()
     {
         var requests = new List<OffsetCommitRequest>();
         var commitAttempt = 0;
+        var commitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var consumer = CreateConsumer(
             requests,
             ErrorCode.None,
             OffsetCommitMode.Auto,
             enableAutoOffsetStore: false,
-            rebalanceTimeoutMs: 25,
-            onOffsetCommitAsync: token => Interlocked.Increment(ref commitAttempt) == 1
-                ? new ValueTask(Task.Delay(Timeout.InfiniteTimeSpan, token))
-                : ValueTask.CompletedTask);
+            onOffsetCommitAsync: async token =>
+            {
+                if (Interlocked.Increment(ref commitAttempt) != 1)
+                    return;
+
+                commitStarted.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            });
         var revoked = new TopicPartition("topic-a", 0);
         consumer.StoreOffset(new TopicPartitionOffset(revoked.Topic, revoked.Partition, 10));
+        using var rebalanceTimeout = new CancellationTokenSource();
 
-        await CommitRevokedOffsetsAsync(consumer, [revoked]);
+        var commit = CommitRevokedOffsetsWithTimeoutAsync(consumer, [revoked], rebalanceTimeout.Token);
+        await commitStarted.Task;
+        await rebalanceTimeout.CancelAsync();
+        await commit;
 
-        cancellationToken.ThrowIfCancellationRequested();
         await Assert.That(requests).Count().IsEqualTo(1);
     }
 
@@ -666,6 +672,20 @@ public sealed class ConsumerDirtyCommitTests
             BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         await (ValueTask)method.Invoke(consumer, [partitions, CancellationToken.None])!;
+    }
+
+    private static async Task CommitRevokedOffsetsWithTimeoutAsync(
+        KafkaConsumer<string, string> consumer,
+        IReadOnlyList<TopicPartition> partitions,
+        CancellationToken commitCancellationToken)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "CommitRevokedOffsetsWithTimeoutAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await (ValueTask)method.Invoke(
+            consumer,
+            [partitions, CancellationToken.None, commitCancellationToken])!;
     }
 
     private static ConsumeResult<string, string> CreateConsumeResult(long offset, int leaderEpoch)


### PR DESCRIPTION
## Summary

- separate revoke timeout scheduling from timeout cancellation handling
- drive the timeout path with deterministic cancellation after the commit request starts
- remove the 25ms timer and 5-second test deadline race

## Root cause

The test depended on `CancellationTokenSource.CancelAfter(25)` firing promptly. During a full unit-suite run under machine load, the timer callback could be delayed beyond the test's 5-second deadline even though the consumer logic was correct.

The production path still schedules cancellation from `RebalanceTimeoutMs`; the test now injects and triggers that cancellation only after the mocked commit has started.

## Validation

- Release build: 0 warnings, 0 errors (`net8.0`, `net10.0`)
- targeted test: passed on `net8.0` and `net10.0`
- concurrent full unit suites: 5,465 passed on `net8.0`; 5,591 passed on `net10.0`

Closes #2193