### PR TITLE
fix(networking): negotiate capabilities per connection

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -915,12 +915,6 @@ public sealed class AdminClient : IAdminClient
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(Protocol.ApiKey.ListTransactions))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support ListTransactions (API key 66).");
-        }
-
         var opts = options ?? new ListTransactionsOptions();
 
         return await WithRetryAsync(async () =>
@@ -1016,12 +1010,6 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTransactions))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support DescribeTransactions (API key 65).");
-        }
-
         var transactionalIdList = transactionalIds.ToList();
         if (transactionalIdList.Count == 0)
         {
@@ -1100,12 +1088,6 @@ public sealed class AdminClient : IAdminClient
         ArgumentNullException.ThrowIfNull(partitions);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(Protocol.ApiKey.DescribeProducers))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support DescribeProducers (API key 61).");
-        }
 
         var partitionList = partitions.ToList();
         if (partitionList.Count == 0)
@@ -1210,12 +1192,6 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(Protocol.ApiKey.InitProducerId))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support InitProducerId (API key 22).");
-        }
-
         var transactionalIdList = transactionalIds.ToList();
         if (transactionalIdList.Count == 0)
         {
@@ -1304,12 +1280,6 @@ public sealed class AdminClient : IAdminClient
         ArgumentNullException.ThrowIfNull(transaction);
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(Protocol.ApiKey.WriteTxnMarkers))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support WriteTxnMarkers (API key 27).");
-        }
 
         return await WithRetryAsync(async () =>
         {

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -136,18 +136,16 @@ public sealed class AdminClient : IAdminClient
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.ListClientMetricsResources))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support ListClientMetricsResources (API key 74).");
-        }
-
         return await WithRetryAsync<IReadOnlyList<ClientMetricsResourceListing>>(async () =>
         {
             using var connectionLease = await LeaseAnyBrokerConnectionAsync(cancellationToken).ConfigureAwait(false);
             var connection = connectionLease.Connection;
+            if (!_metadataManager.HasApiKey(connection, Protocol.ApiKey.ListClientMetricsResources))
+                throw new Errors.BrokerVersionException($"Broker {connection.BrokerId} does not support ListClientMetricsResources (API key 74).");
             var request = new ListClientMetricsResourcesRequest();
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.ListClientMetricsResources,
                 ListClientMetricsResourcesRequest.LowestSupportedVersion,
                 ListClientMetricsResourcesRequest.HighestSupportedVersion);
@@ -219,6 +217,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.CreateTopics,
                 CreateTopicsRequest.LowestSupportedVersion,
                 CreateTopicsRequest.HighestSupportedVersion);
@@ -346,6 +345,7 @@ public sealed class AdminClient : IAdminClient
             var controller = controllerLease.Connection;
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DeleteTopics,
                 DeleteTopicsRequest.LowestSupportedVersion,
                 DeleteTopicsRequest.HighestSupportedVersion);
@@ -513,11 +513,6 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTopicPartitions))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support DescribeTopicPartitions (API key 75).");
-        }
-
         return await WithRetryAsync(async () =>
         {
             var brokers = _metadataManager.Metadata.GetBrokers();
@@ -529,6 +524,9 @@ public sealed class AdminClient : IAdminClient
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
 
             var connection = connectionLease.Connection;
+            if (!_metadataManager.HasApiKey(connection, Protocol.ApiKey.DescribeTopicPartitions))
+                throw new Errors.BrokerVersionException($"Broker {connection.BrokerId} does not support DescribeTopicPartitions (API key 75).");
+
             var request = new DescribeTopicPartitionsRequest
             {
                 Topics = topicList.Select(static name => new DescribeTopicPartitionsRequestTopic
@@ -546,6 +544,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.DescribeTopicPartitions,
                 DescribeTopicPartitionsRequest.LowestSupportedVersion,
                 DescribeTopicPartitionsRequest.HighestSupportedVersion);
@@ -669,11 +668,6 @@ public sealed class AdminClient : IAdminClient
         IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
         CancellationToken cancellationToken)
     {
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.ConsumerGroupDescribe))
-        {
-            return await DescribeConsumerGroupsWithClassicApiAsync(groupsByCoordinator, cancellationToken).ConfigureAwait(false);
-        }
-
         var (descriptions, classicFallbackGroups) = await DescribeConsumerGroupsWithKip848Async(
             groupsByCoordinator,
             cancellationToken).ConfigureAwait(false);
@@ -695,11 +689,6 @@ public sealed class AdminClient : IAdminClient
         IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
         CancellationToken cancellationToken)
     {
-        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-            Protocol.ApiKey.ConsumerGroupDescribe,
-            ConsumerGroupDescribeRequest.LowestSupportedVersion,
-            ConsumerGroupDescribeRequest.HighestSupportedVersion);
-
         var result = new Dictionary<string, GroupDescription>();
         var classicFallbackGroups = new Dictionary<int, List<string>>();
 
@@ -707,6 +696,17 @@ public sealed class AdminClient : IAdminClient
         {
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
             var connection = connectionLease.Connection;
+            if (!_metadataManager.HasApiKey(connection, Protocol.ApiKey.ConsumerGroupDescribe))
+            {
+                classicFallbackGroups[coordinatorId] = groups;
+                continue;
+            }
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                Protocol.ApiKey.ConsumerGroupDescribe,
+                ConsumerGroupDescribeRequest.LowestSupportedVersion,
+                ConsumerGroupDescribeRequest.HighestSupportedVersion);
 
             var request = new ConsumerGroupDescribeRequest
             {
@@ -782,17 +782,17 @@ public sealed class AdminClient : IAdminClient
         IReadOnlyDictionary<int, List<string>> groupsByCoordinator,
         CancellationToken cancellationToken)
     {
-        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-            Protocol.ApiKey.DescribeGroups,
-            DescribeGroupsRequest.LowestSupportedVersion,
-            DescribeGroupsRequest.HighestSupportedVersion);
-
         var result = new Dictionary<string, GroupDescription>();
 
         foreach (var (coordinatorId, groups) in groupsByCoordinator)
         {
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
             var connection = connectionLease.Connection;
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                Protocol.ApiKey.DescribeGroups,
+                DescribeGroupsRequest.LowestSupportedVersion,
+                DescribeGroupsRequest.HighestSupportedVersion);
 
             var request = new DescribeGroupsRequest
             {
@@ -855,16 +855,6 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.ListGroups,
-                ListGroupsRequest.LowestSupportedVersion,
-                ListGroupsRequest.HighestSupportedVersion);
-
-            var request = new ListGroupsRequest
-            {
-                StatesFilter = apiVersion >= 4 ? opts.States : null
-            };
-
             // Query all brokers since each only knows about groups it coordinates
             var seenGroupIds = new HashSet<string>();
             var result = new List<GroupListing>();
@@ -873,6 +863,15 @@ public sealed class AdminClient : IAdminClient
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.ListGroups,
+                    ListGroupsRequest.LowestSupportedVersion,
+                    ListGroupsRequest.HighestSupportedVersion);
+                var request = new ListGroupsRequest
+                {
+                    StatesFilter = apiVersion >= 4 ? opts.States : null
+                };
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -916,7 +915,8 @@ public sealed class AdminClient : IAdminClient
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.ListTransactions))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(Protocol.ApiKey.ListTransactions))
         {
             throw new Errors.BrokerVersionException("Broker does not support ListTransactions (API key 66).");
         }
@@ -931,33 +931,35 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.ListTransactions,
-                ListTransactionsRequest.LowestSupportedVersion,
-                ListTransactionsRequest.HighestSupportedVersion);
-
-            if (opts.DurationFilterMs >= 0 && apiVersion < 1)
-            {
-                throw new Errors.BrokerVersionException("Broker does not support ListTransactions duration filters (API key 66 v1).");
-            }
-
-            if (!string.IsNullOrEmpty(opts.TransactionalIdPattern) && apiVersion < 2)
-            {
-                throw new Errors.BrokerVersionException("Broker does not support ListTransactions transactional ID pattern filters (API key 66 v2).");
-            }
-
-            var request = new ListTransactionsRequest
-            {
-                StateFilters = opts.StateFilters,
-                ProducerIdFilters = opts.ProducerIdFilters,
-                DurationFilterMs = opts.DurationFilterMs,
-                TransactionalIdPattern = opts.TransactionalIdPattern
-            };
-
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.ListTransactions,
+                    ListTransactionsRequest.LowestSupportedVersion,
+                    ListTransactionsRequest.HighestSupportedVersion);
+
+                if (opts.DurationFilterMs >= 0 && apiVersion < 1)
+                {
+                    throw new Errors.BrokerVersionException(
+                        $"Broker {broker.NodeId} does not support ListTransactions duration filters (API key 66 v1).");
+                }
+
+                if (!string.IsNullOrEmpty(opts.TransactionalIdPattern) && apiVersion < 2)
+                {
+                    throw new Errors.BrokerVersionException(
+                        $"Broker {broker.NodeId} does not support ListTransactions transactional ID pattern filters (API key 66 v2).");
+                }
+
+                var request = new ListTransactionsRequest
+                {
+                    StateFilters = opts.StateFilters,
+                    ProducerIdFilters = opts.ProducerIdFilters,
+                    DurationFilterMs = opts.DurationFilterMs,
+                    TransactionalIdPattern = opts.TransactionalIdPattern
+                };
                 var response = await connection.SendAsync<ListTransactionsRequest, ListTransactionsResponse>(
                     request,
                     apiVersion,
@@ -1014,7 +1016,8 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTransactions))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(Protocol.ApiKey.DescribeTransactions))
         {
             throw new Errors.BrokerVersionException("Broker does not support DescribeTransactions (API key 65).");
         }
@@ -1040,17 +1043,17 @@ public sealed class AdminClient : IAdminClient
                 ids.Add(transactionalId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DescribeTransactions,
-                DescribeTransactionsRequest.LowestSupportedVersion,
-                DescribeTransactionsRequest.HighestSupportedVersion);
-
             var result = new Dictionary<string, TransactionDescription>(StringComparer.Ordinal);
 
             foreach (var (coordinatorId, ids) in idsByCoordinator)
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DescribeTransactions,
+                    DescribeTransactionsRequest.LowestSupportedVersion,
+                    DescribeTransactionsRequest.HighestSupportedVersion);
                 var request = new DescribeTransactionsRequest
                 {
                     TransactionalIds = ids
@@ -1098,7 +1101,8 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeProducers))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(Protocol.ApiKey.DescribeProducers))
         {
             throw new Errors.BrokerVersionException("Broker does not support DescribeProducers (API key 61).");
         }
@@ -1142,17 +1146,17 @@ public sealed class AdminClient : IAdminClient
                 ((List<int>)topicEntry.PartitionIndexes).Add(topicPartition.Partition);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DescribeProducers,
-                DescribeProducersRequest.LowestSupportedVersion,
-                DescribeProducersRequest.HighestSupportedVersion);
-
             var result = new Dictionary<TopicPartition, DescribeProducersResultInfo>();
 
             foreach (var (leaderId, topics) in partitionsByLeader)
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DescribeProducers,
+                    DescribeProducersRequest.LowestSupportedVersion,
+                    DescribeProducersRequest.HighestSupportedVersion);
                 var request = new DescribeProducersRequest
                 {
                     Topics = topics
@@ -1206,10 +1210,8 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!SupportsApiRange(
-            Protocol.ApiKey.InitProducerId,
-            InitProducerIdRequest.LowestSupportedVersion,
-            InitProducerIdRequest.HighestSupportedVersion))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(Protocol.ApiKey.InitProducerId))
         {
             throw new Errors.BrokerVersionException("Broker does not support InitProducerId (API key 22).");
         }
@@ -1237,17 +1239,20 @@ public sealed class AdminClient : IAdminClient
                 ids.Add(transactionalId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.InitProducerId,
-                InitProducerIdRequest.LowestSupportedVersion,
-                InitProducerIdRequest.HighestSupportedVersion);
-
             var result = new Dictionary<string, FenceProducersResultInfo>(StringComparer.Ordinal);
 
             foreach (var (coordinatorId, ids) in idsByCoordinator)
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                if (!_metadataManager.HasApiKey(connection, Protocol.ApiKey.InitProducerId))
+                    throw new Errors.BrokerVersionException($"Broker {coordinatorId} does not support InitProducerId (API key 22).");
+
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.InitProducerId,
+                    InitProducerIdRequest.LowestSupportedVersion,
+                    InitProducerIdRequest.HighestSupportedVersion);
 
                 foreach (var transactionalId in ids)
                 {
@@ -1300,10 +1305,8 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!SupportsApiRange(
-            Protocol.ApiKey.WriteTxnMarkers,
-            WriteTxnMarkersRequest.LowestSupportedVersion,
-            WriteTxnMarkersRequest.HighestSupportedVersion))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(Protocol.ApiKey.WriteTxnMarkers))
         {
             throw new Errors.BrokerVersionException("Broker does not support WriteTxnMarkers (API key 27).");
         }
@@ -1317,11 +1320,6 @@ public sealed class AdminClient : IAdminClient
                 throw new KafkaException(Protocol.ErrorCode.LeaderNotAvailable,
                     $"No leader available for {topicPartition.Topic}-{topicPartition.Partition}");
             }
-
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.WriteTxnMarkers,
-                WriteTxnMarkersRequest.LowestSupportedVersion,
-                WriteTxnMarkersRequest.HighestSupportedVersion);
 
             var request = new WriteTxnMarkersRequest
             {
@@ -1348,6 +1346,14 @@ public sealed class AdminClient : IAdminClient
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderNode.NodeId, cancellationToken).ConfigureAwait(false);
 
             var connection = connectionLease.Connection;
+            if (!_metadataManager.HasApiKey(connection, Protocol.ApiKey.WriteTxnMarkers))
+                throw new Errors.BrokerVersionException($"Broker {leaderNode.NodeId} does not support WriteTxnMarkers (API key 27).");
+
+            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                Protocol.ApiKey.WriteTxnMarkers,
+                WriteTxnMarkersRequest.LowestSupportedVersion,
+                WriteTxnMarkersRequest.HighestSupportedVersion);
             var response = await connection.SendAsync<WriteTxnMarkersRequest, WriteTxnMarkersResponse>(
                 request,
                 apiVersion,
@@ -1396,15 +1402,15 @@ public sealed class AdminClient : IAdminClient
                 groups.Add(groupId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DeleteGroups,
-                DeleteGroupsRequest.LowestSupportedVersion,
-                DeleteGroupsRequest.HighestSupportedVersion);
-
             foreach (var (coordinatorId, groups) in groupsByCoordinator)
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(coordinatorId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DeleteGroups,
+                    DeleteGroupsRequest.LowestSupportedVersion,
+                    DeleteGroupsRequest.HighestSupportedVersion);
 
                 var request = new DeleteGroupsRequest
                 {
@@ -1461,6 +1467,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.OffsetFetch,
                 OffsetFetchRequest.LowestSupportedVersion,
                 OffsetFetchRequest.HighestSupportedVersion);
@@ -1538,6 +1545,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.OffsetCommit,
                 OffsetCommitRequest.LowestSupportedVersion,
                 OffsetCommitRequest.HighestSupportedVersion);
@@ -1591,17 +1599,17 @@ public sealed class AdminClient : IAdminClient
                 leaderOffsets.Add((tp, offset));
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DeleteRecords,
-                DeleteRecordsRequest.LowestSupportedVersion,
-                DeleteRecordsRequest.HighestSupportedVersion);
-
             var result = new Dictionary<TopicPartition, long>();
 
             foreach (var (leaderId, leaderOffsets) in partitionsByLeader)
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(leaderId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DeleteRecords,
+                    DeleteRecordsRequest.LowestSupportedVersion,
+                    DeleteRecordsRequest.HighestSupportedVersion);
 
                 // Build topics array from offsets grouped by topic
                 var topics = leaderOffsets
@@ -1672,6 +1680,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.CreatePartitions,
                 CreatePartitionsRequest.LowestSupportedVersion,
                 CreatePartitionsRequest.HighestSupportedVersion);
@@ -1746,6 +1755,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.AlterPartitionReassignments,
                 AlterPartitionReassignmentsRequest.LowestSupportedVersion,
                 AlterPartitionReassignmentsRequest.HighestSupportedVersion);
@@ -1815,6 +1825,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.ListPartitionReassignments,
                 ListPartitionReassignmentsRequest.LowestSupportedVersion,
                 ListPartitionReassignmentsRequest.HighestSupportedVersion);
@@ -1926,6 +1937,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DescribeUserScramCredentials,
                 DescribeUserScramCredentialsRequest.LowestSupportedVersion,
                 DescribeUserScramCredentialsRequest.HighestSupportedVersion);
@@ -2022,6 +2034,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.AlterUserScramCredentials,
                 AlterUserScramCredentialsRequest.LowestSupportedVersion,
                 AlterUserScramCredentialsRequest.HighestSupportedVersion);
@@ -2065,6 +2078,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.DescribeClientQuotas,
                 DescribeClientQuotasRequest.LowestSupportedVersion,
                 DescribeClientQuotasRequest.HighestSupportedVersion);
@@ -2121,6 +2135,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.AlterClientQuotas,
                 AlterClientQuotasRequest.LowestSupportedVersion,
                 AlterClientQuotasRequest.HighestSupportedVersion);
@@ -2261,6 +2276,7 @@ public sealed class AdminClient : IAdminClient
         };
 
         var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            controller,
             Protocol.ApiKey.CreateDelegationToken,
             CreateDelegationTokenRequest.LowestSupportedVersion,
             CreateDelegationTokenRequest.HighestSupportedVersion);
@@ -2304,6 +2320,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.RenewDelegationToken,
                 RenewDelegationTokenRequest.LowestSupportedVersion,
                 RenewDelegationTokenRequest.HighestSupportedVersion);
@@ -2343,6 +2360,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.ExpireDelegationToken,
                 ExpireDelegationTokenRequest.LowestSupportedVersion,
                 ExpireDelegationTokenRequest.HighestSupportedVersion);
@@ -2379,6 +2397,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DescribeDelegationToken,
                 DescribeDelegationTokenRequest.LowestSupportedVersion,
                 DescribeDelegationTokenRequest.HighestSupportedVersion);
@@ -2515,6 +2534,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.DescribeConfigs,
                 DescribeConfigsRequest.LowestSupportedVersion,
                 DescribeConfigsRequest.HighestSupportedVersion);
@@ -2603,6 +2623,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.AlterConfigs,
                 AlterConfigsRequest.LowestSupportedVersion,
                 AlterConfigsRequest.HighestSupportedVersion);
@@ -2664,6 +2685,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.IncrementalAlterConfigs,
                 IncrementalAlterConfigsRequest.LowestSupportedVersion,
                 IncrementalAlterConfigsRequest.HighestSupportedVersion);
@@ -2719,6 +2741,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.CreateAcls,
                 CreateAclsRequest.LowestSupportedVersion,
                 CreateAclsRequest.HighestSupportedVersion);
@@ -2775,6 +2798,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DeleteAcls,
                 DeleteAclsRequest.LowestSupportedVersion,
                 DeleteAclsRequest.HighestSupportedVersion);
