### PR TITLE
perf(consumer): slim ConsumeOneAsync buffered fast path (#2211)

### DIFF
--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -234,7 +234,10 @@ namespace Dekaf.Consumer
                     return false;
                 }
 
-                Protocol.Records.Record record = pending.CurrentRecord;
+                // `record` references pooled batch storage; every read below happens in
+                // constructor-argument evaluation, before the ctor body runs user
+                // deserializers. Do not touch `record` after the constructor call.
+                ref readonly Protocol.Records.Record record = ref pending.CurrentRecord;
 
                 long offset = pending.CurrentBaseOffset + record.OffsetDelta;
                 long timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;

--- a/src/Dekaf/Consumer/ConsumeRawBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeRawBatch.cs
@@ -153,7 +153,9 @@ namespace Dekaf.Consumer
                     return false;
                 }
 
-                Protocol.Records.Record record = pending.CurrentRecord;
+                // `record` references pooled batch storage; all reads complete before
+                // control returns to the caller. Do not hold it across MoveNext calls.
+                ref readonly Protocol.Records.Record record = ref pending.CurrentRecord;
 
                 long offset = pending.CurrentBaseOffset + record.OffsetDelta;
                 long timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -212,7 +212,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         };
     }
 
-    private bool IsCurrentPollGenerationExpired()
+    private bool IsCurrentPollGenerationExpired() => IsCurrentPollGenerationExpired(Stopwatch.GetTimestamp());
+
+    private bool IsCurrentPollGenerationExpired(long timestamp)
     {
         if (Volatile.Read(ref _maxPollExpiredAtPollVersion) == Volatile.Read(ref _pollVersion))
             return true;
@@ -221,7 +223,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return false;
 
         return _state == CoordinatorState.Stable
-            && Stopwatch.GetTimestamp() - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
+            && timestamp - Volatile.Read(ref _lastPollTimestamp) >= _maxPollIntervalStopwatchTicks;
     }
 
     internal async ValueTask<(TopicPartitionSet Assignment, int Version, HashSet<TopicPartition>? Revocations)>
@@ -286,11 +288,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         && Volatile.Read(ref _fatalHeartbeatException) is null
         && Volatile.Read(ref _maxPollExpiredAtPollVersion) < 0;
 
-    internal bool TryRecordPollFast()
+    internal bool TryRecordPollFast() => TryRecordPollFast(out _);
+
+    /// <summary>
+    /// Records a poll without taking the coordinator lock. <paramref name="timestamp"/>
+    /// is the <see cref="Stopwatch.GetTimestamp"/> value this call read, or 0 when an
+    /// early-out branch never needed one — callers can reuse it to avoid a second read.
+    /// </summary>
+    internal bool TryRecordPollFast(out long timestamp)
     {
         // The fatal can be published after the assignment-currency gate. Surface it here,
         // before either a buffered dequeue or the timeout-bound coordinator lock path.
         ThrowIfFatalHeartbeatException();
+
+        timestamp = 0;
 
         // Heartbeat expiry invokes user callbacks outside _lock. Keep its poll generation
         // unchanged so EnsureActiveGroup cannot rejoin until notification completes.
@@ -303,10 +314,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             return true;
         }
 
-        if (IsCurrentPollGenerationExpired())
+        // One timestamp read serves the expiry check, the poll record, and the caller.
+        timestamp = Stopwatch.GetTimestamp();
+        if (IsCurrentPollGenerationExpired(timestamp))
             return false;
 
-        RecordPollIfLossNotificationComplete(Stopwatch.GetTimestamp());
+        RecordPollIfLossNotificationComplete(timestamp);
         return true;
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -108,6 +108,10 @@ internal sealed class PendingFetchData : IDisposable
     private int _headerGeneration;
     private bool _eagerParsed;
     private bool _hasBufferedCurrent;
+
+    // Only CreateError assigns this; instances carrying an error never parse, so
+    // EagerParseAll may check _eagerParsed before draining it. A second writer would
+    // break that ordering — keep the invariant if one is ever added.
     private ConsumeException? _error;
 
     public string Topic { get; private set; } = null!;
