### PR TITLE
fix(producer): consolidate pending-response cleanup

### DIFF
--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -53,6 +53,18 @@ internal static class DekafMetrics
             unit: "{fault}",
             description: "Producer completion-source faults isolated while completing messages.");
 
+    internal static readonly Counter<long> PendingResponseCleanupDeferred =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "dekaf.producer.pending_response.cleanup.deferred",
+            unit: "{response}",
+            description: "Pending responses whose pooled arrays remained owned by a send loop after disposal timed out.");
+
+    internal static readonly Counter<long> PendingResponseCleanupRecovered =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "dekaf.producer.pending_response.cleanup.recovered",
+            unit: "{response}",
+            description: "Deferred pending-response array cleanups later completed by the send loop; deferred minus recovered is still stranded.");
+
     // Consumer metrics
     internal static readonly Counter<long> MessagesReceived =
         DekafDiagnostics.Meter.CreateCounter<long>(

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -192,6 +192,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         private ArrayReturnGuard ReturnGuard { get; } = new();
 
         /// <summary>
+        /// True for the default-valued tombstone left in a pending list by
+        /// <c>ClaimPendingResponseAt</c>. Live entries always have Count &gt; 0
+        /// (SendCoalescedAsync never constructs an empty PendingResponse).
+        /// </summary>
+        public bool IsClaimed => Count == 0;
+
+        /// <summary>
         /// Returns true if the batch at index <paramref name="i"/> is the same incarnation
         /// that was present when this PendingResponse was created.
         /// </summary>
@@ -3081,8 +3088,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// the connection and calls cancelInFlightRequests() for the node.
     /// <para/>
     /// Processing happens synchronously in the single-threaded send loop. Entries are
-    /// removed from the connection's pending list BEFORE processing, so ProcessCompletedResponses
-    /// cannot also process the same batches (eliminating the race condition).
+    /// claimed (tombstoned) in the connection's pending list BEFORE processing, so
+    /// ProcessCompletedResponses cannot also process the same batches (eliminating the
+    /// race condition), and the list is cleared once after the scan.
     /// <para/>
     /// The affected connection is also invalidated so the next send
     /// establishes a fresh connection. Response tasks from the old connection are orphaned —
@@ -3124,9 +3132,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
 
-            while (pendingList.Count > 0)
+            // Claim entries in a single forward scan (preserving per-partition FIFO
+            // redelivery order) and clear the list once at the end. Repeated RemoveAt(0)
+            // would be O(n²) over up to MaxInFlightRequestsPerConnection entries — a
+            // send-loop stall at the worst moment, right as a request timeout fires.
+            for (var entryIdx = 0; entryIdx < pendingList.Count; entryIdx++)
             {
-                var pending = RemovePendingResponseAt(connIdx, 0);
+                var pending = ClaimPendingResponseAt(connIdx, entryIdx);
+                if (pending.IsClaimed)
+                    continue;
                 try
                 {
                     for (var j = 0; j < pending.Count; j++)
@@ -3178,6 +3192,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     ReturnPendingResponseArrays(in pending);
                 }
             }
+
+            pendingList.Clear();
 
             if (_hasMigratingPartitions)
                 CompleteMigrations(connIdx);
@@ -4652,19 +4668,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         var pendingList = _pendingResponsesByConnection[connectionIndex];
         var pending = pendingList[index];
         pendingList[index] = default;
-        if (pending.Count == 0)
+        if (pending.IsClaimed)
             return pending;
 
         Interlocked.Decrement(ref _totalPendingResponseCount);
         Interlocked.Add(ref _totalPendingResponseBytes, -pending.EncodedBytes);
         Interlocked.Add(ref _pendingResponseBytesByConnection[connectionIndex], -pending.EncodedBytes);
-        return pending;
-    }
-
-    private PendingResponse RemovePendingResponseAt(int connectionIndex, int index)
-    {
-        var pending = ClaimPendingResponseAt(connectionIndex, index);
-        _pendingResponsesByConnection[connectionIndex].RemoveAt(index);
         return pending;
     }
 
@@ -4674,7 +4683,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         for (var readIndex = 0; readIndex < pendingResponses.Count; readIndex++)
         {
             var pending = pendingResponses[readIndex];
-            if (pending.Count == 0)
+            if (pending.IsClaimed)
                 continue;
 
             pendingResponses[writeIndex++] = pending;
@@ -4704,10 +4713,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
              connectionIndex++)
         {
             var pendingList = _pendingResponsesByConnection[connectionIndex];
-            while (pendingList.Count > 0)
+            // Forward-scan claim + single Clear, as in HandleTimedOutRequests.
+            for (var entryIdx = 0; entryIdx < pendingList.Count; entryIdx++)
             {
-                var pending = RemovePendingResponseAt(connectionIndex, 0);
-                if (pending.Count == 0)
+                var pending = ClaimPendingResponseAt(connectionIndex, entryIdx);
+                if (pending.IsClaimed)
                     continue;
 
                 try
@@ -4740,6 +4750,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     ReturnPendingResponseArrays(in pending);
                 }
             }
+
+            pendingList.Clear();
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -438,6 +438,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _count--;
         }
 
+        /// <summary>Clears one partition's queue in a single pass, keeping the count in sync.</summary>
+        public void ClearQueue(List<BatchReference> queue)
+        {
+            _count -= queue.Count;
+            queue.Clear();
+        }
+
         public bool HasRetry(TopicPartition topicPartition)
         {
             if (!_partitions.TryGetValue(topicPartition, out var queue))
@@ -2588,17 +2595,30 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!carryOver.Partitions.TryGetValue(topicPartition, out var queue))
                 continue;
 
-            while (queue.Count > 0)
+            // Forward scan + single ClearQueue: repeated RemoveAt(0) would be O(n²), and
+            // the queue can hold a deep retry backlog (bounded by BufferMemory, not
+            // max-in-flight). The per-entry body never throws, so every entry is either
+            // failed here or — if the loop dies catastrophically — still queued for the
+            // loop-exit sweep; the old remove-then-finalize order could drop a batch
+            // (removed but not yet failed) if finalization threw.
+            for (var i = 0; i < queue.Count; i++)
             {
-                var batchReference = queue[0];
-                carryOver.RemoveAt(queue, 0);
+                var batchReference = queue[i];
                 if (!batchReference.IsCurrentIncarnation())
                 {
                     LogStaleBatchInSendSkipped(_instanceId, _brokerId);
                     continue;
                 }
 
-                FinalizeFailedTransactionEnrollmentRetry(batchReference.Batch);
+                try
+                {
+                    FinalizeFailedTransactionEnrollmentRetry(batchReference.Batch);
+                }
+                catch (Exception finalizeError)
+                {
+                    LogBatchCleanupStepFailed(finalizeError, _brokerId);
+                }
+
                 try
                 {
                     FailAndCleanupBatch(batchReference.Batch, batchReference.Generation, error);
@@ -2608,6 +2628,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     LogBatchCleanupStepFailed(cleanupError, _brokerId);
                 }
             }
