### PR TITLE
perf(producer): ValueTask-native ProduceAllAsync — no per-message Task allocation or thread-pool hop

### DIFF
--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -25,7 +25,10 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// // Single message - await immediately (recommended)
     /// var metadata = await producer.ProduceAsync(message);
     ///
-    /// // Multiple messages in parallel - convert to Task (recommended)
+    /// // Multiple messages in parallel - ProduceAllAsync (recommended, no per-message Task)
+    /// var results = await producer.ProduceAllAsync(messages);
+    ///
+    /// // Alternatively, convert each ValueTask to Task
     /// var tasks = new List&lt;Task&lt;RecordMetadata&gt;&gt;();
     /// for (int i = 0; i &lt; count; i++)
     ///     tasks.Add(producer.ProduceAsync(message).AsTask());
@@ -131,8 +134,10 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// </summary>
     /// <remarks>
     /// <para>This method is the recommended way to produce multiple messages in parallel.
-    /// It handles the <see cref="ValueTask{TResult}"/> to <see cref="Task{TResult}"/> conversion
-    /// internally, avoiding the error-prone pattern of storing ValueTask instances in collections.</para>
+    /// It awaits each message's <see cref="ValueTask{TResult}"/> internally through a single
+    /// counting completion, avoiding both the error-prone pattern of storing ValueTask instances
+    /// in collections and the per-message <see cref="Task{TResult}"/> allocations of
+    /// <c>AsTask()</c> + <see cref="Task.WhenAll(Task[])"/>.</para>
     /// </remarks>
     /// <param name="messages">The messages to produce.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -495,18 +495,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     public ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken = default)
-    {
-        if (_retryPolicy is not null)
-            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: true, cancellationToken);
-
-        return ProduceAsyncCore(message, runContinuationsAsynchronously: true, cancellationToken);
-    }
+        => ProduceAsync(message, runContinuationsAsynchronously: true, cancellationToken);
 
     internal ValueTask<RecordMetadata> ProduceTransactionAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
+        => ProduceAsync(message, !_options.InlineTransactionCompletions, cancellationToken);
+
+    private ValueTask<RecordMetadata> ProduceAsync(
+        ProducerMessage<TKey, TValue> message,
+        bool runContinuationsAsynchronously,
+        CancellationToken cancellationToken)
     {
-        var runContinuationsAsynchronously = !_options.InlineTransactionCompletions;
         if (_retryPolicy is not null)
             return ProduceAsyncWithRetry(message, runContinuationsAsynchronously, cancellationToken);
 
@@ -683,6 +683,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
@@ -695,10 +696,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 Headers = headers,
                 Partition = partition,
                 Timestamp = timestamp
-            }, cancellationToken);
+            }, runContinuationsAsynchronously, cancellationToken);
         }
 
-        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously: true, cancellationToken);
+        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(
@@ -1628,7 +1629,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         TValue value,
         CancellationToken cancellationToken = default)
     {
-        return ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, cancellationToken);
+        return ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, runContinuationsAsynchronously: true, cancellationToken);
     }
 
     ValueTask<RecordMetadata> IProducerFastPath<TKey, TValue>.ProduceAsync(
@@ -1639,7 +1640,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         int? partition,
         DateTimeOffset? timestamp,
         CancellationToken cancellationToken)
-        => ProduceAsync(topic, key, value, headers, partition, timestamp, cancellationToken);
+        => ProduceAsync(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously: true, cancellationToken);
 
     /// <inheritdoc />
     public async Task<RecordMetadata[]> ProduceAllAsync(
@@ -1660,7 +1661,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             try
             {
-                completion.Register(i, ProduceForAllAsync(messageList[i], cancellationToken));
+                // runContinuationsAsynchronously: false is safe here — see ProduceAllCompletion remarks.
+                completion.Register(i, ProduceAsync(messageList[i], runContinuationsAsynchronously: false, cancellationToken));
             }
             catch (Exception ex)
             {
@@ -1668,6 +1670,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 // registration; already-registered operations still complete before the
                 // aggregate faults, so no pooled completion is abandoned.
                 completion.RecordFailure(i, ex);
+                completion.AbortRegistration(messageList.Count - i);
                 break;
             }
         }
@@ -1697,62 +1700,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var (key, value) = messageList[i];
             try
             {
-                completion.Register(i, ProduceForAllAsync(topic, key, value, cancellationToken));
+                // runContinuationsAsynchronously: false is safe here — see ProduceAllCompletion remarks.
+                completion.Register(i, ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, runContinuationsAsynchronously: false, cancellationToken));
             }
             catch (Exception ex)
             {
                 // See the message-list overload: stop registration, let in-flight operations
                 // finish, then surface the failure from the aggregate await.
                 completion.RecordFailure(i, ex);
+                completion.AbortRegistration(messageList.Count - i);
                 break;
             }
         }
 
         return await completion.WaitAsync().ConfigureAwait(false);
-    }
-
-    // ProduceAllAsync produces with runContinuationsAsynchronously: false. The only continuation
-    // attached to each per-message completion is ProduceAllCompletion's bounded harvest (array
-    // store + counter decrement), so running it inline on the broker sender's ack path is safe
-    // and avoids one thread-pool hop per acked message. The aggregate completion still runs its
-    // continuation asynchronously, so user code never executes on the sender loop.
-    private ValueTask<RecordMetadata> ProduceForAllAsync(
-        ProducerMessage<TKey, TValue> message,
-        CancellationToken cancellationToken)
-    {
-        if (_retryPolicy is not null)
-            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: false, cancellationToken);
-
-        return ProduceAsyncCore(message, runContinuationsAsynchronously: false, cancellationToken);
-    }
-
-    private ValueTask<RecordMetadata> ProduceForAllAsync(
-        string topic,
-        TKey? key,
-        TValue value,
-        CancellationToken cancellationToken)
-    {
-        // Mirrors the private ProduceAsync(topic, ...) dispatch: features that need the full
-        // message object fall back to the message-based path.
-        if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
-        {
-            return ProduceForAllAsync(new ProducerMessage<TKey, TValue>
-            {
-                Topic = topic,
-                Key = key,
-                Value = value
-            }, cancellationToken);
-        }
-
-        return ProduceAsyncCore(
-            topic,
-            key,
-            value,
-            headers: null,
-            partition: null,
-            timestamp: null,
-            runContinuationsAsynchronously: false,
-            cancellationToken);
     }
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -698,7 +698,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }, cancellationToken);
         }
 
-        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, cancellationToken);
+        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously: true, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(
@@ -708,6 +708,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         ThrowIfProduceCannotStart();
@@ -722,11 +723,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var prepare = PrepareSerializersAsync(topic, key, value, headers, cancellationToken);
             if (!prepare.IsCompletedSuccessfully)
             {
-                return AwaitPrepareThenProduce(prepare, topic, key, value, headers, partition, timestamp, cancellationToken);
+                return AwaitPrepareThenProduce(prepare, topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
             }
         }
 
-        return ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, cancellationToken);
+        return ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
@@ -736,6 +737,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         if (TryProduceSyncForAsync(
@@ -745,7 +747,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             headers,
             partition,
             timestamp,
-            runContinuationsAsynchronously: true,
+            runContinuationsAsynchronously,
             out var completion))
         {
             // POST-QUEUE: Message appended to batch, committed to being sent
@@ -770,7 +772,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Headers = headers,
             Partition = partition,
             Timestamp = timestamp
-        }, activity: null, runContinuationsAsynchronously: true, cancellationToken);
+        }, activity: null, runContinuationsAsynchronously, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
@@ -781,10 +783,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
+        bool runContinuationsAsynchronously,
         CancellationToken cancellationToken)
     {
         await prepare.ConfigureAwait(false);
-        return await ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, cancellationToken).ConfigureAwait(false);
+        return await ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1652,14 +1655,24 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return [];
         }
 
