### PR TITLE
perf(producer): implement KIP-126 batch splitting

### DIFF
--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -41,6 +41,12 @@ internal static class DekafMetrics
             unit: "{retry}",
             description: "Number of produce retries.");
 
+    internal static readonly Counter<long> BatchSplits =
+        DekafDiagnostics.Meter.CreateCounter<long>(
+            "dekaf.producer.batch.splits",
+            unit: "{split}",
+            description: "Number of oversized produce batches split for KIP-126 retry.");
+
     internal static readonly Counter<long> InlineContinuationExceptions =
         DekafDiagnostics.Meter.CreateCounter<long>(
             "dekaf.producer.inline_continuation.exceptions",

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -761,6 +761,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// no ambient context (e.g. <c>AsyncLocal</c>, <c>SecurityContext</c>) needs to flow.
     /// </remarks>
     private readonly Action _responseCompletionCallback;
+    private readonly Action _senderRetryReadyCallback;
     private int _disposed;
     private int _deferredPendingResponseCleanupCount;
 
@@ -880,6 +881,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 _eventChannel.Writer.TryWrite(SendLoopEvent.ResponseReady());
             _anyResponseCompleted.Signal();
         };
+        _senderRetryReadyCallback = _anyResponseCompleted.Signal;
         _cts = new CancellationTokenSource();
         _retainedConnectionGroupPool = connectionPool as ConnectionPool;
         try
@@ -3077,7 +3079,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             CompleteInflightEntry(batch);
                             var splitRetries = _accumulator.SplitForSenderRetry(
                                 batch,
-                                pending.BatchGenerations[j]);
+                                pending.BatchGenerations[j],
+                                _senderRetryReadyCallback);
                             if (splitRetries is not null)
                             {
                                 // ProcessCompletedResponses walks requests oldest-first. Put

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -331,6 +331,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         private readonly Dictionary<TopicPartition, List<BatchReference>> _partitions = new();
         private int _count;
         private bool _mayContainUnreadyBatch;
+        private TopicPartition _readdedPrefixPartition;
+        private int _readdedPrefixCount;
+        private bool _hasReaddedPrefix;
 
         public int Count => _count;
         public Dictionary<TopicPartition, List<BatchReference>> Partitions => _partitions;
@@ -374,6 +377,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Insert(0, batchRef);
             _count++;
             _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
+        }
+
+        /// <summary>
+        /// Re-adds an older wire-ready prefix entry before the unready suffix that blocked it.
+        /// Multiple re-adds retain their original drain order.
+        /// </summary>
+        public void ReAddBeforeUnreadySuffix(BatchReference batchRef)
+        {
+            var queue = GetOrCreateQueue(batchRef.Batch.TopicPartition);
+            if (!_hasReaddedPrefix || _readdedPrefixPartition != batchRef.Batch.TopicPartition)
+            {
+                _readdedPrefixPartition = batchRef.Batch.TopicPartition;
+                _readdedPrefixCount = 0;
+                _hasReaddedPrefix = true;
+            }
+
+            queue.Insert(_readdedPrefixCount++, batchRef);
+            _count++;
         }
 
         /// <summary>
@@ -426,6 +447,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         /// </summary>
         public void DrainTo(List<BatchReference> destination)
         {
+            if (_hasReaddedPrefix)
+                _hasReaddedPrefix = false;
+
             if (!_mayContainUnreadyBatch)
             {
                 foreach (var kvp in _partitions)
@@ -1391,7 +1415,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 for (var i = 0; i < drainList.Count; i++)
                 {
                     CoalesceBatch(drainList[i], coalescedBatches, coalescedGenerations, ref coalescedCount,
-                        ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
+                        ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver,
+                        fromCarryOver: true);
                 }
 
                 // Read from the event channel lazily during coalescing (like main reads
@@ -1414,7 +1439,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             var carryBefore = carryOver.Count;
                             channelReads++;
                             CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
-                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
+                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver,
+                                fromCarryOver: false);
                             if (carryOver.Count > carryBefore)
                             {
                                 channelCarryOvers++;
@@ -1488,7 +1514,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         {
                             var countBefore = coalescedCount;
                             CoalesceBatch(evt.GetBatchReference(), coalescedBatches, coalescedGenerations, ref coalescedCount,
-                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver);
+                                ref coalescedRequestBudgetUsed, coalescedPartitions, carryOver,
+                                fromCarryOver: false);
                             if (coalescedCount > countBefore)
                             {
                                 var now = Stopwatch.GetTimestamp();
@@ -2169,7 +2196,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         ref int coalescedCount,
         ref long coalescedRequestBudgetUsed,
         HashSet<TopicPartition> coalescedPartitions,
-        PartitionCarryOver carryOver)
+        PartitionCarryOver carryOver,
+        bool fromCarryOver)
     {
         // Batch may have been returned to pool or re-rented by a racing owner before
         // the send loop sees this reference. Skip silently; the original owner already
@@ -2212,7 +2240,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // Check backoff — carry over if backoff hasn't elapsed
             if (batch.RetryNotBefore > 0 && now < batch.RetryNotBefore)
             {
-                carryOver.Add(batchRef);
+                RequeueBatch(carryOver, batchRef, fromCarryOver);
                 return;
             }
 
@@ -2221,7 +2249,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // that same-connection pipeline drains, then order the retry before new work.
             if (!_isIdempotent && HasPendingResponseForPartition(batch.TopicPartition))
             {
-                carryOver.Add(batchRef);
+                RequeueBatch(carryOver, batchRef, fromCarryOver);
                 return;
             }
 
@@ -2256,6 +2284,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     coalescedCount,
                     coalescedRequestBudgetUsed,
                     carryOver,
+                    fromCarryOver,
                     out var batchRequestBodySize))
                 return;
 
@@ -2263,7 +2292,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             {
                 // Same partition already in this request (shouldn't happen — only one
                 // retry per partition at a time). Carry over as safety net.
-                carryOver.Add(batchRef);
+                RequeueBatch(carryOver, batchRef, fromCarryOver);
                 return;
             }
 
@@ -2286,7 +2315,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             LogPartitionMuted(_brokerId, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
             batch.AppendDiag('O');
-            carryOver.Add(batchRef);
+            RequeueBatch(carryOver, batchRef, fromCarryOver);
             return;
         }
 
@@ -2296,6 +2325,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 coalescedCount,
                 coalescedRequestBudgetUsed,
                 carryOver,
+                fromCarryOver,
                 out var normalBatchRequestBodySize))
             return;
 
@@ -2303,7 +2333,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         if (!coalescedPartitions.Add(batch.TopicPartition))
         {
             batch.AppendDiag('O');
-            carryOver.Add(batchRef);
+            RequeueBatch(carryOver, batchRef, fromCarryOver);
             return;
         }
 
@@ -2402,6 +2432,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         int coalescedCount,
         long coalescedRequestBudgetUsed,
         PartitionCarryOver carryOver,
+        bool fromCarryOver,
         out int batchRequestBodySize)
     {
         batchRequestBodySize = 0;
@@ -2422,8 +2453,20 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         var batch = batchRef.Batch;
         batch.AppendDiag('O');
-        carryOver.Add(batchRef);
+        RequeueBatch(carryOver, batchRef, fromCarryOver);
         return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RequeueBatch(
+        PartitionCarryOver carryOver,
+        BatchReference batchRef,
+        bool fromCarryOver)
+    {
+        if (fromCarryOver)
+            carryOver.ReAddBeforeUnreadySuffix(batchRef);
+        else
+            carryOver.Add(batchRef);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1997,7 +1997,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     var wakeupMs = ComputeNextWakeupMs(carryOver);
                     if (wakeupMs > 0)
                     {
-                        await Task.Delay(Math.Min(wakeupMs, 100), cancellationToken).ConfigureAwait(false);
+                        await WaitForNoPendingCarryOverAsync(wakeupMs, cancellationToken)
+                            .ConfigureAwait(false);
                     }
                 }
             }
@@ -3569,6 +3570,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // Throws OperationCanceledException only on shutdown (via RegisterShutdownToken).
         await _anyResponseCompleted.WaitAsync(timeoutMs).ConfigureAwait(false);
     }
+
+    private ValueTask WaitForNoPendingCarryOverAsync(
+        int wakeupMs,
+        CancellationToken cancellationToken) =>
+        WaitForAnyResponseAsync(Math.Min(wakeupMs, 100), cancellationToken);
 
     internal static bool ShouldPublishResponseReadyEvent(int totalMaxInFlight)
         => totalMaxInFlight > 1;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -2479,7 +2479,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             var generation = generations[readIdx];
             if (!batch.TryAcquireResourcePin(generation))
             {
-                LogStaleBatchInSendSkipped(_instanceId, _brokerId);
+                if (!_accumulator.TryCleanupFailedPreSerializationBatch(batch, generation))
+                    LogStaleBatchInSendSkipped(_instanceId, _brokerId);
                 continue;
             }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3022,12 +3022,13 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         && batch.RecordCount > 1
                         && !batch.IsSendCompleted)
                     {
+                        var splitTopicPartition = batch.TopicPartition;
                         LogBatchSplit(
                             _brokerId,
-                            batch.TopicPartition.Topic,
-                            batch.TopicPartition.Partition,
+                            splitTopicPartition.Topic,
+                            splitTopicPartition.Partition,
                             batch.RecordCount);
-                        MutePartition(batch.TopicPartition);
+                        MutePartition(splitTopicPartition);
                         try
                         {
                             CompleteInflightEntry(batch);
@@ -3036,18 +3037,18 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                                 // Keep the BrokerSender fence until the first split retry is
                                 // coalesced, but let the accumulator drain the children that
                                 // were inserted ahead of newer partition work.
-                                _accumulator.UnmutePartition(batch.TopicPartition);
+                                _accumulator.UnmutePartition(splitTopicPartition);
                                 batches[j] = null!;
                                 continue;
                             }
                         }
                         catch
                         {
-                            UnmutePartition(batch.TopicPartition);
+                            UnmutePartition(splitTopicPartition);
                             throw;
                         }
 
-                        UnmutePartition(batch.TopicPartition);
+                        UnmutePartition(splitTopicPartition);
                     }
 
                     if (partitionResponse.ErrorCode.IsRetriable()

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -244,7 +244,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         TransactionEnrollmentReady
     }
 
-    private readonly struct BatchReference
+    internal readonly struct BatchReference
     {
         public readonly ReadyBatch Batch;
         public readonly int Generation;
@@ -326,10 +326,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     /// partition), so List.Insert(0, item) O(n) shifts are negligible compared to the GC
     /// pressure from LinkedListNode allocations at high throughput.
     /// </remarks>
-    private sealed class PartitionCarryOver
+    internal sealed class PartitionCarryOver
     {
         private readonly Dictionary<TopicPartition, List<BatchReference>> _partitions = new();
         private int _count;
+        private bool _mayContainUnreadyBatch;
 
         public int Count => _count;
         public Dictionary<TopicPartition, List<BatchReference>> Partitions => _partitions;
@@ -355,6 +356,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Add(batchRef);
             _count++;
+            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
         }
 
         /// <summary>
@@ -371,6 +373,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             GetOrCreateQueue(batchRef.Batch.TopicPartition).Insert(0, batchRef);
             _count++;
+            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
         }
 
         /// <summary>
@@ -399,6 +402,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             queue.Insert(insertIdx, batchRef);
             _count++;
+            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
         }
 
         private void AddLoopExitRedelivery(BatchReference batchRef)
@@ -412,22 +416,60 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             queue.Insert(insertIdx, batchRef);
             _count++;
+            _mayContainUnreadyBatch |= !batchRef.Batch.IsPreSerialized;
         }
 
         /// <summary>
-        /// Drains all batches to the destination in per-partition FIFO order, then clears.
-        /// Used before coalescing to iterate in deterministic per-partition order.
+        /// Drains each partition's wire-ready prefix to the destination in FIFO order.
+        /// A split retry can enter carry-over before asynchronous compression completes;
+        /// keeping its suffix queued prevents later same-partition retries overtaking it.
         /// </summary>
         public void DrainTo(List<BatchReference> destination)
         {
+            if (!_mayContainUnreadyBatch)
+            {
+                foreach (var kvp in _partitions)
+                {
+                    var queue = kvp.Value;
+                    for (var i = 0; i < queue.Count; i++)
+                        destination.Add(queue[i]);
+                    queue.Clear();
+                }
+
+                _count = 0;
+                return;
+            }
+
+            var hasUnreadyBatch = false;
             foreach (var kvp in _partitions)
             {
                 var queue = kvp.Value;
-                for (var i = 0; i < queue.Count; i++)
+                var readyCount = 0;
+                while (readyCount < queue.Count)
+                {
+                    var batchReference = queue[readyCount];
+                    if (batchReference.IsCurrentIncarnation()
+                        && !batchReference.Batch.IsPreSerialized)
+                    {
+                        hasUnreadyBatch = true;
+                        break;
+                    }
+
+                    readyCount++;
+                }
+
+                for (var i = 0; i < readyCount; i++)
                     destination.Add(queue[i]);
-                queue.Clear();
+
+                if (readyCount == queue.Count)
+                    queue.Clear();
+                else if (readyCount > 0)
+                    queue.RemoveRange(0, readyCount);
+
+                _count -= readyCount;
             }
-            _count = 0;
+
+            _mayContainUnreadyBatch = hasUnreadyBatch;
         }
 
         public void Clear()
@@ -435,6 +477,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             foreach (var kvp in _partitions)
                 kvp.Value.Clear();
             _count = 0;
+            _mayContainUnreadyBatch = false;
         }
 
         public void RemoveAt(List<BatchReference> queue, int index)
@@ -3032,12 +3075,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         try
                         {
                             CompleteInflightEntry(batch);
-                            if (_accumulator.SplitAndReenqueue(batch, pending.BatchGenerations[j]))
+                            var splitRetries = _accumulator.SplitForSenderRetry(
+                                batch,
+                                pending.BatchGenerations[j]);
+                            if (splitRetries is not null)
                             {
-                                // Keep the BrokerSender fence until the first split retry is
-                                // coalesced, but let the accumulator drain the children that
-                                // were inserted ahead of newer partition work.
-                                _accumulator.UnmutePartition(splitTopicPartition);
+                                // ProcessCompletedResponses walks requests oldest-first. Put
+                                // every child on that same retry path now, so a later response
+                                // cannot publish a newer retry ahead of this split range.
+                                for (var i = 0; i < splitRetries.Count; i++)
+                                {
+                                    var splitRetry = splitRetries[i];
+                                    carryOver.AddAfterRetries(new BatchReference(
+                                        splitRetry,
+                                        splitRetry.Generation));
+                                }
+
                                 batches[j] = null!;
                                 continue;
                             }

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3018,6 +3018,38 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 }
                 else if (partitionResponse.ErrorCode != ErrorCode.None)
                 {
+                    if (partitionResponse.ErrorCode == ErrorCode.MessageTooLarge
+                        && batch.RecordCount > 1
+                        && !batch.IsSendCompleted)
+                    {
+                        LogBatchSplit(
+                            _brokerId,
+                            batch.TopicPartition.Topic,
+                            batch.TopicPartition.Partition,
+                            batch.RecordCount);
+                        MutePartition(batch.TopicPartition);
+                        try
+                        {
+                            CompleteInflightEntry(batch);
+                            if (_accumulator.SplitAndReenqueue(batch, pending.BatchGenerations[j]))
+                            {
+                                // Keep the BrokerSender fence until the first split retry is
+                                // coalesced, but let the accumulator drain the children that
+                                // were inserted ahead of newer partition work.
+                                _accumulator.UnmutePartition(batch.TopicPartition);
+                                batches[j] = null!;
+                                continue;
+                            }
+                        }
+                        catch
+                        {
+                            UnmutePartition(batch.TopicPartition);
+                            throw;
+                        }
+
+                        UnmutePartition(batch.TopicPartition);
+                    }
+
                     if (partitionResponse.ErrorCode.IsRetriable()
                         || (partitionResponse.ErrorCode == ErrorCode.ConcurrentTransactions
                             && _isTransactional()
@@ -3606,7 +3638,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         batch.InflightEntry = _inflightTracker.Register(
                             batch.TopicPartition,
                             batch.RecordBatch.BaseSequence,
-                            batch.CompletionSourcesCount);
+                            batch.RecordCount);
                     }
                 }
             }
@@ -5912,6 +5944,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] delivery timeout exceeded for {Topic}-{Partition}")]
     private partial void LogDeliveryTimeoutExceeded(int brokerId, string topic, int partition);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BrokerSender[{BrokerId}] splitting oversized batch for {Topic}-{Partition} ({RecordCount} records)")]
+    private partial void LogBatchSplit(int brokerId, string topic, int partition, int recordCount);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "BrokerSender[{BrokerId}] re-sequencing batch {Topic}-{Partition}: stale epoch {StaleEpoch} -> current {CurrentEpoch}")]
     private partial void LogStaleEpochResequencing(int brokerId, string topic, int partition, short staleEpoch, short currentEpoch);

