### PR TITLE
Fix KIP-320 log truncation recovery

### DIFF
--- a/docs/docs/consumer/offset-management.md
+++ b/docs/docs/consumer/offset-management.md
@@ -257,13 +257,14 @@ foreach (var (tp, offset) in offsets)
 
 After broker failover, leader-epoch validation can report that a new leader's log ends before
 records already prefetched from the previous leader. Dekaf clears stale buffered records for the
-affected partition and resumes from the broker's corrected offset without rewinding records already
-yielded to the application.
+affected partition. When an automatic offset-reset policy is configured, Dekaf resumes from the
+broker's precise divergence offset and logs a warning. Offsets from the truncated tail can therefore
+appear again with different records; this is required to avoid silently skipping the replacement log.
 
-This recovery is internal. Dekaf logs a warning instead of surfacing a terminal
-`ConsumeException(OffsetOutOfRange)`. Applications that used that exception to detect log
-truncation should monitor warning logs instead. Other `OffsetOutOfRange` handling continues to
-follow the configured auto-offset-reset policy.
+With `AutoOffsetReset.None`, Dekaf throws `LogTruncationException` instead. Its
+`TruncationOffsets` identify the first divergent offset and last common leader epoch for each
+affected partition. Catch it, reconcile downstream state, then seek to the selected recovery offset.
+Other `OffsetOutOfRange` handling continues to follow the configured auto-offset-reset policy.
 
 ## Delivery Semantics
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4777,7 +4777,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         // Keep partitions marked while clearing. Background prefetches use this
         // marker to avoid advancing positions for data that will be discarded.
-        ApplyPendingDivergingEpochResets(partitionsToRemove);
+        var logTruncationException = ApplyPendingDivergingEpochResets(partitionsToRemove);
         ClearFetchBufferForPartitions(partitionsToRemove);
 
         foreach (var partition in partitionsToRemove)
@@ -4785,6 +4785,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 0);
         Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 0);
+
+        if (logTruncationException is not null)
+            throw logTruncationException;
+
         return true;
     }
 
@@ -4808,23 +4812,51 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return cleared;
     }
 
-    private void ApplyPendingDivergingEpochResets(IReadOnlyCollection<TopicPartition> partitions)
+    private LogTruncationException? ApplyPendingDivergingEpochResets(
+        IReadOnlyCollection<TopicPartition> partitions)
     {
+        List<TopicPartitionOffset>? truncationOffsets = null;
         foreach (var partition in partitions)
         {
             if (!_pendingDivergingEpochResets.TryRemove(partition, out var reset))
                 continue;
 
-            // Refetch unread common-prefix records that were buffered before the divergence
-            // response. Only offsets already yielded to the application are safe to skip.
-            var resumeOffset = _positions.GetValueOrDefault(partition, reset.EndOffset);
+            if (_options.AutoOffsetReset == AutoOffsetReset.None)
+            {
+                (truncationOffsets ??= []).Add(new TopicPartitionOffset(
+                    partition.Topic,
+                    partition.Partition,
+                    reset.EndOffset,
+                    reset.Epoch));
+                continue;
+            }
+
+            // Refetch unread common-prefix records. Cap positions from the corrected epoch at
+            // its boundary, but preserve records already delivered from a newer leader epoch.
+            var resumeOffset = BoundDivergingResumeOffset(
+                _positions.GetValueOrDefault(partition, reset.EndOffset),
+                GetLastConsumedLeaderEpoch(partition),
+                reset);
+
+            if (TryGetActiveConsumedPosition(partition, out var activePosition, out var activeLeaderEpoch))
+            {
+                resumeOffset = Math.Max(
+                    resumeOffset,
+                    BoundDivergingResumeOffset(activePosition, activeLeaderEpoch, reset));
+            }
 
             foreach (var pending in _pendingFetches)
             {
-                if (TryGetConsumedPosition(pending, out var pendingPartition, out var nextOffset, out _)
+                if (TryGetConsumedPosition(
+                        pending,
+                        out var pendingPartition,
+                        out var nextOffset,
+                        out var pendingLeaderEpoch)
                     && pendingPartition.Equals(partition))
                 {
-                    resumeOffset = Math.Max(resumeOffset, nextOffset);
+                    resumeOffset = Math.Max(
+                        resumeOffset,
+                        BoundDivergingResumeOffset(nextOffset, pendingLeaderEpoch, reset));
                 }
             }
 
@@ -4844,7 +4876,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 reset.EndOffset,
                 reset.Epoch);
         }
+
+        return truncationOffsets is null ? null : new LogTruncationException(truncationOffsets);
     }