-        // Convert ValueTask to Task for each message and await all
-        var tasks = new Task<RecordMetadata>[messageList.Count];
+        var completion = ProduceAllCompletion.Rent(messageList.Count);
         for (var i = 0; i < messageList.Count; i++)
         {
-            tasks[i] = ProduceAsync(messageList[i], cancellationToken).AsTask();
+            try
+            {
+                completion.Register(i, ProduceForAllAsync(messageList[i], cancellationToken));
+            }
+            catch (Exception ex)
+            {
+                // Synchronous produce failure (disposed, cancelled, interceptor throw) stops
+                // registration; already-registered operations still complete before the
+                // aggregate faults, so no pooled completion is abandoned.
+                completion.RecordFailure(i, ex);
+                break;
+            }
         }
 
-        return await Task.WhenAll(tasks).ConfigureAwait(false);
+        return await completion.WaitAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -1678,15 +1691,68 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return [];
         }
 
-        // Convert ValueTask to Task for each message and await all
-        var tasks = new Task<RecordMetadata>[messageList.Count];
+        var completion = ProduceAllCompletion.Rent(messageList.Count);
         for (var i = 0; i < messageList.Count; i++)
         {
             var (key, value) = messageList[i];
-            tasks[i] = ProduceAsync(topic, key, value, cancellationToken).AsTask();
+            try
+            {
+                completion.Register(i, ProduceForAllAsync(topic, key, value, cancellationToken));
+            }
+            catch (Exception ex)
+            {
+                // See the message-list overload: stop registration, let in-flight operations
+                // finish, then surface the failure from the aggregate await.
+                completion.RecordFailure(i, ex);
+                break;
+            }
         }
 
-        return await Task.WhenAll(tasks).ConfigureAwait(false);
+        return await completion.WaitAsync().ConfigureAwait(false);
+    }
+
+    // ProduceAllAsync produces with runContinuationsAsynchronously: false. The only continuation
+    // attached to each per-message completion is ProduceAllCompletion's bounded harvest (array
+    // store + counter decrement), so running it inline on the broker sender's ack path is safe
+    // and avoids one thread-pool hop per acked message. The aggregate completion still runs its
+    // continuation asynchronously, so user code never executes on the sender loop.
+    private ValueTask<RecordMetadata> ProduceForAllAsync(
+        ProducerMessage<TKey, TValue> message,
+        CancellationToken cancellationToken)
+    {
+        if (_retryPolicy is not null)
+            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously: false, cancellationToken);
+
+        return ProduceAsyncCore(message, runContinuationsAsynchronously: false, cancellationToken);
+    }
+
+    private ValueTask<RecordMetadata> ProduceForAllAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken)
+    {
+        // Mirrors the private ProduceAsync(topic, ...) dispatch: features that need the full
+        // message object fall back to the message-based path.
+        if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
+        {
+            return ProduceForAllAsync(new ProducerMessage<TKey, TValue>
+            {
+                Topic = topic,
+                Key = key,
+                Value = value
+            }, cancellationToken);
+        }
+
+        return ProduceAsyncCore(
+            topic,
+            key,
+            value,
+            headers: null,
+            partition: null,
+            timestamp: null,
+            runContinuationsAsynchronously: false,
+            cancellationToken);
     }
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -495,27 +495,38 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     public ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken = default)
-        => ProduceAsync(message, runContinuationsAsynchronously: true, cancellationToken);
+        => ProduceAsync(message, ProduceContinuationMode.Async, cancellationToken);
 
     internal ValueTask<RecordMetadata> ProduceTransactionAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
-        => ProduceAsync(message, !_options.InlineTransactionCompletions, cancellationToken);
+        => ProduceAsync(
+            message,
+            _options.InlineTransactionCompletions ? ProduceContinuationMode.Inline : ProduceContinuationMode.Async,
+            cancellationToken);
 
     private ValueTask<RecordMetadata> ProduceAsync(
         ProducerMessage<TKey, TValue> message,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
+        // The retry wrapper's continuation runs retry-policy code (classification, delay
+        // computation); ProduceAllAsync's bounded-harvest inline request must not run it on the
+        // broker ack thread. The InlineTransactionCompletions opt-in keeps its documented
+        // inline behavior.
         if (_retryPolicy is not null)
-            return ProduceAsyncWithRetry(message, runContinuationsAsynchronously, cancellationToken);
+        {
+            if (continuationMode == ProduceContinuationMode.InlineWhenDirect)
+                continuationMode = ProduceContinuationMode.Async;
+            return ProduceAsyncWithRetry(message, continuationMode, cancellationToken);
+        }
 
-        return ProduceAsyncCore(message, runContinuationsAsynchronously, cancellationToken);
+        return ProduceAsyncCore(message, continuationMode, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(
         ProducerMessage<TKey, TValue> message,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         ThrowIfProduceCannotStart();
@@ -552,12 +563,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     prepare,
                     message,
                     activity,
-                    runContinuationsAsynchronously,
+                    continuationMode,
                     cancellationToken);
             }
         }
 
-        return ProduceAfterPrepare(message, activity, runContinuationsAsynchronously, cancellationToken);
+        return ProduceAfterPrepare(message, activity, continuationMode, cancellationToken);
     }
 
     // Stops and error-tags a started span when async serializer preparation fails before the
@@ -577,9 +588,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
+        // AwaitWithActivity/AwaitWithMetrics interpose an async state machine whose continuation
+        // (metric emission, activity export/dispose) runs on the completing thread; ProduceAllAsync's
+        // inline request is only safe for the bare and cancellation awaits, whose continuations are
+        // bounded. Hoisted so the mode and the wrapper choice below can never disagree if a metrics
+        // listener starts mid-call.
+        var metricsEnabled = ProducerMetricsEnabled();
+        if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
+            continuationMode = ProduceContinuationMode.Async;
+        var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
+
         // Fast path: Try synchronous produce if metadata is initialized and cached.
         // This bypasses channel overhead for 99%+ of calls after warmup.
         if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var completion))
@@ -590,7 +611,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 return AwaitWithActivity(completion!, activity, message.Topic, cancellationToken);
             }
-            if (ProducerMetricsEnabled())
+            if (metricsEnabled)
             {
                 return AwaitWithMetrics(completion!, message.Topic, cancellationToken);
             }
@@ -603,14 +624,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Slow path: Fall back to channel-based async processing.
         // This handles first-time metadata initialization or cache misses.
-        return ProduceAsyncSlow(message, activity, runContinuationsAsynchronously, cancellationToken);
+        return ProduceAsyncSlow(message, activity, continuationMode, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
         ValueTask prepare,
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         try
@@ -628,7 +649,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return await ProduceAfterPrepare(
             message,
             activity,
-            runContinuationsAsynchronously,
+            continuationMode,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -683,7 +704,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
@@ -696,10 +717,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 Headers = headers,
                 Partition = partition,
                 Timestamp = timestamp
-            }, runContinuationsAsynchronously, cancellationToken);
+            }, continuationMode, cancellationToken);
         }
 