@@ -312,14 +316,29 @@ internal sealed class PendingFetchData : IDisposable
     /// Gets the current record via direct array access, bypassing lazy record-list
     /// indexer overhead (Volatile.Read + disposed check + EnsureParsedUpTo per access).
     /// Safe because EagerParseAll() is called before iteration begins.
+    /// Returns by readonly reference so consume loops avoid copying the ~80-byte
+    /// Record struct per message; the reference is only valid until the next
+    /// MoveNext/Dispose call.
     /// </summary>
-    public Record CurrentRecord
+    public ref readonly Record CurrentRecord
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _currentRecordsArray is not null
-            ? _currentRecordsArray[_currentRecordsArrayOffset + _recordIndex]
-            : _currentRecords![_recordIndex];
+        get
+        {
+            var array = _currentRecordsArray;
+            if (array is not null)
+                return ref array[_currentRecordsArrayOffset + _recordIndex];
+
+            _fallbackCurrentRecord = _currentRecords![_recordIndex];
+            return ref _fallbackCurrentRecord;
+        }
     }
+
+    // Staging slot for non-array record lists. Kept as a lazy per-access path on purpose:
+    // fault-modelling lists (and any list that throws from its indexer) must fail at the
+    // faulted record so the good prefix is still yielded — an eager per-batch copy would
+    // move the throw ahead of those yields and break mid-batch fault recovery.
+    private Record _fallbackCurrentRecord;
 
     // Cached batch state updated only on batch transitions, amortizing per-record cost.
     // _currentRecordsArray bypasses IReadOnlyList<Record> virtual dispatch + lazy parsing
@@ -383,11 +402,14 @@ internal sealed class PendingFetchData : IDisposable
     /// </summary>
     public void EagerParseAll()
     {
-        if (Interlocked.Exchange(ref _error, null) is { } error)
-            throw error;
-
+        // Check _eagerParsed first: it is only set after a successful parse, and _error
+        // is only set on instances that never parse (CreateError), so the order swap is
+        // safe and spares the already-parsed steady state a full-fence Interlocked per poll.
         if (_eagerParsed)
             return;
+
+        if (Interlocked.Exchange(ref _error, null) is { } error)
+            throw error;
 
         AttachParsedRecordSlab(_batches);
 
@@ -422,7 +444,10 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsCount = records.Count;
 
         // Cache raw array for direct indexing (bypasses lazy-list indexer overhead).
+        // Lists that resolve to no array (fault-modelling doubles) stay on the lazy
+        // per-access indexer via _fallbackCurrentRecord.
         _currentRecordsArray = batch.GetParsedRecordsArray()
+            ?? records as Record[]
             ?? (records is Protocol.Records.LazyRecordList lazyList ? lazyList.GetParsedArray() : null);
         _currentRecordsArrayOffset = batch.GetParsedRecordsOffset();
 
@@ -640,6 +665,7 @@ internal sealed class PendingFetchData : IDisposable
         _currentRecordsArrayOffset = 0;
         _currentRecords = null;
         _currentRecordsCount = 0;
+        _fallbackCurrentRecord = default;
         _eagerParsed = false;
         _hasBufferedCurrent = false;
         _error = null;
@@ -836,6 +862,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger _logger;
 
+    // _subscription is the authoritative store; _subscriptionSnapshot (below) is its
+    // lock-free read side, republished after every mutation. Hot paths must read the
+    // snapshot: ConcurrentDictionary.Count/IsEmpty acquire every stripe lock (issue
+    // #2211). The _paused/_pausedSnapshot pair follows the same split.
     private readonly ConcurrentDictionary<string, byte> _subscription = new();
     private readonly HashSet<TopicPartition> _assignment = [];
     private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
@@ -3728,29 +3758,45 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return bytes;
     }
 
