### PR TITLE
fix(networking): conform reconnect backoff to KIP-144

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -812,8 +812,10 @@ internal static class DekafOptionsBinding
         builder.WithDeliveryLatencyTarget(TimeSpan.FromMilliseconds(options.DeliveryLatencyTargetMs));
         builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(options.DeliveryTimeoutMs));
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
-        builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
-        builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
+        if (options.IsReconnectBackoffMsConfigured)
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
+        if (options.IsReconnectBackoffMaxMsConfigured)
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
         ApplySocketConnectionOptions(
             options.ConnectionTimeout,
@@ -907,8 +909,10 @@ internal static class DekafOptionsBinding
         builder.WithHeartbeatInterval(TimeSpan.FromMilliseconds(options.HeartbeatIntervalMs));
         builder.WithRebalanceTimeout(TimeSpan.FromMilliseconds(options.RebalanceTimeoutMs));
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
-        builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
-        builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
+        if (options.IsReconnectBackoffMsConfigured)
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
+        if (options.IsReconnectBackoffMaxMsConfigured)
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
         ApplySocketConnectionOptions(
             options.ConnectionTimeout,
@@ -968,8 +972,10 @@ internal static class DekafOptionsBinding
         if (options.ClientId is not null)
             builder.WithClientId(options.ClientId);
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
-        builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
-        builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
+        if (options.IsReconnectBackoffMsConfigured)
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
+        if (options.IsReconnectBackoffMaxMsConfigured)
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs));
         builder.WithConnectionsMaxIdle(ToTimeout(options.ConnectionsMaxIdleMs));
         ApplySocketConnectionOptions(
             options.ConnectionTimeout,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -35,6 +35,11 @@ public sealed class AdminClient : IAdminClient
 
     public AdminClient(AdminClientOptions options, ILoggerFactory? loggerFactory = null, MetadataOptions? metadataOptions = null)
     {
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            options.ReconnectBackoffMs,
+            options.ReconnectBackoffMaxMs,
+            options.IsReconnectBackoffMsConfigured,
+            options.IsReconnectBackoffMaxMsConfigured);
         _options = options;
         _logger = loggerFactory?.CreateLogger<AdminClient>();
         _ownsResources = true;
@@ -55,7 +60,7 @@ public sealed class AdminClient : IAdminClient
                 TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
-                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(reconnectBackoffMaxMs),
                 ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4623,11 +4623,36 @@ public sealed class AdminClient : IAdminClient
 /// </summary>
 public sealed class AdminClientOptions
 {
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
+    private bool _isReconnectBackoffMsConfigured;
+    private bool _isReconnectBackoffMaxMsConfigured;
+
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; } = "dekaf-admin";
     public int RequestTimeoutMs { get; init; } = 30000;
-    public int ReconnectBackoffMs { get; init; } = 50;
-    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+    public int ReconnectBackoffMs
+    {
+        get => _reconnectBackoffMs;
+        init
+        {
+            _reconnectBackoffMs = value;
+            _isReconnectBackoffMsConfigured = true;
+        }
+    }
+
+    public int ReconnectBackoffMaxMs
+    {
+        get => _reconnectBackoffMaxMs;
+        init
+        {
+            _reconnectBackoffMaxMs = value;
+            _isReconnectBackoffMaxMsConfigured = true;
+        }
+    }
+
+    internal bool IsReconnectBackoffMsConfigured => _isReconnectBackoffMsConfigured;
+    internal bool IsReconnectBackoffMaxMsConfigured => _isReconnectBackoffMaxMsConfigured;
 
     /// <summary>
     /// Maximum idle time in milliseconds before unused broker connections are closed.
@@ -4749,6 +4774,8 @@ public sealed class AdminClientBuilder
     private Func<CancellationToken, ValueTask<OAuthBearerToken>>? _oauthTokenProvider;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private bool _reconnectBackoffConfigured;
+    private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -5101,6 +5128,7 @@ public sealed class AdminClientBuilder
     /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// When the maximum is not configured, it uses this value and disables exponential growth.
     /// </summary>
     /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
     public AdminClientBuilder WithReconnectBackoff(TimeSpan backoff)
@@ -5110,6 +5138,7 @@ public sealed class AdminClientBuilder
             backoff,
             nameof(backoff),
             "Reconnect backoff cannot be negative");