@@ -2850,6 +2874,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DescribeAcls,
                 DescribeAclsRequest.LowestSupportedVersion,
                 DescribeAclsRequest.HighestSupportedVersion);
@@ -2933,6 +2958,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.OffsetDelete,
                 OffsetDeleteRequest.LowestSupportedVersion,
                 OffsetDeleteRequest.HighestSupportedVersion);
@@ -3048,6 +3074,7 @@ public sealed class AdminClient : IAdminClient
                 };
 
                 var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
                     Protocol.ApiKey.ListOffsets,
                     ListOffsetsRequest.LowestSupportedVersion,
                     ListOffsetsRequest.HighestSupportedVersion);
@@ -3136,6 +3163,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.ElectLeaders,
                 ElectLeadersRequest.LowestSupportedVersion,
                 ElectLeadersRequest.HighestSupportedVersion);
@@ -3180,16 +3208,12 @@ public sealed class AdminClient : IAdminClient
     {
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.DescribeQuorum))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support DescribeQuorum (API key 55).");
-        }
-
         return await WithRetryAsync(async () =>
         {
             using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
             var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.DescribeQuorum,
                 DescribeQuorumRequest.LowestSupportedVersion,
                 DescribeQuorumRequest.HighestSupportedVersion);
@@ -3269,16 +3293,12 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.AddRaftVoter))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support AddRaftVoter (API key 80).");
-        }
-
         await WithRetryAsync(async () =>
         {
             using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
             var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.AddRaftVoter,
                 AddRaftVoterRequest.LowestSupportedVersion,
                 AddRaftVoterRequest.HighestSupportedVersion);
@@ -3327,16 +3347,12 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.RemoveRaftVoter))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support RemoveRaftVoter (API key 81).");
-        }
-
         await WithRetryAsync(async () =>
         {
             using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
             var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.RemoveRaftVoter,
                 RemoveRaftVoterRequest.LowestSupportedVersion,
                 RemoveRaftVoterRequest.HighestSupportedVersion);
@@ -3368,16 +3384,12 @@ public sealed class AdminClient : IAdminClient
 
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
 
-        if (!_metadataManager.HasApiKey(Protocol.ApiKey.UnregisterBroker))
-        {
-            throw new Errors.BrokerVersionException("Broker does not support UnregisterBroker (API key 64).");
-        }
-
         await WithRetryAsync(async () =>
         {
             using var controllerLease = await LeaseControllerAsync(cancellationToken).ConfigureAwait(false);
             var controller = controllerLease.Connection;
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                controller,
                 Protocol.ApiKey.UnregisterBroker,
                 UnregisterBrokerRequest.LowestSupportedVersion,
                 UnregisterBrokerRequest.HighestSupportedVersion);
@@ -3422,16 +3434,16 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<int, IReadOnlyDictionary<string, LogDirDescription>>>(async () =>
         {
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.DescribeLogDirs,
-                DescribeLogDirsRequest.LowestSupportedVersion,
-                DescribeLogDirsRequest.HighestSupportedVersion);
-
             // Fan out to all requested brokers in parallel.
             var brokerResults = await Task.WhenAll(brokerIdList.Select(async brokerId =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.DescribeLogDirs,
+                    DescribeLogDirsRequest.LowestSupportedVersion,
+                    DescribeLogDirsRequest.HighestSupportedVersion);
                 var response = await connection.SendAsync<DescribeLogDirsRequest, DescribeLogDirsResponse>(
                     new DescribeLogDirsRequest { Topics = topicFilters },
                     apiVersion,
@@ -3513,17 +3525,17 @@ public sealed class AdminClient : IAdminClient
 
         return await WithRetryAsync<IReadOnlyDictionary<TopicPartitionReplica, AlterReplicaLogDirResultInfo>>(async () =>
         {
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.AlterReplicaLogDirs,
-                AlterReplicaLogDirsRequest.LowestSupportedVersion,
-                AlterReplicaLogDirsRequest.HighestSupportedVersion);
-
             // Fan out to all target brokers in parallel.
             var brokerResults = await Task.WhenAll(assignmentsByBroker.Select(async brokerAssignments =>
             {
                 var brokerId = brokerAssignments.Key;
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.AlterReplicaLogDirs,
+                    AlterReplicaLogDirsRequest.LowestSupportedVersion,
+                    AlterReplicaLogDirsRequest.HighestSupportedVersion);
                 var request = new AlterReplicaLogDirsRequest
                 {
                     Dirs = BuildAlterReplicaLogDirsRequestDirs(brokerAssignments)
@@ -3681,15 +3693,15 @@ public sealed class AdminClient : IAdminClient
                 groups.Add(groupId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.StreamsGroupDescribe,
-                StreamsGroupDescribeRequest.LowestSupportedVersion,
-                StreamsGroupDescribeRequest.HighestSupportedVersion);
-
             var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.StreamsGroupDescribe,
+                    StreamsGroupDescribeRequest.LowestSupportedVersion,
+                    StreamsGroupDescribeRequest.HighestSupportedVersion);
 
                 var request = new StreamsGroupDescribeRequest
                 {
@@ -3742,21 +3754,20 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.ListGroups,
-                ListGroupsRequest.LowestSupportedVersion,
-                ListGroupsRequest.HighestSupportedVersion);
-
-            var request = new ListGroupsRequest
-            {
-                StatesFilter = apiVersion >= 4 ? opts.States : null,
-                TypesFilter = apiVersion >= 5 ? ["streams"] : null
-            };
-
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.ListGroups,
+                    ListGroupsRequest.LowestSupportedVersion,
+                    ListGroupsRequest.HighestSupportedVersion);
+                var request = new ListGroupsRequest
+                {
+                    StatesFilter = apiVersion >= 4 ? opts.States : null,
+                    TypesFilter = apiVersion >= 5 ? ["streams"] : null
+                };
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -3769,13 +3780,13 @@ public sealed class AdminClient : IAdminClient
                         $"ListStreamsGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
                 }
 
-                return response;
+                return (Response: response, ApiVersion: apiVersion);
             })).ConfigureAwait(false);
 
             var seenGroupIds = new HashSet<string>();
             var result = new List<GroupListing>();
 
-            foreach (var response in responses)
+            foreach (var (response, apiVersion) in responses)
             {
                 foreach (var group in response.Groups)
                 {
@@ -3947,16 +3958,16 @@ public sealed class AdminClient : IAdminClient
                 groups.Add(groupId);
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.ShareGroupDescribe,
-                ShareGroupDescribeRequest.LowestSupportedVersion,
-                ShareGroupDescribeRequest.HighestSupportedVersion);
-
             // Fan out ShareGroupDescribe requests to all coordinators in parallel
             var describeResponses = await Task.WhenAll(groupsByCoordinator.Select(async kvp =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(kvp.Key, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.ShareGroupDescribe,
+                    ShareGroupDescribeRequest.LowestSupportedVersion,
+                    ShareGroupDescribeRequest.HighestSupportedVersion);
 
                 var request = new ShareGroupDescribeRequest
                 {
@@ -4030,22 +4041,21 @@ public sealed class AdminClient : IAdminClient
                 throw new InvalidOperationException("No brokers available");
             }
 
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                Protocol.ApiKey.ListGroups,
-                ListGroupsRequest.LowestSupportedVersion,
-                ListGroupsRequest.HighestSupportedVersion);
-
-            var request = new ListGroupsRequest
-            {
-                StatesFilter = apiVersion >= 4 ? opts.States : null,
-                TypesFilter = apiVersion >= 5 ? ["share"] : null
-            };
-
             // Fan out to all brokers in parallel
             var responses = await Task.WhenAll(brokers.Select(async broker =>
             {
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(broker.NodeId, cancellationToken).ConfigureAwait(false);
                 var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.ListGroups,
+                    ListGroupsRequest.LowestSupportedVersion,
+                    ListGroupsRequest.HighestSupportedVersion);
+                var request = new ListGroupsRequest
+                {
+                    StatesFilter = apiVersion >= 4 ? opts.States : null,
+                    TypesFilter = apiVersion >= 5 ? ["share"] : null
+                };
 
                 var response = await connection.SendAsync<ListGroupsRequest, ListGroupsResponse>(
                     request,
@@ -4058,14 +4068,14 @@ public sealed class AdminClient : IAdminClient
                         $"ListShareGroups failed on broker {broker.NodeId}: {response.ErrorCode}");
                 }
 
-                return response;
+                return (Response: response, ApiVersion: apiVersion);
             })).ConfigureAwait(false);
 
             // Merge and deduplicate results
             var seenGroupIds = new HashSet<string>();
             var result = new List<GroupListing>();
 
-            foreach (var response in responses)
+            foreach (var (response, apiVersion) in responses)
             {
                 foreach (var group in response.Groups)
                 {
@@ -4138,6 +4148,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.DescribeShareGroupOffsets,
                 DescribeShareGroupOffsetsRequest.LowestSupportedVersion,
                 DescribeShareGroupOffsetsRequest.HighestSupportedVersion);
@@ -4216,6 +4227,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.AlterShareGroupOffsets,
                 AlterShareGroupOffsetsRequest.LowestSupportedVersion,
                 AlterShareGroupOffsetsRequest.HighestSupportedVersion);
@@ -4278,6 +4290,7 @@ public sealed class AdminClient : IAdminClient
             };
 
             var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 Protocol.ApiKey.DeleteShareGroupOffsets,
                 DeleteShareGroupOffsetsRequest.LowestSupportedVersion,
                 DeleteShareGroupOffsetsRequest.HighestSupportedVersion);
@@ -4358,13 +4371,6 @@ public sealed class AdminClient : IAdminClient
 
     private ValueTask<T> WithRetryAsync<T>(Func<ValueTask<T>> operation, CancellationToken cancellationToken)
         => RetryHelper.WithRetryAsync(operation, _metadataManager, cancellationToken);
-
-    private bool SupportsApiRange(Protocol.ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion)
-        => _metadataManager.TryGetNegotiatedApiVersion(
-            apiKey,
-            lowestSupportedVersion,
-            highestSupportedVersion,
-            out _);
 
     private static WriteTxnMarkersResponsePartition FindAbortTransactionPartition(
         WriteTxnMarkersResponse response,
@@ -4478,6 +4484,7 @@ public sealed class AdminClient : IAdminClient
         };
 
         var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
             Protocol.ApiKey.FindCoordinator,
             FindCoordinatorRequest.LowestSupportedVersion,
             FindCoordinatorRequest.HighestSupportedVersion);
@@ -4522,6 +4529,7 @@ public sealed class AdminClient : IAdminClient
         };
 
         var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
             Protocol.ApiKey.FindCoordinator,
             FindCoordinatorRequest.LowestSupportedVersion,
             FindCoordinatorRequest.HighestSupportedVersion);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -70,7 +70,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly SemaphoreSlim _fetchLock = new(1, 1);
 
     private volatile CoordinatorState _state = CoordinatorState.Unjoined;
-    private GroupException? _fatalHeartbeatException;
+    private KafkaException? _fatalHeartbeatException;
     private int _disposed;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
@@ -443,7 +443,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             or ErrorCode.CoordinatorNotAvailable
             or ErrorCode.CoordinatorLoadInProgress;
 
-    private async ValueTask StoreFatalHeartbeatExceptionAsync(GroupException exception)
+    private async ValueTask StoreFatalHeartbeatExceptionAsync(KafkaException exception)
     {
         Interlocked.CompareExchange(ref _fatalHeartbeatException, exception, null);
 
@@ -1741,6 +1741,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             catch (Exception ex)
             {
                 LogHeartbeatFailed(ex);
+
+                if (ex is BrokerVersionException brokerVersionException)
+                {
+                    await StoreFatalHeartbeatExceptionAsync(brokerVersionException).ConfigureAwait(false);
+                    break;
+                }
 
                 if (ex is Errors.GroupException ge)
                 {

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -525,6 +525,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             // Use negotiated API version
             var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.FindCoordinator,
                 FindCoordinatorRequest.LowestSupportedVersion,
                 FindCoordinatorRequest.HighestSupportedVersion);
@@ -764,6 +765,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                 // Use negotiated API version
                 var offsetCommitVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
                     ApiKey.OffsetCommit,
                     OffsetCommitRequest.LowestSupportedVersion,
                     OffsetCommitRequest.HighestSupportedVersion);
@@ -890,6 +892,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
                     // Use negotiated API version
                     var offsetFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+                        connection,
                         ApiKey.OffsetFetch,
                         OffsetFetchRequest.LowestSupportedVersion,
                         OffsetFetchRequest.HighestSupportedVersion);
@@ -1171,7 +1174,23 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                  IsCurrentPollGenerationExpired()))
                 return default;
 
+            if (!_metadataManager.HasApiKey(connection, ApiKey.ConsumerGroupHeartbeat))
+            {
+                throw new BrokerVersionException(
+                    "The target Kafka broker does not support the ConsumerGroupHeartbeat API " +
+                    "(KIP-848, introduced in Kafka 4.0). Dekaf's consumer requires Kafka 4.0 or later.");
+            }
+
+            if (_subscribedTopicRegex is not null &&
+                !_metadataManager.SupportsApiVersion(connection, ApiKey.ConsumerGroupHeartbeat, 1))
+            {
+                throw new BrokerVersionException(
+                    "Server-side regex subscriptions require ConsumerGroupHeartbeat v1 " +
+                    "(Kafka 4.1 or later). Use Subscribe(Func<string, bool>) for client-side filtering on older brokers.");
+            }
+
             var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.ConsumerGroupHeartbeat,
                 ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
                 ConsumerGroupHeartbeatRequest.HighestSupportedVersion);
@@ -1543,14 +1562,16 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
-        if (!_metadataManager.HasApiKey(ApiKey.ConsumerGroupHeartbeat))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(ApiKey.ConsumerGroupHeartbeat))
         {
             throw new BrokerVersionException(
                 "The connected Kafka broker does not support the ConsumerGroupHeartbeat API " +
                 "(KIP-848, introduced in Kafka 4.0). Dekaf's consumer requires Kafka 4.0 or later.");
         }
 
-        if (subscribedTopicRegex is not null &&
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            subscribedTopicRegex is not null &&
             !_metadataManager.SupportsApiVersion(ApiKey.ConsumerGroupHeartbeat, 1))
         {
             throw new BrokerVersionException(
@@ -1885,6 +1906,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             };
 
             var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.ConsumerGroupHeartbeat,
                 ConsumerGroupHeartbeatRequest.LowestSupportedVersion,
                 ConsumerGroupHeartbeatRequest.HighestSupportedVersion);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1562,23 +1562,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         string? subscribedTopicRegex,
         CancellationToken cancellationToken)
     {
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(ApiKey.ConsumerGroupHeartbeat))
-        {
-            throw new BrokerVersionException(
-                "The connected Kafka broker does not support the ConsumerGroupHeartbeat API " +
-                "(KIP-848, introduced in Kafka 4.0). Dekaf's consumer requires Kafka 4.0 or later.");
-        }
-
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            subscribedTopicRegex is not null &&
-            !_metadataManager.SupportsApiVersion(ApiKey.ConsumerGroupHeartbeat, 1))
-        {
-            throw new BrokerVersionException(
-                "Server-side regex subscriptions require ConsumerGroupHeartbeat v1 " +
-                "(Kafka 4.1 or later). Use Subscribe(Func<string, bool>) for client-side filtering on older brokers.");
-        }
-
         UpdateSubscription(topics, subscribedTopicRegex);
 
         ConsumerHeartbeatResult heartbeatResult = default;
@@ -1677,7 +1660,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
-                    (ex is Errors.KafkaException ke && ke is not Errors.GroupException && !cancellationToken.IsCancellationRequested))
+                    (ex is Errors.KafkaException ke &&
+                     ke is not Errors.GroupException and not BrokerVersionException &&
+                     !cancellationToken.IsCancellationRequested))
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -410,8 +410,18 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         ThrowIfFatalHeartbeatException();
 
-        if (_state == CoordinatorState.Stable && SubscriptionMatches(topics, subscribedTopicRegex))
-            return;
+        if (_state == CoordinatorState.Stable)
+        {
+            if (SubscriptionMatches(topics, subscribedTopicRegex))
+                return;
+
+            if (subscribedTopicRegex is not null)
+            {
+                using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                    _coordinatorId, _getCoordinationConnectionIndex(), cancellationToken).ConfigureAwait(false);
+                EnsureServerSideRegexSupported(connectionLease.Connection, subscribedTopicRegex);
+            }
+        }
 
         await EnsureActiveGroupConsumerProtocolAsync(topics, subscribedTopicRegex, cancellationToken).ConfigureAwait(false);
     }
@@ -1147,6 +1157,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private static void CompleteRevocationCommit(ConsumerHeartbeatResult result)
         => result.RevocationCommitCompletion?.TrySetResult(true);
 
+    private void EnsureServerSideRegexSupported(IKafkaConnection connection, string? subscribedTopicRegex)
+    {
+        if (subscribedTopicRegex is not null &&
+            !_metadataManager.SupportsApiVersion(connection, ApiKey.ConsumerGroupHeartbeat, 1))
+        {
+            throw new BrokerVersionException(
+                "Server-side regex subscriptions require ConsumerGroupHeartbeat v1 " +
+                "(Kafka 4.1 or later). Use Subscribe(Func<string, bool>) for client-side filtering on older brokers.");
+        }
+    }
+
     /// <summary>
     /// Sends a ConsumerGroupHeartbeat request and processes the response.
     /// </summary>
@@ -1181,13 +1202,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     "(KIP-848, introduced in Kafka 4.0). Dekaf's consumer requires Kafka 4.0 or later.");
             }
 
-            if (_subscribedTopicRegex is not null &&
-                !_metadataManager.SupportsApiVersion(connection, ApiKey.ConsumerGroupHeartbeat, 1))
-            {
-                throw new BrokerVersionException(
-                    "Server-side regex subscriptions require ConsumerGroupHeartbeat v1 " +
-                    "(Kafka 4.1 or later). Use Subscribe(Func<string, bool>) for client-side filtering on older brokers.");
-            }
+            EnsureServerSideRegexSupported(connection, _subscribedTopicRegex);
 
             var version = _metadataManager.GetNegotiatedApiVersion(
                 connection,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -985,7 +985,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly object _autoCommitStartLock = new();
     private CancellationTokenSource? _autoCommitCts;
     private Task? _autoCommitTask;
-    private int _fetchApiVersion = -1;
     private readonly ConsumerConnectionScaler? _connectionScaler;
     private int _appliedConnectionCount;
     private Task? _connectionRoutingTransitionTask;
@@ -3015,17 +3014,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             cancellationToken).ConfigureAwait(false);
         var connection = connectionLease.Connection;
 
-        // Ensure API version is negotiated (thread-safe initialization)
-        var apiVersion = _fetchApiVersion;
-        if (apiVersion < 0)
-        {
-            apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.Fetch,
-                FetchRequest.LowestSupportedVersion,
-                FetchRequest.HighestSupportedVersion);
-            Interlocked.CompareExchange(ref _fetchApiVersion, apiVersion, -1);
-            apiVersion = _fetchApiVersion;
-        }
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
+            ApiKey.Fetch,
+            FetchRequest.LowestSupportedVersion,
+            FetchRequest.HighestSupportedVersion);
 
         // Resolve any special offset values — pass index range to avoid GetRange allocation
         await ResolveSpecialOffsetsAsync(partitions, partitionStartIndex, partitionCount, cancellationToken).ConfigureAwait(false);
