### PR TITLE
fix(benchmarks): measure the library, not the harness

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -985,11 +985,14 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     /// Writes the record batch to the output buffer.
     /// </summary>
     /// <remarks>
-    /// Current encoding requests one contiguous destination span for the CRC field plus
+    /// <para>Current encoding requests one contiguous destination span for the CRC field plus
     /// the CRC-covered batch body. This keeps the array-backed writer path zero-copy and
     /// lets the CRC be backpatched in place, but it means segmented writers must be able
     /// to provide that full span. A streaming writer path would need incremental CRC32C
-    /// calculation while emitting fields and records in smaller segments.
+    /// calculation while emitting fields and records in smaller segments.</para>
+    /// <para>Write does not mutate batch state — the CRC is computed into the output only —
+    /// and may be invoked repeatedly on the same instance. The epoch-bump rewrite path
+    /// (<see cref="WithProducerState"/>) and the benchmarks rely on this.</para>
     /// </remarks>
     /// <returns>
     /// The exact number of bytes written to <paramref name="output"/>. Callers that

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
@@ -1,6 +1,5 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Engines;
 using Dekaf.Benchmarks.Infrastructure;
 using DekafConsumer = Dekaf.Consumer;
 
@@ -21,7 +20,10 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 /// Single-message poll benchmarks live in <see cref="ConsumerPollBenchmarks"/>.
 /// </remarks>
 [MemoryDiagnoser]
-[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+// Lower counts than the default tier: [IterationSetup] forces single-invocation
+// iterations here, and each one pays a full consumer build + group join (~seconds),
+// so every extra iteration buys exactly one sample at high setup cost.
+[ThroughputJob(warmupCount: 3, iterationCount: 8)]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
 public class ConsumerBenchmarks
@@ -83,14 +85,11 @@ public class ConsumerBenchmarks
     public void ConfluentIterationSetup()
     {
         _confluentConsumer = new Confluent.Kafka.ConsumerBuilder<string, string>(
-            new Confluent.Kafka.ConsumerConfig
-            {
-                BootstrapServers = _kafka.BootstrapServers,
-                ClientId = "confluent-consumer-benchmark",
-                GroupId = $"confluent-benchmark-{Guid.NewGuid():N}",
-                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest,
-                EnableAutoCommit = false
-            }).Build();
+            ConfluentBenchmarkConfigs.CreateConsumerConfig(
+                _kafka.BootstrapServers,
+                clientId: "confluent-consumer-benchmark",
+                groupId: $"confluent-benchmark-{Guid.NewGuid():N}",
+                enableAutoCommit: false)).Build();
         _confluentConsumer.Subscribe(_topic);
 
         // Prime through group join and the first fetch so the timed region starts warm.

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -41,8 +41,8 @@ public class ConsumerPollBenchmarks
             AddJob(Job.Default
                 .WithStrategy(RunStrategy.Throughput)
                 .WithLaunchCount(1)
-                .WithWarmupCount(3)
-                .WithIterationCount(3)
+                .WithWarmupCount(5)
+                .WithIterationCount(10)
                 .WithInvocationCount(PollsPerIteration)
                 .WithUnrollFactor(1));
         }
@@ -97,13 +97,10 @@ public class ConsumerPollBenchmarks
     public void ConfluentIterationSetup()
     {
         _confluentPollConsumer = new Confluent.Kafka.ConsumerBuilder<string, string>(
-            new Confluent.Kafka.ConsumerConfig
-            {
-                BootstrapServers = _kafka.BootstrapServers,
-                ClientId = "confluent-poll-benchmark",
-                GroupId = $"confluent-poll-{Guid.NewGuid():N}",
-                AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest
-            }).Build();
+            ConfluentBenchmarkConfigs.CreateConsumerConfig(
+                _kafka.BootstrapServers,
+                clientId: "confluent-poll-benchmark",
+                groupId: $"confluent-poll-{Guid.NewGuid():N}")).Build();
         _confluentPollConsumer.Subscribe(_topic);
 
         if (_confluentPollConsumer.Consume(PollTimeout) is null)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -1,6 +1,5 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Engines;
 using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Tooling;
 using DekafProducer = Dekaf.Producer;
@@ -11,8 +10,15 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 /// Producer benchmarks comparing Dekaf vs Confluent.Kafka.
 /// Confluent is marked as baseline for ratio comparison.
 /// </summary>
