### PR TITLE
fix(protocol): reject unsupported API ranges

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4357,19 +4357,11 @@ public sealed class AdminClient : IAdminClient
         => RetryHelper.WithRetryAsync(operation, _metadataManager, cancellationToken);
 
     private bool SupportsApiRange(Protocol.ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion)
-    {
-        if (!_metadataManager.HasApiKey(apiKey))
-            return false;
-
-        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+        => _metadataManager.TryGetNegotiatedApiVersion(
             apiKey,
             lowestSupportedVersion,
-            highestSupportedVersion);
-
-        return apiVersion >= lowestSupportedVersion &&
-               apiVersion <= highestSupportedVersion &&
-               _metadataManager.SupportsApiVersion(apiKey, apiVersion);
-    }
+            highestSupportedVersion,
+            out _);
 
     private static WriteTxnMarkersResponsePartition FindAbortTransactionPartition(
         WriteTxnMarkersResponse response,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -1532,12 +1532,10 @@ public sealed class AdminClient : IAdminClient
                 Topics = topicOffsets
             };
 
-            // Cap at v7 for admin offset commits — v8+ requires valid MemberId/GenerationId
-            // for group membership validation, which admin operations don't have.
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                 Protocol.ApiKey.OffsetCommit,
                 OffsetCommitRequest.LowestSupportedVersion,
-                Math.Min(OffsetCommitRequest.HighestSupportedVersion, (short)7));
+                OffsetCommitRequest.HighestSupportedVersion);
 
             var response = await connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
                 request,

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Dekaf.Errors;
@@ -169,40 +170,95 @@ public sealed partial class MetadataManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets the negotiated API version for the specified API key.
-    /// Returns the minimum of the broker's max version and our supported version.
+    /// Attempts to get the highest API version supported by both the broker and client.
     /// Negotiated versions are cached for performance.
     /// </summary>
-    public short GetNegotiatedApiVersion(ApiKey apiKey, short ourMinVersion, short ourMaxVersion)
+    public bool TryGetNegotiatedApiVersion(
+        ApiKey apiKey,
+        short ourMinVersion,
+        short ourMaxVersion,
+        out short negotiatedVersion)
     {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ourMinVersion, ourMaxVersion);
+
         var cacheKey = (apiKey, ourMinVersion, ourMaxVersion);
 
         // Check cache first (fast path)
         if (_negotiatedVersionCache.TryGetValue(cacheKey, out var cached))
         {
-            return cached;
+            negotiatedVersion = cached;
+            return true;
         }
 
-        // Calculate and cache
-        short negotiated;
-        if (_brokerApiVersions.TryGetValue(apiKey, out var brokerVersions))
+        if (!_brokerApiVersions.TryGetValue(apiKey, out var brokerVersions))
         {
-            // Use the minimum of our max and broker's max
-            negotiated = Math.Min(ourMaxVersion, brokerVersions.MaxVersion);
-            // But not below our minimum or broker's minimum
-            negotiated = Math.Max(negotiated, ourMinVersion);
-            negotiated = Math.Max(negotiated, brokerVersions.MinVersion);
-        }
-        else
-        {
-            // Fall back to our minimum version if we don't have broker info yet
-            negotiated = ourMinVersion;
+            negotiatedVersion = default;
+            return false;
         }
 
-        // Cache it (benign race - same value computed)
-        _negotiatedVersionCache.TryAdd(cacheKey, negotiated);
-        return negotiated;
+        var lowestUsableVersion = Math.Max(ourMinVersion, brokerVersions.MinVersion);
+        var highestUsableVersion = Math.Min(ourMaxVersion, brokerVersions.MaxVersion);
+        if (lowestUsableVersion > highestUsableVersion)
+        {
+            negotiatedVersion = default;
+            return false;
+        }
+
+        // Benign race: concurrent callers calculate the same intersection.
+        _negotiatedVersionCache.TryAdd(cacheKey, highestUsableVersion);
+        negotiatedVersion = highestUsableVersion;
+        return true;
     }