@@ -5244,6 +5237,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var connection = lease.Connection;
 
             var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.ListOffsets,
                 ListOffsetsRequest.LowestSupportedVersion,
                 ListOffsetsRequest.HighestSupportedVersion);
@@ -5762,6 +5756,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var connection = lease.Connection;
 
             var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.ListOffsets,
                 ListOffsetsRequest.LowestSupportedVersion,
                 ListOffsetsRequest.HighestSupportedVersion);
@@ -6423,17 +6418,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             cancellationToken).ConfigureAwait(false);
         var connection = connectionLease.Connection;
 
-        // Ensure API version is negotiated (thread-safe initialization)
-        var apiVersion = _fetchApiVersion;
-        if (apiVersion < 0)
-        {
-            apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.Fetch,
-                FetchRequest.LowestSupportedVersion,
-                FetchRequest.HighestSupportedVersion);
-            Interlocked.CompareExchange(ref _fetchApiVersion, apiVersion, -1);
-            apiVersion = _fetchApiVersion;
-        }
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
+            ApiKey.Fetch,
+            FetchRequest.LowestSupportedVersion,
+            FetchRequest.HighestSupportedVersion);
 
         // Resolve any special offset values (-1 for end, -2 for beginning) before fetching
         await ResolveSpecialOffsetsAsync(partitions, 0, partitions.Count, cancellationToken).ConfigureAwait(false);
@@ -7884,6 +7873,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var connection = connectionLease.Connection;
 
         var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
             ApiKey.ListOffsets,
             ListOffsetsRequest.LowestSupportedVersion,
             ListOffsetsRequest.HighestSupportedVersion);

--- a/src/Dekaf/Metadata/ApiVersionNegotiator.cs
+++ b/src/Dekaf/Metadata/ApiVersionNegotiator.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+
+namespace Dekaf.Metadata;
+
+internal static class ApiVersionNegotiator
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryNegotiate(
+        short brokerMinVersion,
+        short brokerMaxVersion,
+        short clientMinVersion,
+        short clientMaxVersion,
+        out short negotiatedVersion)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(clientMinVersion, clientMaxVersion);
+
+        var lowestUsableVersion = Math.Max(clientMinVersion, brokerMinVersion);
+        var highestUsableVersion = Math.Min(clientMaxVersion, brokerMaxVersion);
+        if (lowestUsableVersion > highestUsableVersion)
+        {
+            negotiatedVersion = default;
+            return false;
+        }
+
+        negotiatedVersion = highestUsableVersion;
+        return true;
+    }
+
+    [DoesNotReturn]
+    public static void ThrowApiAbsent(ApiKey apiKey, short clientMinVersion, short clientMaxVersion) =>
+        throw new BrokerVersionException(
+            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
+            $"[{clientMinVersion}, {clientMaxVersion}]: API absent.");
+
+    [DoesNotReturn]
+    public static void ThrowDisjointRange(
+        ApiKey apiKey,
+        short brokerMinVersion,
+        short brokerMaxVersion,
+        short clientMinVersion,
+        short clientMaxVersion) =>
+        throw new BrokerVersionException(
+            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
+            $"[{clientMinVersion}, {clientMaxVersion}]: broker [{brokerMinVersion}, {brokerMaxVersion}].");
+}

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1093,6 +1093,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
             return;
 
         var capabilities = provider.Capabilities;
+        if (replaceExisting)
+            _brokerApiVersions.Clear();
+
         for (var key = 0; key < capabilities.ApiRangeCount; key++)
         {
             var apiKey = (ApiKey)key;

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -757,7 +757,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
 
-                SeedVersionlessCapabilities(connection, metadataApiVersion);
+                UpdateVersionlessCapabilities(connection, metadataApiVersion);
 
                 // KIP-1102: If the broker signals rebootstrap, prefer fresh topology
                 // from re-resolved DNS over the current response's potentially-stale data.
@@ -903,7 +903,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
 
-                SeedVersionlessCapabilities(connection, metadataApiVersion);
+                UpdateVersionlessCapabilities(
+                    connection,
+                    metadataApiVersion,
+                    replaceExisting: true);
 
                 _metadata.Update(response, mergeTopics: topics is not null);
 
@@ -1080,11 +1083,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
         LogNegotiatedApiVersion(_metadataApiVersion);
     }
 
-    private void SeedVersionlessCapabilities(
+    private void UpdateVersionlessCapabilities(
         IKafkaConnection connection,
-        short metadataApiVersion)
+        short metadataApiVersion,
+        bool replaceExisting = false)
     {
-        if (_metadataApiVersion >= 0 || connection is not IKafkaCapabilityProvider provider)
+        if ((!replaceExisting && _metadataApiVersion >= 0)
+            || connection is not IKafkaCapabilityProvider provider)
             return;
 
         var capabilities = provider.Capabilities;

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -28,7 +28,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private readonly object _endpointCacheLock = new();
 
     private volatile short _metadataApiVersion = -1;
-    private readonly object _legacyApiVersionSnapshotLock = new();
     private readonly ConcurrentDictionary<ApiKey, (short MinVersion, short MaxVersion)> _brokerApiVersions = new();
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
     private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
@@ -162,34 +161,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// Gets the current cluster metadata.
     /// </summary>
     public ClusterMetadata Metadata => _metadata;
-
-    internal bool HasLegacyApiVersionSnapshot => !_brokerApiVersions.IsEmpty;
-
-    internal void EnsureLegacyApiVersionSnapshot(KafkaConnectionCapabilities capabilities)
-    {
-        if (HasLegacyApiVersionSnapshot)
-            return;
-
-        lock (_legacyApiVersionSnapshotLock)
-        {
-            if (HasLegacyApiVersionSnapshot)
-                return;
-
-            for (var key = 0; key <= (int)ApiKey.DeleteShareGroupOffsets; key++)
-            {
-                var apiKey = (ApiKey)key;
-                if (capabilities.TryGetApiRange(apiKey, out var minVersion, out var maxVersion))
-                    _brokerApiVersions[apiKey] = (minVersion, maxVersion);
-            }
-
-            _negotiatedVersionCache.Clear();
-            _finalizedFeatures = capabilities.FinalizedFeatures;
-            _metadataApiVersion = capabilities.NegotiateVersion(
-                ApiKey.Metadata,
-                MetadataRequest.LowestSupportedVersion,
-                MetadataRequest.HighestSupportedVersion);
-        }
-    }
 
     /// <summary>
     /// Returns true if the broker reported support for the given API key during version negotiation.
@@ -763,11 +734,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 // Production connections negotiate before becoming ready. Keep explicit
                 // negotiation only for injected test connections without a capability snapshot.
-                if (connection is IKafkaCapabilityProvider capabilityProvider)
-                {
-                    EnsureLegacyApiVersionSnapshot(capabilityProvider.Capabilities);
-                }
-                else if (_metadataApiVersion < 0)
+                if (connection is not IKafkaCapabilityProvider && _metadataApiVersion < 0)
                 {
                     await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
                 }
@@ -914,9 +881,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
 
-                if (connection is IKafkaCapabilityProvider capabilityProvider)
-                    EnsureLegacyApiVersionSnapshot(capabilityProvider.Capabilities);
-                else
+                if (connection is not IKafkaCapabilityProvider)
                     await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
 
                 var metadataApiVersion = connection is IKafkaCapabilityProvider

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Dekaf.Errors;
@@ -163,15 +162,27 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     public ClusterMetadata Metadata => _metadata;
 
+    internal bool HasLegacyApiVersionSnapshot => !_brokerApiVersions.IsEmpty;
+
     /// <summary>
     /// Returns true if the broker reported support for the given API key during version negotiation.
     /// </summary>
     public bool HasApiKey(ApiKey apiKey) => _brokerApiVersions.ContainsKey(apiKey);
 
+    internal bool HasApiKey(IKafkaConnection connection, ApiKey apiKey) =>
+        connection is IKafkaCapabilityProvider provider
+            ? provider.Capabilities.HasApi(apiKey)
+            : HasApiKey(apiKey);
+
     internal bool SupportsApiVersion(ApiKey apiKey, short version) =>
         _brokerApiVersions.TryGetValue(apiKey, out var versions) &&
         versions.MinVersion <= version &&
         versions.MaxVersion >= version;
+
+    internal bool SupportsApiVersion(IKafkaConnection connection, ApiKey apiKey, short version) =>
+        connection is IKafkaCapabilityProvider provider
+            ? provider.Capabilities.SupportsVersion(apiKey, version)
+            : SupportsApiVersion(apiKey, version);
 
     /// <summary>
     /// Seeds a broker API version entry. Internal — used by unit tests to bypass negotiation.
@@ -209,9 +220,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
             return false;
         }
 
-        var lowestUsableVersion = Math.Max(ourMinVersion, brokerVersions.MinVersion);
-        var highestUsableVersion = Math.Min(ourMaxVersion, brokerVersions.MaxVersion);
-        if (lowestUsableVersion > highestUsableVersion)
+        if (!ApiVersionNegotiator.TryNegotiate(
+                brokerVersions.MinVersion,
+                brokerVersions.MaxVersion,
+                ourMinVersion,
+                ourMaxVersion,
+                out var highestUsableVersion))
         {
             negotiatedVersion = default;
             return false;
@@ -222,6 +236,33 @@ public sealed partial class MetadataManager : IAsyncDisposable
         negotiatedVersion = highestUsableVersion;
         return true;
     }
+
+    internal short GetNegotiatedApiVersion(
+        IKafkaConnection connection,
+        ApiKey apiKey,
+        short ourMinVersion,
+        short ourMaxVersion) =>
+        connection is IKafkaCapabilityProvider provider
+            ? provider.Capabilities.NegotiateVersion(apiKey, ourMinVersion, ourMaxVersion)
+            : GetNegotiatedApiVersion(apiKey, ourMinVersion, ourMaxVersion);
+
+    internal bool TryGetNegotiatedApiVersion(
+        IKafkaConnection connection,
+        ApiKey apiKey,
+        short ourMinVersion,
+        short ourMaxVersion,
+        out short negotiatedVersion) =>
+        connection is IKafkaCapabilityProvider provider
+            ? provider.Capabilities.TryNegotiateVersion(
+                apiKey,
+                ourMinVersion,
+                ourMaxVersion,
+                out negotiatedVersion)
+            : TryGetNegotiatedApiVersion(
+                apiKey,
+                ourMinVersion,
+                ourMaxVersion,
+                out negotiatedVersion);
 
     /// <summary>
     /// Gets the highest API version supported by both the broker and client.
@@ -243,35 +284,27 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         if (!_brokerApiVersions.TryGetValue(apiKey, out var brokerVersions))
         {
-            ThrowApiAbsent(apiKey, ourMinVersion, ourMaxVersion);
+            ApiVersionNegotiator.ThrowApiAbsent(apiKey, ourMinVersion, ourMaxVersion);
         }
 
-        var lowestUsableVersion = Math.Max(ourMinVersion, brokerVersions.MinVersion);
-        var highestUsableVersion = Math.Min(ourMaxVersion, brokerVersions.MaxVersion);
-        if (lowestUsableVersion > highestUsableVersion)
+        if (!ApiVersionNegotiator.TryNegotiate(
+                brokerVersions.MinVersion,
+                brokerVersions.MaxVersion,
+                ourMinVersion,
+                ourMaxVersion,
+                out var highestUsableVersion))
         {
-            ThrowDisjointApiRange(apiKey, ourMinVersion, ourMaxVersion, brokerVersions);
+            ApiVersionNegotiator.ThrowDisjointRange(
+                apiKey,
+                brokerVersions.MinVersion,
+                brokerVersions.MaxVersion,
+                ourMinVersion,
+                ourMaxVersion);
         }
 
         _negotiatedVersionCache.TryAdd(cacheKey, highestUsableVersion);
         return highestUsableVersion;
     }
-
-    [DoesNotReturn]
-    private static void ThrowApiAbsent(ApiKey apiKey, short ourMinVersion, short ourMaxVersion) =>
-        throw new BrokerVersionException(
-            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
-            $"[{ourMinVersion}, {ourMaxVersion}]: API absent.");
-
-    [DoesNotReturn]
-    private static void ThrowDisjointApiRange(
-        ApiKey apiKey,
-        short ourMinVersion,
-        short ourMaxVersion,
-        (short MinVersion, short MaxVersion) brokerVersions) =>
-        throw new BrokerVersionException(
-            $"Broker does not support {apiKey} (API key {(short)apiKey}) for client " +
-            $"[{ourMinVersion}, {ourMaxVersion}]: broker [{brokerVersions.MinVersion}, {brokerVersions.MaxVersion}].");
 
     /// <summary>
     /// Returns the max finalized version for a broker feature, or 0 if the feature is not present.
@@ -290,6 +323,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         return 0;
     }
+
+    internal short GetFinalizedFeatureVersion(
+        IKafkaConnection connection,
+        string featureName) =>
+        connection is IKafkaCapabilityProvider provider
+            ? provider.Capabilities.GetFinalizedFeatureVersion(featureName)
+            : GetFinalizedFeatureVersion(featureName);
 
     /// <summary>
     /// Initializes the metadata manager by fetching initial metadata.
@@ -694,11 +734,20 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
 
-                // Negotiate API version if not already done
-                if (_metadataApiVersion < 0)
+                // Production connections negotiate before becoming ready. Keep explicit
+                // negotiation only for injected test connections without a capability snapshot.
+                if (connection is not IKafkaCapabilityProvider && _metadataApiVersion < 0)
                 {
                     await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
                 }
+
+                var metadataApiVersion = connection is IKafkaCapabilityProvider
+                    ? GetNegotiatedApiVersion(
+                        connection,
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                    : _metadataApiVersion;
 
                 // Build metadata request
                 var request = topics is null
@@ -707,7 +756,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 var response = await connection.SendAsync<MetadataRequest, MetadataResponse>(
                     request,
-                    _metadataApiVersion,
+                    metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
 
                 // KIP-1102: If the broker signals rebootstrap, prefer fresh topology
@@ -834,8 +883,16 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
 
-                // Re-negotiate API versions with new broker
-                await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
+                if (connection is not IKafkaCapabilityProvider)
+                    await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
+
+                var metadataApiVersion = connection is IKafkaCapabilityProvider
+                    ? GetNegotiatedApiVersion(
+                        connection,
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                    : _metadataApiVersion;
 
                 var request = topics is null
                     ? MetadataRequest.ForAllTopics()
@@ -843,7 +900,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 var response = await connection.SendAsync<MetadataRequest, MetadataResponse>(
                     request,
-                    _metadataApiVersion,
+                    metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
 
                 _metadata.Update(response, mergeTopics: topics is not null);

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -757,6 +757,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
 
+                SeedVersionlessCapabilities(connection, metadataApiVersion);
+
                 // KIP-1102: If the broker signals rebootstrap, prefer fresh topology
                 // from re-resolved DNS over the current response's potentially-stale data.
                 if (response.ErrorCode == ErrorCode.RebootstrapRequired
@@ -900,6 +902,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     request,
                     metadataApiVersion,
                     cancellationToken).ConfigureAwait(false);
+
+                SeedVersionlessCapabilities(connection, metadataApiVersion);
 
                 _metadata.Update(response, mergeTopics: topics is not null);
 
@@ -1074,6 +1078,26 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _finalizedFeatures = response.FinalizedFeatures;
 
         LogNegotiatedApiVersion(_metadataApiVersion);
+    }
+
+    private void SeedVersionlessCapabilities(
+        IKafkaConnection connection,
+        short metadataApiVersion)
+    {
+        if (_metadataApiVersion >= 0 || connection is not IKafkaCapabilityProvider provider)
+            return;
+
+        var capabilities = provider.Capabilities;
+        for (var key = 0; key < capabilities.ApiRangeCount; key++)
+        {
+            var apiKey = (ApiKey)key;
+            if (capabilities.TryGetApiRange(apiKey, out var minVersion, out var maxVersion))
+                _brokerApiVersions[apiKey] = (minVersion, maxVersion);
+        }
+
+        _negotiatedVersionCache.Clear();
+        _finalizedFeatures = capabilities.FinalizedFeatures;
+        _metadataApiVersion = metadataApiVersion;
     }
 
     internal IReadOnlyList<(string Host, int Port)> GetEndpointsToTry()

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -28,6 +28,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private readonly object _endpointCacheLock = new();
 
     private volatile short _metadataApiVersion = -1;
+    private readonly object _legacyApiVersionSnapshotLock = new();
     private readonly ConcurrentDictionary<ApiKey, (short MinVersion, short MaxVersion)> _brokerApiVersions = new();
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
     private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
@@ -163,6 +164,32 @@ public sealed partial class MetadataManager : IAsyncDisposable
     public ClusterMetadata Metadata => _metadata;
 
     internal bool HasLegacyApiVersionSnapshot => !_brokerApiVersions.IsEmpty;
+
+    internal void EnsureLegacyApiVersionSnapshot(KafkaConnectionCapabilities capabilities)
+    {
+        if (HasLegacyApiVersionSnapshot)
+            return;
+
+        lock (_legacyApiVersionSnapshotLock)
+        {
+            if (HasLegacyApiVersionSnapshot)
+                return;
+
+            for (var key = 0; key <= (int)ApiKey.DeleteShareGroupOffsets; key++)
+            {
+                var apiKey = (ApiKey)key;
+                if (capabilities.TryGetApiRange(apiKey, out var minVersion, out var maxVersion))
+                    _brokerApiVersions[apiKey] = (minVersion, maxVersion);
+            }
+
+            _negotiatedVersionCache.Clear();
+            _finalizedFeatures = capabilities.FinalizedFeatures;
+            _metadataApiVersion = capabilities.NegotiateVersion(
+                ApiKey.Metadata,
+                MetadataRequest.LowestSupportedVersion,
+                MetadataRequest.HighestSupportedVersion);
+        }
+    }
 
     /// <summary>
     /// Returns true if the broker reported support for the given API key during version negotiation.
@@ -736,7 +763,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 // Production connections negotiate before becoming ready. Keep explicit
                 // negotiation only for injected test connections without a capability snapshot.
-                if (connection is not IKafkaCapabilityProvider && _metadataApiVersion < 0)
+                if (connection is IKafkaCapabilityProvider capabilityProvider)
+                {
+                    EnsureLegacyApiVersionSnapshot(capabilityProvider.Capabilities);
+                }
+                else if (_metadataApiVersion < 0)
                 {
                     await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
                 }
@@ -883,7 +914,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
 
-                if (connection is not IKafkaCapabilityProvider)
+                if (connection is IKafkaCapabilityProvider capabilityProvider)
+                    EnsureLegacyApiVersionSnapshot(capabilityProvider.Capabilities);
+                else
                     await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
 
                 var metadataApiVersion = connection is IKafkaCapabilityProvider

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -618,11 +618,22 @@ public sealed partial class KafkaConnection :
             ClientSoftwareVersion = typeof(KafkaConnection).Assembly.GetName().Version?.ToString() ?? "0.0.0"
         };
 
-        var response = await SendAsyncCore<ApiVersionsRequest, ApiVersionsResponse>(
-            request,
-            apiVersion: 3,
-            requireReady: false,
-            cancellationToken).ConfigureAwait(false);
+        ApiVersionsResponse response;
+        try
+        {
+            response = await SendAsyncCore<ApiVersionsRequest, ApiVersionsResponse>(
+                request,
+                apiVersion: 3,
+                requireReady: false,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new KafkaException(
+                ErrorCode.RequestTimedOut,
+                $"ApiVersions negotiation timed out for {_host}:{_port}",
+                ex);
+        }
 
         return KafkaConnectionCapabilities.Create(response);
     }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -75,6 +75,7 @@ internal static class ConnectionHelper
 /// </summary>
 public sealed partial class KafkaConnection :
     IKafkaConnection,
+    IKafkaCapabilityProvider,
     IIdleTrackedKafkaConnection,
     IRetirableKafkaConnection,
     IKafkaPipelinedWriteCompletionConnection
@@ -151,6 +152,7 @@ public sealed partial class KafkaConnection :
     private Task? _disposeTask;
     private int _disposed;
     private int _connected;
+    private KafkaConnectionCapabilities? _capabilities;
     private bool _hasReceivedResponse;
     private long _lastUsedTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
     private readonly SemaphoreSlim _connectLock = new(1, 1);
@@ -169,6 +171,10 @@ public sealed partial class KafkaConnection :
     public string Host => _host;
     public int Port => _port;
     public bool IsConnected => Volatile.Read(ref _disposed) == 0 && Volatile.Read(ref _connected) != 0 && (_socket?.Connected ?? false);
+
+    KafkaConnectionCapabilities IKafkaCapabilityProvider.Capabilities =>
+        Volatile.Read(ref _capabilities)
+        ?? throw new InvalidOperationException("Kafka connection is not ready: ApiVersions negotiation has not completed.");
 
     long IIdleTrackedKafkaConnection.LastUsedTimestampMs => Volatile.Read(ref _lastUsedTimestampMs);
 
@@ -355,6 +361,8 @@ public sealed partial class KafkaConnection :
     {
         LogConnecting(_host, _port);
 
+        Volatile.Write(ref _capabilities, null);
+
         using var connectTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         connectTimeoutCts.CancelAfter(_options.ConnectionTimeout);
         var (socket, targetHost) = await ConnectSocketAsync(connectTimeoutCts.Token).ConfigureAwait(false);
@@ -447,6 +455,10 @@ public sealed partial class KafkaConnection :
 
         _receiveCts = new CancellationTokenSource();
         _receiveTask = ReceiveLoopAsync(_receiveCts.Token);
+
+        var capabilities = await NegotiateCapabilitiesAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+        Volatile.Write(ref _capabilities, capabilities);
+
         Touch();
         Volatile.Write(ref _connected, 1);
         _telemetryMetricCollector?.RecordConnectionCreated();
@@ -511,10 +523,19 @@ public sealed partial class KafkaConnection :
         return socket;
     }
 
-    public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+        => SendAsyncCore<TRequest, TResponse>(request, apiVersion, requireReady: true, cancellationToken);
+
+    private async ValueTask<TResponse> SendAsyncCore<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        bool requireReady,
+        CancellationToken cancellationToken)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -523,7 +544,7 @@ public sealed partial class KafkaConnection :
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
 
-        if (!IsConnected)
+        if (requireReady ? !IsConnected : !(_socket?.Connected ?? false))
             throw new InvalidOperationException("Not connected");
 
         Touch();
@@ -586,6 +607,24 @@ public sealed partial class KafkaConnection :
 
             throw;
         }