--- a/src/Dekaf/Producer/CompressionRatioEstimator.cs
+++ b/src/Dekaf/Producer/CompressionRatioEstimator.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// KIP-126 compression ratio estimates, isolated per producer, topic, and codec.
+/// </summary>
+internal sealed class CompressionRatioEstimator
+{
+    internal const double EstimationFactor = 1.05;
+    internal const double ImprovingStep = 0.005;
+    internal const double DeterioratingStep = 0.05;
+
+    private readonly ConcurrentDictionary<(string Topic, CompressionType Type), Estimate> _estimates = new();
+
+    internal double Get(string topic, CompressionType type)
+        => type == CompressionType.None
+            ? 1.0
+            : _estimates.GetOrAdd((topic, type), static _ => new Estimate()).Value;
+
+    internal double Update(string topic, CompressionType type, double observedRatio)
+    {
+        if (type == CompressionType.None
+            || double.IsNaN(observedRatio)
+            || double.IsInfinity(observedRatio)
+            || observedRatio <= 0)
+            return 1.0;
+
+        return _estimates.GetOrAdd((topic, type), static _ => new Estimate())
+            .Update(observedRatio);
+    }
+
+    internal void ResetAfterSplit(string topic, CompressionType type, double observedRatio)
+    {
+        if (type == CompressionType.None)
+            return;
+
+        _estimates.GetOrAdd((topic, type), static _ => new Estimate())
+            .Reset(Math.Max(1.0, observedRatio));
+    }
+
+    private sealed class Estimate
+    {
+        private readonly object _lock = new();
+        private double _value = 1.0;
+
+        internal double Value
+        {
+            get
+            {
+                lock (_lock)
+                    return _value;
+            }
+        }
+
+        internal double Update(double observedRatio)
+        {
+            lock (_lock)
+            {
+                if (observedRatio > _value)
+                    _value = Math.Max(_value + DeterioratingStep, observedRatio);
+                else if (observedRatio < _value)
+                    _value = Math.Max(_value - ImprovingStep, observedRatio);
+
+                return _value;
+            }
+        }
+
+        internal void Reset(double value)
+        {
+            lock (_lock)
+                _value = value;
+        }
+    }
+}

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -7622,7 +7622,13 @@ internal sealed class PartitionBatch
         }
         if (hasCallback || _callbacks is not null)
         {
-            _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
+            if (_callbacks is null)
+            {
+                _callbacks = ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
+                // A callback array can have been returned uncleared by GrowArray. Records
+                // appended before this batch's first callback never wrote their slots.
+                Array.Clear(_callbacks, 0, Math.Min(recordIndex, _callbacks.Length));
+            }
             if (recordIndex >= _callbacks.Length)
             {
                 GrowArray(

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1971,7 +1971,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 if (oversizedBatch)
                 {
-                    FailOversizedBatch(batch, batchRequestSize, maxRequestSize);
+                    if (!SplitAndReenqueue(batch, batch.Generation))
+                        FailOversizedBatch(batch, batchRequestSize, maxRequestSize);
                     continue;
                 }
 
@@ -7097,7 +7098,7 @@ internal sealed class PartitionBatch
             ? Math.Clamp(options.InitialBatchRecordCapacity, 16, 16384)
             : ComputeInitialRecordCapacity(options.BatchSize);
 
-        CreateAppendBuffer(options);
+        CreateAppendBuffer(options, rentFullArenaFromPool: false);
         _recordCount = 0;
 
         // Rent arrays from pool - eliminates List allocations
@@ -7784,7 +7785,7 @@ internal sealed class PartitionBatch
         }
     }
 
-    private void CreateAppendBuffer(ProducerOptions options)
+    private void CreateAppendBuffer(ProducerOptions options, bool rentFullArenaFromPool = true)
     {
         if (options.BufferMemoryAllocationStrategy == BufferMemoryAllocationStrategy.Incremental)
         {
@@ -7796,7 +7797,10 @@ internal sealed class PartitionBatch
             _incrementalBuffer = null;
             // Compression-based expansion grows lazily only after the batch fills,
             // keeping idle partitions bounded by BatchSize.
-            _arena = BatchArena.RentOrCreate(GetNormalArenaCapacity(options));
+            var normalCapacity = GetNormalArenaCapacity(options);
+            _arena = rentFullArenaFromPool
+                ? BatchArena.RentOrCreate(normalCapacity)
+                : new BatchArena(normalCapacity);
         }
     }
 

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -7423,9 +7423,11 @@ internal sealed class PartitionBatch
         var compressedRecordsBudget = Math.Max(
             1,
             wireBatchSizeLimit - RecordBatch.TotalBatchHeaderSize);
-        var maximumUncompressedRecordsBudget = Math.Min(
-            int.MaxValue - RecordBatch.TotalBatchHeaderSize,
-            (long)Math.Min(options.BufferMemory, (ulong)long.MaxValue));
+        var maximumUncompressedRecordsBudget = Math.Max(
+            1,
+            Math.Min(
+                int.MaxValue - RecordBatch.TotalBatchHeaderSize,
+                (long)Math.Min(options.BufferMemory, (ulong)long.MaxValue)));
         var estimatedUncompressedRecordsBudget = compressedRecordsBudget
             / Math.Max(double.Epsilon, estimatedRatio * CompressionRatioEstimator.EstimationFactor);
         var uncompressedRecordsBudget = (long)Math.Clamp(

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -942,7 +942,22 @@ internal sealed class BatchArena
     internal int Capacity => _buffer.Length;
 
     internal void SetMaxPooledCapacity(int maxPooledCapacity)
-        => _maxPooledCapacity = Math.Max(_maxPooledCapacity, maxPooledCapacity);
+        => _maxPooledCapacity = maxPooledCapacity;
+
+    internal void Grow(int capacity, int maxPooledCapacity)
+    {
+        if (capacity <= _buffer.Length)
+        {
+            _maxPooledCapacity = maxPooledCapacity;
+            return;
+        }
+
+        var position = Volatile.Read(ref _position);
+        var expanded = GC.AllocateUninitializedArray<byte>(capacity, pinned: true);
+        _buffer.AsSpan(0, position).CopyTo(expanded);
+        _buffer = expanded;
+        _maxPooledCapacity = maxPooledCapacity;
+    }
 
     /// <summary>
     /// Gets the current position in the arena (total bytes used).
@@ -2136,10 +2151,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             splitBytes += child.DataSize;
         Interlocked.Add(ref _bufferedBytes, splitBytes);
 
-        OnBatchExitsPipeline(source);
-        ReleaseBatchMemory(source);
-        ReturnReadyBatch(source);
-
         var pd = GetOrCreateDeque(splitBatches[0].TopicPartition);
         using (var guard = new SpinLockGuard(ref pd.Lock))
         {
@@ -2160,6 +2171,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 ProducerDebugCounters.RecordBatchQueuedToReady();
             }
         }
+
+        // Publish replacement tracking before retiring the source. Flush/close waiters must
+        // never observe an in-flight count of zero between the rejected batch and its children.
+        OnBatchExitsPipeline(source);
+        ReleaseBatchMemory(source);
+        ReturnReadyBatch(source);
 
         foreach (var child in splitBatches)
             StartPreSerialization(child);
@@ -7143,7 +7160,7 @@ internal sealed class PartitionBatch
             topicPartition,
             _options,
             _compressionRatioEstimator);
-        EnsureArenaCapacityForLimit();
+        EnsureNormalArenaCapacity();
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
         _recordCount = 0;
         _completionSourceCount = 0;
@@ -7324,12 +7341,15 @@ internal sealed class PartitionBatch
         _effectiveBatchSizeLimit = Math.Max(
             RecordBatch.TotalBatchHeaderSize + 1,
             encodedBatchSizeLimit);
-        EnsureArenaCapacityForLimit();
+        EnsureNormalArenaCapacity();
     }
 
-    private void EnsureArenaCapacityForLimit()
+    private void EnsureNormalArenaCapacity()
     {
-        var requiredCapacity = GetEffectiveArenaCapacity(_options, _effectiveBatchSizeLimit);
+        if (_incrementalBuffer is not null)
+            return;
+
+        var requiredCapacity = GetNormalArenaCapacity(_options);
         if (_arena is not null && _arena.Capacity >= requiredCapacity)
         {
             _arena.SetMaxPooledCapacity(requiredCapacity);
@@ -7585,6 +7605,10 @@ internal sealed class PartitionBatch
         {
             EnsureArenaCanFitFirstRecord(encodedRecordSize);
         }
+        else
+        {
+            EnsureArenaCanFitNextRecord(encodedRecordSize);
+        }
 
         // Delivery arrays are record-aligned so a rejected batch can be split without
         // losing callback/future ownership or returning incorrect record offsets.
@@ -7764,8 +7788,9 @@ internal sealed class PartitionBatch
         else
         {
             _incrementalBuffer = null;
-            _arena = BatchArena.RentOrCreate(
-                GetEffectiveArenaCapacity(options, _effectiveBatchSizeLimit));
+            // Compression-based expansion grows lazily only after the batch fills,
+            // keeping idle partitions bounded by BatchSize.
+            _arena = BatchArena.RentOrCreate(GetNormalArenaCapacity(options));
         }
     }
 
@@ -7830,6 +7855,21 @@ internal sealed class PartitionBatch
         }
 
         _arena = BatchArena.RentOrCreate(capacity, normalCapacity);
+    }
+
+    private void EnsureArenaCanFitNextRecord(int encodedRecordSize)
+    {
+        var arena = _arena;
+        if (arena is null || encodedRecordSize <= arena.RemainingCapacity)
+            return;
+
+        var maximumCapacity = GetEffectiveArenaCapacity(_options, _effectiveBatchSizeLimit);
+        var requiredCapacity = checked(arena.Position + encodedRecordSize);
+        if (requiredCapacity > maximumCapacity)
+            return;
+
+        var doubledCapacity = (int)Math.Min((long)arena.Capacity * 2, maximumCapacity);
+        arena.Grow(Math.Max(requiredCapacity, doubledCapacity), GetNormalArenaCapacity(_options));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2131,13 +2131,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return false;
         }
 
-        OnBatchExitsPipeline(source);
-        ReturnReadyBatch(source);
-
         var splitBytes = 0L;
         foreach (var child in splitBatches)
             splitBytes += child.DataSize;
         Interlocked.Add(ref _bufferedBytes, splitBytes);
+
+        OnBatchExitsPipeline(source);
+        ReleaseBatchMemory(source);
+        ReturnReadyBatch(source);
 
         var pd = GetOrCreateDeque(splitBatches[0].TopicPartition);
         using (var guard = new SpinLockGuard(ref pd.Lock))
@@ -7589,14 +7590,22 @@ internal sealed class PartitionBatch
         // losing callback/future ownership or returning incorrect record offsets.
         if (recordIndex >= _completionSources.Length)
         {
-            GrowArray(ref _completionSources, ref _recordCount, ProducerContainerPools.CompletionSources);
+            GrowArray(
+                ref _completionSources,
+                _recordCount,
+                recordIndex + 1,
+                ProducerContainerPools.CompletionSources);
         }
         if (hasCallback || _callbacks is not null)
         {
             _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
             if (recordIndex >= _callbacks.Length)
             {
-                GrowArray(ref _callbacks!, ref _recordCount, ProducerContainerPools.Callbacks);
+                GrowArray(
+                    ref _callbacks!,
+                    _recordCount,
+                    recordIndex + 1,
+                    ProducerContainerPools.Callbacks);
             }
         }
 
@@ -7824,11 +7833,15 @@ internal sealed class PartitionBatch
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void GrowArray<T>(ref T[] array, ref int count, ArrayPool<T> pool)
+    private static void GrowArray<T>(
+        ref T[] array,
+        int count,
+        int requiredCapacity,
+        ArrayPool<T> pool)
     {
-        var newSize = array.Length * 2;
+        var newSize = Math.Max(checked(array.Length * 2), requiredCapacity);
         var newArray = pool.Rent(newSize);
-        Array.Copy(array, newArray, count);
+        Array.Copy(array, newArray, Math.Min(count, array.Length));
         pool.Return(array, clearArray: false);
         array = newArray;
     }
@@ -7945,12 +7958,12 @@ internal sealed class PartitionBatch
                 batch,
                 _completionSources,
                 _completionSourceCount,
+                _recordCount,
                 _estimatedSize,
                 _arena,
                 _callbacks,
                 _callbackCount,
                 _arrayReuseQueue,
-                _recordCount,
                 _createdStopwatchTimestamp,
                 _options.LingerMs * Stopwatch.Frequency / 1_000,
                 _incrementalBuffer);
@@ -8817,16 +8830,19 @@ internal sealed class ReadyBatch
         RecordBatch recordBatch,
         PooledValueTaskSource<RecordMetadata>[]? completionSourcesArray,
         int completionSourcesCount,
+        int recordCount,
         int dataSize,
         BatchArena? arena = null,
         Action<RecordMetadata, Exception?>?[]? callbacks = null,
         int callbackCount = 0,
         BatchArrayReuseQueue? arrayReuseQueue = null,
-        int recordCount = 0,
         long createdStopwatchTimestamp = 0,
         long lingerTicks = 0,
         IncrementalBatchBuffer? incrementalBuffer = null)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(recordCount, completionSourcesCount);
+        ArgumentOutOfRangeException.ThrowIfLessThan(recordCount, callbackCount);
+
         // The generation increment must happen BEFORE the lifecycle flags are cleared.
         // Stale-reference holders validate liveness by reading _returnedToPool first and
         // _generation second (see IsCurrentIncarnation). With the increment ordered first,
@@ -8859,7 +8875,7 @@ internal sealed class ReadyBatch
         _completionSourcesCount = completionSourcesCount;
         // Captured at seal time because the RecordBatch's record list may be recycled or
         // never materialized by the time a (possibly stale) Fail needs the count.
-        _recordCount = recordCount > 0 ? recordCount : completionSourcesCount;
+        _recordCount = recordCount;
         DataSize = dataSize;
         EncodedSize = dataSize;
         UnackedBudget = null;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2059,9 +2059,23 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// The source delivery deadline and idempotent sequence range are retained.
     /// </summary>
     internal bool SplitAndReenqueue(ReadyBatch source, int expectedGeneration)
+        => SplitBatch(source, expectedGeneration, reenqueue: true) is not null;
+
+    /// <summary>
+    /// KIP-126 split used for a broker rejection. Returns the ordered children to the
+    /// owning sender instead of publishing them through the accumulator, so they can
+    /// enter the sender's retry deque ahead of newer in-flight retries.
+    /// </summary>
+    internal List<ReadyBatch>? SplitForSenderRetry(ReadyBatch source, int expectedGeneration)
+        => SplitBatch(source, expectedGeneration, reenqueue: false);
+
+    private List<ReadyBatch>? SplitBatch(
+        ReadyBatch source,
+        int expectedGeneration,
+        bool reenqueue)
     {
         if (source.RecordCount <= 1 || !source.TryAcquireResourcePin(expectedGeneration))
-            return false;
+            return null;
 
         var splitBatches = new List<ReadyBatch>();
         PartitionBatch? building = null;
@@ -2123,7 +2137,9 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (_options.CompressionType == CompressionType.None)
                     PrepareBatchForPublish(child, child.Generation);
                 else
-                    child.SetPreSerializationTask(CreatePreSerializationTask(child));
+                    child.SetPreSerializationTask(reenqueue
+                        ? CreatePreSerializationTask(child)
+                        : CreateSenderRetryPreSerializationTask(child));
                 splitBatches.Add(child);
             }
         }
@@ -2148,7 +2164,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         if (splitBatches.Count == 0 || !source.TryAbandonForSplit(expectedGeneration))
         {
             DiscardUnpublishedSplitBatches(splitBatches);
-            return false;
+            return null;
         }
 
         var splitBytes = 0L;
@@ -2169,11 +2185,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                         child.TopicPartition.Topic,
                         child.TopicPartition.Partition));
                 OnBatchEntersPipeline(pd, child);
-                if (ProducerId >= 0)
-                    pd.InsertInSequenceOrder(child);
-                else
-                    pd.AddFirst(child);
-                ProducerDebugCounters.RecordBatchQueuedToReady();
+                if (reenqueue)
+                {
+                    if (ProducerId >= 0)
+                        pd.InsertInSequenceOrder(child);
+                    else
+                        pd.AddFirst(child);
+                    ProducerDebugCounters.RecordBatchQueuedToReady();
+                }
             }
         }
 
@@ -2184,14 +2203,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         ReturnReadyBatch(source);
 
         foreach (var child in splitBatches)
-            StartPreSerialization(child);
+        {
+            if (reenqueue)
+                StartPreSerialization(child);
+            else
+                StartSenderRetryPreSerialization(child);
+        }
 
         Diagnostics.DekafMetrics.BatchSplits.Add(1, new TagList
         {
             { Diagnostics.DekafDiagnostics.MessagingDestinationName, splitBatches[0].TopicPartition.Topic }
         });
         SignalWakeup();
-        return true;
+        return splitBatches;
     }
 
     private void DiscardUnpublishedSplitBatches(List<ReadyBatch> batches)
@@ -4566,6 +4590,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         readyBatch.StartPreSerializationTask();
     }
 
+    private void StartSenderRetryPreSerialization(ReadyBatch readyBatch)
+    {
+        if (readyBatch.IsPreSerialized)
+        {
+            SignalWakeup();
+            return;
+        }
+
+        readyBatch.StartPreSerializationTask();
+    }
+
     private Task CreatePreSerializationTask(ReadyBatch readyBatch)
     {
         var generation = readyBatch.Generation;
@@ -4580,13 +4615,45 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             TaskCreationOptions.DenyChildAttach);
     }
 
+    private Task CreateSenderRetryPreSerializationTask(ReadyBatch readyBatch)
+    {
+        var generation = readyBatch.Generation;
+        return new Task(
+            static state =>
+            {
+                var workItem = (SenderRetryPreSerializationWorkItem)state!;
+                workItem.Accumulator.PreSerializeSenderRetryBatch(workItem.Batch, workItem.Generation);
+            },
+            new SenderRetryPreSerializationWorkItem(this, readyBatch, generation),
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach);
+    }
+
     private void PreSerializeAndPublishBatch(ReadyBatch readyBatch, int generation)
     {
         if (PrepareBatchForPublish(readyBatch, generation) && readyBatch.IsCurrentIncarnation(generation))
             PublishSealedBatch(readyBatch);
     }
 
+    private void PreSerializeSenderRetryBatch(ReadyBatch readyBatch, int generation)
+    {
+        if (PrepareBatchForPublish(readyBatch, generation) && readyBatch.IsCurrentIncarnation(generation))
+            SignalWakeup();
+    }
+
     private sealed class PreSerializationWorkItem(
+        RecordAccumulator accumulator,
+        ReadyBatch batch,
+        int generation)
+    {
+        public RecordAccumulator Accumulator { get; } = accumulator;
+
+        public ReadyBatch Batch { get; } = batch;
+
+        public int Generation { get; } = generation;
+    }
+
+    private sealed class SenderRetryPreSerializationWorkItem(
         RecordAccumulator accumulator,
         ReadyBatch batch,
         int generation)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -941,6 +941,9 @@ internal sealed class BatchArena
 
     internal int Capacity => _buffer.Length;
 
+    internal void SetMaxPooledCapacity(int maxPooledCapacity)
+        => _maxPooledCapacity = Math.Max(_maxPooledCapacity, maxPooledCapacity);
+
     /// <summary>
     /// Gets the current position in the arena (total bytes used).
     /// Uses volatile read for thread-safe access.