+/// <remarks>
+/// Message keys are pre-created in <c>[GlobalSetup]</c> so the Allocated column reflects
+/// the clients, not the benchmark's own key-string interpolation. Dekaf ops use the
+/// allocation-optimized <c>ProduceAsync(topic, key, value)</c> / <c>FireAsync(topic, key, value)</c>
+/// overloads — the idiomatic hot-path API — rather than allocating a
+/// <see cref="DekafProducer.ProducerMessage{TKey, TValue}"/> per message.
+/// </remarks>
 [MemoryDiagnoser]
-[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+[ThroughputJob]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
 public class ProducerBenchmarks
@@ -25,6 +31,7 @@ public class ProducerBenchmarks
     private const string Topic = "benchmark-producer";
     private static readonly TimeSpan QueueFullRetryTimeout = TimeSpan.FromSeconds(30);
     private string _messageValue = null!;
+    private string[] _keys = null!;
 
     [Params(100, 1000)]
     public int MessageSize { get; set; }
@@ -39,6 +46,7 @@ public class ProducerBenchmarks
         await _kafka.CreateTopicAsync(Topic, 3).ConfigureAwait(false);
 
         _messageValue = new string('x', MessageSize);
+        _keys = BenchmarkData.CreateKeys(BatchSize);
 
         _dekafProducer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
@@ -147,12 +155,8 @@ public class ProducerBenchmarks
     [Benchmark]
     public async Task<DekafProducer.RecordMetadata> Dekaf_ProduceSingle()
     {
-        return await _dekafProducer.ProduceAsync(new DekafProducer.ProducerMessage<string, string>
-        {
-            Topic = Topic,
-            Key = "key",
-            Value = _messageValue
-        }, CancellationToken.None).ConfigureAwait(false);
+        return await _dekafProducer.ProduceAsync(Topic, "key", _messageValue, CancellationToken.None)
+            .ConfigureAwait(false);
     }
 
     // ===== Batch Produce =====
@@ -167,7 +171,7 @@ public class ProducerBenchmarks
         {
             tasks.Add(_confluentProducer.ProduceAsync(Topic, new Confluent.Kafka.Message<string, string>
             {
-                Key = $"key-{i}",
+                Key = _keys[i],
                 Value = _messageValue
             }));
         }
@@ -181,14 +185,12 @@ public class ProducerBenchmarks
     {
         var tasks = new List<Task<DekafProducer.RecordMetadata>>(BatchSize);
 
+        // .AsTask() per message is required: the pooled ValueTask contract forbids
+        // collecting raw ValueTasks for deferred await (see IKafkaProducer remarks).
         for (var i = 0; i < BatchSize; i++)
         {
-            tasks.Add(_dekafProducer.ProduceAsync(new DekafProducer.ProducerMessage<string, string>
-            {
-                Topic = Topic,
-                Key = $"key-{i}",
-                Value = _messageValue
-            }, CancellationToken.None).AsTask());
+            tasks.Add(_dekafProducer.ProduceAsync(Topic, _keys[i], _messageValue, CancellationToken.None)
+                .AsTask());
         }
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -202,7 +204,7 @@ public class ProducerBenchmarks
     {
         for (var i = 0; i < BatchSize; i++)
         {
-            ProduceConfluentFireAndForget($"key-{i}", _messageValue);
+            ProduceConfluentFireAndForget(_keys[i], _messageValue);
         }
     }
 
@@ -229,7 +231,7 @@ public class ProducerBenchmarks
     {
         for (var i = 0; i < BatchSize; i++)
         {
-            await _dekafProducer.FireAsync(Topic, $"key-{i}", _messageValue);
+            await _dekafProducer.FireAsync(Topic, _keys[i], _messageValue);
         }
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerModeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerModeBenchmarks.cs
@@ -30,18 +30,10 @@ public class ProducerModeBenchmarks
     private const int BatchCount = 1000;
 
     private string _messageValue = null!;
-    private static readonly string[] PreAllocatedKeys = CreateKeys(BatchCount);
+    private static readonly string[] PreAllocatedKeys = BenchmarkData.CreateKeys(BatchCount);
 
     [Params(100, 1000)]
     public int MessageSize { get; set; }
-
-    private static string[] CreateKeys(int count)
-    {
-        var keys = new string[count];
-        for (var i = 0; i < count; i++)
-            keys[i] = $"key-{i}";
-        return keys;
-    }
 
     [GlobalSetup]
     public async Task Setup()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CompressionBenchmarks.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Compression.Snappy;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
@@ -9,7 +10,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// Tests Snappy compression/decompression performance.
 /// </summary>
 [MemoryDiagnoser]
-[ShortRunJob]
+[ThroughputJob]
 public class CompressionBenchmarks
 {
     private readonly SnappyCompressionCodec _codec = new();
@@ -37,23 +38,23 @@ public class CompressionBenchmarks
         _outputBuffer.Clear();
     }
 
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _outputBuffer.Clear();
-    }
+    // No [IterationSetup]: its presence would force single-invocation iterations
+    // (cold single-shot Tier-0 samples, meaningless statistics for microsecond ops).
+    // Each benchmark clears _outputBuffer itself instead.
 
     // ===== Compression =====
 
     [Benchmark(Description = "Snappy Compress 1KB")]
     public void Snappy_Compress_1KB()
     {
+        _outputBuffer.Clear();
         _codec.Compress(new ReadOnlySequence<byte>(_smallData), _outputBuffer);
     }
 
     [Benchmark(Description = "Snappy Compress 1MB")]
     public void Snappy_Compress_1MB()
     {
+        _outputBuffer.Clear();
         _codec.Compress(new ReadOnlySequence<byte>(_largeData), _outputBuffer);
     }
 
@@ -62,12 +63,14 @@ public class CompressionBenchmarks
     [Benchmark(Description = "Snappy Decompress 1KB")]
     public void Snappy_Decompress_1KB()
     {
+        _outputBuffer.Clear();
         _codec.Decompress(new ReadOnlySequence<byte>(_smallCompressed), _outputBuffer);
     }
 
     [Benchmark(Description = "Snappy Decompress 1MB")]
     public void Snappy_Decompress_1MB()
     {
+        _outputBuffer.Clear();
         _codec.Decompress(new ReadOnlySequence<byte>(_largeCompressed), _outputBuffer);
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Metadata;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -18,7 +19,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class ProducerFireHotPathBenchmarks
 {
     private const string Topic = "producer-fire-hot-path";
-    private static readonly string[] Keys = CreateKeys();
+    private static readonly string[] Keys = BenchmarkData.CreateKeys(10_000);
 
     private KafkaProducer<string, string> _producer = null!;
     private RecordAccumulator _accumulator = null!;
@@ -109,14 +110,6 @@ public class ProducerFireHotPathBenchmarks
                 spinner.SpinOnce();
             }
         }
-    }
-
-    private static string[] CreateKeys()
-    {
-        var keys = new string[10_000];
-        for (var i = 0; i < keys.Length; i++)
-            keys[i] = $"key-{i}";
-        return keys;
     }
 
     private static void SeedMetadata(KafkaProducer<string, string> producer)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 
@@ -9,14 +10,21 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// Zero-allocation protocol benchmarks for Kafka wire protocol operations.
 /// These benchmarks verify Dekaf's allocation-free design.
 /// </summary>
+/// <remarks>
+/// The RecordBatch write benchmarks reuse a batch built in <c>[GlobalSetup]</c>
+/// (<see cref="RecordBatch.Write"/> does not mutate the batch), and the read benchmarks
+/// return the batch to its pool the way the consumer path does — so the Allocated column
+/// measures the library, not the benchmark's own input construction.
+/// </remarks>
 [MemoryDiagnoser]
-[ShortRunJob]
+[ThroughputJob]
 public class ProtocolBenchmarks
 {
     private ArrayBufferWriter<byte> _buffer = null!;
     private byte[] _int32Data = null!;
     private byte[] _varIntData = null!;
     private byte[] _recordBatchBytes = null!;
+    private RecordBatch _writeBatch = null!;
     private string _testString = null!;
     private string _longString = null!;
 
@@ -63,13 +71,13 @@ public class ProtocolBenchmarks
         };
         batch.Write(tempBuffer);
         _recordBatchBytes = tempBuffer.WrittenSpan.ToArray();
+
+        _writeBatch = CreateTenRecordBatch();
     }
 