+    }
+
+    private async ValueTask<KafkaConnectionCapabilities> NegotiateCapabilitiesAsync(
+        CancellationToken cancellationToken)
+    {
+        var request = new ApiVersionsRequest
+        {
+            ClientSoftwareName = "dekaf",
+            ClientSoftwareVersion = typeof(KafkaConnection).Assembly.GetName().Version?.ToString() ?? "0.0.0"
+        };
+
+        var response = await SendAsyncCore<ApiVersionsRequest, ApiVersionsResponse>(
+            request,
+            apiVersion: 3,
+            requireReady: false,
+            cancellationToken).ConfigureAwait(false);
+
+        return KafkaConnectionCapabilities.Create(response);
     }
 
     public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(

--- a/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
+++ b/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
@@ -1,0 +1,195 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Metadata;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Networking;
+
+internal interface IKafkaCapabilityProvider
+{
+    KafkaConnectionCapabilities Capabilities { get; }
+}
+
+/// <summary>
+/// Immutable API and feature snapshot owned by one physical Kafka connection generation.
+/// </summary>
+internal sealed class KafkaConnectionCapabilities
+{
+    private const int ApiKeyCount = (int)ApiKey.DeleteShareGroupOffsets + 1;
+    private const int MissingRange = -1;
+
+    private readonly int[] _apiRanges;
+    private readonly SupportedFeature[] _supportedFeatures;
+    private readonly FinalizedFeature[] _finalizedFeatures;
+
+    private KafkaConnectionCapabilities(
+        int[] apiRanges,
+        SupportedFeature[] supportedFeatures,
+        long finalizedFeaturesEpoch,
+        FinalizedFeature[] finalizedFeatures,
+        bool zkMigrationReady)
+    {
+        _apiRanges = apiRanges;
+        _supportedFeatures = supportedFeatures;
+        FinalizedFeaturesEpoch = finalizedFeaturesEpoch;
+        _finalizedFeatures = finalizedFeatures;
+        ZkMigrationReady = zkMigrationReady;
+    }
+
+    public long FinalizedFeaturesEpoch { get; }
+    public bool ZkMigrationReady { get; }
+
+    public static KafkaConnectionCapabilities Create(ApiVersionsResponse response)
+    {
+        if (response.ErrorCode != ErrorCode.None)
+            throw new InvalidOperationException($"ApiVersions failed: {response.ErrorCode}");
+
+        var ranges = new int[ApiKeyCount];
+        Array.Fill(ranges, MissingRange);
+
+        foreach (var version in response.ApiKeys)
+        {
+            var key = (int)version.ApiKey;
+            if ((uint)key >= (uint)ranges.Length || version.MinVersion > version.MaxVersion)
+                continue;
+
+            ranges[key] = Pack(version.MinVersion, version.MaxVersion);
+        }
+
+        var supportedFeatures = CopyFeatures(response.SupportedFeatures);
+        var finalizedFeatures = CopyFeatures(response.FinalizedFeatures);
+
+        return new KafkaConnectionCapabilities(
+            ranges,
+            supportedFeatures,
+            response.FinalizedFeaturesEpoch,
+            finalizedFeatures,
+            response.ZkMigrationReady);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool HasApi(ApiKey apiKey)
+    {
+        var key = (int)apiKey;
+        return (uint)key < (uint)_apiRanges.Length && _apiRanges[key] != MissingRange;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SupportsVersion(ApiKey apiKey, short version)
+    {
+        var key = (int)apiKey;
+        if ((uint)key >= (uint)_apiRanges.Length)
+            return false;
+
+        var range = _apiRanges[key];
+        return range != MissingRange && version >= UnpackMin(range) && version <= UnpackMax(range);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public short NegotiateVersion(ApiKey apiKey, short clientMinVersion, short clientMaxVersion)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(clientMinVersion, clientMaxVersion);
+
+        var key = (int)apiKey;
+        if ((uint)key >= (uint)_apiRanges.Length || _apiRanges[key] == MissingRange)
+            ApiVersionNegotiator.ThrowApiAbsent(apiKey, clientMinVersion, clientMaxVersion);
+
+        var range = _apiRanges[key];
+        var brokerMinVersion = UnpackMin(range);
+        var brokerMaxVersion = UnpackMax(range);
+        if (!ApiVersionNegotiator.TryNegotiate(
+                brokerMinVersion,
+                brokerMaxVersion,
+                clientMinVersion,
+                clientMaxVersion,
+                out var negotiatedVersion))
+        {
+            ApiVersionNegotiator.ThrowDisjointRange(
+                apiKey,
+                brokerMinVersion,
+                brokerMaxVersion,
+                clientMinVersion,
+                clientMaxVersion);
+        }
+
+        return negotiatedVersion;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryNegotiateVersion(
+        ApiKey apiKey,
+        short clientMinVersion,
+        short clientMaxVersion,
+        out short negotiatedVersion)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(clientMinVersion, clientMaxVersion);
+
+        var key = (int)apiKey;
+        if ((uint)key >= (uint)_apiRanges.Length || _apiRanges[key] == MissingRange)
+        {
+            negotiatedVersion = default;
+            return false;
+        }
+
+        var range = _apiRanges[key];
+        return ApiVersionNegotiator.TryNegotiate(
+            UnpackMin(range),
+            UnpackMax(range),
+            clientMinVersion,
+            clientMaxVersion,
+            out negotiatedVersion);
+    }
+
+    public short GetFinalizedFeatureVersion(string featureName)
+    {
+        foreach (var feature in _finalizedFeatures)
+        {
+            if (string.Equals(feature.Name, featureName, StringComparison.Ordinal))
+                return feature.MaxVersionLevel;
+        }
+
+        return 0;
+    }
+
+    public bool TryGetSupportedFeatureRange(
+        string featureName,
+        out short minVersion,
+        out short maxVersion)
+    {
+        foreach (var feature in _supportedFeatures)
+        {
+            if (string.Equals(feature.Name, featureName, StringComparison.Ordinal))
+            {
+                minVersion = feature.MinVersion;
+                maxVersion = feature.MaxVersion;
+                return true;
+            }
+        }
+
+        minVersion = default;
+        maxVersion = default;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Pack(short minVersion, short maxVersion)
+        => (minVersion << 16) | (ushort)maxVersion;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static short UnpackMin(int range) => (short)(range >> 16);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static short UnpackMax(int range) => (short)range;
+
+    private static T[] CopyFeatures<T>(IReadOnlyList<T>? source)
+    {
+        if (source is null || source.Count == 0)
+            return [];
+
+        var copy = new T[source.Count];
+        for (var i = 0; i < copy.Length; i++)
+            copy[i] = source[i];
+
+        return copy;
+    }
+}

--- a/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
+++ b/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
@@ -171,8 +171,30 @@ internal sealed class KafkaConnectionCapabilities
         return false;
     }
 
+    public bool TryGetApiRange(
+        ApiKey apiKey,
+        out short minVersion,
+        out short maxVersion)
+    {
+        var key = (int)apiKey;
+        if ((uint)key >= (uint)_apiRanges.Length || _apiRanges[key] == MissingRange)
+        {
+            minVersion = default;
+            maxVersion = default;
+            return false;
+        }
+
+        var range = _apiRanges[key];
+        minVersion = UnpackMin(range);
+        maxVersion = UnpackMax(range);
+        return true;
+    }
+
+    internal IReadOnlyList<FinalizedFeature> FinalizedFeatures => _finalizedFeatures;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int Pack(short minVersion, short maxVersion)
+        // Kafka API versions are non-negative; -1 is reserved as MissingRange.
         => (minVersion << 16) | (ushort)maxVersion;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
+++ b/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
@@ -191,6 +191,7 @@ internal sealed class KafkaConnectionCapabilities
     }
 
     internal IReadOnlyList<FinalizedFeature> FinalizedFeatures => _finalizedFeatures;
+    internal int ApiRangeCount => _apiRanges.Length;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int Pack(short minVersion, short maxVersion)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3851,6 +3851,24 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
         }
+        catch (BrokerVersionException ex)
+        {
+            // A broker capability mismatch cannot be repaired by retrying the same
+            // partition leader. Surface the negotiated-version failure immediately.
+            for (var i = 0; i < count; i++)
+            {
+                var batch = batches[i];
+                if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
+                    continue;
+
+                FailAndCleanupBatch(batch, ex);
+            }
+
+            scratch.ClearReferences();
+
+            if (!pendingResponseAdded)
+                ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+        }
         catch (Exception ex)
         {
             // Send failed (connection error, timeout, etc.) — retry batches instead of permanently failing.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -500,7 +500,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private readonly int _maxInFlight;
     private int _totalMaxInFlight;
 
-    // Per-producer shared API version (read via volatile, written via Interlocked)
+    // Compatibility fallback for injected test connections that do not expose a physical
+    // capability snapshot. Production KafkaConnection instances never use these delegates.
     private readonly Func<int> _getProduceApiVersion;
     private readonly Action<int> _setProduceApiVersion;
 
@@ -3016,9 +3017,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     if (partitionResponse.ErrorCode.IsRetriable()
                         || (partitionResponse.ErrorCode == ErrorCode.ConcurrentTransactions
                             && _isTransactional()
-                            && _usesTransactionV2()
-                            && _getProduceApiVersion()
-                                >= ProduceRequest.ImplicitTransactionPartitionEnrollmentVersion)
+                            && _usesTransactionV2())
                         || partitionResponse.ErrorCode == ErrorCode.OutOfOrderSequenceNumber
                         || partitionResponse.ErrorCode == ErrorCode.InvalidProducerEpoch
                         || partitionResponse.ErrorCode == ErrorCode.UnknownProducerId)
@@ -3619,7 +3618,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             for (var i = 0; i < count; i++)
                 batches[i].AppendDiag('G');
 
-            var apiVersion = EnsureApiVersion();
+            var apiVersion = EnsureApiVersion(connection);
 
             count = AcquireResourcePins(batches, generations, count);
             if (count == 0)
@@ -4135,20 +4134,42 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     }
 
     /// <summary>
-    /// Ensures API version is negotiated. Thread-safe initialization.
+    /// Selects Produce version from the exact physical connection generation.
     /// </summary>
-    private int EnsureApiVersion()
+    private int EnsureApiVersion(IKafkaConnection connection)
     {
-        var version = _getProduceApiVersion();
-        if (version < 0)
+        int version;
+        if (connection is IKafkaCapabilityProvider)
         {
             version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.Produce,
                 ProduceRequest.LowestSupportedVersion,
                 ProduceRequest.HighestSupportedVersion);
-            _setProduceApiVersion(version);
-            version = _getProduceApiVersion();
         }
+        else
+        {
+            version = _getProduceApiVersion();
+            if (version < 0)
+            {
+                version = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.Produce,
+                    ProduceRequest.LowestSupportedVersion,
+                    ProduceRequest.HighestSupportedVersion);
+                _setProduceApiVersion(version);
+                version = _getProduceApiVersion();
+            }
+        }
+
+        if (_usesTransactionV2() &&
+            version < ProduceRequest.ImplicitTransactionPartitionEnrollmentVersion)
+        {
+            throw new BrokerVersionException(
+                $"Transaction V2 requires Produce v{ProduceRequest.ImplicitTransactionPartitionEnrollmentVersion} " +
+                $"or later, but broker {_brokerId} negotiated v{version} on this connection.");
+        }
+
         return GetProduceRequestVersion(version, _isTransactional(), _usesTransactionV2());
     }
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -79,6 +79,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private volatile bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
+    private volatile int _produceApiVersion = -1;
     private int _maxObservedBrokerThrottleTimeMs;
     private int _disposed;
 
@@ -3041,8 +3042,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _options,
             _compressionCodecs,
             _inflightTracker,
-            static () => -1,
-            static _ => { },
+            () => _produceApiVersion,
+            version => Interlocked.CompareExchange(ref _produceApiVersion, version, -1),
             () => _accumulator.IsTransactional,
             TryEnsurePartitionsInTransaction,
             bumpEpoch: useEpochRecovery ? BumpEpochLocally : null,

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2154,9 +2154,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             TransactionVersionFeature);
         if (featureVersion != _currentTransactionFeatureVersion)
         {
-            throw new InvalidOperationException(
+            _transactionState = TransactionState.FatalError;
+            throw CreateTransactionException(
+                ErrorCode.UnsupportedVersion,
+                TransactionErrorClassification.Fatal,
                 "The coordinator transaction.version changed after producer initialization. " +
-                "Call InitTransactionsAsync() to acquire a fresh producer epoch before beginning another transaction.");
+                "Close the producer and initialize a new instance before beginning another transaction.");
         }
     }
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -79,7 +79,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private volatile bool _initialized;
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
-    private volatile int _produceApiVersion = -1;
     private int _maxObservedBrokerThrottleTimeMs;
     private int _disposed;
 
@@ -112,6 +111,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private long _partitionEnrollmentGeneration;
     private readonly Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask> _addPartitionsToTransaction;
     internal volatile bool _currentTransactionUsesTV2;
+    private short _currentTransactionFeatureVersion;
 
     // In-flight batch tracker for coordinated retry with multiple in-flight batches per partition.
     // Always initialized but only actively used for idempotent producers. Non-idempotent producers
@@ -1869,15 +1869,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 $"Cannot begin transaction in state: {_transactionState}");
         }
 
-        var finalizedTransactionUsesTV2 =
-            _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
-        if (finalizedTransactionUsesTV2 != _currentTransactionUsesTV2)
-        {
-            throw new InvalidOperationException(
-                "The broker transaction.version changed after producer initialization. " +
-                "Call InitTransactionsAsync() to acquire a fresh producer epoch before beginning another transaction.");
-        }
-
         _transactionState = TransactionState.InTransaction;
         _preparedTransactionState = PreparedTransactionState.Empty;
         _lastTransactionError = ErrorCode.None;
@@ -1901,8 +1892,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         ThrowIfNotInitialized();
         ThrowIfFatalTransactionError("Cannot initialize transactions");