+        _reconnectBackoffConfigured = true;
         return this;
     }
 
@@ -5125,6 +5154,7 @@ public sealed class AdminClientBuilder
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        _reconnectBackoffMaxConfigured = true;
         return this;
     }
 
@@ -5221,7 +5251,11 @@ public sealed class AdminClientBuilder
     {
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified");
-        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            _reconnectBackoffMs,
+            _reconnectBackoffMaxMs,
+            _reconnectBackoffConfigured,
+            _reconnectBackoffMaxConfigured);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -5231,7 +5265,7 @@ public sealed class AdminClientBuilder
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
-            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -79,6 +79,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private int? _requestTimeoutMs;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private bool _reconnectBackoffConfigured;
+    private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -931,6 +933,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// When the maximum is not configured, it uses this value and disables exponential growth.
     /// </summary>
     /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
     public ProducerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
@@ -940,6 +943,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Reconnect backoff cannot be negative");
+        _reconnectBackoffConfigured = true;
         return this;
     }
 
@@ -955,6 +959,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        _reconnectBackoffMaxConfigured = true;
         return this;
     }
 
@@ -1172,7 +1177,11 @@ public sealed class ProducerBuilder<TKey, TValue>
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
-        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            _reconnectBackoffMs,
+            _reconnectBackoffMaxMs,
+            _reconnectBackoffConfigured,
+            _reconnectBackoffMaxConfigured);
 
         ProducerOptions.ValidateArenaCapacity(_batchSize, _arenaCapacity);
 
@@ -1218,7 +1227,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             DeliveryTimeoutMs = _deliveryTimeoutMs ?? 120000,
             RequestTimeoutMs = _requestTimeoutMs ?? 30000,
             ReconnectBackoffMs = _reconnectBackoffMs,
-            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
@@ -1429,6 +1438,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxConnectionsPerBroker = ConsumerOptions.DefaultMaxConnectionsPerBroker;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private bool _reconnectBackoffConfigured;
+    private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -2249,6 +2260,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// When the maximum is not configured, it uses this value and disables exponential growth.
     /// </summary>
     /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
     public ConsumerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
@@ -2258,6 +2270,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Reconnect backoff cannot be negative");
+        _reconnectBackoffConfigured = true;
         return this;
     }
 
@@ -2273,6 +2286,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        _reconnectBackoffMaxConfigured = true;
         return this;
     }
 
@@ -2634,7 +2648,11 @@ public sealed class ConsumerBuilder<TKey, TValue>
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}). " +
                 $"Adaptive scaling would be permanently disabled since the initial connection count already exceeds the maximum.");
-        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            _reconnectBackoffMs,
+            _reconnectBackoffMaxMs,
+            _reconnectBackoffConfigured,
+            _reconnectBackoffMaxConfigured);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -2666,7 +2684,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             RebalanceTimeoutMs = _rebalanceTimeoutMs,
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
-            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
@@ -2824,6 +2842,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _connectionsPerBroker = 2;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private bool _reconnectBackoffConfigured;
+    private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
@@ -2951,6 +2971,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// When the maximum is not configured, it uses this value and disables exponential growth.
     /// </summary>
     /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
     public ShareConsumerBuilder<TKey, TValue> WithReconnectBackoff(TimeSpan backoff)
@@ -2960,6 +2981,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Reconnect backoff cannot be negative");
+        _reconnectBackoffConfigured = true;
         return this;
     }
 
@@ -2975,6 +2997,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        _reconnectBackoffMaxConfigured = true;
         return this;
     }
 
@@ -3290,7 +3313,11 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         if (_bootstrapServers.Count == 0)
             throw new InvalidOperationException("Bootstrap servers must be specified. Call WithBootstrapServers() before Build().");
         ArgumentNullException.ThrowIfNullOrEmpty(_groupId, nameof(_groupId));
