### PR TITLE
test(integration): bound shared fixture load

### DIFF
--- a/tests/Dekaf.Tests.Integration/KafkaFixtureConcurrencyGateTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaFixtureConcurrencyGateTests.cs
@@ -1,0 +1,46 @@
+namespace Dekaf.Tests.Integration;
+
+[Category("Infrastructure")]
+public sealed class KafkaFixtureConcurrencyGateTests
+{
+    [Test]
+    public async Task Gate_IsBoundedAndScopedPerKafkaFixture()
+    {
+        await using var firstFixture = new StubKafkaTestContainer("first");
+        await using var secondFixture = new StubKafkaTestContainer("second");
+
+        var firstGate = KafkaFixtureConcurrencyGate.Get(firstFixture);
+        var sameFixtureGate = KafkaFixtureConcurrencyGate.Get(firstFixture);
+        var secondFixtureGate = KafkaFixtureConcurrencyGate.Get(secondFixture);
+
+        await Assert.That(firstGate.CurrentCount)
+            .IsEqualTo(KafkaFixtureConcurrencyGate.MaximumConcurrencyPerFixture);
+        await Assert.That(ReferenceEquals(firstGate, sameFixtureGate)).IsTrue();
+        await Assert.That(ReferenceEquals(firstGate, secondFixtureGate)).IsFalse();
+    }
+
+    [Test]
+    public async Task Gate_BlocksAfterMaximumConcurrencyUntilPermitReleases()
+    {
+        await using var fixture = new StubKafkaTestContainer("bounded");
+        var gate = KafkaFixtureConcurrencyGate.Get(fixture);
+
+        for (var i = 0; i < KafkaFixtureConcurrencyGate.MaximumConcurrencyPerFixture; i++)
+            await gate.WaitAsync();
+
+        var waiting = gate.WaitAsync();
+        await Assert.That(waiting.IsCompleted).IsFalse();
+
+        gate.Release();
+        await waiting.WaitAsync(TimeSpan.FromSeconds(1));
+
+        for (var i = 0; i < KafkaFixtureConcurrencyGate.MaximumConcurrencyPerFixture; i++)
+            gate.Release();
+    }
+
+    private sealed class StubKafkaTestContainer(string name) : KafkaTestContainer
+    {
+        public override string ContainerName => name;
+        public override int Version => 0;
+    }
+}

--- a/tests/Dekaf.Tests.Integration/KafkaFixtureConcurrencyGateTests.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaFixtureConcurrencyGateTests.cs
@@ -1,6 +1,6 @@
 namespace Dekaf.Tests.Integration;
 
-[Category("Infrastructure")]
+[Category("Retry")]
 public sealed class KafkaFixtureConcurrencyGateTests
 {
     [Test]

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -1,6 +1,21 @@
+using System.Runtime.CompilerServices;
 using Dekaf.Consumer;
 
 namespace Dekaf.Tests.Integration;
+
+internal static class KafkaFixtureConcurrencyGate
+{
+    // Four coordinator-heavy tests per fixture is the proven-safe bound from #1638.
+    // Apply it to all shared-fixture traffic so unrelated clients cannot consume the
+    // broker capacity that transaction, group, and share coordinators need for progress.
+    internal const int MaximumConcurrencyPerFixture = 4;
+
+    private static readonly ConditionalWeakTable<KafkaTestContainer, SemaphoreSlim> Gates = new();
+
+    internal static SemaphoreSlim Get(KafkaTestContainer kafka) =>
+        Gates.GetValue(kafka, static _ =>
+            new SemaphoreSlim(MaximumConcurrencyPerFixture, MaximumConcurrencyPerFixture));
+}
 
 /// <summary>
 /// Base class for integration tests that require a Kafka container.
@@ -13,7 +28,28 @@ namespace Dekaf.Tests.Integration;
 [ClassDataSource<KafkaContainerDefault>(Shared = SharedType.PerTestSession)]
 public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer)
 {
+    private readonly SemaphoreSlim _fixtureConcurrencyGate =
+        KafkaFixtureConcurrencyGate.Get(kafkaTestContainer);
+    private bool _fixtureGateEntered;
+
     public KafkaTestContainer KafkaContainer { get; } = kafkaTestContainer;
+
+    [Before(Test)]
+    public async Task EnterKafkaFixtureConcurrencyGate(CancellationToken cancellationToken)
+    {
+        await _fixtureConcurrencyGate.WaitAsync(cancellationToken);
+        _fixtureGateEntered = true;
+    }
+
+    [After(Test)]
+    public void ExitKafkaFixtureConcurrencyGate()
+    {
+        if (!_fixtureGateEntered)
+            return;
+
+        _fixtureGateEntered = false;
+        _fixtureConcurrencyGate.Release();
+    }
 
     /// <summary>
     /// Polls until a condition is true, replacing fixed <c>Task.Delay</c> waits.


### PR DESCRIPTION
## Summary

- add a fixture-scoped concurrency gate for every integration test using the shared Kafka fixture
- cap shared-fixture traffic at 4, matching the coordinator-safe limit established by #1638 / #1666
- keep independent Kafka fixtures concurrent and preserve the existing transaction-specific gate
- add deterministic gate scope/capacity tests; no sleeps or timeout increases

## Validation

- `dotnet build tests/Dekaf.Tests.Integration --configuration Release --no-restore` — passed, 0 warnings
- fixture gate tests — 2/2 passed
- original issue reproductions — 3/3 passed:
  - `FenceProducersAsync_FencesActiveTransactionalProducer`
  - `AbortTransactionAsync_WritesAbortMarkerForOpenTransaction`
  - `DescribeShareGroups_ReturnsGroupInfo`
- cap 8 full net10 suite — 819/820; all three original failures passed; distinct `StaleMemberEpoch` failure tracked in #2278
- cap 4 full net10 suite — 819/820; all three original failures passed; distinct Confluent interop timeout tracked in #2279
- no failed full-suite run was rerun unchanged
- `/simplify` review completed
- `git diff --check origin/main...HEAD` — clean

Test-only change; no `src/` hot path or benchmark impact.

Closes #2267