-        ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction);
-
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_transactionLock, nameof(KafkaProducer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
         try
         {
@@ -1911,7 +1900,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
 
             // Step 2: Initialize the producer ID via the coordinator
-            _currentTransactionUsesTV2 = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature) >= 2;
             await ReinitializeProducerIdAsync(cancellationToken, keepPreparedTransaction).ConfigureAwait(false);
 
             _transactionState = _preparedTransactionState.HasTransaction
@@ -1995,8 +1983,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         if (!_options.EnableTwoPhaseCommit && !keepPreparedTransaction)
             return;
 
-        var transactionVersion = _metadataManager.GetFinalizedFeatureVersion(TransactionVersionFeature);
-        if (transactionVersion < 3)
+        if (_currentTransactionFeatureVersion < 3)
         {
             throw new BrokerVersionException(
                 "Broker does not support KIP-939 two-phase commit (transaction.version >= 3 required).");
@@ -2112,18 +2099,64 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private async ValueTask<TResponse> SendWithConnectionLeaseAsync<TRequest, TResponse>(
         int brokerId,
         TRequest request,
-        short apiVersion,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        short minimumRequiredVersion = short.MinValue,
+        bool captureTransactionFeatures = false,
+        bool requireTransactionFeatureMatch = false,
+        bool keepPreparedTransaction = false)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
         using var connectionLease = await _connectionPool.LeaseConnectionAsync(
             brokerId,
             cancellationToken).ConfigureAwait(false);
-        return await connectionLease.Connection.SendAsync<TRequest, TResponse>(
+        var connection = connectionLease.Connection;
+        if (captureTransactionFeatures)
+            CaptureTransactionFeatures(connection, keepPreparedTransaction);
+        else if (requireTransactionFeatureMatch)
+            EnsureTransactionFeatureMatch(connection);
+
+        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
+            KafkaMessageMetadata<TRequest, TResponse>.ApiKey,
+            KafkaMessageMetadata<TRequest, TResponse>.LowestSupportedVersion,
+            KafkaMessageMetadata<TRequest, TResponse>.HighestSupportedVersion);
+        if (apiVersion < minimumRequiredVersion)
+        {
+            throw new BrokerVersionException(
+                $"Broker {brokerId} does not support {KafkaMessageMetadata<TRequest, TResponse>.ApiKey} " +
+                $"v{minimumRequiredVersion} required by this operation; negotiated v{apiVersion}.");
+        }
+
+        return await connection.SendAsync<TRequest, TResponse>(
             request,
             apiVersion,
             cancellationToken).ConfigureAwait(false);
+    }
+
+    private void CaptureTransactionFeatures(
+        IKafkaConnection connection,
+        bool keepPreparedTransaction)
+    {
+        var featureVersion = _metadataManager.GetFinalizedFeatureVersion(
+            connection,
+            TransactionVersionFeature);
+        _currentTransactionFeatureVersion = featureVersion;
+        _currentTransactionUsesTV2 = featureVersion >= 2;
+        ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction);
+    }
+
+    private void EnsureTransactionFeatureMatch(IKafkaConnection connection)
+    {
+        var featureVersion = _metadataManager.GetFinalizedFeatureVersion(
+            connection,
+            TransactionVersionFeature);
+        if (featureVersion != _currentTransactionFeatureVersion)
+        {
+            throw new InvalidOperationException(
+                "The coordinator transaction.version changed after producer initialization. " +
+                "Call InitTransactionsAsync() to acquire a fresh producer epoch before beginning another transaction.");
+        }
     }
 
     internal async ValueTask ReinitializeProducerIdAsync(
@@ -2135,17 +2168,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var initProducerIdVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.InitProducerId,
-                InitProducerIdRequest.LowestSupportedVersion,
-                InitProducerIdRequest.HighestSupportedVersion);
-
-            if ((_options.EnableTwoPhaseCommit || keepPreparedTransaction) && initProducerIdVersion < 6)
-            {
-                throw new BrokerVersionException(
-                    "Broker does not support InitProducerId v6 required for KIP-939 two-phase commit.");
-            }
-
             var request = new InitProducerIdRequest
             {
                 TransactionalId = _options.TransactionalId,
@@ -2159,8 +2181,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
                     _transactionCoordinatorId,
                     request,
-                    initProducerIdVersion,
-                    cancellationToken)
+                    cancellationToken,
+                    minimumRequiredVersion: (_options.EnableTwoPhaseCommit || keepPreparedTransaction)
+                        ? (short)6
+                        : short.MinValue,
+                    captureTransactionFeatures: true,
+                    keepPreparedTransaction: keepPreparedTransaction)
                 .ConfigureAwait(false);
 
             if (response.ErrorCode != ErrorCode.None)
@@ -2242,15 +2268,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.FindCoordinator,
-                FindCoordinatorRequest.LowestSupportedVersion,
-                FindCoordinatorRequest.HighestSupportedVersion);
-
             var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
                 brokers[0].NodeId,
                 request,
-                findCoordinatorVersion,
                 cancellationToken).ConfigureAwait(false);
 
             if (response.Coordinators.Count == 0)
@@ -2323,11 +2343,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             });
         }
 
-        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.AddPartitionsToTxn,
-            AddPartitionsToTxnRequest.LowestSupportedVersion,
-            AddPartitionsToTxnRequest.HighestSupportedVersion);
-
         var request = new AddPartitionsToTxnRequest
         {
             TransactionalId = _options.TransactionalId!,
@@ -2344,8 +2359,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var response = await SendWithConnectionLeaseAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
                     _transactionCoordinatorId,
                     request,
-                    apiVersion,
-                    cancellationToken)
+                    cancellationToken,
+                    requireTransactionFeatureMatch: true)
                 .ConfigureAwait(false);
 
             // Check for retriable errors in the response
@@ -2443,11 +2458,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.EndTxn,
-                EndTxnRequest.LowestSupportedVersion,
-                EndTxnRequest.HighestSupportedVersion);
-
             var request = new EndTxnRequest
             {
                 TransactionalId = _options.TransactionalId!,
@@ -2462,6 +2472,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                        cancellationToken).ConfigureAwait(false))
             {
                 var connection = connectionLease.Connection;
+                EnsureTransactionFeatureMatch(connection);
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.EndTxn,
+                    EndTxnRequest.LowestSupportedVersion,
+                    EndTxnRequest.HighestSupportedVersion);
                 if (afterRequestWrittenAsync is null)
                 {
                     response = await connection
@@ -2563,11 +2579,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
             // Step 1: Add offsets to the transaction via the transaction coordinator
-            var addOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.AddOffsetsToTxn,
-                AddOffsetsToTxnRequest.LowestSupportedVersion,
-                AddOffsetsToTxnRequest.HighestSupportedVersion);
-
             var addOffsetsRequest = new AddOffsetsToTxnRequest
             {
                 TransactionalId = _options.TransactionalId!,
@@ -2579,8 +2590,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var addOffsetsResponse = await SendWithConnectionLeaseAsync<AddOffsetsToTxnRequest, AddOffsetsToTxnResponse>(
                     _transactionCoordinatorId,
                     addOffsetsRequest,
-                    addOffsetsVersion,
-                    cancellationToken)
+                    cancellationToken,
+                    requireTransactionFeatureMatch: true)
                 .ConfigureAwait(false);
 
             if (addOffsetsResponse.ErrorCode != ErrorCode.None)
@@ -2596,11 +2607,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             // Step 2: Find the group coordinator
             var brokers = _metadataManager.Metadata.GetBrokers();
-            var findCoordVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.FindCoordinator,
-                FindCoordinatorRequest.LowestSupportedVersion,
-                FindCoordinatorRequest.HighestSupportedVersion);
-
             var findCoordRequest = new FindCoordinatorRequest
             {
                 Key = consumerGroupId,
@@ -2610,7 +2616,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var findCoordResponse = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
                     brokers[0].NodeId,
                     findCoordRequest,
-                    findCoordVersion,
                     cancellationToken)
                 .ConfigureAwait(false);
 
@@ -2635,11 +2640,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             // Step 3: Send TxnOffsetCommit to the group coordinator
-            var txnOffsetCommitVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.TxnOffsetCommit,
-                TxnOffsetCommitRequest.LowestSupportedVersion,
-                TxnOffsetCommitRequest.HighestSupportedVersion);
-
             // Group offsets by topic
             var topicOffsets = new Dictionary<string, List<TxnOffsetCommitRequestPartition>>();
             foreach (var offset in offsets)
@@ -2679,8 +2679,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var txnOffsetCommitResponse = await SendWithConnectionLeaseAsync<TxnOffsetCommitRequest, TxnOffsetCommitResponse>(
                     coord.NodeId,
                     txnOffsetCommitRequest,
-                    txnOffsetCommitVersion,
-                    cancellationToken)
+                    cancellationToken,
+                    requireTransactionFeatureMatch: true)
                 .ConfigureAwait(false);
 
             // Check for errors across all partitions
@@ -3041,8 +3041,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _options,
             _compressionCodecs,
             _inflightTracker,
-            () => _produceApiVersion,
-            version => Interlocked.CompareExchange(ref _produceApiVersion, version, -1),
+            static () => -1,
+            static _ => { },
             () => _accumulator.IsTransactional,
             TryEnsurePartitionsInTransaction,
             bumpEpoch: useEpochRecovery ? BumpEpochLocally : null,
@@ -3138,8 +3138,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         lock (_partitionsInTransactionLock)
         {
-            var usesImplicitEnrollment = _currentTransactionUsesTV2
-                && _produceApiVersion >= ProduceRequest.ImplicitTransactionPartitionEnrollmentVersion;
+            var usesImplicitEnrollment = _currentTransactionUsesTV2;
             if (usesImplicitEnrollment)
             {
                 for (var i = 0; i < count; i++)
@@ -3763,11 +3762,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return;
             }
 
-            var initProducerIdVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.InitProducerId,
-                InitProducerIdRequest.LowestSupportedVersion,
-                InitProducerIdRequest.HighestSupportedVersion);
-
             // Retry with backoff for retriable errors (e.g. CoordinatorLoadInProgress during broker startup)
             var retryDelayMs = _options.RetryBackoffMs;
 
@@ -3793,7 +3787,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
                         brokers[0].NodeId,
                         request,
-                        initProducerIdVersion,
                         cancellationToken)
                     .ConfigureAwait(false);
 
@@ -3891,11 +3884,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return (_producerId, _producerEpoch);
             }
 
-            var initProducerIdVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.InitProducerId,
-                InitProducerIdRequest.LowestSupportedVersion,
-                InitProducerIdRequest.HighestSupportedVersion);
-
             var retryDelayMs = _options.RetryBackoffMs;
 
             while (true)
@@ -3919,7 +3907,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
                         brokers[0].NodeId,
                         request,
-                        initProducerIdVersion,
                         cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/Dekaf/Protocol/KafkaMessageMetadata.cs
+++ b/src/Dekaf/Protocol/KafkaMessageMetadata.cs
@@ -9,6 +9,10 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
 #if !NETSTANDARD2_0
     public static ApiKey ApiKey => TRequest.ApiKey;
 
+    public static short LowestSupportedVersion => TRequest.LowestSupportedVersion;
+
+    public static short HighestSupportedVersion => TRequest.HighestSupportedVersion;
+
     public static short GetRequestHeaderVersion(short version) => TRequest.GetRequestHeaderVersion(version);
 
     public static short GetResponseHeaderVersion(short version) => TRequest.GetResponseHeaderVersion(version);
@@ -26,6 +30,10 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
     private static readonly ReadResponseDelegate s_readResponse = CreateReadResponseDelegate();
 
     public static ApiKey ApiKey { get; } = ReadApiKey();
+
+    public static short LowestSupportedVersion { get; } = ReadVersion(nameof(LowestSupportedVersion));
+
+    public static short HighestSupportedVersion { get; } = ReadVersion(nameof(HighestSupportedVersion));
 
     public static short GetRequestHeaderVersion(short version)
         => s_getRequestHeaderVersion?.Invoke(version) ?? 2;
@@ -49,6 +57,18 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
         }
 
         return apiKey;
+    }
+
+    private static short ReadVersion(string propertyName)
+    {
+        var property = typeof(TRequest).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static);
+        if (property is null || property.GetValue(null) is not short version)
+        {
+            throw new InvalidOperationException(
+                $"{typeof(TRequest).FullName} must expose a public static {propertyName} property.");
+        }
+
+        return version;
     }
 
     private static HeaderVersionDelegate? CreateHeaderVersionDelegate(string name)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -222,11 +222,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             // Group assigned partitions by leader broker
             var partitionsByBroker = GroupPartitionsByLeader(assignment);
 
-            var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
-                ApiKey.ShareFetch,
-                ShareFetchRequest.LowestSupportedVersion,
-                ShareFetchRequest.HighestSupportedVersion);
-
             // Send fetch requests to all brokers concurrently. Session epochs are per-broker
             // and independent, so parallelism is safe. This avoids waiting for each broker's
             // MaxWaitMs sequentially when partitions span multiple brokers.
@@ -235,25 +230,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
             foreach (var (brokerId, partitions) in partitionsByBroker)
             {
-                var topics = BuildShareFetchTopics(partitions, pendingAcks, shareFetchVersion);
-                var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
-                var maxRecords = shareFetchVersion >= 1 ? _options.MaxPollRecords : 0;
-
-                var request = new ShareFetchRequest
-                {
-                    GroupId = _options.GroupId,
-                    MemberId = _coordinator.MemberId!,
-                    ShareSessionEpoch = sessionEpoch,
-                    MaxWaitMs = _options.FetchMaxWaitMs,
-                    MinBytes = _options.FetchMinBytes,
-                    MaxBytes = _options.FetchMaxBytes,
-                    MaxRecords = maxRecords,
-                    BatchSize = maxRecords,
-                    ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
-                    Topics = topics
-                };
-
-                fetchTasks.Add(SendShareFetchAsync(brokerId, request, shareFetchVersion, cancellationToken));
+                fetchTasks.Add(SendShareFetchForPartitionsAsync(brokerId, partitions, pendingAcks, cancellationToken));
             }
 
             await Task.WhenAll(fetchTasks).ConfigureAwait(false);
@@ -392,17 +369,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         // Group by broker
         var acksByBroker = GroupAcksByLeader(pendingAcks);
 
-        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ShareAcknowledge,
-            ShareAcknowledgeRequest.LowestSupportedVersion,
-            ShareAcknowledgeRequest.HighestSupportedVersion);
-
         // Send to all brokers in parallel, collecting per-broker results
         var results = await Task.WhenAll(acksByBroker.Select(async kvp =>
         {
             try
             {
-                await SendAcknowledgeAsync(kvp.Key, kvp.Value, shareAckVersion, cancellationToken)
+                await SendAcknowledgeAsync(kvp.Key, kvp.Value, cancellationToken)
                     .ConfigureAwait(false);
                 return (Acks: kvp.Value, Error: (Exception?)null);
             }
@@ -541,11 +513,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         if (acksByBroker.Count == 0)
             return;
 
-        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ShareAcknowledge,
-            ShareAcknowledgeRequest.LowestSupportedVersion,
-            ShareAcknowledgeRequest.HighestSupportedVersion);
-
         // Send in the background — best effort, don't block the synchronous caller.
         // Store the task so DisposeAsync can await it before tearing down the connection pool.
         // Chain after any prior release task so DisposeAsync only needs to await the latest reference.
@@ -562,7 +529,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 try
                 {
-                    await SendAcknowledgeAsync(brokerId, acks, shareAckVersion, CancellationToken.None)
+                    await SendAcknowledgeAsync(brokerId, acks, CancellationToken.None)
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -573,15 +540,68 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         });
     }
 
-    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchAsync(
-        int brokerId, ShareFetchRequest request, short version, CancellationToken cancellationToken)
+    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchForPartitionsAsync(
+        int brokerId,
+        List<TopicPartition> partitions,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? pendingAcks,
+        CancellationToken cancellationToken)
     {
         try
         {
             using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
                 .ConfigureAwait(false);
             var connection = connectionLease.Connection;
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion);
+            var maxRecords = version >= 1 ? _options.MaxPollRecords : 0;
+            var request = new ShareFetchRequest
+            {
+                GroupId = _options.GroupId,
+                MemberId = _coordinator.MemberId!,
+                ShareSessionEpoch = _sessionManager.GetSessionEpoch(brokerId),
+                MaxWaitMs = _options.FetchMaxWaitMs,
+                MinBytes = _options.FetchMinBytes,
+                MaxBytes = _options.FetchMaxBytes,
+                MaxRecords = maxRecords,
+                BatchSize = maxRecords,
+                ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
+                Topics = BuildShareFetchTopics(partitions, pendingAcks, version)
+            };
             var response = (ShareFetchResponse)await connection
+                .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
+                .ConfigureAwait(false);
+            return (brokerId, response);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFetchFailed(brokerId, ex);
+            _sessionManager.ResetSession(brokerId);
+            return (brokerId, null);
+        }
+    }
+
+    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchAsync(
+        int brokerId,
+        ShareFetchRequest request,
+        short fallbackVersion,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
+            var version = connection is IKafkaCapabilityProvider
+                ? _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.ShareFetch,
+                    ShareFetchRequest.LowestSupportedVersion,
+                    ShareFetchRequest.HighestSupportedVersion)
+                : fallbackVersion;
+            var response = await connection
                 .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
                 .ConfigureAwait(false);
             return (brokerId, response);
@@ -602,19 +622,33 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
         var partitionsByBroker = GroupPartitionsByLeader(assignment);
 
-        var shareFetchVersion = _metadataManager.GetNegotiatedApiVersion(
-            ApiKey.ShareFetch,
-            ShareFetchRequest.LowestSupportedVersion,
-            ShareFetchRequest.HighestSupportedVersion);
-
         // Send close requests to all brokers in parallel — these are fire-and-forget
         // with MaxWaitMs=0, so there's no reason to wait for each sequentially.
         var closeTasks = new List<Task>(partitionsByBroker.Count);
 
         foreach (var (brokerId, partitions) in partitionsByBroker)
         {
-            var topics = BuildShareFetchTopics(partitions, pendingAcks: null, shareFetchVersion);
+            closeTasks.Add(CloseSessionForBrokerAsync(brokerId, partitions, cancellationToken));
+        }
 
+        await Task.WhenAll(closeTasks).ConfigureAwait(false);
+    }
+
+    private async Task CloseSessionForBrokerAsync(
+        int brokerId,
+        List<TopicPartition> partitions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
+                .ConfigureAwait(false);
+            var connection = connectionLease.Connection;
+            var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion);
             var request = new ShareFetchRequest
             {
                 GroupId = _options.GroupId,
@@ -623,25 +657,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 MaxWaitMs = 0,
                 MinBytes = 0,
                 MaxBytes = 0,
-                MaxRecords = shareFetchVersion >= 1 ? 1 : 0,
+                MaxRecords = version >= 1 ? 1 : 0,
                 ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
-                Topics = topics
+                Topics = BuildShareFetchTopics(partitions, pendingAcks: null, version)
             };
-
-            closeTasks.Add(CloseSessionForBrokerAsync(brokerId, request, shareFetchVersion, cancellationToken));
-        }
-
-        await Task.WhenAll(closeTasks).ConfigureAwait(false);
-    }
-
-    private async Task CloseSessionForBrokerAsync(
-        int brokerId, ShareFetchRequest request, short version, CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
-                .ConfigureAwait(false);
-            var connection = connectionLease.Connection;
             await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
                 request, version, cancellationToken).ConfigureAwait(false);
         }
@@ -654,7 +673,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private async Task SendAcknowledgeAsync(
         int brokerId,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> topicAcks,
-        short shareAckVersion,
         CancellationToken cancellationToken)
     {
         var topics = BuildShareAcknowledgeTopics(topicAcks);
@@ -671,6 +689,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
+        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
+            connection,
+            ApiKey.ShareAcknowledge,
+            ShareAcknowledgeRequest.LowestSupportedVersion,
+            ShareAcknowledgeRequest.HighestSupportedVersion);
 
         var response = (ShareAcknowledgeResponse)await connection
             .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Dekaf.Compression;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -575,38 +576,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 .ConfigureAwait(false);
             return (brokerId, response);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            LogFetchFailed(brokerId, ex);
-            _sessionManager.ResetSession(brokerId);
-            return (brokerId, null);
-        }
-    }
-
-    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchAsync(
-        int brokerId,
-        ShareFetchRequest request,
-        short fallbackVersion,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
-                .ConfigureAwait(false);
-            var connection = connectionLease.Connection;
-            var version = connection is IKafkaCapabilityProvider
-                ? _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    ApiKey.ShareFetch,
-                    ShareFetchRequest.LowestSupportedVersion,
-                    ShareFetchRequest.HighestSupportedVersion)
-                : fallbackVersion;
-            var response = await connection
-                .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
-                .ConfigureAwait(false);
-            return (brokerId, response);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)
         {
             LogFetchFailed(brokerId, ex);
             _sessionManager.ResetSession(brokerId);

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -141,6 +141,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             var connection = connectionLease.Connection;
 
             var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.FindCoordinator,
                 FindCoordinatorRequest.LowestSupportedVersion,
                 FindCoordinatorRequest.HighestSupportedVersion);