+
+    private static long BoundDivergingResumeOffset(
+        long nextOffset,
+        int consumedLeaderEpoch,
+        (long EndOffset, int Epoch) reset) =>
+        nextOffset > reset.EndOffset && consumedLeaderEpoch <= reset.Epoch
+            ? reset.EndOffset
+            : nextOffset;
 
     private bool HasPendingCoordinatorRevocations() =>
         Volatile.Read(ref _coordinatorRevokedPartitionsPendingFetchClearPending) != 0;

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Dekaf.Protocol;
 using Dekaf.Serialization;
 
@@ -90,6 +91,39 @@ public class KafkaException : Exception
             => new AuthenticationException(errorCode, message),
         _ => new KafkaException(errorCode, message),
     };
+}
+
+/// <summary>
+/// Exception thrown when a consumer detects that a partition log was truncated and
+/// <c>auto.offset.reset</c> is configured as <c>none</c>.
+/// </summary>
+public sealed class LogTruncationException : KafkaException
+{
+    /// <summary>
+    /// Creates a log truncation exception for the corrected partition offsets.
+    /// </summary>
+    public LogTruncationException(IReadOnlyList<TopicPartitionOffset> truncationOffsets)
+        : base(Protocol.ErrorCode.OffsetOutOfRange, CreateMessage(truncationOffsets))
+    {
+        TruncationOffsets = new ReadOnlyCollection<TopicPartitionOffset>(truncationOffsets.ToArray());
+    }
+
+    /// <summary>
+    /// The first divergent offset and last common leader epoch for each truncated partition.
+    /// </summary>
+    public IReadOnlyList<TopicPartitionOffset> TruncationOffsets { get; }
+
+    private static string CreateMessage(IReadOnlyList<TopicPartitionOffset> truncationOffsets)
+    {
+        ArgumentNullException.ThrowIfNull(truncationOffsets);
+        if (truncationOffsets.Count == 0)
+            throw new ArgumentException("At least one truncation offset is required.", nameof(truncationOffsets));
+
+        return truncationOffsets.Count == 1
+            ? $"Log truncation detected for {truncationOffsets[0].Topic}-{truncationOffsets[0].Partition} " +
+              $"at offset {truncationOffsets[0].Offset}"
+            : $"Log truncation detected for {truncationOffsets.Count} partitions";
+    }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Integration/ConsumerLogTruncationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerLogTruncationIntegrationTests.cs
@@ -1,0 +1,356 @@
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerLogTruncationIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    private const int CommonRecordCount = 3;
+    private const int UnreplicatedRecordCount = 3;
+    private const int TruncatedPosition = CommonRecordCount + UnreplicatedRecordCount;
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task Consumer_UncleanLeaderElection_DetectsTruncation_DoesNotSilentlyContinue(
+        CancellationToken cancellationToken)
+    {
+        string? topic = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            topic = await CreateDivergentLogAsync(scenarioCancellation.Token).ConfigureAwait(false);
+            var partition = new TopicPartition(topic, 0);
+            ConsumeResult<string, string> consumedTail;
+            await using (var initialConsumer = await CreateAssignedConsumerAsync(
+                topic,
+                AutoOffsetReset.Earliest,
+                scenarioCancellation.Token).ConfigureAwait(false))
+            {
+                consumedTail = await ConsumeThroughUnreplicatedTailAsync(
+                    initialConsumer,
+                    scenarioCancellation.Token).ConfigureAwait(false);
+            }
+
+            await ElectStaleFollowerAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+            await ProduceRangeAsync(
+                topic,
+                "replacement",
+                CommonRecordCount,
+                count: UnreplicatedRecordCount + 1,
+                Acks.Leader,
+                scenarioCancellation.Token).ConfigureAwait(false);
+            await RestoreFormerLeaderAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+
+            await using var validatingConsumer = await CreateAssignedConsumerAsync(
+                topic,
+                AutoOffsetReset.None,
+                scenarioCancellation.Token,
+                offset: TruncatedPosition,
+                leaderEpoch: consumedTail.LeaderEpoch ?? -1).ConfigureAwait(false);
+            var exception = await Assert.That(async () => await validatingConsumer
+                    .ConsumeOneAsync(TimeSpan.FromSeconds(60), scenarioCancellation.Token)
+                    .ConfigureAwait(false))
+                .Throws<LogTruncationException>();
+
+            await Assert.That(consumedTail.Offset).IsEqualTo(TruncatedPosition - 1);
+            await Assert.That(consumedTail.LeaderEpoch).IsNotNull();
+            var truncation = exception!.TruncationOffsets.Single();
+            await Assert.That(truncation.Topic).IsEqualTo(topic);
+            await Assert.That(truncation.Partition).IsEqualTo(partition.Partition);
+            await Assert.That(truncation.Offset).IsEqualTo(CommonRecordCount);
+            await Assert.That(truncation.LeaderEpoch).IsGreaterThanOrEqualTo(0);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await RestoreClusterAsync(topic).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task Consumer_TruncationWithAutoOffsetReset_RepositionsDeterministically(
+        CancellationToken cancellationToken)
+    {
+        string? topic = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var logs = new CapturingLoggerProvider();
+        using var loggerFactory = CreateLoggerFactory(logs);
+
+        try
+        {
+            topic = await CreateCommonLogAsync(scenarioCancellation.Token).ConfigureAwait(false);
+            var partition = new TopicPartition(topic, 0);
+
+            await using var consumer = await CreateAssignedConsumerAsync(
+                topic,
+                AutoOffsetReset.Earliest,
+                scenarioCancellation.Token,
+                loggerFactory).ConfigureAwait(false);
+            _ = await ConsumeRecordsAsync(consumer, CommonRecordCount, scenarioCancellation.Token)
+                .ConfigureAwait(false);
+
+            await AppendUnreplicatedTailAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+            _ = await ConsumeRecordsAsync(consumer, UnreplicatedRecordCount, scenarioCancellation.Token)
+                .ConfigureAwait(false);
+            consumer.Pause(partition);
+
+            await ElectStaleFollowerAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+            await ProduceRangeAsync(
+                topic,
+                "replacement",
+                CommonRecordCount,
+                count: UnreplicatedRecordCount + 1,
+                Acks.Leader,
+                scenarioCancellation.Token).ConfigureAwait(false);
+            await RestoreFormerLeaderAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+
+            consumer.Resume(partition);
+            var firstAfterTruncation = await consumer
+                .ConsumeOneAsync(TimeSpan.FromSeconds(60), scenarioCancellation.Token)
+                .ConfigureAwait(false);
+
+            await Assert.That(firstAfterTruncation).IsNotNull();
+            await Assert.That(firstAfterTruncation!.Value.Offset).IsEqualTo(CommonRecordCount);
+            await Assert.That(firstAfterTruncation.Value.Value).IsEqualTo($"replacement-{CommonRecordCount}");
+            await Assert.That(logs.Entries).Contains(entry =>
+                entry.Message.Contains($"Log truncation detected for {topic}-0", StringComparison.Ordinal)
+                && entry.TryGetProperty<long>("ResumeOffset", out var resumeOffset)
+                && resumeOffset == CommonRecordCount
+                && entry.TryGetProperty<long>("EndOffset", out var endOffset)
+                && endOffset == CommonRecordCount);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await RestoreClusterAsync(topic).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(300_000)]
+    public async Task Consumer_CommittedOffsetBeyondTruncatedLog_GroupRestartRecovers(
+        CancellationToken cancellationToken)
+    {
+        string? topic = null;
+        var groupId = $"truncation-group-{Guid.NewGuid():N}";
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            topic = await CreateDivergentLogAsync(scenarioCancellation.Token).ConfigureAwait(false);
+
+            await using (var firstConsumer = await CreateGroupConsumerAsync(
+                topic,
+                groupId,
+                scenarioCancellation.Token).ConfigureAwait(false))
+            {
+                var consumedTail = await ConsumeThroughUnreplicatedTailAsync(
+                    firstConsumer,
+                    scenarioCancellation.Token).ConfigureAwait(false);
+                await firstConsumer.CommitAsync([
+                    new TopicPartitionOffset(
+                        topic,
+                        partition: 0,
+                        TruncatedPosition,
+                        consumedTail.LeaderEpoch ?? -1)
+                ], scenarioCancellation.Token).ConfigureAwait(false);
+            }
+
+            await ElectStaleFollowerAsync(topic, scenarioCancellation.Token).ConfigureAwait(false);
+            await ProduceRangeAsync(
+                topic,
+                "replacement",
+                CommonRecordCount,
+                count: UnreplicatedRecordCount + 1,
+                Acks.Leader,
+                scenarioCancellation.Token).ConfigureAwait(false);
+
+            await using var restartedConsumer = await CreateGroupConsumerAsync(
+                topic,
+                groupId,
+                scenarioCancellation.Token).ConfigureAwait(false);
+            var firstAfterRestart = await restartedConsumer
+                .ConsumeOneAsync(TimeSpan.FromSeconds(60), scenarioCancellation.Token)
+                .ConfigureAwait(false);
+
+            await Assert.That(firstAfterRestart).IsNotNull();
+            await Assert.That(firstAfterRestart!.Value.Offset).IsEqualTo(CommonRecordCount);
+            await Assert.That(firstAfterRestart.Value.Value).IsEqualTo($"replacement-{CommonRecordCount}");
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await RestoreClusterAsync(topic).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<string> CreateDivergentLogAsync(CancellationToken cancellationToken)
+    {
+        var topic = await CreateCommonLogAsync(cancellationToken).ConfigureAwait(false);
+        await AppendUnreplicatedTailAsync(topic, cancellationToken).ConfigureAwait(false);
+        return topic;
+    }
+
+    private async Task<string> CreateCommonLogAsync(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateUncleanElectionTopicAsync().ConfigureAwait(false);
+        await ProduceRangeAsync(
+            topic,
+            "common",
+            start: 0,
+            CommonRecordCount,
+            Acks.All,
+            cancellationToken).ConfigureAwait(false);
+        return topic;
+    }
+
+    private async Task AppendUnreplicatedTailAsync(string topic, CancellationToken cancellationToken)
+    {
+        await kafka.StopBrokerAsync(nodeId: 2, cancellationToken).ConfigureAwait(false);
+        await kafka.WaitForInSyncReplicasAsync(topic, expectedCount: 1, cancellationToken)
+            .ConfigureAwait(false);
+
+        await ProduceRangeAsync(
+            topic,
+            "unreplicated",
+            CommonRecordCount,
+            UnreplicatedRecordCount,
+            Acks.Leader,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ElectStaleFollowerAsync(string topic, CancellationToken cancellationToken)
+    {
+        await kafka.StopBrokerAsync(nodeId: 1, cancellationToken).ConfigureAwait(false);
+        await kafka.StartBrokerWithoutClusterWaitAsync(nodeId: 2, cancellationToken).ConfigureAwait(false);
+
+        var newLeader = await kafka.WaitForPartitionLeaderChangeAsync(
+            topic,
+            previousLeaderId: 1,
+            cancellationToken).ConfigureAwait(false);
+        if (newLeader != 2)
+            throw new InvalidOperationException($"Expected stale broker 2 to become leader, actual broker {newLeader}.");
+    }
+
+    private async Task RestoreClusterAsync(string? topic)
+    {
+        await kafka.StartBrokersAsync([1, 2], CancellationToken.None).ConfigureAwait(false);
+        if (topic is not null)
+            await kafka.WaitForInSyncReplicasAsync(topic, expectedCount: 2, CancellationToken.None)
+                .ConfigureAwait(false);
+    }
+
+    private async Task RestoreFormerLeaderAsync(string topic, CancellationToken cancellationToken)
+    {
+        await kafka.StartBrokerAsync(nodeId: 1, cancellationToken).ConfigureAwait(false);
+        await kafka.WaitForInSyncReplicasAsync(topic, expectedCount: 2, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateAssignedConsumerAsync(
+        string topic,
+        AutoOffsetReset autoOffsetReset,
+        CancellationToken cancellationToken,
+        ILoggerFactory? loggerFactory = null,
+        long offset = 0,
+        int leaderEpoch = -1)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"truncation-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(autoOffsetReset)
+            .WithLoggerFactory(loggerFactory ?? GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.IncrementalAssign([new TopicPartitionOffset(topic, 0, offset, leaderEpoch)]);
+        return consumer;
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateGroupConsumerAsync(
+        string topic,
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"truncation-group-consumer-{Guid.NewGuid():N}")
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.Subscribe(topic);
+        return consumer;
+    }
+
+    private static Task<ConsumeResult<string, string>> ConsumeThroughUnreplicatedTailAsync(
+        IKafkaConsumer<string, string> consumer,
+        CancellationToken cancellationToken) =>
+        ConsumeRecordsAsync(consumer, TruncatedPosition, cancellationToken);
+
+    private static async Task<ConsumeResult<string, string>> ConsumeRecordsAsync(
+        IKafkaConsumer<string, string> consumer,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        ConsumeResult<string, string>? last = null;
+        for (var index = 0; index < count; index++)
+        {
+            last = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(60), cancellationToken)
+                .ConfigureAwait(false);
+            if (last is null)
+                throw new InvalidOperationException($"Expected record {index} before truncation.");
+        }
+
+        return last ?? throw new InvalidOperationException("No records were consumed before truncation.");
+    }
+
+    private async Task ProduceRangeAsync(
+        string topic,
+        string valuePrefix,
+        int start,
+        int count,
+        Acks acks,
+        CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"truncation-producer-{Guid.NewGuid():N}")
+            .WithAcks(acks)
+            .WithIdempotence(acks == Acks.All)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        for (var value = start; value < start + count; value++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = value.ToString(),
+                Value = $"{valuePrefix}-{value}"
+            }, cancellationToken).ConfigureAwait(false);
+        }
+
+        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(CapturingLoggerProvider logs) =>
+        LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Warning);
+            builder.AddProvider(logs);
+        });
+}

--- a/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaContainerDefault.cs
@@ -18,6 +18,8 @@ public class KafkaContainerDefault : KafkaTestContainer
     private static readonly string Tag =
         Environment.GetEnvironmentVariable("KAFKA_TEST_IMAGE_TAG") is { Length: > 0 } tag ? tag : DefaultTag;
 
+    internal static string ImageTag => Tag;
+
     public override string ContainerName => $"apache/kafka:{Tag}";
 
     public override int Version { get; } = ParseVersion(Tag);

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Integration;
 
 public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
-    private const string Image = "apache/kafka:4.2.1";
+    private static readonly string Image = $"apache/kafka:{KafkaContainerDefault.ImageTag}";
     private const int InternalBrokerPort = 9092;
     private const int ControllerPort = 9093;
     private const int ExternalBrokerPort = 19092;
@@ -150,6 +150,33 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         return topic;
     }
 
