### PR TITLE
fix(producer): stop DrainPendingAppends self-request livelock; add dispatch backstop and tripwires

### DIFF
--- a/scripts/run-integration-categories.sh
+++ b/scripts/run-integration-categories.sh
@@ -37,6 +37,12 @@ chmod +x "$exe"
 # Aggressive GC to reduce memory pressure on CI runners.
 export DOTNET_GCConserveMemory=9
 
+# Per-test OTel spans are the primary post-mortem evidence for timing failures
+# (#2199 was solved from them). The default 100-span cap truncated them in run
+# 29612262949, leaving the failing test with zero spans. Overridable from the
+# environment.
+export TUNIT_OTEL_MAX_EXTERNAL_SPANS="${TUNIT_OTEL_MAX_EXTERNAL_SPANS:-5000}"
+
 for category in "${categories[@]}"; do
   if [ "$tfm" = "aot" ] && [ "$category" = "Interop" ]; then
     echo "Skipping Interop for NativeAOT because Confluent.Kafka requires runtime reflection"

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1219,6 +1219,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // sealed batches exist.
     private readonly ConcurrentQueue<TopicPartition> _readyPartitions = new();
 
+    // Sealed batches currently resident in partition deques (enqueued, not yet drained).
+    // Maintained by PartitionDeque's add/remove methods so every entry/exit path is
+    // counted by construction. Gates the lost-notification backstop and feeds the
+    // buffer-timeout diagnostics. One Interlocked op per batch, not per message.
+    private long _dispatchQueuedBatchCount;
+
+    // Stopwatch timestamp of the first consecutive idle Ready() pass observed while
+    // deque-resident batches existed; 0 when the last pass was not idle. Sender-thread
+    // only. See RecoverStrandedSealedBatches.
+    private long _dispatchIdleSinceTimestamp;
+
+    // Sustained idle window (1.5 fallback ticks) before rescanning deques for batches
+    // whose ready notification was lost. Time-based rather than pass-counted: wakeups
+    // are signal-driven, so consecutive passes can be microseconds apart and would fire
+    // the rescan during the ordinary seal→publish window.
+    private static readonly long StrandedBatchRescanIdleTicks = Stopwatch.Frequency * 150 / 1000;
+
     // Per-node partition tracking: populated by Ready() with the specific partitions it
     // consumed from _readyPartitions for each node. Used by DrainBatchesForOneNode to
     // re-enqueue only those specific partitions on leader migration (instead of the O(n)
@@ -1361,6 +1378,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private long _pendingAppendDrainRequestVersion;
     private long _pendingAppendDrainEntryCount;
 
+    // Cumulative scan passes across all drain invocations. With self-requests suppressed,
+    // growth is bounded by real drain requests; runaway growth is the livelock signature
+    // (#2207). Exposed for tests via PendingAppendDrainPassCountForTest.
+    private long _pendingAppendDrainPassCount;
+
+    // True while the current thread is the active DrainPendingAppends owner running its
+    // scan. Makes re-entrant self-requests no-ops — see the guard at the top of
+    // DrainPendingAppends (#2207).
+    [ThreadStatic]
+    private static bool t_inPendingAppendDrainScan;
+
     private readonly record struct AdmissionReservation(
         PartitionDeque? Deque,
         BrokerUnackedByteBudget? Budget,
@@ -1383,8 +1411,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Uses a ring-buffer backing array instead of LinkedList to eliminate per-batch
     /// LinkedListNode and HashSet allocations. Typical deques hold 1-3 batches.
     /// </summary>
-    private sealed class PartitionDeque
+    private sealed class PartitionDeque(RecordAccumulator owner)
     {
+        private readonly RecordAccumulator _owner = owner;
         private ReadyBatch?[] _items = new ReadyBatch?[4];
         private int _head;
         private int _count;
@@ -1453,6 +1482,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _items[_head] = null;
             _head = (_head + 1) % _items.Length;
             _count--;
+            Interlocked.Decrement(ref _owner._dispatchQueuedBatchCount);
 
             // Shrink if utilization drops below 25% and array is above minimum capacity.
             // Prevents sticky peak allocation from temporary bursts (e.g., network partition).
@@ -1474,6 +1504,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             EnsureCapacity();
             _items[(_head + _count) % _items.Length] = batch;
             _count++;
+            Interlocked.Increment(ref _owner._dispatchQueuedBatchCount);
         }
 
         /// <summary>Add to front of deque (retry/reenqueue — Java's addFirst).</summary>
@@ -1483,6 +1514,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             _head = (_head - 1 + _items.Length) % _items.Length;
             _items[_head] = batch;
             _count++;
+            Interlocked.Increment(ref _owner._dispatchQueuedBatchCount);
         }
 
         /// <summary>Whether the deque contains the specified batch. O(n) linear scan.