@@ -1151,6 +1154,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     private readonly PartitionBatchPool _batchPool;
     private readonly ReadyBatchPool _readyBatchPool; // Pool for ReadyBatch objects to eliminate per-batch allocations
+    private readonly CompressionRatioEstimator _compressionRatioEstimator = new();
 
     // O(1) counter for fast flush-check (is anything in-flight?).
     // The separate _inFlightBatches dictionary provides reference-tracking for orphan sweep.
@@ -2030,6 +2034,153 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         SignalWakeup();
     }
 
+    /// <summary>
+    /// KIP-126: replaces a broker-rejected compressed batch with smaller, ordered batches.
+    /// The source delivery deadline and idempotent sequence range are retained.
+    /// </summary>
+    internal bool SplitAndReenqueue(ReadyBatch source, int expectedGeneration)
+    {
+        if (source.RecordCount <= 1 || !source.TryAcquireResourcePin(expectedGeneration))
+            return false;
+
+        var splitBatches = new List<ReadyBatch>();
+        PartitionBatch? building = null;
+        try
+        {
+            var sourceRecordBatch = source.RecordBatch;
+            var records = sourceRecordBatch.Records;
+            var topicPartition = source.TopicPartition;
+            var sourceBaseSequence = sourceRecordBatch.BaseSequence;
+            var splitRecordsBudget = source.IsSplitBatch
+                ? Math.Max(source.MaxRecordSize, Math.Max(1, source.DataSize / 2))
+                : Math.Max(1, _options.BatchSize - RecordBatch.TotalBatchHeaderSize);
+            var splitBatchSizeLimit = checked(RecordBatch.TotalBatchHeaderSize + splitRecordsBudget);
+
+            _compressionRatioEstimator.ResetAfterSplit(
+                topicPartition.Topic,
+                _options.CompressionType,
+                source.ObservedCompressionRatio);
+
+            var recordIndex = 0;
+            while (recordIndex < source.RecordCount)
+            {
+                var childStartIndex = recordIndex;
+                var childMaxRecordSize = 0;
+                building = _batchPool.Rent(topicPartition, partitionCount: 1);
+                building.SetTransactionState(
+                    sourceRecordBatch.ProducerId,
+                    sourceRecordBatch.ProducerEpoch,
+                    (sourceRecordBatch.Attributes & RecordBatchAttributes.IsTransactional) != 0);
+                building.SetSplitBatchSizeLimit(splitBatchSizeLimit);
+
+                while (recordIndex < source.RecordCount)
+                {
+                    var record = records[recordIndex];
+                    var result = building.TryAppendSplitRecord(
+                        sourceRecordBatch.BaseTimestamp + record.TimestampDelta,
+                        record,
+                        source.GetCompletionSource(recordIndex),
+                        source.GetCallback(recordIndex));
+                    if (!result.Success)
+                        break;
+
+                    childMaxRecordSize = Math.Max(childMaxRecordSize, result.ActualSizeAdded);
+                    recordIndex++;
+                }
+
+                if (recordIndex == childStartIndex)
+                    throw new InvalidOperationException("KIP-126 split could not fit its first record.");
+
+                var child = building.Complete()
+                    ?? throw new InvalidOperationException("KIP-126 produced an empty split batch.");
+                _batchPool.Return(building);
+                building = null;
+
+                if (sourceBaseSequence >= 0)
+                    child.RecordBatch.BaseSequence = checked(sourceBaseSequence + childStartIndex);
+                child.PreserveDeliveryTimeline(source);
+                child.MarkAsSplitBatch(childMaxRecordSize);
+                if (_options.CompressionType == CompressionType.None)
+                    PrepareBatchForPublish(child, child.Generation);
+                else
+                    child.SetPreSerializationTask(CreatePreSerializationTask(child));
+                splitBatches.Add(child);
+            }
+        }
+        catch
+        {
+            if (building is not null)
+            {
+                building.DiscardSplitBuild();
+                _batchPool.Return(building);
+            }
+
+            DiscardUnpublishedSplitBatches(splitBatches);
+            throw;
+        }
+        finally
+        {
+            source.ReleaseResourcePin();
+        }
+
+        // A first split may still produce one child when the broker's limit is below the
+        // configured BatchSize. Re-enqueue it as a split batch so the next rejection halves it.
+        if (splitBatches.Count == 0 || !source.TryAbandonForSplit(expectedGeneration))
+        {
+            DiscardUnpublishedSplitBatches(splitBatches);
+            return false;
+        }
+
+        OnBatchExitsPipeline(source);
+        ReturnReadyBatch(source);
+
+        var splitBytes = 0L;
+        foreach (var child in splitBatches)
+            splitBytes += child.DataSize;
+        Interlocked.Add(ref _bufferedBytes, splitBytes);
+
+        var pd = GetOrCreateDeque(splitBatches[0].TopicPartition);
+        using (var guard = new SpinLockGuard(ref pd.Lock))
+        {
+            for (var i = splitBatches.Count - 1; i >= 0; i--)
+            {
+                var child = splitBatches[i];
+                AttributeUntrackedBudget(
+                    child,
+                    ResolveAndCacheUnackedBudget(
+                        pd,
+                        child.TopicPartition.Topic,
+                        child.TopicPartition.Partition));
+                OnBatchEntersPipeline(pd, child);
+                if (ProducerId >= 0)
+                    pd.InsertInSequenceOrder(child);
+                else
+                    pd.AddFirst(child);
+                ProducerDebugCounters.RecordBatchQueuedToReady();
+            }
+        }
+
+        foreach (var child in splitBatches)
+            StartPreSerialization(child);
+
+        Diagnostics.DekafMetrics.BatchSplits.Add(1, new TagList
+        {
+            { Diagnostics.DekafDiagnostics.MessagingDestinationName, splitBatches[0].TopicPartition.Topic }
+        });
+        SignalWakeup();
+        return true;
+    }
+
+    private void DiscardUnpublishedSplitBatches(List<ReadyBatch> batches)
+    {
+        foreach (var batch in batches)
+        {
+            batch.TrySetMemoryReleased();
+            batch.TryAbandonForSplit(batch.Generation);
+            ReturnReadyBatch(batch);
+        }
+    }
+
     internal void MutePartition(TopicPartition tp)
     {
         lock (_partitionMuteLock)
@@ -2494,7 +2645,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // ReadyBatch lifecycle spans seal→send→response→cleanup (longer than PartitionBatch),
         // so its pool needs to be larger to avoid exhaustion under sustained throughput.
         _readyBatchPool = new ReadyBatchPool(maxPoolSize: poolSize * ReadyBatchPoolSizeRatio);
-        _batchPool = new PartitionBatchPool(options, maxPoolSize: poolSize);
+        _batchPool = new PartitionBatchPool(options, _compressionRatioEstimator, maxPoolSize: poolSize);
         _batchPool.SetReadyBatchPool(_readyBatchPool); // Wire up pools
         _maxBufferMemory = (long)options.BufferMemory;
 
@@ -4447,6 +4598,17 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             {
                 readyBatch.RecordBatch.PreCompress(_options.CompressionType, _compressionCodecs);
                 readyBatch.SetEncodedSize(readyBatch.RecordBatch.GetEncodedSize(_options.CompressionType));
+                if (_options.CompressionType != CompressionType.None
+                    && readyBatch.RecordBatch.PreEncodedRecordsLength > 0)
+                {
+                    var observedRatio = (double)readyBatch.RecordBatch.PreCompressedLength
+                        / readyBatch.RecordBatch.PreEncodedRecordsLength;
+                    readyBatch.ObservedCompressionRatio = observedRatio;
+                    _compressionRatioEstimator.Update(
+                        readyBatch.TopicPartition.Topic,
+                        _options.CompressionType,
+                        observedRatio);
+                }
             }
             catch (Exception ex)
             {
@@ -6768,6 +6930,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
 {
     private readonly ProducerOptions _options;
+    private readonly CompressionRatioEstimator _compressionRatioEstimator;
     private ReadyBatchPool? _readyBatchPool;
     private readonly BatchArrayReuseQueue _arrayReuseQueue;
 
@@ -6777,10 +6940,14 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
     /// <param name="options">Producer options for configuring new batches.</param>
     /// <param name="maxPoolSize">Maximum number of batches to keep pooled.
     /// Defaults to <see cref="BatchArena.DefaultPoolSize"/> since each pooled batch retains a BatchArena.</param>
-    public PartitionBatchPool(ProducerOptions options, int maxPoolSize = BatchArena.DefaultPoolSize)
+    public PartitionBatchPool(
+        ProducerOptions options,
+        CompressionRatioEstimator? compressionRatioEstimator = null,
+        int maxPoolSize = BatchArena.DefaultPoolSize)
         : base(maxPoolSize)
     {
         _options = options;
+        _compressionRatioEstimator = compressionRatioEstimator ?? new CompressionRatioEstimator();
         _arrayReuseQueue = new BatchArrayReuseQueue(maxSize: maxPoolSize);
     }
 
@@ -6795,7 +6962,7 @@ internal sealed class PartitionBatchPool : ObjectPool<PartitionBatch>
 
     protected override PartitionBatch Create()
     {
-        var batch = new PartitionBatch(default, _options);
+        var batch = new PartitionBatch(default, _options, _compressionRatioEstimator);
         batch.SetReadyBatchPool(_readyBatchPool);
         batch.SetArrayReuseQueue(_arrayReuseQueue);
         return batch;
@@ -6840,6 +7007,7 @@ internal sealed class PartitionBatch
     private TopicPartition _topicPartition;
     private int _partitionCount;
     private ProducerOptions _options;
+    private readonly CompressionRatioEstimator _compressionRatioEstimator;
     private readonly int _initialRecordCapacity;
     private ReadyBatchPool? _readyBatchPool; // Pool for renting ReadyBatch objects
     private BatchArrayReuseQueue? _arrayReuseQueue; // Reuse queue for working arrays
@@ -6883,14 +7051,28 @@ internal sealed class PartitionBatch
     /// ArenaCapacity. Records encode directly into the arena, so explicit values below
     /// the BatchSize-derived minimum are rejected during producer construction.
     /// </summary>
-    private static int GetEffectiveArenaCapacity(ProducerOptions options) =>
+    private static int GetNormalArenaCapacity(ProducerOptions options) =>
         ProducerOptions.GetEffectiveArenaCapacity(options.BatchSize, options.ArenaCapacity);
 
+    private static int GetEffectiveArenaCapacity(ProducerOptions options, int effectiveBatchSizeLimit) =>
+        Math.Max(
+            GetNormalArenaCapacity(options),
+            Math.Max(1, effectiveBatchSizeLimit - RecordBatch.TotalBatchHeaderSize));
+
     public PartitionBatch(TopicPartition topicPartition, ProducerOptions options)
+        : this(topicPartition, options, compressionRatioEstimator: null)
+    {
+    }
+
+    internal PartitionBatch(
+        TopicPartition topicPartition,
+        ProducerOptions options,
+        CompressionRatioEstimator? compressionRatioEstimator)
     {
         _topicPartition = topicPartition;
         _options = options;
-        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(topicPartition, options);
+        _compressionRatioEstimator = compressionRatioEstimator ?? new CompressionRatioEstimator();
+        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(topicPartition, options, _compressionRatioEstimator);
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
 
         _initialRecordCapacity = options.InitialBatchRecordCapacity > 0
@@ -6956,7 +7138,11 @@ internal sealed class PartitionBatch
     {
         _topicPartition = topicPartition;
         _partitionCount = partitionCount;
-        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(topicPartition, _options);
+        _effectiveBatchSizeLimit = GetEffectiveBatchSizeLimit(
+            topicPartition,
+            _options,
+            _compressionRatioEstimator);
+        EnsureArenaCapacityForLimit();
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
         _recordCount = 0;
         _completionSourceCount = 0;
@@ -7100,7 +7286,8 @@ internal sealed class PartitionBatch
 
     private static int GetEffectiveBatchSizeLimit(
         TopicPartition topicPartition,
-        ProducerOptions options)
+        ProducerOptions options,
+        CompressionRatioEstimator compressionRatioEstimator)
     {
         var maxRequestSize = options.MaxRequestSize > 0
             ? options.MaxRequestSize
@@ -7109,7 +7296,49 @@ internal sealed class PartitionBatch
             maxRequestSize,
             options.TransactionalId,
             topicPartition.Topic ?? string.Empty);
-        return Math.Min(options.BatchSize, maxEncodedBatchSize);
+        var wireBatchSizeLimit = Math.Min(options.BatchSize, maxEncodedBatchSize);
+        if (options.CompressionType == CompressionType.None)
+            return wireBatchSizeLimit;
+
+        var estimatedRatio = compressionRatioEstimator.Get(
+            topicPartition.Topic ?? string.Empty,
+            options.CompressionType);
+        var compressedRecordsBudget = Math.Max(
+            1,
+            wireBatchSizeLimit - RecordBatch.TotalBatchHeaderSize);
+        var maximumUncompressedRecordsBudget = Math.Min(
+            int.MaxValue - RecordBatch.TotalBatchHeaderSize,
+            (long)Math.Min(options.BufferMemory, (ulong)long.MaxValue));
+        var estimatedUncompressedRecordsBudget = compressedRecordsBudget
+            / Math.Max(double.Epsilon, estimatedRatio * CompressionRatioEstimator.EstimationFactor);
+        var uncompressedRecordsBudget = (long)Math.Clamp(
+            estimatedUncompressedRecordsBudget,
+            1.0,
+            maximumUncompressedRecordsBudget);
+        return checked(RecordBatch.TotalBatchHeaderSize + (int)uncompressedRecordsBudget);
+    }
+
+    internal void SetSplitBatchSizeLimit(int encodedBatchSizeLimit)
+    {
+        _effectiveBatchSizeLimit = Math.Max(
+            RecordBatch.TotalBatchHeaderSize + 1,
+            encodedBatchSizeLimit);
+        EnsureArenaCapacityForLimit();
+    }
+
+    private void EnsureArenaCapacityForLimit()
+    {
+        var requiredCapacity = GetEffectiveArenaCapacity(_options, _effectiveBatchSizeLimit);
+        if (_arena is not null && _arena.Capacity >= requiredCapacity)
+        {
+            _arena.SetMaxPooledCapacity(requiredCapacity);
+            return;
+        }
+
+        if (_arena is not null)
+            BatchArena.ReturnToPool(_arena);
+
+        _arena = BatchArena.RentOrCreate(requiredCapacity);
     }
 
     internal readonly record struct ReservedRecordAppend(
@@ -7356,17 +7585,18 @@ internal sealed class PartitionBatch
             EnsureArenaCanFitFirstRecord(encodedRecordSize);
         }
 
-        // Grow arrays if needed (rare - only happens if batch fills beyond initial capacity)
-        if (hasCompletionSource && _completionSourceCount >= _completionSources.Length)
+        // Delivery arrays are record-aligned so a rejected batch can be split without
+        // losing callback/future ownership or returning incorrect record offsets.
+        if (recordIndex >= _completionSources.Length)
         {
-            GrowArray(ref _completionSources, ref _completionSourceCount, ProducerContainerPools.CompletionSources);
+            GrowArray(ref _completionSources, ref _recordCount, ProducerContainerPools.CompletionSources);
         }
-        if (hasCallback)
+        if (hasCallback || _callbacks is not null)
         {
             _callbacks ??= ProducerContainerPools.Callbacks.Rent(_initialRecordCapacity);
-            if (_callbackCount >= _callbacks.Length)
+            if (recordIndex >= _callbacks.Length)
             {
-                GrowArray(ref _callbacks!, ref _callbackCount, ProducerContainerPools.Callbacks);
+                GrowArray(ref _callbacks!, ref _recordCount, ProducerContainerPools.Callbacks);
             }
         }
 
@@ -7480,15 +7710,18 @@ internal sealed class PartitionBatch
         _encodedRecordsLength += reservedAppend.EncodedRecordSize;
         _maxTimestamp = recordIndex == 0 ? reservedAppend.Timestamp : Math.Max(_maxTimestamp, reservedAppend.Timestamp);
 
+        _completionSources[recordIndex] = completionSource!;
         if (completionSource is not null)
         {
-            _completionSources[_completionSourceCount++] = completionSource;
+            _completionSourceCount++;
             ProducerDebugCounters.RecordCompletionSourceStoredInBatch();
         }
 
+        if (_callbacks is not null)
+            _callbacks[recordIndex] = callback;
         if (callback is not null)
         {
-            _callbacks![_callbackCount++] = callback;
+            _callbackCount++;
         }
 
         _recordCount = recordIndex + 1;
@@ -7522,8 +7755,54 @@ internal sealed class PartitionBatch
         else
         {
             _incrementalBuffer = null;
-            _arena = BatchArena.RentOrCreate(GetEffectiveArenaCapacity(options));
+            _arena = BatchArena.RentOrCreate(
+                GetEffectiveArenaCapacity(options, _effectiveBatchSizeLimit));
         }
+    }
+
+    internal RecordAppendResult TryAppendSplitRecord(
+        long timestamp,
+        in Record record,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback)
+    {
+        var result = TryReserveAppend(
+            timestamp,
+            record.IsKeyNull,
+            record.Key.Length,
+            record.IsValueNull,
+            record.Value.Length,
+            record.Headers,
+            record.HeaderCount,
+            completionSource is not null,
+            callback is not null,
+            out var reservedAppend);
+        if (!result.Success)
+            return result;
+
+        try
+        {
+            EncodeReservedAppend(
+                reservedAppend,
+                record.Key.Span,
+                record.IsKeyNull,
+                record.Value.Span,
+                record.IsValueNull,
+                record.Headers,
+                record.HeaderCount);
+        }
+        catch
+        {
+            CancelReservedAppend(reservedAppend);
+            throw;
+        }
+
+        CommitReservedAppend(
+            reservedAppend,
+            completionSource,
+            callback,
+            reservedAppend.EncodedRecordSize);
+        return result;
     }
 
     private void EnsureArenaCanFitFirstRecord(int encodedRecordSize)
@@ -7534,7 +7813,7 @@ internal sealed class PartitionBatch
             return;
         }
 
-        var normalCapacity = GetEffectiveArenaCapacity(_options);
+        var normalCapacity = GetNormalArenaCapacity(_options);
         var capacity = Math.Max(normalCapacity, encodedRecordSize);
         if (arena is not null)
         {
@@ -7732,13 +8011,16 @@ internal sealed class PartitionBatch
 
         if (_completionSourceCount > 0 && _completionSources is not null)
         {
-            for (var i = 0; i < _completionSourceCount; i++)
-                PooledCompletionSource.TrySetException(_completionSources[i], exception);
+            for (var i = 0; i < _recordCount; i++)
+            {
+                if (_completionSources[i] is { } source)
+                    PooledCompletionSource.TrySetException(source, exception);
+            }
         }
 
         if (_callbackCount > 0 && _callbacks is not null)
         {
-            for (var i = 0; i < _callbackCount; i++)
+            for (var i = 0; i < _recordCount; i++)
             {
                 var callback = _callbacks[i];
                 if (callback is null)
@@ -7761,6 +8043,25 @@ internal sealed class PartitionBatch
         _completedBatch = null;
 
         return bytesToRelease;
+    }
+
+    internal void DiscardSplitBuild()
+    {
+        if (_completionSources is not null)
+            Array.Clear(_completionSources, 0, Math.Min(_recordCount, _completionSources.Length));
+        if (_callbacks is not null)
+            Array.Clear(_callbacks, 0, Math.Min(_recordCount, _callbacks.Length));
+
+        ReleaseAdmissionReservation();
+        ReturnBatchArraysToPool();
+        _recordCount = 0;
+        _completionSourceCount = 0;
+        _callbackCount = 0;
+        _encodedRecordsStart = 0;
+        _encodedRecordsLength = 0;
+        _estimatedSize = 0;
+        _reservedSize = 0;
+        _completedBatch = null;
     }
 
     private void ReleaseAdmissionReservation()
@@ -7984,6 +8285,25 @@ internal sealed class ReadyBatch
     // Callbacks for Send(message, callback) - inline invocation without ThreadPool
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
     private int _callbackCount;
+
+    internal PooledValueTaskSource<RecordMetadata>? GetCompletionSource(int recordIndex)
+        => _completionSourcesArray?[recordIndex];
+
+    internal Action<RecordMetadata, Exception?>? GetCallback(int recordIndex)
+        => _callbacks?[recordIndex];
+
+    internal bool IsSplitBatch { get; private set; }
+
+    internal int MaxRecordSize { get; private set; }
+
+    internal double ObservedCompressionRatio { get; set; } = 1.0;
+
+    internal void MarkAsSplitBatch(int maxRecordSize)
+    {
+        IsSplitBatch = true;
+        MaxRecordSize = maxRecordSize;
+        IsRetry = true;
+    }
 
     // In-flight tracker entry for coordinated retry with multiple in-flight batches per partition.
     // Set by KafkaProducer when registering with PartitionInflightTracker, cleared in Reset().
@@ -8368,6 +8688,14 @@ internal sealed class ReadyBatch
         IsRetry = true;
     }
 
+    internal void PreserveDeliveryTimeline(ReadyBatch source)
+    {
+        StopwatchCreatedTicks = source.StopwatchCreatedTicks;
+        StopwatchSealedTicks = source.StopwatchSealedTicks;
+        GovernedOriginTicks = source.GovernedOriginTicks;
+        _createdTimestamp = Stopwatch.GetTimestamp();
+    }
+
     // DoneTask is observed only by diagnostics/tests; producer flushing uses the accumulator's
     // in-flight counter. Allocate its source lazily so the hot path remains allocation-free.
     // A Task is deliberately used instead of a resettable IValueTaskSource: ReadyBatch can be
@@ -8531,7 +8859,7 @@ internal sealed class ReadyBatch
         _completionSourcesCount = completionSourcesCount;
         // Captured at seal time because the RecordBatch's record list may be recycled or
         // never materialized by the time a (possibly stale) Fail needs the count.
-        _recordCount = recordCount;
+        _recordCount = recordCount > 0 ? recordCount : completionSourcesCount;
         DataSize = dataSize;
         EncodedSize = dataSize;
         UnackedBudget = null;
@@ -8551,6 +8879,9 @@ internal sealed class ReadyBatch
             StopwatchSealedTicks,
             StopwatchCreatedTicks + lingerTicks);
         _createdTimestamp = StopwatchSealedTicks;
+        IsSplitBatch = false;
+        MaxRecordSize = 0;
+        ObservedCompressionRatio = 1.0;
     }
 
     /// <summary>
@@ -8573,10 +8904,10 @@ internal sealed class ReadyBatch
                     $"Batch recycled without completing delivery — this indicates a bug in the producer pipeline " +
                     $"(tp={_topicPartition}, sendCompleted={Volatile.Read(ref _sendCompleted)}, " +
                     $"completed={Volatile.Read(ref _completed)}, trace={DiagTrace})");