+    public async Task<string> CreateUncleanElectionTopicAsync()
+    {
+        var topic = $"unclean-election-{Guid.NewGuid():N}";
+        await using var admin = CreateAdminClient();
+
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = -1,
+                ReplicationFactor = -1,
+                ReplicaAssignments = new Dictionary<int, IReadOnlyList<int>>
+                {
+                    [0] = [1, 2]
+                },
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = "1",
+                    ["unclean.leader.election.enable"] = "true"
+                }
+            }
+        ]).ConfigureAwait(false);
+
+        await WaitForTopicAssignmentAsync(admin, topic).ConfigureAwait(false);
+        return topic;
+    }
+
     public async Task<int> GetPartitionLeaderIdAsync(
         string topic,
         CancellationToken cancellationToken = default)
@@ -164,10 +191,26 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
 
     public async Task StartBrokerAsync(int nodeId, CancellationToken cancellationToken = default)
     {
+        await StartBrokerWithoutClusterWaitAsync(nodeId, cancellationToken).ConfigureAwait(false);
+
+        await WaitForClusterAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StartBrokerWithoutClusterWaitAsync(
+        int nodeId,
+        CancellationToken cancellationToken = default)
+    {
         var broker = GetBroker(nodeId);
         if (broker.State != TestcontainersStates.Running)
             await broker.StartAsync(cancellationToken).ConfigureAwait(false);
+    }
 
+    public async Task StartBrokersAsync(
+        IReadOnlyCollection<int> nodeIds,
+        CancellationToken cancellationToken = default)
+    {
+        await Task.WhenAll(nodeIds.Select(nodeId =>
+            StartBrokerWithoutClusterWaitAsync(nodeId, cancellationToken))).ConfigureAwait(false);
         await WaitForClusterAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerLeaderDiscoveryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
@@ -582,7 +583,7 @@ public sealed class ConsumerLeaderDiscoveryTests
     }
 
     [Test]
-    public async Task ResetToDivergingEpoch_DoesNotRewindDeliveredPosition()
+    public async Task ResetToDivergingEpoch_CapsDeliveredPositionAtDivergence()
     {
         var pool = Substitute.For<IConnectionPool>();
         await using var metadataManager = CreateMetadataManager(pool);
@@ -594,8 +595,49 @@ public sealed class ConsumerLeaderDiscoveryTests
         InvokeResetToDivergingEpoch(consumer, partitionResponse);
 
         await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
-        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(43);
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(42);
         await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_PreservesActiveNewEpochPositionBeyondBoundary()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(pool, metadataManager);
+        var partition = new TopicPartition(Topic, 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 0)]);
+        PublishActiveConsumedPosition(consumer, partition, position: 26, leaderEpoch: 10);
+
+        InvokeResetToDivergingEpoch(
+            consumer,
+            CreateDivergingEpochResponse(epoch: 9, endOffset: 25));
+
+        await Assert.That(ClearFetchBufferForPendingCoordinatorRevocations(consumer)).IsTrue();
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(26);
+        await Assert.That(GetActiveConsumedPosition(consumer, partition).HasValue).IsFalse();
+    }
+
+    [Test]
+    public async Task ResetToDivergingEpoch_WithNoAutoReset_ThrowsLogTruncationException()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(pool);
+        await using var consumer = CreateConsumer(
+            pool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.None);
+        consumer.IncrementalAssign([new TopicPartitionOffset(Topic, 0, 43, leaderEpoch: 6)]);
+
+        InvokeResetToDivergingEpoch(consumer, CreateDivergingEpochResponse());
+
+        var exception = await Assert.That(() => ClearFetchBufferForPendingCoordinatorRevocations(consumer))
+            .Throws<LogTruncationException>();
+        await Assert.That(exception!.TruncationOffsets).Contains(
+            new TopicPartitionOffset(Topic, 0, 42, leaderEpoch: 7));
+        await Assert.That(exception.ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
+        await Assert.That(consumer.GetPosition(new TopicPartition(Topic, 0))).IsEqualTo(43);
+        await Assert.That(GetLastConsumedLeaderEpoch(consumer)).IsEqualTo(6);
     }
 
     [Test]