-        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            _reconnectBackoffMs,
+            _reconnectBackoffMaxMs,
+            _reconnectBackoffConfigured,
+            _reconnectBackoffMaxConfigured);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -3314,7 +3341,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             HeartbeatIntervalMs = _heartbeatIntervalMs,
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
-            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -57,6 +57,10 @@ public enum OffsetStoreTiming
 /// </summary>
 public sealed class ConsumerOptions
 {
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
+    private bool _isReconnectBackoffMsConfigured;
+    private bool _isReconnectBackoffMaxMsConfigured;
     internal const int DefaultMaxConnectionsPerBroker = 4;
 
     /// <summary>
@@ -192,14 +196,34 @@ public sealed class ConsumerOptions
     /// <summary>
     /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
+    /// When set without <see cref="ReconnectBackoffMaxMs"/>, the maximum uses this value.
     /// </summary>
-    public int ReconnectBackoffMs { get; init; } = 50;
+    public int ReconnectBackoffMs
+    {
+        get => _reconnectBackoffMs;
+        init
+        {
+            _reconnectBackoffMs = value;
+            _isReconnectBackoffMsConfigured = true;
+        }
+    }
 
     /// <summary>
     /// Maximum delay in milliseconds before reconnecting to a broker after repeated failures.
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
-    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+    public int ReconnectBackoffMaxMs
+    {
+        get => _reconnectBackoffMaxMs;
+        init
+        {
+            _reconnectBackoffMaxMs = value;
+            _isReconnectBackoffMaxMsConfigured = true;
+        }
+    }
+
+    internal bool IsReconnectBackoffMsConfigured => _isReconnectBackoffMsConfigured;
+    internal bool IsReconnectBackoffMaxMsConfigured => _isReconnectBackoffMaxMsConfigured;
 
     /// <summary>
     /// Maximum idle time in milliseconds before unused broker connections are closed.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1114,6 +1114,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private static (IConnectionPool, MetadataManager, ClientTelemetryMetricCollector) CreateInfrastructure(
         ConsumerOptions options, ILoggerFactory? loggerFactory, MetadataOptions? metadataOptions)
     {
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            options.ReconnectBackoffMs,
+            options.ReconnectBackoffMaxMs,
+            options.IsReconnectBackoffMsConfigured,
+            options.IsReconnectBackoffMaxMsConfigured);
         var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
         var connectionPool = new ConnectionPool(
             options.ClientId,
@@ -1129,7 +1134,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
-                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(reconnectBackoffMaxMs),
                 ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,

--- a/src/Dekaf/Internal/ReconnectBackoffValidation.cs
+++ b/src/Dekaf/Internal/ReconnectBackoffValidation.cs
@@ -22,4 +22,18 @@ internal static class ReconnectBackoffValidation
                 "Maximum reconnect backoff must be greater than or equal to reconnect backoff");
         }
     }
+
+    public static int ResolveMaximumMilliseconds(
+        int reconnectBackoffMs,
+        int reconnectBackoffMaxMs,
+        bool reconnectBackoffConfigured,
+        bool reconnectBackoffMaxConfigured)
+    {
+        var effectiveMaximum = reconnectBackoffConfigured && !reconnectBackoffMaxConfigured
+            ? reconnectBackoffMs
+            : reconnectBackoffMaxMs;
+
+        ValidateMilliseconds(reconnectBackoffMs, effectiveMaximum);
+        return effectiveMaximum;
+    }
 }

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -82,6 +82,8 @@ public sealed class KafkaClientBuilder
     private int _requestTimeoutMs = 30000;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
+    private bool _reconnectBackoffConfigured;
+    private bool _reconnectBackoffMaxConfigured;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -144,6 +146,7 @@ public sealed class KafkaClientBuilder
     /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
+    /// When the maximum is not configured, it uses this value and disables exponential growth.
     /// </summary>
     /// <param name="backoff">The reconnect backoff. Cannot be negative.</param>
     public KafkaClientBuilder WithReconnectBackoff(TimeSpan backoff)
@@ -152,6 +155,7 @@ public sealed class KafkaClientBuilder
             backoff,
             nameof(backoff),
             "Reconnect backoff cannot be negative");
+        _reconnectBackoffConfigured = true;
         return this;
     }
 
@@ -166,6 +170,7 @@ public sealed class KafkaClientBuilder
             backoff,
             nameof(backoff),
             "Maximum reconnect backoff cannot be negative");
+        _reconnectBackoffMaxConfigured = true;
         return this;
     }
 