-    [IterationSetup]
-    public void IterationSetup()
-    {
-        _buffer.Clear();
-    }
+    // No [IterationSetup]: its presence would force single-invocation iterations
+    // (cold single-shot Tier-0 samples, meaningless statistics for microsecond ops).
+    // Each write benchmark clears _buffer itself; read benchmarks don't use it.
 
     // ===== Write Operations =====
 
@@ -195,20 +203,16 @@ public class ProtocolBenchmarks
     public void WriteRecordBatch()
     {
         _buffer.Clear();
-        var batch = CreateTenRecordBatch();
-
-        batch.Write(_buffer);
+        _writeBatch.Write(_buffer);
     }
 
     [Benchmark(Description = "Write RecordBatch pre-serialized (10 records)")]
     public void WriteRecordBatchPreSerialized()
     {
         _buffer.Clear();
-        var batch = CreateTenRecordBatch();
-
-        batch.PreCompress(CompressionType.None, null);
-        batch.Write(_buffer);
-        batch.ReturnPreCompressedBuffer();
+        _writeBatch.PreCompress(CompressionType.None, null);
+        _writeBatch.Write(_buffer);
+        _writeBatch.ReturnPreCompressedBuffer();
     }
 
     private static RecordBatch CreateTenRecordBatch() => new()