-    public async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneAsync(
+    public ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneAsync(
         TimeSpan timeout,
         CancellationToken cancellationToken = default)
     {
         var timeoutMilliseconds = ValidateConsumeOneTimeout(timeout);
 
+        // Synchronous buffered fast path: no async state machine, so a buffered record
+        // costs one ValueTask wrap instead of builder Start/SetResult plus the state
+        // machine's struct spills (~35% of the per-poll budget, issue #2211). Exceptions
+        // from validation and the buffered drain throw synchronously rather than faulting
+        // the returned ValueTask — the standard idiom for a sync-completing ValueTask method.
         var pollRecorded = false;
         long? bufferedDrainStarted = null;
         if (!RequiresRuntimeTimeoutValidation(timeoutMilliseconds)
             && CanUseBufferedConsumeOneFastPath(cancellationToken))
         {
-            pollRecorded = _coordinator?.TryRecordPollFast() ?? true;
+            long pollTimestamp = 0;
+            pollRecorded = _coordinator?.TryRecordPollFast(out pollTimestamp) ?? true;
             if (pollRecorded)
             {
-                bufferedDrainStarted = Stopwatch.GetTimestamp();
+                // Reuse the coordinator's timestamp read when it took one this poll.
+                bufferedDrainStarted = pollTimestamp != 0 ? pollTimestamp : Stopwatch.GetTimestamp();
                 if (TryConsumeOneFromPendingFetches(out var bufferedResult))
-                    return bufferedResult;
+                    return new ValueTask<ConsumeResult<TKey, TValue>?>(bufferedResult);
 
                 if (TryDequeuePendingEofResult(out var eofResult))
-                    return eofResult;
+                    return new ValueTask<ConsumeResult<TKey, TValue>?>(eofResult);
             }
         }
 
+        return ConsumeOneWithTimeoutAsync(timeout, bufferedDrainStarted, pollRecorded, cancellationToken);
+    }
+
+    private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneWithTimeoutAsync(
+        TimeSpan timeout,
+        long? bufferedDrainStarted,
+        bool pollRecorded,
+        CancellationToken cancellationToken)
+    {
         using var timeoutCts = _ctsPool.Rent();
         timeoutCts.CancelAfter(CalculateRemainingConsumeOneTimeout(timeout, bufferedDrainStarted));
 
@@ -4053,18 +4099,28 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (!pending.MoveNext())
                             break;
 
-                        var record = pending.CurrentRecord;
+                        ref readonly var record = ref pending.CurrentRecord;
                         offset = pending.CurrentBaseOffset + record.OffsetDelta;
                         var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
                         var timestampType = pending.CurrentTimestampType;
-                        var messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
-                                           (record.IsValueNull ? 0 : record.Value.Length);
+                        // Hoist every record field used below: `record` references pooled
+                        // batch storage, and everything past this point (activity listeners,
+                        // deserializers, interceptors) can run user code that Seeks/Assigns
+                        // and recycles that storage.
+                        var keyData = record.Key;
+                        var valueData = record.Value;
+                        var isKeyNull = record.IsKeyNull;
+                        var isValueNull = record.IsValueNull;
+                        var pooledHeaders = record.Headers;
+                        var pooledHeaderCount = record.HeaderCount;
+                        var messageBytes = (isKeyNull ? 0 : keyData.Length) +
+                                           (isValueNull ? 0 : valueData.Length);
 
                         if (hasTraceListeners)
                         {
                             var headers = LazyConsumeHeaders.Create(
-                                record.Headers,
-                                record.HeaderCount,
+                                pooledHeaders,
+                                pooledHeaderCount,
                                 pending,
                                 pending.HeaderGeneration);
                             activity = StartConsumeActivity(pending, headers, offset, messageBytes);
@@ -4077,12 +4133,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             topic: pending.Topic,
                             partition: pending.PartitionIndex,
                             offset: offset,
-                            keyData: record.Key,
-                            isKeyNull: record.IsKeyNull,
-                            valueData: record.Value,
-                            isValueNull: record.IsValueNull,
-                            pooledHeaders: record.Headers,
-                            pooledHeaderCount: record.HeaderCount,
+                            keyData: keyData,
+                            isKeyNull: isKeyNull,
+                            valueData: valueData,
+                            isValueNull: isValueNull,
+                            pooledHeaders: pooledHeaders,
+                            pooledHeaderCount: pooledHeaderCount,
                             headerOwner: pending,
                             timestampMs: timestampMs,
                             timestampType: timestampType,
@@ -4105,8 +4161,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (rawTrackingEnabled)
                         {
-                            _currentRawKey = record.IsKeyNull ? ReadOnlyMemory<byte>.Empty : record.Key;
-                            _currentRawValue = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;
+                            _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
+                            _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
                         }
 
                         return true;
@@ -5483,7 +5539,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private bool IsManualAssignmentEnsureCurrent()
     {
-        if (_topicFilter is not null || _topicPattern is not null || !_subscription.IsEmpty)
+        // Read the published snapshot, not _subscription: ConcurrentDictionary.IsEmpty
+        // acquires every stripe lock, which dominated the buffered ConsumeOne fast path
+        // (~45% of per-poll CPU, issue #2211). The snapshot is republished after every
+        // subscription mutation, and CanUseBufferedConsumeOneFastPath already keys its
+        // subscription-vs-manual routing off the same snapshot.
+        if (_topicFilter is not null || _topicPattern is not null || _subscriptionSnapshot.Count != 0)
             return false;
 
         var assignmentEnsureVersion = Volatile.Read(ref _assignmentEnsureVersion);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
@@ -1,0 +1,200 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Micro-benchmark for the <c>ConsumeOneAsync</c> buffered fast path (issue #2211) —
+/// no Docker, no network. A consumer is put into the initialized state using the same
+/// reflection-seeding pattern as the fast-path unit tests, pending fetches are seeded
+/// directly, and each invocation measures one full public <c>ConsumeOneAsync</c> call
+/// that drains a buffered record.
+/// </summary>
+/// <remarks>
+/// The grouped variant mirrors the state the real <c>ConsumerPollBenchmarks</c> consumer
+/// reaches in steady state: coordinator present (poll accounting via
+/// <c>TryRecordPollFast</c>), auto-commit mode with a running auto-commit loop
+/// (surrogate incomplete task), and the per-record seqlock position publish. The
+/// no-group variant is the floor: manual commit mode, no coordinator, no publish.
+/// </remarks>
+[MemoryDiagnoser]
+[Config(typeof(FastPathJobConfig))]
+public class ConsumeOneBufferedFastPathBenchmarks
+{
+    private const int PollsPerIteration = 10_000;
+    private const int RecordsPerBatch = 1_000;
+    private const int BatchCount = PollsPerIteration / RecordsPerBatch;
+    private const string Topic = "consume-one-fast-path";
+    private const int Partition = 0;
+    private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
+
+    private sealed class FastPathJobConfig : ManualConfig
+    {
+        public FastPathJobConfig()
+        {
+            AddJob(Job.Default
+                .WithStrategy(RunStrategy.Throughput)
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(10)
+                .WithInvocationCount(PollsPerIteration)
+                .WithUnrollFactor(1));
+        }
+    }
+
+    [Params(100, 1000)]
+    public int MessageSize { get; set; }
+
+    private Record[][] _batchRecords = null!;
+    private KafkaConsumer<string, string> _groupedConsumer = null!;
+    private KafkaConsumer<string, string> _noGroupConsumer = null!;
+    private TaskCompletionSource _autoCommitSurrogate = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var value = Encoding.UTF8.GetBytes(new string('x', MessageSize));
+
+        _batchRecords = new Record[BatchCount][];
+        for (var b = 0; b < BatchCount; b++)
+        {
+            var records = new Record[RecordsPerBatch];
+            for (var i = 0; i < RecordsPerBatch; i++)
+            {
+                records[i] = new Record
+                {
+                    OffsetDelta = i,
+                    TimestampDelta = i,
+                    Key = Encoding.UTF8.GetBytes($"key-{b * RecordsPerBatch + i}"),
+                    IsKeyNull = false,
+                    Value = value,
+                    IsValueNull = false,
+                    Headers = null,
+                    HeaderCount = 0,
+                };
+            }
+            _batchRecords[b] = records;
+        }
+
+        _groupedConsumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "consume-one-fast-path-benchmark",
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200,
+            },
+            Serializers.String,
+            Serializers.String);
+        InitializeForBufferedFastPath(_groupedConsumer);
+
+        // CanUseBufferedConsumeOneFastPath requires a live auto-commit loop in Auto mode.
+        // A surrogate incomplete task satisfies IsAutoCommitRunning without network I/O.
+        _autoCommitSurrogate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetPrivateField(_groupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
+
+        _noGroupConsumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200,
+            },
+            Serializers.String,
+            Serializers.String);
+        InitializeForBufferedFastPath(_noGroupConsumer);
+    }
+
+    [IterationSetup(Targets = [nameof(PollOne_Grouped_AutoCommit)])]
+    public void GroupedIterationSetup() => ReseedPendingFetches(_groupedConsumer);
+
+    [IterationSetup(Targets = [nameof(PollOne_NoGroup_ManualCommit)])]
+    public void NoGroupIterationSetup() => ReseedPendingFetches(_noGroupConsumer);
+
+    [BenchmarkCategory("PollOneFastPath")]
+    [Benchmark(Baseline = true)]
+    public ValueTask<ConsumeResult<string, string>?> PollOne_Grouped_AutoCommit()
+        => _groupedConsumer.ConsumeOneAsync(PollTimeout);
+
+    [BenchmarkCategory("PollOneFastPath")]
+    [Benchmark]
+    public ValueTask<ConsumeResult<string, string>?> PollOne_NoGroup_ManualCommit()
+        => _noGroupConsumer.ConsumeOneAsync(PollTimeout);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _autoCommitSurrogate.TrySetResult();
+        DrainPendingFetches(_groupedConsumer);
+        DrainPendingFetches(_noGroupConsumer);
+        _groupedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _noGroupConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private void ReseedPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        DrainPendingFetches(consumer);
+
+        var batches = new RecordBatch[BatchCount];
+        for (var b = 0; b < BatchCount; b++)
+        {
+            var batch = RecordBatch.RentFromPool();
+            batch.BaseOffset = (long)b * RecordsPerBatch;
+            batch.BaseTimestamp = 1_700_000_000_000L;
+            batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
+            batch.LastOffsetDelta = RecordsPerBatch - 1;
+            batch.Attributes = RecordBatchAttributes.None;
+            batch.Records = _batchRecords[b];
+            batches[b] = batch;
+        }
+
+        GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(Topic, Partition, batches));
+    }
+
+    private static void DrainPendingFetches(KafkaConsumer<string, string> consumer)
+    {
+        var pendingFetches = GetPendingFetches(consumer);
+        while (pendingFetches.Count > 0)
+            pendingFetches.Dequeue().Dispose();
+    }
+
+    private static void InitializeForBufferedFastPath(KafkaConsumer<string, string> consumer)
+    {
+        SetPrivateField(consumer, "_initialized", true);
+
+        var tp = new TopicPartition(Topic, Partition);
+        consumer.Assign(tp);
+        GetFetchPositions(consumer)[tp] = 0;
+
+        // Mark the manual assignment as acknowledged so the fast path's currency check passes.
+        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
+        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
+    }
+
+    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+        => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
+
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer)
+        => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
+
+    private static object? GetPrivateField(KafkaConsumer<string, string> consumer, string fieldName)
+        => RequireField(fieldName).GetValue(consumer);
+
+    private static void SetPrivateField(KafkaConsumer<string, string> consumer, string fieldName, object? value)
+        => RequireField(fieldName).SetValue(consumer, value);
+
+    private static FieldInfo RequireField(string fieldName)
+        => typeof(KafkaConsumer<string, string>).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+           ?? throw new InvalidOperationException($"{fieldName} field not found.");
+}