+
+            carryOver.ClearQueue(queue);
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -621,8 +621,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly long _scaleDownSustainedMs;
 
     // Maintained counter for O(1) hot-path access. Incremented in SendCoalescedAsync
-    // when a PendingResponse is added, decremented in ProcessCompletedResponses and
-    // HandleTimedOutRequests when entries are removed. Must use Interlocked: with
+    // when a PendingResponse is added and decremented when ClaimPendingResponseAt
+    // transfers its ownership out of the list. Must use Interlocked: with
     // multi-connection sends, concurrent SendCoalescedAsync calls increment from
     // different threads. Non-atomic ++ silently loses increments, causing the send
     // loop to undercount pending responses and enter idle wait prematurely.
@@ -699,6 +699,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </remarks>
     private readonly Action _responseCompletionCallback;
     private int _disposed;
+    private int _deferredPendingResponseCleanupCount;
 
     public BrokerSender(
         int brokerId,
@@ -2000,30 +2001,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // Disposition order preserves per-partition FIFO for redelivery:
                 // in-flight pending responses hold the oldest batches, then already-recovered work,
                 // send-failed retries, this pass's coalesced head, carry-over, and channel backlog.
-                for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
-                {
-                    var pendingList = _pendingResponsesByConnection[connIdx];
-                    for (var i = 0; i < pendingList.Count; i++)
-                    {
-                        var pr = pendingList[i];
-                        for (var j = 0; j < pr.Count; j++)
-                        {
-                            if (pr.IsSameIncarnation(j))
-                                CollectOrFailOnLoopExit(
-                                    new BatchReference(pr.Batches[j], pr.BatchGenerations[j]),
-                                    redeliver, disposedException,
-                                    recoveredBatches, recoveredBatchSet);
-                        }
-                        pr.ResponseTask.Abandon();
-                        ReturnPendingResponseArrays(in pr);
-                    }
-                    Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
-                    var removedBytes = SumEncodedBytes(pendingList);
-                    Interlocked.Add(ref _totalPendingResponseBytes, -removedBytes);
-                    Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -removedBytes);
-                    pendingList.Clear();
-                    // No TrimExcess — lists are unreachable after disposal
-                }
+                CleanupPendingResponsesOnLoopExit(
+                    redeliver,
+                    disposedException,
+                    recoveredBatches,
+                    recoveredBatchSet);
+                RecordDeferredPendingResponseCleanupRecovered();
 
                 while (_loopExitRedeliveries.TryDequeue(out var redelivery))
                 {
@@ -2710,7 +2693,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// <summary>
     /// Polls _pendingResponsesByConnection for completed response tasks and processes them inline.
     /// Equivalent to Java's Sender processing completed sends inside NetworkClient.poll().
-    /// Uses compact-in-place pattern to avoid list allocation during removal.
+    /// Claims completed entries before processing, then compacts their tombstones in place.
+    /// This prevents exit cleanup from observing a returned array after an exception without
+    /// adding allocations or quadratic List.RemoveAt shifts to the response hot path.
     /// </summary>
     private void ProcessCompletedResponses(
         PartitionCarryOver carryOver,
@@ -2730,156 +2715,165 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var pendingList = _pendingResponsesByConnection[connIdx];
             if (pendingList.Count == 0) continue;
 
-            var writeIdx = 0;
-            long completedResponseBytes = 0;
+            var removedAny = false;
             for (var i = 0; i < pendingList.Count; i++)
             {
                 var pending = pendingList[i];
                 if (!pending.ResponseTask.IsCompleted)
                 {
-                    // Keep this entry — compact in-place
-                    pendingList[writeIdx++] = pending;
                     continue;
                 }
 
+                pending = ClaimPendingResponseAt(connIdx, i);
+                removedAny = true;
                 var task = pending.ResponseTask;
-                completedResponseBytes += pending.EncodedBytes;
                 var batches = pending.Batches;
                 var count = pending.Count;
+                ProduceResponse? responseToReturn = null;
+                Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? responseLookupToClear = null;
 
-                if (task.IsFaulted || task.IsCanceled)
+                try
                 {
-                    Exception ex;
-                    try
+                    if (task.IsFaulted || task.IsCanceled)
                     {
-                        _ = task.GetResult();
-                        ex = new OperationCanceledException();
-                    }
-                    catch (Exception responseException)
-                    {
-                        ex = responseException;
-                    }
-                    LogResponseFailed(ex, _brokerId);
-                    _pinnedConnections[connIdx] = null; // Invalidate only the affected connection
-
-                    for (var j = 0; j < count; j++)
-                    {
-                        if (pending.IsSameIncarnation(j))
+                        Exception ex;
+                        try
                         {
-                            batches[j].AppendDiag('P'); // Faulted/cancelled response processed
-                            try
+                            _ = task.GetResult();
+                            ex = new OperationCanceledException();
+                        }
+                        catch (Exception responseException)
+                        {
+                            ex = responseException;
+                        }
+                        LogResponseFailed(ex, _brokerId);
+                        _pinnedConnections[connIdx] = null; // Invalidate only the affected connection
+
+                        for (var j = 0; j < count; j++)
+                        {
+                            if (pending.IsSameIncarnation(j))
                             {
-                                HandleRetriableBatch(batches[j], pending.BatchGenerations[j], ErrorCode.NetworkException,
-                                    carryOver, cancellationToken);
-                            }
-                            catch (Exception batchEx)
-                            {
-                                try { FailAndCleanupBatch(batches[j], ex); }
-                                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                                LogBatchCleanupStepFailed(batchEx, _brokerId);
+                                batches[j].AppendDiag('P'); // Faulted/cancelled response processed
+                                try
+                                {
+                                    HandleRetriableBatch(batches[j], pending.BatchGenerations[j], ErrorCode.NetworkException,
+                                        carryOver, cancellationToken);
+                                }
+                                catch (Exception batchEx)
+                                {
+                                    try { FailAndCleanupBatch(batches[j], ex); }
+                                    catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                                    LogBatchCleanupStepFailed(batchEx, _brokerId);
+                                }
                             }
                         }
+
+                        continue;
+                    }
+
+                    var response = task.GetResult();
+                    responseToReturn = response;
+                    ObserveBrokerThrottle(response.ThrottleTimeMs);
+                    var allPartitionsSucceeded = true;
+                    var anyPartitionSucceeded = false;
+                    ProduceResponsePartitionData? directResponse = null;
+                    // Reuse caller-provided dictionary to avoid per-response allocation.
+                    // The dictionary is cleared after use in ProcessResponseBatches.
+                    var responseLookup = reusableResponseLookup;
+                    responseLookupToClear = responseLookup;
+                    if (count == 1
+                        && batches[0] is { } directBatch
+                        && response.TopicCount == 1
+                        && response.Responses[0].PartitionCount == 1
+                        && IsMatchingResponsePartition(
+                            directBatch.TopicPartition,
+                            response.Responses[0].Name,
+                            response.Responses[0].PartitionResponses[0].Index))
+                    {
+                        var partitionResponse = response.Responses[0].PartitionResponses[0];
+                        directResponse = partitionResponse;
+                        allPartitionsSucceeded = partitionResponse.ErrorCode == ErrorCode.None;
+                        anyPartitionSucceeded = allPartitionsSucceeded;
+                    }
+                    else
+                    {
+                        for (var t = 0; t < response.TopicCount; t++)
+                        {
+                            ref var topicResp = ref response.Responses[t];
+                            for (var p = 0; p < topicResp.PartitionCount; p++)
+                            {
+                                if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
+                                    allPartitionsSucceeded = false;
+                                else
+                                    anyPartitionSucceeded = true;
+                                responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
+                                responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] =
+                                    topicResp.PartitionResponses[p];
+                            }
+                        }
+                    }
+
+                    if (allPartitionsSucceeded && _unackedBudget is { } unackedBudget)
+                    {
+                        // Feed logical request bytes and direct timing into the broker window.
+                        // Publication remains once per response pass, keeping the ack path O(1).
+                        lastAckTimestamp = Stopwatch.GetTimestamp();
+                        unackedBudget.OnAcked(
+                            pending.DataBytes,
+                            pending.DeliverySnapshotAtSend,
+                            lastAckTimestamp);
+                        anyAckedThisPass = true;
+                    }
+                    else if (anyPartitionSucceeded && _unackedBudget is { } partiallyAckedBudget)
+                    {
+                        // Mixed responses carry no cleanly attributable request timing, so they
+                        // feed no window sample — but a delivered partition still proves the
+                        // broker drains data, which must end the cold-start clamp.
+                        partiallyAckedBudget.NotePartialDeliverySuccess();
+                    }
+
+                    // Diagnostic: log response content and expected batches for mismatch diagnosis
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        var batchKeys = string.Join(", ",
+                            Enumerable.Range(0, count)
+                                .Where(idx => batches[idx] is not null)
+                                .Select(idx => $"{batches[idx].TopicPartition.Topic}-{batches[idx].TopicPartition.Partition}"));
+                        var respKeys = directResponse is not null
+                            ? $"{batches[0].TopicPartition.Topic}-{directResponse.Value.Index}"
+                            : responseLookup is not null
+                                ? string.Join(", ", responseLookup.Keys.Select(k => $"{k.Topic}-{k.Partition}"))
+                                : "(empty)";
+                        LogProduceResponseProcessed(_instanceId, _brokerId, task.Id, count, batchKeys,
+                            directResponse is not null ? 1 : responseLookup?.Count ?? 0, respKeys);
+                    }
+
+                    responseLookupToClear = responseLookup;
+                    ProcessResponseBatches(pending, directResponse, responseLookup, response.NodeEndpoints,
+                        carryOver, cancellationToken, task.Id);
+                }
+                catch
+                {
+                    QueueDetachedPendingResponseForLoopExit(in pending);
+                    throw;
+                }
+                finally
+                {
+                    try { responseLookupToClear?.Clear(); }
+                    catch (Exception clearEx) { LogBatchCleanupStepFailed(clearEx, _brokerId); }
+                    if (responseToReturn is not null)
+                    {
+                        try { responseToReturn.Return(); }
+                        catch (Exception returnEx) { LogBatchCleanupStepFailed(returnEx, _brokerId); }
                     }
 
                     ReturnPendingResponseArrays(in pending);
-                    continue;
                 }
-
-                var response = task.GetResult();
-                ObserveBrokerThrottle(response.ThrottleTimeMs);
-                var allPartitionsSucceeded = true;
-                var anyPartitionSucceeded = false;
-                ProduceResponsePartitionData? directResponse = null;
-                // Reuse caller-provided dictionary to avoid per-response allocation.
-                // The dictionary is cleared after use in ProcessResponseBatches.
-                var responseLookup = reusableResponseLookup;
-                if (count == 1
-                    && batches[0] is { } directBatch
-                    && response.TopicCount == 1
-                    && response.Responses[0].PartitionCount == 1
-                    && IsMatchingResponsePartition(
-                        directBatch.TopicPartition,
-                        response.Responses[0].Name,
-                        response.Responses[0].PartitionResponses[0].Index))
-                {
-                    var partitionResponse = response.Responses[0].PartitionResponses[0];
-                    directResponse = partitionResponse;
-                    allPartitionsSucceeded = partitionResponse.ErrorCode == ErrorCode.None;
-                    anyPartitionSucceeded = allPartitionsSucceeded;
-                }
-                else
-                {
-                    for (var t = 0; t < response.TopicCount; t++)
-                    {
-                        ref var topicResp = ref response.Responses[t];
-                        for (var p = 0; p < topicResp.PartitionCount; p++)
-                        {
-                            if (topicResp.PartitionResponses[p].ErrorCode != ErrorCode.None)
-                                allPartitionsSucceeded = false;
-                            else
-                                anyPartitionSucceeded = true;
-                            responseLookup ??= new Dictionary<(string, int), ProduceResponsePartitionData>();
-                            responseLookup[(topicResp.Name, topicResp.PartitionResponses[p].Index)] =
-                                topicResp.PartitionResponses[p];
-                        }
-                    }
-                }
-
-                if (allPartitionsSucceeded && _unackedBudget is { } unackedBudget)
-                {
-                    // Feed logical request bytes and direct timing into the broker window.
-                    // Publication remains once per response pass, keeping the ack path O(1).
-                    lastAckTimestamp = Stopwatch.GetTimestamp();
-                    unackedBudget.OnAcked(
-                        pending.DataBytes,
-                        pending.DeliverySnapshotAtSend,
-                        lastAckTimestamp);
-                    anyAckedThisPass = true;
-                }
-                else if (anyPartitionSucceeded && _unackedBudget is { } partiallyAckedBudget)
-                {
-                    // Mixed responses carry no cleanly attributable request timing, so they
-                    // feed no window sample — but a delivered partition still proves the
-                    // broker drains data, which must end the cold-start clamp.
-                    partiallyAckedBudget.NotePartialDeliverySuccess();
-                }
-
-                // Diagnostic: log response content and expected batches for mismatch diagnosis
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    var batchKeys = string.Join(", ",
-                        Enumerable.Range(0, count)
-                            .Where(idx => batches[idx] is not null)
-                            .Select(idx => $"{batches[idx].TopicPartition.Topic}-{batches[idx].TopicPartition.Partition}"));
-                    var respKeys = directResponse is not null
-                        ? $"{batches[0].TopicPartition.Topic}-{directResponse.Value.Index}"
-                        : responseLookup is not null
-                            ? string.Join(", ", responseLookup.Keys.Select(k => $"{k.Topic}-{k.Partition}"))
-                            : "(empty)";
-                    LogProduceResponseProcessed(_instanceId, _brokerId, task.Id, count, batchKeys,
-                        directResponse is not null ? 1 : responseLookup?.Count ?? 0, respKeys);
-                }
-
-                ProcessResponseBatches(pending, directResponse, responseLookup, response.NodeEndpoints,
-                    carryOver, cancellationToken, task.Id);
-
-                // Clear for reuse on next response (avoids per-response dictionary allocation)
-                responseLookup?.Clear();
-
-                // Return pooled ProduceResponse for reuse
-                if (response is ProduceResponse poolableResponse)
-                    poolableResponse.Return();
-
-                ReturnPendingResponseArrays(in pending);
             }
 
