### PR TITLE
Fix KIP-74 consumer fetch fairness

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -957,6 +957,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), List<PendingFetchData>> _prefetchPendingItemsByBroker = new();
     private readonly BrokerPrefetchScheduler _brokerPrefetchScheduler = new();
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchSessionHandler> _fetchSessions = new();
+    // KIP-74 request-order cursor. KIP-227 rotates incremental-session responses on the broker;
+    // this cursor orders full requests, including session creation and reset, per connection.
+    private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchPartitionOrderState>
+        _fetchPartitionOrderStates = new();
     private readonly StuckFetchPositionTracker _stuckFetchPositionTracker = new(MaxConsecutiveEmptyParsedFetches);
     private readonly PrefetchFailureTracker _prefetchFailureTracker = new(
         MaxRepeatedDeterministicPrefetchFailures,
@@ -3008,7 +3012,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         try
         {
             // Build fetch request — pass index range to avoid GetRange allocation
-            var topicData = BuildFetchRequestTopics(partitions, partitionStartIndex, partitionCount, brokerId);
+            var topicData = BuildFetchRequestTopicsForConnection(
+                partitions,
+                partitionStartIndex,
+                partitionCount,
+                brokerId,
+                connectionIndex);
             FetchSessionBuildResult? fetchSessionBuild = fetchSessionHandler?.Build(topicData, _metadataManager.Metadata);
 
             var request = FetchRequest.Rent();
@@ -6946,10 +6955,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private List<FetchRequestTopic> BuildFetchRequestTopics(
         List<TopicPartition> partitions, int startIndex, int count, int brokerId)
+        => BuildFetchRequestTopicsForConnection(partitions, startIndex, count, brokerId, connectionIndex: 0);
+
+    private List<FetchRequestTopic> BuildFetchRequestTopicsForConnection(
+        List<TopicPartition> partitions, int startIndex, int count, int brokerId, int connectionIndex)
     {
         if (count == 0)
             return ConsumerFetchPools.RentFetchRequestTopicList(0);
 
+        var orderState = _fetchPartitionOrderStates.GetOrAdd(
+            (brokerId, connectionIndex),
+            static _ => new FetchPartitionOrderState());
+        var rotation = orderState.GetAndAdvance();
         var cacheKey = new FetchRequestCacheKey(brokerId, startIndex, count);
 
         // Take snapshots of current state under lock
@@ -6965,20 +6982,34 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (cachedEntry is not null
             && PartitionRangeEquals(partitions, startIndex, count, cachedEntry.Partitions))
         {
+            var cachedRotationStart = cachedEntry.RotationStarts[(int)((uint)rotation % (uint)cachedEntry.RotationStarts.Count)];
             // Cache hit: build a fresh result list with snapshot offsets under lock.
             // Each broker task gets its own FetchRequestPartition objects so that
             // concurrent calls cannot mutate offsets visible to another task.
             // This allocates per fetch cycle (per-batch), not per-message.
-            return BuildFetchResult(
-                cachedEntry.TopicPartitions,
-                _fetchPositions,
-                _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-                _metadataManager.Metadata,
-                _lastConsumedLeaderEpochs);
+            return cachedRotationStart == default
+                ? BuildFetchResult(
+                    cachedEntry.TopicPartitions,
+                    _fetchPositions,
+                    _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+                    _metadataManager.Metadata,
+                    _lastConsumedLeaderEpochs)
+                : BuildRotatedFetchResult(
+                    cachedEntry.TopicPartitions,
+                    _fetchPositions,
+                    cachedEntry.TopicOrder,
+                    cachedRotationStart.TopicIndex,
+                    cachedRotationStart.PartitionIndex,
+                    _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+                    _metadataManager.Metadata,
+                    _lastConsumedLeaderEpochs);
         }
 
         // Cache miss: build fresh structure with TopicPartition stored alongside.
         var topicPartitions = new Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>();
+        var topicIndexes = new Dictionary<string, int>();
+        var topicOrder = new List<string>();
+        var rotationStarts = new List<(int TopicIndex, int PartitionIndex)>(count);
         var rangePartitions = new List<TopicPartition>(count);
 
         var endIndex = startIndex + count;
@@ -6990,7 +7021,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 list = [];
                 topicPartitions[p.Topic] = list;
+                topicIndexes[p.Topic] = topicOrder.Count;
+                topicOrder.Add(p.Topic);
             }
+
+            rotationStarts.Add((topicIndexes[p.Topic], list.Count));
 
             list.Add((
                 new FetchRequestPartition
@@ -7006,12 +7041,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Build result with fresh copies so the caller owns its own FetchRequestPartition
         // instances. The cached dict stores templates; each caller gets independent copies
         // to prevent any shared-state issues with concurrent PrefetchFromBrokerAsync calls.
-        var result = BuildFetchResult(
-            topicPartitions,
-            _fetchPositions,
-            _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-            _metadataManager.Metadata,
-            _lastConsumedLeaderEpochs);
+        var newRotationStart = rotationStarts[(int)((uint)rotation % (uint)rotationStarts.Count)];
+        var result = newRotationStart == default
+            ? BuildFetchResult(
+                topicPartitions,
+                _fetchPositions,
+                _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+                _metadataManager.Metadata,
+                _lastConsumedLeaderEpochs)
+            : BuildRotatedFetchResult(
+                topicPartitions,
+                _fetchPositions,
+                topicOrder,
+                newRotationStart.TopicIndex,
+                newRotationStart.PartitionIndex,
+                _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
+                _metadataManager.Metadata,
+                _lastConsumedLeaderEpochs);
 
         // Update cache if this range is new or the cached partition range is stale.
         lock (_fetchCacheLock)
@@ -7021,7 +7067,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 _fetchRequestTemplateCache[cacheKey] = new FetchRequestTemplateCacheEntry(
                     rangePartitions,
-                    topicPartitions);
+                    topicPartitions,
+                    topicOrder,
+                    rotationStarts);
             }
         }
 
@@ -7032,12 +7080,26 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private sealed class FetchRequestTemplateCacheEntry(
         List<TopicPartition> partitions,
-        Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> topicPartitions)
+        Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> topicPartitions,
+        List<string> topicOrder,
+        List<(int TopicIndex, int PartitionIndex)> rotationStarts)
     {
         public List<TopicPartition> Partitions { get; } = partitions;
 
         public Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> TopicPartitions { get; }
             = topicPartitions;
+
+        public List<string> TopicOrder { get; } = topicOrder;
+
+        public List<(int TopicIndex, int PartitionIndex)> RotationStarts { get; } = rotationStarts;
+    }
+
+    private sealed class FetchPartitionOrderState
+    {
+        private int _nextRotation = -1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetAndAdvance() => Interlocked.Increment(ref _nextRotation);
     }
 
     /// <summary>