@@ -227,12 +231,13 @@ public class ProtocolBenchmarks
     };
 
     [Benchmark(Description = "Read RecordBatch (10 records)")]
-    public RecordBatch ReadRecordBatch()
+    public long ReadRecordBatch()
     {
         var reader = new KafkaProtocolReader(_recordBatchBytes);
         var batch = RecordBatch.Read(ref reader);
-        batch.Dispose();
-        return batch;
+        var baseOffset = batch.BaseOffset;
+        batch.DisposeAndReturnUnownedConsumerBatch();
+        return baseOffset;
     }
 
     [Benchmark(Description = "Read + Iterate RecordBatch (10 records)")]
@@ -245,7 +250,7 @@ public class ProtocolBenchmarks
         {
             sum += batch.Records[i].OffsetDelta;
         }
-        batch.Dispose();
+        batch.DisposeAndReturnUnownedConsumerBatch();
         return sum;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SerializerBenchmarks.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 
@@ -15,10 +16,12 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// the single baseline lives in the Writer category. There is deliberately no
 /// <c>[IterationSetup]</c>: its presence would force single-invocation iterations, which
 /// cannot produce meaningful statistics for nanosecond-scale operations — buffers are
-/// reset inside each benchmark instead.
+/// reset inside each benchmark instead. The Writer and Batch benchmarks exercise
+/// <see cref="ReusableBufferWriter"/> — the writer the production serialization path
+/// actually uses (thread-local buffers in <c>ProducerThreadCache</c>).
 /// </remarks>
 [MemoryDiagnoser]
-[ShortRunJob]
+[ThroughputJob]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
 public class SerializerBenchmarks
@@ -31,6 +34,11 @@ public class SerializerBenchmarks
     private byte[] _stringBytes = null!;
     private SerializationContext _context;
 
+    // Persistent buffers for ReusableBufferWriter, mirroring the producer's
+    // thread-local KeySerializationBuffer/ValueSerializationBuffer.
+    private byte[]? _reusableKeyBuffer;
+    private byte[]? _reusableValueBuffer;
+
     [GlobalSetup]
     public void Setup()
     {
@@ -39,9 +47,7 @@ public class SerializerBenchmarks
         _mediumString = new string('a', 100);
         _largeString = new string('a', 1000);
 
-        // Pre-created so the batch benchmark's Allocated column reflects the library,
-        // not the benchmark's own key-string interpolation.
-        _batchKeys = [.. Enumerable.Range(0, 100).Select(i => $"key-{i}")];
+        _batchKeys = BenchmarkData.CreateKeys(100);
 
         _context = new SerializationContext
         {
@@ -107,20 +113,22 @@ public class SerializerBenchmarks
 
         for (var i = 0; i < 100; i++)
         {
-            var keyWriter = new PooledBufferWriter(initialCapacity: 64);
+            var keyWriter = new ReusableBufferWriter(ref _reusableKeyBuffer, 64);
             Serializers.String.Serialize(_batchKeys[i], ref keyWriter, keyContext);
             var keyMemory = keyWriter.ToPooledMemory();
+            keyWriter.UpdateBufferRef(ref _reusableKeyBuffer);
 
-            var valueWriter = new PooledBufferWriter(initialCapacity: 256);
+            var valueWriter = new ReusableBufferWriter(ref _reusableValueBuffer, 256);
             Serializers.String.Serialize(_mediumString, ref valueWriter, valueContext);
             var valueMemory = valueWriter.ToPooledMemory();
+            valueWriter.UpdateBufferRef(ref _reusableValueBuffer);
 
             keyMemory.Return();
             valueMemory.Return();
         }
     }
 
-    // ===== PooledBufferWriter vs ArrayBufferWriter =====
+    // ===== ReusableBufferWriter (production path) vs ArrayBufferWriter =====
 
     [BenchmarkCategory("Writer")]
     [Benchmark(Baseline = true, Description = "ArrayBufferWriter + Copy")]
@@ -135,11 +143,12 @@ public class SerializerBenchmarks
     }
 
     [BenchmarkCategory("Writer")]