-        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
+        return ProduceAsyncCore(topic, key, value, headers, partition, timestamp, continuationMode, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAsyncCore(
@@ -709,7 +730,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         ThrowIfProduceCannotStart();
@@ -724,11 +745,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var prepare = PrepareSerializersAsync(topic, key, value, headers, cancellationToken);
             if (!prepare.IsCompletedSuccessfully)
             {
-                return AwaitPrepareThenProduce(prepare, topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
+                return AwaitPrepareThenProduce(prepare, topic, key, value, headers, partition, timestamp, continuationMode, cancellationToken);
             }
         }
 
-        return ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken);
+        return ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, continuationMode, cancellationToken);
     }
 
     private ValueTask<RecordMetadata> ProduceAfterPrepare(
@@ -738,9 +759,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
+        // See the message-based ProduceAfterPrepare: the metrics wrapper's continuation must not
+        // run inline on the broker ack thread, and the hoisted check keeps mode and wrapper in sync.
+        var metricsEnabled = ProducerMetricsEnabled();
+        if (continuationMode == ProduceContinuationMode.InlineWhenDirect && metricsEnabled)
+            continuationMode = ProduceContinuationMode.Async;
+        var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
+
         if (TryProduceSyncForAsync(
             topic,
             key,
@@ -753,7 +781,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             // POST-QUEUE: Message appended to batch, committed to being sent
             // Message WILL be delivered, but caller can stop waiting via cancellation token.
-            if (ProducerMetricsEnabled())
+            if (metricsEnabled)
             {
                 return AwaitWithMetrics(completion!, topic, cancellationToken);
             }
@@ -773,7 +801,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Headers = headers,
             Partition = partition,
             Timestamp = timestamp
-        }, activity: null, runContinuationsAsynchronously, cancellationToken);
+        }, activity: null, continuationMode, cancellationToken);
     }
 
     private async ValueTask<RecordMetadata> AwaitPrepareThenProduce(
@@ -784,17 +812,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         Headers? headers,
         int? partition,
         DateTimeOffset? timestamp,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         await prepare.ConfigureAwait(false);
-        return await ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously, cancellationToken).ConfigureAwait(false);
+        return await ProduceAfterPrepare(topic, key, value, headers, partition, timestamp, continuationMode, cancellationToken).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private async ValueTask<RecordMetadata> ProduceAsyncWithRetry(
         ProducerMessage<TKey, TValue> message,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
         var attempt = 0;
@@ -804,7 +832,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 return await ProduceAsyncCore(
                     message,
-                    runContinuationsAsynchronously,
+                    continuationMode,
                     cancellationToken).ConfigureAwait(false);
             }
             catch (KafkaException ex) when (ex.IsRetriable)
@@ -1016,9 +1044,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private async ValueTask<RecordMetadata> ProduceAsyncSlow(
         ProducerMessage<TKey, TValue> message,
         Activity? activity,
-        bool runContinuationsAsynchronously,
+        ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
+        // See ProduceAfterPrepare: instrumented awaits interpose a state machine that must not
+        // run inline on the broker ack thread. Callers may have gated already, but the slow path
+        // re-checks because a metrics listener can start between their check and this one.
+        var metricsEnabled = ProducerMetricsEnabled();
+        if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
+            continuationMode = ProduceContinuationMode.Async;
+        var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
+
         // Retry fast path - metadata should already be initialized via InitializeAsync()
         if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var fastCompletion))
         {
@@ -1026,7 +1062,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 return await AwaitWithActivity(fastCompletion!, activity, message.Topic, cancellationToken).ConfigureAwait(false);
             }
-            if (ProducerMetricsEnabled())
+            if (metricsEnabled)
             {
                 return await AwaitWithMetrics(fastCompletion!, message.Topic, cancellationToken).ConfigureAwait(false);
             }
@@ -1056,7 +1092,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             return await AwaitWithActivity(completion, activity, message.Topic, cancellationToken).ConfigureAwait(false);
         }
-        if (ProducerMetricsEnabled())
+        if (metricsEnabled)
         {
             return await AwaitWithMetrics(completion, message.Topic, cancellationToken).ConfigureAwait(false);
         }
@@ -1629,7 +1665,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         TValue value,
         CancellationToken cancellationToken = default)
     {
-        return ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, runContinuationsAsynchronously: true, cancellationToken);
+        return ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, ProduceContinuationMode.Async, cancellationToken);
     }
 
     ValueTask<RecordMetadata> IProducerFastPath<TKey, TValue>.ProduceAsync(
@@ -1640,7 +1676,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         int? partition,
         DateTimeOffset? timestamp,
         CancellationToken cancellationToken)