@@ -7112,6 +7174,107 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return result;
+    }
+
+    internal static List<FetchRequestTopic> BuildRotatedFetchResult(
+        Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>> templateDict,
+        ConcurrentDictionary<TopicPartition, long> fetchPositions,
+        List<string> topicOrder,
+        int topicRotation,
+        int firstTopicPartitionRotation,
+        int? adaptivePartitionMaxBytes = null,
+        ClusterMetadata? clusterMetadata = null,
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null)
+    {
+        var result = ConsumerFetchPools.RentFetchRequestTopicList(templateDict.Count);
+        var topicCount = topicOrder.Count;
+        var topicStart = (int)((uint)topicRotation % (uint)topicCount);
+        for (var topicOffset = 0; topicOffset < topicCount; topicOffset++)
+        {
+            var topic = topicOrder[(topicStart + topicOffset) % topicCount];
+            AddFetchRequestTopic(
+                result,
+                topic,
+                templateDict[topic],
+                fetchPositions,
+                adaptivePartitionMaxBytes,
+                clusterMetadata,
+                lastConsumedLeaderEpochs,
+                topicOffset == 0 ? firstTopicPartitionRotation : 0);
+        }
+
+        return result;
+    }
+
+    private static void AddFetchRequestTopic(
+        List<FetchRequestTopic> result,
+        string topic,
+        List<(FetchRequestPartition Partition, TopicPartition TopicPartition)> cachedPartitions,
+        ConcurrentDictionary<TopicPartition, long> fetchPositions,
+        int? adaptivePartitionMaxBytes,
+        ClusterMetadata? clusterMetadata,
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs,
+        int partitionRotation)
+    {
+        var partitionList = ConsumerFetchPools.RentFetchRequestPartitionList(cachedPartitions.Count);
+        var partitionCount = cachedPartitions.Count;
+        var partitionStart = (int)((uint)partitionRotation % (uint)partitionCount);
+
+        for (var partitionIndex = partitionStart; partitionIndex < partitionCount; partitionIndex++)
+            AddFetchRequestPartition(
+                partitionList,
+                cachedPartitions[partitionIndex],
+                fetchPositions,
+                adaptivePartitionMaxBytes,
+                clusterMetadata,
+                lastConsumedLeaderEpochs);
+
+        for (var partitionIndex = 0; partitionIndex < partitionStart; partitionIndex++)
+            AddFetchRequestPartition(
+                partitionList,
+                cachedPartitions[partitionIndex],
+                fetchPositions,
+                adaptivePartitionMaxBytes,
+                clusterMetadata,
+                lastConsumedLeaderEpochs);
+
+        if (partitionList.Count == 0)
+        {
+            ConsumerFetchPools.ReturnFetchRequestPartitionList(partitionList);
+            return;
+        }
+
+        result.Add(new FetchRequestTopic
+        {
+            Topic = topic,
+            TopicId = clusterMetadata?.GetTopic(topic)?.TopicId ?? Guid.Empty,
+            Partitions = partitionList
+        });
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddFetchRequestPartition(
+        List<FetchRequestPartition> partitionList,
+        (FetchRequestPartition Partition, TopicPartition TopicPartition) cachedPartition,
+        ConcurrentDictionary<TopicPartition, long> fetchPositions,
+        int? adaptivePartitionMaxBytes,
+        ClusterMetadata? clusterMetadata,
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs)
+    {
+        var (template, tp) = cachedPartition;
+        if (!fetchPositions.TryGetValue(tp, out var fetchOffset))
+            return;
+
+        var currentLeaderEpoch = clusterMetadata?.GetPartitionInfo(tp.Topic, tp.Partition)?.LeaderEpoch ?? -1;
+        partitionList.Add(new FetchRequestPartition
+        {
+            Partition = template.Partition,
+            FetchOffset = fetchOffset,
+            CurrentLeaderEpoch = currentLeaderEpoch,
+            LastFetchedEpoch = lastConsumedLeaderEpochs?.GetValueOrDefault(tp, -1) ?? -1,
+            LogStartOffset = template.LogStartOffset,
+            PartitionMaxBytes = adaptivePartitionMaxBytes ?? template.PartitionMaxBytes
+        });
     }
 
     internal static List<ForgottenTopic> BuildForgottenTopicsData(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -7181,7 +7181,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
         List<string> topicOrder,
         int topicRotation,
-        int firstTopicPartitionRotation,
+        int partitionRotation,
         int? adaptivePartitionMaxBytes = null,
         ClusterMetadata? clusterMetadata = null,
         ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null)
@@ -7200,7 +7200,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 adaptivePartitionMaxBytes,
                 clusterMetadata,
                 lastConsumedLeaderEpochs,
-                topicOffset == 0 ? firstTopicPartitionRotation : 0);
+                partitionRotation);
         }
 
         return result;