-                for (var i = 0; i < _completionSourcesCount; i++)
+                for (var i = 0; i < _recordCount; i++)
                 {
-                    if (PooledCompletionSource.TrySetException(
-                        _completionSourcesArray[i], orphanedException))
+                    if (_completionSourcesArray[i] is { } source
+                        && PooledCompletionSource.TrySetException(source, orphanedException))
                         failedCount++;
                 }
             }
@@ -8623,6 +8954,9 @@ internal sealed class ReadyBatch
         LoopExitRedeliveryOrder = 0;
         RetryNotBefore = 0;
         RetryFailureCount = 0;
+        IsSplitBatch = false;
+        MaxRecordSize = 0;
+        ObservedCompressionRatio = 1.0;
         _diagTraceLen = 0;
 
         // NOTE: _cleanedUp, _completed, and _sendCompleted are NOT reset here. They stay
@@ -8666,10 +9000,10 @@ internal sealed class ReadyBatch
 #if DEBUG
                 var completedCount = 0;
 #endif
-                for (var i = 0; i < _completionSourcesCount; i++)
+                for (var i = 0; i < _recordCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (PooledCompletionSource.TrySetResult(source, new RecordMetadata
+                    if (source is not null && PooledCompletionSource.TrySetResult(source, new RecordMetadata
                     {
                         Topic = _topicPartition.Topic,
                         Partition = _topicPartition.Partition,
@@ -8691,7 +9025,7 @@ internal sealed class ReadyBatch
             // Callbacks are invoked on the sender thread, so they must be non-blocking
             if (_callbackCount > 0 && _callbacks is not null)
             {
-                for (var i = 0; i < _callbackCount; i++)
+                for (var i = 0; i < _recordCount; i++)
                 {
                     var callback = _callbacks[i];
                     if (callback is not null)
@@ -8760,6 +9094,30 @@ internal sealed class ReadyBatch
         return true;
     }
 
+    /// <summary>
+    /// Ends the rejected source batch after its delivery work has moved to split children.
+    /// No record future or callback is completed here.
+    /// </summary>
+    internal bool TryAbandonForSplit(int expectedGeneration)
+    {
+        if (!TryAcquireResourcePin(expectedGeneration))
+            return false;
+
+        try
+        {
+            if (Interlocked.CompareExchange(ref _sendCompleted, 1, 0) != 0)
+                return false;
+
+            CompleteDoneTask(succeeded: true);
+            Cleanup();
+            return true;
+        }
+        finally
+        {
+            ReleaseResourcePin();
+        }
+    }
+
     internal void CompleteTerminalBookkeeping()
         => Volatile.Write(ref _terminalBookkeepingCompleted, 1);
 
@@ -8815,10 +9173,10 @@ internal sealed class ReadyBatch
 #if DEBUG
                 var failedCount = 0;
 #endif
-                for (var i = 0; i < _completionSourcesCount; i++)
+                for (var i = 0; i < _recordCount; i++)
                 {
                     var source = _completionSourcesArray[i];
-                    if (PooledCompletionSource.TrySetException(source, exception))
+                    if (source is not null && PooledCompletionSource.TrySetException(source, exception))
                     {
 #if DEBUG
                         failedCount++;
@@ -8833,7 +9191,7 @@ internal sealed class ReadyBatch
             // Invoke callbacks with exception - NO ThreadPool scheduling
             if (_callbackCount > 0 && _callbacks is not null)
             {
-                for (var i = 0; i < _callbackCount; i++)
+                for (var i = 0; i < _recordCount; i++)
                 {
                     var callback = _callbacks[i];
                     if (callback is not null)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -361,7 +361,7 @@ internal static class ProducerDataPool
 /// Dedicated <see cref="ArrayPool{T}"/> instances for producer batch container arrays.
 /// <para/>
 /// <b>Why not <see cref="ArrayPool{T}.Shared"/>?</b>
-/// Batch container arrays (<c>PooledValueTaskSource[]</c>, <c>Header[]</c>, <c>Action[]</c>)
+/// Batch container arrays (<c>PooledValueTaskSource[]</c>, <c>int[]</c>, <c>Header[]</c>, <c>Action[]</c>)
 /// are rented on the producer/accumulator thread during batch creation but returned on
 /// BrokerSender LongRunning threads during
 /// <see cref="ReadyBatch.Cleanup"/>. <c>ArrayPool&lt;T&gt;.Shared</c> uses TLS-based caching
@@ -397,6 +397,10 @@ internal static class ProducerContainerPools
     internal static readonly ArrayPool<PooledValueTaskSource<RecordMetadata>> CompletionSources =
         ArrayPool<PooledValueTaskSource<RecordMetadata>>.Create(
             maxArrayLength: MaxRecordArrayLength, maxArraysPerBucket: 16);
+
+    /// <summary>Pool for sparse delivery record-index arrays.</summary>
+    internal static readonly ArrayPool<int> DeliveryIndexes =
+        ArrayPool<int>.Create(maxArrayLength: MaxRecordArrayLength, maxArraysPerBucket: 16);
 
     /// <summary>Pool for Header[] arrays (per-message headers).</summary>
     internal static ArrayPool<Header> Headers => s_headers.Pool;
@@ -7040,10 +7044,17 @@ internal sealed class PartitionBatch
     // Zero-allocation array management: use pooled arrays instead of List<T>
     private PooledValueTaskSource<RecordMetadata>[] _completionSources;
     private int _completionSourceCount;
+    // Dense prefixes need no index array; only delivery records after the first gap are tracked.
+    private int _completionSourceDenseCount;
+    private int[]? _completionSourceIndexes;
+    private int _completionSourceIndexCount;
 
     // Callbacks for Send(message, callback) - stored directly in batch for inline invocation
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
     private int _callbackCount;
+    private int _callbackDenseCount;
+    private int[]? _callbackIndexes;
+    private int _callbackIndexCount;
 
     private long _baseTimestamp;
     private long _maxTimestamp;
@@ -7165,7 +7176,11 @@ internal sealed class PartitionBatch
         _createdStopwatchTimestamp = Stopwatch.GetTimestamp();
         _recordCount = 0;
         _completionSourceCount = 0;
+        _completionSourceDenseCount = 0;
+        _completionSourceIndexCount = 0;
         _callbackCount = 0;
+        _callbackDenseCount = 0;
+        _callbackIndexCount = 0;
         _baseTimestamp = 0;
         _maxTimestamp = 0;
         _encodedRecordsStart = 0;
@@ -7217,6 +7232,11 @@ internal sealed class PartitionBatch
         // and those messages would be lost when Reset() is later called.
         _recordCount = 0;
         _completionSourceCount = 0;
+        _completionSourceDenseCount = 0;
+        _completionSourceIndexCount = 0;
+        _callbackCount = 0;
+        _callbackDenseCount = 0;
+        _callbackIndexCount = 0;
         _baseTimestamp = 0;
         _maxTimestamp = 0;
         _encodedRecordsStart = 0;
@@ -7754,6 +7774,12 @@ internal sealed class PartitionBatch
         _completionSources[recordIndex] = completionSource!;
         if (completionSource is not null)
         {
+            TrackDeliveryIndex(
+                recordIndex,
+                _completionSourceCount,
+                ref _completionSourceDenseCount,
+                ref _completionSourceIndexes,
+                ref _completionSourceIndexCount);
             _completionSourceCount++;
             ProducerDebugCounters.RecordCompletionSourceStoredInBatch();
         }
@@ -7762,6 +7788,12 @@ internal sealed class PartitionBatch
             _callbacks[recordIndex] = callback;
         if (callback is not null)
         {
+            TrackDeliveryIndex(
+                recordIndex,
+                _callbackCount,
+                ref _callbackDenseCount,
+                ref _callbackIndexes,
+                ref _callbackIndexCount);
             _callbackCount++;
         }
 
@@ -7901,6 +7933,34 @@ internal sealed class PartitionBatch
         array = newArray;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void TrackDeliveryIndex(
+        int recordIndex,
+        int deliveryCount,
+        ref int denseCount,
+        ref int[]? sparseIndexes,
+        ref int sparseCount)
+    {
+        if (recordIndex == deliveryCount)
+            return;
+
+        if (sparseIndexes is null)
+        {
+            denseCount = deliveryCount;
+            sparseIndexes = ProducerContainerPools.DeliveryIndexes.Rent(16);
+        }
+        else if (sparseCount >= sparseIndexes.Length)
+        {
+            GrowArray(
+                ref sparseIndexes,
+                sparseCount,
+                sparseCount + 1,
+                ProducerContainerPools.DeliveryIndexes);
+        }
+
+        sparseIndexes[sparseCount++] = recordIndex;
+    }
+
     /// <summary>
     /// Checks if this batch should be flushed based on linger time and pending completions.
     /// Uses volatile read instead of locking since this is a read-only check.
@@ -8021,7 +8081,13 @@ internal sealed class PartitionBatch
                 _arrayReuseQueue,
                 _createdStopwatchTimestamp,
                 _options.LingerMs * Stopwatch.Frequency / 1_000,
-                _incrementalBuffer);
+                _incrementalBuffer,
+                completionSourceDenseCount: _completionSourceIndexes is null
+                    ? _completionSourceCount
+                    : _completionSourceDenseCount,
+                completionSourceIndexes: _completionSourceIndexes,
+                callbackDenseCount: _callbackIndexes is null ? _callbackCount : _callbackDenseCount,
+                callbackIndexes: _callbackIndexes);
 
             if (_admissionBudget is { } admissionBudget)
             {
@@ -8050,9 +8116,11 @@ internal sealed class PartitionBatch
 
             // Null out references - ownership transferred to ReadyBatch
             _completionSources = null!;
+            _completionSourceIndexes = null;
             _arena = null;
             _incrementalBuffer = null;
             _callbacks = null;
+            _callbackIndexes = null;
         }
         catch
         {
@@ -8079,31 +8147,42 @@ internal sealed class PartitionBatch
 
         if (_completionSourceCount > 0 && _completionSources is not null)
         {
-            for (var i = 0; i < _recordCount; i++)
+            for (var deliveryIndex = 0; deliveryIndex < _completionSourceCount; deliveryIndex++)
             {
-                if (_completionSources[i] is { } source)
+                var recordIndex = _completionSourceIndexes is null
+                                  || deliveryIndex < _completionSourceDenseCount
+                    ? deliveryIndex
+                    : _completionSourceIndexes![deliveryIndex - _completionSourceDenseCount];
+                if (_completionSources[recordIndex] is { } source)
                     PooledCompletionSource.TrySetException(source, exception);
             }
         }
 
         if (_callbackCount > 0 && _callbacks is not null)
         {
-            for (var i = 0; i < _recordCount; i++)
+            for (var deliveryIndex = 0; deliveryIndex < _callbackCount; deliveryIndex++)
             {
-                var callback = _callbacks[i];
+                var recordIndex = _callbackIndexes is null || deliveryIndex < _callbackDenseCount
+                    ? deliveryIndex
+                    : _callbackIndexes![deliveryIndex - _callbackDenseCount];
+                var callback = _callbacks[recordIndex];
                 if (callback is null)
                     continue;
 
                 try { ProducerCallbackContext.Invoke(callback, default, exception); }
                 catch { }
-                _callbacks[i] = null;
+                _callbacks[recordIndex] = null;
             }
         }
 
         ReturnBatchArraysToPool();
         _recordCount = 0;
         _completionSourceCount = 0;
+        _completionSourceDenseCount = 0;
+        _completionSourceIndexCount = 0;
         _callbackCount = 0;
+        _callbackDenseCount = 0;
+        _callbackIndexCount = 0;
         _encodedRecordsStart = 0;
         _encodedRecordsLength = 0;
         _estimatedSize = 0;
@@ -8124,7 +8203,11 @@ internal sealed class PartitionBatch
         ReturnBatchArraysToPool();
         _recordCount = 0;
         _completionSourceCount = 0;
+        _completionSourceDenseCount = 0;
+        _completionSourceIndexCount = 0;
         _callbackCount = 0;
+        _callbackDenseCount = 0;
+        _callbackIndexCount = 0;
         _encodedRecordsStart = 0;
         _encodedRecordsLength = 0;
         _estimatedSize = 0;
@@ -8149,6 +8232,8 @@ internal sealed class PartitionBatch
         // clearArray: false for internal tracking arrays - they will be overwritten on next use
         if (_completionSources is not null)
             ProducerContainerPools.CompletionSources.Return(_completionSources, clearArray: false);
+        if (_completionSourceIndexes is not null)
+            ProducerContainerPools.DeliveryIndexes.Return(_completionSourceIndexes, clearArray: false);
 
         // Return arena buffer if present
         _arena?.Return();
@@ -8157,6 +8242,7 @@ internal sealed class PartitionBatch
 
         // Null out references to prevent accidental reuse
         _completionSources = null!;
+        _completionSourceIndexes = null;
         _arena = null;
         _incrementalBuffer = null;
 
@@ -8164,6 +8250,11 @@ internal sealed class PartitionBatch
         {
             ProducerContainerPools.Callbacks.Return(_callbacks, clearArray: true);
             _callbacks = null;
+        }
+        if (_callbackIndexes is not null)
+        {
+            ProducerContainerPools.DeliveryIndexes.Return(_callbackIndexes, clearArray: false);
+            _callbackIndexes = null;
         }
     }
 
@@ -8340,6 +8431,8 @@ internal sealed class ReadyBatch
     // Working arrays from accumulator (pooled) - mutable for pooling
     private PooledValueTaskSource<RecordMetadata>[]? _completionSourcesArray;
     private int _completionSourcesCount;
+    private int _completionSourceDenseCount;
+    private int[]? _completionSourceIndexes;
 
     // Total records sealed into this batch, captured at Initialize because the
     // RecordBatch's record list may already be recycled when Fail needs the count.
@@ -8353,12 +8446,26 @@ internal sealed class ReadyBatch
     // Callbacks for Send(message, callback) - inline invocation without ThreadPool
     private Action<RecordMetadata, Exception?>?[]? _callbacks;
     private int _callbackCount;
+    private int _callbackDenseCount;
+    private int[]? _callbackIndexes;
 
     internal PooledValueTaskSource<RecordMetadata>? GetCompletionSource(int recordIndex)
         => _completionSourcesArray?[recordIndex];
 
     internal Action<RecordMetadata, Exception?>? GetCallback(int recordIndex)
         => _callbacks?[recordIndex];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetCompletionSourceRecordIndex(int deliveryIndex)
+        => deliveryIndex < _completionSourceDenseCount
+            ? deliveryIndex
+            : _completionSourceIndexes![deliveryIndex - _completionSourceDenseCount];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetCallbackRecordIndex(int deliveryIndex)
+        => deliveryIndex < _callbackDenseCount
+            ? deliveryIndex
+            : _callbackIndexes![deliveryIndex - _callbackDenseCount];
 
     internal bool IsSplitBatch { get; private set; }
 
@@ -8893,7 +9000,11 @@ internal sealed class ReadyBatch
         BatchArrayReuseQueue? arrayReuseQueue = null,
         long createdStopwatchTimestamp = 0,
         long lingerTicks = 0,
-        IncrementalBatchBuffer? incrementalBuffer = null)
+        IncrementalBatchBuffer? incrementalBuffer = null,
+        int completionSourceDenseCount = -1,
+        int[]? completionSourceIndexes = null,
+        int callbackDenseCount = -1,
+        int[]? callbackIndexes = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(recordCount, completionSourcesCount);
         ArgumentOutOfRangeException.ThrowIfLessThan(recordCount, callbackCount);
@@ -8928,6 +9039,10 @@ internal sealed class ReadyBatch
         _recordBatch = recordBatch;
         _completionSourcesArray = completionSourcesArray;
         _completionSourcesCount = completionSourcesCount;
+        _completionSourceDenseCount = completionSourceDenseCount >= 0
+            ? completionSourceDenseCount
+            : completionSourcesCount;
+        _completionSourceIndexes = completionSourceIndexes;
         // Captured at seal time because the RecordBatch's record list may be recycled or
         // never materialized by the time a (possibly stale) Fail needs the count.
         _recordCount = recordCount;
@@ -8941,6 +9056,8 @@ internal sealed class ReadyBatch
         _incrementalBuffer = incrementalBuffer;
         _callbacks = callbacks;
         _callbackCount = callbackCount;
+        _callbackDenseCount = callbackDenseCount >= 0 ? callbackDenseCount : callbackCount;
+        _callbackIndexes = callbackIndexes;
         _arrayReuseQueue = arrayReuseQueue;
         StopwatchSealedTicks = Stopwatch.GetTimestamp();
         StopwatchCreatedTicks = createdStopwatchTimestamp > 0
@@ -8975,9 +9092,10 @@ internal sealed class ReadyBatch
                     $"Batch recycled without completing delivery — this indicates a bug in the producer pipeline " +
                     $"(tp={_topicPartition}, sendCompleted={Volatile.Read(ref _sendCompleted)}, " +
                     $"completed={Volatile.Read(ref _completed)}, trace={DiagTrace})");
-                for (var i = 0; i < _recordCount; i++)
+                for (var deliveryIndex = 0; deliveryIndex < _completionSourcesCount; deliveryIndex++)
                 {
-                    if (_completionSourcesArray[i] is { } source
+                    var recordIndex = GetCompletionSourceRecordIndex(deliveryIndex);
+                    if (_completionSourcesArray[recordIndex] is { } source
                         && PooledCompletionSource.TrySetException(source, orphanedException))
                         failedCount++;
                 }
@@ -8997,12 +9115,16 @@ internal sealed class ReadyBatch
         _recordBatch = null!;
         _completionSourcesArray = null;
         _completionSourcesCount = 0;
+        _completionSourceDenseCount = 0;
+        _completionSourceIndexes = null;
         DataSize = 0;
         EncodedSize = 0;
         _arena = null;
         _incrementalBuffer = null;
         _callbacks = null;
         _callbackCount = 0;
+        _callbackDenseCount = 0;
+        _callbackIndexes = null;
         _arrayReuseQueue = null;
         InflightEntry = null;
         var orphanedBudget = Interlocked.Exchange(ref UnackedBudget, null);
@@ -9071,14 +9193,15 @@ internal sealed class ReadyBatch
 #if DEBUG
                 var completedCount = 0;
 #endif
-                for (var i = 0; i < _recordCount; i++)
+                for (var deliveryIndex = 0; deliveryIndex < _completionSourcesCount; deliveryIndex++)
                 {
-                    var source = _completionSourcesArray[i];
+                    var recordIndex = GetCompletionSourceRecordIndex(deliveryIndex);
+                    var source = _completionSourcesArray[recordIndex];
                     if (source is not null && PooledCompletionSource.TrySetResult(source, new RecordMetadata
                     {
                         Topic = _topicPartition.Topic,
                         Partition = _topicPartition.Partition,
-                        Offset = baseOffset + i,
+                        Offset = baseOffset + recordIndex,
                         Timestamp = timestamp
                     }))
                     {
@@ -9096,9 +9219,10 @@ internal sealed class ReadyBatch
             // Callbacks are invoked on the sender thread, so they must be non-blocking
             if (_callbackCount > 0 && _callbacks is not null)
             {
-                for (var i = 0; i < _recordCount; i++)
+                for (var deliveryIndex = 0; deliveryIndex < _callbackCount; deliveryIndex++)
                 {
-                    var callback = _callbacks[i];
+                    var recordIndex = GetCallbackRecordIndex(deliveryIndex);
+                    var callback = _callbacks[recordIndex];
                     if (callback is not null)
                     {
                         try
@@ -9109,7 +9233,7 @@ internal sealed class ReadyBatch
                                 {
                                     Topic = _topicPartition.Topic,
                                     Partition = _topicPartition.Partition,
-                                    Offset = baseOffset + i,
+                                    Offset = baseOffset + recordIndex,
                                     Timestamp = timestamp
                                 },
                                 null);
@@ -9119,7 +9243,7 @@ internal sealed class ReadyBatch
                             // Swallow callback exceptions - don't crash sender loop
                             // User callbacks are responsible for their own error handling
                         }
-                        _callbacks[i] = null; // Clear for pool reuse
+                        _callbacks[recordIndex] = null; // Clear for pool reuse
                     }
                 }
             }
@@ -9244,9 +9368,10 @@ internal sealed class ReadyBatch
 #if DEBUG
                 var failedCount = 0;
 #endif
-                for (var i = 0; i < _recordCount; i++)
+                for (var deliveryIndex = 0; deliveryIndex < _completionSourcesCount; deliveryIndex++)
                 {
-                    var source = _completionSourcesArray[i];
+                    var recordIndex = GetCompletionSourceRecordIndex(deliveryIndex);
+                    var source = _completionSourcesArray[recordIndex];
                     if (source is not null && PooledCompletionSource.TrySetException(source, exception))
                     {
 #if DEBUG
@@ -9262,9 +9387,10 @@ internal sealed class ReadyBatch
             // Invoke callbacks with exception - NO ThreadPool scheduling
             if (_callbackCount > 0 && _callbacks is not null)
             {
-                for (var i = 0; i < _recordCount; i++)
+                for (var deliveryIndex = 0; deliveryIndex < _callbackCount; deliveryIndex++)
                 {
-                    var callback = _callbacks[i];
+                    var recordIndex = GetCallbackRecordIndex(deliveryIndex);
+                    var callback = _callbacks[recordIndex];
                     if (callback is not null)
                     {
                         try
@@ -9275,7 +9401,7 @@ internal sealed class ReadyBatch
                         {
                             // Swallow callback exceptions - don't crash during failure handling
                         }
-                        _callbacks[i] = null; // Clear for pool reuse
+                        _callbacks[recordIndex] = null; // Clear for pool reuse
                     }
                 }
             }
@@ -9458,10 +9584,12 @@ internal sealed class ReadyBatch
             return;
 
         var completionSourcesArray = _completionSourcesArray;
+        var completionSourceIndexes = _completionSourceIndexes;
         var arrayReuseQueue = _arrayReuseQueue;
         var arena = _arena;
         var incrementalBuffer = _incrementalBuffer;
         var callbacks = _callbacks;
+        var callbackIndexes = _callbackIndexes;
         var recordBatch = _recordBatch;
 
         try
@@ -9485,6 +9613,8 @@ internal sealed class ReadyBatch
                     ProducerContainerPools.CompletionSources.Return(completionSourcesArray, clearArray: false);
                 }
             }
+            if (completionSourceIndexes is not null)
+                ProducerContainerPools.DeliveryIndexes.Return(completionSourceIndexes, clearArray: false);
 
             // Return arena to pool for reuse (arena-based path)
             // This avoids allocating a new BatchArena object on each batch recycle
@@ -9503,6 +9633,8 @@ internal sealed class ReadyBatch
             {
                 ProducerContainerPools.Callbacks.Return(callbacks, clearArray: true);
             }
+            if (callbackIndexes is not null)
+                ProducerContainerPools.DeliveryIndexes.Return(callbackIndexes, clearArray: false);
 
             // Return pre-compressed buffer and RecordBatch to pool.
             // ReturnPreCompressedBuffer() releases the producer-pool buffer, then ReturnToPool()

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2064,7 +2064,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         try
         {
             var sourceRecordBatch = source.RecordBatch;
-            var records = sourceRecordBatch.Records;
+            var records = sourceRecordBatch.GetRecordsForSplit();
             var topicPartition = source.TopicPartition;
             var sourceBaseSequence = sourceRecordBatch.BaseSequence;
             var splitRecordsBudget = source.IsSplitBatch
@@ -7636,7 +7636,8 @@ internal sealed class PartitionBatch
                     ref _callbacks!,
                     _recordCount,
                     recordIndex + 1,
-                    ProducerContainerPools.Callbacks);
+                    ProducerContainerPools.Callbacks,
+                    clearExpandedGap: true);
             }
         }
 
@@ -7887,11 +7888,15 @@ internal sealed class PartitionBatch
         ref T[] array,
         int count,
         int requiredCapacity,
-        ArrayPool<T> pool)
+        ArrayPool<T> pool,
+        bool clearExpandedGap = false)
     {
         var newSize = Math.Max(checked(array.Length * 2), requiredCapacity);
         var newArray = pool.Rent(newSize);
-        Array.Copy(array, newArray, Math.Min(count, array.Length));
+        var copiedCount = Math.Min(count, array.Length);
+        Array.Copy(array, newArray, copiedCount);
+        if (clearExpandedGap && requiredCapacity > copiedCount)
+            Array.Clear(newArray, copiedCount, requiredCapacity - copiedCount);
         pool.Return(array, clearArray: false);
         array = newArray;
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2227,6 +2227,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         foreach (var batch in batches)
         {
+            batch.ClearUnstartedPreSerializationTask();
             batch.TrySetMemoryReleased();
             batch.TryAbandonForSplit(batch.Generation);
             ReturnReadyBatch(batch);
@@ -8823,6 +8824,11 @@ internal sealed class ReadyBatch
     internal void SetPreSerializationTask(Task task)
     {
         Volatile.Write(ref _preSerializationTask, task);
+    }
+
+    internal void ClearUnstartedPreSerializationTask()
+    {
+        Volatile.Write(ref _preSerializationTask, null);
     }
 
     internal void StartPreSerializationTask()

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2137,7 +2137,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 if (sourceBaseSequence >= 0)
                     child.RecordBatch.BaseSequence = checked(sourceBaseSequence + childStartIndex);
                 child.PreserveDeliveryTimeline(source);
-                child.MarkAsSplitBatch(childMaxRecordSize);
+                child.MarkAsSplitBatch(childMaxRecordSize, isRetry: !reenqueue);
                 if (_options.CompressionType == CompressionType.None)
                     PrepareBatchForPublish(child, child.Generation);
                 else
@@ -8553,11 +8553,11 @@ internal sealed class ReadyBatch
 
     internal double ObservedCompressionRatio { get; set; } = 1.0;
 
-    internal void MarkAsSplitBatch(int maxRecordSize)
+    internal void MarkAsSplitBatch(int maxRecordSize, bool isRetry)
     {
         IsSplitBatch = true;
         MaxRecordSize = maxRecordSize;
-        IsRetry = true;
+        IsRetry = isRetry;
     }
 
     // In-flight tracker entry for coordinated retry with multiple in-flight batches per partition.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2059,20 +2059,24 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// The source delivery deadline and idempotent sequence range are retained.
     /// </summary>
     internal bool SplitAndReenqueue(ReadyBatch source, int expectedGeneration)
-        => SplitBatch(source, expectedGeneration, reenqueue: true) is not null;
+        => SplitBatch(source, expectedGeneration, reenqueue: true, senderWakeup: null) is not null;
 
     /// <summary>
     /// KIP-126 split used for a broker rejection. Returns the ordered children to the
     /// owning sender instead of publishing them through the accumulator, so they can
     /// enter the sender's retry deque ahead of newer in-flight retries.
     /// </summary>
-    internal List<ReadyBatch>? SplitForSenderRetry(ReadyBatch source, int expectedGeneration)
-        => SplitBatch(source, expectedGeneration, reenqueue: false);
+    internal List<ReadyBatch>? SplitForSenderRetry(
+        ReadyBatch source,
+        int expectedGeneration,
+        Action senderWakeup)
+        => SplitBatch(source, expectedGeneration, reenqueue: false, senderWakeup);
 
     private List<ReadyBatch>? SplitBatch(
         ReadyBatch source,
         int expectedGeneration,
-        bool reenqueue)
+        bool reenqueue,
+        Action? senderWakeup)
     {
         if (source.RecordCount <= 1 || !source.TryAcquireResourcePin(expectedGeneration))
             return null;
@@ -2139,7 +2143,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 else
                     child.SetPreSerializationTask(reenqueue
                         ? CreatePreSerializationTask(child)
-                        : CreateSenderRetryPreSerializationTask(child));
+                        : CreateSenderRetryPreSerializationTask(child, senderWakeup!));
                 splitBatches.Add(child);
             }
         }
@@ -2207,14 +2211,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (reenqueue)
                 StartPreSerialization(child);
             else
-                StartSenderRetryPreSerialization(child);
+                StartSenderRetryPreSerialization(child, senderWakeup!);
         }
 
         Diagnostics.DekafMetrics.BatchSplits.Add(1, new TagList
         {
             { Diagnostics.DekafDiagnostics.MessagingDestinationName, splitBatches[0].TopicPartition.Topic }
         });
-        SignalWakeup();
+        if (reenqueue)
+            SignalWakeup();
         return splitBatches;
     }
 