-        => ProduceAsync(topic, key, value, headers, partition, timestamp, runContinuationsAsynchronously: true, cancellationToken);
+        => ProduceAsync(topic, key, value, headers, partition, timestamp, ProduceContinuationMode.Async, cancellationToken);
 
     /// <inheritdoc />
     public async Task<RecordMetadata[]> ProduceAllAsync(
@@ -1661,8 +1697,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             try
             {
-                // runContinuationsAsynchronously: false is safe here — see ProduceAllCompletion remarks.
-                completion.Register(i, ProduceAsync(messageList[i], runContinuationsAsynchronously: false, cancellationToken));
+                // InlineWhenDirect: safe because the sole direct continuation is the bounded
+                // harvest; instrumented/retry paths upgrade to Async — see ProduceAllCompletion remarks.
+                completion.Register(i, ProduceAsync(messageList[i], ProduceContinuationMode.InlineWhenDirect, cancellationToken));
             }
             catch (Exception ex)
             {
@@ -1700,8 +1737,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var (key, value) = messageList[i];
             try
             {
-                // runContinuationsAsynchronously: false is safe here — see ProduceAllCompletion remarks.
-                completion.Register(i, ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, runContinuationsAsynchronously: false, cancellationToken));
+                // InlineWhenDirect: safe because the sole direct continuation is the bounded
+                // harvest; instrumented/retry paths upgrade to Async — see ProduceAllCompletion remarks.
+                completion.Register(i, ProduceAsync(topic, key, value, headers: null, partition: null, timestamp: null, ProduceContinuationMode.InlineWhenDirect, cancellationToken));
             }
             catch (Exception ex)
             {

--- a/src/Dekaf/Producer/ProduceAllCompletion.cs
+++ b/src/Dekaf/Producer/ProduceAllCompletion.cs
@@ -22,9 +22,11 @@ namespace Dekaf.Producer;
 /// user code awaiting <c>ProduceAllAsync</c> never executes on the sender loop.
 /// </para>
 /// <para>
-/// On failure the exception with the smallest message index wins, matching the
-/// <see cref="Task.WhenAll(Task[])"/> convention of surfacing the first faulted operation in input
-/// order. All registered operations are always observed (their <c>GetResult</c> is invoked), so
+/// On failure a non-cancellation fault always beats an <see cref="OperationCanceledException"/>
+/// (matching <see cref="Task.WhenAll(Task[])"/>, which faults whenever any child faults, even when
+/// other children were cancelled); among exceptions of the same class the smallest message index
+/// wins, surfacing the first failed operation in input order. All registered operations are always
+/// observed (their <c>GetResult</c> is invoked), so
 /// pooled per-message sources are returned to their pool even when the aggregate faults.
 /// </para>
 /// </remarks>
@@ -80,12 +82,28 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
     {
         lock (_failureGate)
         {
-            if (_firstException is null || index < _firstExceptionIndex)
+            if (_firstException is null || ShouldReplace(_firstException, _firstExceptionIndex, exception, index))
             {
                 _firstException = exception;
                 _firstExceptionIndex = index;
             }
         }
+    }
+
+    /// <summary>
+    /// Faults beat cancellations (matching <see cref="Task.WhenAll(Task[])"/>, where any faulted
+    /// child makes the aggregate fault regardless of cancelled siblings); within the same class
+    /// the smallest message index wins.
+    /// </summary>
+    private static bool ShouldReplace(Exception current, int currentIndex, Exception candidate, int candidateIndex)
+    {
+        var currentIsCancellation = current is OperationCanceledException;
+        var candidateIsCancellation = candidate is OperationCanceledException;
+
+        if (currentIsCancellation != candidateIsCancellation)
+            return currentIsCancellation;
+
+        return candidateIndex < currentIndex;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/ProduceAllCompletion.cs
+++ b/src/Dekaf/Producer/ProduceAllCompletion.cs
@@ -14,7 +14,11 @@ namespace Dekaf.Producer;
 /// zero completes the single aggregate <see cref="IValueTaskSource{T}"/>. Per-message continuations
 /// are bounded (array store + decrement), which is why <c>ProduceAllAsync</c> can produce with
 /// <c>runContinuationsAsynchronously: false</c>: running them inline on the broker sender's ack
-/// path is safe and avoids one thread-pool hop per acked message.
+/// path is safe and avoids one thread-pool hop per acked message. This only holds when the
+/// harvest is the source's direct continuation — the producer upgrades to asynchronous
+/// continuations whenever an instrumented or retry wrapper (<c>AwaitWithMetrics</c>,
+/// <c>AwaitWithActivity</c>, <c>ProduceAsyncWithRetry</c>) interposes its own state machine,
+/// so metric listeners, activity export, and retry-policy code never run on the ack thread.
 /// </para>
 /// <para>
 /// The aggregate continuation always runs asynchronously

--- a/src/Dekaf/Producer/ProduceAllCompletion.cs
+++ b/src/Dekaf/Producer/ProduceAllCompletion.cs
@@ -1,0 +1,197 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
+using Dekaf.Internal;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Pooled counting completion used by <c>ProduceAllAsync</c> to await many produce operations
+/// without allocating a <see cref="Task"/> per message.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each registered produce operation attaches a pooled continuation that stores its result (or
+/// records its failure) and decrements a shared counter; the operation that brings the counter to
+/// zero completes the single aggregate <see cref="IValueTaskSource{T}"/>. Per-message continuations
+/// are bounded (array store + decrement), which is why <c>ProduceAllAsync</c> can produce with
+/// <c>runContinuationsAsynchronously: false</c>: running them inline on the broker sender's ack
+/// path is safe and avoids one thread-pool hop per acked message.
+/// </para>
+/// <para>
+/// The aggregate continuation always runs asynchronously
+/// (<see cref="ManualResetValueTaskSourceCore{T}.RunContinuationsAsynchronously"/> is true), so
+/// user code awaiting <c>ProduceAllAsync</c> never executes on the sender loop.
+/// </para>
+/// <para>
+/// On failure the exception with the smallest message index wins, matching the
+/// <see cref="Task.WhenAll(Task[])"/> convention of surfacing the first faulted operation in input
+/// order. All registered operations are always observed (their <c>GetResult</c> is invoked), so
+/// pooled per-message sources are returned to their pool even when the aggregate faults.
+/// </para>
+/// </remarks>
+internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
+{
+    private static readonly LockFreeStack<ProduceAllCompletion> s_pool = new(64);
+    private static readonly LockFreeStack<PendingOp> s_opPool = new(4096);
+
+    private ManualResetValueTaskSourceCore<RecordMetadata[]> _core = new() { RunContinuationsAsynchronously = true };
+    private readonly System.Threading.Lock _failureGate = new();
+    private RecordMetadata[]? _results;
+    private Exception? _firstException;
+    private int _firstExceptionIndex;
+    private int _remaining;
+
+    /// <summary>
+    /// Rents a completion sized for <paramref name="count"/> operations. Must be finished with
+    /// <see cref="WaitAsync"/>, whose await resets the instance and returns it to the pool.
+    /// </summary>
+    public static ProduceAllCompletion Rent(int count)
+    {
+        if (!s_pool.TryPop(out var completion))
+            completion = new ProduceAllCompletion();
+
+        completion._results = new RecordMetadata[count];
+        // Registration guard: WaitAsync drops this extra count once all operations are
+        // registered, so an early inline completion can never observe zero mid-registration.
+        completion._remaining = 1;
+        return completion;
+    }
+
+    /// <summary>
+    /// Consumes the pending operation's <see cref="ValueTask{T}"/>: harvests inline when already
+    /// completed, otherwise attaches a pooled continuation. Call at most once per index; this is
+    /// the operation's single await for pooled-source purposes.
+    /// </summary>
+    public void Register(int index, ValueTask<RecordMetadata> pending)
+    {
+        var awaiter = pending.ConfigureAwait(false).GetAwaiter();
+        if (awaiter.IsCompleted)
+        {
+            Harvest(index, awaiter, decrement: false);
+            return;
+        }
+
+        Interlocked.Increment(ref _remaining);
+
+        if (!s_opPool.TryPop(out var op))
+            op = new PendingOp();
+        op.Attach(this, index, awaiter);
+    }
+
+    /// <summary>
+    /// Records a failure for <paramref name="index"/> when the produce call itself threw
+    /// synchronously and there is no pending operation to register.
+    /// </summary>
+    public void RecordFailure(int index, Exception exception)
+    {
+        lock (_failureGate)
+        {
+            if (_firstException is null || index < _firstExceptionIndex)
+            {
+                _firstException = exception;
+                _firstExceptionIndex = index;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Completes registration and returns the aggregate task. Await exactly once.
+    /// </summary>
+    public ValueTask<RecordMetadata[]> WaitAsync()
+    {
+        var version = _core.Version;
+        OnOperationCompleted(); // drop the registration guard
+        return new ValueTask<RecordMetadata[]>(this, version);
+    }
+
+    private void Harvest(int index, ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter, bool decrement)
+    {
+        try
+        {
+            _results![index] = awaiter.GetResult();
+        }
+        catch (Exception ex)
+        {
+            RecordFailure(index, ex);
+        }
+
+        if (decrement)
+            OnOperationCompleted();
+    }
+
+    private void OnOperationCompleted()
+    {
+        if (Interlocked.Decrement(ref _remaining) != 0)
+            return;
+
+        // Last completion (or registration guard when everything finished inline).
+        // The Interlocked.Decrement fences make all _results writes and RecordFailure
+        // updates visible here.
+        var exception = _firstException;
+        if (exception is not null)
+            _core.SetException(exception);
+        else
+            _core.SetResult(_results!);
+    }
+
+    RecordMetadata[] IValueTaskSource<RecordMetadata[]>.GetResult(short token)
+    {
+        try
+        {
+            return _core.GetResult(token);
+        }
+        finally
+        {
+            _results = null;
+            _firstException = null;
+            _firstExceptionIndex = 0;
+            _remaining = 0;
+            _core.Reset();
+            s_pool.TryPush(this);
+        }
+    }
+
+    ValueTaskSourceStatus IValueTaskSource<RecordMetadata[]>.GetStatus(short token)
+        => _core.GetStatus(token);
+
+    void IValueTaskSource<RecordMetadata[]>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => _core.OnCompleted(continuation, state, token, flags);
+
+    /// <summary>
+    /// Pooled holder for one in-flight operation's continuation. Returns itself to the pool
+    /// before harvesting so the instance is reusable immediately.
+    /// </summary>
+    private sealed class PendingOp
+    {
+        private readonly Action _run;
+        private ProduceAllCompletion? _owner;
+        private int _index;
+        private ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter _awaiter;
+
+        public PendingOp()
+        {
+            _run = Run;
+        }
+
+        public void Attach(ProduceAllCompletion owner, int index, ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter)
+        {
+            _owner = owner;
+            _index = index;
+            _awaiter = awaiter;
+            _awaiter.UnsafeOnCompleted(_run);
+        }
+
+        private void Run()
+        {
+            var owner = _owner!;
+            var index = _index;
+            var awaiter = _awaiter;
+
+            _owner = null;
+            _awaiter = default;
+            s_opPool.TryPush(this);
+
+            owner.Harvest(index, awaiter, decrement: true);
+        }
+    }
+}

--- a/src/Dekaf/Producer/ProduceAllCompletion.cs
+++ b/src/Dekaf/Producer/ProduceAllCompletion.cs
@@ -1,6 +1,5 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Sources;
-using Dekaf.Internal;
 
 namespace Dekaf.Producer;
 
@@ -31,8 +30,8 @@ namespace Dekaf.Producer;
 /// </remarks>
 internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
 {
-    private static readonly LockFreeStack<ProduceAllCompletion> s_pool = new(64);
-    private static readonly LockFreeStack<PendingOp> s_opPool = new(4096);
+    private static readonly CompletionPool s_pool = new();
+    private static readonly PendingOpPool s_opPool = new();
 
     private ManualResetValueTaskSourceCore<RecordMetadata[]> _core = new() { RunContinuationsAsynchronously = true };
     private readonly System.Threading.Lock _failureGate = new();
@@ -47,35 +46,30 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
     /// </summary>
     public static ProduceAllCompletion Rent(int count)
     {
-        if (!s_pool.TryPop(out var completion))
-            completion = new ProduceAllCompletion();
-
+        var completion = s_pool.Rent();
         completion._results = new RecordMetadata[count];
-        // Registration guard: WaitAsync drops this extra count once all operations are
-        // registered, so an early inline completion can never observe zero mid-registration.
-        completion._remaining = 1;
+        // count operations plus a registration guard that WaitAsync drops, so an early inline
+        // completion can never observe zero mid-registration. Pre-counting keeps the
+        // registration loop free of interlocked operations.
+        completion._remaining = count + 1;
         return completion;
     }
 
     /// <summary>
     /// Consumes the pending operation's <see cref="ValueTask{T}"/>: harvests inline when already
-    /// completed, otherwise attaches a pooled continuation. Call at most once per index; this is
+    /// completed, otherwise attaches a pooled continuation. Call exactly once per index; this is
     /// the operation's single await for pooled-source purposes.
     /// </summary>
-    public void Register(int index, ValueTask<RecordMetadata> pending)
+    public void Register(int index, in ValueTask<RecordMetadata> pending)
     {
         var awaiter = pending.ConfigureAwait(false).GetAwaiter();
         if (awaiter.IsCompleted)
         {
-            Harvest(index, awaiter, decrement: false);
+            Harvest(index, in awaiter);
             return;
         }
 
-        Interlocked.Increment(ref _remaining);
-
-        if (!s_opPool.TryPop(out var op))
-            op = new PendingOp();
-        op.Attach(this, index, awaiter);
+        s_opPool.Rent().Attach(this, index, in awaiter);
     }
 
     /// <summary>
@@ -95,6 +89,17 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
     }
 
     /// <summary>
+    /// Removes operations that will never be registered because a synchronous produce failure
+    /// aborted the registration loop. <paramref name="unregisteredCount"/> is the number of
+    /// messages (including the one that threw) that will never decrement the counter.
+    /// </summary>
+    public void AbortRegistration(int unregisteredCount)
+    {
+        // Cannot reach zero here: the registration guard from Rent is still held.
+        Interlocked.Add(ref _remaining, -unregisteredCount);
+    }
+
+    /// <summary>
     /// Completes registration and returns the aggregate task. Await exactly once.
     /// </summary>
     public ValueTask<RecordMetadata[]> WaitAsync()
@@ -104,7 +109,7 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
         return new ValueTask<RecordMetadata[]>(this, version);
     }
 
-    private void Harvest(int index, ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter, bool decrement)
+    private void Harvest(int index, in ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter)
     {
         try
         {
@@ -115,8 +120,7 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
             RecordFailure(index, ex);
         }
 
-        if (decrement)
-            OnOperationCompleted();
+        OnOperationCompleted();
     }
 
     private void OnOperationCompleted()
@@ -142,12 +146,7 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
         }
         finally
         {
-            _results = null;
-            _firstException = null;
-            _firstExceptionIndex = 0;
-            _remaining = 0;
-            _core.Reset();
-            s_pool.TryPush(this);
+            s_pool.Return(this);
         }
     }
 
@@ -157,9 +156,23 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
     void IValueTaskSource<RecordMetadata[]>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
         => _core.OnCompleted(continuation, state, token, flags);
 
+    private sealed class CompletionPool() : ObjectPool<ProduceAllCompletion>(64)
+    {
+        protected override ProduceAllCompletion Create() => new();
+
+        protected override void Reset(ProduceAllCompletion item)
+        {
+            item._results = null;
+            item._firstException = null;
+            item._firstExceptionIndex = 0;
+            item._remaining = 0;
+            item._core.Reset();
+        }
+    }
+
     /// <summary>
-    /// Pooled holder for one in-flight operation's continuation. Returns itself to the pool
-    /// before harvesting so the instance is reusable immediately.
+    /// Pooled holder for one in-flight operation's continuation. Harvests from its own fields
+    /// and only then returns itself to the pool, so the awaiter is never copied to a local.
     /// </summary>
     private sealed class PendingOp
     {
@@ -173,7 +186,7 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
             _run = Run;
         }
 
-        public void Attach(ProduceAllCompletion owner, int index, ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter)
+        public void Attach(ProduceAllCompletion owner, int index, in ConfiguredValueTaskAwaitable<RecordMetadata>.ConfiguredValueTaskAwaiter awaiter)
         {
             _owner = owner;
             _index = index;
@@ -183,15 +196,21 @@ internal sealed class ProduceAllCompletion : IValueTaskSource<RecordMetadata[]>
 
         private void Run()
         {
-            var owner = _owner!;
-            var index = _index;
-            var awaiter = _awaiter;
+            _owner!.Harvest(_index, in _awaiter);
+            s_opPool.Return(this);
+        }
 
+        internal void ResetForPool()
+        {
             _owner = null;
             _awaiter = default;
-            s_opPool.TryPush(this);
-
-            owner.Harvest(index, awaiter, decrement: true);
         }
+    }
+
+    private sealed class PendingOpPool() : ObjectPool<PendingOp>(ValueTaskSourcePool.FallbackMaxPoolSize)
+    {
+        protected override PendingOp Create() => new();
+
+        protected override void Reset(PendingOp item) => item.ResetForPool();
     }
 }

--- a/src/Dekaf/Producer/ProduceContinuationMode.cs
+++ b/src/Dekaf/Producer/ProduceContinuationMode.cs
@@ -1,0 +1,30 @@
+namespace Dekaf.Producer;
+
+/// <summary>
+/// How a produce operation's pooled per-message completion runs its continuation when the
+/// broker ack completes it.
+/// </summary>
+internal enum ProduceContinuationMode : byte
+{
+    /// <summary>
+    /// Continuations hop to the thread pool. Default for all public produce paths so user
+    /// code never runs on the broker sender's ack thread.
+    /// </summary>
+    Async = 0,
+
+    /// <summary>
+    /// Run the continuation inline on the ack thread, but only while it is the caller's own
+    /// bounded harvest attached directly to the completion (<c>ProduceAllAsync</c>; see
+    /// <see cref="ProduceAllCompletion"/> remarks). Instrumented or retry awaits
+    /// (<c>AwaitWithMetrics</c>, <c>AwaitWithActivity</c>, <c>ProduceAsyncWithRetry</c>)
+    /// interpose their own state machine, so the producer upgrades this mode to
+    /// <see cref="Async"/> whenever such a wrapper is used.
+    /// </summary>
+    InlineWhenDirect = 1,
+
+    /// <summary>
+    /// Always run continuations inline on the ack thread, including through instrumented
+    /// awaits — the documented <c>InlineTransactionCompletions</c> opt-in contract.
+    /// </summary>
+    Inline = 2,
+}

--- a/tests/Dekaf.Tests.Integration/ProduceAllAsyncTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProduceAllAsyncTests.cs
@@ -61,6 +61,82 @@ public class ProduceAllAsyncTests(KafkaTestContainer kafka) : KafkaIntegrationTe
     }
 
     [Test]
+    public async Task ProduceAllAsync_SyncThrowMidLoop_InFlightStillDeliveredAndExceptionSurfaces()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        // The interceptor cancels the token while message "value-3" is being registered, so a
+        // later iteration's entry cancellation check throws synchronously mid-loop — exercising
+        // ProduceAllAsync's catch block (RecordFailure + AbortRegistration) with real in-flight
+        // registrations. Post-append cancellation stops the wait, not delivery.
+        using var cts = new CancellationTokenSource();
+        var interceptor = new CancelTokenOnValueInterceptor(cts, "value-3");
+
+        await using (var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .AddInterceptor(interceptor)
+            .BuildAsync())
+        {
+            var messages = Enumerable.Range(0, 6)
+                .Select(i => ((string?)$"key-{i}", $"value-{i}"))
+                .ToList();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await producer.ProduceAllAsync(topic, messages, cts.Token)
+                    .WaitAsync(TimeSpan.FromSeconds(30)));
+
+            // Messages appended before the throw are still delivered in the background.
+            await producer.FlushAsync();
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        string[] required = ["value-0", "value-1", "value-2"];
+        var consumed = new List<string>();
+        using var consumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var draining = false;
+
+        try
+        {
+            await foreach (var result in consumer.ConsumeAsync(consumeCts.Token))
+            {
+                consumed.Add(result.Value!);
+
+                // Once everything registered before the throw has arrived, keep draining briefly
+                // to prove nothing after the aborted registration loop was produced.
+                if (!draining && required.All(consumed.Contains))
+                {
+                    draining = true;
+                    consumeCts.CancelAfter(TimeSpan.FromSeconds(3));
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Drain window elapsed.
+        }
+
+        foreach (var value in required)
+        {
+            await Assert.That(consumed).Contains(value);
+        }
+
+        // "value-3" raced the cancellation and may or may not have been appended; everything
+        // after the synchronous throw must never have been produced.
+        await Assert.That(consumed).DoesNotContain("value-4");
+        await Assert.That(consumed).DoesNotContain("value-5");
+    }
+
+    [Test]
     public async Task ProduceAllAsync_EmptyList_ReturnsEmptyResults()
     {
         await using var producer = await Kafka.CreateProducer<string, string>()
@@ -116,6 +192,21 @@ public class ProduceAllAsyncTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         for (var i = 0; i < 5; i++)
         {
             await Assert.That(consumed).Contains($"value-{i}");
+        }
+    }
+
+    private sealed class CancelTokenOnValueInterceptor(CancellationTokenSource cts, string triggerValue)
+        : IProducerInterceptor<string, string>
+    {
+        public ProducerMessage<string, string> OnSend(ProducerMessage<string, string> message)
+        {
+            if (message.Value == triggerValue)
+                cts.Cancel();
+            return message;
+        }
+
+        public void OnAcknowledgement(RecordMetadata metadata, Exception? exception)
+        {
         }
     }
 }

--- a/tests/Dekaf.Tests.Integration/ProduceAllAsyncTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProduceAllAsyncTests.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Dekaf.Consumer;
+using Dekaf.Diagnostics;
 using Dekaf.Producer;
 
 namespace Dekaf.Tests.Integration;
@@ -56,6 +59,51 @@ public class ProduceAllAsyncTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         foreach (var result in results)
         {
             await Assert.That(result.Topic).IsEqualTo(topic);
+            await Assert.That(result.Offset).IsGreaterThanOrEqualTo(0);
+        }
+    }
+
+    [Test]
+    [NotInParallel("DekafInstrumentation")]
+    public async Task ProduceAllAsync_WithTracingAndMetricsEnabled_AllDelivered()
+    {
+        // With tracing/metrics active, per-message awaits go through AwaitWithActivity /
+        // AwaitWithMetrics, which must upgrade ProduceAllAsync's inline-continuation request to
+        // asynchronous continuations (instrumentation code must not run on the broker ack
+        // thread). This covers those wrapper paths end-to-end under ProduceAllAsync.
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == DekafDiagnostics.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName)
+                l.EnableMeasurementEvents(instrument);
+        };
+        meterListener.Start();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var messages = Enumerable.Range(0, 100)
+            .Select(i => ((string?)$"key-{i}", $"value-{i}"))
+            .ToList();
+
+        var results = await producer.ProduceAllAsync(topic, messages)
+            .WaitAsync(TimeSpan.FromSeconds(60));
+
+        await Assert.That(results.Length).IsEqualTo(100);
+        foreach (var result in results)
+        {
             await Assert.That(result.Offset).IsGreaterThanOrEqualTo(0);
         }
     }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