@@ -257,7 +258,15 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             .ConfigureAwait(false);
         var connection = connectionLease.Connection;
 
+        if (!_metadataManager.HasApiKey(connection, ApiKey.ShareGroupHeartbeat))
+        {
+            throw new BrokerVersionException(
+                "The target Kafka broker does not support the ShareGroupHeartbeat API " +
+                "(KIP-932, introduced in Kafka 4.0). Share group consumption requires Kafka 4.0 or later.");
+        }
+
         var version = _metadataManager.GetNegotiatedApiVersion(
+            connection,
             ApiKey.ShareGroupHeartbeat,
             ShareGroupHeartbeatRequest.LowestSupportedVersion,
             ShareGroupHeartbeatRequest.HighestSupportedVersion);
@@ -372,7 +381,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         StringSet topics,
         CancellationToken cancellationToken)
     {
-        if (!_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            !_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
         {
             throw new BrokerVersionException(
                 "The connected Kafka broker does not support the ShareGroupHeartbeat API " +
@@ -568,6 +578,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             };
 
             var version = _metadataManager.GetNegotiatedApiVersion(
+                connection,
                 ApiKey.ShareGroupHeartbeat,
                 ShareGroupHeartbeatRequest.LowestSupportedVersion,
                 ShareGroupHeartbeatRequest.HighestSupportedVersion);

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -381,14 +381,6 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         StringSet topics,
         CancellationToken cancellationToken)
     {
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            !_metadataManager.HasApiKey(ApiKey.ShareGroupHeartbeat))
-        {
-            throw new BrokerVersionException(
-                "The connected Kafka broker does not support the ShareGroupHeartbeat API " +
-                "(KIP-932, introduced in Kafka 4.0). Share group consumption requires Kafka 4.0 or later.");
-        }
-
         _subscribedTopics = topics;
         Interlocked.Exchange(ref _subscriptionChanged, 1);
 
@@ -466,7 +458,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
-                    (ex is KafkaException ke && ke is not GroupException && !cancellationToken.IsCancellationRequested))
+                    (ex is KafkaException ke &&
+                     ke is not GroupException and not BrokerVersionException &&
+                     !cancellationToken.IsCancellationRequested))
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -249,16 +249,9 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         Guid clientInstanceId,
         CancellationToken cancellationToken)
     {
-        if (!TryGetNegotiatedVersion(
-                ApiKey.GetTelemetrySubscriptions,
-                GetTelemetrySubscriptionsRequest.LowestSupportedVersion,
-                GetTelemetrySubscriptionsRequest.HighestSupportedVersion,
-                out var apiVersion) ||
-            !TryGetNegotiatedVersion(
-                ApiKey.PushTelemetry,
-                PushTelemetryRequest.LowestSupportedVersion,
-                PushTelemetryRequest.HighestSupportedVersion,
-                out _))
+        if (_metadataManager.HasLegacyApiVersionSnapshot &&
+            (!_metadataManager.HasApiKey(ApiKey.GetTelemetrySubscriptions) ||
+             !_metadataManager.HasApiKey(ApiKey.PushTelemetry)))
         {
             Disable();
             return null;
@@ -269,11 +262,29 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
             var leasedConnection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
             if (leasedConnection is null)
             {
+                Disable();
                 return null;
             }
 
             using var connectionLease = leasedConnection.Value;
             var connection = connectionLease.Connection;
+
+            if (!TryGetNegotiatedVersion(
+                    connection,
+                    ApiKey.GetTelemetrySubscriptions,
+                    GetTelemetrySubscriptionsRequest.LowestSupportedVersion,
+                    GetTelemetrySubscriptionsRequest.HighestSupportedVersion,
+                    out var apiVersion) ||
+                !TryGetNegotiatedVersion(
+                    connection,
+                    ApiKey.PushTelemetry,
+                    PushTelemetryRequest.LowestSupportedVersion,
+                    PushTelemetryRequest.HighestSupportedVersion,
+                    out _))
+            {
+                Disable();
+                return null;
+            }
 
             var response = await connection.SendAsync<GetTelemetrySubscriptionsRequest, GetTelemetrySubscriptionsResponse>(
                 new GetTelemetrySubscriptionsRequest { ClientInstanceId = clientInstanceId },
@@ -333,16 +344,6 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         bool terminating,
         CancellationToken cancellationToken)
     {
-        if (!TryGetNegotiatedVersion(
-                ApiKey.PushTelemetry,
-                PushTelemetryRequest.LowestSupportedVersion,
-                PushTelemetryRequest.HighestSupportedVersion,
-                out var apiVersion))
-        {
-            Disable();
-            return ErrorCode.UnsupportedVersion;
-        }
-
         try
         {
             var leasedConnection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -353,6 +354,17 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
 
             using var connectionLease = leasedConnection.Value;
             var connection = connectionLease.Connection;
+
+            if (!TryGetNegotiatedVersion(
+                    connection,
+                    ApiKey.PushTelemetry,
+                    PushTelemetryRequest.LowestSupportedVersion,
+                    PushTelemetryRequest.HighestSupportedVersion,
+                    out var apiVersion))
+            {
+                Disable();
+                return ErrorCode.UnsupportedVersion;
+            }
 
             var metricSnapshot = _metricCollector?.Collect(subscription) ??
                 ClientTelemetryMetricSnapshot.Empty(subscription.DeltaTemporality);
@@ -455,8 +467,14 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         return brokers.Count == 0 ? null : brokers[0].NodeId;
     }
 
-    private bool TryGetNegotiatedVersion(ApiKey apiKey, short lowestSupportedVersion, short highestSupportedVersion, out short apiVersion)
+    private bool TryGetNegotiatedVersion(
+        IKafkaConnection connection,
+        ApiKey apiKey,
+        short lowestSupportedVersion,
+        short highestSupportedVersion,
+        out short apiVersion)
         => _metadataManager.TryGetNegotiatedApiVersion(
+            connection,
             apiKey,
             lowestSupportedVersion,
             highestSupportedVersion,

--- a/src/Dekaf/Telemetry/ClientTelemetryManager.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryManager.cs
@@ -249,14 +249,6 @@ internal sealed partial class ClientTelemetryManager : IAsyncDisposable
         Guid clientInstanceId,
         CancellationToken cancellationToken)
     {
-        if (_metadataManager.HasLegacyApiVersionSnapshot &&
-            (!_metadataManager.HasApiKey(ApiKey.GetTelemetrySubscriptions) ||
-             !_metadataManager.HasApiKey(ApiKey.PushTelemetry)))
-        {
-            Disable();
-            return null;
-        }
-
         try
         {
             var leasedConnection = await GetTelemetryConnectionAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
@@ -27,7 +27,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
     }
 
     [Test]
-    public async Task ApiVersions_SuccessfullyNegotiates()
+    public async Task Connection_NegotiatesCapabilitySnapshotBeforeUse()
     {
         // This test verifies that ApiVersions request works and returns supported API versions
         var connectionOptions = new ConnectionOptions
@@ -43,6 +43,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         try
         {
             var connection = await pool.GetConnectionAsync(host, port, CancellationToken.None);
+            var capabilities = ((IKafkaCapabilityProvider)connection).Capabilities;
 
             var response = await SendApiVersionsAsync(connection);
 
@@ -57,6 +58,20 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
             await Assert.That(apiKeyIds.Contains(ApiKey.Metadata)).IsTrue();
             await Assert.That(apiKeyIds.Contains(ApiKey.FindCoordinator)).IsTrue();
             await Assert.That(apiKeyIds.Contains(ApiKey.ConsumerGroupHeartbeat)).IsTrue();
+
+            // The physical connection is not exposed until this immutable snapshot exists.
+            await Assert.That(capabilities.HasApi(ApiKey.Produce)).IsTrue();
+            await Assert.That(capabilities.HasApi(ApiKey.Fetch)).IsTrue();
+            await Assert.That(capabilities.HasApi(ApiKey.Metadata)).IsTrue();
+            var brokerMetadata = response.ApiKeys.Single(api => api.ApiKey == ApiKey.Metadata);
+            var expectedMetadataVersion = Math.Min(
+                brokerMetadata.MaxVersion,
+                MetadataRequest.HighestSupportedVersion);
+            await Assert.That(capabilities.NegotiateVersion(
+                    ApiKey.Metadata,
+                    MetadataRequest.LowestSupportedVersion,
+                    MetadataRequest.HighestSupportedVersion))
+                .IsEqualTo(expectedMetadataVersion);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientTransactionIntrospectionTests.cs
@@ -178,11 +178,12 @@ public sealed class AdminClientTransactionIntrospectionTests
     [Test]
     public async Task DescribeTransactionsAsync_WhenApiKeyMissing_ThrowsBrokerVersionException()
     {
-        var (admin, _) = CreateAdminWithMockConnections(includeDescribeTransactionsApi: false);
+        var (admin, connections) = CreateAdminWithMockConnections(includeDescribeTransactionsApi: false);
+        SetupTransactionCoordinatorLookup(connections[1], coordinatorId: 1);
 
         await Assert.That(async () =>
         {
-            await admin.DescribeTransactionsAsync([]);
+            await admin.DescribeTransactionsAsync(["tx-a"]);
         }).Throws<BrokerVersionException>();
     }
 
@@ -284,7 +285,7 @@ public sealed class AdminClientTransactionIntrospectionTests
 
         await Assert.That(async () =>
         {
-            await admin.DescribeProducersAsync([]);
+            await admin.DescribeProducersAsync([new TopicPartition("orders", 0)]);
         }).Throws<BrokerVersionException>();
     }
 
@@ -480,7 +481,8 @@ public sealed class AdminClientTransactionIntrospectionTests
     [Test]
     public async Task FenceProducersAsync_WhenApiKeyMissing_ThrowsBrokerVersionException()
     {
-        var (admin, _) = CreateAdminWithMockConnections(includeInitProducerIdApi: false);
+        var (admin, connections) = CreateAdminWithMockConnections(includeInitProducerIdApi: false);
+        SetupTransactionCoordinatorLookup(connections[1], coordinatorId: 1);
 
         await Assert.That(async () =>
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -266,6 +266,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             Brokers = [new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }],
             Topics = []
         });
+        SetupFindCoordinator();
 
         await using var coordinator = new ConsumerCoordinator(
             CreateConsumerProtocolOptions(), _connectionPool, noHeartbeatManager);
@@ -3109,6 +3110,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     [Test]
     public async Task ConsumerProtocol_ServerSideRegex_BrokerWithoutV1_ThrowsBrokerVersionException()
     {
+        SetupFindCoordinator();
         var options = CreateConsumerProtocolOptions();
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3121,6 +3121,37 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_StableSubscription_RejectsRegexBeforeAcceptingItOnV0Broker()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(heartbeatIntervalMs: 60_000);
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        _connection.ClearReceivedCalls();
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 0);
+
+        await Assert.That(async () =>
+                await coordinator.EnsureActiveGroupAsync(
+                    new HashSet<string>(),
+                    "orders-.*",
+                    CancellationToken.None))
+            .Throws<BrokerVersionException>()
+            .WithMessageContaining("Kafka 4.1");
+
+        await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Any<ConsumerGroupHeartbeatRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task ConsumerProtocol_InvalidRegularExpression_ThrowsGroupException()
     {
         _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3152,6 +3152,31 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_StableRegex_CapabilityLossDuringHeartbeat_PropagatesToPoll()
+    {
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(heartbeatIntervalMs: 60_000);
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string>();
+
+        await coordinator.EnsureActiveGroupAsync(topics, "orders-.*", CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 0);
+        SetPrivateField(coordinator, "_heartbeatIntervalMs", 1);
+
+        await InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(async () =>
+                await coordinator.EnsureActiveGroupAsync(topics, "orders-.*", CancellationToken.None))
+            .Throws<BrokerVersionException>()
+            .WithMessageContaining("Kafka 4.1");
+    }
+
+    [Test]
     public async Task ConsumerProtocol_InvalidRegularExpression_ThrowsGroupException()
     {
         _metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 1);

--- a/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
@@ -1,6 +1,9 @@
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using Dekaf.Networking;
+using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Unit.Networking;
 
@@ -66,7 +69,7 @@ public sealed class ClientDnsLookupTests
         using var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        var acceptTask = listener.AcceptSocketAsync();
+        var acceptTask = AcceptAndCompleteHandshakeAsync(listener);
         // Listener is IPv4-only; IPv6 loopback fails quickly without depending on
         // platform-specific routing for aliases like 127.0.0.2.
         var resolver = new ClientDnsEndpointResolver(new StubDnsLookup(
@@ -91,6 +94,44 @@ public sealed class ClientDnsLookupTests
 
         await Assert.That(connection.IsConnected).IsTrue();
         await Assert.That(endpoints[0].Address).IsEqualTo(IPAddress.Loopback);
+    }
+
+    private static async Task<Socket> AcceptAndCompleteHandshakeAsync(TcpListener listener)
+    {
+        var socket = await listener.AcceptSocketAsync();
+        try
+        {
+            var stream = new NetworkStream(socket, ownsSocket: false);
+            var length = new byte[sizeof(int)];
+            await stream.ReadExactlyAsync(length);
+            var request = new byte[BinaryPrimitives.ReadInt32BigEndian(length)];
+            await stream.ReadExactlyAsync(request);
+
+            var body = new ArrayBufferWriter<byte>();
+            var writer = new KafkaProtocolWriter(body);
+            writer.WriteInt16(0);
+            writer.WriteUnsignedVarInt(2);
+            writer.WriteInt16((short)ApiKey.ApiVersions);
+            writer.WriteInt16(0);
+            writer.WriteInt16(3);
+            writer.WriteEmptyTaggedFields();
+            writer.WriteInt32(0);
+            writer.WriteEmptyTaggedFields();
+
+            var response = new byte[sizeof(int) * 2 + body.WrittenCount];
+            BinaryPrimitives.WriteInt32BigEndian(response, response.Length - sizeof(int));
+            BinaryPrimitives.WriteInt32BigEndian(
+                response.AsSpan(sizeof(int)),
+                BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4)));
+            body.WrittenSpan.CopyTo(response.AsSpan(sizeof(int) * 2));
+            await stream.WriteAsync(response);
+            return socket;
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
     }
 
     private sealed class StubDnsLookup : IDnsLookup

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -1,0 +1,180 @@
+using Dekaf.Networking;
+using Dekaf.Metadata;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public class KafkaConnectionCapabilitiesTests
+{
+    [Test]
+    public async Task NegotiateVersion_UsesOnlySnapshotRange()
+    {
+        var older = CreateCapabilities(new ApiVersion(ApiKey.Produce, 3, 7));
+        var newer = CreateCapabilities(new ApiVersion(ApiKey.Produce, 3, 13));
+
+        await Assert.That(older.NegotiateVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)7);
+        await Assert.That(newer.NegotiateVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)13);
+    }
+
+    [Test]
+    public async Task NegotiateVersion_WhenApiIsAbsent_ThrowsBeforeWrite()
+    {
+        var capabilities = CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 13));
+
+        await Assert.That(() => capabilities.NegotiateVersion(ApiKey.Produce, 3, 13))
+            .Throws<BrokerVersionException>()
+            .WithMessageContaining("Produce");
+    }
+
+    [Test]
+    public async Task NegotiateVersion_WhenRangesAreDisjoint_ThrowsBeforeWrite()
+    {
+        var capabilities = CreateCapabilities(new ApiVersion(ApiKey.Produce, 0, 2));
+
+        await Assert.That(() => capabilities.NegotiateVersion(ApiKey.Produce, 3, 13))
+            .Throws<BrokerVersionException>()
+            .WithMessageContaining("client [3, 13]: broker [0, 2]");
+    }
+
+    [Test]
+    public async Task NegotiateVersion_WhenClientRangeIsInvalid_ThrowsArgumentOutOfRangeException()
+    {
+        var capabilities = CreateCapabilities(new ApiVersion(ApiKey.Produce, 3, 13));
+
+        await Assert.That(() => capabilities.NegotiateVersion(ApiKey.Produce, 13, 3))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => capabilities.TryNegotiateVersion(ApiKey.Produce, 13, 3, out _))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task NewGeneration_DoesNotRetainRemovedApi()
+    {
+        var firstGeneration = CreateCapabilities(
+            new ApiVersion(ApiKey.Metadata, 9, 13),
+            new ApiVersion(ApiKey.Produce, 3, 13));
+        var secondGeneration = CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 13));
+
+        await Assert.That(firstGeneration.HasApi(ApiKey.Produce)).IsTrue();
+        await Assert.That(secondGeneration.HasApi(ApiKey.Produce)).IsFalse();
+    }
+
+    [Test]
+    public async Task Snapshot_CapturesFinalizedFeaturesAndEpoch()
+    {
+        var response = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = [new ApiVersion(ApiKey.Metadata, 9, 13)],
+            SupportedFeatures = [new SupportedFeature("kraft.version", 0, 1)],
+            FinalizedFeaturesEpoch = 42,
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)],
+            ZkMigrationReady = true
+        };
+        var capabilities = KafkaConnectionCapabilities.Create(response);
+
+        await Assert.That(capabilities.TryGetSupportedFeatureRange(
+            "kraft.version",
+            out var minVersion,
+            out var maxVersion)).IsTrue();
+        await Assert.That(minVersion).IsEqualTo((short)0);
+        await Assert.That(maxVersion).IsEqualTo((short)1);
+        await Assert.That(capabilities.TryGetSupportedFeatureRange("missing", out _, out _)).IsFalse();
+        await Assert.That(capabilities.FinalizedFeaturesEpoch).IsEqualTo(42);
+        await Assert.That(capabilities.GetFinalizedFeatureVersion("transaction.version")).IsEqualTo((short)2);
+        await Assert.That(capabilities.GetFinalizedFeatureVersion("missing")).IsEqualTo((short)0);
+        await Assert.That(capabilities.ZkMigrationReady).IsTrue();
+    }
+
+    [Test]
+    public async Task MetadataVersionSelection_UsesExactTargetConnection()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["unused:9092"]);
+        var olderConnection = CreateConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Fetch, 12, 14)));
+        var newerConnection = CreateConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Fetch, 12, 16)));
+
+        var olderVersion = metadata.GetNegotiatedApiVersion(
+            olderConnection,
+            ApiKey.Fetch,
+            ourMinVersion: 12,
+            ourMaxVersion: 16);
+        var newerVersion = metadata.GetNegotiatedApiVersion(
+            newerConnection,
+            ApiKey.Fetch,
+            ourMinVersion: 12,
+            ourMaxVersion: 16);
+
+        await Assert.That(olderVersion).IsEqualTo((short)14);
+        await Assert.That(newerVersion).IsEqualTo((short)16);
+    }
+
+    private static KafkaConnectionCapabilities CreateCapabilities(params ApiVersion[] versions)
+        => KafkaConnectionCapabilities.Create(CreateResponse(versions));
+
+    private static IKafkaConnection CreateConnection(KafkaConnectionCapabilities capabilities)
+        => new CapabilityConnection(capabilities);
+
+    private static ApiVersionsResponse CreateResponse(params ApiVersion[] versions)
+        => new()
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = versions
+        };
+
+    private sealed class CapabilityConnection(KafkaConnectionCapabilities capabilities) :
+        IKafkaConnection,
+        IKafkaCapabilityProvider
+    {
+        public int BrokerId => 1;
+        public string Host => "unused";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public KafkaConnectionCapabilities Capabilities { get; } = capabilities;
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -148,6 +148,59 @@ public class KafkaConnectionCapabilitiesTests
     }
 
     [Test]