--- a/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
@@ -182,6 +182,69 @@ public sealed class FetchBufferEdgeCaseTests(KafkaTestContainer kafka) : KafkaIn
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [NotInParallel]
+    public async Task SmallFetchMaxBytes_HotEarlyPartition_DoesNotStarveLaterPartitions(bool enableFetchSessions)
+    {
+        const int partitionCount = 4;
+        const int hotPartitionMessages = 20;
+        const int otherPartitionMessages = 4;
+        const int maxMessagesBeforeAllPartitions = 12;
+        var value = new string('F', 8 * 1024);
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: partitionCount);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            var messageCount = partition == 0 ? hotPartitionMessages : otherPartitionMessages;
+            for (var message = 0; message < messageCount; message++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = partition,
+                    Key = $"{partition}-{message}",
+                    Value = value
+                }, CancellationToken.None);
+            }
+        }
+
+        await producer.FlushWithTimeoutAsync();
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithFetchSessions(enableFetchSessions)
+            .WithFetchMaxBytes(1024)
+            .WithMaxPartitionFetchBytes(16 * 1024)
+            .WithFetchMaxWait(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        consumer.Assign(
+            new TopicPartition(topic, 0),
+            new TopicPartition(topic, 1),
+            new TopicPartition(topic, 2),
+            new TopicPartition(topic, 3));
+
+        var observedPartitions = new HashSet<int>();
+        var remainingMessages = maxMessagesBeforeAllPartitions;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var message in consumer.ConsumeAsync(cts.Token))
+        {
+            observedPartitions.Add(message.Partition);
+            if (observedPartitions.Count == partitionCount || --remainingMessages == 0)
+                break;
+        }
+
+        await Assert.That(observedPartitions).Count().IsEqualTo(partitionCount);
+    }
+
+    [Test]
     public async Task VaryingMessageSizes_FetchReturnsConsistently()
     {
         // Arrange - produce messages of wildly varying sizes

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
@@ -196,9 +196,9 @@ public sealed class ConsumerFetchPoolsTests
         try
         {
             await Assert.That(GetTopicPartitionOrder(first)).IsEqualTo("topic-a:0,topic-a:1,topic-b:0,topic-b:1");
-            await Assert.That(GetTopicPartitionOrder(second)).IsEqualTo("topic-a:1,topic-a:0,topic-b:0,topic-b:1");
+            await Assert.That(GetTopicPartitionOrder(second)).IsEqualTo("topic-a:1,topic-a:0,topic-b:1,topic-b:0");
             await Assert.That(GetTopicPartitionOrder(third)).IsEqualTo("topic-b:0,topic-b:1,topic-a:0,topic-a:1");
-            await Assert.That(GetTopicPartitionOrder(fourth)).IsEqualTo("topic-b:1,topic-b:0,topic-a:0,topic-a:1");
+            await Assert.That(GetTopicPartitionOrder(fourth)).IsEqualTo("topic-b:1,topic-b:0,topic-a:1,topic-a:0");
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchPoolsTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using Dekaf.Consumer;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 
@@ -13,6 +14,11 @@ public sealed class ConsumerFetchPoolsTests
             "BuildFetchRequestTopics",
             BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("Could not find BuildFetchRequestTopics");
+    private static readonly MethodInfo BuildFetchRequestTopicsForConnectionMethod =
+        typeof(KafkaConsumer<string, string>).GetMethod(
+            "BuildFetchRequestTopicsForConnection",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not find BuildFetchRequestTopicsForConnection");
     private static readonly FieldInfo FetchRequestTemplateCacheField =
         typeof(KafkaConsumer<string, string>).GetField(
             "_fetchRequestTemplateCache",
@@ -173,6 +179,172 @@ public sealed class ConsumerFetchPoolsTests
         await Assert.That(GetFetchRequestTemplateCacheCount(consumer)).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task BuildFetchRequestTopics_RepeatedBuilds_RotatePartitionOrder()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = CreateTemplateCachePartitions();
+
+        var first = InvokeBuildFetchRequestTopics(consumer, partitions);
+        var second = InvokeBuildFetchRequestTopics(consumer, partitions);
+        var third = InvokeBuildFetchRequestTopics(consumer, partitions);
+        var fourth = InvokeBuildFetchRequestTopics(consumer, partitions);
+        try
+        {
+            await Assert.That(GetTopicPartitionOrder(first)).IsEqualTo("topic-a:0,topic-a:1,topic-b:0,topic-b:1");
+            await Assert.That(GetTopicPartitionOrder(second)).IsEqualTo("topic-a:1,topic-a:0,topic-b:0,topic-b:1");
+            await Assert.That(GetTopicPartitionOrder(third)).IsEqualTo("topic-b:0,topic-b:1,topic-a:0,topic-a:1");
+            await Assert.That(GetTopicPartitionOrder(fourth)).IsEqualTo("topic-b:1,topic-b:0,topic-a:0,topic-a:1");
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(first);
+            ConsumerFetchPools.ReturnFetchRequestTopics(second);
+            ConsumerFetchPools.ReturnFetchRequestTopics(third);
+            ConsumerFetchPools.ReturnFetchRequestTopics(fourth);
+        }
+    }
+
+    [Test]
+    public async Task BuildFetchRequestTopics_PreferredReplicaBroker_RotatesIndependently()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = new List<TopicPartition>
+        {
+            new("topic-a", 0),
+            new("topic-a", 1),
+            new("topic-a", 2)
+        };
+
+        var brokerOneFirst = InvokeBuildFetchRequestTopics(consumer, partitions, brokerId: 1);
+        var brokerOneSecond = InvokeBuildFetchRequestTopics(consumer, partitions, brokerId: 1);
+        var brokerTwoFirst = InvokeBuildFetchRequestTopics(consumer, partitions, brokerId: 2);
+        try
+        {
+            await Assert.That(GetPartitionOrder(brokerOneFirst)).IsEqualTo("0,1,2");
+            await Assert.That(GetPartitionOrder(brokerOneSecond)).IsEqualTo("1,2,0");
+            await Assert.That(GetPartitionOrder(brokerTwoFirst)).IsEqualTo("0,1,2");
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(brokerOneFirst);
+            ConsumerFetchPools.ReturnFetchRequestTopics(brokerOneSecond);
+            ConsumerFetchPools.ReturnFetchRequestTopics(brokerTwoFirst);
+        }
+    }
+
+    [Test]
+    public async Task BuildFetchRequestTopics_PrefetchConnections_RotateIndependently()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = new List<TopicPartition>
+        {
+            new("topic-a", 0),
+            new("topic-a", 1),
+            new("topic-a", 2)
+        };
+
+        var connectionZeroFirst = InvokeBuildFetchRequestTopicsForConnection(consumer, partitions, connectionIndex: 0);
+        var connectionZeroSecond = InvokeBuildFetchRequestTopicsForConnection(consumer, partitions, connectionIndex: 0);
+        var connectionOneFirst = InvokeBuildFetchRequestTopicsForConnection(consumer, partitions, connectionIndex: 1);
+        try
+        {
+            await Assert.That(GetPartitionOrder(connectionZeroFirst)).IsEqualTo("0,1,2");
+            await Assert.That(GetPartitionOrder(connectionZeroSecond)).IsEqualTo("1,2,0");
+            await Assert.That(GetPartitionOrder(connectionOneFirst)).IsEqualTo("0,1,2");
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(connectionZeroFirst);
+            ConsumerFetchPools.ReturnFetchRequestTopics(connectionZeroSecond);
+            ConsumerFetchPools.ReturnFetchRequestTopics(connectionOneFirst);
+        }
+    }
+
+    [Test]
+    public async Task BuildFetchRequestTopics_AssignmentChange_ContinuesRoundRobin()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+
+        var original = InvokeBuildFetchRequestTopics(consumer,
+        [
+            new TopicPartition("topic-a", 0),
+            new TopicPartition("topic-a", 1),
+            new TopicPartition("topic-a", 2)
+        ]);
+        var reassigned = InvokeBuildFetchRequestTopics(consumer,
+        [
+            new TopicPartition("topic-b", 10),
+            new TopicPartition("topic-b", 11)
+        ]);
+        try
+        {
+            await Assert.That(GetPartitionOrder(original)).IsEqualTo("0,1,2");
+            await Assert.That(GetPartitionOrder(reassigned)).IsEqualTo("11,10");
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(original);
+            ConsumerFetchPools.ReturnFetchRequestTopics(reassigned);
+        }
+    }
+
+    [Test]
+    public async Task BuildFetchRequestTopics_FetchSessionReset_UsesNextRotation()
+    {
+        await using var built = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("group-a")
+            .Build();
+        var consumer = (KafkaConsumer<string, string>)built;
+        var partitions = new List<TopicPartition>
+        {
+            new("topic-a", 0),
+            new("topic-a", 1),
+            new("topic-a", 2)
+        };
+        var handler = new FetchSessionHandler();
+
+        var initialTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        handler.Build(initialTopics, clusterMetadata: null);
+        handler.HandleResponse(new FetchResponse { SessionId = 42, ErrorCode = ErrorCode.None, Responses = [] });
+        ConsumerFetchPools.ReturnFetchRequestTopics(initialTopics);
+
+        var incrementalTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        handler.Build(incrementalTopics, clusterMetadata: null);
+        handler.HandleError();
+        ConsumerFetchPools.ReturnFetchRequestTopics(incrementalTopics);
+
+        var resetTopics = InvokeBuildFetchRequestTopics(consumer, partitions);
+        try
+        {
+            var resetBuild = handler.Build(resetTopics, clusterMetadata: null);
+
+            await Assert.That(resetBuild.IsFull).IsTrue();
+            await Assert.That(GetPartitionOrder(resetBuild.Topics)).IsEqualTo("2,0,1");
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(resetTopics);
+        }
+    }
+
     private static List<FetchRequestTopic> InvokeBuildFetchRequestTopics(
         KafkaConsumer<string, string> consumer,
         List<TopicPartition> partitions)