-            // Compact: remove processed entries from the end
-            if (writeIdx < pendingList.Count)
+            if (removedAny)
             {
-                Interlocked.Add(ref _totalPendingResponseCount, -(pendingList.Count - writeIdx));
-                Interlocked.Add(ref _totalPendingResponseBytes, -completedResponseBytes);
-                Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -completedResponseBytes);
-                pendingList.RemoveRange(writeIdx, pendingList.Count - writeIdx);
+                CompactClaimedPendingResponses(pendingList);
 
                 // Prevent unbounded capacity ratcheting: when the list shrinks well below
                 // its internal array capacity, trim the excess. This is amortized — it only
@@ -3130,57 +3124,60 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             var deliveryTimeoutTicks = _options.DeliveryTimeoutTicks;
 
-            for (var i = 0; i < pendingList.Count; i++)
+            while (pendingList.Count > 0)
             {
-                var pending = pendingList[i];
-                for (var j = 0; j < pending.Count; j++)
+                var pending = RemovePendingResponseAt(connIdx, 0);
+                try
                 {
-                    if (!pending.IsSameIncarnation(j)) continue;
-                    var batch = pending.Batches[j];
-
-                    batch.AppendDiag('T'); // Timed-out request
-
-                    // Check delivery deadline: if exceeded, permanently fail the batch.
-                    // Otherwise, retry (like Java's handleProduceResponse for disconnected requests).
-                    if (now >= batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
+                    for (var j = 0; j < pending.Count; j++)
                     {
-                        UnmutePartition(batch.TopicPartition);
-                        var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
-                        var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
-                        try
+                        if (!pending.IsSameIncarnation(j)) continue;
+                        var batch = pending.Batches[j];
+
+                        batch.AppendDiag('T'); // Timed-out request
+
+                        // Check delivery deadline: if exceeded, permanently fail the batch.
+                        // Otherwise, retry (like Java's handleProduceResponse for disconnected requests).
+                        if (now >= batch.StopwatchCreatedTicks + deliveryTimeoutTicks)
                         {
-                            FailAndCleanupBatch(batch, new KafkaTimeoutException(
-                                TimeoutKind.Delivery, elapsed, configured,
-                                $"Delivery timeout exceeded while awaiting response for {batch.TopicPartition}"));
-                        }
-                        catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                    }
-                    else
-                    {
-                        try
-                        {
-                            HandleRetriableBatch(batch, pending.BatchGenerations[j], ErrorCode.NetworkException,
-                                carryOver, cancellationToken);
-                        }
-                        catch (Exception batchEx)
-                        {
-                            try { FailAndCleanupBatch(batch, batchEx); }
+                            UnmutePartition(batch.TopicPartition);
+                            var elapsed = Stopwatch.GetElapsedTime(batch.StopwatchCreatedTicks);
+                            var configured = TimeSpan.FromMilliseconds(_options.DeliveryTimeoutMs);
+                            try
+                            {
+                                FailAndCleanupBatch(batch, new KafkaTimeoutException(
+                                    TimeoutKind.Delivery, elapsed, configured,
+                                    $"Delivery timeout exceeded while awaiting response for {batch.TopicPartition}"));
+                            }
                             catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
                         }
+                        else
+                        {
+                            try
+                            {
+                                HandleRetriableBatch(batch, pending.BatchGenerations[j], ErrorCode.NetworkException,
+                                    carryOver, cancellationToken);
+                            }
+                            catch (Exception batchEx)
+                            {
+                                try { FailAndCleanupBatch(batch, batchEx); }
+                                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                            }
+                        }
                     }
+
+                    pending.ResponseTask.Abandon();
                 }
-
-                pending.ResponseTask.Abandon();
-                ReturnPendingResponseArrays(in pending);
+                catch
+                {
+                    QueueDetachedPendingResponseForLoopExit(in pending);
+                    throw;
+                }
+                finally
+                {
+                    ReturnPendingResponseArrays(in pending);
+                }
             }
-
-            // Remove all entries. Response tasks are orphaned — they'll eventually complete
-            // (via CTS timeout or connection disposal) but nobody polls them.
-            Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
-            var removedBytes = SumEncodedBytes(pendingList);
-            Interlocked.Add(ref _totalPendingResponseBytes, -removedBytes);
-            Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -removedBytes);
-            pendingList.Clear();
 
             if (_hasMigratingPartitions)
                 CompleteMigrations(connIdx);