+    public async Task Rebootstrap_RefreshesVersionlessCompatibilitySnapshot()
+    {
+        var initialCapabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys =
+            [
+                new ApiVersion(ApiKey.Metadata, 9, 12),
+                new ApiVersion(ApiKey.Fetch, 12, 14)
+            ],
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 1, 0)]
+        });
+        var replacementCapabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys =
+            [
+                new ApiVersion(ApiKey.Metadata, 9, 13),
+                new ApiVersion(ApiKey.Fetch, 12, 16)
+            ],
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
+        });
+        var initialConnection = new CapabilityConnection(initialCapabilities);
+        var replacementConnection = new CapabilityConnection(replacementCapabilities);
+        var connections = new Queue<IKafkaConnection>([initialConnection, replacementConnection]);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(
+                Arg.Any<string>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(connections.Dequeue()));
+        await using var metadata = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+
+        await metadata.InitializeAsync();
+        await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
+            .IsEqualTo((short)14);
+        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
+            .IsEqualTo((short)1);
+
+        var rebootstrapped = await metadata.TryRebootstrapImmediateAsync(null, CancellationToken.None);
+
+        await Assert.That(rebootstrapped).IsTrue();
+        await Assert.That(replacementConnection.ObservedApiVersion).IsEqualTo((short)13);
+        await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
+            .IsEqualTo((short)16);
+        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
+            .IsEqualTo((short)2);
+    }
+
+    [Test]
     public async Task ConnectionPool_InFlightSendKeepsOriginalCapabilityGenerationDuringReplacement()
     {
         var releaseFirstSend = new TaskCompletionSource(

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -115,6 +115,74 @@ public class KafkaConnectionCapabilitiesTests
         await Assert.That(newerVersion).IsEqualTo((short)16);
     }
 
+    [Test]
+    public async Task LegacySnapshot_SeedsVersionlessMetadataApis()
+    {
+        var capabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys =
+            [
+                new ApiVersion(ApiKey.Metadata, 9, 13),
+                new ApiVersion(ApiKey.Produce, 3, 11)
+            ],
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
+        });
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["unused:9092"]);
+
+        metadata.EnsureLegacyApiVersionSnapshot(capabilities);
+
+        await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsTrue();
+        await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)11);
+        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version")).IsEqualTo((short)2);
+    }
+
+    [Test]
+    public async Task ConnectionPool_InFlightSendKeepsOriginalCapabilityGenerationDuringReplacement()
+    {
+        var releaseFirstSend = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new GenerationConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 12)),
+            releaseFirstSend.Task);
+        var second = new GenerationConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 13)),
+            Task.CompletedTask);
+        var generations = new Queue<IKafkaConnection>([first, second]);
+        await using var pool = new ConnectionPool(
+            clientId: null,
+            connectionOptions: null,
+            connectionsPerBroker: 1,
+            connectionFactory: (_, _, _, _, _) =>
+                ValueTask.FromResult(generations.Dequeue()));
+        pool.RegisterBroker(1, "unused", 9092);
+
+        using var firstLease = await pool.LeaseConnectionAsync(1, CancellationToken.None);
+        var firstVersion = ((IKafkaCapabilityProvider)firstLease.Connection)
+            .Capabilities.NegotiateVersion(ApiKey.Metadata, 9, 13);
+        var inFlightSend = firstLease.Connection
+            .SendAsync<MetadataRequest, MetadataResponse>(
+                MetadataRequest.ForAllTopics(),
+                firstVersion,
+                CancellationToken.None)
+            .AsTask();
+        await first.SendStarted;
+
+        first.Disconnect();
+        using var secondLease = await pool.LeaseConnectionAsync(1, CancellationToken.None);
+        var secondVersion = ((IKafkaCapabilityProvider)secondLease.Connection)
+            .Capabilities.NegotiateVersion(ApiKey.Metadata, 9, 13);
+
+        releaseFirstSend.SetResult();
+        await inFlightSend;
+
+        await Assert.That(secondLease.Connection).IsSameReferenceAs(second);
+        await Assert.That(first.ObservedApiVersion).IsEqualTo((short)12);
+        await Assert.That(secondVersion).IsEqualTo((short)13);
+    }
+
     private static KafkaConnectionCapabilities CreateCapabilities(params ApiVersion[] versions)
         => KafkaConnectionCapabilities.Create(CreateResponse(versions));
 
@@ -146,6 +214,80 @@ public class KafkaConnectionCapabilitiesTests
             CancellationToken cancellationToken = default)
             where TRequest : IKafkaRequest<TResponse>
             where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class GenerationConnection(
+        KafkaConnectionCapabilities capabilities,
+        Task releaseSend) :
+        IKafkaConnection,
+        IKafkaCapabilityProvider
+    {
+        private readonly TaskCompletionSource _sendStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _connected = 1;
+
+        public int BrokerId => 1;
+        public string Host => "unused";
+        public int Port => 9092;
+        public bool IsConnected => Volatile.Read(ref _connected) != 0;
+        public KafkaConnectionCapabilities Capabilities { get; } = capabilities;
+        public Task SendStarted => _sendStarted.Task;
+        public short ObservedApiVersion { get; private set; } = -1;
+
+        public void Disconnect() => Volatile.Write(ref _connected, 0);
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+        {
+            Volatile.Write(ref _connected, 1);
+            return ValueTask.CompletedTask;
+        }
+
+        public async ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            ObservedApiVersion = apiVersion;
+            _sendStarted.TrySetResult();
+            await releaseSend.WaitAsync(cancellationToken);
+            return (TResponse)(IKafkaResponse)new MetadataResponse
+            {
+                Brokers = [],
+                Topics = []
+            };
+        }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
             TRequest request,

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -116,30 +116,6 @@ public class KafkaConnectionCapabilitiesTests
     }
 
     [Test]
-    public async Task LegacySnapshot_SeedsVersionlessMetadataApis()
-    {
-        var capabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
-        {
-            ErrorCode = ErrorCode.None,
-            ApiKeys =
-            [
-                new ApiVersion(ApiKey.Metadata, 9, 13),
-                new ApiVersion(ApiKey.Produce, 3, 11)
-            ],
-            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
-        });
-        await using var metadata = new MetadataManager(
-            Substitute.For<IConnectionPool>(),
-            ["unused:9092"]);
-
-        metadata.EnsureLegacyApiVersionSnapshot(capabilities);
-
-        await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsTrue();
-        await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)11);
-        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version")).IsEqualTo((short)2);
-    }
-
-    [Test]
     public async Task ConnectionPool_InFlightSendKeepsOriginalCapabilityGenerationDuringReplacement()
     {
         var releaseFirstSend = new TaskCompletionSource(

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -156,7 +156,8 @@ public class KafkaConnectionCapabilitiesTests
             ApiKeys =
             [
                 new ApiVersion(ApiKey.Metadata, 9, 12),
-                new ApiVersion(ApiKey.Fetch, 12, 14)
+                new ApiVersion(ApiKey.Fetch, 12, 14),
+                new ApiVersion(ApiKey.Produce, 0, 11)
             ],
             FinalizedFeatures = [new FinalizedFeature("transaction.version", 1, 0)]
         });
@@ -189,6 +190,7 @@ public class KafkaConnectionCapabilitiesTests
             .IsEqualTo((short)14);
         await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
             .IsEqualTo((short)1);
+        await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsTrue();
 
         var rebootstrapped = await metadata.TryRebootstrapImmediateAsync(null, CancellationToken.None);
 
@@ -198,6 +200,7 @@ public class KafkaConnectionCapabilitiesTests
             .IsEqualTo((short)16);
         await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
             .IsEqualTo((short)2);
+        await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -116,6 +116,38 @@ public class KafkaConnectionCapabilitiesTests
     }
 
     [Test]
+    public async Task InitializeAsync_SeedsVersionlessCompatibilitySnapshot()
+    {
+        var capabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys =
+            [
+                new ApiVersion(ApiKey.Metadata, 9, 13),
+                new ApiVersion(ApiKey.Fetch, 12, 16)
+            ],
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
+        });
+        var connection = new CapabilityConnection(capabilities);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("unused", 9092, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+        await using var metadata = new MetadataManager(
+            pool,
+            ["unused:9092"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+
+        await metadata.InitializeAsync();
+
+        await Assert.That(connection.ObservedApiVersion).IsEqualTo((short)13);
+        await Assert.That(metadata.HasApiKey(ApiKey.Fetch)).IsTrue();
+        await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
+            .IsEqualTo((short)16);
+        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
+            .IsEqualTo((short)2);
+    }
+
+    [Test]
     public async Task ConnectionPool_InFlightSendKeepsOriginalCapabilityGenerationDuringReplacement()
     {
         var releaseFirstSend = new TaskCompletionSource(
@@ -181,6 +213,7 @@ public class KafkaConnectionCapabilitiesTests
         public int Port => 9092;
         public bool IsConnected => true;
         public KafkaConnectionCapabilities Capabilities { get; } = capabilities;
+        public short ObservedApiVersion { get; private set; } = -1;
 
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
@@ -189,7 +222,18 @@ public class KafkaConnectionCapabilitiesTests
             short apiVersion,
             CancellationToken cancellationToken = default)
             where TRequest : IKafkaRequest<TResponse>
-            where TResponse : IKafkaResponse => throw new NotSupportedException();
+            where TResponse : IKafkaResponse
+        {
+            if (request is not MetadataRequest)
+                throw new NotSupportedException();
+
+            ObservedApiVersion = apiVersion;
+            return ValueTask.FromResult((TResponse)(IKafkaResponse)new MetadataResponse
+            {
+                Brokers = [],
+                Topics = []
+            });
+        }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
             TRequest request,

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -1,0 +1,264 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Networking;
+using Dekaf.Errors;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public class KafkaConnectionCapabilityHandshakeTests
+{
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConnectAsync_NegotiatesCapabilitiesBeforeConnectionIsReady(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            var request = await ReadFrameAsync(stream, cancellationToken);
+
+            await Assert.That(BinaryPrimitives.ReadInt16BigEndian(request)).IsEqualTo((short)ApiKey.ApiVersions);
+            await Assert.That(BinaryPrimitives.ReadInt16BigEndian(request.AsSpan(2))).IsEqualTo((short)3);
+
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+            requestReceived.SetResult();
+            await releaseResponse.Task.WaitAsync(cancellationToken);
+            var response = BuildResponse(
+                correlationId,
+                ErrorCode.None,
+                new ApiVersion(ApiKey.Metadata, 9, 12),
+                new ApiVersion(ApiKey.Produce, 3, 7));
+            await stream.WriteAsync(response, cancellationToken);
+            await releaseServer.Task.WaitAsync(cancellationToken);
+        }, cancellationToken);
+
+        await using var connection = new KafkaConnection(1, "127.0.0.1", port);
+        var connectTask = connection.ConnectAsync(cancellationToken);
+        await requestReceived.Task.WaitAsync(cancellationToken);
+
+        await Assert.That(connection.IsConnected).IsFalse();
+        await Assert.That(() => ((IKafkaCapabilityProvider)connection).Capabilities)
+            .Throws<InvalidOperationException>();
+
+        releaseResponse.SetResult();
+        await connectTask;
+
+        var capabilities = ((IKafkaCapabilityProvider)connection).Capabilities;
+        await Assert.That(connection.IsConnected).IsTrue();
+        await Assert.That(capabilities.NegotiateVersion(ApiKey.Metadata, 9, 13)).IsEqualTo((short)12);
+        await Assert.That(capabilities.NegotiateVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)7);
+        releaseServer.SetResult();
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConnectAsync_WhenNegotiationFails_DoesNotPublishReadyConnection(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            var request = await ReadFrameAsync(stream, cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+            await stream.WriteAsync(
+                BuildResponse(correlationId, ErrorCode.InvalidRequest),
+                cancellationToken);
+        }, cancellationToken);
+
+        await using var connection = new KafkaConnection(1, "127.0.0.1", port);
+
+        await Assert.That(async () => await connection.ConnectAsync(cancellationToken))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("ApiVersions failed");
+        await serverTask;
+        await Assert.That(connection.IsConnected).IsFalse();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConnectionPool_ReconnectUsesOnlyNewCapabilityGeneration(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var releaseFirstGeneration = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondGeneration = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            await ServeGenerationAsync(
+                listener,
+                releaseFirstGeneration.Task,
+                cancellationToken,
+                new ApiVersion(ApiKey.Metadata, 9, 12),
+                new ApiVersion(ApiKey.Produce, 3, 7));
+            await ServeGenerationAsync(
+                listener,
+                releaseSecondGeneration.Task,
+                cancellationToken,
+                new ApiVersion(ApiKey.Metadata, 9, 13));
+        }, cancellationToken);
+
+        await using var pool = new ConnectionPool(connectionOptions: new ConnectionOptions
+        {
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        });
+
+        var firstConnection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
+        var firstCapabilities = ((IKafkaCapabilityProvider)firstConnection).Capabilities;
+        await Assert.That(firstCapabilities.NegotiateVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)7);
+
+        releaseFirstGeneration.SetResult();
+        await WaitUntilAsync(() => !firstConnection.IsConnected, cancellationToken);
+
+        var secondConnection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
+        var secondCapabilities = ((IKafkaCapabilityProvider)secondConnection).Capabilities;
+
+        await Assert.That(secondConnection).IsNotSameReferenceAs(firstConnection);
+        await Assert.That(secondCapabilities.NegotiateVersion(ApiKey.Metadata, 9, 13)).IsEqualTo((short)13);
+        await Assert.That(() => secondCapabilities.NegotiateVersion(ApiKey.Produce, 3, 13))
+            .Throws<BrokerVersionException>();
+
+        Parallel.For(0, 10_000, _ =>
+        {
+            if (firstCapabilities.NegotiateVersion(ApiKey.Produce, 3, 13) != 7 ||
+                secondCapabilities.HasApi(ApiKey.Produce))
+            {
+                throw new InvalidOperationException("Capability generations were mixed.");
+            }
+        });
+
+        releaseSecondGeneration.SetResult();
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ConnectionPool_NegotiationFailureRetiresOnlyFailedConnection(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var releaseSuccessfulConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using (var failedSocket = await listener.AcceptSocketAsync(cancellationToken))
+            await using (var failedStream = new NetworkStream(failedSocket, ownsSocket: false))
+            {
+                var request = await ReadFrameAsync(failedStream, cancellationToken);
+                var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+                await failedStream.WriteAsync(
+                    BuildResponse(correlationId, ErrorCode.InvalidRequest),
+                    cancellationToken);
+                var successfulGenerationTask = ServeGenerationAsync(
+                    listener,
+                    releaseSuccessfulConnection.Task,
+                    cancellationToken,
+                    new ApiVersion(ApiKey.Metadata, 9, 13));
+                await successfulGenerationTask;
+            }
+        }, cancellationToken);
+
+        await using var pool = new ConnectionPool(connectionOptions: new ConnectionOptions
+        {
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        });
+
+        await Assert.That(async () => await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("ApiVersions failed");
+
+        var connection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
+        await Assert.That(connection.IsConnected).IsTrue();
+        await Assert.That(((IKafkaCapabilityProvider)connection).Capabilities.HasApi(ApiKey.Metadata)).IsTrue();
+
+        releaseSuccessfulConnection.SetResult();
+        await serverTask;
+    }
+
+    private static async Task ServeGenerationAsync(
+        TcpListener listener,
+        Task releaseConnection,
+        CancellationToken cancellationToken,
+        params ApiVersion[] versions)
+    {
+        using var socket = await listener.AcceptSocketAsync(cancellationToken);
+        await using var stream = new NetworkStream(socket, ownsSocket: false);
+        var request = await ReadFrameAsync(stream, cancellationToken);
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+        await stream.WriteAsync(BuildResponse(correlationId, ErrorCode.None, versions), cancellationToken);
+        await releaseConnection.WaitAsync(cancellationToken);
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        while (!predicate())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(
+        NetworkStream stream,
+        CancellationToken cancellationToken)
+    {
+        var length = new byte[sizeof(int)];
+        await stream.ReadExactlyAsync(length, cancellationToken);
+        var frame = new byte[BinaryPrimitives.ReadInt32BigEndian(length)];
+        await stream.ReadExactlyAsync(frame, cancellationToken);
+        return frame;
+    }
+
+    private static byte[] BuildResponse(
+        int correlationId,
+        ErrorCode errorCode,
+        params ApiVersion[] versions)
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(body);
+        writer.WriteInt16((short)errorCode);
+        writer.WriteUnsignedVarInt(versions.Length + 1);
+        foreach (var version in versions)
+        {
+            writer.WriteInt16((short)version.ApiKey);
+            writer.WriteInt16(version.MinVersion);
+            writer.WriteInt16(version.MaxVersion);
+            writer.WriteEmptyTaggedFields();
+        }
+
+        writer.WriteInt32(0);
+        writer.WriteEmptyTaggedFields();
+
+        var frame = new byte[sizeof(int) + sizeof(int) + body.WrittenCount];
+        BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - sizeof(int));
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(sizeof(int)), correlationId);
+        body.WrittenSpan.CopyTo(frame.AsSpan(sizeof(int) * 2));
+        return frame;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -94,6 +94,47 @@ public class KafkaConnectionCapabilityHandshakeTests
 
     [Test]
     [Timeout(5_000)]