@@ -202,6 +374,21 @@ public sealed class ConsumerFetchPoolsTests
             [partitions, startIndex, count, brokerId])!;
     }
 
+    private static List<FetchRequestTopic> InvokeBuildFetchRequestTopicsForConnection(
+        KafkaConsumer<string, string> consumer,
+        List<TopicPartition> partitions,
+        int connectionIndex,
+        int brokerId = 1)
+    {
+        var fetchPositions = (ConcurrentDictionary<TopicPartition, long>)FetchPositionsField.GetValue(consumer)!;
+        for (var i = 0; i < partitions.Count; i++)
+            fetchPositions.TryAdd(partitions[i], 0);
+
+        return (List<FetchRequestTopic>)BuildFetchRequestTopicsForConnectionMethod.Invoke(
+            consumer,
+            [partitions, 0, partitions.Count, brokerId, connectionIndex])!;
+    }
+
     private static int GetFetchRequestTemplateCacheCount(KafkaConsumer<string, string> consumer)
     {
         var cache = FetchRequestTemplateCacheField.GetValue(consumer)
@@ -216,6 +403,13 @@ public sealed class ConsumerFetchPoolsTests
         new("topic-b", 0),
         new("topic-b", 1)
     ];
+
+    private static string GetPartitionOrder(IReadOnlyList<FetchRequestTopic> topics) =>
+        string.Join(',', topics.SelectMany(static topic => topic.Partitions).Select(static partition => partition.Partition));
+
+    private static string GetTopicPartitionOrder(IReadOnlyList<FetchRequestTopic> topics) =>
+        string.Join(',', topics.SelectMany(static topic => topic.Partitions.Select(
+            partition => $"{topic.Topic}:{partition.Partition}")));
 
     private static async Task AssertFetchPoolsRentClearedLists()
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchRequestBuildBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchRequestBuildBenchmarks.cs
@@ -13,20 +13,39 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [ShortRunJob]
 public class FetchRequestBuildBenchmarks
 {
+    private const int TopicCount = 4;
     private const int PartitionCount = 100;
 
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new();
     private readonly Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>
         _templates = [];
+    private readonly Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>
+        _multiTopicTemplates = [];
     private readonly List<string> _topicOrder = ["fetch-ordering"];
+    private readonly List<string> _multiTopicOrder = [];
 
     [GlobalSetup]
     public void Setup()
     {
-        var partitions = new List<(FetchRequestPartition, TopicPartition)>(PartitionCount);
-        for (var partition = 0; partition < PartitionCount; partition++)
+        _templates.Add("fetch-ordering", CreatePartitions("fetch-ordering", PartitionCount));
+
+        var partitionsPerTopic = PartitionCount / TopicCount;
+        for (var topicIndex = 0; topicIndex < TopicCount; topicIndex++)
         {
-            var topicPartition = new TopicPartition("fetch-ordering", partition);
+            var topic = $"fetch-ordering-{topicIndex}";
+            _multiTopicOrder.Add(topic);
+            _multiTopicTemplates.Add(topic, CreatePartitions(topic, partitionsPerTopic));
+        }
+    }
+
+    private List<(FetchRequestPartition Partition, TopicPartition TopicPartition)> CreatePartitions(
+        string topic,
+        int count)
+    {
+        var partitions = new List<(FetchRequestPartition, TopicPartition)>(count);
+        for (var partition = 0; partition < count; partition++)
+        {
+            var topicPartition = new TopicPartition(topic, partition);
             _fetchPositions[topicPartition] = partition;
             partitions.Add((
                 new FetchRequestPartition
@@ -38,7 +57,7 @@ public class FetchRequestBuildBenchmarks
                 topicPartition));
         }
 
-        _templates.Add("fetch-ordering", partitions);
+        return partitions;
     }
 
     [Benchmark(OperationsPerInvoke = PartitionCount)]
@@ -63,10 +82,29 @@ public class FetchRequestBuildBenchmarks
             _fetchPositions,
             _topicOrder,
             topicRotation: 0,
-            firstTopicPartitionRotation: 37);
+            partitionRotation: 37);
         try
         {
             return topics[0].Partitions.Count;
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(topics);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = PartitionCount)]
+    public int BuildMultiTopicRotatedCachedFetchRequest()
+    {
+        var topics = KafkaConsumer<string, string>.BuildRotatedFetchResult(
+            _multiTopicTemplates,
+            _fetchPositions,
+            _multiTopicOrder,
+            topicRotation: 1,
+            partitionRotation: 7);
+        try
+        {
+            return topics.Count;
         }
         finally
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchRequestBuildBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchRequestBuildBenchmarks.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the per-fetch cost of materializing request partitions from a cached template.
+/// This path runs once per broker fetch, not once per consumed message.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class FetchRequestBuildBenchmarks
+{
+    private const int PartitionCount = 100;
+
+    private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new();
+    private readonly Dictionary<string, List<(FetchRequestPartition Partition, TopicPartition TopicPartition)>>
+        _templates = [];
+    private readonly List<string> _topicOrder = ["fetch-ordering"];
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var partitions = new List<(FetchRequestPartition, TopicPartition)>(PartitionCount);
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            var topicPartition = new TopicPartition("fetch-ordering", partition);
+            _fetchPositions[topicPartition] = partition;
+            partitions.Add((
+                new FetchRequestPartition
+                {
+                    Partition = partition,
+                    FetchOffset = 0,
+                    PartitionMaxBytes = 1024 * 1024
+                },
+                topicPartition));
+        }
+
+        _templates.Add("fetch-ordering", partitions);
+    }
+
+    [Benchmark(OperationsPerInvoke = PartitionCount)]
+    public int BuildCachedFetchRequest()
+    {
+        var topics = KafkaConsumer<string, string>.BuildFetchResult(_templates, _fetchPositions);
+        try
+        {
+            return topics[0].Partitions.Count;
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(topics);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = PartitionCount)]
+    public int BuildRotatedCachedFetchRequest()
+    {
+        var topics = KafkaConsumer<string, string>.BuildRotatedFetchResult(
+            _templates,
+            _fetchPositions,
+            _topicOrder,
+            topicRotation: 0,
+            firstTopicPartitionRotation: 37);
+        try
+        {
+            return topics[0].Partitions.Count;
+        }
+        finally
+        {
+            ConsumerFetchPools.ReturnFetchRequestTopics(topics);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2256

## Summary

- rotate full FetchRequest partition order with an allocation-free cursor per (brokerId, connectionIndex)
- cache flattened rotation starts so every partition becomes request-first once per cycle, across topics
- preserve KIP-227 incremental sessions; broker-side response rotation remains active, and session resets use the next full-request rotation
- cover assignment changes, preferred-replica broker changes, prefetch connections, session resets, and KIP-74 starvation with sessions enabled/disabled

## Performance

FetchRequestBuildBenchmarks ([MemoryDiagnoser], .NET 10, 100 partitions):

| Build | Mean / partition | Allocated / partition |
|---|---:|---:|
| Before (d9de72e6) cached | 16.48 ns | 48 B |
| After (5f369c52) cached | 16.62 ns | 48 B |
| After (5f369c52) rotated | 16.24 ns | 48 B |

Cached delta: +0.85% (ShortRun noise); rotated delta: -1.46%. Allocations unchanged. These are existing per-fetch partition wrapper allocations, not per-message allocations.

Command: dotnet run --project tools/Dekaf.Benchmarks --configuration Release -- --filter "*FetchRequestBuildBenchmarks*"

## Validation

- dotnet build tests/Dekaf.Tests.Unit --configuration Release — green, 0 warnings
- full unit suite — 5619/5619 passed
- FetchBufferEdgeCaseTests integration class — 8/8 passed against Kafka 4.3.1
- new starvation integration case passed with fetch sessions enabled and disabled
- git diff --check — clean

References: [KIP-74](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/65864887/KIP-74%2BAdd%2BFetch%2BResponse%2BSize%2BLimit%2Bin%2BBytes), [KIP-227](https://cwiki.apache.org/confluence/display/kafka/kip-227%3A%2Bintroduce%2Bincremental%2Bfetchrequests%2Bto%2Bincrease%2Bpartition%2Bscalability)