### PR TITLE
feat(producer): add incremental batch allocation

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -75,6 +75,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithLinger(...)` | `LingerMs` | Milliseconds |
 | `WithBatchSize(...)` | `BatchSize` | Bytes |
 | `WithBufferMemory(...)` | `BufferMemory` | Bytes; omit to keep auto-tuning |
+| `WithBufferMemoryAllocationStrategy(...)` | `BufferMemoryAllocationStrategy` | `Full` or `Incremental` |
 | `WithMaxBlock(...)` | `MaxBlockMs` | Milliseconds |
 | `WithDeliveryLatencyTarget(...)` | `DeliveryLatencyTargetMs` | TimeSpan; `TimeSpan.Zero` disables |
 | `WithDeliveryTimeout(...)` | `DeliveryTimeoutMs` | Milliseconds |
@@ -356,6 +357,21 @@ Maximum memory the producer uses for buffering unsent messages:
 
 Default: 2GB. When the buffer is full, `ProduceAsync` and `Send` block until space is freed (controlled by `WithMaxBlockMs`). Increase if profiling shows significant time in backpressure waits; decrease in memory-constrained environments.
 
+### WithBufferMemoryAllocationStrategy
+
+Controls when each partition batch allocates its record storage:
+
+```csharp
+.WithBufferMemoryAllocationStrategy(BufferMemoryAllocationStrategy.Incremental)
+```
+
+`Full` (the default) reserves one contiguous arena when a batch starts. `Incremental` rents
+pooled chunks as records arrive, which substantially reduces retained memory when a producer
+has many active partitions whose batches are only partly filled. Records remain zero-copy:
+compression reads the chunk sequence directly, and unencrypted single-batch sends use TCP
+scatter/gather. `BufferMemory`, batch limits, oversized-record behavior, retries, idempotence,
+and transactions have identical semantics under both strategies.
+
 ### WithDeliveryLatencyTarget
 
 Soft target for per-broker queueing latency (append to broker acknowledgement):
@@ -412,6 +428,7 @@ Enable logging:
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |
 | `WithBufferMemory` | auto-tuned | Max buffer for unsent messages |
+| `WithBufferMemoryAllocationStrategy` | Full | Full arena or pooled incremental chunks |
 | `WithDeliveryLatencyTarget` | 10ms | Per-broker queueing latency target; `TimeSpan.Zero` disables |
 | `WithMaxBlock` | 60000ms | Max time produce calls wait for metadata or buffer space |
 | `WithDeliveryTimeout` | 120000ms | Max time for delivery success or failure |

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -803,6 +803,7 @@ internal static class DekafOptionsBinding
         builder.WithLinger(TimeSpan.FromMilliseconds(options.LingerMs));
         builder.WithBatchSize(options.BatchSize);
         builder.WithBufferMemory(options.BufferMemory);
+        builder.WithBufferMemoryAllocationStrategy(options.BufferMemoryAllocationStrategy);
         if (options.EnableIdempotence || options.IsMaxInFlightRequestsPerConnectionConfigured)
             builder.WithMaxInFlightRequestsPerConnection(options.MaxInFlightRequestsPerConnection);
         builder.WithRetries(options.Retries);
@@ -1221,6 +1222,8 @@ internal static class DekafConfigurationBinding
             builder.WithArenaCapacity(arenaCapacity);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.InitialBatchRecordCapacity), out var initialBatchRecordCapacity))
             builder.WithInitialBatchRecordCapacity(initialBatchRecordCapacity);
+        if (TryGetValue<BufferMemoryAllocationStrategy>(configuration, nameof(ProducerOptions.BufferMemoryAllocationStrategy), out var allocationStrategy))
+            builder.WithBufferMemoryAllocationStrategy(allocationStrategy);
         if (TryGetValue<MetadataRecoveryStrategy>(configuration, nameof(ProducerOptions.MetadataRecoveryStrategy), out var metadataRecoveryStrategy))
             builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.MetadataRecoveryRebootstrapTriggerMs), out var rebootstrapMs))

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -29,6 +29,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private Acks _acks = Acks.All;
     private int _lingerMs;
     private int _batchSize = 1048576;
+    private BufferMemoryAllocationStrategy _bufferMemoryAllocationStrategy;
     private string? _transactionalId;
     private bool _inlineTransactionCompletions = true;
     private int? _transactionTimeoutMs;
@@ -164,6 +165,19 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithBufferMemory(ulong bufferMemory)
     {
         _bufferMemory = bufferMemory;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets how producer batch memory is allocated. Incremental allocation grows batches
+    /// from pooled chunks and reduces retained memory when many partitions have small batches.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithBufferMemoryAllocationStrategy(
+        BufferMemoryAllocationStrategy strategy)
+    {
+        if (!Enum.IsDefined(strategy))
+            throw new ArgumentOutOfRangeException(nameof(strategy));
+        _bufferMemoryAllocationStrategy = strategy;
         return this;
     }
 
@@ -1249,6 +1263,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             LingerMs = _lingerMs,
             BatchSize = _batchSize,
             BufferMemory = _bufferMemory ?? memoryBudget.PreviewProducerLimit(),
+            BufferMemoryAllocationStrategy = _bufferMemoryAllocationStrategy,
             IsAutoTuned = _bufferMemory is null,
             MaxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection,
             Retries = _retries,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -175,7 +175,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithBufferMemoryAllocationStrategy(
         BufferMemoryAllocationStrategy strategy)
     {
-        if (!Enum.IsDefined(strategy))
+        if (!ProducerOptions.IsBufferMemoryAllocationStrategyDefined(strategy))
             throw new ArgumentOutOfRangeException(nameof(strategy));
         _bufferMemoryAllocationStrategy = strategy;
         return this;

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1510,7 +1510,15 @@ public sealed partial class KafkaConnection :
             if (Volatile.Read(ref _disposed) != 0)
                 throw new ObjectDisposedException(nameof(KafkaConnection));
 
-            var sender = _scatterGatherSender ??= new SocketScatterGatherSender();
+            var pendingSegmentCount = suffixLength > 0 ? 2 : 1;
+            foreach (var memory in encodedRecords)
+            {
+                if (memory.Length > 0)
+                    pendingSegmentCount = checked(pendingSegmentCount + 1);
+            }
+
+            var sender = _scatterGatherSender ??= new SocketScatterGatherSender(pendingSegmentCount);
+            sender.EnsurePendingSegmentCapacity(pendingSegmentCount);
             var pendingSegments = sender.PendingSegments;
             pendingSegments.Add(new ArraySegment<byte>(metadataArray, 0, prefixLength));
             foreach (var memory in encodedRecords)
@@ -3303,15 +3311,23 @@ public sealed partial class KafkaConnection :
             RunContinuationsAsynchronously = true
         };
 
-        public SocketScatterGatherSender()
+        public SocketScatterGatherSender(int pendingSegmentCapacity = MaximumSegmentsPerSend)
         {
             _eventArgs.Completed += CompleteSend;
+            PendingSegments = new List<ArraySegment<byte>>(
+                Math.Max(MaximumSegmentsPerSend, pendingSegmentCapacity));
         }
 
-        public List<ArraySegment<byte>> PendingSegments { get; } = new(MaximumSegmentsPerSend);
+        public List<ArraySegment<byte>> PendingSegments { get; }
         public List<ArraySegment<byte>> Segments { get; } = new(MaximumSegmentsPerSend);
 
         public bool HasPendingSegments => _pendingSegmentIndex < PendingSegments.Count;
+
+        public void EnsurePendingSegmentCapacity(int capacity)
+        {
+            if (PendingSegments.Capacity < capacity)
+                PendingSegments.Capacity = capacity;
+        }
 
         public void BeginPendingSend()
         {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1397,7 +1397,7 @@ public sealed partial class KafkaConnection :
         short headerVersion,
         out byte[] metadataArray,
         out int prefixLength,
-        out ArraySegment<byte> encodedRecords,
+        out ReadOnlySequence<byte> encodedRecords,
         out int suffixOffset,
         out int suffixLength)
     {
@@ -1442,14 +1442,23 @@ public sealed partial class KafkaConnection :
         if (!batch.TryWriteSegmentedHeader(
                 metadataWriter,
                 partition.Compression,
-                out var encodedRecordsMemory)
-            || !MemoryMarshal.TryGetArray(encodedRecordsMemory, out encodedRecords))
+                out encodedRecords))
         {
             encodedRecords = default;
             return false;
         }
 
-        var segmentedBatchSize = RecordBatch.TotalBatchHeaderSize + encodedRecords.Count;
+        foreach (var segment in encodedRecords)
+        {
+            if (!MemoryMarshal.TryGetArray(segment, out _))
+            {
+                encodedRecords = default;
+                return false;
+            }
+        }
+
+        var encodedRecordsLength = checked((int)encodedRecords.Length);
+        var segmentedBatchSize = RecordBatch.TotalBatchHeaderSize + encodedRecordsLength;
         if (encodedBatchSize != segmentedBatchSize)
         {
             throw new KafkaException(
@@ -1475,7 +1484,7 @@ public sealed partial class KafkaConnection :
                 $"PRODUCE segmented body mismatch: size hint {request.RequestBodySizeHint} but serialized {bodyLength} bytes.");
         }
 
-        var totalLength = checked(metadataWriter.WrittenCount + encodedRecords.Count);
+        var totalLength = checked(metadataWriter.WrittenCount + encodedRecordsLength);
         (metadataArray, _) = metadataWriter.DetachBuffer();
         BinaryPrimitives.WriteInt32BigEndian(metadataArray, totalLength - MessageSizePrefixLength);
         return true;
@@ -1484,7 +1493,7 @@ public sealed partial class KafkaConnection :
     private async Task WriteSegmentedFrameHoldingLockAsync(
         byte[] metadataArray,
         int prefixLength,
-        ArraySegment<byte> encodedRecords,
+        ReadOnlySequence<byte> encodedRecords,
         int suffixOffset,
         int suffixLength)
     {
@@ -1502,20 +1511,25 @@ public sealed partial class KafkaConnection :
                 throw new ObjectDisposedException(nameof(KafkaConnection));
 
             var sender = _scatterGatherSender ??= new SocketScatterGatherSender();
-            var sendSegments = sender.Segments;
-            sendSegments.Add(new ArraySegment<byte>(metadataArray, 0, prefixLength));
-            if (encodedRecords.Count > 0)
-                sendSegments.Add(encodedRecords);
-            if (suffixLength > 0)
-                sendSegments.Add(new ArraySegment<byte>(metadataArray, suffixOffset, suffixLength));
-
-            while (sendSegments.Count > 0)
+            var pendingSegments = sender.PendingSegments;
+            pendingSegments.Add(new ArraySegment<byte>(metadataArray, 0, prefixLength));
+            foreach (var memory in encodedRecords)
             {
+                if (memory.Length > 0 && MemoryMarshal.TryGetArray(memory, out var segment))
+                    pendingSegments.Add(segment);
+            }
+            if (suffixLength > 0)
+                pendingSegments.Add(new ArraySegment<byte>(metadataArray, suffixOffset, suffixLength));
+
+            sender.BeginPendingSend();
+            while (sender.HasPendingSegments)
+            {
+                sender.LoadSendWindow();
                 var bytesSent = await sender.SendAsync(socket).ConfigureAwait(false);
                 if (bytesSent <= 0)
                     throw new IOException("Socket closed while writing a Kafka request frame.");
 
-                ConsumeSentSegments(sendSegments, bytesSent);
+                sender.ConsumeSentBytes(bytesSent);
             }
         }
         catch
@@ -1528,6 +1542,7 @@ public sealed partial class KafkaConnection :
             if (scatterGatherSenderLockHeld)
             {
                 _scatterGatherSender?.Segments.Clear();
+                _scatterGatherSender?.PendingSegments.Clear();
                 SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
             }
 
@@ -3298,7 +3313,10 @@ public sealed partial class KafkaConnection :
 
     private sealed class SocketScatterGatherSender : IValueTaskSource<int>, IDisposable
     {
+        private const int MaximumSegmentsPerSend = 16;
         private readonly SocketAsyncEventArgs _eventArgs = new();
+        private int _pendingSegmentIndex;
+        private int _pendingSegmentOffset;
         private ManualResetValueTaskSourceCore<int> _core = new()
         {
             RunContinuationsAsynchronously = true
@@ -3309,7 +3327,55 @@ public sealed partial class KafkaConnection :
             _eventArgs.Completed += CompleteSend;
         }
 
-        public List<ArraySegment<byte>> Segments { get; } = new(3);
+        public List<ArraySegment<byte>> PendingSegments { get; } = new(MaximumSegmentsPerSend);
+        public List<ArraySegment<byte>> Segments { get; } = new(MaximumSegmentsPerSend);
+
+        public bool HasPendingSegments => _pendingSegmentIndex < PendingSegments.Count;
+
+        public void BeginPendingSend()
+        {
+            _pendingSegmentIndex = 0;
+            _pendingSegmentOffset = 0;
+        }
+
+        public void LoadSendWindow()
+        {
+            Segments.Clear();
+            var end = Math.Min(
+                PendingSegments.Count,
+                _pendingSegmentIndex + MaximumSegmentsPerSend);
+            for (var i = _pendingSegmentIndex; i < end; i++)
+            {
+                var segment = PendingSegments[i];
+                if (i == _pendingSegmentIndex && _pendingSegmentOffset > 0)
+                {
+                    segment = new ArraySegment<byte>(
+                        segment.Array!,
+                        segment.Offset + _pendingSegmentOffset,
+                        segment.Count - _pendingSegmentOffset);
+                }
+
+                Segments.Add(segment);
+            }
+        }
+
+        public void ConsumeSentBytes(int bytesSent)
+        {
+            while (bytesSent > 0)
+            {
+                var segment = PendingSegments[_pendingSegmentIndex];
+                var remaining = segment.Count - _pendingSegmentOffset;
+                if (bytesSent < remaining)
+                {
+                    _pendingSegmentOffset += bytesSent;
+                    return;
+                }
+
+                bytesSent -= remaining;
+                _pendingSegmentIndex++;
+                _pendingSegmentOffset = 0;
+            }
+        }
 
         public ValueTask<int> SendAsync(Socket socket)
         {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1551,25 +1551,6 @@ public sealed partial class KafkaConnection :
         }
     }
 
-    internal static void ConsumeSentSegments(List<ArraySegment<byte>> segments, int bytesSent)
-    {
-        while (bytesSent > 0)
-        {
-            var segment = segments[0];
-            if (bytesSent < segment.Count)
-            {
-                segments[0] = new ArraySegment<byte>(
-                    segment.Array!,
-                    segment.Offset + bytesSent,
-                    segment.Count - bytesSent);
-                return;
-            }
-
-            bytesSent -= segment.Count;
-            segments.RemoveAt(0);
-        }
-    }
-
     /// <summary>
     /// Writes one complete frame while holding the write lock, then releases the lock and
     /// returns the serialization buffer. The socket write is deliberately not cancellable:
@@ -3311,9 +3292,9 @@ public sealed partial class KafkaConnection :
         }
     }
 
-    private sealed class SocketScatterGatherSender : IValueTaskSource<int>, IDisposable
+    internal sealed class SocketScatterGatherSender : IValueTaskSource<int>, IDisposable
     {
-        private const int MaximumSegmentsPerSend = 16;
+        internal const int MaximumSegmentsPerSend = 16;
         private readonly SocketAsyncEventArgs _eventArgs = new();
         private int _pendingSegmentIndex;
         private int _pendingSegmentOffset;

--- a/src/Dekaf/Producer/IncrementalBatchBuffer.cs
+++ b/src/Dekaf/Producer/IncrementalBatchBuffer.cs
@@ -13,9 +13,11 @@ internal sealed class IncrementalBatchBuffer
     internal const int MaximumChunkSize = 16 * 1024;
 
     private const int BufferPoolSize = 1024;
-    private const int SegmentPoolSize = 8192;
+    private const int InitialSegmentPoolSize = 8192;
     private static readonly LockFreeStack<IncrementalBatchBuffer> s_buffers = new(BufferPoolSize);
-    private static readonly LockFreeStack<ChunkSegment> s_segments = new(SegmentPoolSize);
+    private static readonly Lock s_segmentPoolLock = new();
+    private static LockFreeStack<ChunkSegment> s_segments = new(InitialSegmentPoolSize);
+    private static int s_segmentPoolCapacity = InitialSegmentPoolSize;
     private static readonly RatchetableArrayPool<byte> s_chunkArrays = new(
         maxArrayLength: 4 * 1024 * 1024,
         initialArraysPerBucket: BatchArena.DefaultPoolSize);
@@ -32,8 +34,21 @@ internal sealed class IncrementalBatchBuffer
 
     internal int Length => _length;
 
-    internal static void RatchetPoolSize(int arraysPerBucket) =>
-        s_chunkArrays.RatchetBucketCapacity(Math.Min(BufferPoolSize, arraysPerBucket));
+    internal static void RatchetPoolSize(int liveBatchCount, int batchSize)
+    {
+        var chunkPoolSize = ComputeChunkPoolSize(liveBatchCount, batchSize);
+        s_chunkArrays.RatchetBucketCapacity(chunkPoolSize);
+        RatchetSegmentPoolSize(chunkPoolSize);
+    }
+
+    internal static int ComputeChunkPoolSize(int liveBatchCount, int batchSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(liveBatchCount);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+        var chunkSize = GetChunkSize(batchSize);
+        var chunksPerBatch = Math.Max(1, ((long)batchSize + chunkSize - 1) / chunkSize);
+        return checked((int)Math.Min((long)liveBatchCount * chunksPerBatch, int.MaxValue));
+    }
 
     internal static void PreWarm(int count, int batchSize)
     {
@@ -166,9 +181,29 @@ internal sealed class IncrementalBatchBuffer
     private static int GetChunkSize(int batchSize) =>
         Math.Clamp(Math.Min(MaximumChunkSize, batchSize), MinimumChunkSize, MaximumChunkSize);
 
+    private static void RatchetSegmentPoolSize(int capacity)
+    {
+        if (capacity <= Volatile.Read(ref s_segmentPoolCapacity))
+            return;
+
+        lock (s_segmentPoolLock)
+        {
+            if (capacity <= s_segmentPoolCapacity)
+                return;
+
+            var current = Volatile.Read(ref s_segments);
+            var replacement = new LockFreeStack<ChunkSegment>(capacity);
+            while (current.TryPop(out var segment))
+                replacement.TryPush(segment);
+
+            Volatile.Write(ref s_segments, replacement);
+            Volatile.Write(ref s_segmentPoolCapacity, capacity);
+        }
+    }
+
     private static ChunkSegment RentSegment(int capacity)
     {
-        if (!s_segments.TryPop(out var segment))
+        if (!Volatile.Read(ref s_segments).TryPop(out var segment))
             segment = new ChunkSegment();
 
         segment.Initialize(s_chunkArrays.Pool.Rent(capacity));
@@ -179,7 +214,7 @@ internal sealed class IncrementalBatchBuffer
     {
         var buffer = segment.Release();
         s_chunkArrays.Pool.Return(buffer, clearArray: false);
-        s_segments.TryPush(segment);
+        Volatile.Read(ref s_segments).TryPush(segment);
     }
 
     private void ReturnChunks()

--- a/src/Dekaf/Producer/IncrementalBatchBuffer.cs
+++ b/src/Dekaf/Producer/IncrementalBatchBuffer.cs
@@ -1,0 +1,248 @@
+using System.Buffers;
+using Dekaf.Internal;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Pooled, append-only batch storage that rents data in small chunks. Individual records
+/// remain contiguous while the completed batch is exposed as a zero-copy sequence.
+/// </summary>
+internal sealed class IncrementalBatchBuffer
+{
+    internal const int MinimumChunkSize = 128;
+    internal const int MaximumChunkSize = 16 * 1024;
+
+    private const int BufferPoolSize = 1024;
+    private const int SegmentPoolSize = 8192;
+    private static readonly LockFreeStack<IncrementalBatchBuffer> s_buffers = new(BufferPoolSize);
+    private static readonly LockFreeStack<ChunkSegment> s_segments = new(SegmentPoolSize);
+    private static readonly RatchetableArrayPool<byte> s_chunkArrays = new(
+        maxArrayLength: 4 * 1024 * 1024,
+        initialArraysPerBucket: BatchArena.DefaultPoolSize);
+
+    private ChunkSegment? _head;
+    private ChunkSegment? _tail;
+    private int _chunkSize;
+    private int _length;
+    private ChunkSegment? _lastAllocationSegment;
+    private int _lastAllocationOffset;
+    private int _lastAllocationLength;
+
+    private IncrementalBatchBuffer(int batchSize) => Reset(batchSize);
+
+    internal int Length => _length;
+
+    internal static void RatchetPoolSize(int arraysPerBucket) =>
+        s_chunkArrays.RatchetBucketCapacity(Math.Min(BufferPoolSize, arraysPerBucket));
+
+    internal static void PreWarm(int count, int batchSize)
+    {
+        count = Math.Min(BufferPoolSize, count);
+        var chunkSize = GetChunkSize(batchSize);
+        var arrays = new byte[count][];
+        for (var i = 0; i < count; i++)
+            arrays[i] = s_chunkArrays.Pool.Rent(chunkSize);
+
+        for (var i = 0; i < count; i++)
+            s_chunkArrays.Pool.Return(arrays[i], clearArray: false);
+
+        while (s_segments.Count < count && s_segments.TryPush(new ChunkSegment())) { }
+        while (s_buffers.Count < count && s_buffers.TryPush(new IncrementalBatchBuffer(batchSize))) { }
+    }
+
+    internal int RetainedCapacity
+    {
+        get
+        {
+            var capacity = 0;
+            for (var segment = _head; segment is not null; segment = segment.NextSegment)
+                capacity = checked(capacity + segment.Buffer.Length);
+            return capacity;
+        }
+    }
+
+    internal static IncrementalBatchBuffer Rent(int batchSize)
+    {
+        if (!s_buffers.TryPop(out var buffer))
+            return new IncrementalBatchBuffer(batchSize);
+
+        buffer.Reset(batchSize);
+        return buffer;
+    }
+
+    internal static void ReturnToPool(IncrementalBatchBuffer buffer)
+    {
+        buffer.ReturnChunks();
+        s_buffers.TryPush(buffer);
+    }
+
+    internal void Allocate(
+        int length,
+        out byte[] buffer,
+        out int bufferOffset,
+        out int logicalOffset)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+
+        var segment = _tail;
+        if (segment is null || segment.Capacity - segment.Used < length)
+        {
+            segment = RentSegment(Math.Max(_chunkSize, length));
+            if (_tail is null)
+            {
+                _head = segment;
+            }
+            else
+            {
+                _tail.AttachNext(segment);
+                segment.Previous = _tail;
+            }
+
+            _tail = segment;
+        }
+
+        logicalOffset = _length;
+        bufferOffset = segment.Used;
+        buffer = segment.Buffer;
+        segment.SetUsed(checked(segment.Used + length));
+        _length = checked(_length + length);
+        _lastAllocationSegment = segment;
+        _lastAllocationOffset = bufferOffset;
+        _lastAllocationLength = length;
+    }
+
+    internal bool TryRewindLastAllocation(int logicalOffset, int length)
+    {
+        var segment = _lastAllocationSegment;
+        if (segment is null
+            || logicalOffset != _length - length
+            || length != _lastAllocationLength
+            || _lastAllocationOffset + length != segment.Used)
+        {
+            return false;
+        }
+
+        segment.SetUsed(_lastAllocationOffset);
+        _length -= length;
+        _lastAllocationSegment = null;
+        _lastAllocationLength = 0;
+        _lastAllocationOffset = 0;
+
+        if (segment.Used == 0)
+        {
+            var previous = segment.Previous;
+            if (previous is null)
+                _head = null;
+            else
+                previous.DetachNext();
+
+            _tail = previous;
+            ReturnSegment(segment);
+        }
+
+        return true;
+    }
+
+    internal ReadOnlySequence<byte> AsReadOnlySequence()
+    {
+        if (_head is null || _tail is null || _length == 0)
+            return ReadOnlySequence<byte>.Empty;
+
+        for (var segment = _head; segment is not null; segment = segment.NextSegment)
+            segment.CommitMemory();
+
+        return new ReadOnlySequence<byte>(_head, 0, _tail, _tail.Used);
+    }
+
+    private void Reset(int batchSize)
+    {
+        _chunkSize = GetChunkSize(batchSize);
+        _length = 0;
+        _lastAllocationSegment = null;
+        _lastAllocationOffset = 0;
+        _lastAllocationLength = 0;
+    }
+
+    private static int GetChunkSize(int batchSize) =>
+        Math.Clamp(Math.Min(MaximumChunkSize, batchSize), MinimumChunkSize, MaximumChunkSize);
+
+    private static ChunkSegment RentSegment(int capacity)
+    {
+        if (!s_segments.TryPop(out var segment))
+            segment = new ChunkSegment();
+
+        segment.Initialize(s_chunkArrays.Pool.Rent(capacity));
+        return segment;
+    }
+
+    private static void ReturnSegment(ChunkSegment segment)
+    {
+        var buffer = segment.Release();
+        s_chunkArrays.Pool.Return(buffer, clearArray: false);
+        s_segments.TryPush(segment);
+    }
+
+    private void ReturnChunks()
+    {
+        var segment = _head;
+        while (segment is not null)
+        {
+            var next = segment.NextSegment;
+            ReturnSegment(segment);
+            segment = next;
+        }
+
+        _head = null;
+        _tail = null;
+        _length = 0;
+        _lastAllocationSegment = null;
+        _lastAllocationOffset = 0;
+        _lastAllocationLength = 0;
+    }
+
+    private sealed class ChunkSegment : ReadOnlySequenceSegment<byte>
+    {
+        internal byte[] Buffer { get; private set; } = [];
+        internal int Capacity => Buffer.Length;
+        internal int Used { get; private set; }
+        internal ChunkSegment? Previous { get; set; }
+        internal ChunkSegment? NextSegment => (ChunkSegment?)Next;
+
+        internal void Initialize(byte[] buffer)
+        {
+            Buffer = buffer;
+            Used = 0;
+            Previous = null;
+            Next = null;
+            RunningIndex = 0;
+            Memory = buffer.AsMemory(0, 0);
+        }
+
+        internal void SetUsed(int used)
+        {
+            Used = used;
+        }
+
+        internal void CommitMemory() => Memory = Buffer.AsMemory(0, Used);
+
+        internal void AttachNext(ChunkSegment next)
+        {
+            next.RunningIndex = RunningIndex + Used;
+            Next = next;
+        }
+
+        internal void DetachNext() => Next = null;
+
+        internal byte[] Release()
+        {
+            var buffer = Buffer;
+            Buffer = [];
+            Used = 0;
+            Previous = null;
+            Next = null;
+            RunningIndex = 0;
+            Memory = default;
+            return buffer;
+        }
+    }
+}

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -11,6 +11,18 @@ using Dekaf.Telemetry;
 namespace Dekaf.Producer;
 
 /// <summary>
+/// Controls when producer batch storage is allocated.
+/// </summary>
+public enum BufferMemoryAllocationStrategy
+{
+    /// <summary>Allocate the full batch arena when a partition batch is created.</summary>
+    Full,
+
+    /// <summary>Allocate pooled chunks as records are appended.</summary>
+    Incremental
+}
+
+/// <summary>
 /// Configuration options for the Kafka producer.
 /// </summary>
 public sealed class ProducerOptions
@@ -156,6 +168,12 @@ public sealed class ProducerOptions
     /// </para>
     /// </summary>
     public ulong BufferMemory { get; init; } = 256L * 1024 * 1024;
+
+    /// <summary>
+    /// Controls whether each partition batch reserves its full arena immediately or grows
+    /// from pooled chunks as records are appended. Default is <see cref="BufferMemoryAllocationStrategy.Full"/>.
+    /// </summary>
+    public BufferMemoryAllocationStrategy BufferMemoryAllocationStrategy { get; init; }
 
     /// <summary>
     /// True when BufferMemory was auto-tuned from the global memory budget.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -36,6 +36,16 @@ public sealed class ProducerOptions
     private bool _isReconnectBackoffMsConfigured;
     private bool _isReconnectBackoffMaxMsConfigured;
 
+    internal static bool IsBufferMemoryAllocationStrategyDefined(
+        BufferMemoryAllocationStrategy strategy)
+    {
+#if NETSTANDARD2_0
+        return Enum.IsDefined(typeof(BufferMemoryAllocationStrategy), strategy);
+#else
+        return Enum.IsDefined(strategy);
+#endif
+    }
+
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
     /// </summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2474,12 +2474,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
+        if (!Enum.IsDefined(options.BufferMemoryAllocationStrategy))
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.BufferMemoryAllocationStrategy,
+                "Unknown buffer memory allocation strategy.");
 
         // Scale pool sizes with BufferMemory/BatchSize to prevent pool exhaustion.
         // Small batches (e.g., 16KB) create high batch churn (~6,250/sec at 100K msg/sec)
         // and need larger pools than the default 256 designed for 1MB batches.
         var poolSize = ComputePoolSize(options);
-        BatchArena.RatchetPoolSize(poolSize);
+        if (options.BufferMemoryAllocationStrategy == BufferMemoryAllocationStrategy.Full)
+            BatchArena.RatchetPoolSize(poolSize);
+        else
+            IncrementalBatchBuffer.RatchetPoolSize(poolSize * ReadyBatchPoolSizeRatio);
         // ReadyBatch lifecycle spans seal→send→response→cleanup (longer than PartitionBatch),
         // so its pool needs to be larger to avoid exhaustion under sustained throughput.
         _readyBatchPool = new ReadyBatchPool(maxPoolSize: poolSize * ReadyBatchPoolSizeRatio);
@@ -2502,8 +2510,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var preWarmCount = Math.Min(poolSize / 8, 16);
         _readyBatchPool.PreWarm(Math.Min(poolSize, 32));
         _batchPool.PreWarm(preWarmCount);
-        BatchArena.PreWarm(preWarmCount,
-            ProducerOptions.GetEffectiveArenaCapacity(options.BatchSize, options.ArenaCapacity));
+        if (options.BufferMemoryAllocationStrategy == BufferMemoryAllocationStrategy.Full)
+        {
+            BatchArena.PreWarm(preWarmCount,
+                ProducerOptions.GetEffectiveArenaCapacity(options.BatchSize, options.ArenaCapacity));
+        }
+        else
+        {
+            IncrementalBatchBuffer.PreWarm(
+                Math.Min(poolSize * ReadyBatchPoolSizeRatio, 256),
+                options.BatchSize);
+        }
 
         // Create per-partition-affine append worker channels.
         // Each channel is SingleReader (one worker) but allows multiple writers (caller threads).
@@ -6826,6 +6843,7 @@ internal sealed class PartitionBatch
 
     // Arena holding the encoded record bytes - all records in one contiguous buffer
     private BatchArena? _arena;
+    private IncrementalBatchBuffer? _incrementalBuffer;
 
     private int _recordCount;
 
@@ -6876,8 +6894,7 @@ internal sealed class PartitionBatch
             ? Math.Clamp(options.InitialBatchRecordCapacity, 16, 16384)
             : ComputeInitialRecordCapacity(options.BatchSize);
 
-        // Create arena for append-time record encoding
-        _arena = new BatchArena(GetEffectiveArenaCapacity(options));
+        CreateAppendBuffer(options);
         _recordCount = 0;
 
         // Rent arrays from pool - eliminates List allocations
@@ -6962,12 +6979,13 @@ internal sealed class PartitionBatch
         _options = options;
         _arrayReuseQueue = arrayReuseQueue;
 
-        // Arena was transferred to ReadyBatch by Complete(), so _arena should be null.
-        // This is a no-op but kept for safety.
+        // Append storage was transferred to ReadyBatch by Complete(). These are no-ops
+        // in the normal path but retained for failure safety.
         _arena?.Return();
+        if (_incrementalBuffer is not null)
+            IncrementalBatchBuffer.ReturnToPool(_incrementalBuffer);
 
-        // Rent or create arena for the pooled batch
-        _arena = BatchArena.RentOrCreate(GetEffectiveArenaCapacity(options));
+        CreateAppendBuffer(options);
 
         // The completion sources array was transferred to ReadyBatch by Complete() and is now null.
         // Try to reclaim one from the reuse queue first (returned by ReadyBatch.Cleanup()),
@@ -7007,6 +7025,9 @@ internal sealed class PartitionBatch
     /// Returns null if arena is not available (batch completed or arena full).
     /// </summary>
     public BatchArena? Arena => Volatile.Read(ref _isCompleted) == 0 ? _arena : null;
+
+    internal int RetainedBatchBufferCapacity =>
+        _arena?.Capacity ?? _incrementalBuffer?.RetainedCapacity ?? 0;
 
     public TopicPartition TopicPartition => _topicPartition;
     public int PartitionCount => _partitionCount;
@@ -7089,14 +7110,17 @@ internal sealed class PartitionBatch
     }
 
     internal readonly record struct ReservedRecordAppend(
-        BatchArena Arena,
+        BatchArena? Arena,
+        IncrementalBatchBuffer? IncrementalBuffer,
+        byte[] Buffer,
         int RecordIndex,
         long Timestamp,
         long BaseTimestamp,
         long TimestampDelta,
         int BodySize,
         int EncodedRecordSize,
-        int EncodedOffset);
+        int EncodedOffset,
+        int LogicalOffset);
 
     /// <summary>
     /// Returns the batch creation timestamp from Stopwatch for efficient age comparisons.
@@ -7324,7 +7348,7 @@ internal sealed class PartitionBatch
             return new RecordAppendResult(false);
         }
 
-        if (recordIndex == 0)
+        if (recordIndex == 0 && _incrementalBuffer is null)
         {
             EnsureArenaCanFitFirstRecord(encodedRecordSize);
         }
@@ -7343,7 +7367,24 @@ internal sealed class PartitionBatch
             }
         }
 
-        if (_arena is null || !_arena.TryAllocate(encodedRecordSize, out _, out var encodedOffset))
+        byte[] encodedBuffer;
+        int encodedOffset;
+        int logicalOffset;
+        if (_incrementalBuffer is not null)
+        {
+            _incrementalBuffer.Allocate(
+                encodedRecordSize,
+                out encodedBuffer,
+                out encodedOffset,
+                out logicalOffset);
+        }
+        else if (_arena is not null
+                 && _arena.TryAllocate(encodedRecordSize, out _, out encodedOffset))
+        {
+            encodedBuffer = _arena.Buffer;
+            logicalOffset = encodedOffset;
+        }
+        else
         {
             reservedAppend = default;
             return new RecordAppendResult(false);
@@ -7351,13 +7392,16 @@ internal sealed class PartitionBatch
 
         reservedAppend = new ReservedRecordAppend(
             _arena,
+            _incrementalBuffer,
+            encodedBuffer,
             recordIndex,
             timestamp,
             baseTimestamp,
             timestampDelta,
             bodySize,
             encodedRecordSize,
-            encodedOffset);
+            encodedOffset,
+            logicalOffset);
 
         var firstCompletionSourceInBatch = hasCompletionSource && _completionSourceCount == 0;
         return new RecordAppendResult(
@@ -7387,7 +7431,7 @@ internal sealed class PartitionBatch
         Header[]? headers,
         int headerCount)
     {
-        var encodedRecord = reservedAppend.Arena.Buffer.AsSpan(
+        var encodedRecord = reservedAppend.Buffer.AsSpan(
             reservedAppend.EncodedOffset,
             reservedAppend.EncodedRecordSize);
 
@@ -7426,10 +7470,10 @@ internal sealed class PartitionBatch
         if (recordIndex == 0)
         {
             _baseTimestamp = reservedAppend.BaseTimestamp;
-            _encodedRecordsStart = reservedAppend.EncodedOffset;
+            _encodedRecordsStart = reservedAppend.LogicalOffset;
         }
 
-        Debug.Assert(reservedAppend.EncodedOffset == _encodedRecordsStart + _encodedRecordsLength);
+        Debug.Assert(reservedAppend.LogicalOffset == _encodedRecordsStart + _encodedRecordsLength);
         _encodedRecordsLength += reservedAppend.EncodedRecordSize;
         _maxTimestamp = recordIndex == 0 ? reservedAppend.Timestamp : Math.Max(_maxTimestamp, reservedAppend.Timestamp);
 
@@ -7451,7 +7495,32 @@ internal sealed class PartitionBatch
 
     internal static void CancelReservedAppend(in ReservedRecordAppend reservedAppend)
     {
-        reservedAppend.Arena.TryRewindLastAllocation(reservedAppend.EncodedOffset, reservedAppend.EncodedRecordSize);
+        if (reservedAppend.Arena is not null)
+        {
+            reservedAppend.Arena.TryRewindLastAllocation(
+                reservedAppend.EncodedOffset,
+                reservedAppend.EncodedRecordSize);
+        }
+        else
+        {
+            reservedAppend.IncrementalBuffer?.TryRewindLastAllocation(
+                reservedAppend.LogicalOffset,
+                reservedAppend.EncodedRecordSize);
+        }
+    }
+
+    private void CreateAppendBuffer(ProducerOptions options)
+    {
+        if (options.BufferMemoryAllocationStrategy == BufferMemoryAllocationStrategy.Incremental)
+        {
+            _arena = null;
+            _incrementalBuffer = IncrementalBatchBuffer.Rent(options.BatchSize);
+        }
+        else
+        {
+            _incrementalBuffer = null;
+            _arena = BatchArena.RentOrCreate(GetEffectiveArenaCapacity(options));
+        }
     }
 
     private void EnsureArenaCanFitFirstRecord(int encodedRecordSize)
@@ -7559,8 +7628,6 @@ internal sealed class PartitionBatch
         ReadyBatch? readyBatch = null;
         try
         {
-            var encodedRecords = _arena!.GetMemory(_encodedRecordsStart, _encodedRecordsLength);
-
             // Rent from pool to eliminate per-batch RecordBatch class allocation.
             // The batch lives through the send pipeline (1-10ms) and would otherwise
             // survive Gen0 collection, contributing to high Gen1/Gen0 promotion rate.
@@ -7573,8 +7640,17 @@ internal sealed class PartitionBatch
             batch.ProducerEpoch = _producerEpoch;
             batch.BaseSequence = baseSequence;
             batch.Attributes = attributes;
-            batch.SetPreEncodedRecords(encodedRecords);
-            batch.Records = LazyRecordList.Create(encodedRecords, _recordCount);
+            if (_incrementalBuffer is not null)
+            {
+                batch.SetPreEncodedRecords(_incrementalBuffer.AsReadOnlySequence());
+                batch.Records = ProducerRecordCountList.Rent(_recordCount);
+            }
+            else
+            {
+                var encodedRecords = _arena!.GetMemory(_encodedRecordsStart, _encodedRecordsLength);
+                batch.SetPreEncodedRecords(encodedRecords);
+                batch.Records = LazyRecordList.Create(encodedRecords, _recordCount);
+            }
 
             // Rent ReadyBatch from pool or create new if no pool available
             // This eliminates per-batch class allocations at high throughput
@@ -7594,7 +7670,8 @@ internal sealed class PartitionBatch
                 _arrayReuseQueue,
                 _recordCount,
                 _createdStopwatchTimestamp,
-                _options.LingerMs * Stopwatch.Frequency / 1_000);
+                _options.LingerMs * Stopwatch.Frequency / 1_000,
+                _incrementalBuffer);
 
             if (_admissionBudget is { } admissionBudget)
             {
@@ -7624,6 +7701,7 @@ internal sealed class PartitionBatch
             // Null out references - ownership transferred to ReadyBatch
             _completionSources = null!;
             _arena = null;
+            _incrementalBuffer = null;
             _callbacks = null;
         }
         catch
@@ -7702,10 +7780,13 @@ internal sealed class PartitionBatch
 
         // Return arena buffer if present
         _arena?.Return();
+        if (_incrementalBuffer is not null)
+            IncrementalBatchBuffer.ReturnToPool(_incrementalBuffer);
 
         // Null out references to prevent accidental reuse
         _completionSources = null!;
         _arena = null;
+        _incrementalBuffer = null;
 
         if (_callbacks is not null)
         {
@@ -7895,6 +7976,7 @@ internal sealed class ReadyBatch
     // Reuse queue for returning working arrays back to PartitionBatch without ArrayPool round-trip
     private BatchArrayReuseQueue? _arrayReuseQueue;
     private BatchArena? _arena; // Arena holding the batch's encoded record bytes
+    private IncrementalBatchBuffer? _incrementalBuffer;
 
     // Callbacks for Send(message, callback) - inline invocation without ThreadPool
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
@@ -8408,7 +8490,8 @@ internal sealed class ReadyBatch
         BatchArrayReuseQueue? arrayReuseQueue = null,
         int recordCount = 0,
         long createdStopwatchTimestamp = 0,
-        long lingerTicks = 0)
+        long lingerTicks = 0,
+        IncrementalBatchBuffer? incrementalBuffer = null)
     {
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
@@ -8450,6 +8533,7 @@ internal sealed class ReadyBatch
         AdmissionGeneration = 0;
         UnackedBudgetPipelineTracked = 0;
         _arena = arena;
+        _incrementalBuffer = incrementalBuffer;
         _callbacks = callbacks;
         _callbackCount = callbackCount;
         _arrayReuseQueue = arrayReuseQueue;
@@ -8508,6 +8592,7 @@ internal sealed class ReadyBatch
         DataSize = 0;
         EncodedSize = 0;
         _arena = null;
+        _incrementalBuffer = null;
         _callbacks = null;
         _callbackCount = 0;
         _arrayReuseQueue = null;
@@ -8939,6 +9024,7 @@ internal sealed class ReadyBatch
         var completionSourcesArray = _completionSourcesArray;
         var arrayReuseQueue = _arrayReuseQueue;
         var arena = _arena;
+        var incrementalBuffer = _incrementalBuffer;
         var callbacks = _callbacks;
         var recordBatch = _recordBatch;
 
@@ -8969,6 +9055,11 @@ internal sealed class ReadyBatch
             if (arena is not null)
             {
                 BatchArena.ReturnToPool(arena);
+            }
+
+            if (incrementalBuffer is not null)
+            {
+                IncrementalBatchBuffer.ReturnToPool(incrementalBuffer);
             }
 
             // Return callback array to dedicated pool if present

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2474,7 +2474,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         ProducerOptions.ValidateArenaCapacity(options.BatchSize, options.ArenaCapacity);
-        if (!Enum.IsDefined(options.BufferMemoryAllocationStrategy))
+        if (!ProducerOptions.IsBufferMemoryAllocationStrategyDefined(
+                options.BufferMemoryAllocationStrategy))
             throw new ArgumentOutOfRangeException(
                 nameof(options),
                 options.BufferMemoryAllocationStrategy,

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2487,7 +2487,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (options.BufferMemoryAllocationStrategy == BufferMemoryAllocationStrategy.Full)
             BatchArena.RatchetPoolSize(poolSize);
         else
-            IncrementalBatchBuffer.RatchetPoolSize(poolSize * ReadyBatchPoolSizeRatio);
+            IncrementalBatchBuffer.RatchetPoolSize(
+                poolSize * ReadyBatchPoolSizeRatio,
+                options.BatchSize);
         // ReadyBatch lifecycle spans seal→send→response→cleanup (longer than PartitionBatch),
         // so its pool needs to be larger to avoid exhaustion under sustained throughput.
         _readyBatchPool = new ReadyBatchPool(maxPoolSize: poolSize * ReadyBatchPoolSizeRatio);

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -668,6 +668,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     internal bool HasPreCompressedRecords => PreCompressedRecords is not null;
 
     private ReadOnlyMemory<byte> _preEncodedRecords;
+    private ReadOnlySequence<byte> _segmentedPreEncodedRecords;
+    private bool _hasSegmentedPreEncodedRecords;
     private bool _hasPreEncodedRecords;
     // Valid only while _preEncodedRecords remains retained for this batch and unmodified through Write().
     private uint _preEncodedRecordsCrc;
@@ -677,8 +679,25 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     internal void SetPreEncodedRecords(ReadOnlyMemory<byte> records)
     {
         _preEncodedRecords = records;
+        _segmentedPreEncodedRecords = default;
         _hasPreEncodedRecords = true;
+        _hasSegmentedPreEncodedRecords = false;
         _preEncodedRecordsCrc = Crc32C.Compute(records.Span);
+    }
+
+    internal void SetPreEncodedRecords(ReadOnlySequence<byte> records)
+    {
+        if (records.IsSingleSegment)
+        {
+            SetPreEncodedRecords(records.First);
+            return;
+        }
+
+        _preEncodedRecords = default;
+        _segmentedPreEncodedRecords = records;
+        _hasPreEncodedRecords = true;
+        _hasSegmentedPreEncodedRecords = true;
+        _preEncodedRecordsCrc = Crc32C.Compute(records);
     }
 
     /// <summary>
@@ -716,8 +735,10 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         var codec = registry.GetCodec(compression);
         if (_hasPreEncodedRecords)
         {
-            using var compressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, _preEncodedRecords.Length);
-            codec.Compress(new ReadOnlySequence<byte>(_preEncodedRecords), compressedBuffer);
+            using var compressedBuffer = new DetachableBufferWriter(
+                ProducerDataPool.BytePool,
+                GetPreEncodedRecordsLength());
+            codec.Compress(GetPreEncodedRecordsSequence(), compressedBuffer);
             PreCompressedRecordsCrc = Crc32C.Compute(compressedBuffer.WrittenSpan);
             PreCompressedRecords = compressedBuffer.DetachBuffer(out var compressedLength);
             PreCompressedLength = compressedLength;
@@ -878,7 +899,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             item.PreCompressedType = CompressionType.None;
             item.PreCompressedRecordsCrc = 0;
             item._preEncodedRecords = default;
+            item._segmentedPreEncodedRecords = default;
             item._hasPreEncodedRecords = false;
+            item._hasSegmentedPreEncodedRecords = false;
             item._preEncodedRecordsCrc = 0;
             item._consumerPoolOwner = null;
             item._consumerPoolOwnerGeneration = 0;
@@ -959,7 +982,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         batch.BaseSequence = baseSequence;
         batch.Records = Records;
         batch._preEncodedRecords = _preEncodedRecords;
+        batch._segmentedPreEncodedRecords = _segmentedPreEncodedRecords;
         batch._hasPreEncodedRecords = _hasPreEncodedRecords;
+        batch._hasSegmentedPreEncodedRecords = _hasSegmentedPreEncodedRecords;
         batch._preEncodedRecordsCrc = _preEncodedRecordsCrc;
 
         // Transfer pre-compressed data — records content is unchanged,
@@ -1009,6 +1034,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         // If pre-compressed at seal time, use that data directly (skip CPU-bound compression
         // on the send loop thread). Otherwise, serialize and compress inline.
         ReadOnlySpan<byte> compressedRecords;
+        ReadOnlySequence<byte> segmentedRecords = default;
+        var recordsAreSegmented = false;
         uint compressedRecordsCrc;
         CompressionType effectiveCompression;
 
@@ -1023,6 +1050,14 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                 compressedRecords = PreCompressedRecords.AsSpan(0, PreCompressedLength);
                 compressedRecordsCrc = PreCompressedRecordsCrc;
                 effectiveCompression = PreCompressedType;
+            }
+            else if (_hasSegmentedPreEncodedRecords)
+            {
+                compressedRecords = default;
+                segmentedRecords = _segmentedPreEncodedRecords;
+                recordsAreSegmented = true;
+                compressedRecordsCrc = _preEncodedRecordsCrc;
+                effectiveCompression = CompressionType.None;
             }
             else if (_hasPreEncodedRecords)
             {
@@ -1048,13 +1083,13 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
                     var compressedBuffer = GetCompressedBuffer(cache);
                     codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), compressedBuffer);
                     compressedRecords = compressedBuffer.WrittenSpan;
-                    compressedRecordsCrc = Crc32C.Compute(compressedRecords);
+                    compressedRecordsCrc = Crc32C.Compute(compressedBuffer.WrittenSpan);
                     effectiveCompression = compression;
                 }
                 else
                 {
                     compressedRecords = recordsBuffer.WrittenSpan;
-                    compressedRecordsCrc = Crc32C.Compute(compressedRecords);
+                    compressedRecordsCrc = Crc32C.Compute(recordsBuffer.WrittenSpan);
                     effectiveCompression = CompressionType.None;
                 }
             }
@@ -1063,7 +1098,10 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             // 4 (partition leader epoch) + 1 (magic) + 4 (crc) + 2 (attributes) +
             // 4 (last offset delta) + 8 (base timestamp) + 8 (max timestamp) +
             // 8 (producer id) + 2 (producer epoch) + 4 (base sequence) + 4 (records count) + records
-            var batchLength = BatchHeaderSize + compressedRecords.Length;
+            var recordsLength = recordsAreSegmented
+                ? checked((int)segmentedRecords.Length)
+                : compressedRecords.Length;
+            var batchLength = BatchHeaderSize + recordsLength;
 
             writer.WriteInt64(BaseOffset);
             writer.WriteInt32(batchLength);
@@ -1073,7 +1111,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             // CRC content size: 2 (attributes) + 4 (lastOffsetDelta) + 8 (baseTimestamp) +
             // 8 (maxTimestamp) + 8 (producerId) + 2 (producerEpoch) + 4 (baseSequence) +
             // 4 (recordsCount) + compressedRecords = 40 + records
-            var crcContentSize = CrcContentFixedSize + compressedRecords.Length;
+            var crcContentSize = CrcContentFixedSize + recordsLength;
 
             // Get one contiguous span for CRC (4 bytes) + content, write content directly,
             // calculate CRC, and backpatch. This avoids a crcBuffer intermediate copy, but
@@ -1105,9 +1143,12 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             BinaryPrimitives.WriteInt32BigEndian(contentSpan[offset..], records.Count);
             offset += 4;
             var headerCrc = Crc32C.Compute(contentSpan[..CrcContentFixedSize]);
-            compressedRecords.CopyTo(contentSpan[offset..]);
+            if (recordsAreSegmented)
+                segmentedRecords.CopyTo(contentSpan[offset..]);
+            else
+                compressedRecords.CopyTo(contentSpan[offset..]);
 
-            var crc = Crc32C.Combine(headerCrc, compressedRecordsCrc, compressedRecords.Length);
+            var crc = Crc32C.Combine(headerCrc, compressedRecordsCrc, recordsLength);
 
             // Backpatch CRC at the beginning
             BinaryPrimitives.WriteInt32BigEndian(crcAndContentSpan, (int)crc);
@@ -1117,7 +1158,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             // because compressedRecords may reference the cache's buffer writer.
             output.Advance(4 + crcContentSize);
 
-            return TotalBatchHeaderSize + compressedRecords.Length;
+            return TotalBatchHeaderSize + recordsLength;
         }
         finally
         {
@@ -1129,19 +1170,20 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     internal bool TryWriteSegmentedHeader(
         IBufferWriter<byte> output,
         CompressionType compression,
-        out ReadOnlyMemory<byte> encodedRecords)
+        out ReadOnlySequence<byte> encodedRecords)
     {
         uint encodedRecordsCrc;
         CompressionType effectiveCompression;
         if (PreCompressedRecords is { } preCompressedRecords)
         {
-            encodedRecords = preCompressedRecords.AsMemory(0, PreCompressedLength);
+            encodedRecords = new ReadOnlySequence<byte>(
+                preCompressedRecords.AsMemory(0, PreCompressedLength));
             encodedRecordsCrc = PreCompressedRecordsCrc;
             effectiveCompression = PreCompressedType;
         }
         else if (compression == CompressionType.None && _hasPreEncodedRecords)
         {
-            encodedRecords = _preEncodedRecords;
+            encodedRecords = GetPreEncodedRecordsSequence();
             encodedRecordsCrc = _preEncodedRecordsCrc;
             effectiveCompression = CompressionType.None;
         }
@@ -1153,7 +1195,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
         var writer = new KafkaProtocolWriter(output);
         writer.WriteInt64(BaseOffset);
-        writer.WriteInt32(BatchHeaderSize + encodedRecords.Length);
+        var encodedRecordsLength = checked((int)encodedRecords.Length);
+        writer.WriteInt32(BatchHeaderSize + encodedRecordsLength);
         writer.WriteInt32(PartitionLeaderEpoch);
         writer.WriteUInt8(Magic);
 
@@ -1173,7 +1216,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         BinaryPrimitives.WriteInt32BigEndian(contentSpan[36..], Records.Count);
 
         var headerCrc = Crc32C.Compute(contentSpan[..CrcContentFixedSize]);
-        var crc = Crc32C.Combine(headerCrc, encodedRecordsCrc, encodedRecords.Length);
+        var crc = Crc32C.Combine(headerCrc, encodedRecordsCrc, encodedRecordsLength);
         BinaryPrimitives.WriteInt32BigEndian(crcAndContentSpan, (int)crc);
         output.Advance(sizeof(uint) + CrcContentFixedSize);
         return true;
@@ -1198,10 +1241,20 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             throw new InvalidOperationException("Compressed RecordBatch size requires pre-compressed records.");
 
         if (_hasPreEncodedRecords)
-            return _preEncodedRecords.Length;
+            return GetPreEncodedRecordsLength();
 
         return GetEncodedRecordsLength(Records);
     }
+
+    private ReadOnlySequence<byte> GetPreEncodedRecordsSequence() =>
+        _hasSegmentedPreEncodedRecords
+            ? _segmentedPreEncodedRecords
+            : new ReadOnlySequence<byte>(_preEncodedRecords);
+
+    private int GetPreEncodedRecordsLength() =>
+        _hasSegmentedPreEncodedRecords
+            ? checked((int)_segmentedPreEncodedRecords.Length)
+            : _preEncodedRecords.Length;
 
     private static void WriteRecords(IReadOnlyList<Record> records, ref KafkaProtocolWriter writer)
     {
@@ -1519,6 +1572,52 @@ internal readonly struct PooledRecordData
     public byte[]? PooledArray => _pooledArray;
 
     public static implicit operator ReadOnlyMemory<byte>(PooledRecordData data) => data.Memory;
+}
+
+/// <summary>
+/// Count-only producer record view. Producer batches already contain encoded records, so send
+/// paths need only the count and never materialize <see cref="Record"/> instances.
+/// </summary>
+internal sealed class ProducerRecordCountList : IReadOnlyList<Record>, IDisposable
+{
+    private static readonly ProducerRecordCountListPool s_pool = new();
+    private int _count;
+    private int _disposed;
+
+    private sealed class ProducerRecordCountListPool()
+        : ObjectPool<ProducerRecordCountList>(2048)
+    {
+        protected override ProducerRecordCountList Create() => new();
+        protected override void Reset(ProducerRecordCountList item) => item._count = 0;
+    }
+
+    private ProducerRecordCountList() { }
+
+    internal static ProducerRecordCountList Rent(int count)
+    {
+        var list = s_pool.Rent();
+        list._count = count;
+        Volatile.Write(ref list._disposed, 0);
+        return list;
+    }
+
+    public int Count => Volatile.Read(ref _disposed) == 0
+        ? _count
+        : throw new ObjectDisposedException(nameof(ProducerRecordCountList));
+
+    public Record this[int index] => throw new NotSupportedException(
+        "Producer record data is retained in encoded form and cannot be indexed.");
+
+    public IEnumerator<Record> GetEnumerator() => throw new NotSupportedException(
+        "Producer record data is retained in encoded form and cannot be enumerated.");
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            s_pool.Return(this);
+    }
 }
 
 internal sealed class LazyRecordList : IReadOnlyList<Record>, IDisposable

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -12,6 +12,36 @@ namespace Dekaf.Tests.Integration;
 public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    public async Task Producer_WithIncrementalBatchMemory_ProducesAcrossChunkBoundaries()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        await using var producer = await Kafka.CreateProducer<string, byte[]>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-incremental-memory")
+            .WithBatchSize(256 * 1024)
+            .WithLinger(TimeSpan.FromMilliseconds(100))
+            .WithBufferMemoryAllocationStrategy(BufferMemoryAllocationStrategy.Incremental)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var produces = new Task<RecordMetadata>[64];
+        for (var i = 0; i < produces.Length; i++)
+        {
+            produces[i] = producer.ProduceAsync(new ProducerMessage<string, byte[]>
+            {
+                Topic = topic,
+                Key = "shared-key",
+                Value = new byte[1024]
+            }, CancellationToken.None).AsTask();
+        }
+
+        var results = await Task.WhenAll(produces).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(results.Length).IsEqualTo(produces.Length);
+        await Assert.That(results.All(static result => result.Offset >= 0)).IsTrue();
+    }
+
+    [Test]
     public async Task Producer_ProduceWithAcksAll_SuccessfullyProduces()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -1,3 +1,5 @@
+using Dekaf.Producer;
+
 namespace Dekaf.Tests.Unit.Builder;
 
 public class ProducerBuilderValidationTests
@@ -262,6 +264,24 @@ public class ProducerBuilderValidationTests
         var builder = Kafka.CreateProducer<string, string>();
         var result = builder.WithBufferMemory(1024);
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithBufferMemoryAllocationStrategy_ReturnsSameBuilder()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        var result = builder.WithBufferMemoryAllocationStrategy(
+            BufferMemoryAllocationStrategy.Incremental);
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    [Test]
+    public async Task WithBufferMemoryAllocationStrategy_InvalidValue_Throws()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+        await Assert.That(() => builder.WithBufferMemoryAllocationStrategy(
+                (BufferMemoryAllocationStrategy)42))
+            .Throws<ArgumentOutOfRangeException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -647,6 +647,7 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:ValueTaskSourcePoolSize"] = "128",
             ["Kafka:Producers:Orders:ArenaCapacity"] = "131072",
             ["Kafka:Producers:Orders:InitialBatchRecordCapacity"] = "32",
+            ["Kafka:Producers:Orders:BufferMemoryAllocationStrategy"] = "Incremental",
             ["Kafka:Producers:Orders:MetadataRecoveryStrategy"] = "None",
             ["Kafka:Producers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "60000",
             ["Kafka:Producers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly"
@@ -696,6 +697,8 @@ public class DependencyInjectionTests
         await Assert.That(options.ValueTaskSourcePoolSize).IsEqualTo(128);
         await Assert.That(options.ArenaCapacity).IsEqualTo(131072);
         await Assert.That(options.InitialBatchRecordCapacity).IsEqualTo(32);
+        await Assert.That(options.BufferMemoryAllocationStrategy)
+            .IsEqualTo(BufferMemoryAllocationStrategy.Incremental);
         await Assert.That(options.MetadataRecoveryStrategy).IsEqualTo(MetadataRecoveryStrategy.None);
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(60000);
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Reflection;
@@ -182,14 +183,16 @@ public sealed class KafkaConnectionTests
         await Assert.That(segmented).IsTrue();
         try
         {
-            var actual = new byte[prefixLength + encodedRecords.Count + suffixLength];
+            var encodedRecordsLength = checked((int)encodedRecords.Length);
+            var actual = new byte[prefixLength + encodedRecordsLength + suffixLength];
             metadataArray.AsSpan(0, prefixLength).CopyTo(actual);
-            encodedRecords.AsSpan().CopyTo(actual.AsSpan(prefixLength));
+            encodedRecords.CopyTo(actual.AsSpan(prefixLength));
             metadataArray.AsSpan(suffixOffset, suffixLength)
-                .CopyTo(actual.AsSpan(prefixLength + encodedRecords.Count));
+                .CopyTo(actual.AsSpan(prefixLength + encodedRecordsLength));
 
             await Assert.That(actual).IsEquivalentTo(expected);
-            await Assert.That(encodedRecords.Array).IsSameReferenceAs(encodedRecordsBackingArray);
+            MemoryMarshal.TryGetArray(encodedRecords.First, out var firstRecordsSegment);
+            await Assert.That(firstRecordsSegment.Array).IsSameReferenceAs(encodedRecordsBackingArray);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -238,6 +238,18 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task ScatterGatherSender_PreSizesChunkedPendingSegments()
+    {
+        const int chunkedBatchSegmentCount = 66;
+
+        using var sender = new KafkaConnection.SocketScatterGatherSender(
+            chunkedBatchSegmentCount);
+
+        await Assert.That(sender.PendingSegments.Capacity)
+            .IsGreaterThanOrEqualTo(chunkedBatchSegmentCount);
+    }
+
+    [Test]
     public async Task SingleBatchProduceSegments_UnpreparedCompressedBatch_FallsBack()
     {
         var batch = new RecordBatch

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -202,29 +202,39 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
-    public async Task ConsumeSentSegments_PartialSend_AdvancesAcrossSegmentBoundary()
+    public async Task ScatterGatherSender_PartialSend_AdvancesAcrossWindowBoundary()
     {
-        var first = new byte[3];
-        var second = new byte[4];
-        var third = new byte[2];
-        var segments = new List<ArraySegment<byte>>
-        {
-            new(first),
-            new(second),
-            new(third)
-        };
+        using var sender = new KafkaConnection.SocketScatterGatherSender();
+        var buffers = Enumerable.Range(
+                0,
+                KafkaConnection.SocketScatterGatherSender.MaximumSegmentsPerSend + 2)
+            .Select(_ => new byte[4])
+            .ToArray();
+        foreach (var buffer in buffers)
+            sender.PendingSegments.Add(new ArraySegment<byte>(buffer));
 
-        KafkaConnection.ConsumeSentSegments(segments, 5);
+        sender.BeginPendingSend();
+        sender.LoadSendWindow();
+        await Assert.That(sender.Segments.Count)
+            .IsEqualTo(KafkaConnection.SocketScatterGatherSender.MaximumSegmentsPerSend);
 
-        await Assert.That(segments.Count).IsEqualTo(2);
-        await Assert.That(segments[0].Array).IsSameReferenceAs(second);
-        await Assert.That(segments[0].Offset).IsEqualTo(2);
-        await Assert.That(segments[0].Count).IsEqualTo(2);
-        await Assert.That(segments[1].Array).IsSameReferenceAs(third);
+        sender.ConsumeSentBytes((15 * 4) + 2);
+        sender.LoadSendWindow();
 
-        KafkaConnection.ConsumeSentSegments(segments, 4);
+        await Assert.That(sender.Segments.Count).IsEqualTo(3);
+        await Assert.That(sender.Segments[0].Array).IsSameReferenceAs(buffers[15]);
+        await Assert.That(sender.Segments[0].Offset).IsEqualTo(2);
+        await Assert.That(sender.Segments[0].Count).IsEqualTo(2);
+        await Assert.That(sender.Segments[1].Array).IsSameReferenceAs(buffers[16]);
+        await Assert.That(sender.Segments[2].Array).IsSameReferenceAs(buffers[17]);
 
-        await Assert.That(segments).IsEmpty();
+        sender.ConsumeSentBytes(6);
+        sender.LoadSendWindow();
+        await Assert.That(sender.Segments.Count).IsEqualTo(1);
+        await Assert.That(sender.Segments[0].Array).IsSameReferenceAs(buffers[17]);
+
+        sender.ConsumeSentBytes(4);
+        await Assert.That(sender.HasPendingSegments).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/IncrementalBatchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IncrementalBatchBufferTests.cs
@@ -1,0 +1,163 @@
+using System.Buffers;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class IncrementalBatchBufferTests
+{
+    [Test]
+    public async Task IncrementalStrategy_AllocatesStorageAsRecordsArrive()
+    {
+        var incremental = new PartitionBatch(
+            new TopicPartition("topic", 0),
+            CreateOptions(BufferMemoryAllocationStrategy.Incremental));
+        var full = new PartitionBatch(
+            new TopicPartition("topic", 0),
+            CreateOptions(BufferMemoryAllocationStrategy.Full));
+
+        await Assert.That(incremental.RetainedBatchBufferCapacity).IsEqualTo(0);
+        await Assert.That(full.RetainedBatchBufferCapacity).IsGreaterThanOrEqualTo(1024 * 1024);
+
+        var result = Append(incremental, timestamp: 1, new byte[32]);
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(incremental.RetainedBatchBufferCapacity)
+            .IsLessThanOrEqualTo(IncrementalBatchBuffer.MaximumChunkSize);
+
+        incremental.Complete()!.CompleteSend(0, DateTimeOffset.UnixEpoch);
+        full.FailCompleteFailure(new InvalidOperationException("test cleanup"));
+    }
+
+    [Test]
+    [Arguments(CompressionType.None)]
+    [Arguments(CompressionType.Gzip)]
+    public async Task IncrementalStrategy_ProducesByteEquivalentBatch(CompressionType compression)
+    {
+        var full = CreateCompletedBatch(BufferMemoryAllocationStrategy.Full);
+        var incremental = CreateCompletedBatch(BufferMemoryAllocationStrategy.Incremental);
+
+        try
+        {
+            full.RecordBatch.PreCompress(compression, null);
+            incremental.RecordBatch.PreCompress(compression, null);
+
+            var fullBytes = Write(full.RecordBatch, compression);
+            var incrementalBytes = Write(incremental.RecordBatch, compression);
+
+            if (compression == CompressionType.None)
+            {
+                await Assert.That(incrementalBytes).IsEquivalentTo(fullBytes);
+            }
+            else
+            {
+                using var parsedFull = Read(fullBytes);
+                using var parsedIncremental = Read(incrementalBytes);
+                await Assert.That(parsedIncremental.Records.Count).IsEqualTo(parsedFull.Records.Count);
+                for (var i = 0; i < parsedFull.Records.Count; i++)
+                {
+                    await Assert.That(parsedIncremental.Records[i].Value.ToArray())
+                        .IsEquivalentTo(parsedFull.Records[i].Value.ToArray());
+                }
+            }
+        }
+        finally
+        {
+            full.CompleteSend(0, DateTimeOffset.UnixEpoch);
+            incremental.CompleteSend(0, DateTimeOffset.UnixEpoch);
+        }
+    }
+
+    [Test]
+    public async Task IncrementalStrategy_EncodingFailureRewindsAndReturnsChunk()
+    {
+        var buffer = IncrementalBatchBuffer.Rent(1024 * 1024);
+        try
+        {
+            buffer.Allocate(200, out var first, out var firstOffset, out var logicalOffset);
+            first.AsSpan(firstOffset, 200).Fill(0x2a);
+
+            await Assert.That(buffer.Length).IsEqualTo(200);
+            await Assert.That(buffer.TryRewindLastAllocation(logicalOffset, 200)).IsTrue();
+            await Assert.That(buffer.Length).IsEqualTo(0);
+            await Assert.That(buffer.RetainedCapacity).IsEqualTo(0);
+        }
+        finally
+        {
+            IncrementalBatchBuffer.ReturnToPool(buffer);
+        }
+    }
+
+    [Test]
+    public async Task IncrementalStrategy_FirstOversizedRecordUsesDedicatedChunk()
+    {
+        var options = CreateOptions(
+            BufferMemoryAllocationStrategy.Incremental,
+            batchSize: 1024,
+            maxRequestSize: 64 * 1024);
+        var batch = new PartitionBatch(new TopicPartition("topic", 0), options);
+        var value = new byte[8 * 1024];
+
+        var result = Append(batch, timestamp: 1, value);
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(batch.RetainedBatchBufferCapacity).IsGreaterThanOrEqualTo(value.Length);
+        batch.Complete()!.CompleteSend(0, DateTimeOffset.UnixEpoch);
+    }
+
+    private static ProducerOptions CreateOptions(
+        BufferMemoryAllocationStrategy strategy,
+        int batchSize = 1024 * 1024,
+        int maxRequestSize = 1024 * 1024) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        BufferMemory = 64 * 1024 * 1024,
+        BatchSize = batchSize,
+        MaxRequestSize = maxRequestSize,
+        LingerMs = 10_000,
+        BufferMemoryAllocationStrategy = strategy
+    };
+
+    private static ReadyBatch CreateCompletedBatch(BufferMemoryAllocationStrategy strategy)
+    {
+        var batch = new PartitionBatch(new TopicPartition("topic", 3), CreateOptions(strategy));
+        for (var i = 0; i < 40; i++)
+        {
+            var value = new byte[997 + i];
+            value.AsSpan().Fill((byte)i);
+            var result = Append(batch, 1_700_000_000_000 + i, value);
+            if (!result.Success)
+                throw new InvalidOperationException($"Record {i} did not fit.");
+        }
+
+        return batch.Complete()!;
+    }
+
+    private static RecordAppendResult Append(PartitionBatch batch, long timestamp, byte[] value) =>
+        batch.TryAppendFromSpans(
+            timestamp,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            PartitionBatch.EstimateRecordSize(0, value.Length, null, 0));
+
+    private static byte[] Write(RecordBatch batch, CompressionType compression)
+    {
+        var output = new ArrayBufferWriter<byte>();
+        batch.Write(output, compression);
+        return output.WrittenSpan.ToArray();
+    }
+
+    private static RecordBatch Read(byte[] bytes)
+    {
+        var reader = new KafkaProtocolReader(bytes);
+        return RecordBatch.Read(ref reader, codecs: null, availableBytes: bytes.Length, checkCrcs: true);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/IncrementalBatchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/IncrementalBatchBufferTests.cs
@@ -9,6 +9,21 @@ namespace Dekaf.Tests.Unit.Producer;
 public class IncrementalBatchBufferTests
 {
     [Test]
+    public async Task ChunkPoolSize_ScalesByChunksPerLiveBatch()
+    {
+        const int liveBatchCount = 256;
+        const int batchSize = 1024 * 1024;
+
+        var poolSize = IncrementalBatchBuffer.ComputeChunkPoolSize(liveBatchCount, batchSize);
+        var partialChunkPoolSize = IncrementalBatchBuffer.ComputeChunkPoolSize(
+            liveBatchCount,
+            IncrementalBatchBuffer.MaximumChunkSize + 1);
+
+        await Assert.That(poolSize).IsEqualTo(liveBatchCount * 64);
+        await Assert.That(partialChunkPoolSize).IsEqualTo(liveBatchCount * 2);
+    }
+
+    [Test]
     public async Task IncrementalStrategy_AllocatesStorageAsRecordsArrive()
     {
         var incremental = new PartitionBatch(

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -209,6 +209,14 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task BufferMemoryAllocationStrategy_DefaultsTo_Full()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.BufferMemoryAllocationStrategy)
+            .IsEqualTo(BufferMemoryAllocationStrategy.Full);
+    }
+
+    [Test]
     public async Task ValueTaskSourcePoolSize_DefaultsTo_0_AutoCalculate()
     {
         var options = CreateOptions();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
@@ -52,7 +52,7 @@ public class BatchMemoryAllocationBenchmarks
 
         if (AllocationStrategy == BufferMemoryAllocationStrategy.Incremental)
         {
-            IncrementalBatchBuffer.RatchetPoolSize(poolSize * 2);
+            IncrementalBatchBuffer.RatchetPoolSize(poolSize * 2, _options.BatchSize);
             IncrementalBatchBuffer.PreWarm(poolSize * 2, _options.BatchSize);
         }
         else

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
@@ -1,0 +1,136 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Compares deterministic append throughput and steady-state allocations for full and
+/// incremental batch storage without the accumulator benchmark's asynchronous drainer noise.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class BatchMemoryAllocationBenchmarks
+{
+    private const int OperationsPerInvoke = 100;
+    private readonly TopicPartition _topicPartition = new("benchmark-topic", 0);
+    private ProducerOptions _options = null!;
+    private PartitionBatchPool _batchPool = null!;
+    private ReadyBatchPool _readyBatchPool = null!;
+    private PartitionBatch _batch = null!;
+    private byte[] _value = null!;
+    private int _estimatedSize;
+    private long _timestamp;
+
+    [Params(100, 1000)]
+    public int MessageSize { get; set; }
+
+    [Params(BufferMemoryAllocationStrategy.Full, BufferMemoryAllocationStrategy.Incremental)]
+    public BufferMemoryAllocationStrategy AllocationStrategy { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1_048_576,
+            BufferMemory = 256L * 1024 * 1024,
+            LingerMs = 100,
+            BufferMemoryAllocationStrategy = AllocationStrategy
+        };
+        _value = new byte[MessageSize];
+        _estimatedSize = PartitionBatch.EstimateRecordSize(0, MessageSize, null, 0);
+        _timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        const int poolSize = BatchArena.DefaultPoolSize;
+        _readyBatchPool = new ReadyBatchPool(poolSize * 2);
+        _batchPool = new PartitionBatchPool(_options, poolSize);
+        _batchPool.SetReadyBatchPool(_readyBatchPool);
+
+        if (AllocationStrategy == BufferMemoryAllocationStrategy.Incremental)
+        {
+            IncrementalBatchBuffer.RatchetPoolSize(poolSize * 2);
+            IncrementalBatchBuffer.PreWarm(poolSize * 2, _options.BatchSize);
+        }
+        else
+        {
+            BatchArena.PreWarm(16, ProducerOptions.GetEffectiveArenaCapacity(
+                _options.BatchSize,
+                _options.ArenaCapacity));
+        }
+
+        _readyBatchPool.PreWarm(32);
+        _batchPool.PreWarm(16);
+        _batch = _batchPool.Rent(_topicPartition, partitionCount: 1);
+
+        for (var i = 0; i < 100_000; i++)
+            AppendOne();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => CompleteAndReturnBatch();
+
+    [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+    public int Append()
+    {
+        for (var i = 0; i < OperationsPerInvoke; i++)
+            AppendOne();
+
+        return _batch.RecordCount;
+    }
+
+    private void AppendOne()
+    {
+        var result = _batch.TryAppendFromSpans(
+            _timestamp++,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            _value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: null,
+            _estimatedSize);
+
+        if (result.Success)
+            return;
+
+        RotateBatch();
+        if (!_batch.TryAppendFromSpans(
+                _timestamp++,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                _value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                _estimatedSize).Success)
+        {
+            throw new InvalidOperationException("Record did not fit in an empty benchmark batch.");
+        }
+    }
+
+    private void RotateBatch()
+    {
+        CompleteAndReturnBatch();
+        _batch = _batchPool.Rent(_topicPartition, partitionCount: 1);
+    }
+
+    private void CompleteAndReturnBatch()
+    {
+        var completed = _batch.Complete();
+        if (completed is not null)
+        {
+            completed.CompleteSend(0, DateTimeOffset.UnixEpoch);
+            _readyBatchPool.Return(completed);
+        }
+
+        _batchPool.Return(_batch);
+    }
+}


### PR DESCRIPTION
## Summary

- add KIP-1332-style `Full` (default) and opt-in `Incremental` producer batch allocation
- store incremental records in pooled 16 KiB chunks and expose them as `ReadOnlySequence<byte>`
- compress segmented input without flattening and send uncompressed input with bounded TCP scatter/gather windows
- return chunks on success, failure, retry, cancellation, disposal, and pool recycle paths
- wire fluent API, options/configuration binding, docs, tests, integration coverage, and benchmarks

Reference: https://cwiki.apache.org/confluence/spaces/KAFKA/pages/421957499/KIP-1332%2BDynamic%2Bmemory%2Ballocation%2Bfor%2Bthe%2BKafka%2Bproducer

## Validation

- Release unit tests: net10.0 5622/5622 passed
- Release unit tests: net8.0 5496/5496 passed on the feature build
- post-rebase focused unit tests: 52/52 passed
- Kafka integration: incremental batch crossing chunk boundaries passed
- builds: net10.0, netstandard2.0, integration, benchmarks; 0 warnings/errors
- deterministic BenchmarkDotNet append benchmark: 0 B/op for both strategies

| Message | Full | Incremental | Delta |
|---:|---:|---:|---:|
| 100 B | 43.38 ns | 51.15 ns | +17.9% |
| 1000 B | 162.18 ns | 250.20 ns | +54.3% |

Incremental mode trades append CPU for proportional retained memory; the default full path remains unchanged. A 1 MiB batch with one 32-byte value retained at most one 16 KiB chunk instead of a >=1 MiB arena.

One later combined net8.0 rerun observed the existing timing race in `AdaptiveScaleDownTests.PartitionLimitedPressure_DisposeFlushesPartialWindow` (3 diagnostics vs 2); it passed isolated, and no changed code touches that diagnostic path.

Closes #2239