@@ -459,7 +464,11 @@ public sealed class KafkaClientBuilder
         if (_maxConnectionsPerBroker < _connectionsPerBroker)
             throw new InvalidOperationException(
                 $"MaxConnectionsPerBroker ({_maxConnectionsPerBroker}) must be >= ConnectionsPerBroker ({_connectionsPerBroker}).");
-        ReconnectBackoffValidation.ValidateMilliseconds(_reconnectBackoffMs, _reconnectBackoffMaxMs);
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            _reconnectBackoffMs,
+            _reconnectBackoffMaxMs,
+            _reconnectBackoffConfigured,
+            _reconnectBackoffMaxConfigured);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -469,7 +478,7 @@ public sealed class KafkaClientBuilder
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
-            ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
+            ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -16,6 +16,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
 {
     private const int MaxConnectionReapDiagnosticEvents = 256;
     private static readonly TimeSpan DefaultIdleReapDrainTimeout = TimeSpan.FromSeconds(5);
+    private static readonly Func<double> SharedRandomDouble = static () => Random.Shared.NextDouble();
     private readonly string? _clientId;
     private readonly ConnectionOptions _connectionOptions;
     private readonly ILoggerFactory? _loggerFactory;
@@ -50,6 +51,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     /// Parameters: brokerId, host, port, index, cancellationToken.
     /// </summary>
     private readonly Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>>? _connectionFactory;
+    private readonly Func<double> _randomDouble;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
@@ -94,7 +96,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         ResponseBufferPool responseBufferPool,
         int? pipeMemoryBucketCapacity = null,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
-        TimeSpan? idleReapDrainTimeout = null)
+        TimeSpan? idleReapDrainTimeout = null,
+        Func<double>? randomDouble = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -107,6 +110,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         _responseBufferPool = responseBufferPool;
         _telemetryMetricCollector = telemetryMetricCollector;
         _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
+        _randomDouble = randomDouble ?? SharedRandomDouble;
         var bucketCapacity = pipeMemoryBucketCapacity ?? ScaledBucketCapacity(_connectionsPerBroker);
         _sharedPipeMemoryPool = PipeMemoryPool.Create(maxArraysPerBucket: bucketCapacity);
         _currentPipeMemoryBucketCapacity = bucketCapacity;
@@ -122,7 +126,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         ConnectionOptions? connectionOptions,
         int connectionsPerBroker,
         Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>> connectionFactory,
-        TimeSpan? idleReapDrainTimeout = null)
+        TimeSpan? idleReapDrainTimeout = null,
+        Func<double>? randomDouble = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -135,6 +140,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         _responseBufferPool = ResponseBufferPool.Default;
         _connectionFactory = connectionFactory;
         _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
+        _randomDouble = randomDouble ?? SharedRandomDouble;
         // No shared pool needed: factory-created connections manage their own pools.
         StartIdleConnectionReaper();
     }
@@ -1078,7 +1084,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         LogReconnectBackoffReset(brokerId, host, port);
     }
 
-    private TimeSpan CalculateReconnectBackoffDelay(int failureCount)
+    internal TimeSpan CalculateReconnectBackoffDelay(int failureCount)
     {
         var minMs = _connectionOptions.ReconnectBackoff.TotalMilliseconds;
         var maxMs = _connectionOptions.ReconnectBackoffMax.TotalMilliseconds;
@@ -1087,13 +1093,10 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
 
         var exponent = Math.Min(failureCount - 1, 30);
         var baseMs = Math.Min(maxMs, minMs * Math.Pow(2, exponent));
-        if (baseMs < maxMs)
-        {
-            var jitterMaxMs = Math.Max(1, (int)Math.Ceiling(baseMs * 0.2));
-            baseMs = Math.Min(maxMs, baseMs + Random.Shared.Next(jitterMaxMs + 1));
-        }
+        var randomValue = Math.Clamp(_randomDouble(), 0, 1);
+        var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));
 
-        return TimeSpan.FromMilliseconds(baseMs);
+        return TimeSpan.FromMilliseconds(Math.Min(maxMs, jitteredMs));
     }
 
     private static long ToStopwatchTicks(TimeSpan delay)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1091,6 +1091,9 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         if (minMs <= 0 || maxMs <= 0)
             return TimeSpan.Zero;
 
