### PR TITLE
feat(oauth): support KIP-1258 client assertions

### DIFF
--- a/docs/docs/security/oauth.md
+++ b/docs/docs/security/oauth.md
@@ -86,6 +86,39 @@ the same key object to sign new assertions.
 `byte[]`, nested `IReadOnlyDictionary<string, object?>`, and arrays/enumerables
 of those values. Use `JsonElement` when you need to pass a custom object shape.
 
+## Client Assertion Authentication (KIP-1258)
+
+Use private-key JWT client authentication when the identity provider requires
+`private_key_jwt` but the OAuth grant must remain `client_credentials`:
+
+```csharp
+using System.Security.Cryptography;
+using Dekaf;
+
+var privateKey = RSA.Create();
+privateKey.ImportFromPem(File.ReadAllText("client-key.pem"));
+
+await using var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .UseTls()
+    .WithOAuthBearerClientAssertion(options =>
+    {
+        options.TokenEndpoint = "https://auth.example.com/oauth2/token";
+        options.ClientId = "my-kafka-client";
+        options.PrivateKey = privateKey;
+        options.Audience = "https://auth.example.com/oauth2/token";
+        options.Scopes = ["kafka:produce", "kafka:consume"];
+        options.KeyId = "key-2026-07";
+    })
+    .BuildAsync();
+```
+
+Dekaf posts `grant_type=client_credentials`, `client_assertion_type`, and a freshly
+signed `client_assertion`. It does not send HTTP Basic credentials or fall back to a
+client secret if assertion signing or token retrieval fails. The same builder method
+is available for producers, consumers, share consumers, admin clients, and shared
+`KafkaClient` instances.
+
 ## Azure AD Example
 
 ```csharp

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4953,6 +4953,28 @@ public sealed class AdminClientBuilder
         return WithOAuthBearerJwtBearer(options);
     }
 
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public AdminClientBuilder WithOAuthBearerClientAssertion(OAuthBearerClientAssertionOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public AdminClientBuilder WithOAuthBearerClientAssertion(Action<OAuthBearerClientAssertionOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerClientAssertionOptions();
+        configure(options);
+        return WithOAuthBearerClientAssertion(options);
+    }
+
     /// <summary>
     /// Configures SASL/OAUTHBEARER authentication using Azure IMDS managed identity.
     /// </summary>

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -667,6 +667,28 @@ public sealed class ProducerBuilder<TKey, TValue>
         return WithOAuthBearerJwtBearer(options);
     }
 
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(OAuthBearerClientAssertionOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public ProducerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(Action<OAuthBearerClientAssertionOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerClientAssertionOptions();
+        configure(options);
+        return WithOAuthBearerClientAssertion(options);
+    }
+
     /// <summary>
     /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
     /// </summary>
@@ -1978,6 +2000,28 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return WithOAuthBearerJwtBearer(options);
     }
 
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(OAuthBearerClientAssertionOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    /// <summary>Configures private-key JWT client authentication for <c>client_credentials</c>.</summary>
+    public ConsumerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(Action<OAuthBearerClientAssertionOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerClientAssertionOptions();
+        configure(options);
+        return WithOAuthBearerClientAssertion(options);
+    }
+
     /// <summary>
     /// Configures OAUTHBEARER authentication using Azure IMDS managed identity.
     /// </summary>
@@ -3153,6 +3197,26 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         var options = new OAuthBearerJwtBearerOptions();
         configure(options);
         return WithOAuthBearerJwtBearer(options);
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(OAuthBearerClientAssertionOptions options)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerClientAssertion(Action<OAuthBearerClientAssertionOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerClientAssertionOptions();
+        configure(options);
+        return WithOAuthBearerClientAssertion(options);
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -314,6 +314,25 @@ public sealed class KafkaClientBuilder
         return WithOAuthBearerJwtBearer(options);
     }
 
+    public KafkaClientBuilder WithOAuthBearerClientAssertion(OAuthBearerClientAssertionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var oauthConfig = options.ToOAuthBearerConfig();
+        _saslMechanism = SaslMechanism.OAuthBearer;
+        _oauthConfig = oauthConfig;
+        _oauthTokenProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public KafkaClientBuilder WithOAuthBearerClientAssertion(Action<OAuthBearerClientAssertionOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        var options = new OAuthBearerClientAssertionOptions();
+        configure(options);
+        return WithOAuthBearerClientAssertion(options);
+    }
+
     public KafkaClientBuilder WithOAuthBearerAzureImds(OAuthBearerAzureImdsOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);

--- a/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
@@ -1,0 +1,118 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// Configures RFC 7523 private-key JWT client authentication for the
+/// <c>client_credentials</c> grant.
+/// </summary>
+public sealed class OAuthBearerClientAssertionOptions
+{
+    /// <summary>OAuth token endpoint that receives the client assertion.</summary>
+    public string? TokenEndpoint { get; set; }
+
+    /// <summary>OAuth client identifier; defaults the assertion issuer and subject.</summary>
+    public string? ClientId { get; set; }
+
+    /// <summary>RSA or ECDSA private key used to sign each assertion.</summary>
+    public AsymmetricAlgorithm? PrivateKey { get; set; }
+
+    /// <summary>Intended audience for the assertion.</summary>
+    public string? Audience { get; set; }
+
+    /// <summary>Assertion issuer; defaults to <see cref="ClientId"/>.</summary>
+    public string? Issuer { get; set; }
+
+    /// <summary>Assertion subject; defaults to <see cref="ClientId"/>.</summary>
+    public string? Subject { get; set; }
+
+    /// <summary>Optional key identifier written to the JWT header.</summary>
+    public string? KeyId { get; set; }
+
+    /// <summary>Scopes sent as a space-delimited token request parameter.</summary>
+    public IReadOnlyList<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Additional AOT-safe JWT claims. Supported values match
+    /// <see cref="OAuthBearerJwtBearerOptions.AdditionalClaims"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?>? AdditionalClaims { get; set; }
+
+    /// <summary>Additional non-reserved form parameters for the token request.</summary>
+    public IReadOnlyDictionary<string, string>? AdditionalParameters { get; set; }
+
+    /// <summary>Assertion lifetime. Defaults to five minutes.</summary>
+    public TimeSpan AssertionLifetime { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Seconds before token expiration that trigger refresh.</summary>
+    public int TokenRefreshBufferSeconds { get; set; } = 60;
+
+    /// <summary>Signing algorithm; inferred from <see cref="PrivateKey"/> when omitted.</summary>
+    public OAuthBearerJwtSigningAlgorithm? SigningAlgorithm { get; set; }
+
+    internal OAuthBearerConfig ToOAuthBearerConfig()
+    {
+        Validate();
+        var options = Clone();
+        return new OAuthBearerConfig
+        {
+            GrantType = OAuthBearerGrantType.ClientCredentials,
+            TokenEndpointUrl = options.TokenEndpoint!,
+            ClientId = options.ClientId!,
+            Scope = options.Scopes is { Count: > 0 } ? string.Join(" ", options.Scopes) : null,
+            AdditionalParameters = options.AdditionalParameters,
+            ClientAssertion = options,
+            TokenRefreshBufferSeconds = options.TokenRefreshBufferSeconds
+        };
+    }
+
+    private void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(TokenEndpoint))
+            throw new InvalidOperationException("OAuth client-assertion token endpoint is required");
+        if (string.IsNullOrWhiteSpace(ClientId))
+            throw new InvalidOperationException("OAuth client-assertion client ID is required");
+        if (string.IsNullOrWhiteSpace(Audience))
+            throw new InvalidOperationException("OAuth client-assertion audience is required");
+        if (PrivateKey is null)
+            throw new InvalidOperationException("OAuth client-assertion private key is required");
+        if (AssertionLifetime <= TimeSpan.Zero)
+            throw new InvalidOperationException("OAuth client-assertion lifetime must be positive");
+        if (TokenRefreshBufferSeconds < 0)
+            throw new InvalidOperationException("OAuth client-assertion token refresh buffer must be non-negative");
+
+        if (AdditionalParameters is not null)
+        {
+            foreach (var name in AdditionalParameters.Keys)
+            {
+                if (name is "grant_type" or "client_id" or "client_assertion_type" or "client_assertion")
+                {
+                    throw new InvalidOperationException(
+                        $"OAuth client-assertion additional parameter '{name}' is reserved");
+                }
+            }
+        }
+    }
+
+    private OAuthBearerClientAssertionOptions Clone() => new()
+    {
+        TokenEndpoint = TokenEndpoint,
+        ClientId = ClientId,
+        PrivateKey = PrivateKey,
+        Audience = Audience,
+        Issuer = Issuer,
+        Subject = Subject,
+        KeyId = KeyId,
+        Scopes = Scopes is null ? null : Scopes.ToArray(),
+        AdditionalClaims = AdditionalClaims is null
+            ? null
+            : AdditionalClaims.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+        AdditionalParameters = AdditionalParameters is null
+            ? null
+            : AdditionalParameters.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal),
+        AssertionLifetime = AssertionLifetime,
+        TokenRefreshBufferSeconds = TokenRefreshBufferSeconds,
+        SigningAlgorithm = SigningAlgorithm
+    };
+}

--- a/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
@@ -86,7 +86,11 @@ public sealed class OAuthBearerClientAssertionOptions
         {
             foreach (var name in AdditionalParameters.Keys)
             {
-                if (name is "grant_type" or "client_id" or "client_assertion_type" or "client_assertion")
+                if (name is "grant_type"
+                    or "client_id"
+                    or "client_secret"
+                    or "client_assertion_type"
+                    or "client_assertion")
                 {
                     throw new InvalidOperationException(
                         $"OAuth client-assertion additional parameter '{name}' is reserved");

--- a/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
@@ -42,6 +42,14 @@ public sealed class OAuthBearerConfig
     public OAuthBearerJwtBearerOptions? JwtBearer { get; init; }
 
     /// <summary>
+    /// Private-key JWT client authentication settings for the
+    /// <see cref="OAuthBearerGrantType.ClientCredentials"/> grant.
+    /// When configured, client assertion authentication takes precedence over
+    /// <see cref="ClientSecret"/> and never falls back to it at runtime.
+    /// </summary>
+    public OAuthBearerClientAssertionOptions? ClientAssertion { get; init; }
+
+    /// <summary>
     /// Azure IMDS managed identity settings. Required when <see cref="GrantType"/> is
     /// <see cref="OAuthBearerGrantType.AzureImds"/>.
     /// </summary>

--- a/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerJwtAssertion.cs
@@ -25,27 +25,67 @@ internal static class OAuthBearerJwtAssertion
         var options = config.JwtBearer
             ?? throw new InvalidOperationException("JWT-bearer OAuth config requires JwtBearer options");
 
-        var clientId = Required(config.ClientId, "OAuth client ID is required");
-        var audience = Required(options.Audience, "JWT-bearer OAuth audience is required");
-        var issuer = string.IsNullOrWhiteSpace(options.Issuer) ? clientId : options.Issuer!;
-        var subject = string.IsNullOrWhiteSpace(options.Subject) ? clientId : options.Subject!;
-        var privateKey = options.PrivateKey
+        return Create(
+            config.ClientId,
+            options.PrivateKey,
+            options.Audience,
+            options.Issuer,
+            options.Subject,
+            options.KeyId,
+            options.AdditionalClaims,
+            options.AssertionLifetime,
+            options.SigningAlgorithm,
+            now);
+    }
+
+    internal static string Create(
+        string clientId,
+        OAuthBearerClientAssertionOptions options,
+        DateTimeOffset now) => Create(
+        clientId,
+        options.PrivateKey,
+        options.Audience,
+        options.Issuer,
+        options.Subject,
+        options.KeyId,
+        options.AdditionalClaims,
+        options.AssertionLifetime,
+        options.SigningAlgorithm,
+        now);
+
+    private static string Create(
+        string clientIdValue,
+        AsymmetricAlgorithm? privateKeyValue,
+        string? audienceValue,
+        string? issuerValue,
+        string? subjectValue,
+        string? keyId,
+        IReadOnlyDictionary<string, object?>? additionalClaims,
+        TimeSpan assertionLifetime,
+        OAuthBearerJwtSigningAlgorithm? signingAlgorithm,
+        DateTimeOffset now)
+    {
+        var clientId = Required(clientIdValue, "OAuth client ID is required");
+        var audience = Required(audienceValue, "JWT-bearer OAuth audience is required");
+        var issuer = string.IsNullOrWhiteSpace(issuerValue) ? clientId : issuerValue!;
+        var subject = string.IsNullOrWhiteSpace(subjectValue) ? clientId : subjectValue!;
+        var privateKey = privateKeyValue
             ?? throw new InvalidOperationException("JWT-bearer OAuth private key is required");
-        if (options.AssertionLifetime <= TimeSpan.Zero)
+        if (assertionLifetime <= TimeSpan.Zero)
             throw new InvalidOperationException("JWT-bearer assertion lifetime must be positive");
 
-        ValidateAdditionalClaims(options.AdditionalClaims);
+        ValidateAdditionalClaims(additionalClaims);
 
-        var algorithm = ResolveAlgorithm(privateKey, options.SigningAlgorithm);
+        var algorithm = ResolveAlgorithm(privateKey, signingAlgorithm);
         var header = Base64UrlJson(writer =>
         {
             writer.WriteString("alg", AlgorithmName(algorithm));
             writer.WriteString("typ", "JWT");
-            if (!string.IsNullOrWhiteSpace(options.KeyId))
-                writer.WriteString("kid", options.KeyId);
+            if (!string.IsNullOrWhiteSpace(keyId))
+                writer.WriteString("kid", keyId);
         });
 
-        var expiresAt = now.Add(options.AssertionLifetime);
+        var expiresAt = now.Add(assertionLifetime);
         var payload = Base64UrlJson(writer =>
         {
             writer.WriteString("iss", issuer);
@@ -55,9 +95,9 @@ internal static class OAuthBearerJwtAssertion
             writer.WriteNumber("exp", expiresAt.ToUnixTimeSeconds());
             writer.WriteString("jti", Guid.NewGuid().ToString("N"));
 
-            if (options.AdditionalClaims is not null)
+            if (additionalClaims is not null)
             {
-                foreach (var (name, value) in options.AdditionalClaims)
+                foreach (var (name, value) in additionalClaims)
                 {
                     WriteAdditionalClaim(writer, name, value);
                 }

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -131,7 +131,7 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         };
 
         // If client secret is provided, use HTTP Basic authentication
-        if (!string.IsNullOrEmpty(_config.ClientSecret))
+        if (_config.ClientAssertion is null && !string.IsNullOrEmpty(_config.ClientSecret))
         {
             var credentials = Convert.ToBase64String(
                 Encoding.UTF8.GetBytes($"{_config.ClientId}:{_config.ClientSecret}"));
@@ -217,11 +217,23 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
     private Dictionary<string, string> BuildClientCredentialsTokenRequestBody()
     {
-        return new Dictionary<string, string>
+        var body = new Dictionary<string, string>
         {
             ["grant_type"] = "client_credentials",
             ["client_id"] = _config.ClientId
         };
+
+        if (_config.ClientAssertion is not null)
+        {
+            body["client_assertion_type"] =
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+            body["client_assertion"] = OAuthBearerJwtAssertion.Create(
+                _config.ClientId,
+                _config.ClientAssertion,
+                DateTimeOffset.UtcNow);
+        }
+
+        return body;
     }
 
     private Dictionary<string, string> BuildJwtBearerTokenRequestBody()

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -121,13 +121,25 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     }
 
     [Test]
-    public async Task Producer_WithOAuthBearerClientAssertion_InvalidOptionsDoNotChangeMechanism()
+    public async Task WithOAuthBearerClientAssertion_WhenValidationFails_DoesNotChangeExistingSaslMechanism()
     {
-        var builder = Kafka.CreateProducer<string, string>().WithSaslPlain("user", "pass");
+        var invalidOptions = new OAuthBearerClientAssertionOptions();
 
-        await Assert.That(() => builder.WithOAuthBearerClientAssertion(new OAuthBearerClientAssertionOptions()))
-            .Throws<InvalidOperationException>();
-        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.Plain);
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
+            Kafka.CreateProducer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerClientAssertion(invalidOptions));
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
+            Kafka.CreateConsumer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerClientAssertion(invalidOptions));
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
+            Kafka.CreateShareConsumer<string, string>().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerClientAssertion(invalidOptions));
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
+            Kafka.CreateAdminClient().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerClientAssertion(invalidOptions));
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
+            Kafka.Connect().WithSaslPlain("user", "pass"),
+            builder => builder.WithOAuthBearerClientAssertion(invalidOptions));
     }
 
     [Test]
@@ -253,19 +265,19 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     {
         var invalidOptions = new OAuthBearerJwtBearerOptions();
 
-        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
             Kafka.CreateProducer<string, string>().WithSaslPlain("user", "pass"),
             builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
-        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
             Kafka.CreateConsumer<string, string>().WithSaslPlain("user", "pass"),
             builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
-        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
             Kafka.CreateShareConsumer<string, string>().WithSaslPlain("user", "pass"),
             builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
-        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
             Kafka.CreateAdminClient().WithSaslPlain("user", "pass"),
             builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
-        await AssertInvalidJwtBearerDoesNotChangeSaslMechanism(
+        await AssertInvalidOAuthOptionsDoNotChangeSaslMechanism(
             Kafka.Connect().WithSaslPlain("user", "pass"),
             builder => builder.WithOAuthBearerJwtBearer(invalidOptions));
     }
@@ -293,7 +305,7 @@ public sealed class OAuthBearerJwtBearerBuilderTests
         Audience = "https://auth.example.test/token"
     };
 
-    private static async Task AssertInvalidJwtBearerDoesNotChangeSaslMechanism<TBuilder>(
+    private static async Task AssertInvalidOAuthOptionsDoNotChangeSaslMechanism<TBuilder>(
         TBuilder builder,
         Action<TBuilder> configure)
     {

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -143,13 +143,18 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     }
 
     [Test]
-    public async Task Producer_WithOAuthBearerClientAssertion_ReservedFormParameterThrows()
+    [Arguments("grant_type")]
+    [Arguments("client_id")]
+    [Arguments("client_secret")]
+    [Arguments("client_assertion_type")]
+    [Arguments("client_assertion")]
+    public async Task Producer_WithOAuthBearerClientAssertion_ReservedFormParameterThrows(string parameterName)
     {
         using var rsa = RSA.Create(2048);
         var options = CreateClientAssertionOptions(rsa);
         options.AdditionalParameters = new Dictionary<string, string>
         {
-            ["client_assertion"] = "override"
+            [parameterName] = "override"
         };
 
         await Assert.That(() => Kafka.CreateProducer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/OAuthBearerJwtBearerBuilderTests.cs
@@ -80,6 +80,73 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     }
 
     [Test]
+    public async Task WithOAuthBearerClientAssertion_ConfiguresEveryClientBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var options = CreateClientAssertionOptions(rsa);
+        var producer = Kafka.CreateProducer<string, string>();
+        var consumer = Kafka.CreateConsumer<string, string>();
+        var shareConsumer = Kafka.CreateShareConsumer<string, string>();
+        var admin = Kafka.CreateAdminClient();
+        var client = Kafka.Connect();
+
+        await Assert.That(producer.WithOAuthBearerClientAssertion(options)).IsSameReferenceAs(producer);
+        await Assert.That(consumer.WithOAuthBearerClientAssertion(options)).IsSameReferenceAs(consumer);
+        await Assert.That(shareConsumer.WithOAuthBearerClientAssertion(options)).IsSameReferenceAs(shareConsumer);
+        await Assert.That(admin.WithOAuthBearerClientAssertion(options)).IsSameReferenceAs(admin);
+        await Assert.That(client.WithOAuthBearerClientAssertion(options)).IsSameReferenceAs(client);
+
+        foreach (var builder in new object[] { producer, consumer, shareConsumer, admin, client })
+        {
+            await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.OAuthBearer);
+            await Assert.That(GetOAuthConfig(builder)!.ClientAssertion).IsNotNull();
+        }
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerClientAssertionAction_ReturnsSameBuilder()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = Kafka.CreateProducer<string, string>();
+
+        var result = builder.WithOAuthBearerClientAssertion(options =>
+        {
+            options.TokenEndpoint = "https://auth.example.test/token";
+            options.ClientId = "client";
+            options.PrivateKey = rsa;
+            options.Audience = "https://auth.example.test/token";
+        });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerClientAssertion_InvalidOptionsDoNotChangeMechanism()
+    {
+        var builder = Kafka.CreateProducer<string, string>().WithSaslPlain("user", "pass");
+
+        await Assert.That(() => builder.WithOAuthBearerClientAssertion(new OAuthBearerClientAssertionOptions()))
+            .Throws<InvalidOperationException>();
+        await Assert.That(GetSaslMechanism(builder)).IsEqualTo(SaslMechanism.Plain);
+    }
+
+    [Test]
+    public async Task Producer_WithOAuthBearerClientAssertion_ReservedFormParameterThrows()
+    {
+        using var rsa = RSA.Create(2048);
+        var options = CreateClientAssertionOptions(rsa);
+        options.AdditionalParameters = new Dictionary<string, string>
+        {
+            ["client_assertion"] = "override"
+        };
+
+        await Assert.That(() => Kafka.CreateProducer<string, string>()
+                .WithOAuthBearerClientAssertion(options))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("reserved");
+    }
+
+    [Test]
     public async Task Producer_WithOAuthBearerAzureImds_ReturnsSameBuilderAndConfiguresGrant()
     {
         var builder = Kafka.CreateProducer<string, string>();
@@ -215,6 +282,15 @@ public sealed class OAuthBearerJwtBearerBuilderTests
     {
         Resource = "api://kafka",
         ClientId = "managed-identity-client"
+    };
+
+    private static OAuthBearerClientAssertionOptions CreateClientAssertionOptions(
+        AsymmetricAlgorithm privateKey) => new()
+    {
+        TokenEndpoint = "https://auth.example.test/token",
+        ClientId = "client",
+        PrivateKey = privateKey,
+        Audience = "https://auth.example.test/token"
     };
 
     private static async Task AssertInvalidJwtBearerDoesNotChangeSaslMechanism<TBuilder>(

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -278,6 +278,105 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    public async Task GetTokenAsync_WithClientAssertion_SendsPrivateKeyJwtAuthentication()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler();
+        var config = new OAuthBearerClientAssertionOptions
+        {
+            TokenEndpoint = "https://auth.example.test/token",
+            ClientId = "assertion-client",
+            PrivateKey = rsa,
+            Audience = "https://auth.example.test/token",
+            Issuer = "issuer",
+            Subject = "subject",
+            KeyId = "key-2",
+            Scopes = ["kafka:produce"],
+            AdditionalClaims = new Dictionary<string, object?> { ["tenant"] = "alpha" }
+        }.ToOAuthBearerConfig();
+        using var provider = new OAuthBearerTokenProvider(config, new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        var form = handler.Requests.Single();
+        await Assert.That(form["grant_type"]).IsEqualTo("client_credentials");
+        await Assert.That(form["client_id"]).IsEqualTo("assertion-client");
+        await Assert.That(form["client_assertion_type"])
+            .IsEqualTo("urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+        await Assert.That(form.ContainsKey("assertion")).IsFalse();
+        await Assert.That(handler.AuthorizationSchemes.Single()).IsNull();
+
+        var parts = form["client_assertion"].Split('.');
+        var payload = DecodeJwtPart(parts[1]);
+        await Assert.That(payload.GetProperty("iss").GetString()).IsEqualTo("issuer");
+        await Assert.That(payload.GetProperty("sub").GetString()).IsEqualTo("subject");
+        await Assert.That(payload.GetProperty("aud").GetString())
+            .IsEqualTo("https://auth.example.test/token");
+        await Assert.That(payload.GetProperty("tenant").GetString()).IsEqualTo("alpha");
+
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        await Assert.That(rsa.VerifyData(
+            signingInput,
+            Base64UrlDecode(parts[2]),
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithClientSecret_PreservesBasicAuthentication()
+    {
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = "client",
+            ClientSecret = "secret"
+        }, new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        var form = handler.Requests.Single();
+        await Assert.That(form["grant_type"]).IsEqualTo("client_credentials");
+        await Assert.That(form.ContainsKey("client_assertion")).IsFalse();
+        await Assert.That(handler.AuthorizationSchemes.Single()).IsEqualTo("Basic");
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WhenClientAssertionIsRejected_DoesNotFallBackToSecret()
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler
+        {
+            ResponseStatusCode = HttpStatusCode.Unauthorized
+        };
+        var assertionOptions = new OAuthBearerClientAssertionOptions
+        {
+            TokenEndpoint = "https://auth.example.test/token",
+            ClientId = "client",
+            PrivateKey = rsa,
+            Audience = "https://auth.example.test/token"
+        };
+        var config = new OAuthBearerConfig
+        {
+            TokenEndpointUrl = assertionOptions.TokenEndpoint!,
+            ClientId = assertionOptions.ClientId!,
+            ClientSecret = "must-not-be-used",
+            ClientAssertion = assertionOptions
+        };
+        using var provider = new OAuthBearerTokenProvider(config, new HttpClient(handler));
+
+        await Assert.That(async () =>
+        {
+            _ = await provider.GetTokenAsync();
+        })
+            .Throws<Dekaf.Errors.AuthenticationException>();
+
+        await Assert.That(handler.Requests).Count().IsEqualTo(1);
+        await Assert.That(handler.Requests[0].ContainsKey("client_assertion")).IsTrue();
+        await Assert.That(handler.AuthorizationSchemes.Single()).IsNull();
+    }
+
+    [Test]
     public async Task GetTokenAsync_WithAzureImds_SendsMetadataGetRequest()
     {
         var handler = new CapturingAzureImdsHandler();
@@ -427,7 +526,9 @@ public sealed class OAuthBearerTokenProviderTests
     private sealed class CapturingTokenEndpointHandler : HttpMessageHandler
     {
         public List<IReadOnlyDictionary<string, string>> Requests { get; } = [];
+        public List<string?> AuthorizationSchemes { get; } = [];
         public int ExpiresInSeconds { get; init; } = 3600;
+        public HttpStatusCode ResponseStatusCode { get; init; } = HttpStatusCode.OK;
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -435,10 +536,11 @@ public sealed class OAuthBearerTokenProviderTests
         {
             var body = await request.Content!.ReadAsStringAsync(cancellationToken);
             Requests.Add(ParseForm(body));
+            AuthorizationSchemes.Add(request.Headers.Authorization?.Scheme);
 
             var count = Requests.Count;
             var json = $$"""{"access_token":"access-token-{{count}}","expires_in":{{ExpiresInSeconds}},"sub":"principal-{{count}}"}""";
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            return new HttpResponseMessage(ResponseStatusCode)
             {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
             };


### PR DESCRIPTION
## Summary
- add RFC 7523 private-key JWT client authentication for `client_credentials`
- reuse existing RSA/ECDSA assertion signing and suppress client-secret fallback
- expose producer, consumer, share consumer, admin, and shared-client builders
- document KIP-1258 configuration and validate reserved form parameters

## Test plan
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release` (0 warnings)
- focused OAuth tests: 42 passed on net10; 39 passed on net8 before final validation-only additions
- full net8 unit suite: 5,495 passed
- full net10 unit suite: 5,620 passed; unrelated `LockFreeStackTests.TryPush_TryPop_DoNotAllocateInSteadyState` allocation-sensitive test failed in suite order and passed isolated

Closes #2220