@@ -1,0 +1,64 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for <c>KafkaProducer.ProduceAllAsync</c>'s synchronous-throw handling: a produce call
+/// that throws before registering (here: producer never initialized) must be recorded via the
+/// completion's abort path and surface from the aggregate await instead of hanging or leaking.
+/// </summary>
+public class KafkaProducerProduceAllTests
+{
+    [Test]
+    public async Task ProduceAllAsync_KeyValueOverload_SyncThrow_FaultsAggregateWithoutHanging()
+    {
+        // Build() without InitializeAsync: the first ProduceAsync throws synchronously at entry,
+        // driving ProduceAllAsync's catch block (RecordFailure + AbortRegistration at index 0).
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        try
+        {
+            var messages = new (string? Key, string Value)[] { ("k0", "v0"), ("k1", "v1"), ("k2", "v2") };
+
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await producer.ProduceAllAsync("test-topic", messages)
+                    .WaitAsync(TimeSpan.FromSeconds(10)));
+
+            await Assert.That(thrown!.Message).Contains("InitializeAsync");
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ProduceAllAsync_MessageListOverload_SyncThrow_FaultsAggregateWithoutHanging()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        try
+        {
+            var messages = Enumerable.Range(0, 3).Select(i => new ProducerMessage<string, string>
+            {
+                Topic = "test-topic",
+                Key = $"k{i}",
+                Value = $"v{i}"
+            }).ToList();
+
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await producer.ProduceAllAsync(messages)
+                    .WaitAsync(TimeSpan.FromSeconds(10)));
+
+            await Assert.That(thrown!.Message).Contains("InitializeAsync");
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
@@ -118,10 +118,33 @@ public class ProduceAllCompletionTests
 
         completion.Register(0, new ValueTask<RecordMetadata>(Metadata(0)));
         completion.RecordFailure(1, new ObjectDisposedException("producer"));
+        completion.AbortRegistration(1);
 
         var thrown = await Assert.ThrowsAsync<ObjectDisposedException>(
             async () => await completion.WaitAsync());
         await Assert.That(thrown).IsNotNull();
+    }
+
+    [Test]
+    public async Task AbortRegistration_MidLoop_WaitsForInFlightThenFaults()
+    {
+        // Simulates a sync produce throw at index 1 of 4: index 0 is still in flight,
+        // indices 1-3 never register. The aggregate must wait for index 0, then fault.
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var inFlight = pool.Rent();
+
+        var completion = ProduceAllCompletion.Rent(4);
+        completion.Register(0, inFlight.Task);
+        completion.RecordFailure(1, new InvalidOperationException("sync-throw"));
+        completion.AbortRegistration(3);
+
+        var aggregate = completion.WaitAsync();
+        await Assert.That(aggregate.IsCompleted).IsFalse();
+
+        inFlight.SetResult(Metadata(0));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(async () => await aggregate);
+        await Assert.That(thrown!.Message).IsEqualTo("sync-throw");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
@@ -1,0 +1,193 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class ProduceAllCompletionTests
+{
+    private static RecordMetadata Metadata(int offset) => new()
+    {
+        Topic = "test-topic",
+        Partition = 0,
+        Offset = offset,
+        Timestamp = DateTimeOffset.UnixEpoch
+    };
+
+    [Test]
+    public async Task AllSynchronousCompletions_ReturnsResultsInOrder()
+    {
+        var completion = ProduceAllCompletion.Rent(3);
+
+        for (var i = 0; i < 3; i++)
+        {
+            completion.Register(i, new ValueTask<RecordMetadata>(Metadata(i)));
+        }
+
+        var results = await completion.WaitAsync();
+
+        await Assert.That(results.Length).IsEqualTo(3);
+        for (var i = 0; i < 3; i++)
+        {
+            await Assert.That(results[i].Offset).IsEqualTo(i);
+        }
+    }
+
+    [Test]
+    public async Task AsynchronousCompletions_OutOfOrder_ResultsInInputOrder()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(3);
+
+        var sources = new PooledValueTaskSource<RecordMetadata>[3];
+        for (var i = 0; i < 3; i++)
+        {
+            sources[i] = pool.Rent();
+            completion.Register(i, sources[i].Task);
+        }
+
+        var aggregate = completion.WaitAsync();
+
+        // Complete in reverse order
+        sources[2].SetResult(Metadata(2));
+        sources[1].SetResult(Metadata(1));
+        sources[0].SetResult(Metadata(0));
+
+        var results = await aggregate;
+
+        await Assert.That(results.Length).IsEqualTo(3);
+        for (var i = 0; i < 3; i++)
+        {
+            await Assert.That(results[i].Offset).IsEqualTo(i);
+        }
+    }
+
+    [Test]
+    public async Task MixedSyncAndAsyncCompletions_ResultsInInputOrder()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(4);
+
+        var pendingA = pool.Rent();
+        var pendingB = pool.Rent();
+
+        completion.Register(0, new ValueTask<RecordMetadata>(Metadata(0)));
+        completion.Register(1, pendingA.Task);
+        completion.Register(2, new ValueTask<RecordMetadata>(Metadata(2)));
+        completion.Register(3, pendingB.Task);
+
+        var aggregate = completion.WaitAsync();
+
+        pendingB.SetResult(Metadata(3));
+        pendingA.SetResult(Metadata(1));
+
+        var results = await aggregate;
+
+        for (var i = 0; i < 4; i++)
+        {
+            await Assert.That(results[i].Offset).IsEqualTo(i);
+        }
+    }
+
+    [Test]
+    public async Task Failure_SmallestIndexWins()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(3);
+
+        var sources = new PooledValueTaskSource<RecordMetadata>[3];
+        for (var i = 0; i < 3; i++)
+        {
+            sources[i] = pool.Rent();
+            completion.Register(i, sources[i].Task);
+        }
+
+        var aggregate = completion.WaitAsync();
+
+        // Later-index failure completes first; earlier index must still win.
+        sources[2].SetException(new InvalidOperationException("index-2"));
+        sources[1].SetException(new InvalidOperationException("index-1"));
+        sources[0].SetResult(Metadata(0));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(async () => await aggregate);
+        await Assert.That(thrown!.Message).IsEqualTo("index-1");
+    }
+
+    [Test]
+    public async Task RecordFailure_SynchronousThrow_SurfacesFromAggregate()
+    {
+        var completion = ProduceAllCompletion.Rent(2);
+
+        completion.Register(0, new ValueTask<RecordMetadata>(Metadata(0)));
+        completion.RecordFailure(1, new ObjectDisposedException("producer"));
+
+        var thrown = await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await completion.WaitAsync());
+        await Assert.That(thrown).IsNotNull();
+    }
+
+    [Test]
+    public async Task PooledReuse_SecondUseAfterFirstAwait_Works()
+    {
+        var first = ProduceAllCompletion.Rent(1);
+        first.Register(0, new ValueTask<RecordMetadata>(Metadata(7)));
+        var firstResults = await first.WaitAsync();
+        await Assert.That(firstResults[0].Offset).IsEqualTo(7);
+
+        // The pool should hand back the same reset instance; either way it must behave freshly.
+        var second = ProduceAllCompletion.Rent(2);
+        second.Register(0, new ValueTask<RecordMetadata>(Metadata(10)));
+        second.Register(1, new ValueTask<RecordMetadata>(Metadata(11)));
+        var secondResults = await second.WaitAsync();
+
+        await Assert.That(secondResults.Length).IsEqualTo(2);
+        await Assert.That(secondResults[0].Offset).IsEqualTo(10);
+        await Assert.That(secondResults[1].Offset).IsEqualTo(11);
+    }
+
+    [Test]
+    public async Task ManyConcurrentCompletions_AllHarvested()
+    {
+        const int count = 1000;
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(count);
+
+        var sources = new PooledValueTaskSource<RecordMetadata>[count];
+        for (var i = 0; i < count; i++)
+        {
+            sources[i] = pool.Rent();
+            completion.Register(i, sources[i].Task);
+        }
+
+        var aggregate = completion.WaitAsync();
+
+        Parallel.For(0, count, i => sources[i].SetResult(Metadata(i)));
+
+        var results = await aggregate;
+
+        await Assert.That(results.Length).IsEqualTo(count);
+        for (var i = 0; i < count; i++)
+        {
+            await Assert.That(results[i].Offset).IsEqualTo(i);
+        }
+    }
+
+    [Test]
+    public async Task InlineContinuations_CompleteOnSettingThread()
+    {
+        // ProduceAllAsync rents per-message sources with RunContinuationsAsynchronously = false;
+        // the harvest continuation must complete the aggregate synchronously on the acking thread.
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var source = pool.Rent();
+        source.SetRunContinuationsAsynchronously(false);
+
+        var completion = ProduceAllCompletion.Rent(1);
+        completion.Register(0, source.Task);
+        var aggregate = completion.WaitAsync();
+
+        source.SetResult(Metadata(1));
+
+        // No other thread involved: the aggregate must already be completed.
+        await Assert.That(aggregate.IsCompleted).IsTrue();
+        var results = await aggregate;
+        await Assert.That(results[0].Offset).IsEqualTo(1);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProduceAllCompletionTests.cs
@@ -112,6 +112,65 @@ public class ProduceAllCompletionTests
     }
 
     [Test]