+
+    /// <summary>
+    /// Gets the highest API version supported by both the broker and client.
+    /// </summary>
+    /// <exception cref="BrokerVersionException">
+    /// The broker omitted the API key or its supported range does not overlap the client range.
+    /// </exception>
+    public short GetNegotiatedApiVersion(ApiKey apiKey, short ourMinVersion, short ourMaxVersion)
+    {
+        // Keep this cache-hit path direct. Delegating to TryGetNegotiatedApiVersion measurably
+        // regresses request-path throughput even though both methods use the same negotiation rules.
+        var cacheKey = (apiKey, ourMinVersion, ourMaxVersion);
+        if (_negotiatedVersionCache.TryGetValue(cacheKey, out var negotiatedVersion))
+        {
+            return negotiatedVersion;
+        }
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(ourMinVersion, ourMaxVersion);
+
+        if (!_brokerApiVersions.TryGetValue(apiKey, out var brokerVersions))
+        {
+            ThrowApiAbsent(apiKey, ourMinVersion, ourMaxVersion);
+        }
+
+        var lowestUsableVersion = Math.Max(ourMinVersion, brokerVersions.MinVersion);
+        var highestUsableVersion = Math.Min(ourMaxVersion, brokerVersions.MaxVersion);
+        if (lowestUsableVersion > highestUsableVersion)
+        {
+            ThrowDisjointApiRange(apiKey, ourMinVersion, ourMaxVersion, brokerVersions);
+        }
+
+        _negotiatedVersionCache.TryAdd(cacheKey, highestUsableVersion);
+        return highestUsableVersion;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowApiAbsent(ApiKey apiKey, short ourMinVersion, short ourMaxVersion) =>
+        throw new BrokerVersionException(
+            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
+            $"[{ourMinVersion}, {ourMaxVersion}]: API absent.");
+
+    [DoesNotReturn]
+    private static void ThrowDisjointApiRange(
+        ApiKey apiKey,
+        short ourMinVersion,
+        short ourMaxVersion,
+        (short MinVersion, short MaxVersion) brokerVersions) =>
+        throw new BrokerVersionException(
+            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
+            $"[{ourMinVersion}, {ourMaxVersion}]: broker [{brokerVersions.MinVersion}, {brokerVersions.MaxVersion}].");
 
     /// <summary>
     /// Returns the max finalized version for a broker feature, or 0 if the feature is not present.

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -456,22 +456,11 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
     }
 
     private bool TryGetNegotiatedVersion(ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion, out short apiVersion)
-    {
-        apiVersion = lowestSupportedVersion;
-        if (!_metadataManager.HasApiKey(apiKey))
-        {
-            return false;
-        }
-
-        var negotiated = _metadataManager.GetNegotiatedApiVersion(apiKey, lowestSupportedVersion, highestSupportedVersion);
-        if (negotiated < lowestSupportedVersion || negotiated > highestSupportedVersion)
-        {
-            return false;
-        }
-
-        apiVersion = negotiated;
-        return true;
-    }
+        => _metadataManager.TryGetNegotiatedApiVersion(
+            apiKey,
+            lowestSupportedVersion,
+            highestSupportedVersion,
+            out apiVersion);
 
     private bool TrySelectCompression(IReadOnlyList<sbyte> acceptedCompressionTypes, out sbyte compressionType)
     {

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientAlterConsumerGroupOffsetsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientAlterConsumerGroupOffsetsTests.cs
@@ -1,0 +1,100 @@
+using Dekaf.Admin;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Admin;
+
+public sealed class AdminClientAlterConsumerGroupOffsetsTests
+{
+    [Test]
+    public async Task AlterConsumerGroupOffsetsAsync_NegotiatesHighestSupportedTopicNameVersion()
+    {
+        const string groupId = "test-group";
+        const string topic = "test-topic";
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(1);
+        connection.Host.Returns("localhost");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = groupId,
+                        NodeId = 1,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+
+        connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new OffsetCommitResponse
+            {
+                Topics =
+                [
+                    new OffsetCommitResponseTopic
+                    {
+                        Name = topic,
+                        Partitions =
+                        [
+                            new OffsetCommitResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                ErrorCode = ErrorCode.None
+                            }
+                        ]
+                    }
+                ]
+            }));
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+
+        var metadataManager = new MetadataManager(pool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 1,
+                    Host = "localhost",
+                    Port = 9092
+                }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 1,
+            Topics = []
+        });
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.SetApiVersion(ApiKey.OffsetCommit, 2, 9);
+
+        await using var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["localhost:9092"] },
+            pool,
+            metadataManager);
+
+        await admin.AlterConsumerGroupOffsetsAsync(groupId, [new TopicPartitionOffset(topic, 0, 42)]);
+
+        await connection.Received(1).SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+            Arg.Any<OffsetCommitRequest>(),
+            9,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -31,6 +31,99 @@ public class MetadataManagerTests
             bootstrapServers: ["localhost:9092"]);
     }
 