@@ -3462,15 +3459,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     connectionCount)
                 : null,
             _getTimestamp());
-    }
-
-    private static long SumEncodedBytes(List<PendingResponse> pendingResponses)
-    {
-        long total = 0;
-        for (var i = 0; i < pendingResponses.Count; i++)
-            total += pendingResponses[i].EncodedBytes;
-
-        return total;
     }
 
     /// <summary>
@@ -4655,6 +4643,106 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Transfers send-loop ownership of an entry to its caller before processing. The default-valued
+    /// tombstone makes exit cleanup skip the entry if processing throws before compaction.
+    /// </summary>
+    private PendingResponse ClaimPendingResponseAt(int connectionIndex, int index)
+    {
+        var pendingList = _pendingResponsesByConnection[connectionIndex];
+        var pending = pendingList[index];
+        pendingList[index] = default;
+        if (pending.Count == 0)
+            return pending;
+
+        Interlocked.Decrement(ref _totalPendingResponseCount);
+        Interlocked.Add(ref _totalPendingResponseBytes, -pending.EncodedBytes);
+        Interlocked.Add(ref _pendingResponseBytesByConnection[connectionIndex], -pending.EncodedBytes);
+        return pending;
+    }
+
+    private PendingResponse RemovePendingResponseAt(int connectionIndex, int index)
+    {
+        var pending = ClaimPendingResponseAt(connectionIndex, index);
+        _pendingResponsesByConnection[connectionIndex].RemoveAt(index);
+        return pending;
+    }
+
+    private static void CompactClaimedPendingResponses(List<PendingResponse> pendingResponses)
+    {
+        var writeIndex = 0;
+        for (var readIndex = 0; readIndex < pendingResponses.Count; readIndex++)
+        {
+            var pending = pendingResponses[readIndex];
+            if (pending.Count == 0)
+                continue;
+
+            pendingResponses[writeIndex++] = pending;
+        }
+
+        if (writeIndex < pendingResponses.Count)
+            pendingResponses.RemoveRange(writeIndex, pendingResponses.Count - writeIndex);
+    }
+
+    private void QueueDetachedPendingResponseForLoopExit(in PendingResponse pending)
+    {
+        for (var i = 0; i < pending.Count; i++)
+        {
+            if (pending.IsSameIncarnation(i))
+                _loopExitRedeliveries.Enqueue((pending.Batches[i], pending.BatchGenerations[i]));
+        }
+    }
+
+    private void CleanupPendingResponsesOnLoopExit(
+        bool redeliver,
+        ObjectDisposedException disposedException,
+        List<BatchReference>? recoveredBatches,
+        HashSet<(ReadyBatch Batch, int Generation)>? recoveredBatchSet)
+    {
+        for (var connectionIndex = 0;
+             connectionIndex < _pendingResponsesByConnection.Length;
+             connectionIndex++)
+        {
+            var pendingList = _pendingResponsesByConnection[connectionIndex];
+            while (pendingList.Count > 0)
+            {
+                var pending = RemovePendingResponseAt(connectionIndex, 0);
+                if (pending.Count == 0)
+                    continue;
+
+                try
+                {
+                    for (var i = 0; i < pending.Count; i++)
+                    {
+                        if (!pending.IsSameIncarnation(i))
+                            continue;
+
+                        try
+                        {
+                            CollectOrFailOnLoopExit(
+                                new BatchReference(pending.Batches[i], pending.BatchGenerations[i]),
+                                redeliver,
+                                disposedException,
+                                recoveredBatches,
+                                recoveredBatchSet);
+                        }
+                        catch (Exception cleanupEx)
+                        {
+                            LogBatchCleanupStepFailed(cleanupEx, _brokerId);
+                        }
+                    }
+
+                    try { pending.ResponseTask.Abandon(); }
+                    catch (Exception abandonEx) { LogBatchCleanupStepFailed(abandonEx, _brokerId); }
+                }
+                finally
+                {
+                    ReturnPendingResponseArrays(in pending);
+                }
+            }
+        }
+    }
+
     private void DisposeCarryOverBatchesOnLoopExit(
         PartitionCarryOver carryOver,
         bool redeliver,
@@ -4849,8 +4937,43 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// </summary>
     private void ReturnPendingResponseArrays(in PendingResponse pending)
     {
-        if (!pending.TryReturnBatchesArray())
-            LogPendingResponseArraysAlreadyReturned(_instanceId, _brokerId);
+        try
+        {
+            if (!pending.TryReturnBatchesArray())
+                LogPendingResponseArraysAlreadyReturned(_instanceId, _brokerId);
+        }
+        catch (Exception returnEx)
+        {
+            LogBatchCleanupStepFailed(returnEx, _brokerId);
+        }
+    }
+
+    private void RecordDeferredPendingResponseCleanup(int pendingCount)
+    {
+        Interlocked.Exchange(ref _deferredPendingResponseCleanupCount, pendingCount);
+        var tags = new TagList
+        {
+            { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
+        };
+        Diagnostics.DekafMetrics.PendingResponseCleanupDeferred.Add(pendingCount, tags);
+
+        // Close the race where the send loop completed between the caller's IsCompleted
+        // check and publishing the deferred count.
+        if (_sendLoopTask.IsCompleted)
+            RecordDeferredPendingResponseCleanupRecovered();
+    }
+
+    private void RecordDeferredPendingResponseCleanupRecovered()
+    {
+        var recoveredCount = Interlocked.Exchange(ref _deferredPendingResponseCleanupCount, 0);
+        if (recoveredCount == 0)
+            return;
+
+        var tags = new TagList
+        {
+            { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
+        };
+        Diagnostics.DekafMetrics.PendingResponseCleanupRecovered.Add(recoveredCount, tags);
     }
 
     public async ValueTask DisposeAsync()
@@ -4892,9 +5015,12 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             LogBatchCleanupStepFailed(ex, _brokerId);
         }
 
-        // True when the loop finished (normally or faulted — its exit cleanup ran either way);
-        // false when the WaitAsync above timed out and the loop is still running.
-        var sendLoopExited = _sendLoopTask.IsCompleted;
+        var deferredPendingCount = Volatile.Read(ref _totalPendingResponseCount);
+        if (deferredPendingCount > 0 && !_sendLoopTask.IsCompleted)
+        {
+            RecordDeferredPendingResponseCleanup(deferredPendingCount);
+            LogSkippingPendingResponseCleanup(_brokerId, deferredPendingCount);
+        }
 
         // A final send-loop iteration may have already detached a retirement drain after
         // clearing the raw connection fields. Wait for every such drain before inspecting
@@ -4943,48 +5069,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
 
         ClearMigratingPartitions();
-
-        var totalPending = _totalPendingResponseCount;
-        if (totalPending > 0 && !sendLoopExited)
-        {
-            // The send loop is still running and owns _pendingResponsesByConnection. Touching
-            // the lists here would race the loop's own exit cleanup and return the same rented
-            // arrays to ArrayPool.Shared twice — duplicate pool entries later hand one array to
-            // two concurrent requests, pairing responses with the wrong batches (#2187). The
-            // loop's exit path fails these batches and returns the arrays when it completes.
-            LogSkippingPendingResponseCleanup(_brokerId, totalPending);
-        }
-        else if (totalPending > 0)
-        {
-            LogFailingPendingResponses(_brokerId, totalPending);
-
-            for (var connIdx = 0; connIdx < _pendingResponsesByConnection.Length; connIdx++)
-            {
-                var pendingList = _pendingResponsesByConnection[connIdx];
-                for (var i = 0; i < pendingList.Count; i++)
-                {
-                    var pr = pendingList[i];
-                    for (var j = 0; j < pr.Count; j++)
-                    {
-                        if (pr.IsSameIncarnation(j))
-                        {
-                            try { FailAndCleanupBatch(pr.Batches[j], new ObjectDisposedException(nameof(BrokerSender))); }
-                            catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
-                        }
-                    }
-
-                    pr.ResponseTask.Abandon();
-                    ReturnPendingResponseArrays(in pr);
-                }
-
-                Interlocked.Add(ref _totalPendingResponseCount, -pendingList.Count);
-                var removedBytes = SumEncodedBytes(pendingList);
-                Interlocked.Add(ref _totalPendingResponseBytes, -removedBytes);
-                Interlocked.Add(ref _pendingResponseBytesByConnection[connIdx], -removedBytes);
-                pendingList.Clear();
-                // No TrimExcess — lists are unreachable after disposal
-            }
-        }
 
         _cts.Dispose();
         _anyResponseCompleted.Dispose();
@@ -5699,9 +5783,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "BrokerSender[{BrokerId}] waiting for send loop to finish")]
     private partial void LogWaitingForSendLoop(int brokerId);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] failing {RemainingCount} pending responses during disposal")]