@@ -1539,6 +1571,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             }
             _items[(_head + insertAt) % _items.Length] = batch;
             _count++;
+            Interlocked.Increment(ref _owner._dispatchQueuedBatchCount);
         }
 
         private void EnsureCapacity()
@@ -1568,7 +1601,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     private PartitionDeque GetOrCreateDeque(TopicPartition tp)
-        => _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
+        => _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
 
     /// <summary>
     /// Drains the push-based notification queue to find partitions with sendable data.
@@ -1687,10 +1720,87 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 nodePartitions.Add(tp);
         }
 
+        // Lost-notification backstop — see RecoverStrandedSealedBatches. A stranded batch
+        // is recoverable only while deque-resident, so the gate short-circuits on that
+        // count and fires only after a sustained idle window.
+        if (readyNodes.Count == 0
+            && Volatile.Read(ref _dispatchQueuedBatchCount) > 0
+            && _readyPartitions.IsEmpty)
+        {
+            if (_dispatchIdleSinceTimestamp == 0)
+            {
+                _dispatchIdleSinceTimestamp = nowTimestamp;
+            }
+            else if (nowTimestamp - _dispatchIdleSinceTimestamp >= StrandedBatchRescanIdleTicks)
+            {
+                _dispatchIdleSinceTimestamp = nowTimestamp;
+                RecoverStrandedSealedBatches(metadataManager, nowTimestamp);
+            }
+        }
+        else
+        {
+            _dispatchIdleSinceTimestamp = 0;
+        }
+
         // With push-based notifications, the sender wakes on SignalWakeup() from batch
-        // sealing or DeferReenqueue timer expiry. The 100ms fallback is a safety-net poll
-        // in case a notification is missed (e.g., during disposal races).
+        // sealing or DeferReenqueue timer expiry. The 100ms fallback tick re-polls
+        // _readyPartitions and, via the backstop above, rescans the deques themselves when
+        // a notification appears to have been lost.
         return (100, unknownLeadersExist);
+    }
+
+    /// <summary>
+    /// Re-publishes sealed batches whose ready notification was lost. _readyPartitions is
+    /// the sender's only view of sealed batches, so a lost publish would otherwise strand
+    /// its batch until close re-seals the partition (release-gate run 29612262949: a
+    /// sealed first-wave batch sat invisible for the full MaxBlockMs against a healthy
+    /// broker, freezing the partition because ShouldDeferPartialBatchSeal keeps the next
+    /// batch open behind it). Runs only after a sustained idle window with deque-resident
+    /// batches, so steady traffic never pays for the scan. Heads whose next publish has a
+    /// live owner elsewhere (muted → unmute paths, retry backoff → DeferReenqueue timer,
+    /// pre-serialization pending → worker completion publish) are not treated as stranded.
+    /// The Warning captures the stranded state — it is the diagnostic for any
+    /// notification-loss race, so a firing tripwire should be root-caused, not silenced.
+    /// </summary>
+    private void RecoverStrandedSealedBatches(MetadataManager metadataManager, long nowTimestamp)
+    {
+        foreach (var (topicPartition, pd) in _partitionDeques)
+        {
+            if (_mutedPartitions.ContainsKey(topicPartition))
+                continue;
+
+            ReadyBatch? head;
+            int dequeDepth;
+            {
+                using var guard = new SpinLockGuard(ref pd.Lock);
+                head = pd.PeekFirst();
+                dequeDepth = pd.Count;
+            }
+
+            if (head is null)
+                continue;
+
+            if (head.IsRetry && head.RetryNotBefore > nowTimestamp)
+                continue;
+
+            if (!head.IsPreSerialized)
+            {
+                // The pre-serialization worker owns this head's next publish. Re-publish
+                // defensively (Ready keeps unready heads alive) without the tripwire.
+                LogUnserializedSealedBatchRepublished(topicPartition.Topic, topicPartition.Partition);
+                _readyPartitions.Enqueue(topicPartition);
+                continue;
+            }
+
+            var leaderKnown = metadataManager.TryGetCachedPartitionLeader(
+                topicPartition.Topic, topicPartition.Partition) is not null;
+            LogStrandedSealedBatchRecovered(
+                topicPartition.Topic,
+                topicPartition.Partition,
+                dequeDepth,
+                leaderKnown);
+            _readyPartitions.Enqueue(topicPartition);
+        }
     }
 
     /// <summary>