+        if (maxMs <= minMs)
+            return TimeSpan.FromMilliseconds(maxMs);
+
         var exponent = Math.Min(failureCount - 1, 30);
         var baseMs = Math.Min(maxMs, minMs * Math.Pow(2, exponent));
         var randomValue = Math.Clamp(_randomDouble(), 0, 1);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -228,6 +228,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ILoggerFactory? loggerFactory,
         MetadataOptions? metadataOptions)
     {
+        var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
+            options.ReconnectBackoffMs,
+            options.ReconnectBackoffMaxMs,
+            options.IsReconnectBackoffMsConfigured,
+            options.IsReconnectBackoffMaxMsConfigured);
         var sharedPoolSizes = PoolSizing.ForSharedPools(
             brokerCount: options.BootstrapServers.Count,
             connectionsPerBroker: options.ConnectionsPerBroker,
@@ -249,7 +254,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
                 RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
                 ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
-                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(reconnectBackoffMaxMs),
                 ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -19,6 +19,10 @@ public sealed class ProducerOptions
     internal const int IdempotentMaxInFlightRequestsPerConnection = 5;
     internal const int NonIdempotentDefaultMaxInFlightRequestsPerConnection = 100;
     internal const int MaxAllowedMaxInFlightRequestsPerConnection = 1_000_000;
+    private int _reconnectBackoffMs = 50;
+    private int _reconnectBackoffMaxMs = 1000;
+    private bool _isReconnectBackoffMsConfigured;
+    private bool _isReconnectBackoffMaxMsConfigured;
 
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
@@ -43,14 +47,34 @@ public sealed class ProducerOptions
     /// <summary>
     /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
+    /// When set without <see cref="ReconnectBackoffMaxMs"/>, the maximum uses this value.
     /// </summary>
-    public int ReconnectBackoffMs { get; init; } = 50;
+    public int ReconnectBackoffMs
+    {
+        get => _reconnectBackoffMs;
+        init
+        {
+            _reconnectBackoffMs = value;
+            _isReconnectBackoffMsConfigured = true;
+        }
+    }
 
     /// <summary>
     /// Maximum delay in milliseconds before reconnecting to a broker after repeated failures.
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
-    public int ReconnectBackoffMaxMs { get; init; } = 1000;
+    public int ReconnectBackoffMaxMs
+    {
+        get => _reconnectBackoffMaxMs;
+        init
+        {
+            _reconnectBackoffMaxMs = value;
+            _isReconnectBackoffMaxMsConfigured = true;
+        }
+    }
+
+    internal bool IsReconnectBackoffMsConfigured => _isReconnectBackoffMsConfigured;
+    internal bool IsReconnectBackoffMaxMsConfigured => _isReconnectBackoffMaxMsConfigured;
 
     /// <summary>
     /// Maximum idle time in milliseconds before unused broker connections are closed.

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -76,6 +76,55 @@ public sealed class ConnectionBuilderOptionsTests
     }
 
     [Test]
+    public async Task Builders_WithOnlyReconnectBackoff_UseFixedBackoff()
+    {
+        var expected = TimeSpan.FromMilliseconds(123);
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithReconnectBackoff(expected)
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("consumer-group")
+            .WithReconnectBackoff(expected)
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("share-group")
+            .WithReconnectBackoff(expected)
+            .Build();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092")
+            .WithReconnectBackoff(expected)
+            .Build();
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithReconnectBackoff(expected));
+        await using var clientProducer = client.CreateProducer<string, string>().Build();
+
+        await AssertFixedReconnectBackoff(GetConnectionOptions(producer), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(consumer), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(shareConsumer), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(admin), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(clientProducer), expected);
+    }
+
+    [Test]
+    public async Task ProducerBuilder_WithBothReconnectBackoffs_PreservesExponentialRange()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithReconnectBackoff(TimeSpan.FromMilliseconds(123))
+            .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(456))
+            .Build();
+
+        var options = GetConnectionOptions(producer);
+
+        await Assert.That(options.ReconnectBackoff).IsEqualTo(TimeSpan.FromMilliseconds(123));
+        await Assert.That(options.ReconnectBackoffMax).IsEqualTo(TimeSpan.FromMilliseconds(456));
+    }
+
+    [Test]
     public async Task BuilderConnectionOptions_CanDisableTcpKeepAlive()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -117,6 +166,12 @@ public sealed class ConnectionBuilderOptionsTests
         await Assert.That(options.TcpKeepAliveTime).IsEqualTo(TimeSpan.FromSeconds(11));
         await Assert.That(options.TcpKeepAliveInterval).IsEqualTo(TimeSpan.FromSeconds(3));
         await Assert.That(options.TcpKeepAliveRetryCount).IsEqualTo(4);