-    private partial void LogFailingPendingResponses(int brokerId, int remainingCount);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] send loop still running after disposal wait; leaving {RemainingCount} pending responses to its exit cleanup")]
     private partial void LogSkippingPendingResponseCleanup(int brokerId, int remainingCount);

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2652,7 +2652,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private void FailTransactionEnrollmentBatch(ReadyBatch batch, int generation, Exception error)
     {
-        FinalizeFailedTransactionEnrollmentRetry(batch);
+        // Each step independently guarded: a finalize (unmute) hiccup must neither skip
+        // failing the batch nor escape into the send loop's outer catch, where it would
+        // tear down the whole sender over a single batch.
+        try
+        {
+            FinalizeFailedTransactionEnrollmentRetry(batch);
+        }
+        catch (Exception finalizeError)
+        {
+            LogBatchCleanupStepFailed(finalizeError, _brokerId);
+        }
+
         try
         {
             FailAndCleanupBatch(batch, generation, error);
@@ -2874,8 +2885,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 finally
                 {
                     // A ??=-allocated lookup (reusable was null) is a throwaway local, so only
-                    // the caller's reused dictionary ever needs clearing.
-                    reusableResponseLookup?.Clear();
+                    // the caller's reused dictionary ever needs clearing. Guarded like every
+                    // other step here so a throw cannot skip the pooled-array returns below.
+                    try { reusableResponseLookup?.Clear(); }
+                    catch (Exception clearEx) { LogBatchCleanupStepFailed(clearEx, _brokerId); }
                     if (responseToReturn is not null)
                     {
                         try { responseToReturn.Return(); }
@@ -3188,7 +3201,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         }
                     }
 
-                    pending.ResponseTask.Abandon();
+                    try { pending.ResponseTask.Abandon(); }
+                    catch (Exception abandonEx) { LogBatchCleanupStepFailed(abandonEx, _brokerId); }
                 }
                 catch
                 {

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2020,7 +2020,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     disposedException,
                     recoveredBatches,
                     recoveredBatchSet);
-                RecordDeferredPendingResponseCleanupRecovered();
 
                 while (_loopExitRedeliveries.TryDequeue(out var redelivery))
                 {
@@ -2597,10 +2596,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             // Forward scan + single ClearQueue: repeated RemoveAt(0) would be O(n²), and
             // the queue can hold a deep retry backlog (bounded by BufferMemory, not
-            // max-in-flight). The per-entry body never throws, so every entry is either
-            // failed here or — if the loop dies catastrophically — still queued for the
-            // loop-exit sweep; the old remove-then-finalize order could drop a batch
-            // (removed but not yet failed) if finalization threw.
+            // max-in-flight). Failing in place before removal also means an escaped
+            // exception leaves unprocessed entries queued for the loop-exit sweep — the
+            // old remove-then-finalize order could drop a batch (removed but not yet
+            // failed) with no cleanup path.
             for (var i = 0; i < queue.Count; i++)
             {
                 var batchReference = queue[i];
@@ -2610,23 +2609,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     continue;
                 }
 
-                try
-                {
-                    FinalizeFailedTransactionEnrollmentRetry(batchReference.Batch);
-                }
-                catch (Exception finalizeError)
-                {
-                    LogBatchCleanupStepFailed(finalizeError, _brokerId);
-                }
-
-                try
-                {
-                    FailAndCleanupBatch(batchReference.Batch, batchReference.Generation, error);
-                }
-                catch (Exception cleanupError)
-                {
-                    LogBatchCleanupStepFailed(cleanupError, _brokerId);
-                }
+                FailTransactionEnrollmentBatch(batchReference.Batch, batchReference.Generation, error);
             }
 
             carryOver.ClearQueue(queue);
@@ -2659,20 +2642,25 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 continue;
             }
 
