### PR TITLE
fix(producer): enforce delivery timeout floor

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1176,6 +1176,16 @@ public sealed class ProducerBuilder<TKey, TValue>
 
         ProducerOptions.ValidateArenaCapacity(_batchSize, _arenaCapacity);
 
+        var deliveryTimeoutMs = _deliveryTimeoutMs ?? 120_000;
+        var requestTimeoutMs = _requestTimeoutMs ?? 30_000;
+        var minimumDeliveryTimeoutMs = (long)requestTimeoutMs + _lingerMs;
+        if (deliveryTimeoutMs < minimumDeliveryTimeoutMs)
+        {
+            throw new InvalidOperationException(
+                $"DeliveryTimeoutMs ({deliveryTimeoutMs}) must be greater than or equal to " +
+                $"RequestTimeoutMs ({requestTimeoutMs}) + LingerMs ({_lingerMs}) = {minimumDeliveryTimeoutMs}.");
+        }
+
         // Java Kafka client enforces acks=all when enable.idempotence=true.
         // With acks=leader, the leader acknowledges before ISR replication completes,
         // which can cause OutOfOrderSequenceNumber on leader failover and makes the
@@ -1215,8 +1225,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             RetryBackoffMaxMs = _retryBackoffMaxMs,
             MaxBlockMs = _maxBlockMs ?? 60000, // 60 seconds default
             DeliveryLatencyTargetMs = _deliveryLatencyTargetMs ?? 10,
-            DeliveryTimeoutMs = _deliveryTimeoutMs ?? 120000,
-            RequestTimeoutMs = _requestTimeoutMs ?? 30000,
+            DeliveryTimeoutMs = deliveryTimeoutMs,
+            RequestTimeoutMs = requestTimeoutMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = _reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -147,6 +147,108 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task Build_DeliveryTimeoutEqualToRequestTimeoutPlusLinger_Succeeds()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(30_000))
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(30_005))
+            .Build();
+
+        await Assert.That(producer).IsNotNull();
+    }
+
+    [Test]
+    public async Task Build_DeliveryTimeoutGreaterThanRequestTimeoutPlusLinger_Succeeds()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(30_000))
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(30_006))
+            .Build();
+
+        await Assert.That(producer).IsNotNull();
+    }
+
+    [Test]
+    public async Task Build_DeliveryTimeoutBelowRequestTimeoutPlusLinger_ThrowsWithEffectiveValues()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(30_000))
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(30_004));
+
+        var act = () => builder.Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("DeliveryTimeoutMs (30004)")
+            .And.HasMessageContaining("RequestTimeoutMs (30000)")
+            .And.HasMessageContaining("LingerMs (5)")
+            .And.HasMessageContaining("30005");
+    }
+
+    [Test]
+    public async Task Build_HighThroughputProfileUsesEffectiveLingerForDeliveryTimeoutValidation()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(30_000))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(30_099))
+            .ForHighThroughput();
+
+        var act = () => builder.Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("LingerMs (100)")
+            .And.HasMessageContaining("30100");
+    }
+
+    [Test]
+    public async Task Build_DefaultTimeoutsRemainUnchanged()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(120_000);
+        await Assert.That(options.RequestTimeoutMs).IsEqualTo(30_000);
+        await Assert.That(options.LingerMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Build_LargeTimeoutsAtValidBoundary_Succeeds()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(int.MaxValue - 1L))
+            .WithLinger(TimeSpan.FromMilliseconds(1))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(int.MaxValue))
+            .Build();
+
+        await Assert.That(producer).IsNotNull();
+    }
+
+    [Test]
+    public async Task Build_LargeTimeoutSum_DoesNotOverflow()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRequestTimeout(TimeSpan.FromMilliseconds(int.MaxValue))
+            .WithLinger(TimeSpan.FromMilliseconds(int.MaxValue))
+            .WithDeliveryTimeout(TimeSpan.FromMilliseconds(int.MaxValue));
+
+        var act = () => builder.Build();
+
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .And.HasMessageContaining("4294967294");
+    }
+
+    [Test]
     public async Task WithBatchSize_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateProducer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -573,7 +573,7 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:RetryBackoffMaxMs"] = "250",
             ["Kafka:Producers:Orders:MaxBlockMs"] = "1000",
             ["Kafka:Producers:Orders:DeliveryLatencyTargetMs"] = "17",
-            ["Kafka:Producers:Orders:DeliveryTimeoutMs"] = "2000",
+            ["Kafka:Producers:Orders:DeliveryTimeoutMs"] = "4000",
             ["Kafka:Producers:Orders:RequestTimeoutMs"] = "3000",
             ["Kafka:Producers:Orders:ReconnectBackoffMs"] = "75",
             ["Kafka:Producers:Orders:ReconnectBackoffMaxMs"] = "750",
@@ -622,7 +622,7 @@ public class DependencyInjectionTests
         await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(250);
         await Assert.That(options.MaxBlockMs).IsEqualTo(1000);
         await Assert.That(options.DeliveryLatencyTargetMs).IsEqualTo(17);
-        await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(2000);
+        await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(4000);
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(3000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(75);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(750);


### PR DESCRIPTION
## Summary
- enforce KIP-91 `DeliveryTimeoutMs >= RequestTimeoutMs + LingerMs` during producer build
- resolve defaults/profile values before validation and use `long` arithmetic for overflow safety
- report every effective value plus required minimum in invalid-configuration errors
- cover equality, greater, one-below, defaults, profiles, and large-value boundaries
- correct an existing DI fixture whose timeout combination violated KIP-91

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] `ProducerBuilderValidationTests` (63/63)
- [x] corrected DI configuration test (1/1)
- [x] full net10 unit suite (5621/5621)
- [x] `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- [x] `ProducerTimeoutTests` integration suite (5/5)
- [x] `/simplify`

## Performance

Validation runs once in `ProducerBuilder.Build()` before producer construction. No serialization, produce, consume, batch, or networking hot path changed; per-message allocations and protected runtime metrics are unaffected.

Closes #2254