+    public async Task ConnectAsync_WhenNegotiationTimesOut_ThrowsKafkaException(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            _ = await ReadFrameAsync(stream, cancellationToken);
+            await releaseServer.Task.WaitAsync(cancellationToken);
+        }, cancellationToken);
+
+        await using var connection = new KafkaConnection(
+            1,
+            "127.0.0.1",
+            port,
+            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(50) });
+
+        try
+        {
+            var exception = await Assert.That(async () => await connection.ConnectAsync(cancellationToken))
+                .Throws<KafkaException>();
+
+            await Assert.That(exception).IsNotNull();
+            await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+            await Assert.That(connection.IsConnected).IsFalse();
+        }
+        finally
+        {
+            releaseServer.TrySetResult();
+        }
+
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(5_000)]
     public async Task ConnectionPool_ReconnectUsesOnlyNewCapabilityGeneration(
         CancellationToken cancellationToken)
     {

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -381,7 +381,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -427,7 +427,7 @@ public sealed class KafkaConnectionTests
                 ApiVersionsResponse>();
             var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -491,7 +491,7 @@ public sealed class KafkaConnectionTests
                 ApiVersionsResponse>();
             var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -540,7 +540,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
@@ -605,7 +605,7 @@ public sealed class KafkaConnectionTests
                 ApiVersionsResponse>();
             var expectedAfterReturn = Math.Max(1, baseline);
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
@@ -647,7 +647,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -687,7 +687,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -708,7 +708,7 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
-    public async Task ReceiveLoop_FailureBeforeFirstResponse_LogsDebug(CancellationToken cancellationToken)
+    public async Task ReceiveLoop_FailureAfterCapabilityHandshake_LogsError(CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
@@ -717,7 +717,7 @@ public sealed class KafkaConnectionTests
         {
             var logger = new CapturingLogger<KafkaConnection>();
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -730,11 +730,8 @@ public sealed class KafkaConnectionTests
             await WaitForReceiveLoopFailureAsync(logger, cancellationToken);
 
             await Assert.That(logger.Entries.Any(entry =>
-                entry.Level == LogLevel.Debug &&
-                entry.Message.Contains("before first response", StringComparison.Ordinal))).IsTrue();
-            await Assert.That(logger.Entries.Any(entry =>
                 entry.Level == LogLevel.Error &&
-                entry.Message.Contains("Error in receive loop", StringComparison.Ordinal))).IsFalse();
+                entry.Message.Contains("Error in receive loop", StringComparison.Ordinal))).IsTrue();
         }
         finally
         {
@@ -753,7 +750,7 @@ public sealed class KafkaConnectionTests
         {
             var logger = new CapturingLogger<KafkaConnection>();
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -797,7 +794,7 @@ public sealed class KafkaConnectionTests
         {
             var logger = new CapturingLogger<KafkaConnection>();
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -846,7 +843,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -925,7 +922,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
 
             await connection.ConnectAsync(cancellationToken);
@@ -949,7 +946,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(
                 IPAddress.Loopback.ToString(),
                 port,
@@ -983,7 +980,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
 
             await connection.ConnectAsync(cancellationToken);
@@ -1017,7 +1014,7 @@ public sealed class KafkaConnectionTests
         try
         {
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var acceptTask = listener.AcceptTcpClientAsync(cancellationToken);
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
             await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
             await connection.ConnectAsync(cancellationToken);
             using var serverClient = await acceptTask.ConfigureAwait(false);
@@ -1323,6 +1320,30 @@ public sealed class KafkaConnectionTests
         BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(4), correlationId);
         bodyBuffer.WrittenSpan.CopyTo(frame.AsSpan(8));
         return frame;
+    }
+
+    private static async Task<TcpClient> AcceptAndCompleteHandshakeAsync(
+        TcpListener listener,
+        CancellationToken cancellationToken)
+    {
+        var client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var stream = client.GetStream();
+            var request = await ReadRequestFrameAsync(stream, cancellationToken).ConfigureAwait(false);
+            await Assert.That(BinaryPrimitives.ReadInt16BigEndian(request))
+                .IsEqualTo((short)ApiKey.ApiVersions);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+            await stream.WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken).ConfigureAwait(false);
+            return client;
+        }
+        catch
+        {
+            client.Dispose();
+            throw;
+        }
     }
 
     private static async Task<byte[]> ReadRequestFrameAsync(NetworkStream stream, CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -836,6 +836,49 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Timeout(120_000)]
+    public async Task SendLoop_UnsupportedTv2ProduceVersion_FailsWithoutRetry(
+        CancellationToken cancellationToken)
+    {
+        var response = new TaskCompletionSource<ProduceResponse>();
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>([response]);
+        var sendCount = 0;
+        var (pool, _) = CreateMockConnection(
+            responses,
+            () => Interlocked.Increment(ref sendCount));
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+        var options = CreateOptions(transactionalId: "test-transaction");
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledged = new TaskCompletionSource<Exception?>();
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, exception) => acknowledged.TrySetResult(exception),
+            produceApiVersion: ProduceRequest.ImplicitTransactionPartitionEnrollmentVersion - 1,
+            isTransactional: true,
+            usesTransactionV2: true);
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+
+            var exception = await acknowledged.Task.WaitAsync(cancellationToken);
+
+            await Assert.That(exception).IsTypeOf<BrokerVersionException>();
+            await Assert.That(Volatile.Read(ref sendCount)).IsEqualTo(0);
+        }
+        finally
+        {
+            response.TrySetResult(CreateSuccessResponse("test-topic", partition: 0, baseOffset: 42));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [Arguments(true)]
     [Arguments(false)]
     [Timeout(120_000)]

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -496,6 +496,27 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task CommitAsync_FeatureDriftPreservesFatalState()
+    {
+        var preparedState = new PreparedTransactionState(42, 5);
+        await using var harness = BuildPreparedCompletionHarness(
+            preparedState,
+            currentProducerId: preparedState.ProducerId,
+            currentProducerEpoch: preparedState.ProducerEpoch);
+        harness.Producer._preparedTransactionState = PreparedTransactionState.Empty;
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+        SetFinalizedTransactionVersion(harness.Producer, 2);
+
+        var exception = await Assert.That(() => transaction.CommitAsync().AsTask())
+            .Throws<FatalTransactionException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.UnsupportedVersion);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
     public async Task CommitAfterRequestWrittenAsync_CallbackFailure_AbandonsResponse()
     {
         var preparedState = new PreparedTransactionState(1001, 4);

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -574,16 +574,17 @@ public sealed class TransactionTests
     [Test]
     public async Task InitTransactionsAsync_WithKeepPreparedAndUnsupportedFeature_ThrowsBrokerVersionException()
     {
-        await using var producer = Kafka.CreateProducer<string, string>()
-            .WithBootstrapServers("localhost:9092")
-            .WithTransactionalId("test-txn-id")
-            .Build();
-
-        SetInstanceField(producer, "_initialized", true);
+        await using var harness = BuildPreparedCompletionHarness(
+            new PreparedTransactionState(1001, 4),
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            transactionFeatureVersion: 2);
 
         await Assert.That(async () =>
         {
-            await producer.InitTransactionsAsync(keepPreparedTransaction: true);
+            await harness.Producer.ReinitializeProducerIdAsync(
+                CancellationToken.None,
+                keepPreparedTransaction: true);
         }).Throws<BrokerVersionException>();
     }
 
@@ -651,7 +652,6 @@ public sealed class TransactionTests
             metadataManager,
             DekafMemoryBudget.Global,
             addPartitionsToTransaction: AddPartitions);
-        SetInstanceField(producer, "_produceApiVersion", 12);
         producer._currentTransactionUsesTV2 = true;
         var implicitBatch = CreateEnrollmentBatch("implicit-topic", 0);
         var implicitResult = producer.TryEnsurePartitionsInTransaction(
@@ -880,7 +880,7 @@ public sealed class TransactionTests
     [Test]
     [Arguments(false, (short)2)]
     [Arguments(true, (short)1)]
-    public async Task BeginTransaction_FeatureVersionChanged_RequiresReinitialization(
+    public async Task BeginTransaction_GlobalFeatureVersionChanged_DoesNotOverrideConnectionSnapshot(
         bool initializedWithTV2,
         short finalizedVersion)
     {
@@ -891,13 +891,17 @@ public sealed class TransactionTests
         var kafkaProducer = (KafkaProducer<string, string>)producer;
         kafkaProducer._transactionState = TransactionState.Ready;
         kafkaProducer._currentTransactionUsesTV2 = initializedWithTV2;
+        SetInstanceField(
+            kafkaProducer,
+            "_currentTransactionFeatureVersion",
+            initializedWithTV2 ? (short)2 : (short)1);
         SetFinalizedTransactionVersion(kafkaProducer, finalizedVersion);
 
-        var exception = await Assert.That(() => producer.BeginTransaction())
-            .Throws<InvalidOperationException>();
+        var transaction = producer.BeginTransaction();
 
-        await Assert.That(exception!.Message).Contains("InitTransactionsAsync");
-        await Assert.That(kafkaProducer._transactionState).IsEqualTo(TransactionState.Ready);
+        await Assert.That(kafkaProducer._transactionState).IsEqualTo(TransactionState.InTransaction);
+        kafkaProducer._transactionState = TransactionState.Ready;
+        await transaction.DisposeAsync();
     }
 
     private static ReadyBatch CreateEnrollmentBatch(string topic, int partition)
@@ -928,6 +932,7 @@ public sealed class TransactionTests
         SetInstanceField(producer, "_producerEpoch", (short)5);
         SetFinalizedTransactionVersion(producer, 3);
         producer._currentTransactionUsesTV2 = true;
+        SetInstanceField(producer, "_currentTransactionFeatureVersion", (short)3);
         producer._transactionState = TransactionState.Ready;
         return producer;
     }
@@ -936,7 +941,8 @@ public sealed class TransactionTests
         PreparedTransactionState preparedState,
         long currentProducerId,
         short currentProducerEpoch,
-        ErrorCode endTxnError = ErrorCode.None)
+        ErrorCode endTxnError = ErrorCode.None,
+        short transactionFeatureVersion = 3)
     {
         var connection = new LeaseTrackingConnection(
             preparedState,
@@ -960,6 +966,13 @@ public sealed class TransactionTests
             ApiKey.InitProducerId,
             InitProducerIdRequest.LowestSupportedVersion,
             InitProducerIdRequest.HighestSupportedVersion);
+        SetInstanceField<IReadOnlyList<FinalizedFeature>>(
+            metadataManager,
+            "_finalizedFeatures",
+            [new FinalizedFeature(
+                "transaction.version",
+                transactionFeatureVersion,
+                transactionFeatureVersion)]);
 
         var producer = new KafkaProducer<string, string>(
             new ProducerOptions
@@ -980,6 +993,7 @@ public sealed class TransactionTests
         SetInstanceField(producer, "_producerEpoch", currentProducerEpoch);
         SetInstanceField(producer, "_transactionCoordinatorId", 1);
         SetInstanceField(producer, "_currentTransactionUsesTV2", true);
+        SetInstanceField(producer, "_currentTransactionFeatureVersion", transactionFeatureVersion);
         producer._preparedTransactionState = preparedState;
         producer._transactionState = TransactionState.PreparedTransaction;
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -16,15 +16,15 @@ public sealed class ShareConsumerConnectionOwnershipTests
     public async Task LeaveGroupAsync_HoldsConnectionLeaseThroughRequest()
     {
         var options = CreateOptions();
-        var connection = new LeaseTrackingConnection();
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.ShareGroupHeartbeat,
+                ShareGroupHeartbeatRequest.LowestSupportedVersion,
+                ShareGroupHeartbeatRequest.HighestSupportedVersion));
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionByIndexAsync(1, 1, Arg.Any<CancellationToken>())
             .Returns(connection);
         await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
-        metadataManager.SetApiVersion(
-            ApiKey.ShareGroupHeartbeat,
-            ShareGroupHeartbeatRequest.LowestSupportedVersion,
-            ShareGroupHeartbeatRequest.HighestSupportedVersion);
         await using var coordinator = new ShareConsumerCoordinator(
             options,
             pool,
@@ -45,10 +45,14 @@ public sealed class ShareConsumerConnectionOwnershipTests
     }
 
     [Test]
-    public async Task SendShareFetchAsync_HoldsConnectionLeaseThroughRequest()
+    public async Task SendShareFetchForPartitionsAsync_HoldsConnectionLeaseThroughRequest()
     {
         var options = CreateOptions();
-        var connection = new LeaseTrackingConnection();
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion));
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
         await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
@@ -59,27 +63,68 @@ public sealed class ShareConsumerConnectionOwnershipTests
             pool,
             metadataManager);
 
-        var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
-            "SendShareFetchAsync",
-            BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var sendTask = (Task)method.Invoke(
-            consumer,
-            [
-                1,
-                new ShareFetchRequest
-                {
-                    GroupId = options.GroupId,
-                    MemberId = "member-1",
-                    Topics = []
-                },
-                (short)0,
-                CancellationToken.None
-            ])!;
+        SetMemberId(consumer, "member-1");
+
+        var sendTask = InvokeSendShareFetchForPartitionsAsync(consumer);
 
         await sendTask;
 
         await Assert.That(connection.LeaseCountDuringSend).IsEqualTo(1);
         await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SendShareFetchForPartitionsAsync_PropagatesBrokerVersionException()
+    {
+        var options = CreateOptions();
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.Metadata,
+                MetadataRequest.LowestSupportedVersion,
+                MetadataRequest.HighestSupportedVersion));
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        await using var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+        SetMemberId(consumer, "member-1");
+
+        var sendTask = InvokeSendShareFetchForPartitionsAsync(consumer);
+
+        await Assert.That(async () => await sendTask).Throws<BrokerVersionException>();
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
+    private static Task InvokeSendShareFetchForPartitionsAsync(
+        KafkaShareConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaShareConsumer<string, string>).GetMethod(
+            "SendShareFetchForPartitionsAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task)method.Invoke(
+            consumer,
+            [
+                1,
+                new List<TopicPartition> { new("topic", 0) },
+                null,
+                CancellationToken.None
+            ])!;
+    }
+
+    private static void SetMemberId(
+        KafkaShareConsumer<string, string> consumer,
+        string memberId)
+    {
+        var coordinator = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        typeof(ShareConsumerCoordinator)
+            .GetField("_memberId", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, memberId);
     }
 
     private static ShareConsumerOptions CreateOptions() => new()
@@ -89,7 +134,10 @@ public sealed class ShareConsumerConnectionOwnershipTests
         ConnectionsPerBroker = 2
     };
 
-    private sealed class LeaseTrackingConnection : IKafkaConnection, IRetirableKafkaConnection
+    private sealed class LeaseTrackingConnection(params ApiVersion[] versions) :
+        IKafkaConnection,
+        IRetirableKafkaConnection,
+        IKafkaCapabilityProvider
     {
         private int _leaseCount;
         private int _retirementState;
@@ -98,6 +146,12 @@ public sealed class ShareConsumerConnectionOwnershipTests
         public string Host => "localhost";
         public int Port => 9092;
         public bool IsConnected => true;
+        public KafkaConnectionCapabilities Capabilities { get; } =
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = versions
+            });
         public int LeaseCount => Volatile.Read(ref _leaseCount);
         public int LeaseCountDuringSend { get; private set; }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionCapabilitiesBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionCapabilitiesBenchmarks.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class KafkaConnectionCapabilitiesBenchmarks
+{
+    private readonly ConcurrentDictionary<(ApiKey Key, short Min, short Max), short> _dictionary = new();
+    private ApiVersionsResponse _response = null!;
+    private KafkaConnectionCapabilities _capabilities = null!;
+    private int _volatileProducerVersion = 13;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _response = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = Enum.GetValues<ApiKey>()
+                .Select(static key => new ApiVersion(key, 0, 13))
+                .ToArray()
+        };
+        _capabilities = KafkaConnectionCapabilities.Create(_response);
+        _dictionary[(ApiKey.Produce, 3, 13)] = 13;
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("SteadyStateLookup")]
+    public int VolatileProducerCache() => Volatile.Read(ref _volatileProducerVersion);
+
+    [Benchmark]
+    [BenchmarkCategory("SteadyStateLookup")]
+    public short ConnectionSnapshotLookup() =>
+        _capabilities.NegotiateVersion(ApiKey.Produce, 3, 13);
+
+    [Benchmark]
+    [BenchmarkCategory("SteadyStateLookup")]
+    public short ConcurrentDictionaryLookup() =>
+        _dictionary.TryGetValue((ApiKey.Produce, 3, 13), out var version) ? version : (short)-1;
+
+    [Benchmark]
+    [BenchmarkCategory("ConnectionSetup")]
+    public object ConnectionSnapshotCreation() =>
+        KafkaConnectionCapabilities.Create(_response);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionReadyBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/KafkaConnectionReadyBenchmarks.cs
@@ -1,0 +1,120 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures TCP connection readiness including the mandatory per-connection ApiVersions RPC.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class KafkaConnectionReadyBenchmarks
+{
+    private TcpListener _listener = null!;
+    private CancellationTokenSource _serverCancellation = null!;
+    private Task _serverTask = null!;
+    private int _port;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _serverCancellation = new CancellationTokenSource();
+        _serverTask = RunServerAsync(_serverCancellation.Token);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ConnectionSetup")]
+    public async Task ConnectionReadyLatency()
+    {
+        await using var connection = new KafkaConnection(1, IPAddress.Loopback.ToString(), _port);
+        await connection.ConnectAsync().ConfigureAwait(false);
+        if (!connection.IsConnected)
+            throw new InvalidOperationException("Connection was exposed before capability negotiation completed.");
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _serverCancellation.CancelAsync().ConfigureAwait(false);
+        _listener.Stop();
+        try
+        {
+            await _serverTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (SocketException) when (_serverCancellation.IsCancellationRequested)
+        {
+        }
+
+        _serverCancellation.Dispose();
+    }
+
+    private async Task RunServerAsync(CancellationToken cancellationToken)
+    {
+        var lengthBuffer = new byte[sizeof(int)];
+        var peerClosedBuffer = new byte[1];
+        var response = BuildResponseFrame();
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var stream = client.GetStream();
+                await stream.ReadExactlyAsync(lengthBuffer, cancellationToken).ConfigureAwait(false);
+                var length = BinaryPrimitives.ReadInt32BigEndian(lengthBuffer);
+                var request = ArrayPool<byte>.Shared.Rent(length);
+                try
+                {
+                    await stream.ReadExactlyAsync(request.AsMemory(0, length), cancellationToken).ConfigureAwait(false);
+                    var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+                    BinaryPrimitives.WriteInt32BigEndian(response.AsSpan(sizeof(int)), correlationId);
+                    await stream.WriteAsync(response, cancellationToken).ConfigureAwait(false);
+                    await stream.ReadAtLeastAsync(
+                        peerClosedBuffer,
+                        minimumBytes: 1,
+                        throwOnEndOfStream: false,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(request);
+                }
+            }
+            catch (IOException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // KafkaConnection aborts the socket during disposal; continue serving the next setup.
+            }
+        }
+    }
+
+    private static byte[] BuildResponseFrame()
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(body);
+        writer.WriteInt16(0);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ApiKey.ApiVersions);
+        writer.WriteInt16(0);
+        writer.WriteInt16(3);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt32(0);
+        writer.WriteEmptyTaggedFields();
+
+        var frame = new byte[sizeof(int) + sizeof(int) + body.WrittenCount];
+        BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - sizeof(int));
+        body.WrittenSpan.CopyTo(frame.AsSpan(sizeof(int) * 2));
+        return frame;
+    }
+}


### PR DESCRIPTION
## Summary
- negotiate `ApiVersions` on every physical Kafka connection before publishing readiness
- store immutable per-generation API ranges and node/finalized features, then select versions only after leasing the target connection
- remove producer/fetch global version caches and route admin, consumer, share consumer, transactions, telemetry, metadata, and rebootstrap through connection capabilities
- preserve #2227 strict overlap validation through a shared negotiation primitive

## Validation
- net10 unit suite: 5,653 passed
- net8 unit suite: 5,527 passed
- netstandard2.0 + net10 source build: clean
- benchmark build and scoped formatting: clean
- snapshot lookup dry benchmark: 0 B allocated, 0.97x volatile-cache baseline; dictionary lookup 2.48x baseline
- loopback connection-ready benchmark: 402.9 us mean including mandatory handshake

Closes #2228