@@ -4590,11 +4595,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         readyBatch.StartPreSerializationTask();
     }
 
-    private void StartSenderRetryPreSerialization(ReadyBatch readyBatch)
+    private static void StartSenderRetryPreSerialization(ReadyBatch readyBatch, Action senderWakeup)
     {
         if (readyBatch.IsPreSerialized)
         {
-            SignalWakeup();
+            senderWakeup();
             return;
         }
 
@@ -4615,16 +4620,19 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             TaskCreationOptions.DenyChildAttach);
     }
 
-    private Task CreateSenderRetryPreSerializationTask(ReadyBatch readyBatch)
+    private Task CreateSenderRetryPreSerializationTask(ReadyBatch readyBatch, Action senderWakeup)
     {
         var generation = readyBatch.Generation;
         return new Task(
             static state =>
             {
                 var workItem = (SenderRetryPreSerializationWorkItem)state!;
-                workItem.Accumulator.PreSerializeSenderRetryBatch(workItem.Batch, workItem.Generation);
+                workItem.Accumulator.PreSerializeSenderRetryBatch(
+                    workItem.Batch,
+                    workItem.Generation,
+                    workItem.SenderWakeup);
             },
-            new SenderRetryPreSerializationWorkItem(this, readyBatch, generation),
+            new SenderRetryPreSerializationWorkItem(this, readyBatch, generation, senderWakeup),
             CancellationToken.None,
             TaskCreationOptions.DenyChildAttach);
     }
@@ -4635,10 +4643,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             PublishSealedBatch(readyBatch);
     }
 
-    private void PreSerializeSenderRetryBatch(ReadyBatch readyBatch, int generation)
+    private void PreSerializeSenderRetryBatch(ReadyBatch readyBatch, int generation, Action senderWakeup)
     {
         if (PrepareBatchForPublish(readyBatch, generation) && readyBatch.IsCurrentIncarnation(generation))
-            SignalWakeup();
+            senderWakeup();
     }
 
     private sealed class PreSerializationWorkItem(
@@ -4656,13 +4664,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private sealed class SenderRetryPreSerializationWorkItem(
         RecordAccumulator accumulator,
         ReadyBatch batch,
-        int generation)
+        int generation,
+        Action senderWakeup)
     {
         public RecordAccumulator Accumulator { get; } = accumulator;
 
         public ReadyBatch Batch { get; } = batch;
 
         public int Generation { get; } = generation;
+
+        public Action SenderWakeup { get; } = senderWakeup;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2796,6 +2796,38 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
+    /// Releases accounting and pool ownership for a sender-owned batch that failed during
+    /// pre-serialization. The cleanup pin keeps the expected incarnation stable while this
+    /// path claims the sole pool return.
+    /// </summary>
+    internal bool TryCleanupFailedPreSerializationBatch(ReadyBatch batch, int expectedGeneration)
+    {
+        if (!batch.TryAcquireCleanupPin(expectedGeneration))
+            return false;
+
+        var returnClaimed = false;
+        try
+        {
+            returnClaimed = batch.IsSendCompleted && TryClaimReadyBatchReturn(batch);
+            if (returnClaimed)
+            {
+                try { ReleaseBatchMemory(batch); }
+                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx); }
+                try { OnBatchExitsPipeline(batch); }
+                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx); }
+            }
+        }
+        finally
+        {
+            batch.ReleaseResourcePin();
+        }
+
+        if (returnClaimed)
+            CompleteClaimedReadyBatchReturn(batch);
+        return returnClaimed;
+    }
+
+    /// <summary>
     /// Publishes completion of generation-safe terminal bookkeeping and returns the batch
     /// without touching it after a racing return owner can recycle it.
     /// </summary>