-    [Benchmark(Description = "PooledBufferWriter Direct")]
-    public void Serialize_PooledBufferWriter()
+    [Benchmark(Description = "ReusableBufferWriter Direct")]
+    public void Serialize_ReusableBufferWriter()
     {
-        var pooledWriter = new PooledBufferWriter(initialCapacity: 256);
-        Serializers.String.Serialize(_mediumString, ref pooledWriter, _context);
-        pooledWriter.ToPooledMemory().Return();
+        var writer = new ReusableBufferWriter(ref _reusableValueBuffer, 256);
+        Serializers.String.Serialize(_mediumString, ref writer, _context);
+        writer.ToPooledMemory().Return();
+        writer.UpdateBufferRef(ref _reusableValueBuffer);
     }
 }

--- a/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkData.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BenchmarkData.cs
@@ -1,0 +1,20 @@
+namespace Dekaf.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Shared benchmark input builders.
+/// </summary>
+public static class BenchmarkData
+{
+    /// <summary>
+    /// Pre-creates "key-{i}" strings. Call from <c>[GlobalSetup]</c> or a static field
+    /// initializer so the Allocated column reflects the code under test, not the
+    /// benchmark's own key-string interpolation.
+    /// </summary>
+    public static string[] CreateKeys(int count)
+    {
+        var keys = new string[count];
+        for (var i = 0; i < count; i++)
+            keys[i] = $"key-{i}";
+        return keys;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/ConfluentBenchmarkConfigs.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/ConfluentBenchmarkConfigs.cs
@@ -1,0 +1,29 @@
+namespace Dekaf.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Shared Confluent.Kafka configs for the comparison benchmarks, kept in one place so
+/// the fairness-critical settings cannot drift between benchmark classes.
+/// </summary>
+public static class ConfluentBenchmarkConfigs
+{
+    /// <summary>
+    /// Consumer config doing the same work as Dekaf's defaults. <c>CheckCrcs</c> is on
+    /// because Dekaf validates batch CRCs by default (Java-client parity) while
+    /// librdkafka defaults <c>check.crcs</c> off — without it the two clients are not
+    /// doing the same work and the comparison is invalid.
+    /// </summary>
+    public static Confluent.Kafka.ConsumerConfig CreateConsumerConfig(
+        string bootstrapServers,
+        string clientId,
+        string groupId,
+        bool enableAutoCommit = true)
+        => new()
+        {
+            BootstrapServers = bootstrapServers,
+            ClientId = clientId,
+            GroupId = groupId,
+            AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest,
+            EnableAutoCommit = enableAutoCommit,
+            CheckCrcs = true
+        };
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/ThroughputJobAttribute.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/ThroughputJobAttribute.cs
@@ -1,0 +1,26 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+
+namespace Dekaf.Benchmarks.Infrastructure;
+
+/// <summary>
+/// The high-fidelity throughput job used by the published benchmark tables
+/// (docs/docs/benchmarks.md): single launch, throughput strategy, with enough
+/// iterations that the 99.9% confidence interval stays well below the mean on
+/// shared CI runners (3-iteration jobs routinely produced Error &gt; Mean).
+/// Classes whose iterations are single-shot and setup-dominated may pass lower
+/// counts — one extra iteration there buys one sample at seconds of setup cost.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ThroughputJobAttribute : JobConfigBaseAttribute
+{
+    public ThroughputJobAttribute(int warmupCount = 5, int iterationCount = 10)
+        : base(Job.Default
+            .WithStrategy(RunStrategy.Throughput)
+            .WithLaunchCount(1)
+            .WithWarmupCount(warmupCount)
+            .WithIterationCount(iterationCount))
+    {
+    }
+}


### PR DESCRIPTION
## Why

A four-agent audit of the published benchmark tables (docs/benchmarks) found that most nonzero Allocated figures and the worst-looking ratios were **harness-owned, not library costs**, and that 3-warmup/3-iteration jobs on shared 2-core runners routinely produced Error > Mean. This PR fixes the harness so the tables show what the library actually does. Library-side follow-ups from the same audit are tracked in #2211, #2212, #2213, #2214.

## Changes

**Measurement correctness**
- **RecordBatch write benchmarks** built their 10-record input (strings, UTF8 arrays, LINQ, list) inside the measured op. Input now built once in `[GlobalSetup]` and reused — `RecordBatch.Write` is non-mutating, and that contract is now documented on `Write` itself. Local before/after: 20.8 μs / 2480 B → **512 ns / 0 B**.
- **RecordBatch read benchmarks** called `Dispose()` but never returned the pooled batch, re-allocating it every op. Now released via the production `DisposeAndReturnUnownedConsumerBatch()` (same pattern as `KafkaShareConsumer`). Local: 4.8 μs / 192 B → **113 ns / 0 B**. The pre-serialized write variant now shows only the genuine 40 B `DetachableBufferWriter` allocation (#2214's target).
- **Removed redundant `[IterationSetup]`** from `ProtocolBenchmarks` and `CompressionBenchmarks` — its presence forces InvocationCount=1 (cold single-shot Tier-0 samples; the same bug the poll benchmarks already fixed and documented). Ops clear their own buffer instead. This alone explains the previous protocol-table Error values (e.g. Write 1000 VarInts: Error 180 μs on a 41.7 μs mean).
- **Producer benchmarks** interpolated `$"key-{i}"` per message inside the measured ops — that was ~all of FireAndForget's reported 41 B/msg. Keys are pre-created via a shared `BenchmarkData.CreateKeys` (also de-dups three pre-existing inline copies), and Dekaf ops use the allocation-optimized `ProduceAsync/FireAsync(topic, key, value)` overloads instead of allocating a `ProducerMessage` per message. `.AsTask()` per message stays — the pooled ValueTask contract requires it; removing that cost is #2212.
- **Serializer benchmarks** measured `PooledBufferWriter`, which has **zero call sites** in `src/` — the production path uses `ReusableBufferWriter`. Writer/Batch benchmarks now exercise the real writer. Local: batch 100 messages 14.2 μs → **7.3 μs, 0 B** (the dead type was also slower).

**Fairness**
- **Consumer benchmarks now set `CheckCrcs = true` on the Confluent side** (new shared `ConfluentBenchmarkConfigs` factory so it can't drift between the two consumer classes). Dekaf validates batch CRCs by default (Java-client parity); librdkafka defaults `check.crcs` off — previously the comparison had Dekaf doing per-batch CRC32C work Confluent skipped.

**Statistical quality**
- New `[ThroughputJob]` attribute (1 launch / 5 warmup / 10 iterations) replaces the copy-pasted 3/3 `[SimpleJob]` on the six published-table classes; `ConsumerPollBenchmarks`' manual config bumped to the same counts. `ConsumerBenchmarks` runs 3/8 — its iterations are single-invocation and dominated by ~3 s of consumer build + group join, so extra iterations there buy one sample each at high CI cost (~+2–3 min client-job wall time overall, well within limits).

## Expected table impact

Protocol write/read rows drop to `-` (true zero-alloc) except the 40 B pre-compress wrapper; FireAndForget Allocated drops to ~0 B/msg; ProduceBatch Allocated drops by ~120 B/msg (remaining Task-per-message cost is #2212); consumer ratios become like-for-like on CRC work; Error columns shrink across all tables. Times are not comparable to the previous table for Protocol/Compression rows (they were single-shot Tier-0 before).

## Validation

- `dotnet build` clean (0 warnings).
- Changed unit benchmarks executed locally in-process: numbers above; `[ThroughputJob]` confirmed applied (WarmupCount=5, IterationCount=10 in job summary).
- Client benchmarks need Kafka — validated by the benchmarks workflow on merge.

## Note

`PooledBufferWriter` (`KafkaProducer.cs:4731`) is now production- and benchmark-dead, kept alive only by its unit tests. Left in place here; removal can ride a future cleanup.