+    }
+
+    private static async Task AssertFixedReconnectBackoff(ConnectionOptions options, TimeSpan expected)
+    {
+        await Assert.That(options.ReconnectBackoff).IsEqualTo(expected);
+        await Assert.That(options.ReconnectBackoffMax).IsEqualTo(expected);
     }
 
     private static ConnectionOptions GetConnectionOptions(object client)

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -1,7 +1,10 @@
 using System.Net.Security;
 using System.Reflection;
 using Dekaf.Admin;
+using Dekaf.Consumer;
 using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Builder;
 
@@ -107,6 +110,39 @@ public sealed class ConnectionBuilderOptionsTests
         await AssertFixedReconnectBackoff(GetConnectionOptions(shareConsumer), expected);
         await AssertFixedReconnectBackoff(GetConnectionOptions(admin), expected);
         await AssertFixedReconnectBackoff(GetConnectionOptions(clientProducer), expected);
+    }
+
+    [Test]
+    public async Task DirectClientOptions_WithOnlyReconnectBackoff_UseFixedBackoff()
+    {
+        var expected = TimeSpan.FromMilliseconds(123);
+
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                ReconnectBackoffMs = 123
+            },
+            Serializers.String,
+            Serializers.String);
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "consumer-group",
+                ReconnectBackoffMs = 123
+            },
+            Serializers.String,
+            Serializers.String);
+        await using var admin = new AdminClient(new AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ReconnectBackoffMs = 123
+        });
+
+        await AssertFixedReconnectBackoff(GetConnectionOptions(producer), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(consumer), expected);
+        await AssertFixedReconnectBackoff(GetConnectionOptions(admin), expected);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -196,6 +196,60 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducer_WithTypedOptionsAndOnlyReconnectBackoff_UsesFixedBackoff()
+    {
+        var services = new ServiceCollection();
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["broker1:9092"],
+            ReconnectBackoffMs = 125
+        };
+
+        services.AddDekaf(builder => builder.AddProducer<string, string>(options));
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var boundOptions = GetProducerOptions(producer);
+
+        await Assert.That(boundOptions.ReconnectBackoffMs).IsEqualTo(125);
+        await Assert.That(boundOptions.ReconnectBackoffMaxMs).IsEqualTo(125);
+    }
+
+    [Test]
+    public async Task TypedConsumerAndAdminOptions_WithOnlyReconnectBackoff_UseFixedBackoff()
+    {
+        var services = new ServiceCollection();
+        var consumerOptions = new ConsumerOptions
+        {
+            BootstrapServers = ["broker1:9092"],
+            GroupId = "group",
+            ReconnectBackoffMs = 145
+        };
+        var adminOptions = new AdminClientOptions
+        {
+            BootstrapServers = ["broker1:9092"],
+            ReconnectBackoffMs = 155
+        };
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(consumerOptions);
+            builder.AddAdminClient(adminOptions);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var admin = provider.GetRequiredService<IAdminClient>();
+        var boundConsumerOptions = GetConsumerOptions(consumer);
+        var boundAdminOptions = GetAdminOptions(admin);
+
+        await Assert.That(boundConsumerOptions.ReconnectBackoffMs).IsEqualTo(145);
+        await Assert.That(boundConsumerOptions.ReconnectBackoffMaxMs).IsEqualTo(145);
+        await Assert.That(boundAdminOptions.ReconnectBackoffMs).IsEqualTo(155);
+        await Assert.That(boundAdminOptions.ReconnectBackoffMaxMs).IsEqualTo(155);
+    }
+
+    [Test]
     public async Task AddProducer_WithTypedOptionsAndIdempotenceDisabled_UsesNonIdempotentMaxInFlightDefault()
     {
         var services = new ServiceCollection();
@@ -645,6 +699,60 @@ public class DependencyInjectionTests
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(60000);
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
+    }
+
+    [Test]
+    public async Task AddProducer_WithConfigurationAndOnlyReconnectBackoff_UsesFixedBackoff()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9092",
+            ["Kafka:ReconnectBackoffMs"] = "135"
+        });
+
+        services.AddDekaf(builder => builder.AddProducer<string, string>(configuration.GetSection("Kafka")));
+
+        var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredService<IKafkaProducer<string, string>>();
+        var options = GetProducerOptions(producer);
+
+        await Assert.That(options.ReconnectBackoffMs).IsEqualTo(135);
+        await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(135);
+    }
+
+    [Test]
+    public async Task ConsumerAndAdminConfiguration_WithOnlyReconnectBackoff_UseFixedBackoff()
+    {
+        var services = new ServiceCollection();
+        var consumerConfiguration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9092",
+            ["Kafka:GroupId"] = "group",
+            ["Kafka:ReconnectBackoffMs"] = "165"
+        });
+        var adminConfiguration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "broker1:9092",
+            ["Kafka:ReconnectBackoffMs"] = "175"
+        });
+
+        services.AddDekaf(builder =>
+        {
+            builder.AddConsumer<string, string>(consumerConfiguration.GetSection("Kafka"));
+            builder.AddAdminClient(adminConfiguration.GetSection("Kafka"));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var consumer = provider.GetRequiredService<IKafkaConsumer<string, string>>();
+        var admin = provider.GetRequiredService<IAdminClient>();
+        var consumerOptions = GetConsumerOptions(consumer);
+        var adminOptions = GetAdminOptions(admin);
+
+        await Assert.That(consumerOptions.ReconnectBackoffMs).IsEqualTo(165);
+        await Assert.That(consumerOptions.ReconnectBackoffMaxMs).IsEqualTo(165);
+        await Assert.That(adminOptions.ReconnectBackoffMs).IsEqualTo(175);
+        await Assert.That(adminOptions.ReconnectBackoffMaxMs).IsEqualTo(175);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -820,6 +820,22 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [Arguments(0.0)]
+    [Arguments(0.5)]
+    [Arguments(0.999999)]
+    public async Task CalculateReconnectBackoffDelay_FixedBackoffDoesNotApplyJitter(double randomValue)
+    {
+        await using var pool = CreateReconnectBackoffPool(
+            reconnectBackoffMs: 123,
+            reconnectBackoffMaxMs: 123,
+            randomValue);
+
+        var delay = pool.CalculateReconnectBackoffDelay(failureCount: 10);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(123));
+    }
+
+    [Test]
     public async Task CalculateReconnectBackoffDelay_DefaultsGrowExponentiallyToMaximum()
     {
         await using var pool = CreateReconnectBackoffPool(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -802,6 +802,61 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [Arguments(0.0, 80.0)]
+    [Arguments(0.5, 100.0)]
+    [Arguments(0.999999, 119.99996)]
+    public async Task CalculateReconnectBackoffDelay_UsesSymmetricTwentyPercentJitter(
+        double randomValue,
+        double expectedMilliseconds)
+    {
+        await using var pool = CreateReconnectBackoffPool(
+            reconnectBackoffMs: 100,
+            reconnectBackoffMaxMs: 1000,
+            randomValue);
+
+        var delay = pool.CalculateReconnectBackoffDelay(failureCount: 1);
+
+        await Assert.That(delay.TotalMilliseconds).IsEqualTo(expectedMilliseconds).Within(0.001);
+    }
+
+    [Test]
+    public async Task CalculateReconnectBackoffDelay_DefaultsGrowExponentiallyToMaximum()
+    {
+        await using var pool = CreateReconnectBackoffPool(
+            reconnectBackoffMs: 50,
+            reconnectBackoffMaxMs: 1000,
+            randomValue: 0.5);
+
+        var delays = Enumerable.Range(1, 7)
+            .Select(pool.CalculateReconnectBackoffDelay)
+            .ToArray();
+
+        await Assert.That(delays).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(50),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(400),
+            TimeSpan.FromMilliseconds(800),
+            TimeSpan.FromMilliseconds(1000),
+            TimeSpan.FromMilliseconds(1000)
+        });
+    }
+
+    [Test]
+    public async Task CalculateReconnectBackoffDelay_CapsJitterAtConfiguredMaximum()
+    {
+        await using var pool = CreateReconnectBackoffPool(
+            reconnectBackoffMs: 100,
+            reconnectBackoffMaxMs: 150,
+            randomValue: 0.999999);
+
+        var delay = pool.CalculateReconnectBackoffDelay(failureCount: 2);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(150));
+    }
+
+    [Test]
     [NotInParallel]
     public async Task ReplaceConnectionInGroup_DuringReconnectBackoff_RespectsConnectionTimeout()
     {
@@ -919,6 +974,21 @@ public sealed class ConnectionPoolTests
         ClientId = "client",
         ClientSecret = "secret"
     };