@@ -9030,6 +9062,29 @@ internal sealed class ReadyBatch
             if (Interlocked.CompareExchange(ref _activeResourcePins, current + 1, current) == current)
             {
                 if (IsCurrentIncarnation(expectedGeneration) && Volatile.Read(ref _cleanedUp) == 0)
+                    return true;
+
+                ReleaseResourcePin();
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Pins a terminal batch whose payload cleanup has started. This is reserved for the
+    /// cold owner-cleanup path; normal serialization pins must continue rejecting cleaned batches.
+    /// </summary>
+    internal bool TryAcquireCleanupPin(int expectedGeneration)
+    {
+        while (true)
+        {
+            if (!IsCurrentIncarnation(expectedGeneration))
+                return false;
+
+            var current = Volatile.Read(ref _activeResourcePins);
+            if (Interlocked.CompareExchange(ref _activeResourcePins, current + 1, current) == current)
+            {
+                if (IsCurrentIncarnation(expectedGeneration))
                     return true;
 
                 ReleaseResourcePin();

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -676,6 +676,8 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal bool HasPreEncodedRecords => _hasPreEncodedRecords;
 
+    internal int PreEncodedRecordsLength => _hasPreEncodedRecords ? _preEncodedRecords.Length : 0;
+
     internal void SetPreEncodedRecords(ReadOnlyMemory<byte> records)
     {
         _preEncodedRecords = records;

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -676,7 +676,45 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     internal bool HasPreEncodedRecords => _hasPreEncodedRecords;
 
-    internal int PreEncodedRecordsLength => _hasPreEncodedRecords ? _preEncodedRecords.Length : 0;
+    internal int PreEncodedRecordsLength => _hasPreEncodedRecords ? GetPreEncodedRecordsLength() : 0;
+
+    internal IReadOnlyList<Record> GetRecordsForSplit()
+    {
+        if (_records is not ProducerRecordCountList countOnlyRecords)
+            return Records;
+
+        if (!_hasPreEncodedRecords)
+            throw new InvalidOperationException("Producer records cannot be split without encoded data.");
+
+        var encodedLength = GetPreEncodedRecordsLength();
+        var encodedRecords = ArrayPool<byte>.Shared.Rent(encodedLength);
+        try
+        {
+            GetPreEncodedRecordsSequence().CopyTo(encodedRecords);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(encodedRecords, clearArray: false);
+            throw;
+        }
+
+        LazyRecordList materializedRecords;
+        try
+        {
+            materializedRecords = LazyRecordList.Create(
+                new PooledRecordData(encodedRecords, encodedLength),
+                countOnlyRecords.Count);
+        }
+        catch
+        {
+            ArrayPool<byte>.Shared.Return(encodedRecords, clearArray: false);
+            throw;
+        }
+
+        countOnlyRecords.Dispose();
+        _records = materializedRecords;
+        return materializedRecords;
+    }
 
     internal void SetPreEncodedRecords(ReadOnlyMemory<byte> records)
     {

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -25,6 +25,7 @@ public sealed class DekafMetricInstrumentTests
         DekafMetrics.OperationDuration.Record(0);
         DekafMetrics.ProduceErrors.Add(0);
         DekafMetrics.Retries.Add(0);
+        DekafMetrics.BatchSplits.Add(0);
         DekafMetrics.InlineContinuationExceptions.Add(0);
         DekafMetrics.CompletionSourceFaults.Add(0);
         DekafMetrics.PendingResponseCleanupDeferred.Add(0);
@@ -39,6 +40,7 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.client.operation.duration");
         await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
         await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.batch.splits");
         await Assert.That(instrumentNames).Contains("dekaf.producer.inline_continuation.exceptions");
         await Assert.That(instrumentNames).Contains("dekaf.producer.completion_source.faults");
         await Assert.That(instrumentNames).Contains("dekaf.producer.pending_response.cleanup.deferred");

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -532,6 +532,7 @@ public sealed class AdaptiveScaleDownTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             completionSourcesCount: 1,
+            recordCount: 1,
             dataSize: dataSize);
 
         batch.TrySetMemoryReleased(); // Skip accumulator memory tracking in tests

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -570,13 +570,13 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
     private static MetadataResponse CreateRoutingMetadata(
         int partitionZeroLeader,
         int partitionThreeLeader = 1) => new()
-    {
-        Brokers =
+        {
+            Brokers =
         [
             new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9093 },
             new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9094 }
         ],
-        Topics =
+            Topics =
         [
             new TopicMetadata
             {
@@ -605,7 +605,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
                 ]
             }
         ]
-    };
+        };
 
     private static ReadyBatch CreateMinimalBatch(string topic, int partition)
     {
@@ -615,6 +615,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 100);
         return batch;
     }
@@ -1014,6 +1015,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
                 new RecordBatch { Records = Array.Empty<Record>() },
                 completionSourcesArray: null,
                 completionSourcesCount: 0,
+                recordCount: 0,
                 dataSize: 100);
 
             var coalescedBatches = new ReadyBatch[4];

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -272,7 +272,8 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
         ref int coalescedCount,
         HashSet<TopicPartition> coalescedPartitions,
         object carryOver,
-        int? capturedGeneration = null)
+        int? capturedGeneration = null,
+        bool fromCarryOver = false)
     {
         var coalescedRequestBudgetUsed = 0L;
         for (var i = 0; i < coalescedCount; i++)
@@ -292,7 +293,8 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             coalescedCount,
             coalescedRequestBudgetUsed,
             coalescedPartitions,
-            carryOver
+            carryOver,
+            fromCarryOver
         };
 
         CoalesceBatchMethod.Invoke(sender, args);
@@ -986,6 +988,85 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             await sender.DisposeAsync();
             await accumulator.DisposeAsync();
             await vtPool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task CoalesceBatch_BackoffReadyPrefix_StaysAheadOfUnreadySuffix()
+    {
+        var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
+        var (pool, _) = CreateMockConnection(responseQueue);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            var olderRetry = CreateTestBatch(sourcePool, "test-topic", partition: 0);
+            var unreadySplit = CreateTestBatch(
+                sourcePool,
+                "test-topic",
+                partition: 0,
+                markPreSerialized: false);
+            olderRetry.IsRetry = true;
+            olderRetry.RetryNotBefore = Stopwatch.GetTimestamp() + Stopwatch.Frequency;
+            unreadySplit.IsRetry = true;
+
+            var carryOver = new BrokerSender.PartitionCarryOver();
+            carryOver.AddAfterRetries(new BrokerSender.BatchReference(olderRetry, olderRetry.Generation));
+            carryOver.AddAfterRetries(new BrokerSender.BatchReference(unreadySplit, unreadySplit.Generation));
+            var drained = new List<BrokerSender.BatchReference>();
+            carryOver.DrainTo(drained);
+            var coalescedBatches = new ReadyBatch[4];
+            var coalescedGenerations = new int[4];
+            var coalescedCount = 0;
+            var coalescedPartitions = new HashSet<TopicPartition>();
+
+            InvokeCoalesceBatch(
+                sender,
+                olderRetry,
+                coalescedBatches,
+                coalescedGenerations,
+                ref coalescedCount,
+                coalescedPartitions,
+                carryOver,
+                fromCarryOver: true);
+
+            unreadySplit.MarkPreSerialized();
+            drained.Clear();
+            carryOver.DrainTo(drained);
+
+            await Assert.That(coalescedCount).IsEqualTo(0);
+            await Assert.That(drained).Count().IsEqualTo(2);
+            await Assert.That(ReferenceEquals(drained[0].Batch, olderRetry)).IsTrue();
+            await Assert.That(ReferenceEquals(drained[1].Batch, unreadySplit)).IsTrue();
+
+            // Repeated all-ready drain/requeue cycles must reset the prefix insertion cursor.
+            carryOver.Add(new BrokerSender.BatchReference(olderRetry, olderRetry.Generation));
+            for (var i = 0; i < 2; i++)
+            {
+                drained.Clear();
+                carryOver.DrainTo(drained);
+                await Assert.That(drained).Count().IsEqualTo(1);
+                InvokeCoalesceBatch(
+                    sender,
+                    drained[0].Batch,
+                    coalescedBatches,
+                    coalescedGenerations,
+                    ref coalescedCount,
+                    coalescedPartitions,
+                    carryOver,
+                    fromCarryOver: true);
+            }
+
+            await Assert.That(carryOver.Count).IsEqualTo(1);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await sourcePool.DisposeAsync();
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -113,6 +113,57 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             ]
         };
 
+    [Test]
+    public async Task PartitionCarryOver_UnreadySplitPrefixBlocksLaterRetry()
+    {
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        try
+        {
+            var firstSplit = CreateTestBatch(
+                sourcePool,
+                "test-topic",
+                partition: 0,
+                markPreSerialized: false);
+            var secondSplit = CreateTestBatch(
+                sourcePool,
+                "test-topic",
+                partition: 0,
+                markPreSerialized: false);
+            var newerRetry = CreateTestBatch(sourcePool, "test-topic", partition: 0);
+            firstSplit.IsRetry = true;
+            secondSplit.IsRetry = true;
+            newerRetry.IsRetry = true;
+
+            var carryOver = new BrokerSender.PartitionCarryOver();
+            carryOver.AddAfterRetries(new BrokerSender.BatchReference(firstSplit, firstSplit.Generation));
+            carryOver.AddAfterRetries(new BrokerSender.BatchReference(secondSplit, secondSplit.Generation));
+            carryOver.AddAfterRetries(new BrokerSender.BatchReference(newerRetry, newerRetry.Generation));
+            var drained = new List<BrokerSender.BatchReference>();
+
+            carryOver.DrainTo(drained);
+            await Assert.That(drained).IsEmpty();
+            await Assert.That(carryOver.Count).IsEqualTo(3);
+
+            firstSplit.MarkPreSerialized();
+            carryOver.DrainTo(drained);
+            await Assert.That(drained).Count().IsEqualTo(1);
+            await Assert.That(ReferenceEquals(drained[0].Batch, firstSplit)).IsTrue();
+            await Assert.That(carryOver.Count).IsEqualTo(2);
+
+            drained.Clear();
+            secondSplit.MarkPreSerialized();
+            carryOver.DrainTo(drained);
+            await Assert.That(drained).Count().IsEqualTo(2);
+            await Assert.That(ReferenceEquals(drained[0].Batch, secondSplit)).IsTrue();
+            await Assert.That(ReferenceEquals(drained[1].Batch, newerRetry)).IsTrue();
+            await Assert.That(carryOver.Count).IsEqualTo(0);
+        }
+        finally
+        {
+            await sourcePool.DisposeAsync();
+        }
+    }
+
     private static ProduceResponse CreateInlineLeaderErrorResponse(
         string topic,
         int partition,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -332,6 +332,89 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    public async Task FailedSenderSplit_PreSerializationFailure_ReleasesPipelineAccounting()
+    {
+        const string topic = "failed-sender-split";
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1_000,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.Gzip,
+            LingerMs = 0
+        };
+        var codecs = new CompressionCodecRegistry();
+        codecs.Register(new ThrowingCompressionCodec());
+        var accumulator = new RecordAccumulator(options, codecs);
+        var sender = CreateSender(
+            Substitute.For<IConnectionPool>(),
+            options,
+            accumulator,
+            static (_, _, _, _, _) => { });
+        var sourceBuilder = new PartitionBatch(new TopicPartition(topic, 0), options);
+        sourceBuilder.SetSplitBatchSizeLimit(4_096);
+        for (var i = 0; i < 8; i++)
+        {
+            var value = new byte[120];
+            value.AsSpan().Fill((byte)i);
+            var appended = sourceBuilder.TryAppendFromSpans(
+                timestamp: 1_000 + i,
+                keyData: default,
+                keyIsNull: true,
+                valueData: value,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                estimatedSize: PartitionBatch.EstimateRecordSize(0, value.Length, null, 0));
+            if (!appended.Success)
+                throw new InvalidOperationException("Test record did not fit.");
+        }
+
+        var source = sourceBuilder.Complete()!;
+        source.MarkAsSplitBatch(maxRecordSize: 128, isRetry: true);
+        source.MarkPreSerialized();
+        source.TrySetMemoryReleased();
+
+        try
+        {
+            var children = accumulator.SplitForSenderRetry(
+                source,
+                source.Generation,
+                static () => { })!;
+            var generations = children.Select(static child => child.Generation).ToArray();
+            foreach (var child in children)
+                child.WaitForPreSerializationIfStarted();
+
+            await Assert.That(children).Count().IsGreaterThan(1);
+            await Assert.That(children.All(static child => child.IsSendCompleted)).IsTrue();
+            await Assert.That(accumulator.BufferedBytes).IsGreaterThan(0);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(children.Count);
+
+            var acquireMethod = typeof(BrokerSender).GetMethod(
+                "AcquireResourcePins",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var batches = children.ToArray();
+            var acquired = (int)acquireMethod.Invoke(
+                sender,
+                [batches, generations, batches.Length])!;
+
+            await Assert.That(acquired).IsEqualTo(0);
+            await Assert.That(children.All(static child => child.IsReturnedToPool)).IsTrue();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0);
+            await Assert.That(accumulator.HasPendingWork()).IsFalse();
+            await accumulator.FlushAsync(CancellationToken.None);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task SelectWaveCoalesceBounds_ScalesWithLingerAndRetainsHardCaps()
     {
         var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);
@@ -769,6 +852,17 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             TransactionalId = transactionalId,
             SaslMechanism = saslMechanism
         };
+
+    private sealed class ThrowingCompressionCodec : ICompressionCodec
+    {
+        public CompressionType Type => CompressionType.Gzip;
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+            => throw new InvalidOperationException("Injected compression failure.");
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+            => throw new NotSupportedException();
+    }
 
     /// <summary>
     /// Creates a mock connection pool that returns a controllable mock connection.

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -802,6 +802,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             completionSourcesCount: 1,
+            recordCount: 1,
             dataSize: 100);
         batch.TrySetMemoryReleased();
         return (batch, delivery);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -295,6 +295,43 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    public async Task SenderRetryReady_WakesNoPendingCarryOverWait(CancellationToken cancellationToken)