+    [Test]
+    [Arguments((short)0, (short)3, (short)2, (short)6, (short)3)]
+    [Arguments((short)2, (short)6, (short)0, (short)3, (short)3)]
+    [Arguments((short)4, (short)4, (short)4, (short)4, (short)4)]
+    public async Task GetNegotiatedApiVersion_OverlappingRanges_ReturnsHighestCommonVersion(
+        short brokerMinVersion,
+        short brokerMaxVersion,
+        short clientMinVersion,
+        short clientMaxVersion,
+        short expectedVersion)
+    {
+        await using var manager = CreateTestManager();
+        manager.SetApiVersion(ApiKey.Fetch, brokerMinVersion, brokerMaxVersion);
+
+        var version = manager.GetNegotiatedApiVersion(ApiKey.Fetch, clientMinVersion, clientMaxVersion);
+
+        await Assert.That(version).IsEqualTo(expectedVersion);
+    }
+
+    [Test]
+    [Arguments((short)0, (short)3, (short)5, (short)6)]
+    [Arguments((short)5, (short)6, (short)0, (short)3)]
+    public async Task GetNegotiatedApiVersion_DisjointRanges_ThrowsBrokerVersionException(
+        short brokerMinVersion,
+        short brokerMaxVersion,
+        short clientMinVersion,
+        short clientMaxVersion)
+    {
+        await using var manager = CreateTestManager();
+        manager.SetApiVersion(ApiKey.Fetch, brokerMinVersion, brokerMaxVersion);
+
+        var exception = Assert.Throws<BrokerVersionException>(() =>
+            manager.GetNegotiatedApiVersion(ApiKey.Fetch, clientMinVersion, clientMaxVersion));
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("Fetch");
+        await Assert.That(exception.Message).Contains($"client [{clientMinVersion}, {clientMaxVersion}]");
+        await Assert.That(exception.Message).Contains($"broker [{brokerMinVersion}, {brokerMaxVersion}]");
+    }
+
+    [Test]
+    public async Task GetNegotiatedApiVersion_MissingApiKey_ThrowsBrokerVersionException()
+    {
+        await using var manager = CreateTestManager();
+
+        var exception = Assert.Throws<BrokerVersionException>(() =>
+            manager.GetNegotiatedApiVersion(ApiKey.Fetch, 0, 18));
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("Fetch");
+        await Assert.That(exception.Message).Contains("client [0, 18]");
+        await Assert.That(exception.Message).Contains("API absent");
+    }
+
+    [Test]
+    public async Task GetNegotiatedApiVersion_InvalidClientRange_ThrowsArgumentOutOfRangeException()
+    {
+        await using var manager = CreateTestManager();
+        manager.SetApiVersion(ApiKey.Fetch, 0, 18);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            manager.GetNegotiatedApiVersion(ApiKey.Fetch, 5, 4));
+
+        await Assert.That(exception).IsNotNull();
+    }
+
+    [Test]
+    public async Task TryGetNegotiatedApiVersion_ReturnsFalseForMissingOrDisjointApi()
+    {
+        await using var manager = CreateTestManager();
+        manager.SetApiVersion(ApiKey.Fetch, 0, 3);
+
+        var disjoint = manager.TryGetNegotiatedApiVersion(ApiKey.Fetch, 5, 6, out var disjointVersion);
+        var missing = manager.TryGetNegotiatedApiVersion(ApiKey.Produce, 0, 12, out var missingVersion);
+
+        await Assert.That(disjoint).IsFalse();
+        await Assert.That(disjointVersion).IsEqualTo(default(short));
+        await Assert.That(missing).IsFalse();
+        await Assert.That(missingVersion).IsEqualTo(default(short));
+    }
+
+    [Test]
+    public async Task TryGetNegotiatedApiVersion_OverlappingRange_ReturnsHighestCommonVersion()
+    {
+        await using var manager = CreateTestManager();
+        manager.SetApiVersion(ApiKey.Fetch, 2, 6);
+
+        var supported = manager.TryGetNegotiatedApiVersion(ApiKey.Fetch, 0, 3, out var version);
+
+        await Assert.That(supported).IsTrue();
+        await Assert.That(version).IsEqualTo((short)3);
+    }
+
     /// <summary>
     /// Helper to create a test MetadataResponse with the specified brokers.
     /// </summary>

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ApiVersionNegotiationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ApiVersionNegotiationBenchmarks.cs
@@ -1,0 +1,31 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ApiVersionNegotiationBenchmarks
+{
+    private MetadataManager _metadataManager = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _metadataManager = new MetadataManager(
+            connectionPool: null!,
+            bootstrapServers: ["localhost:9092"]);
+        _metadataManager.SetApiVersion(ApiKey.Fetch, 0, 18);
+
+        _ = _metadataManager.GetNegotiatedApiVersion(ApiKey.Fetch, 4, 17);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup() => await _metadataManager.DisposeAsync().ConfigureAwait(false);
+
+    [Benchmark]
+    public short GetNegotiatedApiVersion() =>
+        _metadataManager.GetNegotiatedApiVersion(ApiKey.Fetch, 4, 17);
+}


### PR DESCRIPTION
## Summary
- negotiate the true inclusive client/broker API-version intersection
- throw detailed `BrokerVersionException` failures for absent or disjoint APIs before request serialization
- add allocation-free `TryGetNegotiatedApiVersion` probes and use them for optional admin/telemetry capabilities
- cover overlap, exact-version, disjoint, absent, and invalid-range boundaries

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused `MetadataManagerTests` (31/31)
- [x] full net10 unit suite (5623/5623)
- [x] `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- [x] `ProtocolVersionTests` integration suite (11/11)
- [x] `/simplify`

## Performance

`ApiVersionNegotiationBenchmarks.GetNegotiatedApiVersion`, .NET 10.0.10, same machine/configuration, `[MemoryDiagnoser]`:

| Revision | Mean | Allocated |
|---|---:|---:|
| baseline `d9de72e6` | 1.446 ns | 0 B |
| candidate `da7597bf` | 1.476 ns | 0 B |

Delta: +2.1%; 99.9% confidence intervals overlap (`1.422-1.470 ns` vs `1.414-1.538 ns`), so no material throughput regression. Hot path remains zero-allocation.

Closes #2227
