### PR TITLE
feat(consumer): bound fetch response memory

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -50,6 +50,7 @@ builder.Services.AddDekaf(dekaf =>
         "OffsetCommitMode": "Manual",
         "FetchMinBytes": 1024,
         "FetchMaxBytes": 52428800,
+        "FetchBufferMemoryBytes": 104857600,
         "FetchMaxWaitMs": 200,
         "MaxPollRecords": 500,
         "UseTls": true
@@ -88,6 +89,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithAutoOffsetResetByDuration(...)` | `AutoOffsetReset`, `AutoOffsetResetDuration` | Use `AutoOffsetReset: ByDuration` plus a duration, or Kafka-style `by_duration:PT24H` |
 | `WithFetchMinBytes(...)` | `FetchMinBytes` | Bytes |
 | `WithFetchMaxBytes(...)` | `FetchMaxBytes` | Bytes |
+| `WithFetchBufferMemory(...)` | `FetchBufferMemoryBytes` | Aggregate raw Fetch response bytes; default 100 MiB |
 | `WithMaxPartitionFetchBytes(...)` | `MaxPartitionFetchBytes` | Bytes |
 | `WithFetchMaxWait(...)` | `FetchMaxWaitMs` | Milliseconds |
 | `WithFetchSessions(...)` | `EnableFetchSessions` | Boolean |
@@ -234,10 +236,18 @@ Control how data is fetched from brokers:
 ```csharp
 .WithFetchMinBytes(1024)
 .WithFetchMaxBytes(50 * 1024 * 1024)
+.WithFetchBufferMemory(100L * 1024 * 1024)
 .WithMaxPartitionFetchBytes(4 * 1024 * 1024)
 .WithFetchMaxWait(TimeSpan.FromMilliseconds(200))
 .WithFetchSessions(enabled: true)
 ```
+
+`WithFetchBufferMemory` bounds the exact aggregate bytes held by raw Fetch responses
+across brokers and pipelined requests. It must be at least the configured `FetchMaxBytes`.
+An adaptive or oversized first-batch response larger than the limit is admitted only when
+it is the sole reservation. Coordinator responses do not consume this budget. Observe current pressure through
+`dekaf.consumer.fetch_buffer.used_bytes`, `free_bytes`,
+`depleted_percent`, and `depleted_duration`.
 
 ## Session Settings
 
@@ -410,6 +420,7 @@ For transactional reads:
 | `WithAutoOffsetReset`, `WithAutoOffsetResetByDuration` | Latest | Start position |
 | `WithFetchMinBytes` | 1 | Minimum fetch bytes |
 | `WithFetchMaxBytes` | 52428800 | Maximum total fetch bytes |
+| `WithFetchBufferMemory` | 104857600 | Aggregate queued and in-flight raw Fetch response limit |
 | `WithMaxPartitionFetchBytes` | 1048576 | Maximum fetch bytes per partition |
 | `WithFetchMaxWait` | 200ms | Maximum fetch wait |
 | `WithFetchSessions` | true | Enable incremental fetch sessions |

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1424,6 +1424,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private TimeSpan? _autoOffsetResetDuration;
     private int _fetchMinBytes = 1;
     private int _fetchMaxBytes = 52428800;
+    private long _fetchBufferMemoryBytes = 100L * 1024 * 1024;
+    private bool _isFetchBufferMemoryConfigured;
     private int _maxPartitionFetchBytes = 1048576;
     private int _fetchMaxWaitMs = 200;
     private int _maxPollRecords = 500;
@@ -1765,6 +1767,21 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _fetchMaxBytes = maxBytes;
         if (_usesHighThroughputAdaptiveDefaults)
             ApplyHighThroughputAdaptiveDefaults();
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the aggregate raw Fetch response memory limit across queued and in-flight
+    /// requests. Equivalent to Kafka consumer <c>buffer.memory</c>. Default is 100 MiB.
+    /// </summary>
+    /// <param name="bytes">
+    /// Maximum raw Fetch response bytes. Must cover <see cref="WithFetchMaxBytes"/>.
+    /// </param>
+    public ConsumerBuilder<TKey, TValue> WithFetchBufferMemory(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(bytes, 1);
+        _fetchBufferMemoryBytes = bytes;
+        _isFetchBufferMemoryConfigured = true;
         return this;
     }
 
@@ -2422,8 +2439,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// <item><description>FetchMinBytes: 1KB (wait for more data)</description></item>
     /// <item><description>FetchMaxWaitMs: 200ms (matches default; higher values like 500ms cause stalls when the prefetch pipeline restarts after hitting memory limits)</description></item>
     /// <item><description>MaxPartitionFetchBytes: 4MB (larger fetch responses reduce round-trip overhead per byte)</description></item>
-    /// <item><description>FetchMaxBytes: 100MB (allow larger total fetch responses; note that the response buffer pool
-    /// may retain up to 8 arrays of this size per consumer instance)</description></item>
+    /// <item><description>FetchMaxBytes: 100MB initially, adapting up to 200MB</description></item>
+    /// <item><description>FetchBufferMemory: 1000MB unless explicitly configured (bounds aggregate raw Fetch responses)</description></item>
     /// <item><description>PrefetchPipelineDepth: 5 (aggressive prefetching to hide network latency)</description></item>
     /// <item><description>ConnectionsPerBroker: 3 for standalone consumers (two fetch connections plus one coordination connection)</description></item>
     /// <item><description>AdaptiveFetchSizing: enabled (auto-grows fetch sizes when consumer keeps up, shrinks under prefetch memory pressure)</description></item>
@@ -2431,9 +2448,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
     /// broker-side validation already cover corruption in transit — matches librdkafka's default. Re-enable with
     /// <see cref="WithCheckCrcs"/> after this preset if end-to-end validation is required)</description></item>
     /// </list>
-    /// <para><b>Memory note:</b> The combined in-flight memory ceiling is
-    /// <c>PrefetchPipelineDepth × FetchMaxBytes</c> — with these defaults that is
-    /// 5 × 100 MB ≈ 500 MB peak per consumer instance.</para>
+    /// <para><b>Memory note:</b> Raw queued and in-flight Fetch responses are bounded by
+    /// <c>FetchBufferMemory</c>. The preset derives 5 × 200 MB = 1000 MB from its pipeline
+    /// depth and adaptive fetch maximum unless <see cref="WithFetchBufferMemory"/> was called.</para>
     /// <para>These settings can be overridden by calling other builder methods after this one.</para>
     /// </remarks>
     /// <returns>The builder instance for method chaining.</returns>
@@ -2481,6 +2498,11 @@ public sealed class ConsumerBuilder<TKey, TValue>
             InitialFetchMaxBytes = initialFetchMaxBytes,
             MaxFetchMaxBytes = maxFetchMaxBytes
         };
+
+        if (!_isFetchBufferMemoryConfigured)
+        {
+            _fetchBufferMemoryBytes = (long)maxFetchMaxBytes * _prefetchPipelineDepth;
+        }
     }
 
     /// <summary>
@@ -2728,6 +2750,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             AutoOffsetResetDuration = _autoOffsetResetDuration,
             FetchMinBytes = _fetchMinBytes,
             FetchMaxBytes = _fetchMaxBytes,
+            FetchBufferMemoryBytes = _fetchBufferMemoryBytes,
             MaxPartitionFetchBytes = _maxPartitionFetchBytes,
             FetchMaxWaitMs = _fetchMaxWaitMs,
             EnableFetchSessions = _enableFetchSessions,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -2817,7 +2817,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
                 options,
                 keyDeserializer,
                 valueDeserializer,
-                _clientInfrastructure.ConnectionPool,
+                _clientInfrastructure.ConsumerConnectionPool,
                 _clientInfrastructure.MetadataManager,
                 memoryBudget,
                 _loggerFactory);

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -144,6 +144,18 @@ public sealed class ConsumerOptions
     public int FetchMaxBytes { get; init; } = 52428800;
 
     /// <summary>
+    /// Aggregate raw Fetch response memory limit in bytes across queued and in-flight
+    /// requests. Memory is reserved on demand and is not preallocated. Must be at least
+    /// <see cref="FetchMaxBytes"/>. Default is 100 MiB.
+    /// </summary>
+    /// <remarks>
+    /// Kafka may return one record batch larger than the configured fetch limits so a
+    /// consumer can make progress. Such an oversized response is admitted only when it is
+    /// the pool's sole reservation.
+    /// </remarks>
+    public long FetchBufferMemoryBytes { get; init; } = 100L * 1024 * 1024;
+
+    /// <summary>
     /// Maximum bytes per partition.
     /// </summary>
     public int MaxPartitionFetchBytes { get; init; } = 1048576;
@@ -375,10 +387,6 @@ public sealed class ConsumerOptions
     /// opts this consumer out of auto-tuning. The explicit amount is subtracted from the
     /// global budget before auto-tuned instances are sized, so explicit overrides still count
     /// against the process-wide total.
-    /// </para>
-    /// <para>
-    /// This value may be automatically raised at runtime when the pipeline depth and
-    /// assigned partition count require a larger buffer to avoid stalling prefetch.
     /// </para>
     /// </summary>
     public int QueuedMaxMessagesKbytes { get; init; } = 65536;

--- a/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
+++ b/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 
@@ -17,6 +18,7 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
     private long _depletedStartTimestamp;
     private long _depletedTimestampTicks;
     private int _waiterCount;
+    private int _pendingWakeCount;
     private int _disposed;
 
     public FetchBufferMemoryPool(long limitBytes)
@@ -28,6 +30,7 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
     public long LimitBytes => _limitBytes;
     public long UsedBytes => Interlocked.Read(ref _usedBytes);
     public long FreeBytes => Math.Max(0, _limitBytes - UsedBytes);
+    internal int PendingWakeCount => Volatile.Read(ref _pendingWakeCount);
 
     public double DepletedPercent
     {
@@ -97,13 +100,12 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
             {
                 await _memoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                if (TryReserve(bytes))
-                    return FetchBufferMemoryReservation.Create(this, bytes);
+                ConsumePendingWake();
+                var reserved = TryReserve(bytes);
+                SignalNextWaiter(currentWaiterIncluded: true);
 
-                // The awakened waiter may need more memory than another waiter. Pass the
-                // edge-triggered signal to an already-queued waiter before waiting again.
-                if (Volatile.Read(ref _waiterCount) > 1)
-                    SignalMemoryAvailable();
+                if (reserved)
+                    return FetchBufferMemoryReservation.Create(this, bytes);
             }
         }
         finally
@@ -114,8 +116,8 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
                 if (Volatile.Read(ref _waiterCount) > 0)
                     BeginDepletion();
             }
-            else if (Volatile.Read(ref _disposed) != 0 || FreeBytes > 0)
-                SignalMemoryAvailable();
+            else
+                SignalNextWaiter(currentWaiterIncluded: false);
         }
     }
 
@@ -131,7 +133,7 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
         }
 
         if (Volatile.Read(ref _waiterCount) > 0)
-            SignalMemoryAvailable();
+            WakeWaitersAfterCapacityChanged();
     }
 
     private void BeginDepletion()
@@ -174,12 +176,71 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
         }
     }
 
+    private void EnsurePendingWakes(int waiterCount)
+    {
+        // A capacity change grants at most one attempt per waiter. The final waiter
+        // consumes the budget without re-signaling, so insufficient capacity sleeps
+        // until another Release instead of bouncing the semaphore indefinitely.
+        var pending = Volatile.Read(ref _pendingWakeCount);
+        while (pending < waiterCount)
+        {
+            var observed = Interlocked.CompareExchange(
+                ref _pendingWakeCount,
+                waiterCount,
+                pending);
+            if (observed == pending)
+                return;
+
+            pending = observed;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void WakeWaitersAfterCapacityChanged()
+    {
+        var waiterCount = Volatile.Read(ref _waiterCount);
+        if (waiterCount <= 0)
+            return;
+
+        EnsurePendingWakes(waiterCount);
+        SignalMemoryAvailable();
+    }
+
+    private void ConsumePendingWake()
+    {
+        var pending = Volatile.Read(ref _pendingWakeCount);
+        while (pending > 0)
+        {
+            var observed = Interlocked.CompareExchange(
+                ref _pendingWakeCount,
+                pending - 1,
+                pending);
+            if (observed == pending)
+                return;
+
+            pending = observed;
+        }
+    }
+
+    private void SignalNextWaiter(bool currentWaiterIncluded)
+    {
+        var minimumWaiterCount = currentWaiterIncluded ? 1 : 0;
+        if (Volatile.Read(ref _pendingWakeCount) > 0
+            && Volatile.Read(ref _waiterCount) > minimumWaiterCount)
+        {
+            SignalMemoryAvailable();
+        }
+    }
+
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
         EndDepletion();
+        var waiterCount = Volatile.Read(ref _waiterCount);
+        if (waiterCount > 0)
+            EnsurePendingWakes(waiterCount);
         SignalMemoryAvailable();
     }
 }

--- a/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
+++ b/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Tracks aggregate raw Fetch response memory across queued and in-flight requests.
+/// Memory is reserved, not preallocated.
+/// </summary>
+internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
+{
+    private readonly long _limitBytes;
+    private readonly long _createdTimestamp = Stopwatch.GetTimestamp();
+    private readonly SemaphoreSlim _memoryAvailable = new(0, 1);
+    private long _usedBytes;
+    private long _depletedStartTimestamp;
+    private long _depletedTimestampTicks;
+    private int _waiterCount;
+    private int _disposed;
+
+    public FetchBufferMemoryPool(long limitBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(limitBytes, 1);
+        _limitBytes = limitBytes;
+    }
+
+    public long LimitBytes => _limitBytes;
+    public long UsedBytes => Interlocked.Read(ref _usedBytes);
+    public long FreeBytes => Math.Max(0, _limitBytes - UsedBytes);
+
+    public double DepletedPercent
+    {
+        get
+        {
+            var elapsed = Stopwatch.GetTimestamp() - _createdTimestamp;
+            return elapsed <= 0
+                ? 0
+                : Math.Min(100, GetDepletedTimestampTicks() * 100d / elapsed);
+        }
+    }
+
+    public double DepletedDurationSeconds =>
+        GetDepletedTimestampTicks() / (double)Stopwatch.Frequency;
+
+    public bool TryReserve(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(bytes, 1);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
+        while (true)
+        {
+            var used = Interlocked.Read(ref _usedBytes);
+            // One response larger than the configured pool may proceed only when it is
+            // the sole reservation. Kafka permits the first record batch to cross fetch
+            // limits so consumers can always make progress.
+            if (used != 0 && bytes > _limitBytes - used)
+            {
+                return false;
+            }
+
+            var updated = used + bytes;
+            if (updated < used)
+                throw new OverflowException("Fetch buffer memory reservation overflowed");
+
+            if (Interlocked.CompareExchange(ref _usedBytes, updated, used) == used)
+                return true;
+        }
+    }
+
+    public ValueTask<IResponseMemoryReservation> ReserveAsync(
+        int bytes,
+        CancellationToken cancellationToken)
+    {
+        if (TryReserve(bytes))
+            return new ValueTask<IResponseMemoryReservation>(
+                FetchBufferMemoryReservation.Create(this, bytes));
+
+        return ReserveSlowAsync(this, bytes, cancellationToken);
+    }
+
+    private static async ValueTask<IResponseMemoryReservation> ReserveSlowAsync(
+        FetchBufferMemoryPool pool,
+        int bytes,
+        CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref pool._waiterCount);
+        pool.BeginDepletion();
+        try
+        {
+            while (true)
+            {
+                await pool._memoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                if (pool.TryReserve(bytes))
+                    return FetchBufferMemoryReservation.Create(pool, bytes);
+
+                // The awakened waiter may need more memory than another waiter. Pass the
+                // edge-triggered signal to an already-queued waiter before waiting again.
+                if (Volatile.Read(ref pool._waiterCount) > 1)
+                    pool.SignalMemoryAvailable();
+            }
+        }
+        finally
+        {
+            if (Interlocked.Decrement(ref pool._waiterCount) == 0)
+            {
+                pool.EndDepletion();
+                if (Volatile.Read(ref pool._waiterCount) > 0)
+                    pool.BeginDepletion();
+            }
+            else if (Volatile.Read(ref pool._disposed) != 0 || pool.FreeBytes > 0)
+                pool.SignalMemoryAvailable();
+        }
+    }
+
+    internal void Release(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(bytes, 1);
+
+        var used = Interlocked.Add(ref _usedBytes, -bytes);
+        if (used < 0)
+        {
+            Interlocked.Add(ref _usedBytes, bytes);
+            throw new InvalidOperationException("Fetch buffer memory released more bytes than were reserved");
+        }
+
+        if (Volatile.Read(ref _waiterCount) > 0)
+            SignalMemoryAvailable();
+    }
+
+    private void BeginDepletion()
+    {
+        if (Volatile.Read(ref _depletedStartTimestamp) != 0)
+            return;
+
+        _ = Interlocked.CompareExchange(
+            ref _depletedStartTimestamp,
+            Stopwatch.GetTimestamp(),
+            0);
+    }
+
+    private void EndDepletion()
+    {
+        var started = Interlocked.Exchange(ref _depletedStartTimestamp, 0);
+        if (started != 0)
+            Interlocked.Add(ref _depletedTimestampTicks, Stopwatch.GetTimestamp() - started);
+    }
+
+    private long GetDepletedTimestampTicks()
+    {
+        var ticks = Interlocked.Read(ref _depletedTimestampTicks);
+        var started = Volatile.Read(ref _depletedStartTimestamp);
+        return started == 0 ? ticks : ticks + Stopwatch.GetTimestamp() - started;
+    }
+
+    private void SignalMemoryAvailable()
+    {
+        if (_memoryAvailable.CurrentCount != 0)
+            return;
+
+        try
+        {
+            _memoryAvailable.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // Another release won the edge-triggered signal race.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        EndDepletion();
+        SignalMemoryAvailable();
+    }
+}
+
+/// <summary>
+/// Releases a fetch-buffer reservation with its raw response storage.
+/// </summary>
+internal sealed class FetchBufferMemoryReservation : IResponseMemoryReservation
+{
+    private static readonly FetchBufferMemoryReservationPool s_pool = new();
+
+    private FetchBufferMemoryPool? _pool;
+    private long _reservedBytes;
+    private int _disposed;
+
+    private FetchBufferMemoryReservation()
+    {
+    }
+
+    internal static FetchBufferMemoryReservation Create(
+        FetchBufferMemoryPool pool,
+        long reservedBytes)
+    {
+        var owner = s_pool.Rent();
+        owner._pool = pool;
+        owner._reservedBytes = reservedBytes;
+        owner._disposed = 0;
+        return owner;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _pool?.Release(_reservedBytes);
+        s_pool.Return(this);
+    }
+
+    private sealed class FetchBufferMemoryReservationPool()
+        : ObjectPool<FetchBufferMemoryReservation>(maxPoolSize: 128)
+    {
+        protected override FetchBufferMemoryReservation Create() => new();
+
+        protected override void Reset(FetchBufferMemoryReservation item)
+        {
+            item._pool = null;
+            item._reservedBytes = 0;
+            item._disposed = 1;
+        }
+    }
+}

--- a/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
+++ b/src/Dekaf/Consumer/FetchBufferMemoryPool.cs
@@ -76,41 +76,46 @@ internal sealed class FetchBufferMemoryPool : IResponseMemoryPool, IDisposable
             return new ValueTask<IResponseMemoryReservation>(
                 FetchBufferMemoryReservation.Create(this, bytes));
 
-        return ReserveSlowAsync(this, bytes, cancellationToken);
+        return ReserveSlowAsync(bytes, cancellationToken);
     }
 
-    private static async ValueTask<IResponseMemoryReservation> ReserveSlowAsync(
-        FetchBufferMemoryPool pool,
+    internal async ValueTask<IResponseMemoryReservation> ReserveSlowAsync(
         int bytes,
         CancellationToken cancellationToken)
     {
-        Interlocked.Increment(ref pool._waiterCount);
-        pool.BeginDepletion();
+        Interlocked.Increment(ref _waiterCount);
         try
         {
+            // Capacity may have been released after ReserveAsync's fast-path check but
+            // before this waiter became visible to Release. Recheck before sleeping so
+            // that release cannot be lost in that registration gap.
+            if (TryReserve(bytes))
+                return FetchBufferMemoryReservation.Create(this, bytes);
+
+            BeginDepletion();
             while (true)
             {
-                await pool._memoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _memoryAvailable.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-                if (pool.TryReserve(bytes))
-                    return FetchBufferMemoryReservation.Create(pool, bytes);
+                if (TryReserve(bytes))
+                    return FetchBufferMemoryReservation.Create(this, bytes);
 
                 // The awakened waiter may need more memory than another waiter. Pass the
                 // edge-triggered signal to an already-queued waiter before waiting again.
-                if (Volatile.Read(ref pool._waiterCount) > 1)
-                    pool.SignalMemoryAvailable();
+                if (Volatile.Read(ref _waiterCount) > 1)
+                    SignalMemoryAvailable();
             }
         }
         finally
         {
-            if (Interlocked.Decrement(ref pool._waiterCount) == 0)
+            if (Interlocked.Decrement(ref _waiterCount) == 0)
             {
-                pool.EndDepletion();
-                if (Volatile.Read(ref pool._waiterCount) > 0)
-                    pool.BeginDepletion();
+                EndDepletion();
+                if (Volatile.Read(ref _waiterCount) > 0)
+                    BeginDepletion();
             }
-            else if (Volatile.Read(ref pool._disposed) != 0 || pool.FreeBytes > 0)
-                pool.SignalMemoryAvailable();
+            else if (Volatile.Read(ref _disposed) != 0 || FreeBytes > 0)
+                SignalMemoryAvailable();
         }
     }
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -855,6 +855,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
     private readonly ClientTelemetryManager _telemetryManager;
+    private readonly FetchBufferMemoryPool _fetchBufferMemoryPool;
+    private readonly Diagnostics.ConsumerFetchBufferStateSource _fetchBufferMetricSource;
     private readonly IDekafMemoryBudget _memoryBudget;
     private readonly bool _ownsInfrastructure;
     private readonly ConsumerCoordinator? _coordinator;
@@ -1092,7 +1094,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         MetadataManager metadataManager,
         ILoggerFactory? loggerFactory = null)
         : this(options, keyDeserializer, valueDeserializer,
-            (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
+            (
+                connectionPool,
+                metadataManager,
+                new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer),
+                new FetchBufferMemoryPool(options.FetchBufferMemoryBytes)),
             loggerFactory,
             ownsInfrastructure: true,
             DekafMemoryBudget.Global)
@@ -1108,14 +1114,22 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory = null)
         : this(options, keyDeserializer, valueDeserializer,
-            (connectionPool, metadataManager, new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer)),
+            (
+                connectionPool,
+                metadataManager,
+                new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer),
+                new FetchBufferMemoryPool(options.FetchBufferMemoryBytes)),
             loggerFactory,
             ownsInfrastructure: false,
             memoryBudget)
     {
     }
 
-    private static (IConnectionPool, MetadataManager, ClientTelemetryMetricCollector) CreateInfrastructure(
+    private static (
+        IConnectionPool,
+        MetadataManager,
+        ClientTelemetryMetricCollector,
+        FetchBufferMemoryPool) CreateInfrastructure(
         ConsumerOptions options, ILoggerFactory? loggerFactory, MetadataOptions? metadataOptions)
     {
         var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
@@ -1123,7 +1137,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             options.ReconnectBackoffMaxMs,
             options.IsReconnectBackoffMsConfigured,
             options.IsReconnectBackoffMaxMsConfigured);
+        ValidateFetchBufferMemory(options);
         var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
+        var fetchBufferMemoryPool = new FetchBufferMemoryPool(options.FetchBufferMemoryBytes);
         var connectionPool = new ConnectionPool(
             options.ClientId,
             new ConnectionOptions
@@ -1155,7 +1171,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,
             CreateResponseBufferPool(options),
-            telemetryMetricCollector: telemetryMetricCollector);
+            telemetryMetricCollector: telemetryMetricCollector,
+            responseMemoryAdmissionsEnabled: true);
 
         var metadataManager = new MetadataManager(
             connectionPool,
@@ -1163,7 +1180,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             options: metadataOptions,
             logger: loggerFactory?.CreateLogger<MetadataManager>());
 
-        return (connectionPool, metadataManager, telemetryMetricCollector);
+        return (connectionPool, metadataManager, telemetryMetricCollector, fetchBufferMemoryPool);
     }
 
     private static ResponseBufferPool CreateResponseBufferPool(ConsumerOptions options)
@@ -1207,11 +1224,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             InitialFetchMaxBytes = options.FetchMaxBytes
         };
 
+    internal static void ValidateFetchBufferMemory(ConsumerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.FetchBufferMemoryBytes, 1);
+
+        if (options.FetchBufferMemoryBytes < options.FetchMaxBytes)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.FetchBufferMemoryBytes,
+                $"Fetch buffer memory must be at least FetchMaxBytes ({options.FetchMaxBytes})");
+        }
+    }
+
     private KafkaConsumer(
         ConsumerOptions options,
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
-        (IConnectionPool Pool, MetadataManager Metadata, ClientTelemetryMetricCollector TelemetryMetricCollector) infrastructure,
+        (
+            IConnectionPool Pool,
+            MetadataManager Metadata,
+            ClientTelemetryMetricCollector TelemetryMetricCollector,
+            FetchBufferMemoryPool FetchBufferMemoryPool) infrastructure,
         ILoggerFactory? loggerFactory,
         bool ownsInfrastructure,
         IDekafMemoryBudget memoryBudget)
@@ -1220,9 +1255,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollIntervalMs, 1);
+        ValidateFetchBufferMemory(options);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
+        _fetchBufferMemoryPool = infrastructure.FetchBufferMemoryPool;
+        _fetchBufferMetricSource = new Diagnostics.ConsumerFetchBufferStateSource(
+            _fetchBufferMemoryPool,
+            options.ClientId,
+            options.GroupId);
         _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
         _keyDeserializer = keyDeserializer;
         _valueDeserializer = valueDeserializer;
@@ -1312,6 +1353,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Register this instance's lag callback with the shared static gauge.
         // The callback is invoked only during metric collection (~every 5-60s), not on the hot path.
         Diagnostics.DekafMetrics.RegisterConsumerLagCallback(ObserveConsumerLag);
+        Diagnostics.DekafMetrics.RegisterConsumerFetchBufferState(_fetchBufferMetricSource);
     }
 
     private ValueTask BeginConnectionRoutingTransitionAsync(
@@ -2544,12 +2586,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         continue;
                     }
 
-                    var maxBytes = CalculatePrefetchMaxBytes(
-                        (int)Math.Min(CurrentQueuedMaxBytes / 1024, int.MaxValue),
-                        _assignmentSnapshot.Count,
-                        _adaptiveFetchSizer?.CurrentPartitionFetchBytes ?? _options.MaxPartitionFetchBytes,
-                        _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes,
-                        _options.PrefetchPipelineDepth);
+                    var maxBytes = CalculatePrefetchMaxBytes(CurrentQueuedMaxBytes);
                     var currentPrefetchedBytes = Interlocked.Read(ref _prefetchedBytes);
                     if (PrefetchLoopControl.ShouldWaitForMemory(currentPrefetchedBytes, maxBytes))
                     {
@@ -2937,28 +2974,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// ErrorCode and are always transient — the ErrorCode guard excludes them.
     /// </remarks>
     /// <summary>
-    /// Calculates the effective prefetch memory budget, auto-scaling above the configured
-    /// maximum when the partition count and pipeline depth require more headroom.
+    /// Calculates the exact configured queued-record prefetch budget.
     /// </summary>
-    internal static long CalculatePrefetchMaxBytes(
-        int queuedMaxMessagesKbytes,
-        int partitionCount,
-        int maxPartitionFetchBytes,
-        int fetchMaxBytes,
-        int pipelineDepth)
-    {
-        var configuredMax = (long)queuedMaxMessagesKbytes * 1024;
-        // Auto-scale: ensure the budget fits (pipelineDepth + 1) full fetch responses.
-        // The +1 provides headroom so the consume loop can drain a completed response
-        // while the pipeline keeps its full depth of in-flight fetches.
-        // A single fetch response is capped at FetchMaxBytes by the broker, even when
-        // partitionCount * MaxPartitionFetchBytes would exceed it.
-        var fetchResponseSize = Math.Min(
-            (long)partitionCount * maxPartitionFetchBytes,
-            fetchMaxBytes);
-        var minRequired = fetchResponseSize * (pipelineDepth + 1);
-        return Math.Max(configuredMax, minRequired);
-    }
+    internal static long CalculatePrefetchMaxBytes(ulong configuredBytes) =>
+        configuredBytes > long.MaxValue ? long.MaxValue : (long)configuredBytes;
+
+    private int CurrentFetchMaxBytes =>
+        _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
 
     internal static int CalculatePrefetchBufferCapacity(ConsumerOptions options)
     {
@@ -3016,6 +3038,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         try
         {
+            var fetchMaxBytes = CurrentFetchMaxBytes;
             // Build fetch request — pass index range to avoid GetRange allocation
             var topicData = BuildFetchRequestTopicsForConnection(
                 partitions,
@@ -3028,8 +3051,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var request = FetchRequest.Rent();
             request.MaxWaitMs = _options.FetchMaxWaitMs;
             request.MinBytes = _options.FetchMinBytes;
-            request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
+            request.MaxBytes = fetchMaxBytes;
             request.CheckCrcs = _options.CheckCrcs;
+            request.ResponseMemoryPool = _fetchBufferMemoryPool;
             request.IsolationLevel = _options.IsolationLevel;
             request.RackId = _options.ClientRack;
             request.Topics = fetchSessionBuild?.Topics ?? topicData;
@@ -3178,13 +3202,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             if (stuckError is not null)
                             {
                                 DisposePendingFetches(pendingItems);
-                                memoryOwner?.Dispose();
-                                memoryOwner = null;
                                 throw stuckError;
                             }
                         }
                     }
                 }
+            }
+            catch
+            {
+                DisposePendingFetches(pendingItems);
+                memoryOwner?.Dispose();
+                memoryOwner = null;
+                throw;
             }
             finally
             {
@@ -3208,7 +3237,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 await WritePrefetchedItemsAsync(pendingItems, fetchBufferEpoch, cancellationToken).ConfigureAwait(false);
             }
 
-            // If no pending items were created but we have a memory owner, dispose it
             memoryOwner?.Dispose();
         }
         finally
@@ -6374,6 +6402,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int fetchBufferEpoch,
         CancellationToken cancellationToken)
     {
+        var fetchMaxBytes = CurrentFetchMaxBytes;
         using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
             brokerId,
             0,
@@ -6408,8 +6437,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         var request = FetchRequest.Rent();
         request.MaxWaitMs = _options.FetchMaxWaitMs;
         request.MinBytes = _options.FetchMinBytes;
-        request.MaxBytes = _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes;
+        request.MaxBytes = fetchMaxBytes;
         request.CheckCrcs = _options.CheckCrcs;
+        request.ResponseMemoryPool = _fetchBufferMemoryPool;
         request.IsolationLevel = _options.IsolationLevel;
         request.RackId = _options.ClientRack;
         request.Topics = fetchSessionBuild?.Topics ?? topicData;
@@ -6559,13 +6589,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 pendingItems = null;
                             }
 
-                            memoryOwner?.Dispose();
-                            memoryOwner = null;
                             throw stuckError;
                         }
                     }
                 }
             }
+        }
+        catch
+        {
+            if (pendingItems is not null)
+            {
+                DisposePendingFetches(pendingItems);
+                ConsumerFetchPools.ReturnPendingFetchDataList(pendingItems);
+                pendingItems = null;
+            }
+
+            memoryOwner?.Dispose();
+            memoryOwner = null;
+            throw;
         }
         finally
         {
@@ -6577,13 +6618,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             response.ReturnToPool();
         }
 
-        if (pendingItems is not null && pendingItems.Count > 0 && memoryOwner is not null)
+        if (pendingItems is { Count: > 0 } && memoryOwner is not null)
         {
             AssignSharedMemoryOwner(pendingItems, memoryOwner);
             memoryOwner = null; // Transferred
         }
 
-        // If no pending items were created but we have a memory owner, dispose it
         memoryOwner?.Dispose();
 
         return pendingItems;
@@ -7451,12 +7491,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void RatchetRecordWrapperPools(int partitionCount)
     {
-        var prefetchMaxBytes = CalculatePrefetchMaxBytes(
-            (int)Math.Min(CurrentQueuedMaxBytes / 1024, int.MaxValue),
-            Math.Max(1, partitionCount),
-            _adaptiveFetchSizer?.CurrentPartitionFetchBytes ?? _options.MaxPartitionFetchBytes,
-            _adaptiveFetchSizer?.CurrentFetchMaxBytes ?? _options.FetchMaxBytes,
-            _options.PrefetchPipelineDepth);
+        var prefetchMaxBytes = CalculatePrefetchMaxBytes(CurrentQueuedMaxBytes);
         var wrapperPoolSize = PoolSizing.ForConsumerRecordWrappers(prefetchMaxBytes);
         RecordBatch.RatchetPoolSize(wrapperPoolSize);
         LazyRecordList.RatchetPoolSize(wrapperPoolSize);
@@ -7918,6 +7953,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         // Unregister lag callback so the OTel SDK no longer invokes it on this disposed instance
         Diagnostics.DekafMetrics.UnregisterConsumerLagCallback(ObserveConsumerLag);
+        Diagnostics.DekafMetrics.UnregisterConsumerFetchBufferState(_fetchBufferMetricSource);
 
         // If not already closed, perform graceful close first
         // Use 30 seconds to allow CommitAsync (which may take up to RequestTimeoutMs=30s) to complete
@@ -8029,6 +8065,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             TrackPrefetchedBytes(prefetched, release: true);
             prefetched.Dispose();
         }
+
+        _fetchBufferMemoryPool.Dispose();
 
         _assignmentLock.Dispose();
         _initLock.Dispose();

--- a/src/Dekaf/Diagnostics/ConsumerFetchBufferStateSource.cs
+++ b/src/Dekaf/Diagnostics/ConsumerFetchBufferStateSource.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Dekaf.Consumer;
+
+namespace Dekaf.Diagnostics;
+
+internal sealed class ConsumerFetchBufferStateSource(
+    FetchBufferMemoryPool pool,
+    string? clientId,
+    string? groupId)
+{
+    public Measurement<long> UsedBytes() => new(pool.UsedBytes, CreateTags());
+    public Measurement<long> FreeBytes() => new(pool.FreeBytes, CreateTags());
+    public Measurement<double> DepletedPercent() => new(pool.DepletedPercent, CreateTags());
+    public Measurement<double> DepletedDuration() => new(pool.DepletedDurationSeconds, CreateTags());
+
+    private TagList CreateTags()
+    {
+        TagList tags = default;
+        if (clientId is not null)
+            tags.Add(DekafDiagnostics.MessagingClientId, clientId);
+        if (groupId is not null)
+            tags.Add(DekafDiagnostics.MessagingConsumerGroupName, groupId);
+        return tags;
+    }
+}

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -101,6 +101,7 @@ internal static class DekafMetrics
     // duplicate instrument registration and ensuring disposed consumers stop reporting.
 
     private static readonly ConcurrentDictionary<Func<IEnumerable<Measurement<long>>>, byte> ConsumerLagCallbacks = new();
+    private static readonly ConcurrentDictionary<ConsumerFetchBufferStateSource, byte> ConsumerFetchBufferStateSources = new();
 
     internal static readonly ObservableGauge<long> ConsumerLagGauge =
         DekafDiagnostics.Meter.CreateObservableGauge(
@@ -108,6 +109,34 @@ internal static class DekafMetrics
             observeValues: ObserveAllConsumerLag,
             unit: "{message}",
             description: "Difference between high watermark and consumed position per partition.");
+
+    internal static readonly ObservableGauge<long> ConsumerFetchBufferUsedBytes =
+        DekafDiagnostics.Meter.CreateObservableGauge(
+            "dekaf.consumer.fetch_buffer.used_bytes",
+            observeValues: static () => ObserveConsumerFetchBuffers(static source => source.UsedBytes()),
+            unit: "By",
+            description: "Raw Fetch response bytes reserved across queued and in-flight requests.");
+
+    internal static readonly ObservableGauge<long> ConsumerFetchBufferFreeBytes =
+        DekafDiagnostics.Meter.CreateObservableGauge(
+            "dekaf.consumer.fetch_buffer.free_bytes",
+            observeValues: static () => ObserveConsumerFetchBuffers(static source => source.FreeBytes()),
+            unit: "By",
+            description: "Unreserved raw Fetch response memory.");
+
+    internal static readonly ObservableGauge<double> ConsumerFetchBufferDepletedPercent =
+        DekafDiagnostics.Meter.CreateObservableGauge(
+            "dekaf.consumer.fetch_buffer.depleted_percent",
+            observeValues: static () => ObserveConsumerFetchBuffers(static source => source.DepletedPercent()),
+            unit: "%",
+            description: "Percentage of consumer lifetime spent waiting for Fetch response memory.");
+
+    internal static readonly ObservableCounter<double> ConsumerFetchBufferDepletedDuration =
+        DekafDiagnostics.Meter.CreateObservableCounter(
+            "dekaf.consumer.fetch_buffer.depleted_duration",
+            observeValues: static () => ObserveConsumerFetchBuffers(static source => source.DepletedDuration()),
+            unit: "s",
+            description: "Total duration spent waiting for Fetch response memory.");
 
     /// <summary>
     /// Registers a consumer lag observation callback. Called from <c>KafkaConsumer</c> constructor.
@@ -123,6 +152,16 @@ internal static class DekafMetrics
     internal static void UnregisterConsumerLagCallback(Func<IEnumerable<Measurement<long>>> callback)
     {
         ConsumerLagCallbacks.TryRemove(callback, out _);
+    }
+
+    internal static void RegisterConsumerFetchBufferState(ConsumerFetchBufferStateSource source)
+    {
+        ConsumerFetchBufferStateSources.TryAdd(source, 0);
+    }
+
+    internal static void UnregisterConsumerFetchBufferState(ConsumerFetchBufferStateSource source)
+    {
+        ConsumerFetchBufferStateSources.TryRemove(source, out _);
     }
 
     private static IEnumerable<Measurement<long>> ObserveAllConsumerLag()
@@ -144,6 +183,26 @@ internal static class DekafMetrics
             {
                 yield return measurement;
             }
+        }
+    }
+
+    private static IEnumerable<Measurement<T>> ObserveConsumerFetchBuffers<T>(
+        Func<ConsumerFetchBufferStateSource, Measurement<T>> selector)
+        where T : struct
+    {
+        foreach (var (source, _) in ConsumerFetchBufferStateSources)
+        {
+            Measurement<T> measurement;
+            try
+            {
+                measurement = selector(source);
+            }
+            catch
+            {
+                continue;
+            }
+
+            yield return measurement;
         }
     }
 

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -579,6 +579,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     private KafkaClientInfrastructure(
         IReadOnlyList<string> bootstrapServers,
         ConnectionPool connectionPool,
+        ConnectionPool consumerConnectionPool,
         MetadataManager metadataManager,
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory,
@@ -588,6 +589,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     {
         BootstrapServers = bootstrapServers;
         ConnectionPool = connectionPool;
+        ConsumerConnectionPool = consumerConnectionPool;
         MetadataManager = metadataManager;
         MemoryBudget = memoryBudget;
         LoggerFactory = loggerFactory;
@@ -598,6 +600,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
 
     public IReadOnlyList<string> BootstrapServers { get; }
     public ConnectionPool ConnectionPool { get; }
+    public ConnectionPool ConsumerConnectionPool { get; }
     public MetadataManager MetadataManager { get; }
     public IDekafMemoryBudget MemoryBudget { get; }
     public ILoggerFactory? LoggerFactory { get; }
@@ -614,35 +617,17 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             batchSize: 1048576,
             maxConnectionsPerBroker: options.MaxConnectionsPerBroker);
 
+        var connectionOptions = CreateConnectionOptions(options);
         var connectionPool = new ConnectionPool(
             options.ClientId,
-            new ConnectionOptions
-            {
-                UseTls = options.UseTls,
-                TlsConfig = options.TlsConfig,
-                RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
-                ConnectionTimeout = options.ConnectionTimeout,
-                EnableTcpKeepAlive = options.EnableTcpKeepAlive,
-                TcpKeepAliveTime = options.TcpKeepAliveTime,
-                TcpKeepAliveInterval = options.TcpKeepAliveInterval,
-                TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
-                RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
-                ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
-                ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
-                ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
-                SaslMechanism = options.SaslMechanism,
-                SaslUsername = options.SaslUsername,
-                SaslPassword = options.SaslPassword,
-                SaslScramTokenAuth = options.SaslScramTokenAuth,
-                GssapiConfig = options.GssapiConfig,
-                OAuthBearerConfig = options.OAuthBearerConfig,
-                OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
-                AwsMskIamConfig = options.AwsMskIamConfig,
-                SendBufferSize = options.SocketSendBufferBytes,
-                ReceiveBufferSize = options.SocketReceiveBufferBytes,
-                MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
-                ClientDnsLookup = options.ClientDnsLookup
-            },
+            connectionOptions,
+            options.LoggerFactory,
+            options.ConnectionsPerBroker,
+            ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
+            pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
+        var consumerConnectionPool = new ConnectionPool(
+            options.ClientId,
+            connectionOptions,
             options.LoggerFactory,
             options.ConnectionsPerBroker,
             ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
@@ -662,10 +647,12 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.BootstrapServers,
             options: metadataOptions,
             logger: options.LoggerFactory?.CreateLogger<MetadataManager>());
+        metadataManager.SetAdditionalBrokerRegistrationTarget(consumerConnectionPool);
 
         return new KafkaClientInfrastructure(
             options.BootstrapServers,
             connectionPool,
+            consumerConnectionPool,
             metadataManager,
             new ClientMemoryBudget(options.MemoryBudgetBytes),
             options.LoggerFactory,
@@ -674,12 +661,41 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.ProducerMaxConnectionsPerBroker);
     }
 
+    private static ConnectionOptions CreateConnectionOptions(KafkaClientOptions options) => new()
+    {
+        UseTls = options.UseTls,
+        TlsConfig = options.TlsConfig,
+        RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
+        ConnectionTimeout = options.ConnectionTimeout,
+        EnableTcpKeepAlive = options.EnableTcpKeepAlive,
+        TcpKeepAliveTime = options.TcpKeepAliveTime,
+        TcpKeepAliveInterval = options.TcpKeepAliveInterval,
+        TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
+        RequestTimeout = TimeSpan.FromMilliseconds(options.RequestTimeoutMs),
+        ReconnectBackoff = TimeSpan.FromMilliseconds(options.ReconnectBackoffMs),
+        ReconnectBackoffMax = TimeSpan.FromMilliseconds(options.ReconnectBackoffMaxMs),
+        ConnectionsMaxIdleMs = options.ConnectionsMaxIdleMs,
+        SaslMechanism = options.SaslMechanism,
+        SaslUsername = options.SaslUsername,
+        SaslPassword = options.SaslPassword,
+        SaslScramTokenAuth = options.SaslScramTokenAuth,
+        GssapiConfig = options.GssapiConfig,
+        OAuthBearerConfig = options.OAuthBearerConfig,
+        OAuthBearerTokenProvider = options.OAuthBearerTokenProvider,
+        AwsMskIamConfig = options.AwsMskIamConfig,
+        SendBufferSize = options.SocketSendBufferBytes,
+        ReceiveBufferSize = options.SocketReceiveBufferBytes,
+        MaxInFlightRequestsPerConnection = options.MaxInFlightRequestsPerConnection,
+        ClientDnsLookup = options.ClientDnsLookup
+    };
+
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
         await MetadataManager.DisposeAsync().ConfigureAwait(false);
+        await ConsumerConnectionPool.DisposeAsync().ConfigureAwait(false);
         await ConnectionPool.DisposeAsync().ConfigureAwait(false);
     }
 }

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -646,7 +646,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.LoggerFactory,
             options.ConnectionsPerBroker,
             ResponseBufferPool.Create(SharedResponseBufferFetchMaxBytes),
-            pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket);
+            pipeMemoryBucketCapacity: poolSizes.PipeMemoryArraysPerBucket,
+            responseMemoryAdmissionsEnabled: true);
 
         var metadataOptions = new MetadataOptions
         {

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -18,6 +18,7 @@ namespace Dekaf.Metadata;
 public sealed partial class MetadataManager : IAsyncDisposable
 {
     private readonly IConnectionPool _connectionPool;
+    private IConnectionPool? _additionalBrokerRegistrationTarget;
     private readonly MetadataOptions _options;
     private readonly ILogger _logger;
     private readonly ClusterMetadata _metadata = new();
@@ -142,6 +143,18 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     _originalBootstrapHostnames.Add(server);
                 }
             }
+        }
+    }
+
+    internal void SetAdditionalBrokerRegistrationTarget(IConnectionPool connectionPool)
+    {
+        ArgumentNullException.ThrowIfNull(connectionPool);
+        if (Interlocked.CompareExchange(
+                ref _additionalBrokerRegistrationTarget,
+                connectionPool,
+                null) is not null)
+        {
+            throw new InvalidOperationException("An additional broker registration target is already configured");
         }
     }
 
@@ -720,7 +733,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 // Register brokers with connection pool
                 foreach (var broker in response.Brokers)
                 {
-                    _connectionPool.RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+                    RegisterBroker(broker.NodeId, broker.Host, broker.Port);
                 }
 
                 LogMetadataRefreshed(response.Brokers.Count, response.Topics.Count);
@@ -844,7 +857,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 foreach (var broker in response.Brokers)
                 {
-                    _connectionPool.RegisterBroker(broker.NodeId, broker.Host, broker.Port);
+                    RegisterBroker(broker.NodeId, broker.Host, broker.Port);
                 }
 
                 LogRebootstrapSuccessful(response.Brokers.Count, host, port);
@@ -869,6 +882,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
         LogRebootstrapFailed(lastException);
         return false;
+    }
+
+    private void RegisterBroker(int brokerId, string host, int port)
+    {
+        _connectionPool.RegisterBroker(brokerId, host, port);
+        Volatile.Read(ref _additionalBrokerRegistrationTarget)?.RegisterBroker(brokerId, host, port);
     }
 
     /// <summary>

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -23,6 +23,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     private readonly ILogger _logger;
     private readonly int _connectionsPerBroker;
     private readonly ResponseBufferPool _responseBufferPool;
+    private readonly bool _responseMemoryAdmissionsEnabled;
     private readonly ClientTelemetryMetricCollector? _telemetryMetricCollector;
     private readonly TimeSpan _idleReapDrainTimeout;
     private readonly OAuthBearerTokenProvider? _sharedOAuthBearerTokenProvider;
@@ -97,7 +98,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         int? pipeMemoryBucketCapacity = null,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
         TimeSpan? idleReapDrainTimeout = null,
-        Func<double>? randomDouble = null)
+        Func<double>? randomDouble = null,
+        bool responseMemoryAdmissionsEnabled = false)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -108,6 +110,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         _logger = loggerFactory?.CreateLogger<ConnectionPool>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
         _responseBufferPool = responseBufferPool;
+        _responseMemoryAdmissionsEnabled = responseMemoryAdmissionsEnabled;
         _telemetryMetricCollector = telemetryMetricCollector;
         _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
         _randomDouble = randomDouble ?? SharedRandomDouble;
@@ -791,7 +794,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _loggerFactory?.CreateLogger<KafkaConnection>(),
                 _responseBufferPool,
                 _sharedPipeMemoryPool,
-                _telemetryMetricCollector);
+                _telemetryMetricCollector,
+                _responseMemoryAdmissionsEnabled);
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
@@ -965,7 +969,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _loggerFactory?.CreateLogger<KafkaConnection>(),
                 _responseBufferPool,
                 _sharedPipeMemoryPool,
-                _telemetryMetricCollector);
+                _telemetryMetricCollector,
+                _responseMemoryAdmissionsEnabled);
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -85,6 +85,8 @@ public sealed partial class KafkaConnection :
     private readonly ILogger _logger;
     private readonly ConnectionOptions _options;
     private readonly ResponseBufferPool _responseBufferPool;
+    private readonly bool _responseMemoryAdmissionsEnabled;
+    private readonly Func<int, ResponseFrameAdmission> _responseFrameAdmission;
     private readonly Func<Task, TimeSpan, Task> _waitForAbandonedWriteAsync;
 
     private Socket? _socket;
@@ -237,7 +239,8 @@ public sealed partial class KafkaConnection :
         ILogger<KafkaConnection>? logger,
         ResponseBufferPool responseBufferPool,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
-        Func<Task, TimeSpan, Task>? waitForAbandonedWriteAsync = null)
+        Func<Task, TimeSpan, Task>? waitForAbandonedWriteAsync = null,
+        bool responseMemoryAdmissionsEnabled = false)
     {
         _host = host;
         _port = port;
@@ -250,6 +253,8 @@ public sealed partial class KafkaConnection :
         _timeoutCtsPool = new CancellationTokenSourcePool(connectionSizes.CancellationTokenSources);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaConnection>.Instance;
         _responseBufferPool = responseBufferPool;
+        _responseMemoryAdmissionsEnabled = responseMemoryAdmissionsEnabled;
+        _responseFrameAdmission = GetResponseFrameAdmission;
         _telemetryMetricCollector = telemetryMetricCollector;
         _waitForAbandonedWriteAsync = waitForAbandonedWriteAsync ?? WaitForAbandonedWriteAsync;
         _receiveTimeoutStopwatchTicks =
@@ -288,8 +293,17 @@ public sealed partial class KafkaConnection :
         ILogger<KafkaConnection>? logger,
         ResponseBufferPool responseBufferPool,
         PipeMemoryPool? sharedPipeMemoryPool = null,
-        ClientTelemetryMetricCollector? telemetryMetricCollector = null)
-        : this(host, port, clientId, options, logger, responseBufferPool, telemetryMetricCollector)
+        ClientTelemetryMetricCollector? telemetryMetricCollector = null,
+        bool responseMemoryAdmissionsEnabled = false)
+        : this(
+            host,
+            port,
+            clientId,
+            options,
+            logger,
+            responseBufferPool,
+            telemetryMetricCollector,
+            responseMemoryAdmissionsEnabled: responseMemoryAdmissionsEnabled)
     {
         BrokerId = brokerId;
         _sharedPipeMemoryPool = sharedPipeMemoryPool;
@@ -519,11 +533,15 @@ public sealed partial class KafkaConnection :
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
+        var responseMemoryPool = request is FetchRequest fetchRequest
+            ? fetchRequest.ResponseMemoryPool
+            : null;
         pending.Initialize(
             responseHeaderVersion,
             cancellationToken,
             registerCancellation: false,
-            checkCrcs: request is FetchRequest { CheckCrcs: true });
+            checkCrcs: request is FetchRequest { CheckCrcs: true },
+            responseMemoryPool: responseMemoryPool);
         try
         {
             AddPendingRequest(correlationId, pending);
@@ -724,6 +742,9 @@ public sealed partial class KafkaConnection :
 
         await ReservePendingRequestSlotAsync(cancellationToken).ConfigureAwait(false);
         var pending = _pendingRequestPool.Rent();
+        var responseMemoryPool = request is FetchRequest fetchRequest
+            ? fetchRequest.ResponseMemoryPool
+            : null;
         // The pipelined wrapper performs bounded internal parsing, then only signals the
         // sender. Resume it in the receive dispatch frame to avoid a ThreadPool round trip.
         pending.Initialize(
@@ -731,7 +752,8 @@ public sealed partial class KafkaConnection :
             cancellationToken,
             registerCancellation: false,
             checkCrcs: request is FetchRequest { CheckCrcs: true },
-            runContinuationsAsynchronously: false);
+            runContinuationsAsynchronously: false,
+            responseMemoryPool: responseMemoryPool);
         try
         {
             AddPendingRequest(correlationId, pending);
@@ -930,7 +952,8 @@ public sealed partial class KafkaConnection :
                 response = ParsePipelinedResponse<TRequest, TResponse>(
                     pooledBuffer,
                     _apiVersion,
-                    pending.CheckCrcs);
+                    pending.CheckCrcs,
+                    pending.TakeResponseMemoryReservation());
 
                 connection.Touch();
                 connection._telemetryMetricCollector?.RecordRequestLatency(
@@ -1177,7 +1200,8 @@ public sealed partial class KafkaConnection :
             return ParsePipelinedResponse<TRequest, TResponse>(
                 pooledBuffer,
                 apiVersion,
-                pending.CheckCrcs);
+                pending.CheckCrcs,
+                pending.TakeResponseMemoryReservation());
         }
         finally
         {
@@ -1188,12 +1212,17 @@ public sealed partial class KafkaConnection :
     private static TResponse ParsePipelinedResponse<TRequest, TResponse>(
         PooledResponseBuffer pooledBuffer,
         short apiVersion,
-        bool checkCrcs)
+        bool checkCrcs,
+        IResponseMemoryReservation? reservation)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
         if (KafkaMessageMetadata<TRequest, TResponse>.ApiKey == ApiKey.Fetch)
-            return ParseFetchResponse<TRequest, TResponse>(pooledBuffer, apiVersion, checkCrcs);
+            return ParseFetchResponse<TRequest, TResponse>(
+                pooledBuffer,
+                apiVersion,
+                checkCrcs,
+                reservation);
 
         try
         {
@@ -1203,17 +1232,19 @@ public sealed partial class KafkaConnection :
         finally
         {
             pooledBuffer.Dispose();
+            reservation?.Dispose();
         }
     }
 
     internal static TResponse ParseFetchResponse<TRequest, TResponse>(
         PooledResponseBuffer pooledBuffer,
         short apiVersion,
-        bool checkCrcs = false)
+        bool checkCrcs = false,
+        IResponseMemoryReservation? reservation = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        var memoryOwner = pooledBuffer.TransferOwnership();
+        var memoryOwner = pooledBuffer.TransferOwnership(reservation);
         using var parsingScope = ResponseParsingContext.SetPooledMemory(memoryOwner, checkCrcs);
 
         try
@@ -1788,6 +1819,12 @@ public sealed partial class KafkaConnection :
         if (frameReader is null)
             return;
 
+        if (_responseMemoryAdmissionsEnabled)
+        {
+            await ReceiveBoundedLoopAsync(frameReader, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
         LogReceiveLoopStarted(_host, _port);
 
         try
@@ -1829,7 +1866,7 @@ public sealed partial class KafkaConnection :
                     break;
                 }
 
-                DispatchResponse(frame.CorrelationId, frame.Buffer);
+                DispatchResponse(frame.CorrelationId, frame.Buffer, reservation: null);
             }
 
             // While loop exited normally (no exception thrown, so no catch block runs).
@@ -1866,6 +1903,80 @@ public sealed partial class KafkaConnection :
         }
     }
 
+    // Intentionally separate from ReceiveLoopAsync: the producer receive loop must not pay
+    // a per-frame admission branch, larger frame carrier, or reservation handoff.
+    private async Task ReceiveBoundedLoopAsync(
+        ResponseFrameReader frameReader,
+        CancellationToken cancellationToken)
+    {
+        LogReceiveLoopStarted(_host, _port);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                BoundedResponseFrame frame;
+                try
+                {
+                    frame = await frameReader
+                        .ReadBoundedFrameAsync(_responseFrameAdmission)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception) when (ConsumeReceiveTimeoutExpired())
+                {
+                    throw CreateReceiveTimeoutException();
+                }
+
+                if (frame.IsEndOfStream)
+                {
+                    LogReceiveLoopCompleted(_host, _port);
+                    MarkDisposed();
+                    FailAllPendingRequests(new KafkaException(
+                        "Connection closed by remote peer (EOF)"));
+                    break;
+                }
+
+                if (frame.IsDiscarded)
+                {
+                    DispatchDiscardedResponse(frame.CorrelationId);
+                    continue;
+                }
+
+                DispatchResponse(frame.CorrelationId, frame.Buffer, frame.Reservation);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                MarkDisposed();
+                FailAllPendingRequests(new OperationCanceledException("Connection closing", cancellationToken));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            MarkDisposed();
+            FailAllPendingRequests(new OperationCanceledException("Connection closing", cancellationToken));
+        }
+        catch (Exception ex)
+        {
+            if (!_hasReceivedResponse)
+                LogReceiveLoopEndedBeforeFirstResponse(ex, _host, _port);
+            else
+                LogReceiveLoopError(ex);
+
+            MarkDisposed();
+            FailAllPendingRequests(ex);
+        }
+        finally
+        {
+            DisarmReceiveTimeout();
+            frameReader.Dispose();
+        }
+    }
+
     /// <summary>
     /// Invoked by <see cref="ResponseFrameReader"/> after every successful source read.
     /// Extends the receive-timeout deadline on byte progress (a large frame arriving
@@ -1892,27 +2003,60 @@ public sealed partial class KafkaConnection :
             $"Receive timeout after {(int)_options.RequestTimeout.TotalMilliseconds}ms - connection to broker {BrokerId} failed");
     }
 
-    private void DispatchResponse(int correlationId, PooledResponseBuffer responseData)
+    private void DispatchResponse(
+        int correlationId,
+        PooledResponseBuffer responseData,
+        IResponseMemoryReservation? reservation)
     {
         LogReceivedResponse(correlationId, responseData.Length);
 
         if (TryGetPendingRequest(correlationId, out var pending))
         {
             _hasReceivedResponse = true;
-            if (!pending.Request.TryComplete(pending.Version, responseData))
+            if (!pending.Request.TryComplete(pending.Version, responseData, reservation))
+            {
                 responseData.Dispose();
+                reservation?.Dispose();
+            }
         }
         else if (_cancelledCorrelationIds.TryRemove(correlationId))
         {
             _hasReceivedResponse = true;
             LogLateResponseForCancelledRequest(correlationId);
             responseData.Dispose();
+            reservation?.Dispose();
         }
         else
         {
             LogUnknownCorrelationId(correlationId);
             responseData.Dispose();
+            reservation?.Dispose();
         }
+    }
+
+    private ResponseFrameAdmission GetResponseFrameAdmission(int correlationId)
+    {
+        if (!TryGetPendingRequest(correlationId, out var pending))
+            return ResponseFrameAdmission.Discarded;
+
+        if (!pending.Request.TryGetResponseMemoryPool(pending.Version, out var memoryPool))
+            return ResponseFrameAdmission.Discarded;
+
+        return memoryPool is null
+            ? ResponseFrameAdmission.Unrestricted
+            : new ResponseFrameAdmission(memoryPool, Discard: false);
+    }
+
+    private void DispatchDiscardedResponse(int correlationId)
+    {
+        if (_cancelledCorrelationIds.TryRemove(correlationId))
+        {
+            _hasReceivedResponse = true;
+            LogLateResponseForCancelledRequest(correlationId);
+            return;
+        }
+
+        LogUnknownCorrelationId(correlationId);
     }
 
     private ValueTask ReservePendingRequestSlotAsync(CancellationToken cancellationToken)
@@ -4134,7 +4278,12 @@ internal readonly struct PooledResponseBuffer : IDisposable
     private readonly int _offset;
     private readonly ResponseBufferPool? _pool;
 
-    public PooledResponseBuffer(byte[] buffer, int length, bool isPooled, int offset = 0, ResponseBufferPool? pool = null)
+    public PooledResponseBuffer(
+        byte[] buffer,
+        int length,
+        bool isPooled,
+        int offset = 0,
+        ResponseBufferPool? pool = null)
     {
         _buffer = buffer;
         _nativeBuffer = null;
@@ -4144,7 +4293,10 @@ internal readonly struct PooledResponseBuffer : IDisposable
         _pool = pool;
     }
 
-    internal PooledResponseBuffer(NativeResponseBuffer buffer, int length, int offset = 0)
+    internal PooledResponseBuffer(
+        NativeResponseBuffer buffer,
+        int length,
+        int offset = 0)
     {
         _buffer = null;
         _nativeBuffer = buffer;
@@ -4170,19 +4322,28 @@ internal readonly struct PooledResponseBuffer : IDisposable
     public PooledResponseBuffer Slice(int additionalOffset)
     {
         return _nativeBuffer is not null
-            ? new PooledResponseBuffer(_nativeBuffer, Length - additionalOffset, _offset + additionalOffset)
-            : new PooledResponseBuffer(_buffer!, Length - additionalOffset, IsPooled, _offset + additionalOffset, _pool);
+            ? new PooledResponseBuffer(
+                _nativeBuffer,
+                Length - additionalOffset,
+                _offset + additionalOffset)
+            : new PooledResponseBuffer(
+                _buffer!,
+                Length - additionalOffset,
+                IsPooled,
+                _offset + additionalOffset,
+                _pool);
     }
 
     /// <summary>
     /// Transfers ownership of this buffer to a new PooledResponseMemory instance.
     /// After calling this, the buffer should NOT be disposed via this struct.
     /// </summary>
-    public PooledResponseMemory TransferOwnership()
+    public PooledResponseMemory TransferOwnership(
+        IResponseMemoryReservation? reservation = null)
     {
         return _nativeBuffer is not null
-            ? PooledResponseMemory.Create(_nativeBuffer, Length, _offset)
-            : PooledResponseMemory.Create(_buffer!, Length, IsPooled, _offset, _pool);
+            ? PooledResponseMemory.Create(_nativeBuffer, Length, _offset, reservation)
+            : PooledResponseMemory.Create(_buffer!, Length, IsPooled, _offset, _pool, reservation);
     }
 
     public void Dispose()
@@ -4214,19 +4375,30 @@ internal sealed class PooledResponseMemory : IPooledMemory
     private bool _isPooled;
     private int _offset;
     private ResponseBufferPool? _pool;
+    private IResponseMemoryReservation? _reservation;
     private int _pooled;
     private int _disposed = 1;
 
     private PooledResponseMemory() { }
 
-    internal static PooledResponseMemory Create(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool = null)
+    internal static PooledResponseMemory Create(
+        byte[] buffer,
+        int length,
+        bool isPooled,
+        int offset,
+        ResponseBufferPool? pool = null,
+        IResponseMemoryReservation? reservation = null)
     {
         var memory = s_pool.Rent();
-        memory.Initialize(buffer, length, isPooled, offset, pool, pooled: true);
+        memory.Initialize(buffer, length, isPooled, offset, pool, reservation, pooled: true);
         return memory;
     }
 
-    internal static PooledResponseMemory Create(NativeResponseBuffer buffer, int length, int offset)
+    internal static PooledResponseMemory Create(
+        NativeResponseBuffer buffer,
+        int length,
+        int offset,
+        IResponseMemoryReservation? reservation = null)
     {
         var memory = s_pool.Rent();
         memory._buffer = null;
@@ -4235,12 +4407,20 @@ internal sealed class PooledResponseMemory : IPooledMemory
         memory._isPooled = true;
         memory._offset = offset;
         memory._pool = null;
+        memory._reservation = reservation;
         memory._pooled = 1;
         Volatile.Write(ref memory._disposed, 0);
         return memory;
     }
 
-    private void Initialize(byte[] buffer, int length, bool isPooled, int offset, ResponseBufferPool? pool, bool pooled)
+    private void Initialize(
+        byte[] buffer,
+        int length,
+        bool isPooled,
+        int offset,
+        ResponseBufferPool? pool,
+        IResponseMemoryReservation? reservation,
+        bool pooled)
     {
         _buffer = buffer;
         _nativeBuffer = null;
@@ -4248,6 +4428,7 @@ internal sealed class PooledResponseMemory : IPooledMemory
         _isPooled = isPooled;
         _offset = offset;
         _pool = pool;
+        _reservation = reservation;
         _pooled = pooled ? 1 : 0;
         Volatile.Write(ref _disposed, 0);
     }
@@ -4265,11 +4446,19 @@ internal sealed class PooledResponseMemory : IPooledMemory
 
         var buffer = Interlocked.Exchange(ref _buffer, null);
         var nativeBuffer = Interlocked.Exchange(ref _nativeBuffer, null);
-        nativeBuffer?.Return();
-        if (_isPooled && buffer is not null)
+        var reservation = Interlocked.Exchange(ref _reservation, null);
+        try
         {
-            Debug.Assert(_pool is not null, "Pooled buffer must have a non-null pool reference");
-            _pool!.Pool.Return(buffer);
+            nativeBuffer?.Return();
+            if (_isPooled && buffer is not null)
+            {
+                Debug.Assert(_pool is not null, "Pooled buffer must have a non-null pool reference");
+                _pool!.Pool.Return(buffer);
+            }
+        }
+        finally
+        {
+            reservation?.Dispose();
         }
 
         if (Volatile.Read(ref _pooled) != 0)
@@ -4288,6 +4477,7 @@ internal sealed class PooledResponseMemory : IPooledMemory
             item._isPooled = false;
             item._offset = 0;
             item._pool = null;
+            item._reservation = null;
             item._pooled = 0;
             Volatile.Write(ref item._disposed, 1);
         }
@@ -4371,6 +4561,8 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
     private CancellationTokenRegistration _cancellationRegistration;
     private CancellationToken _cancellationToken;
     private bool _checkCrcs;
+    private IResponseMemoryPool? _responseMemoryPool;
+    private IResponseMemoryReservation? _responseMemoryReservation;
     private int _state; // High 16 bits = core version; low 16 bits = State*
 
     /// <summary>
@@ -4381,11 +4573,13 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         CancellationToken cancellationToken,
         bool registerCancellation = true,
         bool checkCrcs = false,
-        bool runContinuationsAsynchronously = true)
+        bool runContinuationsAsynchronously = true,
+        IResponseMemoryPool? responseMemoryPool = null)
     {
         _responseHeaderVersion = responseHeaderVersion;
         _cancellationToken = cancellationToken;
         _checkCrcs = checkCrcs;
+        _responseMemoryPool = responseMemoryPool;
         _core.RunContinuationsAsynchronously = runContinuationsAsynchronously;
         _state = CreateState(_core.Version, StatePending);
 
@@ -4443,18 +4637,41 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
 
     public bool CheckCrcs => _checkCrcs;
 
+    public bool TryGetResponseMemoryPool(
+        short expectedVersion,
+        out IResponseMemoryPool? responseMemoryPool)
+    {
+        if (Volatile.Read(ref _state) != CreateState(expectedVersion, StatePending))
+        {
+            responseMemoryPool = null;
+            return false;
+        }
+
+        responseMemoryPool = _responseMemoryPool;
+        return true;
+    }
+
+    public IResponseMemoryReservation? TakeResponseMemoryReservation() =>
+        Interlocked.Exchange(ref _responseMemoryReservation, null);
+
     /// <summary>
     /// Attempts to complete the request with response data.
     /// Returns false if already completed (cancelled or failed).
     /// </summary>
     public bool TryComplete(PooledResponseBuffer pooledBuffer)
-        => TryComplete(_core.Version, pooledBuffer);
+        => TryComplete(_core.Version, pooledBuffer, reservation: null);
 
     /// <summary>
     /// Attempts to complete the request with response data for the captured version.
     /// Returns false if the request was already completed or reused.
     /// </summary>
     public bool TryComplete(short expectedVersion, PooledResponseBuffer pooledBuffer)
+        => TryComplete(expectedVersion, pooledBuffer, reservation: null);
+
+    internal bool TryComplete(
+        short expectedVersion,
+        PooledResponseBuffer pooledBuffer,
+        IResponseMemoryReservation? reservation)
     {
         // Atomically claim the completing state
         if (!TryClaimCompletion(expectedVersion))
@@ -4468,6 +4685,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         // calling SetResult/SetException.
         PooledResponseBuffer result = default;
         Exception? parseException = null;
+        _responseMemoryReservation = reservation;
 
         try
         {
@@ -4476,6 +4694,7 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         catch (Exception ex)
         {
             pooledBuffer.Dispose();
+            Interlocked.Exchange(ref _responseMemoryReservation, null)?.Dispose();
             parseException = ex;
         }
 
@@ -4658,6 +4877,8 @@ internal sealed class PooledPendingRequest : IValueTaskSource<PooledResponseBuff
         _cancellationRegistration = default;
         _cancellationToken = default;
         _checkCrcs = false;
+        _responseMemoryPool = null;
+        Interlocked.Exchange(ref _responseMemoryReservation, null)?.Dispose();
 
         // Reset the core for reuse
         _core.Reset();

--- a/src/Dekaf/Networking/ResponseFrameReader.cs
+++ b/src/Dekaf/Networking/ResponseFrameReader.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using Dekaf.Protocol;
 
 namespace Dekaf.Networking;
 
@@ -45,6 +46,7 @@ internal sealed class ResponseFrameReader : IDisposable
     // faulted read mid-frame can release pooled storage via AbandonInProgressFrame.
     private byte[]? _frameArray;
     private NativeResponseBuffer? _nativeFrame;
+    private IResponseMemoryReservation? _frameReservation;
     private int _frameSize;
     private int _frameFilled;
 
@@ -157,6 +159,138 @@ internal sealed class ResponseFrameReader : IDisposable
         return ResponseFrame.ForResponse(correlationId, response);
     }
 
+    /// <summary>
+    /// Reads a frame after exact-size admission. Kept separate from <see cref="ReadFrameAsync"/>
+    /// so producer and coordinator-only connections retain their unchanged framing fast path.
+    /// </summary>
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
+    public async ValueTask<BoundedResponseFrame> ReadBoundedFrameAsync(
+        Func<int, ResponseFrameAdmission> getAdmission)
+    {
+        if (_frameArray is null && _nativeFrame is null)
+        {
+            while (BufferedByteCount < 4)
+            {
+                if (_end == _buffer.Length)
+                {
+                    _buffer.Span[_start.._end].CopyTo(_buffer.Span);
+                    _end -= _start;
+                    _start = 0;
+                }
+
+                var read = await ReadSourceAsync(_buffer[_end..]).ConfigureAwait(false);
+                if (read == 0)
+                    return BoundedResponseFrame.EndOfStream;
+
+                _end += read;
+            }
+
+            var frameSize = BinaryPrimitives.ReadInt32BigEndian(_buffer.Span[_start..]);
+            ConnectionHelper.ValidateResponseFrameSize(frameSize, _responseBufferPool.MaxArrayLength);
+            _start += 4;
+
+            while (BufferedByteCount < ConnectionHelper.MinimumResponseFrameSize)
+            {
+                if (_end == _buffer.Length)
+                {
+                    _buffer.Span[_start.._end].CopyTo(_buffer.Span);
+                    _end -= _start;
+                    _start = 0;
+                }
+
+                var read = await ReadSourceAsync(_buffer[_end..]).ConfigureAwait(false);
+                if (read == 0)
+                    return BoundedResponseFrame.EndOfStream;
+
+                _end += read;
+            }
+
+            var frameCorrelationId = BinaryPrimitives.ReadInt32BigEndian(_buffer.Span[_start..]);
+            var admission = getAdmission(frameCorrelationId);
+            if (admission.Discard)
+            {
+                if (!await DiscardFrameAsync(frameSize).ConfigureAwait(false))
+                    return BoundedResponseFrame.EndOfStream;
+
+                return BoundedResponseFrame.ForDiscarded(frameCorrelationId);
+            }
+
+            if (admission.MemoryPool is not null)
+            {
+                _frameReservation = await admission.MemoryPool
+                    .ReserveAsync(frameSize, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            if (frameSize >= ResponseBufferPool.NativeMemoryThresholdBytes)
+                _nativeFrame = _responseBufferPool.RentNative(frameSize);
+            else
+                _frameArray = _responseBufferPool.Pool.Rent(frameSize);
+            _frameSize = frameSize;
+
+            var buffered = Math.Min(frameSize, BufferedByteCount);
+            _buffer.Span.Slice(_start, buffered).CopyTo(FrameMemory.Span);
+            _start += buffered;
+            _frameFilled = buffered;
+
+            if (_start == _end)
+            {
+                _start = 0;
+                _end = 0;
+            }
+        }
+
+        while (_frameFilled < _frameSize)
+        {
+            var read = await ReadSourceAsync(FrameMemory.Slice(_frameFilled, _frameSize - _frameFilled))
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                AbandonInProgressFrame();
+                return BoundedResponseFrame.EndOfStream;
+            }
+
+            _frameFilled += read;
+        }
+
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(FrameMemory.Span);
+        var response = _nativeFrame is not null
+            ? new PooledResponseBuffer(_nativeFrame, _frameSize)
+            : new PooledResponseBuffer(_frameArray!, _frameSize, isPooled: true, pool: _responseBufferPool);
+        var reservation = _frameReservation;
+        _nativeFrame = null;
+        _frameArray = null;
+        _frameReservation = null;
+        return BoundedResponseFrame.ForResponse(correlationId, response, reservation);
+    }
+
+    private async ValueTask<bool> DiscardFrameAsync(int frameSize)
+    {
+        var buffered = Math.Min(frameSize, BufferedByteCount);
+        _start += buffered;
+        var remaining = frameSize - buffered;
+
+        if (_start == _end)
+        {
+            _start = 0;
+            _end = 0;
+        }
+
+        while (remaining > 0)
+        {
+            var read = await ReadSourceAsync(_buffer[..Math.Min(_buffer.Length, remaining)])
+                .ConfigureAwait(false);
+            if (read == 0)
+                return false;
+
+            remaining -= read;
+        }
+
+        return true;
+    }
+
 #if NET
     [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
 #endif
@@ -246,11 +380,20 @@ internal sealed class ResponseFrameReader : IDisposable
     {
         var frameArray = _frameArray;
         var nativeFrame = _nativeFrame;
+        var frameReservation = _frameReservation;
         _frameArray = null;
         _nativeFrame = null;
-        if (frameArray is not null)
-            _responseBufferPool.Pool.Return(frameArray);
-        nativeFrame?.Return();
+        _frameReservation = null;
+        try
+        {
+            if (frameArray is not null)
+                _responseBufferPool.Pool.Return(frameArray);
+            nativeFrame?.Return();
+        }
+        finally
+        {
+            frameReservation?.Dispose();
+        }
     }
 
     private Memory<byte> FrameMemory => _nativeFrame is not null
@@ -262,10 +405,45 @@ internal sealed class ResponseFrameReader : IDisposable
 /// Result of <see cref="ResponseFrameReader.ReadFrameAsync"/>: either a complete response
 /// frame (correlation id + pooled payload) or an end-of-stream marker.
 /// </summary>
-internal readonly record struct ResponseFrame(bool IsEndOfStream, int CorrelationId, PooledResponseBuffer Buffer)
+internal readonly record struct ResponseFrame(
+    bool IsEndOfStream,
+    int CorrelationId,
+    PooledResponseBuffer Buffer)
 {
     public static ResponseFrame EndOfStream => new(IsEndOfStream: true, 0, default);
 
     public static ResponseFrame ForResponse(int correlationId, PooledResponseBuffer buffer)
         => new(IsEndOfStream: false, correlationId, buffer);
+}
+
+internal readonly record struct BoundedResponseFrame(
+    bool IsEndOfStream,
+    bool IsDiscarded,
+    int CorrelationId,
+    PooledResponseBuffer Buffer,
+    IResponseMemoryReservation? Reservation)
+{
+    public static BoundedResponseFrame EndOfStream => new(
+        IsEndOfStream: true,
+        IsDiscarded: false,
+        0,
+        default,
+        null);
+
+    public static BoundedResponseFrame ForResponse(
+        int correlationId,
+        PooledResponseBuffer buffer,
+        IResponseMemoryReservation? reservation)
+        => new(IsEndOfStream: false, IsDiscarded: false, correlationId, buffer, reservation);
+
+    public static BoundedResponseFrame ForDiscarded(int correlationId)
+        => new(IsEndOfStream: false, IsDiscarded: true, correlationId, default, null);
+}
+
+internal readonly record struct ResponseFrameAdmission(
+    IResponseMemoryPool? MemoryPool,
+    bool Discard)
+{
+    public static ResponseFrameAdmission Unrestricted => new(null, false);
+    public static ResponseFrameAdmission Discarded => new(null, true);
 }

--- a/src/Dekaf/Networking/ResponseFrameReader.cs
+++ b/src/Dekaf/Networking/ResponseFrameReader.cs
@@ -27,8 +27,8 @@ namespace Dekaf.Networking;
 /// request more than the frame's remaining bytes, so the source is never over-read.
 /// <para/>
 /// <b>Threading:</b> single consumer — only the connection's receive loop calls
-/// <see cref="ReadFrameAsync"/>. Reads are not cancellable; the owner interrupts an
-/// in-flight read by calling <see cref="Abort"/>.
+/// <see cref="ReadFrameAsync"/>. Source reads are not cancellable; <see cref="Abort"/>
+/// cancels admission waits and interrupts an in-flight source read.
 /// </summary>
 internal sealed class ResponseFrameReader : IDisposable
 {
@@ -36,6 +36,7 @@ internal sealed class ResponseFrameReader : IDisposable
     private readonly Stream? _stream;
     private readonly ResponseBufferPool _responseBufferPool;
     private readonly Action<int>? _onBytesReceived;
+    private readonly CancellationTokenSource _abortCts = new();
 
     private IMemoryOwner<byte>? _bufferOwner;
     private readonly Memory<byte> _buffer;
@@ -220,7 +221,7 @@ internal sealed class ResponseFrameReader : IDisposable
             if (admission.MemoryPool is not null)
             {
                 _frameReservation = await admission.MemoryPool
-                    .ReserveAsync(frameSize, CancellationToken.None)
+                    .ReserveAsync(frameSize, _abortCts.Token)
                     .ConfigureAwait(false);
             }
 
@@ -330,17 +331,27 @@ internal sealed class ResponseFrameReader : IDisposable
     }
 
     /// <summary>
-    /// Faults any in-flight or future source read. Idempotent and thread-safe; called from
-    /// the receive-timeout timer and from disposal. Reads are deliberately not cancellable —
-    /// closing the socket aborts a pending receive on all platforms without blocking the
-    /// caller, the same wake-up mechanism the old read pump relied on for teardown. For
-    /// stream-only readers (tests) the stream is disposed instead, the one case where this
-    /// class touches the source's lifetime.
+    /// Cancels any response-memory admission wait and faults any in-flight or future source
+    /// read. Idempotent and thread-safe; called from the receive-timeout timer and from
+    /// disposal. Source reads are deliberately not cancellable — closing the socket aborts
+    /// a pending receive on all platforms without blocking the caller, the same wake-up
+    /// mechanism the old read pump relied on for teardown. For stream-only readers (tests)
+    /// the stream is disposed instead, the one case where this class touches the source's
+    /// lifetime.
     /// </summary>
     public void Abort()
     {
         if (Interlocked.Exchange(ref _aborted, 1) != 0)
             return;
+
+        try
+        {
+            _abortCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Dispose completed before a concurrent late abort.
+        }
 
         try
         {
@@ -374,6 +385,7 @@ internal sealed class ResponseFrameReader : IDisposable
         AbandonInProgressFrame();
         _bufferOwner?.Dispose();
         _bufferOwner = null;
+        _abortCts.Dispose();
     }
 
     private void AbandonInProgressFrame()

--- a/src/Dekaf/Protocol/IResponseMemoryPool.cs
+++ b/src/Dekaf/Protocol/IResponseMemoryPool.cs
@@ -1,0 +1,16 @@
+namespace Dekaf.Protocol;
+
+/// <summary>
+/// Admits a response buffer before its storage is rented.
+/// </summary>
+internal interface IResponseMemoryPool
+{
+    ValueTask<IResponseMemoryReservation> ReserveAsync(
+        int bytes,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Releases response-buffer capacity when the raw response storage is returned.
+/// </summary>
+internal interface IResponseMemoryReservation : IDisposable;

--- a/src/Dekaf/Protocol/Messages/FetchRequest.cs
+++ b/src/Dekaf/Protocol/Messages/FetchRequest.cs
@@ -48,6 +48,8 @@ public sealed class FetchRequest : IKafkaRequest<FetchResponse>
 
     internal bool CheckCrcs { get; set; } = true;
 
+    internal IResponseMemoryPool? ResponseMemoryPool { get; set; }
+
     /// <summary>
     /// Isolation level (v4+).
     /// </summary>
@@ -102,6 +104,7 @@ public sealed class FetchRequest : IKafkaRequest<FetchResponse>
             item.MinBytes = 0;
             item.MaxBytes = 0x7FFFFFFF;
             item.CheckCrcs = true;
+            item.ResponseMemoryPool = null;
             item.IsolationLevel = IsolationLevel.ReadUncommitted;
             item.SessionId = 0;
             item.SessionEpoch = -1;

--- a/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/FetchBufferEdgeCaseTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Producer;
 
@@ -163,6 +164,7 @@ public sealed class FetchBufferEdgeCaseTests(KafkaTestContainer kafka) : KafkaIn
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
             .WithFetchMaxBytes(fetchMaxBytes)
+            .WithFetchBufferMemory(2 * 1024)
             .WithMaxPartitionFetchBytes(oversizedRecordSize * 2)
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
 
@@ -242,6 +244,69 @@ public sealed class FetchBufferEdgeCaseTests(KafkaTestContainer kafka) : KafkaIn
         }
 
         await Assert.That(observedPartitions).Count().IsEqualTo(partitionCount);
+    }
+
+    [Test]
+    public async Task FetchBufferMemory_BoundsPipelinedResponsesAndRecordsDepletion()
+    {
+        const int messageCount = 18;
+        const int messageSize = 12_000;
+        const long fetchBufferBytes = 64 * 1024;
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 3);
+        var groupId = $"bounded-fetch-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < messageCount; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = new string('X', messageSize),
+                Partition = i % 3
+            }, CancellationToken.None);
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithFetchMaxBytes(32 * 1024)
+            .WithFetchBufferMemory(fetchBufferBytes)
+            .WithMaxPartitionFetchBytes(32 * 1024)
+            .WithPrefetchPipelineDepth(5)
+            .WithConnectionsPerBroker(2)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var concreteConsumer = (KafkaConsumer<string, string>)consumer;
+        var pool = (FetchBufferMemoryPool)typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchBufferMemoryPool", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(concreteConsumer)!;
+
+        using var consumeTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), consumeTimeout.Token);
+        await Assert.That(first).IsNotNull();
+
+        var depletionDeadline = Stopwatch.GetTimestamp() + (5 * Stopwatch.Frequency);
+        while (pool.DepletedDurationSeconds == 0 && Stopwatch.GetTimestamp() < depletionDeadline)
+            await Task.Delay(10, consumeTimeout.Token);
+
+        using (var coordinatorTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            await consumer.CommitAsync(coordinatorTimeout.Token);
+
+        var messages = await ConsumeMessagesAsync(consumer, messageCount - 1);
+
+        await Assert.That(messages).Count().IsEqualTo(messageCount - 1);
+        await Assert.That(pool.UsedBytes).IsLessThanOrEqualTo(fetchBufferBytes);
+        await Assert.That(pool.DepletedDurationSeconds).IsGreaterThan(0);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/KafkaClientIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaClientIntegrationTests.cs
@@ -1,0 +1,33 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+public sealed class KafkaClientIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task SeparateRolePools_ProduceAndConsumeThroughRootClient()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var client = Kafka.Connect(KafkaContainer.BootstrapServers, builder =>
+            builder.WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()));
+        await using var producer = await client.CreateProducer<string, string>().BuildAsync();
+        await using var consumer = await client.CreateConsumer<string, string>()
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync();
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "root-client-key",
+            Value = "root-client-value"
+        }, CancellationToken.None);
+
+        var messages = await ConsumeMessagesAsync(consumer, count: 1);
+
+        await Assert.That(messages.Count).IsEqualTo(1);
+        await Assert.That(messages[0].Key).IsEqualTo("root-client-key");
+        await Assert.That(messages[0].Value).IsEqualTo("root-client-value");
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -534,6 +534,45 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task ForHighThroughput_SizesFetchBufferForFullAdaptivePipeline()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .ForHighThroughput()
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.FetchBufferMemoryBytes).IsEqualTo(1000L * 1024 * 1024);
+    }
+
+    [Test]
+    public async Task WithFetchBufferMemory_ConfiguresAggregateLimit()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithFetchBufferMemory(200L * 1024 * 1024)
+            .Build();
+
+        var options = ((KafkaConsumer<string, string>)consumer).Options;
+
+        await Assert.That(options.FetchBufferMemoryBytes).IsEqualTo(200L * 1024 * 1024);
+    }
+
+    [Test]
+    public async Task Build_FetchBufferBelowFetchMaximum_Throws()
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithFetchMaxBytes(64 * 1024 * 1024)
+            .WithFetchBufferMemory(32 * 1024 * 1024);
+
+        await Assert.That(() => builder.Build())
+            .Throws<ArgumentOutOfRangeException>()
+            .WithMessageContaining("Fetch buffer memory");
+    }
+
+    [Test]
     public async Task ForHighThroughput_FetchOverridesUpdateAdaptiveBounds()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -10,7 +10,7 @@ namespace Dekaf.Tests.Unit.Builder;
 public sealed class KafkaClientBuilderTests
 {
     [Test]
-    public async Task RootClient_CreatedClients_ShareConnectionPoolAndMetadata()
+    public async Task RootClient_CreatedClients_ShareMetadataAndUseRoleAppropriateConnectionPools()
     {
         await using var client = Kafka.Connect("broker1:9092,broker2:9092");
         await using var producer = client.CreateProducer<string, string>().Build();
@@ -21,8 +21,10 @@ public sealed class KafkaClientBuilderTests
         var consumerPool = GetField<IConnectionPool>(consumer, "_connectionPool");
         var adminPool = GetField<IConnectionPool>(admin, "_connectionPool");
 
-        await Assert.That(ReferenceEquals(producerPool, consumerPool)).IsTrue();
+        await Assert.That(ReferenceEquals(producerPool, consumerPool)).IsFalse();
         await Assert.That(ReferenceEquals(producerPool, adminPool)).IsTrue();
+        await Assert.That(GetField<bool>(producerPool, "_responseMemoryAdmissionsEnabled")).IsFalse();
+        await Assert.That(GetField<bool>(consumerPool, "_responseMemoryAdmissionsEnabled")).IsTrue();
 
         var producerMetadata = GetField<MetadataManager>(producer, "_metadataManager");
         var consumerMetadata = GetField<MetadataManager>(consumer, "_metadataManager");
@@ -88,6 +90,22 @@ public sealed class KafkaClientBuilderTests
         var pool = GetField<ConnectionPool>(producer, "_connectionPool");
 
         await producer.DisposeAsync();
+
+        await Assert.That(GetField<int>(pool, "_disposed")).IsEqualTo(0);
+
+        await client.DisposeAsync();
+
+        await Assert.That(GetField<int>(pool, "_disposed")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RootClient_CreatedConsumer_DisposeDoesNotDisposeSharedConsumerPool()
+    {
+        var client = Kafka.Connect("localhost:9092");
+        var consumer = client.CreateConsumer<string, string>().Build();
+        var pool = GetField<ConnectionPool>(consumer, "_connectionPool");
+
+        await consumer.DisposeAsync();
 
         await Assert.That(GetField<int>(pool, "_disposed")).IsEqualTo(0);
 
@@ -258,12 +276,12 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
-    public async Task RootClient_SharedConnectionPool_UsesAdaptiveFetchResponseBufferCeiling()
+    public async Task RootClient_ConsumerConnectionPool_UsesAdaptiveFetchResponseBufferCeiling()
     {
         await using var client = Kafka.Connect("localhost:9092");
-        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var consumer = client.CreateConsumer<string, string>().Build();
 
-        var pool = GetField<ConnectionPool>(producer, "_connectionPool");
+        var pool = GetField<ConnectionPool>(consumer, "_connectionPool");
         var responseBufferPool = GetField<ResponseBufferPool>(pool, "_responseBufferPool");
 
         await Assert.That(responseBufferPool.MaxArrayLength)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchBufferMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerFetchBufferMetricsTests.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Diagnostics;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+[NotInParallel("MeterListener")]
+public sealed class ConsumerFetchBufferMetricsTests
+{
+    private sealed record Sample(string Name, long Value, string? ClientId);
+
+    [Test]
+    public async Task UsedAndFreeGauges_ReportCurrentReservations()
+    {
+        const string clientId = "fetch-buffer-metrics-test";
+        var samples = new List<Sample>();
+        using var listener = CreateListener(samples);
+        await using var consumer = CreateConsumer(clientId);
+        var pool = GetPool(consumer);
+        using var reservation = await pool.ReserveAsync(40, CancellationToken.None);
+
+        listener.RecordObservableInstruments();
+
+        await Assert.That(samples).Contains(new Sample(
+            "dekaf.consumer.fetch_buffer.used_bytes",
+            40,
+            clientId));
+        await Assert.That(samples).Contains(new Sample(
+            "dekaf.consumer.fetch_buffer.free_bytes",
+            60,
+            clientId));
+
+    }
+
+    [Test]
+    public async Task DisposedConsumer_StopsReportingFetchBufferMeasurements()
+    {
+        const string clientId = "disposed-fetch-buffer-metrics-test";
+        var samples = new List<Sample>();
+        using var listener = CreateListener(samples);
+        var consumer = CreateConsumer(clientId);
+
+        listener.RecordObservableInstruments();
+        await Assert.That(samples.Any(sample => sample.ClientId == clientId)).IsTrue();
+
+        await consumer.DisposeAsync();
+        samples.Clear();
+        listener.RecordObservableInstruments();
+
+        await Assert.That(samples.Any(sample => sample.ClientId == clientId)).IsFalse();
+    }
+
+    private static MeterListener CreateListener(List<Sample> samples)
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName
+                && instrument.Name is "dekaf.consumer.fetch_buffer.used_bytes"
+                    or "dekaf.consumer.fetch_buffer.free_bytes")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            string? clientId = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == DekafDiagnostics.MessagingClientId)
+                    clientId = tag.Value as string;
+            }
+
+            samples.Add(new Sample(instrument.Name, value, clientId));
+        });
+        listener.Start();
+        return listener;
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer(string clientId) => new(
+        new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = clientId,
+            FetchMaxBytes = 50,
+            FetchBufferMemoryBytes = 100
+        },
+        Serializers.String,
+        Serializers.String);
+
+    private static FetchBufferMemoryPool GetPool(KafkaConsumer<string, string> consumer) =>
+        (FetchBufferMemoryPool)(typeof(KafkaConsumer<string, string>)
+            .GetField("_fetchBufferMemoryPool", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(consumer)!);
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -76,6 +76,13 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task FetchBufferMemoryBytes_DefaultsTo_100MiB()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.FetchBufferMemoryBytes).IsEqualTo(100L * 1024 * 1024);
+    }
+
+    [Test]
     public async Task MaxPartitionFetchBytes_DefaultsTo_1MB()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerResponseBufferSizingTests.cs
@@ -9,6 +9,16 @@ namespace Dekaf.Tests.Unit.Consumer;
 public sealed class ConsumerResponseBufferSizingTests
 {
     [Test]
+    public async Task QueuedPrefetchBudget_DoesNotRaiseConfiguredLimit()
+    {
+        var configured = 64UL * 1024 * 1024;
+
+        var effective = KafkaConsumer<string, string>.CalculatePrefetchMaxBytes(configured);
+
+        await Assert.That(effective).IsEqualTo(64L * 1024 * 1024);
+    }
+
+    [Test]
     public async Task MaximumPayload_StaticSizing_IncludesOneOversizedPartitionBatch()
     {
         var options = new ConsumerOptions

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
@@ -43,6 +43,23 @@ public sealed class FetchBufferMemoryPoolTests
     }
 
     [Test]
+    public async Task ReserveSlowAsync_RechecksCapacityBeforeWaiting()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var first = await pool.ReserveAsync(100, CancellationToken.None);
+
+        await Assert.That(pool.TryReserve(1)).IsFalse();
+        first.Dispose();
+
+        using var reservation = await pool
+            .ReserveSlowAsync(1, CancellationToken.None)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Reservation_DisposeReleasesMemory()
     {
         using var pool = new FetchBufferMemoryPool(100);

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
@@ -1,0 +1,110 @@
+using Dekaf.Consumer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class FetchBufferMemoryPoolTests
+{
+    [Test]
+    public async Task TryReserve_BoundsAggregateAndAllowsOneOversizedResponse()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+
+        await Assert.That(pool.TryReserve(60)).IsTrue();
+        await Assert.That(pool.TryReserve(50)).IsFalse();
+        await Assert.That(pool.UsedBytes).IsEqualTo(60);
+        await Assert.That(pool.FreeBytes).IsEqualTo(40);
+
+        pool.Release(60);
+
+        await Assert.That(pool.TryReserve(150)).IsTrue();
+        await Assert.That(pool.TryReserve(1)).IsFalse();
+        await Assert.That(pool.UsedBytes).IsEqualTo(150);
+        await Assert.That(pool.FreeBytes).IsEqualTo(0);
+
+        pool.Release(150);
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+        await Assert.That(pool.FreeBytes).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task ReserveAsync_WaitsUntilExistingReservationReleases()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var first = await pool.ReserveAsync(70, CancellationToken.None);
+
+        var waiting = pool.ReserveAsync(40, CancellationToken.None).AsTask();
+        await Assert.That(waiting.IsCompleted).IsFalse();
+
+        first.Dispose();
+        using var second = await waiting.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(40);
+    }
+
+    [Test]
+    public async Task Reservation_DisposeReleasesMemory()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var reservation = await pool.ReserveAsync(60, CancellationToken.None);
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(60);
+
+        reservation.Dispose();
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task FailedReservation_TracksDepletionUntilMemoryIsReleased()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var first = await pool.ReserveAsync(70, CancellationToken.None);
+
+        var waiting = pool.ReserveAsync(40, CancellationToken.None).AsTask();
+        await Task.Delay(20);
+        var depletedBeforeRelease = pool.DepletedDurationSeconds;
+
+        first.Dispose();
+        using var second = await waiting.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(depletedBeforeRelease).IsGreaterThan(0);
+        await Assert.That(pool.DepletedDurationSeconds).IsGreaterThanOrEqualTo(depletedBeforeRelease);
+        await Assert.That(pool.DepletedPercent).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ReserveAsync_CancelledWaiterDoesNotLeakCapacity()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var first = await pool.ReserveAsync(100, CancellationToken.None);
+        using var cancellation = new CancellationTokenSource();
+        var waiting = pool.ReserveAsync(1, cancellation.Token).AsTask();
+
+        cancellation.Cancel();
+
+        await Assert.That(async () => await waiting).Throws<OperationCanceledException>();
+        await Assert.That(pool.UsedBytes).IsEqualTo(100);
+
+        first.Dispose();
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReserveAsync_WakesSmallerWaiterWhenFirstWaiterDoesNotFit()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        using var first = await pool.ReserveAsync(60, CancellationToken.None);
+        var released = await pool.ReserveAsync(20, CancellationToken.None);
+        using var cancellation = new CancellationTokenSource();
+        var large = pool.ReserveAsync(70, cancellation.Token).AsTask();
+        var small = pool.ReserveAsync(20, CancellationToken.None).AsTask();
+
+        released.Dispose();
+        using var smallReservation = await small.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(large.IsCompleted).IsFalse();
+
+        cancellation.Cancel();
+        await Assert.That(async () => await large).Throws<OperationCanceledException>();
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchBufferMemoryPoolTests.cs
@@ -124,4 +124,42 @@ public sealed class FetchBufferMemoryPoolTests
         cancellation.Cancel();
         await Assert.That(async () => await large).Throws<OperationCanceledException>();
     }
+
+    [Test]
+    public async Task ReserveAsync_StopsWakingWhenReleasedCapacityFitsNoWaiter()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        using var retained = await pool.ReserveAsync(80, CancellationToken.None);
+        var released = await pool.ReserveAsync(10, CancellationToken.None);
+        using var cancellation = new CancellationTokenSource();
+        var first = pool.ReserveAsync(70, cancellation.Token).AsTask();
+        var second = pool.ReserveAsync(80, cancellation.Token).AsTask();
+
+        released.Dispose();
+
+        await Assert.That(() => pool.PendingWakeCount).IsEqualTo(0)
+            .Within(5000);
+        await Assert.That(first.IsCompleted).IsFalse();
+        await Assert.That(second.IsCompleted).IsFalse();
+
+        cancellation.Cancel();
+        await Assert.That(async () => await first).Throws<OperationCanceledException>();
+        await Assert.That(async () => await second).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task Dispose_WakesAllWaitingReservations()
+    {
+        var pool = new FetchBufferMemoryPool(100);
+        using var retained = await pool.ReserveAsync(100, CancellationToken.None);
+        var first = pool.ReserveAsync(1, CancellationToken.None).AsTask();
+        var second = pool.ReserveAsync(1, CancellationToken.None).AsTask();
+
+        pool.Dispose();
+
+        await Assert.That(async () => await first.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<ObjectDisposedException>();
+        await Assert.That(async () => await second.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<ObjectDisposedException>();
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -48,6 +48,10 @@ public sealed class DekafMetricInstrumentTests
         await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");
         await Assert.That(instrumentNames).Contains("messaging.consumer.fetch.duration");
         await Assert.That(instrumentNames).Contains("messaging.consumer.lag");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.used_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.free_bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.depleted_percent");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.depleted_duration");
 
         // Producer internal-state gauges (observable — published by listening alone)
         await Assert.That(instrumentNames).Contains("dekaf.producer.buffer.used_bytes");

--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -1,11 +1,72 @@
 using System.Collections.Concurrent;
 using System.Threading.Tasks.Sources;
+using Dekaf.Consumer;
 using Dekaf.Networking;
 
 namespace Dekaf.Tests.Unit.Networking;
 
 public class PooledPendingRequestTests
 {
+    [Test]
+    public async Task TryGetResponseMemoryPool_RejectsCancelledVersion()
+    {
+        using var memoryPool = new FetchBufferMemoryPool(100);
+        var pool = new PendingRequestPool();
+        var request = pool.Rent();
+        request.Initialize(
+            responseHeaderVersion: 0,
+            CancellationToken.None,
+            responseMemoryPool: memoryPool);
+        var version = request.Version;
+
+        await Assert.That(request.TryGetResponseMemoryPool(version, out var admittedPool)).IsTrue();
+        await Assert.That(admittedPool).IsSameReferenceAs(memoryPool);
+
+        request.TrySetCanceled();
+
+        await Assert.That(request.TryGetResponseMemoryPool(version, out _)).IsFalse();
+        pool.Return(request);
+    }
+
+    [Test]
+    public async Task PoolReturn_ReleasesUntakenResponseMemoryReservation()
+    {
+        using var memoryPool = new FetchBufferMemoryPool(100);
+        var reservation = await memoryPool.ReserveAsync(40, CancellationToken.None);
+        var pool = new PendingRequestPool();
+        var request = pool.Rent();
+        request.Initialize(responseHeaderVersion: 0, CancellationToken.None);
+        var buffer = new PooledResponseBuffer(
+            [0, 0, 0, 1, 10],
+            length: 5,
+            isPooled: false);
+
+        await Assert.That(request.TryComplete(request.Version, buffer, reservation)).IsTrue();
+        _ = await request.AsValueTask();
+        await Assert.That(memoryPool.UsedBytes).IsEqualTo(40);
+
+        pool.Return(request);
+
+        await Assert.That(memoryPool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryComplete_ParseFailureReleasesResponseMemoryReservation()
+    {
+        using var memoryPool = new FetchBufferMemoryPool(100);
+        var reservation = await memoryPool.ReserveAsync(40, CancellationToken.None);
+        var pool = new PendingRequestPool();
+        var request = pool.Rent();
+        request.Initialize(responseHeaderVersion: 0, CancellationToken.None);
+        var invalidBuffer = new PooledResponseBuffer([0], length: 1, isPooled: false);
+
+        await Assert.That(request.TryComplete(request.Version, invalidBuffer, reservation)).IsTrue();
+        await Assert.That(async () => await request.AsValueTask()).Throws<Exception>();
+        await Assert.That(memoryPool.UsedBytes).IsEqualTo(0);
+
+        pool.Return(request);
+    }
+
     [Test]
     public async Task PoolReturn_ResetsCheckCrcs()
     {

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -74,6 +74,25 @@ public sealed class ResponseFrameReaderTests
     }
 
     [Test]
+    public async Task ReadBoundedFrameAsync_AbortCancelsMemoryAdmissionWait()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        using var existing = await pool.ReserveAsync(100, CancellationToken.None);
+        var frame = BuildFrame(correlationId: 1, payloadSize: 60);
+        using var stream = new ScriptedReadStream([frame]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream);
+
+        var read = reader.ReadBoundedFrameAsync(
+            _ => new ResponseFrameAdmission(pool, Discard: false)).AsTask();
+        await Assert.That(read.IsCompleted).IsFalse();
+
+        reader.Abort();
+
+        await Assert.That(async () => await read).Throws<OperationCanceledException>();
+        await Assert.That(pool.UsedBytes).IsEqualTo(100);
+    }
+
+    [Test]
     public async Task ReadFrameAsync_OversizedFetchProgressesOnlyAsSoleReservation()
     {
         using var pool = new FetchBufferMemoryPool(100);

--- a/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ResponseFrameReaderTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.Versioning;
+using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Networking;
 
@@ -43,6 +44,88 @@ public sealed class ResponseFrameReaderTests
             await Assert.That(result.CorrelationId).IsEqualTo(expectedId);
             await AssertPayloadAsync(result, expectedSize);
         }
+    }
+
+    [Test]
+    public async Task ReadFrameAsync_FetchAdmissionsBoundExactAggregateFrameMemory()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var chunk = Concat(
+            BuildFrame(correlationId: 1, payloadSize: 60),
+            BuildFrame(correlationId: 2, payloadSize: 50));
+        using var stream = new ScriptedReadStream([chunk]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream);
+        ResponseFrameAdmission GetAdmission(int _) => new(pool, Discard: false);
+
+        var first = await reader.ReadBoundedFrameAsync(GetAdmission);
+        await Assert.That(pool.UsedBytes).IsEqualTo(60);
+
+        var secondRead = reader.ReadBoundedFrameAsync(GetAdmission).AsTask();
+        await Assert.That(secondRead.IsCompleted).IsFalse();
+
+        first.Buffer.Dispose();
+        first.Reservation?.Dispose();
+        var second = await secondRead.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(pool.UsedBytes).IsEqualTo(50);
+
+        second.Buffer.Dispose();
+        second.Reservation?.Dispose();
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReadFrameAsync_OversizedFetchProgressesOnlyAsSoleReservation()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var frame = BuildFrame(correlationId: 1, payloadSize: 150);
+        using var stream = new ScriptedReadStream([frame]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream);
+
+        var result = await reader.ReadBoundedFrameAsync(
+            _ => new ResponseFrameAdmission(pool, Discard: false));
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(150);
+        result.Buffer.Dispose();
+        result.Reservation?.Dispose();
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReadFrameAsync_TransferredFetchBufferHoldsReservationUntilOwnerDisposal()
+    {
+        using var pool = new FetchBufferMemoryPool(100);
+        var frame = BuildFrame(correlationId: 1, payloadSize: 60);
+        using var stream = new ScriptedReadStream([frame]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream);
+
+        var result = await reader.ReadBoundedFrameAsync(
+            _ => new ResponseFrameAdmission(pool, Discard: false));
+        var owner = result.Buffer.TransferOwnership(result.Reservation);
+
+        await Assert.That(pool.UsedBytes).IsEqualTo(60);
+        owner.Dispose();
+        await Assert.That(pool.UsedBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReadFrameAsync_DiscardedFrameUsesNoResponseBufferAndPreservesNextFrame()
+    {
+        var chunk = Concat(
+            BuildFrame(correlationId: 1, payloadSize: 100),
+            BuildFrame(correlationId: 2, payloadSize: 20));
+        using var stream = new ScriptedReadStream([chunk]);
+        using var reader = ResponseFrameTestHelpers.CreateReader(stream);
+        ResponseFrameAdmission GetAdmission(int correlationId) => correlationId == 1
+                ? ResponseFrameAdmission.Discarded
+                : ResponseFrameAdmission.Unrestricted;
+
+        var discarded = await reader.ReadBoundedFrameAsync(GetAdmission);
+        var next = await reader.ReadBoundedFrameAsync(GetAdmission);
+
+        await Assert.That(discarded.IsDiscarded).IsTrue();
+        await Assert.That(discarded.CorrelationId).IsEqualTo(1);
+        await Assert.That(next.CorrelationId).IsEqualTo(2);
+        await AssertPayloadAsync(next, payloadSize: 20);
     }
 
     [Test]
@@ -311,7 +394,18 @@ public sealed class ResponseFrameReaderTests
 
     private static async Task AssertPayloadAsync(ResponseFrame result, int payloadSize)
     {
-        var payload = result.Buffer.Data;
+        await AssertPayloadAsync(result.Buffer, payloadSize);
+    }
+
+    private static async Task AssertPayloadAsync(BoundedResponseFrame result, int payloadSize)
+    {
+        await AssertPayloadAsync(result.Buffer, payloadSize);
+        result.Reservation?.Dispose();
+    }
+
+    private static async Task AssertPayloadAsync(PooledResponseBuffer buffer, int payloadSize)
+    {
+        var payload = buffer.Data;
         await Assert.That(payload.Length).IsEqualTo(payloadSize);
 
         // Skip the correlation id; the remaining bytes carry BuildFrame's pattern
@@ -325,7 +419,7 @@ public sealed class ResponseFrameReaderTests
                     $"Payload mismatch at offset {i}: expected {expected}, actual {actual}");
         }
 
-        result.Buffer.Dispose();
+        buffer.Dispose();
     }
 
     private static byte[] Concat(params byte[][] chunks)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchBufferMemoryPoolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/FetchBufferMemoryPoolBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class FetchBufferMemoryPoolBenchmarks
+{
+    private FetchBufferMemoryPool _pool = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pool = new FetchBufferMemoryPool(100 * 1024 * 1024);
+
+        // Seed the pooled reservation owner before measurement.
+        var reservation = _pool.ReserveAsync(1024, CancellationToken.None).Result;
+        reservation.Dispose();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _pool.Dispose();
+
+    [Benchmark]
+    public long ReserveAndRelease()
+    {
+        var reservation = _pool.ReserveAsync(1024, CancellationToken.None);
+        if (!reservation.IsCompletedSuccessfully)
+            throw new InvalidOperationException("Uncontended reservation did not complete synchronously");
+
+        reservation.Result.Dispose();
+        return _pool.UsedBytes;
+    }
+}


### PR DESCRIPTION
## Summary

- add `WithFetchBufferMemory` / `FetchBufferMemoryBytes` with a 100 MiB default and `FetchBufferMemoryBytes >= FetchMaxBytes` validation
- reserve exact raw Fetch frame bytes before response-buffer rent across brokers and pipelined requests
- admit one sole oversized response for Kafka forward progress while excluding coordinator traffic from the budget
- release reservations through parse, cancellation, timeout, reset, failure, and pooled-memory ownership paths
- stop silently increasing the configured queued-record budget
- expose used/free/depleted-percent/depleted-duration consumer telemetry

## Performance

MediumRun, same machine/runtime, base `39dc37c8` vs candidate `4358ae3c` (rebased as `0e662203`):

| Existing unbounded framing path | Base | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| 10,000 × 100 B frames | 501.0 us | 498.7 us | -0.5% | 144 B → 144 B |
| 64 × 1 MiB frames | 3,592.5 us | 3,677.7 us | +2.4% | 2,193 B → 2,193 B |

The large-frame distributions have overlapping 99.9% confidence intervals; the candidate run was flagged multimodal. The existing unbounded reader implementation remains separate and unchanged. New steady-state `FetchBufferMemoryPool.ReserveAndRelease`: 63.57 ns, 0 B allocated.

## Validation

- `dotnet build --configuration Release --no-restore` — 0 warnings, 0 errors
- unit suite — 5,685 passed after rebase
- integration: `FetchMaxBytes_BelowFirstRecord_Kip74StillProgresses` and `FetchBufferMemory_BoundsPipelinedResponsesAndRecordsDepletion` — 2 passed
- concurrent integration initially exposed a canceled pooled-request version race; admission now validates the captured request version, and the concurrent shape passes
- `git diff --check`
- `/simplify` hot-path/allocation review

Fixes #2257