+    {
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var sender = CreateSender(
+            Substitute.For<IConnectionPool>(),
+            options,
+            accumulator,
+            static (_, _, _, _, _) => { });
+
+        try
+        {
+            var waitMethod = typeof(BrokerSender).GetMethod(
+                "WaitForNoPendingCarryOverAsync",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var senderRetryReady = (Action)typeof(BrokerSender).GetField(
+                "_senderRetryReadyCallback",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+            var wait = (ValueTask)waitMethod.Invoke(
+                sender,
+                [10_000, cancellationToken])!;
+            var waitTask = wait.AsTask();
+
+            await Assert.That(waitTask.IsCompleted).IsFalse();
+
+            senderRetryReady();
+
+            await waitTask;
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task SelectWaveCoalesceBounds_ScalesWithLingerAndRetainsHardCaps()
     {
         var zeroLinger = BrokerSender.SelectWaveCoalesceBounds(lingerMs: 0);

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -66,6 +66,83 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
+    public async Task FirstLateCallback_GrowsArrayToRecordIndex()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 64 * 1024,
+            InitialBatchRecordCapacity = 16
+        };
+        var batch = new PartitionBatch(new TopicPartition("late-callback", 0), options);
+        RecordMetadata callbackMetadata = default;
+
+        for (var i = 0; i < 100; i++)
+            Append(batch, i, completionSource: null, callback: null);
+        Append(batch, 100, completionSource: null, (metadata, _) => callbackMetadata = metadata);
+
+        var ready = batch.Complete()!;
+        ready.TrySetMemoryReleased();
+        ready.CompleteSend(500, DateTimeOffset.UnixEpoch);
+
+        await Assert.That(callbackMetadata.Offset).IsEqualTo(600);
+    }
+
+    [Test]
+    public async Task SplitAndReenqueue_ReplacesSourceBufferMemoryReservation()
+    {
+        const string topic = "kip-126-accounting";
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1000,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.None,
+            LingerMs = 60_000
+        };
+        var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(topic, partitionCount: 1);
+        try
+        {
+            for (var i = 0; i < 4; i++)
+            {
+                await Assert.That(await accumulator.AppendAsync(
+                    topic,
+                    partition: 0,
+                    timestamp: 1_000 + i,
+                    PooledMemory.Null,
+                    PooledMemory.Null,
+                    headers: null,
+                    headerCount: 0,
+                    completionSource: null,
+                    callback: null,
+                    CancellationToken.None)).IsTrue();
+            }
+
+            await AccumulatorTestHelpers.SealAllAsync(accumulator);
+            var source = await DrainOneAsync(accumulator, metadataManager);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(source.DataSize);
+
+            await Assert.That(accumulator.SplitAndReenqueue(source, source.Generation)).IsTrue();
+            var child = await DrainOneAsync(accumulator, metadataManager);
+
+            await Assert.That(child.RecordCount).IsEqualTo(4);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(child.DataSize);
+
+            child.CompleteSend(0, DateTimeOffset.UnixEpoch);
+            accumulator.ReleaseBatchMemory(child);
+            accumulator.OnBatchExitsPipeline(child);
+            accumulator.ReturnReadyBatch(child);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task SplitAndReenqueue_PreservesOrderSequencesAndDeliveryOwnership()
     {
         const string topic = "kip-126";

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -247,7 +247,7 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
-    public async Task SplitForSenderRetry_ReturnsOrderedChildrenWithoutAccumulatorPublish()
+    public async Task SplitForSenderRetry_SignalsSenderWhenCompressedChildrenAreReady()
     {
         const string topic = "sender-retry-split";
         var options = new ProducerOptions
@@ -255,7 +255,7 @@ public sealed class Kip126BatchSplittingTests
             BootstrapServers = ["localhost:9092"],
             BatchSize = 1000,
             BufferMemory = 1024 * 1024,
-            CompressionType = CompressionType.None,
+            CompressionType = CompressionType.Gzip,
             LingerMs = 0
         };
         var sourceBuilder = new PartitionBatch(new TopicPartition(topic, 0), options);
@@ -271,12 +271,20 @@ public sealed class Kip126BatchSplittingTests
 
         await using var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
         await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(topic, partitionCount: 1);
-        var children = accumulator.SplitForSenderRetry(source, source.Generation)!;
+        var senderWakeups = 0;
+        var children = accumulator.SplitForSenderRetry(
+            source,
+            source.Generation,
+            () => Interlocked.Increment(ref senderWakeups))!;
         try
         {
+            foreach (var child in children)
+                child.WaitForPreSerializationIfStarted();
+
             await Assert.That(children).Count().IsGreaterThan(1);
             await Assert.That(children.All(static child => child.IsPreSerialized)).IsTrue();
             await Assert.That(children.Sum(static child => child.RecordCount)).IsEqualTo(8);
+            await Assert.That(senderWakeups).IsEqualTo(children.Count);
 
             var expectedSequence = 40;
             foreach (var child in children)

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -327,6 +327,47 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
+    public async Task SplitForSenderRetry_LaterChildBuildFails_DiscardsUnstartedPreSerializationTasks()
+    {
+        const string topic = "sender-retry-split-failure";
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1000,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.Gzip,
+            LingerMs = 0
+        };
+        var sourceBuilder = new PartitionBatch(new TopicPartition(topic, 0), options);
+        sourceBuilder.SetSplitBatchSizeLimit(4096);
+        for (var i = 0; i < 8; i++)
+            Append(sourceBuilder, i, completionSource: null, callback: null);
+
+        var source = sourceBuilder.Complete()!;
+        source.RecordBatch.BaseSequence = int.MaxValue;
+        source.MarkAsSplitBatch(maxRecordSize: 1, isRetry: true);
+        source.MarkPreSerialized();
+        source.TrySetMemoryReleased();
+
+        await using var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
+        try
+        {
+            var splitTask = Task.Run(() => accumulator.SplitForSenderRetry(
+                source,
+                source.Generation,
+                static () => { }));
+
+            await Assert.That(async () => await splitTask.WaitAsync(TimeSpan.FromSeconds(5)))
+                .ThrowsExactly<OverflowException>();
+        }
+        finally
+        {
+            source.Fail(new InvalidOperationException("Test cleanup."));
+            accumulator.ReturnReadyBatch(source);
+        }
+    }
+
+    [Test]
     public async Task Drain_AdaptiveBatchExpandsLocally_SplitsAndReenqueues()
     {
         const string topic = "adaptive-local-split";

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -283,7 +283,7 @@ public sealed class Kip126BatchSplittingTests
 
         var source = sourceBuilder.Complete()!;
         source.RecordBatch.BaseSequence = 40;
-        source.MarkAsSplitBatch(maxRecordSize: 128);
+        source.MarkAsSplitBatch(maxRecordSize: 128, isRetry: true);
         source.MarkPreSerialized();
         source.TrySetMemoryReleased();
 
@@ -375,6 +375,7 @@ public sealed class Kip126BatchSplittingTests
         while (drainedRecords < recordCount)
         {
             var child = await DrainOneAsync(accumulator, metadataManager);
+            await Assert.That(child.IsRetry).IsFalse();
             drainedRecords += child.RecordCount;
             childCount++;
             CompleteAndReturn(accumulator, child, drainedRecords - child.RecordCount);

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -31,6 +31,15 @@ public sealed class Kip126BatchSplittingTests
             new TopicPartition("other", 0), options, estimator);
         await Assert.That(trainedTopicBatch.EffectiveBatchSizeLimit)
             .IsGreaterThan(untrainedTopicBatch.EffectiveBatchSizeLimit);
+        var normalArenaCapacity = ProducerOptions.GetEffectiveArenaCapacity(
+            options.BatchSize,
+            options.ArenaCapacity);
+        await Assert.That(trainedTopicBatch.Arena!.Capacity).IsEqualTo(normalArenaCapacity);
+
+        for (var i = 0; i < 10; i++)
+            Append(trainedTopicBatch, i, completionSource: null, callback: null);
+        await Assert.That(trainedTopicBatch.Arena!.Capacity).IsGreaterThan(normalArenaCapacity);
+
         trainedTopicBatch.Complete();
         untrainedTopicBatch.Complete();
 
@@ -122,8 +131,10 @@ public sealed class Kip126BatchSplittingTests
             await AccumulatorTestHelpers.SealAllAsync(accumulator);
             var source = await DrainOneAsync(accumulator, metadataManager);
             await Assert.That(accumulator.BufferedBytes).IsEqualTo(source.DataSize);
+            var flushTask = accumulator.FlushAsync(CancellationToken.None).AsTask();
 
             await Assert.That(accumulator.SplitAndReenqueue(source, source.Generation)).IsTrue();
+            await Assert.That(flushTask.IsCompleted).IsFalse();
             var child = await DrainOneAsync(accumulator, metadataManager);
 
             await Assert.That(child.RecordCount).IsEqualTo(4);
@@ -133,6 +144,7 @@ public sealed class Kip126BatchSplittingTests
             accumulator.ReleaseBatchMemory(child);
             accumulator.OnBatchExitsPipeline(child);
             accumulator.ReturnReadyBatch(child);
+            await flushTask;
             await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
         }
         finally

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -10,6 +10,24 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class Kip126BatchSplittingTests
 {
     [Test]
+    public async Task CompressedBatch_ZeroBufferMemory_UsesMinimumSizeLimit()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1024,
+            BufferMemory = 0,
+            CompressionType = CompressionType.Gzip
+        };
+
+        var batch = new PartitionBatch(new TopicPartition("zero-buffer", 0), options);
+
+        await Assert.That(batch.EffectiveBatchSizeLimit)
+            .IsEqualTo(RecordBatch.TotalBatchHeaderSize + 1);
+        batch.Complete();
+    }
+
+    [Test]
     public async Task CompressionEstimate_IsPerTopic_AndResetIsConservative()
     {
         var estimator = new CompressionRatioEstimator();

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Dekaf.Compression;
 using Dekaf.Metadata;
 using Dekaf.Producer;
@@ -140,10 +141,7 @@ public sealed class Kip126BatchSplittingTests
             await Assert.That(child.RecordCount).IsEqualTo(4);
             await Assert.That(accumulator.BufferedBytes).IsEqualTo(child.DataSize);
 
-            child.CompleteSend(0, DateTimeOffset.UnixEpoch);
-            accumulator.ReleaseBatchMemory(child);
-            accumulator.OnBatchExitsPipeline(child);
-            accumulator.ReturnReadyBatch(child);
+            CompleteAndReturn(accumulator, child, baseOffset: 0);
             await flushTask;
             await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
         }
@@ -215,11 +213,8 @@ public sealed class Kip126BatchSplittingTests
             var baseOffset = 100L;
             foreach (var batch in drained)
             {
-                batch.CompleteSend(baseOffset, DateTimeOffset.UnixEpoch);
+                CompleteAndReturn(accumulator, batch, baseOffset);
                 baseOffset += batch.RecordCount;
-                accumulator.ReleaseBatchMemory(batch);
-                accumulator.OnBatchExitsPipeline(batch);
-                accumulator.ReturnReadyBatch(batch);
             }
 
             for (var i = 0; i < tasks.Length; i++)
@@ -236,6 +231,66 @@ public sealed class Kip126BatchSplittingTests
             await metadataManager.DisposeAsync();
             await sourcePool.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task Drain_AdaptiveBatchExpandsLocally_SplitsAndReenqueues()
+    {
+        const string topic = "adaptive-local-split";
+        const int recordCount = 100;
+        const int maxRequestSize = 512;
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 256,
+            MaxRequestSize = maxRequestSize,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.Gzip,
+            LingerMs = 60_000
+        };
+        var codecs = new CompressionCodecRegistry();
+        codecs.Register(new SizeSensitiveCompressionCodec(maxRequestSize, options.BatchSize));
+        await using var accumulator = new RecordAccumulator(options, codecs);
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(topic, partitionCount: 1);
+
+        // Model a topic that has learned a strong ratio, allowing the adaptive parent
+        // to grow well beyond BatchSize before its actual compression ratio is known.
+        var estimator = AccumulatorTestHelpers.GetPrivateField<CompressionRatioEstimator>(
+            accumulator,
+            "_compressionRatioEstimator");
+        for (var i = 0; i < 200; i++)
+            estimator.Update(topic, CompressionType.Gzip, observedRatio: 0.1);
+
+        for (var i = 0; i < recordCount; i++)
+            await Assert.That(await AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, topic)).IsTrue();
+        await AccumulatorTestHelpers.SealAllAsync(accumulator);
+
+        var readyNodes = await WaitForReadyNodeAsync(accumulator, metadataManager);
+        var firstDrain = new Dictionary<int, List<ReadyBatch>>();
+        accumulator.Drain(
+            metadataManager,
+            readyNodes,
+            maxRequestSize,
+            firstDrain,
+            new Stack<List<ReadyBatch>>());
+
+        await Assert.That(firstDrain).DoesNotContainKey(1);
+        await Assert.That(accumulator.HasPendingWork()).IsTrue();
+
+        var drainedRecords = 0;
+        var childCount = 0;
+        while (drainedRecords < recordCount)
+        {
+            var child = await DrainOneAsync(accumulator, metadataManager);
+            drainedRecords += child.RecordCount;
+            childCount++;
+            CompleteAndReturn(accumulator, child, drainedRecords - child.RecordCount);
+        }
+
+        await Assert.That(childCount).IsGreaterThan(1);
+        await Assert.That(drainedRecords).IsEqualTo(recordCount);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        await Assert.That(accumulator.HasPendingWork()).IsFalse();
     }
 
     private static void Append(
@@ -265,15 +320,7 @@ public sealed class Kip126BatchSplittingTests
         RecordAccumulator accumulator,
         MetadataManager metadataManager)
     {
-        var readyNodes = new HashSet<int>();
-        await TestWait.UntilAsync(
-            () =>
-            {
-                readyNodes.Clear();
-                accumulator.Ready(metadataManager, readyNodes);
-                return readyNodes.Contains(1);
-            },
-            TimeSpan.FromSeconds(5));
+        var readyNodes = await WaitForReadyNodeAsync(accumulator, metadataManager);
 
         var drainResult = new Dictionary<int, List<ReadyBatch>>();
         accumulator.Drain(
@@ -283,5 +330,51 @@ public sealed class Kip126BatchSplittingTests
             drainResult,
             new Stack<List<ReadyBatch>>());
         return drainResult[1][0];
+    }
+
+    private static async Task<HashSet<int>> WaitForReadyNodeAsync(
+        RecordAccumulator accumulator,
+        MetadataManager metadataManager)
+    {
+        var readyNodes = new HashSet<int>();
+        await TestWait.UntilAsync(
+            () =>
+            {
+                readyNodes.Clear();
+                accumulator.Ready(metadataManager, readyNodes);
+                return readyNodes.Contains(1);
+            },
+            TimeSpan.FromSeconds(5));
+        return readyNodes;
+    }
+
+    private static void CompleteAndReturn(
+        RecordAccumulator accumulator,
+        ReadyBatch batch,
+        long baseOffset)
+    {
+        batch.CompleteSend(baseOffset, DateTimeOffset.UnixEpoch);
+        accumulator.ReleaseBatchMemory(batch);
+        accumulator.OnBatchExitsPipeline(batch);
+        accumulator.ReturnReadyBatch(batch);
+    }
+
+    private sealed class SizeSensitiveCompressionCodec(int expandedSize, int expandAboveBytes)
+        : ICompressionCodec
+    {
+        public CompressionType Type => CompressionType.Gzip;
+
+        public void Compress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            var size = source.Length > expandAboveBytes ? expandedSize : 1;
+            destination.GetSpan(size)[..size].Clear();
+            destination.Advance(size);
+        }
+
+        public void Decompress(ReadOnlySequence<byte> source, IBufferWriter<byte> destination)
+        {
+            foreach (var segment in source)
+                destination.Write(segment.Span);
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -1,0 +1,198 @@
+using Dekaf.Compression;
+using Dekaf.Metadata;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public sealed class Kip126BatchSplittingTests
+{
+    [Test]
+    public async Task CompressionEstimate_IsPerTopic_AndResetIsConservative()
+    {
+        var estimator = new CompressionRatioEstimator();
+
+        for (var i = 0; i < 100; i++)
+            estimator.Update("compressible", CompressionType.Gzip, 0.1);
+
+        await Assert.That(estimator.Get("compressible", CompressionType.Gzip)).IsLessThan(1.0);
+        await Assert.That(estimator.Get("other", CompressionType.Gzip)).IsEqualTo(1.0);
+
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1024,
+            CompressionType = CompressionType.Gzip
+        };
+        var trainedTopicBatch = new PartitionBatch(
+            new TopicPartition("compressible", 0), options, estimator);
+        var untrainedTopicBatch = new PartitionBatch(
+            new TopicPartition("other", 0), options, estimator);
+        await Assert.That(trainedTopicBatch.EffectiveBatchSizeLimit)
+            .IsGreaterThan(untrainedTopicBatch.EffectiveBatchSizeLimit);
+        trainedTopicBatch.Complete();
+        untrainedTopicBatch.Complete();
+
+        estimator.ResetAfterSplit("compressible", CompressionType.Gzip, 0.2);
+
+        await Assert.That(estimator.Get("compressible", CompressionType.Gzip)).IsEqualTo(1.0);
+    }
+
+    [Test]
+    public async Task CompletionAndCallbackOffsets_FollowOriginalRecordIndexes()
+    {
+        var options = new ProducerOptions { BootstrapServers = ["localhost:9092"], BatchSize = 4096 };
+        var batch = new PartitionBatch(new TopicPartition("offsets", 0), options);
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var first = sourcePool.Rent();
+        var third = sourcePool.Rent();
+        var firstTask = first.Task;
+        var thirdTask = third.Task;
+        RecordMetadata callbackMetadata = default;
+
+        Append(batch, 0, first, null);
+        Append(batch, 1, null, (metadata, error) => callbackMetadata = metadata);
+        Append(batch, 2, third, null);
+
+        var ready = batch.Complete()!;
+        ready.TrySetMemoryReleased();
+        ready.CompleteSend(100, DateTimeOffset.UnixEpoch);
+
+        await Assert.That((await firstTask).Offset).IsEqualTo(100);
+        await Assert.That(callbackMetadata.Offset).IsEqualTo(101);
+        await Assert.That((await thirdTask).Offset).IsEqualTo(102);
+        await sourcePool.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SplitAndReenqueue_PreservesOrderSequencesAndDeliveryOwnership()
+    {
+        const string topic = "kip-126";
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1000,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.Gzip,
+            LingerMs = 0
+        };
+        var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sourceBuilder = new PartitionBatch(new TopicPartition(topic, 0), options);
+        sourceBuilder.SetSplitBatchSizeLimit(4096);
+        var tasks = new ValueTask<RecordMetadata>[4];
+        var callbacks = new RecordMetadata[4];
+
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            var source = sourcePool.Rent();
+            tasks[i] = source.Task;
+            var callbackIndex = i;
+            Append(sourceBuilder, i, source, (metadata, error) => callbacks[callbackIndex] = metadata);
+        }
+
+        var sourceBatch = sourceBuilder.Complete()!;
+        sourceBatch.RecordBatch.BaseSequence = 50;
+        sourceBatch.RecordBatch.PreCompress(options.CompressionType, new CompressionCodecRegistry());
+        sourceBatch.ObservedCompressionRatio = (double)sourceBatch.RecordBatch.PreCompressedLength
+            / sourceBatch.RecordBatch.PreEncodedRecordsLength;
+        sourceBatch.SetEncodedSize(sourceBatch.RecordBatch.GetEncodedSize(options.CompressionType));
+        sourceBatch.MarkPreSerialized();
+        sourceBatch.TrySetMemoryReleased();
+        var originalCreatedTicks = sourceBatch.StopwatchCreatedTicks;
+
+        var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
+        var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(topic, partitionCount: 1);
+        var drained = new List<ReadyBatch>();
+        try
+        {
+            accumulator.MutePartition(new TopicPartition(topic, 0));
+            await Assert.That(accumulator.SplitAndReenqueue(sourceBatch, sourceBatch.Generation)).IsTrue();
+            accumulator.UnmutePartition(new TopicPartition(topic, 0));
+
+            var rejectedSplit = await DrainOneAsync(accumulator, metadataManager);
+            await Assert.That(rejectedSplit.RecordCount).IsEqualTo(4);
+            accumulator.ReleaseBatchMemory(rejectedSplit);
+            await Assert.That(accumulator.SplitAndReenqueue(rejectedSplit, rejectedSplit.Generation)).IsTrue();
+
+            while (drained.Sum(static batch => batch.RecordCount) < tasks.Length)
+                drained.Add(await DrainOneAsync(accumulator, metadataManager));
+
+            await Assert.That(drained.Count).IsGreaterThan(1);
+            await Assert.That(drained.Select(static batch => batch.RecordBatch.BaseSequence))
+                .IsEquivalentTo([50, 52]);
+            await Assert.That(drained.All(batch => batch.StopwatchCreatedTicks == originalCreatedTicks)).IsTrue();
+
+            var baseOffset = 100L;
+            foreach (var batch in drained)
+            {
+                batch.CompleteSend(baseOffset, DateTimeOffset.UnixEpoch);
+                baseOffset += batch.RecordCount;
+                accumulator.ReleaseBatchMemory(batch);
+                accumulator.OnBatchExitsPipeline(batch);
+                accumulator.ReturnReadyBatch(batch);
+            }
+
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                await Assert.That((await tasks[i]).Offset).IsEqualTo(100 + i);
+                await Assert.That(callbacks[i].Offset).IsEqualTo(100 + i);
+            }
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await metadataManager.DisposeAsync();
+            await sourcePool.DisposeAsync();
+        }
+    }
+
+    private static void Append(
+        PartitionBatch batch,
+        int index,
+        PooledValueTaskSource<RecordMetadata>? completionSource,
+        Action<RecordMetadata, Exception?>? callback)
+    {
+        var value = new byte[120];
+        value.AsSpan().Fill((byte)index);
+        var result = batch.TryAppendFromSpans(
+            timestamp: 1_000 + index,
+            keyData: default,
+            keyIsNull: true,
+            valueData: value,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource,
+            callback,
+            estimatedSize: PartitionBatch.EstimateRecordSize(0, value.Length, null, 0));
+        if (!result.Success)
+            throw new InvalidOperationException("Test record did not fit.");
+    }
+
+    private static async Task<ReadyBatch> DrainOneAsync(
+        RecordAccumulator accumulator,
+        MetadataManager metadataManager)
+    {
+        var readyNodes = new HashSet<int>();
+        await TestWait.UntilAsync(
+            () =>
+            {
+                readyNodes.Clear();
+                accumulator.Ready(metadataManager, readyNodes);
+                return readyNodes.Contains(1);
+            },
+            TimeSpan.FromSeconds(5));
+
+        var drainResult = new Dictionary<int, List<ReadyBatch>>();
+        accumulator.Drain(
+            metadataManager,
+            readyNodes,
+            int.MaxValue,
+            drainResult,
+            new Stack<List<ReadyBatch>>());
+        return drainResult[1][0];
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -247,6 +247,60 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
+    public async Task SplitForSenderRetry_ReturnsOrderedChildrenWithoutAccumulatorPublish()
+    {
+        const string topic = "sender-retry-split";
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1000,
+            BufferMemory = 1024 * 1024,
+            CompressionType = CompressionType.None,
+            LingerMs = 0
+        };
+        var sourceBuilder = new PartitionBatch(new TopicPartition(topic, 0), options);
+        sourceBuilder.SetSplitBatchSizeLimit(4096);
+        for (var i = 0; i < 8; i++)
+            Append(sourceBuilder, i, completionSource: null, callback: null);
+
+        var source = sourceBuilder.Complete()!;
+        source.RecordBatch.BaseSequence = 40;
+        source.MarkAsSplitBatch(maxRecordSize: 128);
+        source.MarkPreSerialized();
+        source.TrySetMemoryReleased();
+
+        await using var accumulator = new RecordAccumulator(options, new CompressionCodecRegistry());
+        await using var metadataManager = AccumulatorTestHelpers.CreateMetadataManager(topic, partitionCount: 1);
+        var children = accumulator.SplitForSenderRetry(source, source.Generation)!;
+        try
+        {
+            await Assert.That(children).Count().IsGreaterThan(1);
+            await Assert.That(children.All(static child => child.IsPreSerialized)).IsTrue();
+            await Assert.That(children.Sum(static child => child.RecordCount)).IsEqualTo(8);
+
+            var expectedSequence = 40;
+            foreach (var child in children)
+            {
+                await Assert.That(child.RecordBatch.BaseSequence).IsEqualTo(expectedSequence);
+                expectedSequence += child.RecordCount;
+            }
+
+            var readyNodes = new HashSet<int>();
+            accumulator.Ready(metadataManager, readyNodes);
+            await Assert.That(readyNodes).IsEmpty();
+        }
+        finally
+        {
+            var baseOffset = 0L;
+            foreach (var child in children)
+            {
+                CompleteAndReturn(accumulator, child, baseOffset);
+                baseOffset += child.RecordCount;
+            }
+        }
+    }
+
+    [Test]
     public async Task Drain_AdaptiveBatchExpandsLocally_SplitsAndReenqueues()
     {
         const string topic = "adaptive-local-split";

--- a/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/Kip126BatchSplittingTests.cs
@@ -76,8 +76,15 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
+    [NotInParallel]
     public async Task FirstLateCallback_GrowsArrayToRecordIndex()
     {
+        var staleCallbackCount = 0;
+        var staleCallbacks = ProducerContainerPools.Callbacks.Rent(128);
+        for (var i = 0; i <= 100; i++)
+            staleCallbacks[i] = (_, _) => staleCallbackCount++;
+        ProducerContainerPools.Callbacks.Return(staleCallbacks, clearArray: false);
+
         var options = new ProducerOptions
         {
             BootstrapServers = ["localhost:9092"],
@@ -96,6 +103,7 @@ public sealed class Kip126BatchSplittingTests
         ready.CompleteSend(500, DateTimeOffset.UnixEpoch);
 
         await Assert.That(callbackMetadata.Offset).IsEqualTo(600);
+        await Assert.That(staleCallbackCount).IsEqualTo(0);
     }
 
     [Test]
@@ -153,7 +161,10 @@ public sealed class Kip126BatchSplittingTests
     }
 
     [Test]
-    public async Task SplitAndReenqueue_PreservesOrderSequencesAndDeliveryOwnership()
+    [Arguments(BufferMemoryAllocationStrategy.Full)]
+    [Arguments(BufferMemoryAllocationStrategy.Incremental)]
+    public async Task SplitAndReenqueue_PreservesOrderSequencesAndDeliveryOwnership(
+        BufferMemoryAllocationStrategy allocationStrategy)
     {
         const string topic = "kip-126";
         var options = new ProducerOptions
@@ -162,6 +173,7 @@ public sealed class Kip126BatchSplittingTests
             BatchSize = 1000,
             BufferMemory = 1024 * 1024,
             CompressionType = CompressionType.Gzip,
+            BufferMemoryAllocationStrategy = allocationStrategy,
             LingerMs = 0
         };
         var sourcePool = new ValueTaskSourcePool<RecordMetadata>();
@@ -181,6 +193,7 @@ public sealed class Kip126BatchSplittingTests
         var sourceBatch = sourceBuilder.Complete()!;
         sourceBatch.RecordBatch.BaseSequence = 50;
         sourceBatch.RecordBatch.PreCompress(options.CompressionType, new CompressionCodecRegistry());
+        await Assert.That(sourceBatch.RecordBatch.PreEncodedRecordsLength).IsGreaterThan(0);
         sourceBatch.ObservedCompressionRatio = (double)sourceBatch.RecordBatch.PreCompressedLength
             / sourceBatch.RecordBatch.PreEncodedRecordsLength;
         sourceBatch.SetEncodedSize(sourceBatch.RecordBatch.GetEncodedSize(options.CompressionType));

--- a/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MemoryReleasedAtomicityTests.cs
@@ -201,6 +201,7 @@ public class MemoryReleasedAtomicityTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 50);
 
         // Second lifecycle — must succeed again
@@ -217,6 +218,7 @@ public class MemoryReleasedAtomicityTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 100);
         return batch;
     }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledValueTaskSourceTests.cs
