### PR TITLE
fix(oauth): validate direct assertion parameters

### DIFF
--- a/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerClientAssertionOptions.cs
@@ -82,9 +82,15 @@ public sealed class OAuthBearerClientAssertionOptions
         if (TokenRefreshBufferSeconds < 0)
             throw new InvalidOperationException("OAuth client-assertion token refresh buffer must be non-negative");
 
-        if (AdditionalParameters is not null)
+        ValidateAdditionalParameters(AdditionalParameters);
+    }
+
+    internal static void ValidateAdditionalParameters(
+        IReadOnlyDictionary<string, string>? additionalParameters)
+    {
+        if (additionalParameters is not null)
         {
-            foreach (var name in AdditionalParameters.Keys)
+            foreach (var name in additionalParameters.Keys)
             {
                 if (name is "grant_type"
                     or "client_id"

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -191,6 +191,12 @@ public sealed class OAuthBearerTokenProvider : IDisposable
 
     private Dictionary<string, string> BuildTokenRequestBody()
     {
+        if (_config.ClientAssertion is not null)
+        {
+            OAuthBearerClientAssertionOptions.ValidateAdditionalParameters(
+                _config.AdditionalParameters);
+        }
+
         var body = _config.GrantType switch
         {
             OAuthBearerGrantType.ClientCredentials => BuildClientCredentialsTokenRequestBody(),

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -377,6 +377,39 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    [Arguments("grant_type")]
+    [Arguments("client_id")]
+    [Arguments("client_secret")]
+    [Arguments("client_assertion_type")]
+    [Arguments("client_assertion")]
+    public async Task GetTokenAsync_WithDirectClientAssertionAndReservedParameter_Throws(
+        string parameterName)
+    {
+        using var rsa = RSA.Create(2048);
+        var handler = new CapturingTokenEndpointHandler();
+        var config = new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = "client",
+            ClientAssertion = new OAuthBearerClientAssertionOptions
+            {
+                PrivateKey = rsa,
+                Audience = "https://auth.example.test/token"
+            },
+            AdditionalParameters = new Dictionary<string, string>
+            {
+                [parameterName] = "override"
+            }
+        };
+        using var provider = new OAuthBearerTokenProvider(config, new HttpClient(handler));
+
+        await Assert.That(async () => _ = await provider.GetTokenAsync())
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("reserved");
+        await Assert.That(handler.Requests).IsEmpty();
+    }
+
+    [Test]
     public async Task GetTokenAsync_WithAzureImds_SendsMetadataGetRequest()
     {
         var handler = new CapturingAzureImdsHandler();


### PR DESCRIPTION
Follow-up to #2266. That PR merged while its final review fix was being pushed, leaving the direct `OAuthBearerConfig.ClientAssertion` path able to bypass reserved-form validation.

This change:
- shares reserved client-assertion parameter validation
- validates immediately before token-request form merging
- prevents direct config and Schema Registry paths from sending `client_secret` or overriding generated assertion fields
- covers all five reserved names and proves no HTTP request is sent

Validation:
- focused direct-config cases: 5/5 passed
- full unit suite: 5,637/5,637 passed
- Release build: 0 warnings, 0 errors

Closes #2220