+    public async Task Failure_FaultBeatsLowerIndexCancellation()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(3);
+
+        var sources = new PooledValueTaskSource<RecordMetadata>[3];
+        for (var i = 0; i < 3; i++)
+        {
+            sources[i] = pool.Rent();
+            completion.Register(i, sources[i].Task);
+        }
+
+        var aggregate = completion.WaitAsync();
+
+        // A cancelled operation at a lower index must not mask a real delivery fault,
+        // matching Task.WhenAll: any faulted child faults the aggregate.
+        sources[0].SetException(new OperationCanceledException());
+        sources[1].SetResult(Metadata(1));
+        sources[2].SetException(new InvalidOperationException("delivery-failure"));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(async () => await aggregate);
+        await Assert.That(thrown!.Message).IsEqualTo("delivery-failure");
+    }
+
+    [Test]
+    public async Task Failure_LowerIndexCancellationDoesNotReplaceRecordedFault()
+    {
+        var completion = ProduceAllCompletion.Rent(2);
+
+        // Fault is recorded first; the later-arriving cancellation at a smaller index loses.
+        completion.RecordFailure(1, new InvalidOperationException("fault"));
+        completion.RecordFailure(0, new OperationCanceledException());
+        completion.AbortRegistration(2);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await completion.WaitAsync());
+        await Assert.That(thrown!.Message).IsEqualTo("fault");
+    }
+
+    [Test]
+    public async Task Failure_AllCancellations_SurfacesCancellation()
+    {
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var completion = ProduceAllCompletion.Rent(2);
+
+        var first = pool.Rent();
+        var second = pool.Rent();
+        completion.Register(0, first.Task);
+        completion.Register(1, second.Task);
+
+        var aggregate = completion.WaitAsync();
+
+        first.SetException(new OperationCanceledException());
+        second.SetException(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await aggregate);
+    }
+
+    [Test]
     public async Task RecordFailure_SynchronousThrow_SurfacesFromAggregate()
     {
         var completion = ProduceAllCompletion.Rent(2);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -32,6 +32,7 @@ public class ProducerBenchmarks
     private static readonly TimeSpan QueueFullRetryTimeout = TimeSpan.FromSeconds(30);
     private string _messageValue = null!;
     private string[] _keys = null!;
+    private (string? Key, string Value)[] _batchMessages = null!;
 
     [Params(100, 1000)]
     public int MessageSize { get; set; }
@@ -47,6 +48,7 @@ public class ProducerBenchmarks
 
         _messageValue = new string('x', MessageSize);
         _keys = BenchmarkData.CreateKeys(BatchSize);
+        _batchMessages = [.. _keys.Select(key => ((string?)key, _messageValue))];
 
         _dekafProducer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(_kafka.BootstrapServers)
@@ -185,14 +187,7 @@ public class ProducerBenchmarks
     {
         // ProduceAllAsync is the idiomatic batch-produce API: it awaits every message through a
         // single counting completion instead of allocating a Task per message via AsTask().
-        var messages = new (string? Key, string Value)[BatchSize];
-
-        for (var i = 0; i < BatchSize; i++)
-        {
-            messages[i] = (_keys[i], _messageValue);
-        }
-
-        await _dekafProducer.ProduceAllAsync(Topic, messages).ConfigureAwait(false);
+        await _dekafProducer.ProduceAllAsync(Topic, _batchMessages).ConfigureAwait(false);
     }
 
     // ===== Fire-and-Forget =====

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ProducerBenchmarks.cs
@@ -183,17 +183,16 @@ public class ProducerBenchmarks
     [Benchmark]
     public async Task Dekaf_ProduceBatch()
     {
-        var tasks = new List<Task<DekafProducer.RecordMetadata>>(BatchSize);
+        // ProduceAllAsync is the idiomatic batch-produce API: it awaits every message through a
+        // single counting completion instead of allocating a Task per message via AsTask().
+        var messages = new (string? Key, string Value)[BatchSize];
 
-        // .AsTask() per message is required: the pooled ValueTask contract forbids
-        // collecting raw ValueTasks for deferred await (see IKafkaProducer remarks).
         for (var i = 0; i < BatchSize; i++)
         {
-            tasks.Add(_dekafProducer.ProduceAsync(Topic, _keys[i], _messageValue, CancellationToken.None)
-                .AsTask());
+            messages[i] = (_keys[i], _messageValue);
         }
 
-        await Task.WhenAll(tasks).ConfigureAwait(false);
+        await _dekafProducer.ProduceAllAsync(Topic, messages).ConfigureAwait(false);
     }
 
     // ===== Fire-and-Forget =====


### PR DESCRIPTION
Fixes #2212.

## Problem

Two library-side costs on the awaited-completion path (from the 2026-07-18 benchmark audit):

1. **One thread-pool hop per acked message**: `RentCompletion` left `PooledValueTaskSource` at `RunContinuationsAsynchronously = true`, so a 1000-message `ProduceAllAsync` scheduled 1000 thread-pool work items per iteration plus the `Task.WhenAll` fan-in.
2. **One `Task` allocation per message**: `ProduceAllAsync` converted every `ValueTask<RecordMetadata>` via `.AsTask()` (~120–150 B each).

## Change

**`ProduceAllCompletion`** (new, internal): a pooled counting `IValueTaskSource<RecordMetadata[]>`. Each registered produce operation attaches a pooled `PendingOp` continuation that stores its result into the results array and decrements a shared counter; the last completion fires the single aggregate continuation. Failure keeps the smallest-index exception, matching `Task.WhenAll` input-order semantics; every registered operation is always observed, so pooled per-message sources return to their pool even when the aggregate faults.

**Inline per-message continuations**: `ProduceAllAsync` now produces with `runContinuationsAsynchronously: false` — safe because the only continuation on each per-message completion is the bounded harvest (array store + decrement), following the `WithInlineTransactionCompletions` precedent. The aggregate source keeps `RunContinuationsAsynchronously = true`, so **user code never runs on the sender loop** — the 1000 hops collapse to one hop per batch.

**Dispatch unification**: the retry fork (`_retryPolicy`) and the topic/key/value feature predicate now exist once — a private `ProduceAsync(message, bool runContinuationsAsynchronously, ct)` plus the flag threaded through the topic/key/value dispatcher. Public produce passes `true`, transactions pass `!InlineTransactionCompletions`, `ProduceAllAsync` passes `false`.

**Steady-state allocations per `ProduceAllAsync` call**: results array (returned to caller) + async wrapper state machine — both per-batch. Per-message: zero (pooled `PendingOp`s, no interlocked ops in the registration loop; counter pre-set to `count + 1` with a registration guard).

**Benchmark**: `Dekaf_ProduceBatch` now uses `ProduceAllAsync` (per the issue's acceptance criteria), with the message array built in `GlobalSetup` so the measured body isolates the produce path.

## Known trade-offs

- Beyond 4096 concurrent pending registrations process-wide, excess `PendingOp`s allocate (~104 B each) — degradation back to roughly the old `AsTask()` cost, not worse. Capacity references `ValueTaskSourcePool.FallbackMaxPoolSize`.
- A synchronous produce throw mid-loop now surfaces after in-flight registrations complete (previously it propagated immediately, abandoning them); the same exception type is thrown.
- `tools/.../ProducerBenchmarks.cs` will conflict trivially with #2216 (`Dekaf_ProduceBatch` body); resolution: keep `ProduceAllAsync` + #2216's pre-created keys.

## Verification

- Unit: 5609/5609 pass (10 new `ProduceAllCompletionTests`: ordering, out-of-order async completion, mixed sync/async, smallest-index failure, sync-throw abort, pool reuse, 1000-way concurrent harvest, inline-continuation completion).
- Integration (local Docker, Kafka 4.3.1): ProduceAllAsyncTests 4/4, TopicProducerTests 15/15, ConvenienceApiTests 16/16, TransactionTests 5/5.
- Acceptance gates still to run in CI: ProduceBatch 1000x1000 ratio < 1.0 on the benchmark workflow, and a producer stress lane per the Pareto rule before merge if maintainer wants the paid validation.