-            FinalizeFailedTransactionEnrollmentRetry(batch);
-            try
-            {
-                FailAndCleanupBatch(batch, generation, error);
-            }
-            catch (Exception cleanupError)
-            {
-                LogBatchCleanupStepFailed(cleanupError, _brokerId);
-            }
+            FailTransactionEnrollmentBatch(batch, generation, error);
         }
 
         Array.Clear(batches, writeIdx, count - writeIdx);
         Array.Clear(generations, writeIdx, count - writeIdx);
         count = writeIdx;
+    }
+
+    private void FailTransactionEnrollmentBatch(ReadyBatch batch, int generation, Exception error)
+    {
+        FinalizeFailedTransactionEnrollmentRetry(batch);
+        try
+        {
+            FailAndCleanupBatch(batch, generation, error);
+        }
+        catch (Exception cleanupError)
+        {
+            LogBatchCleanupStepFailed(cleanupError, _brokerId);
+        }
     }
 
     private void FinalizeFailedTransactionEnrollmentRetry(ReadyBatch batch)
@@ -2759,7 +2747,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 var batches = pending.Batches;
                 var count = pending.Count;
                 ProduceResponse? responseToReturn = null;
-                Dictionary<(string Topic, int Partition), ProduceResponsePartitionData>? responseLookupToClear = null;
 
                 try
                 {
@@ -2809,7 +2796,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // Reuse caller-provided dictionary to avoid per-response allocation.
                     // The dictionary is cleared after use in ProcessResponseBatches.
                     var responseLookup = reusableResponseLookup;
-                    responseLookupToClear = responseLookup;
                     if (count == 1
                         && batches[0] is { } directBatch
                         && response.TopicCount == 1
@@ -2877,7 +2863,6 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             directResponse is not null ? 1 : responseLookup?.Count ?? 0, respKeys);
                     }
 
-                    responseLookupToClear = responseLookup;
                     ProcessResponseBatches(pending, directResponse, responseLookup, response.NodeEndpoints,
                         carryOver, cancellationToken, task.Id);
                 }