### PR DESCRIPTION
Closes #2211 (tasks 1–2; the published-ratio acceptance check lands with the next scheduled benchmark run — see Validation).

## What

Profiled the buffered `ConsumeOneAsync` fast path with dotnet-trace (folded stacks, pinned core, Docker-free harness) instead of guessing, then slimmed the ranked top costs:

| Rank | Cost | Fix |
|---|---|---|
| 1 (~45% of per-poll CPU, manual-assign mode) | `IsManualAssignmentEnsureCurrent` → `ConcurrentDictionary.IsEmpty` acquires **every stripe lock** per poll | Read the published `_subscriptionSnapshot` (already the fast path's routing source; republished after every subscription mutation). Field-pair comment documents the authoritative-vs-snapshot split. |
| 2 (~35%) | Async state machine of `ConsumeOneAsync` (builder Start/SetResult + struct spills) for a synchronously-completing call | `ConsumeOneAsync` is now a sync method that wraps the buffered result in a `ValueTask`; the CTS/timeout slow path moved verbatim to `ConsumeOneWithTimeoutAsync`. Fast-path exceptions now throw synchronously (standard ValueTask idiom; no internal callers). |
| 3 (~25% incl. caller side) | `Buffer.BulkMoveWithWriteBarrier` copies of the ~80-byte `Record` struct | `PendingFetchData.CurrentRecord` returns `ref readonly`; `CacheCurrentBatchState` also recognizes plain `Record[]` lists. Record fields are hoisted into locals **before** any user code (deserializers, interceptors, activity listeners) can Seek and recycle the pooled batch storage. |
| 4 (minor) | Double `Stopwatch.GetTimestamp` in `TryRecordPollFast`; per-poll full-fence `Interlocked.Exchange` in `EagerParseAll` | One timestamp read shared by the expiry check, the poll record, and the caller's drain-start stamp; `EagerParseAll` checks `_eagerParsed` first (`_error` writer invariant documented at the field). |

Non-array record lists (fault-modelling test doubles) intentionally keep the lazy per-access indexer via a staging field — an eager copy would move a mid-batch fault ahead of the good prefix and break `ConsumeAsyncRecoveryTests` position semantics (learned the hard way during review).

## New benchmark

`ConsumeOneBufferedFastPathBenchmarks` — Docker-free BDN benchmark that seeds `PendingFetchData` directly (same reflection-seeding pattern as the fast-path unit tests) and measures the public `ConsumeOneAsync` buffered path in grouped-auto-commit and no-group shapes.

## Results (local i7-12700K)

Pinned-core tight-loop harness, 10M polls/run, baseline = origin/main:

| Mode (100B messages) | Before | After | Δ |
|---|---|---|---|
| Manual-assign | ~560 ns/poll | ~290 ns/poll | **−48%** |
| Grouped + subscribe shape | ~360 ns/poll | ~285 ns/poll | **−21%** |

BDN micro-benchmark (grouped, 100B): 1.034 µs → 0.680 µs (−34%); allocations unchanged (only the two deserialized strings). Post-change trace shows the async machinery gone; the remainder is `ConsumeResult` construction + UTF8 decode, which Confluent pays too.

## Validation

- Unit suite: **5600/5600** green (three runs across the iteration).
- ConsumeAll/batch paths share the wins (`ref readonly` in both batch enumerators, `EagerParseAll` fence removal) — no path got slower; no behavioral change intended anywhere.
- Local paired Dekaf-vs-Confluent `ConsumerPollBenchmarks` was attempted but is not viable from a worktree (child benchmark process fails to build; `--inProcess` silently downgrades to `InvocationCount=1`, the Tier-0 single-shot trap). The 1.5x-ratio acceptance gate should be read from the next scheduled benchmark publish; no paid stress lane needed for this CPU-local change.
- `/simplify` review (4 agents) applied: timestamp reuse, invariant comments, benchmark cleanup; skipped the guard-split suggestion (unsafe when a topic filter is set but not refresh-due).