+
+    private static ConnectionPool CreateReconnectBackoffPool(
+        int reconnectBackoffMs,
+        int reconnectBackoffMaxMs,
+        double randomValue)
+        => new(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.FromMilliseconds(reconnectBackoffMs),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(reconnectBackoffMaxMs)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("Connection not expected"),
+            randomDouble: () => randomValue);
 
     private static OAuthBearerToken CreateOAuthBearerToken() => new()
     {

--- a/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/StallDetectorTests.cs
@@ -50,6 +50,19 @@ public sealed class StallDetectorTests
     }
 
     [Test]
+    public async Task Observe_FirstObservationAfterExitThreshold_CapturesBeforeExit()
+    {
+        var detector = new StallDetector(CaptureAfter, ExitAfter);
+        detector.Reset(messageCount: 42, TimeSpan.Zero);
+
+        var capture = detector.Observe(messageCount: 42, ExitAfter);
+        var exit = detector.Observe(messageCount: 42, ExitAfter);
+
+        await Assert.That(capture).IsEqualTo(StallAction.Capture);
+        await Assert.That(exit).IsEqualTo(StallAction.CaptureAndExit);
+    }
+
+    [Test]
     public async Task Watchdog_Stall_CapturesThreadStacksBeforeProducerDiagnostics()
     {
         var outputDirectory = CreateOutputDirectory();

--- a/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
+++ b/tools/Dekaf.StressTests/Diagnostics/ProgressWatchdog.cs
@@ -51,6 +51,12 @@ internal sealed class StallDetector
         var stalledFor = now - _lastProgressAt;
         if (stalledFor >= _exitAfter && !_exited)
         {
+            if (!_captured)
+            {
+                _captured = true;
+                return StallAction.Capture;
+            }
+
             _exited = true;
             return StallAction.CaptureAndExit;
         }
@@ -490,13 +496,27 @@ internal sealed class ProgressWatchdog : IDisposable
 
     private static void WriteArtifact(string path, string contents)
     {
+        var temporaryPath = path + ".tmp";
         try
         {
-            File.WriteAllText(path, contents);
+            File.WriteAllText(temporaryPath, contents);
+            File.Move(temporaryPath, path, overwrite: true);
         }
         catch (Exception exception)
         {
             Console.Error.WriteLine($"PROGRESS WATCHDOG: failed to write {path}: {exception.Message}");
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(temporaryPath);
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"PROGRESS WATCHDOG: failed to remove temporary artifact {temporaryPath}: {exception.Message}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- generate symmetric ±20% reconnect jitter with a deterministic injected random source for tests
- derive `reconnect.backoff.max.ms` from an explicitly configured base when max is omitted
- preserve default 50/1000 exponential behavior and explicit base/max behavior across producer, consumer, share consumer, admin, root client, and DI/config binding

## Performance
Reconnect calculation runs only after physical connection failures. No serialization, produce, consume, receive, or per-message hot path changed. Production uses one cached static random delegate; no per-attempt delegate allocation was added.

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release` (net8/net10, 0 warnings)
- [x] full net10 unit suite: 5,625 passed
- [x] focused builder/networking/DI suites: 112 passed
- [ ] full net10 integration suite: 812 passed, 3 unrelated shared-fixture startup failures; captured in #2267 without rerun

Closes #2262