@@ -2042,6 +2152,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </returns>
     internal bool DrainPendingAppends()
     {
+        // Re-entrant requests from the active owner's own scan must not publish a new
+        // request version: every release the scan performs either restores exactly the
+        // pre-attempt state (a failed reserve) or coincides with progress that already
+        // forces another pass. Without this, a failed reserve's admission-slot release
+        // re-requested the drain on every pass — a hot livelock (#2207, run 29612262949:
+        // 2.8M passes at ~7.7k/ms; when the send loop owned the spin, the producer wedged
+        // until max.block.ms because only the send loop could free memory). This is the
+        // admission-side analog of ReleaseMemoryWithoutDrain.
+        if (t_inPendingAppendDrainScan)
+            return true;
+
         // The active owner temporarily moves every candidate out of the concurrent queue
         // while it evaluates admission. An empty queue is therefore conclusive only when
         // no drainer owns that private snapshot.
@@ -2058,10 +2179,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
         Interlocked.Increment(ref _pendingAppendDrainEntryCount);
         var ownsDrainGuard = true;
+        var drainPassCount = 0;
+        var drainSpinTripwire = 100_000;
+        t_inPendingAppendDrainScan = true;
         try
         {
             while (true)
             {
+                drainPassCount++;
+                Interlocked.Increment(ref _pendingAppendDrainPassCount);
+                // Livelock tripwire: with self-requests suppressed, pass counts are bounded
+                // by real concurrent requests. A six-digit count means a feedback edge is
+                // back — capture it instead of silently burning a core (#2207). Geometric
+                // spacing keeps a live spin from flooding the log.
+                if (drainPassCount == drainSpinTripwire)
+                {
+                    LogPendingAppendDrainSpinning(drainPassCount, _pendingAppends.Count, Volatile.Read(ref _bufferedBytes));
+                    drainSpinTripwire *= 10;
+                }
                 var drainRequestVersion = Volatile.Read(ref _pendingAppendDrainRequestVersion);
 
                 // Bail if accumulator is being disposed — DisposeAsync will drain the queue.
@@ -2188,6 +2323,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
         finally
         {
+            t_inPendingAppendDrainScan = false;
             if (ownsDrainGuard)
             {
                 _blockedPendingPartitions.Clear();
@@ -2691,7 +2827,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.NoInlining)]
     private PartitionDeque GetOrCreateDequeSlow(TopicPartition tp, AccumulatorThreadCache cache)
     {
-        var deque = _partitionDeques.GetOrAdd(tp, static _ => new PartitionDeque());
+        var deque = _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
 
         // Update thread-local cache
         cache.CachedAccumulator = this;
@@ -4378,6 +4514,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     internal long PendingAppendDrainEntryCountForTest =>
         Volatile.Read(ref _pendingAppendDrainEntryCount);
 
+    internal long PendingAppendDrainPassCountForTest =>
+        Volatile.Read(ref _pendingAppendDrainPassCount);
+
+    /// <summary>Sealed batches resident in partition deques (enqueued, not yet drained).</summary>
+    internal long DispatchQueuedBatchCount => Volatile.Read(ref _dispatchQueuedBatchCount);
+
     /// <summary>
     /// Gets the current buffer utilization as a ratio (0.0 to 1.0+).
     /// Used by adaptive connection scaling to confirm buffer is actually full.
@@ -4548,12 +4690,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// <see cref="PendingAppend"/> so both timeout sites report identical diagnostics.
     /// In-flight/unsealed counts distinguish genuine backpressure (batches in the pipeline
     /// still hold memory) from orphaned reservations (buffer full with nothing in flight —
-    /// a refund leak, run 29594249742).
+    /// a refund leak, run 29594249742). Dispatch-queued vs ready-notification counts
+    /// distinguish a batch stranded in the accumulator (queued &gt; 0 with no notification —
+    /// a lost publish, run 29612262949) from one stuck at a broker sender (queued == 0).
     /// </summary>
     internal string BuildBufferTimeoutMessage(int recordSize) =>
         $"Failed to allocate buffer within max.block.ms ({_options.MaxBlockMs}ms). " +
         $"Requested {recordSize} bytes, current usage: {BufferedBytes}/{MaxBufferMemory} bytes, " +
-        $"in-flight batches: {InFlightBatchCount}, unsealed batches: {UnsealedBatchCount}. " +
+        $"in-flight batches: {InFlightBatchCount}, unsealed batches: {UnsealedBatchCount}, " +
+        $"dispatch-queued batches: {DispatchQueuedBatchCount}, ready notifications: {_readyPartitions.Count}. " +
         $"Producer is generating messages faster than the network can send them. " +
         $"Consider: increasing BufferMemory, increasing MaxBlockMs, reducing production rate, or checking network connectivity.";
 
@@ -6580,6 +6725,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Non-fatal exception during batch cleanup step (suppressed)")]
     private partial void LogBatchCleanupStepFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Recovered stranded sealed batch for {Topic}-{Partition}: ready notification was lost (deque depth {DequeDepth}, leaderKnown={LeaderKnown}). Re-published to the sender. This state is the diagnostic for a notification-loss race — root-cause it, do not silence it.")]
+    private partial void LogStrandedSealedBatchRecovered(string topic, int partition, int dequeDepth, bool leaderKnown);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Re-published sealed batch for {Topic}-{Partition} still awaiting pre-serialization")]
+    private partial void LogUnserializedSealedBatchRepublished(string topic, int partition);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Pending-append drain owner has run {PassCount} scan passes without exiting (queue depth {QueueDepth}, buffered {BufferedBytes} bytes) — a drain-request feedback edge is livelocking the scan (#2207 family). Root-cause the requester; do not silence this.")]
+    private partial void LogPendingAppendDrainSpinning(int passCount, int queueDepth, long bufferedBytes);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Timed out waiting for in-progress append during accumulator disposal for {Topic}-{Partition}; skipping current batch cleanup")]
     private partial void LogAppendInProgressDisposalTimeout(string topic, int partition);

--- a/tests/Dekaf.Tests.Unit/CapturingLogger.cs
+++ b/tests/Dekaf.Tests.Unit/CapturingLogger.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Unit;
+
+/// <summary>
+/// Thread-safe ILogger that records every entry for assertion. Shared so tests stop
+/// carrying private copies (several older test files still do — consolidate onto this
+/// when touching them).
+/// </summary>
+internal sealed class CapturingLogger : ILogger
+{
+    public ConcurrentQueue<(LogLevel Level, string Message)> Messages { get; } = new();
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => Messages.Enqueue((logLevel, formatter(state, exception)));
+}

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -24,6 +24,41 @@ internal static class AccumulatorTestHelpers
     }
 
     /// <summary>
+    /// Appends one null-key/null-value record. Returns the raw ValueTask so callers can
+    /// either await it or inspect IsCompleted (a pending result means the append queued
+    /// behind BufferMemory backpressure).
+    /// </summary>
+    public static ValueTask<bool> AppendNullRecordAsync(
+        RecordAccumulator accumulator,
+        string topic,
+        int partition = 0,
+        int partitionCount = 1)
+    {
+        return accumulator.AppendAsync(
+            topic,
+            partition,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null,
+            PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            CancellationToken.None,
+            partitionCount);
+    }
+
+    /// <summary>
+    /// Writes a private instance field via reflection.
+    /// </summary>
+    public static void SetPrivateField(object instance, string fieldName, object? value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' not found on {instance.GetType().Name}.");
+        field.SetValue(instance, value);
+    }
+
+    /// <summary>
     /// Runs the accumulator's flush-mode batch sweep without waiting for delivery.
     /// </summary>
     public static ValueTask SealAllAsync(RecordAccumulator accumulator)

--- a/tests/Dekaf.Tests.Unit/Producer/PendingAppendDrainLivelockTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PendingAppendDrainLivelockTests.cs
@@ -1,0 +1,75 @@
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Regression tests for the pending-append drain livelock (#2207): the drain owner's own
+/// failed reserve released its admission slot, which re-requested a drain from inside the
+/// scan, making drainRequested true on every pass. With one unadmittable queued append the
+/// owner spun at millions of passes; when the BrokerSender send loop owned the spin, the
+/// producer wedged until max.block.ms (release-gate run 29612262949). Pre-fix, this test
+/// hangs in DrainPendingAppends; post-fix the owner exits after a bounded number of passes.
+/// </summary>
+public class PendingAppendDrainLivelockTests
+{
+    private const string Topic = "drain-livelock-topic";
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task DrainPendingAppends_UnadmittableQueuedAppend_ExitsWithoutSpinning(
+        CancellationToken cancellationToken)
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-producer",
+            BufferMemory = 4096, // Tiny buffer so a queued append cannot be admitted
+            BatchSize = 1000,
+            LingerMs = 60_000 // Keep the batch open — nothing drains memory during the test
+        };
+        await using var accumulator = new RecordAccumulator(
+            options,
+            resolveLeaderId: static (_, _) => 1);
+
+        // Fill the buffer until an append queues as a PendingAppend (pending ValueTask).
+        ValueTask<bool> blockedAppend = default;
+        var blocked = false;
+        for (var i = 0; i < 200 && !blocked; i++)
+        {
+            var append = AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, Topic);
+            if (append.IsCompleted)
+            {
+                await Assert.That(await append).IsTrue();
+            }
+            else
+            {
+                blockedAppend = append;
+                blocked = true;
+            }
+        }
+
+        await Assert.That(blocked).IsTrue();
+
+        // Pre-fix: the drain owner's own reserve failures re-request the drain and it
+        // never exits (test times out here). Post-fix: no progress + no external request
+        // ends the scan after very few passes.
+        var passesBefore = accumulator.PendingAppendDrainPassCountForTest;
+        _ = accumulator.DrainPendingAppends();
+        var passes = accumulator.PendingAppendDrainPassCountForTest - passesBefore;
+
+        await Assert.That(passes).IsGreaterThanOrEqualTo(1);
+        await Assert.That(passes).IsLessThanOrEqualTo(4);
+
+        // Dispose fails the queued append; observe its exception so nothing goes unobserved.
+        await accumulator.DisposeAsync();
+        try
+        {
+            _ = await blockedAppend;
+        }
+        catch (Exception)
+        {
+            // Expected: dispose fails the queued operation.
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3165,7 +3165,7 @@ public class RecordAccumulatorTests
     {
         var pdType = typeof(RecordAccumulator).GetNestedType("PartitionDeque",
             System.Reflection.BindingFlags.NonPublic)!;
-        var pd = Activator.CreateInstance(pdType)!;
+        var pd = Activator.CreateInstance(pdType, accumulator)!;
         var method = typeof(RecordAccumulator).GetMethod("OnBatchEntersPipeline",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         method!.Invoke(accumulator, [pd, batch]);

--- a/tests/Dekaf.Tests.Unit/Producer/StrandedBatchBackstopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/StrandedBatchBackstopTests.cs
@@ -1,0 +1,157 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for the Ready() lost-notification backstop: a sealed batch whose
+/// _readyPartitions publish was lost must be re-discovered by rescanning the partition
+/// deques after a sustained idle window, instead of stranding until close
+/// (release-gate run 29612262949: a first-wave batch sat invisible for the full
+/// MaxBlockMs against a healthy broker).
+/// </summary>
+public class StrandedBatchBackstopTests
+{
+    private const string Topic = "backstop-topic";
+    private static readonly TopicPartition Partition = new(Topic, 0);
+
+    private static ProducerOptions CreateTestOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "test-producer",
+        BufferMemory = ulong.MaxValue, // Disable buffer limit for unit tests (no producer to drain)
+        BatchSize = 1000,
+        LingerMs = 10
+    };
+
+    private static async Task AppendOneRecordAsync(RecordAccumulator accumulator)
+    {
+        var appended = await AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, Topic);
+        await Assert.That(appended).IsTrue();
+    }
+
+    /// <summary>
+    /// Simulates a lost publish: seals the current batch (which enqueues it and publishes
+    /// its ready notification) and then discards every pending notification.
+    /// </summary>
+    private static async Task SealAndDropNotificationsAsync(RecordAccumulator accumulator)
+    {
+        await AccumulatorTestHelpers.SealAllAsync(accumulator);
+
+        var readyPartitions = AccumulatorTestHelpers.GetPrivateField<ConcurrentQueue<TopicPartition>>(
+            accumulator, "_readyPartitions");
+        while (readyPartitions.TryDequeue(out _))
+        {
+        }
+    }
+
+    private static HashSet<int> RunReadyPass(RecordAccumulator accumulator, MetadataManager metadataManager)
+    {
+        var readyNodes = new HashSet<int>();
+        _ = accumulator.Ready(metadataManager, readyNodes);
+        return readyNodes;
+    }
+
+    private static long DispatchQueuedCount(RecordAccumulator accumulator)
+        => accumulator.DispatchQueuedBatchCount;
+
+    [Test]
+    public async Task Ready_LostNotification_BackstopRepublishesAfterIdleWindow()
+    {
+        var capturingLogger = new CapturingLogger();
+        await using var accumulator = new RecordAccumulator(CreateTestOptions(), logger: capturingLogger);
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(Topic, partitionCount: 1);
+
+        await AppendOneRecordAsync(accumulator);
+        await SealAndDropNotificationsAsync(accumulator);
+        await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(1);
+        await Assert.That(DispatchQueuedCount(accumulator)).IsEqualTo(1);
+
+        // Pass 1: idle — arms the idle window; no recovery yet.
+        await Assert.That(RunReadyPass(accumulator, metadataManager)).IsEmpty();
+        await Assert.That(capturingLogger.Messages.Any(m => m.Level == LogLevel.Warning)).IsFalse();
+
+        // Pass 2 after the idle window has elapsed: rescan re-publishes the stranded
+        // partition and emits the tripwire Warning.
+        AccumulatorTestHelpers.SetPrivateField(
+            accumulator, "_dispatchIdleSinceTimestamp", Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        await Assert.That(RunReadyPass(accumulator, metadataManager)).IsEmpty();
+        await Assert.That(capturingLogger.Messages.Any(m =>
+                m.Level == LogLevel.Warning && m.Message.Contains("Recovered stranded sealed batch")))
+            .IsTrue();
+
+        // Pass 3: the re-published notification makes the partition ready.
+        await Assert.That(RunReadyPass(accumulator, metadataManager)).Contains(1);
+    }
+
+    [Test]
+    public async Task Ready_NotificationIntact_FirstPassIsReady_NoTripwire()
+    {
+        var capturingLogger = new CapturingLogger();
+        await using var accumulator = new RecordAccumulator(CreateTestOptions(), logger: capturingLogger);
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(Topic, partitionCount: 1);
+
+        await AppendOneRecordAsync(accumulator);
+        await AccumulatorTestHelpers.SealAllAsync(accumulator);
+
+        await Assert.That(RunReadyPass(accumulator, metadataManager)).Contains(1);
+        await Assert.That(capturingLogger.Messages.Any(m => m.Level == LogLevel.Warning)).IsFalse();
+    }
+
+    [Test]
+    public async Task Ready_MutedPartition_BackstopDefersToUnmute()
+    {
+        var capturingLogger = new CapturingLogger();
+        await using var accumulator = new RecordAccumulator(CreateTestOptions(), logger: capturingLogger);
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(Topic, partitionCount: 1);
+
+        await AppendOneRecordAsync(accumulator);
+        await SealAndDropNotificationsAsync(accumulator);
+        accumulator.MutePartition(Partition);
+
+        // Muted heads cannot be dispatched; the backstop must neither re-publish nor log,
+        // no matter how long the idle window lasts.
+        for (var pass = 0; pass < 4; pass++)
+        {
+            await Assert.That(RunReadyPass(accumulator, metadataManager)).IsEmpty();
+            AccumulatorTestHelpers.SetPrivateField(
+                accumulator, "_dispatchIdleSinceTimestamp", Stopwatch.GetTimestamp() - Stopwatch.Frequency);
+        }
+        await Assert.That(capturingLogger.Messages.Any(m => m.Level == LogLevel.Warning)).IsFalse();
+
+        // Unmute re-publishes the partition itself (existing contract).
+        accumulator.UnmutePartition(Partition);
+        await Assert.That(RunReadyPass(accumulator, metadataManager)).Contains(1);
+    }
+
+    [Test]
+    public async Task Ready_EmptyPipeline_IdlePassesNeverScanOrLog()
+    {
+        var capturingLogger = new CapturingLogger();
+        await using var accumulator = new RecordAccumulator(CreateTestOptions(), logger: capturingLogger);
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(Topic, partitionCount: 1);
+
+        for (var pass = 0; pass < 5; pass++)
+            await Assert.That(RunReadyPass(accumulator, metadataManager)).IsEmpty();
+
+        await Assert.That(capturingLogger.Messages).IsEmpty();
+        await Assert.That(DispatchQueuedCount(accumulator)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DispatchQueuedCount_ReturnsToZero_AfterDisposeDrainsDeques()
+    {
+        var accumulator = new RecordAccumulator(CreateTestOptions());
+
+        await AppendOneRecordAsync(accumulator);
+        await AccumulatorTestHelpers.SealAllAsync(accumulator);
+        await Assert.That(DispatchQueuedCount(accumulator)).IsEqualTo(1);
+
+        await accumulator.DisposeAsync();
+        await Assert.That(DispatchQueuedCount(accumulator)).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
Fixes #2207.

## Root cause (locally reproduced and bisected — full evidence trail in #2207)

`DrainPendingAppends` livelocks whenever the queue holds an append that cannot currently be admitted (a normal transient state under backpressure): the owner's scan calls `TryReserveForAppend`, whose failure path releases the just-claimed admission slot via `ReleaseAdmissionReservation` — which, seeing `SlowPathAppendCount != 0`, **re-requests a drain from inside the owner's own scan**. The nested self-call bumps `_pendingAppendDrainRequestVersion`, so `drainRequested` is true on every pass and the owner rescans forever. Captured: **2.8 million passes at ~7,700 passes/ms** — a pegged core on every backpressure wave, normally rescued only when memory frees.

The catastrophic variant is the release-gate failure (runs 29612262949, 29594249742-adjacent, 29558105204): when the spin owner is the **BrokerSender send-loop thread** (entered via response processing → `CleanupBatch` → `OnBatchExitsPipeline` → `DrainPendingAppends`), the send loop can never send the next sealed batch — the only action that frees BufferMemory (refunds happen at wire-write) — so nothing can ever admit the queued op and nothing ends the spin. The producer wedges until `max.block.ms` fails the queued appends and a scan empties the queue. Bisect capture: `CompleteSend done` at t=154.8ms → `CleanupBatch done` at t=20067.9ms, releasing within milliseconds of the queued appends' mass timeout. It also reproduced as `Producer_SmallBufferMemory_AllMessagesDelivered` hitting its 5-minute timeout — same bug, different victim, matching #2184's original observations.

The memory release inside the drain already has `ReleaseMemoryWithoutDrain` to prevent exactly this recursion; the admission-slot release (introduced with the admission/governor work, amplified by #2148's unconditional entry version-bump) never got the same discipline — which is why every occurrence postdates #2176.

## Changes

**The fix** (`RecordAccumulator.cs`):
- `t_inPendingAppendDrainScan` thread-scoped marker checked at the top of `DrainPendingAppends`: re-entrant requests from the active owner's own scan are no-ops — one structural choke point covering every owner-reachable call site (the failed-reserve admission-slot release that caused this, plus the transitive release paths inside the scan's `AppendAfterReservation` work, which were benign only by coinciding with progress). The admission-side analog of `ReleaseMemoryWithoutDrain`. External requesters still bump the version; owner-thread releases either restore exactly the pre-attempt state or coincide with progress that forces another pass, so no wake is lost.
- Livelock tripwire: the owner logs a Warning at 100k passes, geometrically spaced (`LogPendingAppendDrainSpinning`) — bounded pass counts are now an invariant; a six-digit count means a feedback edge returned. Pass counter exposed for tests.

**Defense-in-depth** (from the initial investigation, kept deliberately):
- `Ready()` lost-notification backstop: `_readyPartitions` is the sender's only view of sealed batches, and the 100ms fallback tick's own comment claimed a safety net that didn't exist — it only re-read the notification queue. Now, after a sustained idle window (150ms) with deque-resident sealed batches (O(1) gate: counter maintained inside `PartitionDeque`'s add/remove methods; one Interlocked per batch), the deques are rescanned and stranded heads re-published with a Warning tripwire. Heads whose next publish has a live owner (muted, retry backoff, pre-serialization pending) are excluded.
- Buffer-timeout diagnostics now include `dispatch-queued batches` and `ready notifications` — this is the line that disproved the initial lost-notification hypothesis in one glance (`0, 0` = the batch had left the accumulator) and steered the bisect to the send loop.

**CI diagnosability**: `TUNIT_OTEL_MAX_EXTERNAL_SPANS=5000` exported in `run-integration-categories.sh` (overridable) — the per-test OTel spans that solved #2199 were dropped at the default 100-span cap in run 29612262949.

**Test plumbing**: shared `CapturingLogger` helper (instead of a sixth per-file copy), `AccumulatorTestHelpers.SetPrivateField`.

## Tests

- `PendingAppendDrainLivelockTests`: one unadmittable queued append + direct `DrainPendingAppends` call. **Pre-fix it livelocks (test times out; verified by temporarily negating the guard); post-fix the owner exits in ≤4 passes (258ms).**
- `StrandedBatchBackstopTests` (deterministic, reflection-advanced idle window, no delays): lost-notification recovery + tripwire; intact-notification fast path; muted deferral to the unmute contract; empty-pipeline no-op; deque-counter returns to 0 after dispose.
- Full unit suite green (net10.0 + net8.0 spot runs); new tests looped for stability.
- Backpressure integration category vs real Kafka 4.3.1: **34 consecutive clean runs post-fix** (prior failure rate ~1 in 5 locally; the failing release-gate lane only runs on release gates, hiding that rate).

## Cost analysis (no stress lane needed)

The fix removes work: the drain no longer burns hundreds-to-millions of wasted scan passes per backpressure wave (a pegged core in the worst case). Added costs are one `[ThreadStatic]` bool read on admission-release paths, one Interlocked per **batch** at deque add/remove, and one volatile read + queue peek per 100ms sender tick — nothing per message. The O(partitions) backstop rescan runs only after 150ms of idle-with-queued-batches.

## Release note

After merge, re-dispatch the release gate (`publish_nuget=true`) — it is currently blocked on this failure. Watch the AOT/4.3.1 produce lane and grep logs for the two tripwires (`Pending-append drain owner has run`, `Recovered stranded sealed batch`): green + silent = fixed; a firing tripwire is a captured root cause, not noise.