@@ -2888,8 +2873,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 finally
                 {
-                    try { responseLookupToClear?.Clear(); }
-                    catch (Exception clearEx) { LogBatchCleanupStepFailed(clearEx, _brokerId); }
+                    // A ??=-allocated lookup (reusable was null) is a throwaway local, so only
+                    // the caller's reused dictionary ever needs clearing.
+                    reusableResponseLookup?.Clear();
                     if (responseToReturn is not null)
                     {
                         try { responseToReturn.Return(); }
@@ -3749,6 +3735,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     dataBytes += batch.DataSize;
                 }
 
+                Debug.Assert(count > 0,
+                    "PendingResponse must never be constructed empty — Count == 0 is the claimed-tombstone sentinel (IsClaimed).");
                 var pendingResponse = new PendingResponse(
                     responseTask,
                     batches,
@@ -4684,6 +4672,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// <summary>
     /// Transfers send-loop ownership of an entry to its caller before processing. The default-valued
     /// tombstone makes exit cleanup skip the entry if processing throws before compaction.
+    /// Every claim pass must compact or clear its list before returning to the loop: read-only
+    /// scanners (ComputeNextWakeupMs, IsRequestTimeoutDue) assume tombstone-free lists, and a
+    /// surviving tombstone's RequestStartTime of 0 would read as an always-due timeout. Tombstones
+    /// may only outlive a pass when the escaping exception is killing the send loop itself.
     /// </summary>
     private PendingResponse ClaimPendingResponseAt(int connectionIndex, int index)
     {
@@ -4984,17 +4976,23 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private void RecordDeferredPendingResponseCleanup(int pendingCount)
     {
-        Interlocked.Exchange(ref _deferredPendingResponseCleanupCount, pendingCount);
-        var tags = new TagList
-        {
-            { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
-        };
-        Diagnostics.DekafMetrics.PendingResponseCleanupDeferred.Add(pendingCount, tags);
+        Volatile.Write(ref _deferredPendingResponseCleanupCount, pendingCount);
+        Diagnostics.DekafMetrics.PendingResponseCleanupDeferred.Add(pendingCount, BrokerIdTags());
 
-        // Close the race where the send loop completed between the caller's IsCompleted
-        // check and publishing the deferred count.
-        if (_sendLoopTask.IsCompleted)
-            RecordDeferredPendingResponseCleanupRecovered();
+        // Pair the recovered signal with actual loop completion: the loop's finally runs
+        // CleanupPendingResponsesOnLoopExit before its task can complete, so completion
+        // proves the deferred entries were swept. A same-thread IsCompleted re-check is
+        // not enough — the loop can be mid-epilogue (cleanup done, task not yet complete)
+        // when the deferred count is published, which would strand a false "deferred"
+        // reading forever. The continuation is exactly-once via the Exchange in
+        // RecordDeferredPendingResponseCleanupRecovered, and one allocation per deferred
+        // disposal is rare by construction.
+        _ = _sendLoopTask.ContinueWith(
+            static (_, state) => ((BrokerSender)state!).RecordDeferredPendingResponseCleanupRecovered(),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private void RecordDeferredPendingResponseCleanupRecovered()
@@ -5003,12 +5001,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (recoveredCount == 0)
             return;
 
-        var tags = new TagList
-        {
-            { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
-        };
-        Diagnostics.DekafMetrics.PendingResponseCleanupRecovered.Add(recoveredCount, tags);
+        Diagnostics.DekafMetrics.PendingResponseCleanupRecovered.Add(recoveredCount, BrokerIdTags());
     }
+
+    private TagList BrokerIdTags() => new()
+    {
+        { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
+    };
 
     public async ValueTask DisposeAsync()
     {

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -27,6 +27,8 @@ public sealed class DekafMetricInstrumentTests
         DekafMetrics.Retries.Add(0);
         DekafMetrics.InlineContinuationExceptions.Add(0);
         DekafMetrics.CompletionSourceFaults.Add(0);
+        DekafMetrics.PendingResponseCleanupDeferred.Add(0);
+        DekafMetrics.PendingResponseCleanupRecovered.Add(0);
         DekafMetrics.MessagesReceived.Add(0);
         DekafMetrics.BytesReceived.Add(0);
         DekafMetrics.RebalanceDuration.Record(0);
@@ -39,6 +41,8 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
         await Assert.That(instrumentNames).Contains("dekaf.producer.inline_continuation.exceptions");
         await Assert.That(instrumentNames).Contains("dekaf.producer.completion_source.faults");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.pending_response.cleanup.deferred");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.pending_response.cleanup.recovered");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
         await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1437,6 +1437,76 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_TransactionEnrollmentFailure_FailsEntireCarriedOverBacklog(
+        CancellationToken cancellationToken)
+    {
+        // Regression test for the FailPendingTransactionEnrollmentBatches drain: a partition
+        // whose enrollment stays pending accumulates a multi-entry carry-over backlog, and a
+        // late enrollment failure must fail EVERY queued batch (not just the head) and leave
+        // the send loop alive.
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var options = CreateOptions(transactionalId: "test-transaction");
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskPool = new ValueTaskSourcePool<RecordMetadata>();
+        var enrollmentError = new TransactionException("Partition enrollment failed.");
+        var partitionPending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Action<Exception?>? enrollmentCompleted = null;
+
+        var sender = CreateSender(
+            connectionPool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            isTransactional: true,
+            tryEnsurePartitionsInTransaction: (batches, _, completed, pendingPartitions, _) =>
+            {
+                pendingPartitions.Add(batches[0].TopicPartition);
+                enrollmentCompleted = completed;
+                partitionPending.TrySetResult();
+                return TransactionPartitionEnrollmentResult.Pending;
+            });
+
+        try
+        {
+            var first = CreateTestBatchWithDelivery(valueTaskPool, "test-topic", 0);
+            sender.Enqueue(first.Batch);
+            await partitionPending.Task.WaitAsync(cancellationToken);
+
+            // Later batches for the pending partition divert straight to carry-over
+            // ('O' diag) without another enrollment attempt, building the backlog.
+            var second = CreateTestBatchWithDelivery(valueTaskPool, "test-topic", 0);
+            var third = CreateTestBatchWithDelivery(valueTaskPool, "test-topic", 0);
+            sender.Enqueue(second.Batch);
+            sender.Enqueue(third.Batch);
+            await WaitUntilAsync(
+                () => second.Batch.DiagTrace.Contains('O') && third.Batch.DiagTrace.Contains('O'),
+                cancellationToken);
+
+            enrollmentCompleted!(enrollmentError);
+
+            await Assert.That(async () => await first.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<TransactionException>()
+                .WithMessage(enrollmentError.Message);
+            await Assert.That(async () => await second.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<TransactionException>()
+                .WithMessage(enrollmentError.Message);
+            await Assert.That(async () => await third.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<TransactionException>()
+                .WithMessage(enrollmentError.Message);
+            await Assert.That(sender.IsAlive).IsTrue();
+            await connectionPool.DidNotReceiveWithAnyArgs()
+                .GetConnectionAsync(default, default);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskPool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_NonIdempotent_ErrorMutesUntilSamePartitionPipelineDrains(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -927,23 +927,26 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     [NotInParallel("MeterListener")]
     public async Task DeferredPendingResponseCleanup_ReportsDeferredAndRecoveredMetrics()
     {
+        // Resolve instrument names before the listener starts (static-initializer re-entry
+        // landmine — see FireAndForgetDeliveryErrorMetricTests).
+        var deferredName = DekafMetrics.PendingResponseCleanupDeferred.Name;
+        var recoveredName = DekafMetrics.PendingResponseCleanupRecovered.Name;
         var deferredCount = 0L;
         var recoveredCount = 0L;
         using var listener = new MeterListener();
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
             if (instrument.Meter.Name == DekafDiagnostics.MeterName
-                && (instrument.Name == "dekaf.producer.pending_response.cleanup.deferred"
-                    || instrument.Name == "dekaf.producer.pending_response.cleanup.recovered"))
+                && (instrument.Name == deferredName || instrument.Name == recoveredName))
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
         };
         listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
         {
-            if (instrument.Name == "dekaf.producer.pending_response.cleanup.deferred")
+            if (instrument.Name == deferredName)
                 Interlocked.Add(ref deferredCount, measurement);
-            else if (instrument.Name == "dekaf.producer.pending_response.cleanup.recovered")
+            else if (instrument.Name == recoveredName)
                 Interlocked.Add(ref recoveredCount, measurement);
         });
         listener.Start();

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1,9 +1,11 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Reflection;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
+using Dekaf.Diagnostics;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -840,6 +842,61 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task DeferredPendingResponseCleanup_ReportsDeferredAndRecoveredMetrics()
+    {
+        var deferredCount = 0L;
+        var recoveredCount = 0L;
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName
+                && (instrument.Name == "dekaf.producer.pending_response.cleanup.deferred"
+                    || instrument.Name == "dekaf.producer.pending_response.cleanup.recovered"))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            if (instrument.Name == "dekaf.producer.pending_response.cleanup.deferred")
+                Interlocked.Add(ref deferredCount, measurement);
+            else if (instrument.Name == "dekaf.producer.pending_response.cleanup.recovered")
+                Interlocked.Add(ref recoveredCount, measurement);
+        });
+        listener.Start();
+
+        var connection = new TestKafkaConnection();
+        var (pool, _) = CreateScaleTrackingPool(connection);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            typeof(BrokerSender).GetMethod(
+                "RecordDeferredPendingResponseCleanup",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(sender, [3]);
+
+            await Assert.That(Volatile.Read(ref deferredCount)).IsEqualTo(3);
+            await Assert.That(Volatile.Read(ref recoveredCount)).IsEqualTo(0);
+            await Assert.That(GetDeferredPendingResponseCleanupCount(sender)).IsEqualTo(3);
+
+            typeof(BrokerSender).GetMethod(
+                "RecordDeferredPendingResponseCleanupRecovered",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(sender, null);
+
+            await Assert.That(Volatile.Read(ref recoveredCount)).IsEqualTo(3);
+            await Assert.That(GetDeferredPendingResponseCleanupCount(sender)).IsEqualTo(0);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
         }
     }
 
@@ -3448,6 +3505,11 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     private static int GetPendingResponseCount(BrokerSender sender) =>
         (int)typeof(BrokerSender).GetField(
             "_totalPendingResponseCount",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+
+    private static int GetDeferredPendingResponseCleanupCount(BrokerSender sender) =>
+        (int)typeof(BrokerSender).GetField(
+            "_deferredPendingResponseCleanupCount",
             BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
 
     private static BrokerUnackedByteBudget.DeliverySnapshot GetDeliverySnapshot(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -489,6 +489,84 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task ResponseProcessingFailure_WithOtherEntriesPending_CleansUpAllEntries(
+        CancellationToken cancellationToken)
+    {
+        // Regression test for #2195: ProcessCompletedResponses claims the completed entry,
+        // then throws partway through processing it while ANOTHER entry is still pending in
+        // the same connection's list. The claimed entry must be tombstoned (never observed
+        // again by exit cleanup — its pooled arrays were already returned), the surviving
+        // entry must be redelivered, and the pending-response counters must return to zero.
+        var responses = new[]
+        {
+            new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously),
+            new TaskCompletionSource<ProduceResponse>(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var (pool, _) = CreateMockConnection(new Queue<TaskCompletionSource<ProduceResponse>>(responses));
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+        var options = CreateOptions(maxInFlight: 2, enableIdempotence: true, lingerMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var injectedFailure = new InvalidOperationException("injected response-processing failure");
+        var throwOnThrottleObservation = 0;
+        var allRerouted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reroutedCount = 0;
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, _) => { },
+            rerouteBatch: (batch, _) =>
+            {
+                batch.Fail(injectedFailure);
+                if (Interlocked.Increment(ref reroutedCount) == 2)
+                    allRerouted.TrySetResult();
+            },
+            onBrokerThrottle: _ =>
+            {
+                if (Volatile.Read(ref throwOnThrottleObservation) != 0)
+                    throw injectedFailure;
+            });
+
+        try
+        {
+            var first = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 0);
+            sender.Enqueue(first.Batch);
+            await WaitUntilAsync(() => GetPendingResponseCount(sender) == 1, cancellationToken);
+
+            var second = CreateTestBatchWithDelivery(valueTaskSourcePool, "test-topic", 1);
+            sender.Enqueue(second.Batch);
+            await WaitUntilAsync(() => GetPendingResponseCount(sender) == 2, cancellationToken);
+
+            // Completing the first response makes ProcessCompletedResponses claim its entry
+            // and throw from within processing (via the throttle-observation callback) while
+            // the second entry is still pending in the same connection's list.
+            Volatile.Write(ref throwOnThrottleObservation, 1);
+            responses[0].SetResult(CreateSuccessResponse("test-topic", 0, baseOffset: 0));
+            await allRerouted.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(sender.IsAlive).IsFalse();
+            await Assert.That(Volatile.Read(ref reroutedCount)).IsEqualTo(2);
+            await Assert.That(GetPendingResponseCount(sender)).IsEqualTo(0);
+            await Assert.That(GetDeferredPendingResponseCleanupCount(sender)).IsEqualTo(0);
+            await Assert.That(async () => await first.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+            await Assert.That(async () => await second.Delivery.WaitAsync(cancellationToken))
+                .ThrowsExactly<InvalidOperationException>()
+                .WithMessage(injectedFailure.Message);
+        }
+        finally
+        {
+            responses[1].TrySetResult(CreateSuccessResponse("test-topic", 1, baseOffset: 0));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task SendLoop_WaveCoalesce_RearmsWhileResponseIsInFlight(
         CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

- make the send loop the sole owner of pending-response cleanup
- claim entries before processing and compact tombstones afterward, preventing exception paths from exposing returned arrays to exit cleanup
- add deferred and recovered cleanup counters so wedged-loop leaks remain observable

## Root cause

Disposal and the send-loop exit path could both walk `_pendingResponsesByConnection`. Completed and timed-out responses also returned pooled arrays before list compaction, so an escaping exception could leave stale entries visible to exit cleanup.

## Validation

- `dotnet build src/Dekaf/Dekaf.csproj --no-restore`
- full net10.0 unit suite: 5,592 passed

Closes #2195