@@ -736,14 +778,16 @@ public sealed class ConsumerLeaderDiscoveryTests
         MetadataManager metadataManager,
         IDeserializer<string>? keyDeserializer = null,
         IConsumerInterceptor<string, string>? interceptor = null,
-        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Auto)
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Auto,
+        AutoOffsetReset autoOffsetReset = AutoOffsetReset.Latest)
         => new(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
                 ClientId = "test-consumer",
                 Interceptors = interceptor is null ? null : [interceptor],
-                OffsetCommitMode = offsetCommitMode
+                OffsetCommitMode = offsetCommitMode,
+                AutoOffsetReset = autoOffsetReset
             },
             keyDeserializer ?? Serializers.String,
             Serializers.String,
@@ -999,6 +1043,20 @@ public sealed class ConsumerLeaderDiscoveryTests
         return ((long)arguments[1]!, (int)arguments[2]!);
     }
 
+    private static void PublishActiveConsumedPosition(
+        KafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long position,
+        int leaderEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "PublishActiveConsumedPosition",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("PublishActiveConsumedPosition method not found");
+
+        method.CreateDelegate<Action<TopicPartition, long, int>>(consumer)(partition, position, leaderEpoch);
+    }
+
     private static bool ClearFetchBufferForPendingCoordinatorRevocations(
         KafkaConsumer<string, string> consumer)
     {
@@ -1008,7 +1066,7 @@ public sealed class ConsumerLeaderDiscoveryTests
             ?? throw new InvalidOperationException(
                 "ClearFetchBufferForPendingCoordinatorRevocations method not found");
 
-        return (bool)method.Invoke(consumer, [])!;
+        return method.CreateDelegate<Func<bool>>(consumer)();
     }
 
     private sealed class CallbackConsumerInterceptor : IConsumerInterceptor<string, string>


### PR DESCRIPTION
## Summary
- add deterministic RF=2 unclean-leader-election coverage for active consumers, `AutoOffsetReset.None`, and committed group restarts
- honor KIP-320 by rewinding truncated epochs to the broker divergence offset while preserving records already delivered from newer epochs
- surface `LogTruncationException` with immutable truncation offsets when automatic reset is disabled
- make the rack-aware fixture honor `KAFKA_TEST_IMAGE_TAG` and document recovery semantics

## Validation
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`: clean, 0 warnings
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`: clean, 0 warnings
- full unit suite: 5,644 passed
- shared three-broker fixture regression: 6 passed (truncation, clean leader handoff, rolling restart, rack-aware fetch)
- KIP-320 integration matrix:
  - Kafka 4.0.2: 3 passed
  - Kafka 4.1.2: 3 passed
  - Kafka 4.2.1: 3 passed
  - Kafka 4.3.1: 3 passed

## Performance
The production changes execute only after a broker has staged a diverging-epoch correction. The normal consume/poll hot path still returns before this block. No per-message branch or allocation was added; allocations are confined to the rare fault-path exception/correction. A hot-path benchmark delta is therefore not applicable.

Closes #2258