@@ -795,6 +795,7 @@ public class PooledValueTaskSourceTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             completionSourcesCount: 2,
+            recordCount: 2,
             dataSize: 0);
         var doneTask = batch.DoneTask;
 
@@ -843,6 +844,7 @@ public class PooledValueTaskSourceTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             completionSourcesCount: 3,
+            recordCount: 3,
             dataSize: 0);
 
         if (succeeds)
@@ -1114,6 +1116,7 @@ public class PooledValueTaskSourceTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -46,6 +46,7 @@ public sealed class ReadyBatchIncarnationTests
             new RecordBatch { Records = Array.Empty<Record>() },
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 100);
     }
 
@@ -80,6 +81,7 @@ public sealed class ReadyBatchIncarnationTests
             recordBatch,
             completionSourcesArray: null,
             completionSourcesCount: 0,
+            recordCount: 0,
             dataSize: 100,
             arena: arena);
         var generation = batch.Generation;

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3151,6 +3151,7 @@ public class RecordAccumulatorTests
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
+            recordCount: messageCount,
             dataSize: 100);
 
         return batch;
@@ -3293,6 +3294,7 @@ public class RecordAccumulatorTests
                 new RecordBatch { Records = Array.Empty<Record>() },
                 newSources,
                 completionSourcesCount: 1,
+                recordCount: 1,
                 dataSize: 200);
 
             await Assert.That((int)cleanedUpField.GetValue(batch)!).IsEqualTo(0);

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -1724,6 +1724,62 @@ public class RecordAccumulatorTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task PartitionBatch_FirstSparseCallback_ClearsRentedPrefix()
+    {
+        var staleCallbackCount = 0;
+        var callbackCount = 0;
+        var staleCallbacks = ProducerContainerPools.Callbacks.Rent(16);
+        for (var i = 0; i < 6; i++)
+            staleCallbacks[i] = (_, _) => staleCallbackCount++;
+        ProducerContainerPools.Callbacks.Return(staleCallbacks, clearArray: false);
+
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1024,
+            InitialBatchRecordCapacity = 16
+        };
+        var batch = new PartitionBatch(new TopicPartition("test-topic", 0), options);
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var result = batch.TryAppendFromSpans(
+                timestamp + i,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                "value"u8,
+                valueIsNull: false,
+                headers: null,
+                headerCount: 0,
+                completionSource: null,
+                callback: null,
+                estimatedSize: 5);
+            await Assert.That(result.Success).IsTrue();
+        }
+
+        var callbackResult = batch.TryAppendFromSpans(
+            timestamp + 5,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            "value"u8,
+            valueIsNull: false,
+            headers: null,
+            headerCount: 0,
+            completionSource: null,
+            callback: (_, _) => callbackCount++,
+            estimatedSize: 5);
+        await Assert.That(callbackResult.Success).IsTrue();
+
+        var readyBatch = batch.Complete();
+        readyBatch!.CompleteSend(0, DateTimeOffset.UtcNow);
+
+        await Assert.That(staleCallbackCount).IsEqualTo(0);
+        await Assert.That(callbackCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task PartitionBatch_Complete_CalledTwice_ReturnsIdempotent()
     {
         // This test verifies that calling Complete() multiple times on the same PartitionBatch

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -183,6 +183,7 @@ public abstract class ScriptedProduceResponseFixture
             new RecordBatch { Records = Array.Empty<Record>() },
             sources,
             messageCount,
+            recordCount: messageCount,
             dataSize: dataSize);
 
         if (markMemoryReleased)

--- a/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ScriptedProduceResponses.cs
@@ -171,7 +171,8 @@ public abstract class ScriptedProduceResponseFixture
     private protected static ReadyBatch CreateTestBatch(
         ValueTaskSourcePool<RecordMetadata> pool,
         string topic, int partition, int messageCount = 1,
-        bool markMemoryReleased = true, int dataSize = 100)
+        bool markMemoryReleased = true, int dataSize = 100,
+        bool markPreSerialized = true)
     {
         var batch = new ReadyBatch();
         var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(messageCount);
@@ -185,6 +186,9 @@ public abstract class ScriptedProduceResponseFixture
             messageCount,
             recordCount: messageCount,
             dataSize: dataSize);
+
+        if (markPreSerialized)
+            batch.MarkPreSerialized();
 
         if (markMemoryReleased)
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BatchMemoryAllocationBenchmarks.cs
@@ -47,7 +47,7 @@ public class BatchMemoryAllocationBenchmarks
 
         const int poolSize = BatchArena.DefaultPoolSize;
         _readyBatchPool = new ReadyBatchPool(poolSize * 2);
-        _batchPool = new PartitionBatchPool(_options, poolSize);
+        _batchPool = new PartitionBatchPool(_options, maxPoolSize: poolSize);
         _batchPool.SetReadyBatchPool(_readyBatchPool);
 
         if (AllocationStrategy == BufferMemoryAllocationStrategy.Incremental)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerCarryOverBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerCarryOverBenchmarks.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 10, iterationCount: 10)]
+public class ProducerCarryOverBenchmarks
+{
+    private const int BatchCount = 8;
+
+    private readonly BrokerSender.PartitionCarryOver _carryOver = new();
+    private readonly List<BrokerSender.BatchReference> _drained = new(BatchCount);
+    private ReadyBatch[] _batches = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _batches = new ReadyBatch[BatchCount];
+        for (var i = 0; i < _batches.Length; i++)
+        {
+            var batch = new ReadyBatch();
+            batch.Initialize(
+                new TopicPartition("carry-over", 0),
+                new RecordBatch { Records = [] },
+                completionSourcesArray: null,
+                completionSourcesCount: 0,
+                recordCount: 0,
+                dataSize: 0);
+            batch.IsRetry = true;
+            batch.MarkPreSerialized();
+            _batches[i] = batch;
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchCount)]
+    public int EnqueueAndDrainReadyRetries()
+    {
+        for (var i = 0; i < _batches.Length; i++)
+        {
+            var batch = _batches[i];
+            _carryOver.AddAfterRetries(new BrokerSender.BatchReference(batch, batch.Generation));
+        }
+
+        _drained.Clear();
+        _carryOver.DrainTo(_drained);
+        return _drained.Count;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerRetryWaitBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerRetryWaitBenchmarks.cs
@@ -1,0 +1,25 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Internal;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ProducerRetryWaitBenchmarks
+{
+    private readonly AsyncAutoResetSignal _signal = new();
+
+    [Benchmark(Baseline = true)]
+    public Task TimedPoll() => Task.Delay(1);
+
+    [Benchmark]
+    public ValueTask<bool> SignaledWait()
+    {
+        _signal.Signal();
+        return _signal.WaitAsync(100);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _signal.Dispose();
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/SparseReadyBatchCompletionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/SparseReadyBatchCompletionBenchmarks.cs
@@ -1,0 +1,152 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Monitoring, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class SparseReadyBatchCompletionBenchmarks
+{
+    private const int BatchCount = 64;
+    private const int RecordsPerBatch = 16_384;
+
+    private readonly TopicPartition _topicPartition = new("sparse-completion", 0);
+    private readonly ValueTaskSourcePool<RecordMetadata> _sourcePool = new();
+    private readonly ReadyBatch[] _batches = new ReadyBatch[BatchCount];
+    private readonly ValueTask<RecordMetadata>[] _tasks = new ValueTask<RecordMetadata>[BatchCount];
+    private ProducerOptions _options = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1_048_576,
+            InitialBatchRecordCapacity = RecordsPerBatch
+        };
+    }
+
+    [IterationSetup]
+    public void PrepareBatches()
+    {
+        for (var batchIndex = 0; batchIndex < _batches.Length; batchIndex++)
+        {
+            var batch = new PartitionBatch(_topicPartition, _options);
+            for (var recordIndex = 0; recordIndex < RecordsPerBatch - 1; recordIndex++)
+                Append(batch, recordIndex, completionSource: null);
+
+            var source = _sourcePool.Rent();
+            _tasks[batchIndex] = source.Task;
+            Append(batch, RecordsPerBatch - 1, source);
+            _batches[batchIndex] = batch.Complete()!;
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchCount)]
+    public long CompleteSparseBatches()
+    {
+        var offset = 0L;
+        for (var i = 0; i < _batches.Length; i++)
+        {
+            _batches[i].CompleteSend(offset, DateTimeOffset.UnixEpoch);
+            offset += _tasks[i].GetAwaiter().GetResult().Offset;
+        }
+
+        return offset;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _sourcePool.DisposeAsync().GetAwaiter().GetResult();
+
+    private static void Append(
+        PartitionBatch batch,
+        int recordIndex,
+        PooledValueTaskSource<RecordMetadata>? completionSource)
+    {
+        if (!batch.TryAppendFromSpans(
+                recordIndex,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                ReadOnlySpan<byte>.Empty,
+                valueIsNull: true,
+                headers: null,
+                headerCount: 0,
+                completionSource,
+                callback: null,
+                estimatedSize: 16).Success)
+        {
+            throw new InvalidOperationException("Benchmark record did not fit.");
+        }
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Monitoring, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class DenseDeliveryIndexTrackingBenchmarks
+{
+    private const int BatchCount = 256;
+    private const int RecordsPerBatch = 16_384;
+
+    private readonly TopicPartition _topicPartition = new("dense-completion", 0);
+    private readonly PooledValueTaskSource<RecordMetadata> _source = new();
+    private readonly PartitionBatch[] _batches = new PartitionBatch[BatchCount];
+    private ProducerOptions _options = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BatchSize = 1_048_576,
+            InitialBatchRecordCapacity = RecordsPerBatch
+        };
+    }
+
+    [IterationSetup]
+    public void PrepareBatches()
+    {
+        for (var i = 0; i < _batches.Length; i++)
+            _batches[i] = new PartitionBatch(_topicPartition, _options);
+    }
+
+    [Benchmark(OperationsPerInvoke = BatchCount * RecordsPerBatch)]
+    public int AppendDenseCompletions()
+    {
+        for (var batchIndex = 0; batchIndex < _batches.Length; batchIndex++)
+        {
+            var batch = _batches[batchIndex];
+            for (var recordIndex = 0; recordIndex < RecordsPerBatch; recordIndex++)
+            {
+                if (!batch.TryAppendFromSpans(
+                        recordIndex,
+                        ReadOnlySpan<byte>.Empty,
+                        keyIsNull: true,
+                        ReadOnlySpan<byte>.Empty,
+                        valueIsNull: true,
+                        headers: null,
+                        headerCount: 0,
+                        _source,
+                        callback: null,
+                        estimatedSize: 16).Success)
+                {
+                    throw new InvalidOperationException("Benchmark record did not fit.");
+                }
+            }
+        }
+
+        return _batches[^1].RecordCount;
+    }
+
+    [IterationCleanup]
+    public void CleanupBatches()
+    {
+        for (var i = 0; i < _batches.Length; i++)
+        {
+            var ready = _batches[i].Complete()!;
+            ready.TryAbandonForSplit(ready.Generation);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- track KIP-126 compression estimates independently per topic and codec, with conservative improvement/deterioration steps and reset-after-split behavior
- split and re-encode broker-rejected multi-record batches while preserving FIFO order, idempotent sequences, callbacks, cancellation ownership, delivery deadlines, and BufferMemory/unacked-byte accounting
- add `dekaf.producer.batch.splits` telemetry and record-aligned delivery metadata so split children retain exact record offsets

## Validation

- `dotnet build src/Dekaf/Dekaf.csproj -c Release -f netstandard2.0 --no-restore` — clean
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release -f net10.0 --no-restore` — clean
- net8 full unit suite — 5509/5509 passed
- net10 full unit suite — 5634/5635 passed; sole failure was the existing timing race `AdaptiveScaleDownTests.PartitionLimitedPressure_DisposeFlushesPartialWindow` (expected 2 diagnostic events, observed 3), and the exact test passes isolated 1/1
- focused KIP-126 and metric tests — 4/4 passed
- integration test project Release net10 build — clean
- `dotnet format Dekaf.sln --verify-no-changes --no-restore --include ...` — clean

KIP: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=68715855

Closes #2255