### PR TITLE
Implement KIP-580 exponential request backoff

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -910,6 +910,8 @@ internal static class DekafOptionsBinding
         builder.WithHeartbeatInterval(TimeSpan.FromMilliseconds(options.HeartbeatIntervalMs));
         builder.WithRebalanceTimeout(TimeSpan.FromMilliseconds(options.RebalanceTimeoutMs));
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
+        builder.WithRetryBackoff(TimeSpan.FromMilliseconds(options.RetryBackoffMs));
+        builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(options.RetryBackoffMaxMs));
         if (options.IsReconnectBackoffMsConfigured)
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         if (options.IsReconnectBackoffMaxMsConfigured)
@@ -973,6 +975,8 @@ internal static class DekafOptionsBinding
         if (options.ClientId is not null)
             builder.WithClientId(options.ClientId);
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
+        builder.WithRetryBackoff(TimeSpan.FromMilliseconds(options.RetryBackoffMs));
+        builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(options.RetryBackoffMaxMs));
         if (options.IsReconnectBackoffMsConfigured)
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(options.ReconnectBackoffMs));
         if (options.IsReconnectBackoffMaxMsConfigured)
@@ -1295,6 +1299,10 @@ internal static class DekafConfigurationBinding
             builder.WithIsolationLevel(isolationLevel);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RetryBackoffMs), out var retryBackoffMs))
+            builder.WithRetryBackoff(TimeSpan.FromMilliseconds(retryBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RetryBackoffMaxMs), out var retryBackoffMaxMs))
+            builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(retryBackoffMaxMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ReconnectBackoffMs), out var reconnectBackoffMs))
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))
@@ -1346,6 +1354,10 @@ internal static class DekafConfigurationBinding
             builder.WithClientId(clientId);
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.RetryBackoffMs), out var retryBackoffMs))
+            builder.WithRetryBackoff(TimeSpan.FromMilliseconds(retryBackoffMs));
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.RetryBackoffMaxMs), out var retryBackoffMaxMs))
+            builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(retryBackoffMaxMs));
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMs), out var reconnectBackoffMs))
             builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
         if (TryGetValue<int>(configuration, nameof(AdminClientOptions.ReconnectBackoffMaxMs), out var reconnectBackoffMaxMs))

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -35,6 +35,7 @@ public sealed class AdminClient : IAdminClient
 
     public AdminClient(AdminClientOptions options, ILoggerFactory? loggerFactory = null, MetadataOptions? metadataOptions = null)
     {
+        ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         var reconnectBackoffMaxMs = ReconnectBackoffValidation.ResolveMaximumMilliseconds(
             options.ReconnectBackoffMs,
             options.ReconnectBackoffMaxMs,
@@ -75,6 +76,11 @@ public sealed class AdminClient : IAdminClient
             },
             loggerFactory);
 
+        metadataOptions ??= new MetadataOptions
+        {
+            RetryBackoffMs = options.RetryBackoffMs,
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs
+        };
         _metadataManager = new MetadataManager(
             _connectionPool,
             options.BootstrapServers,
@@ -96,6 +102,7 @@ public sealed class AdminClient : IAdminClient
         ILoggerFactory? loggerFactory = null,
         bool ownsResources = false)
     {
+        ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         _options = options;
         _logger = loggerFactory?.CreateLogger<AdminClient>();
         _connectionPool = connectionPool;
@@ -306,11 +313,18 @@ public sealed class AdminClient : IAdminClient
             if (allReady)
                 return;
 
-            await Task.Delay(RetryHelper.RetryDelayMs, cancellationToken).ConfigureAwait(false);
+            if (attempt + 1 < leaderWaitRetries)
+            {
+                var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    attempt + 1);
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         throw new KafkaException(Protocol.ErrorCode.LeaderNotAvailable,
-            $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {leaderWaitRetries * RetryHelper.RetryDelayMs}ms");
+            $"Topic(s) {string.Join(", ", topicNames)} did not have all partition leaders elected after {leaderWaitRetries} attempts");
     }
 
     private async ValueTask<bool> TopicHasAtLeastPartitionCountAsync(
@@ -4337,10 +4351,20 @@ public sealed class AdminClient : IAdminClient
     }
 
     private ValueTask WithRetryAsync(Func<ValueTask> operation, CancellationToken cancellationToken)
-        => RetryHelper.WithRetryAsync(operation, _metadataManager, cancellationToken);
+        => RetryHelper.WithRetryAsync(
+            operation,
+            _metadataManager,
+            cancellationToken,
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs);
 
     private ValueTask<T> WithRetryAsync<T>(Func<ValueTask<T>> operation, CancellationToken cancellationToken)
-        => RetryHelper.WithRetryAsync(operation, _metadataManager, cancellationToken);
+        => RetryHelper.WithRetryAsync(
+            operation,
+            _metadataManager,
+            cancellationToken,
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs);
 
     private static WriteTxnMarkersResponsePartition FindAbortTransactionPartition(
         WriteTxnMarkersResponse response,
@@ -4604,6 +4628,18 @@ public sealed class AdminClientOptions
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; } = "dekaf-admin";
     public int RequestTimeoutMs { get; init; } = 30000;
+
+    /// <summary>
+    /// Initial delay in milliseconds for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public int RetryBackoffMs { get; init; } = 100;
+
+    /// <summary>
+    /// Maximum delay in milliseconds for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public int RetryBackoffMaxMs { get; init; } = 1000;
     public int ReconnectBackoffMs
     {
         get => _reconnectBackoffMs;
@@ -4736,6 +4772,8 @@ public sealed class AdminClientBuilder
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private int _requestTimeoutMs = 30000;
+    private int _retryBackoffMs = 100;
+    private int _retryBackoffMaxMs = 1000;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -4773,6 +4811,8 @@ public sealed class AdminClientBuilder
         _clientInfrastructure = clientInfrastructure;
         _bootstrapServers = clientInfrastructure.BootstrapServers;
         _loggerFactory = clientInfrastructure.LoggerFactory;
+        _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
+        _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
     }
 
     public AdminClientBuilder WithBootstrapServers(string servers)
@@ -5121,6 +5161,34 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Sets the initial delay for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public AdminClientBuilder WithRetryBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public AdminClientBuilder WithRetryBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the initial delay before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to zero to disable the delay.
     /// When the maximum is not configured, it uses this value and disables exponential growth.
@@ -5251,6 +5319,7 @@ public sealed class AdminClientBuilder
             _reconnectBackoffMaxMs,
             _reconnectBackoffConfigured,
             _reconnectBackoffMaxConfigured);
+        ExponentialRetryBackoff.Validate(_retryBackoffMs, _retryBackoffMaxMs);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -5259,6 +5328,8 @@ public sealed class AdminClientBuilder
             BootstrapServers = _bootstrapServers,
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
@@ -5289,7 +5360,9 @@ public sealed class AdminClientBuilder
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
-            ClientDnsLookup = _clientDnsLookup
+            ClientDnsLookup = _clientDnsLookup,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs
         };
 
         return _clientInfrastructure is null

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -108,6 +108,8 @@ public sealed class ProducerBuilder<TKey, TValue>
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
         _maxConnectionsPerBroker = clientInfrastructure.ProducerMaxConnectionsPerBroker;
         _isMaxConnectionsPerBrokerConfigured = true;
+        _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
+        _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -1065,8 +1067,13 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
-    internal ProducerBuilder<TKey, TValue> WithRetryBackoff(TimeSpan backoff)
+    /// <summary>
+    /// Sets the initial delay for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithRetryBackoff(TimeSpan backoff)
     {
+        ThrowIfClientOwnedConnectionSettings();
         if (backoff < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
         ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
@@ -1075,8 +1082,13 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
-    internal ProducerBuilder<TKey, TValue> WithRetryBackoffMax(TimeSpan backoff)
+    /// <summary>
+    /// Sets the maximum delay for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithRetryBackoffMax(TimeSpan backoff)
     {
+        ThrowIfClientOwnedConnectionSettings();
         if (backoff < TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
         ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
@@ -1218,6 +1230,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             _reconnectBackoffMaxMs,
             _reconnectBackoffConfigured,
             _reconnectBackoffMaxConfigured);
+        ExponentialRetryBackoff.Validate(_retryBackoffMs, _retryBackoffMaxMs);
 
         ProducerOptions.ValidateArenaCapacity(_batchSize, _arenaCapacity);
 
@@ -1331,6 +1344,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
             DnsResolver = _dnsResolver,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             // Java parity: initial metadata blocks up to max.block.ms, retrying throughout.
             InitTimeoutMs = options.MaxBlockMs
         };
@@ -1450,6 +1465,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int? _heartbeatIntervalMs;
     private int _rebalanceTimeoutMs = 60000;
     private int _requestTimeoutMs = 30000;
+    private int _retryBackoffMs = 100;
+    private int _retryBackoffMaxMs = 1000;
     private bool _checkCrcs = true;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
@@ -1515,6 +1532,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
         _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
+        _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
+        _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
     }
 
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -2370,6 +2389,34 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Sets the initial delay for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithRetryBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithRetryBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum delay before reconnecting to a broker after repeated connection failures.
     /// Equivalent to Kafka's <c>reconnect.backoff.max.ms</c>.
     /// </summary>
@@ -2753,6 +2800,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             _reconnectBackoffMaxMs,
             _reconnectBackoffConfigured,
             _reconnectBackoffMaxConfigured);
+        ExponentialRetryBackoff.Validate(_retryBackoffMs, _retryBackoffMaxMs);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -2784,6 +2832,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
             HeartbeatIntervalMs = _heartbeatIntervalMs ?? 3000,
             RebalanceTimeoutMs = _rebalanceTimeoutMs,
             RequestTimeoutMs = _requestTimeoutMs,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
@@ -2834,7 +2884,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
-            DnsResolver = _dnsResolver
+            DnsResolver = _dnsResolver,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs
         };
 
         var consumer = _clientInfrastructure is null
@@ -2927,6 +2979,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private int _sessionTimeoutMs = 45000;
     private int _heartbeatIntervalMs = 3000;
     private int _requestTimeoutMs = 30000;
+    private int _retryBackoffMs = 100;
+    private int _retryBackoffMaxMs = 1000;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -2968,6 +3022,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _bootstrapServers = clientInfrastructure.BootstrapServers;
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
+        _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
+        _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -3085,6 +3141,34 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             nameof(backoff),
             "Reconnect backoff cannot be negative");
         _reconnectBackoffConfigured = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the initial delay for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithRetryBackoff(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithRetryBackoffMax(TimeSpan backoff)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
         return this;
     }
 
@@ -3441,6 +3525,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             _reconnectBackoffMaxMs,
             _reconnectBackoffConfigured,
             _reconnectBackoffMaxConfigured);
+        ExponentialRetryBackoff.Validate(_retryBackoffMs, _retryBackoffMaxMs);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -3463,6 +3548,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             SessionTimeoutMs = _sessionTimeoutMs,
             HeartbeatIntervalMs = _heartbeatIntervalMs,
             RequestTimeoutMs = _requestTimeoutMs,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -801,7 +801,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         }
                     }
                 }
-            }, _metadataManager, cancellationToken, onRetry: FindCoordinatorAsync).ConfigureAwait(false);
+            }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs,
+                onRetry: FindCoordinatorAsync).ConfigureAwait(false);
         }
         finally
         {
@@ -1002,6 +1003,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 },
                 _metadataManager,
                 operationToken,
+                _options.RetryBackoffMs,
+                _options.RetryBackoffMaxMs,
                 onRetry: RecoverOffsetFetchAsync,
                 shouldRefreshMetadata: ShouldRefreshMetadataForOffsetFetchRetry).ConfigureAwait(false);
             }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -520,7 +520,6 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         // Retry loop for transient errors (CoordinatorNotAvailable, CoordinatorLoadInProgress)
         const int maxRetries = 5;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -562,10 +561,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             if (errorCode == ErrorCode.CoordinatorNotAvailable ||
                 errorCode == ErrorCode.CoordinatorLoadInProgress)
             {
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 1000); // Exponential backoff, max 1s
                 continue;
             }
 
@@ -590,6 +589,12 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             GroupId = _options.GroupId
         };
     }
+
+    private int CalculateRequestRetryBackoff(int failureCount) =>
+        ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs,
+            failureCount);
 
     /// <summary>
     /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
@@ -1609,7 +1614,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             LogEnsureActiveGroupStarted(_options.GroupId!, _state);
             var startedAt = Stopwatch.GetTimestamp();
             var rebalanceTimeout = TimeSpan.FromMilliseconds(_options.RebalanceTimeoutMs);
-            var retryDelayMs = 200;
+            var retryFailureCount = 0;
 
             while (_state != CoordinatorState.Stable)
             {
@@ -1660,8 +1665,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     // Static member's previous session not yet released — retry with backoff
                     // until the rebalance timeout fires (checked at top of loop)
                     LogRetriableCoordinatorError(ex.ErrorCode);
+                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
                 catch (Errors.GroupException ex) when (ex.ErrorCode == ErrorCode.UnknownMemberId)
                 {
@@ -1673,8 +1678,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 {
                     LogRetriableCoordinatorError(ex.ErrorCode);
                     MarkCoordinatorUnknown();
+                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
@@ -1684,8 +1689,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();
+                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
             }
         }

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -561,6 +561,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             if (errorCode == ErrorCode.CoordinatorNotAvailable ||
                 errorCode == ErrorCode.CoordinatorLoadInProgress)
             {
+                if (attempt == maxRetries - 1)
+                    break;
+
                 var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
 
@@ -595,6 +598,29 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _options.RetryBackoffMs,
             _options.RetryBackoffMaxMs,
             failureCount);
+
+    internal static TimeSpan GetJoinRetryDelay(
+        int retryDelayMs,
+        TimeSpan elapsed,
+        TimeSpan rebalanceTimeout)
+    {
+        var remaining = rebalanceTimeout - elapsed;
+        return remaining <= TimeSpan.Zero
+            ? TimeSpan.Zero
+            : TimeSpan.FromMilliseconds(Math.Min(retryDelayMs, remaining.TotalMilliseconds));
+    }
+
+    private Task DelayForJoinRetryAsync(
+        int failureCount,
+        long startedAt,
+        TimeSpan rebalanceTimeout,
+        CancellationToken cancellationToken) =>
+        Task.Delay(
+            GetJoinRetryDelay(
+                CalculateRequestRetryBackoff(failureCount),
+                Stopwatch.GetElapsedTime(startedAt),
+                rebalanceTimeout),
+            cancellationToken);
 
     /// <summary>
     /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
@@ -1618,7 +1644,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
             while (_state != CoordinatorState.Stable)
             {
-                if (Stopwatch.GetElapsedTime(startedAt) > rebalanceTimeout)
+                if (Stopwatch.GetElapsedTime(startedAt) >= rebalanceTimeout)
                 {
                     throw new KafkaTimeoutException(
                         TimeoutKind.Rebalance,
@@ -1665,8 +1691,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     // Static member's previous session not yet released — retry with backoff
                     // until the rebalance timeout fires (checked at top of loop)
                     LogRetriableCoordinatorError(ex.ErrorCode);
-                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayForJoinRetryAsync(
+                        ++retryFailureCount, startedAt, rebalanceTimeout, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Errors.GroupException ex) when (ex.ErrorCode == ErrorCode.UnknownMemberId)
                 {
@@ -1678,8 +1704,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 {
                     LogRetriableCoordinatorError(ex.ErrorCode);
                     MarkCoordinatorUnknown();
-                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayForJoinRetryAsync(
+                        ++retryFailureCount, startedAt, rebalanceTimeout, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
@@ -1689,8 +1715,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();
-                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayForJoinRetryAsync(
+                        ++retryFailureCount, startedAt, rebalanceTimeout, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -206,6 +206,18 @@ public sealed class ConsumerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Initial delay in milliseconds for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public int RetryBackoffMs { get; init; } = 100;
+
+    /// <summary>
+    /// Maximum delay in milliseconds for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public int RetryBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
     /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
     /// When set without <see cref="ReconnectBackoffMaxMs"/>, the maximum uses this value.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -812,8 +812,6 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private const int MaxConsecutivePrefetchErrors = 50;
     private const int MaxConsecutiveEmptyParsedFetches = 3;
     private const int MaxRepeatedDeterministicPrefetchFailures = 3;
-    private const int InitialPrefetchFailureBackoffMs = 100;
-    private const int MaxPrefetchFailureBackoffMs = 5_000;
     private const long FilterRefreshIntervalMilliseconds = 30_000;
     private static readonly TimeSpan PartitionStopListenerTimeout = TimeSpan.FromSeconds(5);
 
@@ -964,10 +962,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<(int BrokerId, int ConnectionIndex), FetchPartitionOrderState>
         _fetchPartitionOrderStates = new();
     private readonly StuckFetchPositionTracker _stuckFetchPositionTracker = new(MaxConsecutiveEmptyParsedFetches);
-    private readonly PrefetchFailureTracker _prefetchFailureTracker = new(
-        MaxRepeatedDeterministicPrefetchFailures,
-        InitialPrefetchFailureBackoffMs,
-        MaxPrefetchFailureBackoffMs);
+    private readonly PrefetchFailureTracker _prefetchFailureTracker;
 
     // Lock ordering (always acquire in this order to prevent deadlocks):
     //   1. _initLock          — guards one-time initialization; never held while acquiring other locks
@@ -1174,6 +1169,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             telemetryMetricCollector: telemetryMetricCollector,
             responseMemoryAdmissionsEnabled: true);
 
+        metadataOptions ??= new MetadataOptions
+        {
+            RetryBackoffMs = options.RetryBackoffMs,
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs
+        };
         var metadataManager = new MetadataManager(
             connectionPool,
             options.BootstrapServers,
@@ -1264,6 +1264,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _fetchBufferMemoryPool,
             options.ClientId,
             options.GroupId);
+        ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
+        _prefetchFailureTracker = new PrefetchFailureTracker(
+            MaxRepeatedDeterministicPrefetchFailures,
+            options.RetryBackoffMs,
+            options.RetryBackoffMaxMs);
         _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
         _keyDeserializer = keyDeserializer;
         _valueDeserializer = valueDeserializer;
@@ -5300,7 +5305,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _watermarks[topicPartition] = watermarks;
 
             return watermarks;
-        }, _metadataManager, cancellationToken).ConfigureAwait(false);
+        }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -5830,7 +5836,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             return partitionResponse.Offset;
-        }, _metadataManager, cancellationToken);
+        }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs);
     }
 
     internal static KafkaException CreateOffsetResolutionUnavailableException(TopicPartition partition) =>
@@ -7576,7 +7582,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// been yielded but not yet processed (or prefetched but not yet yielded) can never be
     /// committed by this loop. Commits are skipped unless the coordinator is Stable, which
     /// prevents committing with a stale generation mid-rebalance. On failure it retries
-    /// once after 200ms, then waits for the next interval.
+    /// once after the configured request backoff, then waits for the next interval.
     /// </summary>
     private async Task AutoCommitLoopAsync(CancellationToken cancellationToken)
     {
@@ -7613,7 +7619,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             LogAutoCommitFailed(ex);
             try
             {
-                await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+                var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    failureCount: 1);
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
                 await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
             }
             catch { /* Best effort — will retry on next interval */ }
@@ -7727,7 +7737,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     LogCommitOffsetsDuringCloseFailed(ex, attempt + 1);
                     if (attempt < 2)
-                        await Task.Delay(200, cancellationToken).ConfigureAwait(false);
+                    {
+                        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                            _options.RetryBackoffMs,
+                            _options.RetryBackoffMaxMs,
+                            attempt + 1);
+                        await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+                    }
                 }
             }
         }
@@ -7858,7 +7874,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             return results;
-        }, _metadataManager, cancellationToken).ConfigureAwait(false);
+        }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
+            .ConfigureAwait(false);
     }
 
     private async ValueTask<Dictionary<TopicPartition, long>> GetOffsetsForTimesFromBrokerAsync(

--- a/src/Dekaf/Consumer/PrefetchFailureTracker.cs
+++ b/src/Dekaf/Consumer/PrefetchFailureTracker.cs
@@ -1,5 +1,7 @@
 namespace Dekaf.Consumer;
 
+using Dekaf.Retry;
+
 internal readonly record struct PrefetchFailureKey(int BrokerId, int ConnectionIndex);
 
 internal readonly record struct PrefetchPosition(TopicPartition Partition, long Offset);
@@ -13,16 +15,21 @@ internal sealed class PrefetchFailureTracker
     private readonly int _terminalThreshold;
     private readonly int _initialDelayMs;
     private readonly int _maxDelayMs;
+    private readonly Func<double>? _randomDouble;
 
-    public PrefetchFailureTracker(int terminalThreshold, int initialDelayMs, int maxDelayMs)
+    public PrefetchFailureTracker(
+        int terminalThreshold,
+        int initialDelayMs,
+        int maxDelayMs,
+        Func<double>? randomDouble = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(terminalThreshold, 1);
-        ArgumentOutOfRangeException.ThrowIfLessThan(initialDelayMs, 1);
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxDelayMs, initialDelayMs);
+        ExponentialRetryBackoff.Validate(initialDelayMs, maxDelayMs);
 
         _terminalThreshold = terminalThreshold;
         _initialDelayMs = initialDelayMs;
         _maxDelayMs = maxDelayMs;
+        _randomDouble = randomDouble;
     }
 
     public PrefetchFailureDecision Observe(
@@ -49,8 +56,13 @@ internal sealed class PrefetchFailureTracker
 
             _failures[key] = new FailureState(deterministic, storedPositions, count);
 
-            var shift = Math.Min(count - 1, 30);
-            var delayMs = (int)Math.Min(_maxDelayMs, (long)_initialDelayMs << shift);
+            var delayMs = _randomDouble is null
+                ? ExponentialRetryBackoff.CalculateDelayMilliseconds(_initialDelayMs, _maxDelayMs, count)
+                : (int)ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _initialDelayMs,
+                    _maxDelayMs,
+                    count,
+                    _randomDouble());
             return new PrefetchFailureDecision(
                 delayMs,
                 IsTerminal: deterministic && count >= _terminalThreshold,

--- a/src/Dekaf/Consumer/PrefetchFailureTracker.cs
+++ b/src/Dekaf/Consumer/PrefetchFailureTracker.cs
@@ -24,7 +24,8 @@ internal sealed class PrefetchFailureTracker
         Func<double>? randomDouble = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(terminalThreshold, 1);
-        ExponentialRetryBackoff.Validate(initialDelayMs, maxDelayMs);
+        ArgumentOutOfRangeException.ThrowIfLessThan(initialDelayMs, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDelayMs, initialDelayMs);
 
         _terminalThreshold = terminalThreshold;
         _initialDelayMs = initialDelayMs;

--- a/src/Dekaf/Consumer/PrefetchFailureTracker.cs
+++ b/src/Dekaf/Consumer/PrefetchFailureTracker.cs
@@ -24,8 +24,7 @@ internal sealed class PrefetchFailureTracker
         Func<double>? randomDouble = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(terminalThreshold, 1);
-        ArgumentOutOfRangeException.ThrowIfLessThan(initialDelayMs, 1);
-        ArgumentOutOfRangeException.ThrowIfLessThan(maxDelayMs, initialDelayMs);
+        ExponentialRetryBackoff.Validate(initialDelayMs, maxDelayMs);
 
         _terminalThreshold = terminalThreshold;
         _initialDelayMs = initialDelayMs;

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -7,6 +7,7 @@ using Dekaf.Internal;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Producer;
+using Dekaf.Retry;
 using Dekaf.Security;
 using Dekaf.Security.Sasl;
 using Microsoft.Extensions.Logging;
@@ -80,6 +81,8 @@ public sealed class KafkaClientBuilder
     private IReadOnlyList<string> _bootstrapServers = [];
     private string? _clientId;
     private int _requestTimeoutMs = 30000;
+    private int _retryBackoffMs = 100;
+    private int _retryBackoffMaxMs = 1000;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private bool _reconnectBackoffConfigured;
@@ -140,6 +143,32 @@ public sealed class KafkaClientBuilder
         ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
 
         _requestTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the initial delay for retrying failed broker requests for clients sharing this connection.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public KafkaClientBuilder WithRetryBackoff(TimeSpan backoff)
+    {
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMs = (int)backoff.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum delay for retrying repeatedly failed broker requests for shared clients.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public KafkaClientBuilder WithRetryBackoffMax(TimeSpan backoff)
+    {
+        if (backoff < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Maximum retry backoff cannot be negative");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(backoff.TotalMilliseconds, int.MaxValue, nameof(backoff));
+        _retryBackoffMaxMs = (int)backoff.TotalMilliseconds;
         return this;
     }
 
@@ -488,6 +517,7 @@ public sealed class KafkaClientBuilder
             _reconnectBackoffMaxMs,
             _reconnectBackoffConfigured,
             _reconnectBackoffMaxConfigured);
+        ExponentialRetryBackoff.Validate(_retryBackoffMs, _retryBackoffMaxMs);
 
         GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
@@ -496,6 +526,8 @@ public sealed class KafkaClientBuilder
             BootstrapServers = _bootstrapServers,
             ClientId = _clientId,
             RequestTimeoutMs = _requestTimeoutMs,
+            RetryBackoffMs = _retryBackoffMs,
+            RetryBackoffMaxMs = _retryBackoffMaxMs,
             ReconnectBackoffMs = _reconnectBackoffMs,
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             UseTls = _useTls,
@@ -537,6 +569,8 @@ internal sealed class KafkaClientOptions
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; }
     public int RequestTimeoutMs { get; init; }
+    public int RetryBackoffMs { get; init; }
+    public int RetryBackoffMaxMs { get; init; }
     public int ReconnectBackoffMs { get; init; }
     public int ReconnectBackoffMaxMs { get; init; }
     public bool UseTls { get; init; }
@@ -585,7 +619,9 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ILoggerFactory? loggerFactory,
         int connectionsPerBroker,
         int maxConnectionsPerBroker,
-        int producerMaxConnectionsPerBroker)
+        int producerMaxConnectionsPerBroker,
+        int retryBackoffMs,
+        int retryBackoffMaxMs)
     {
         BootstrapServers = bootstrapServers;
         ConnectionPool = connectionPool;
@@ -596,6 +632,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ConnectionsPerBroker = connectionsPerBroker;
         MaxConnectionsPerBroker = maxConnectionsPerBroker;
         ProducerMaxConnectionsPerBroker = producerMaxConnectionsPerBroker;
+        RetryBackoffMs = retryBackoffMs;
+        RetryBackoffMaxMs = retryBackoffMaxMs;
     }
 
     public IReadOnlyList<string> BootstrapServers { get; }
@@ -607,6 +645,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     public int ConnectionsPerBroker { get; }
     public int MaxConnectionsPerBroker { get; }
     public int ProducerMaxConnectionsPerBroker { get; }
+    public int RetryBackoffMs { get; }
+    public int RetryBackoffMaxMs { get; }
 
     public static KafkaClientInfrastructure Create(KafkaClientOptions options)
     {
@@ -639,7 +679,9 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             MetadataRefreshInterval = options.MetadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = options.MetadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = options.MetadataRecoveryRebootstrapTriggerMs,
-            ClientDnsLookup = options.ClientDnsLookup
+            ClientDnsLookup = options.ClientDnsLookup,
+            RetryBackoffMs = options.RetryBackoffMs,
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs
         };
 
         var metadataManager = new MetadataManager(
@@ -658,7 +700,9 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.LoggerFactory,
             options.ConnectionsPerBroker,
             options.MaxConnectionsPerBroker,
-            options.ProducerMaxConnectionsPerBroker);
+            options.ProducerMaxConnectionsPerBroker,
+            options.RetryBackoffMs,
+            options.RetryBackoffMaxMs);
     }
 
     private static ConnectionOptions CreateConnectionOptions(KafkaClientOptions options) => new()

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -7,6 +7,7 @@ using Dekaf.Internal;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Retry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Metadata;
@@ -121,6 +122,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     {
         _connectionPool = connectionPool;
         _options = options ?? new MetadataOptions();
+        ExponentialRetryBackoff.Validate(_options.RetryBackoffMs, _options.RetryBackoffMaxMs);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<MetadataManager>.Instance;
 
         // Pre-parse bootstrap servers to avoid allocation in hot path
@@ -368,7 +370,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
             var initializationToken = linkedCts.Token;
-            var backoffMs = _options.RetryBackoffMs;
             var startedAt = Stopwatch.GetTimestamp();
 
             try
@@ -403,9 +404,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
                                 ex);
                         }
 
+                        var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                            _options.RetryBackoffMs,
+                            _options.RetryBackoffMaxMs,
+                            attempt + 1);
                         LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
                         await Task.Delay((int)Math.Min(backoffMs, remainingMs), initializationToken).ConfigureAwait(false);
-                        backoffMs = Math.Min(backoffMs * 2, _options.RetryBackoffMaxMs);
                     }
                 }
             }
@@ -556,11 +560,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </remarks>
     private async ValueTask<TopicInfo?> GetTopicMetadataSlowAsync(string topicName, CancellationToken cancellationToken)
     {
-        const int initialRetryDelayMs = 100;
-        const int maxRetryDelayMs = 2000;
-
         TopicInfo? topic = null;
-        var retryDelayMs = initialRetryDelayMs;
+        var failureCount = 0;
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -578,8 +579,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
             if (topic is null
                 || topic.ErrorCode is ErrorCode.LeaderNotAvailable or ErrorCode.UnknownTopicOrPartition)
             {
+                failureCount++;
+                var retryDelayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    failureCount);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, maxRetryDelayMs);
                 continue;
             }
 
@@ -1221,12 +1226,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 consecutiveFailures++;
                 LogBackgroundMetadataRefreshFailed(ex, consecutiveFailures);
 
-                // Brief backoff on failures to avoid hammering a failing cluster
-                // Cap at 60 seconds, existing metadata continues to be used
-                var backoffSeconds = Math.Min(consecutiveFailures * 5, 60);
+                var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    consecutiveFailures);
                 try
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(backoffSeconds), cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(backoffMs, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1226,10 +1226,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 consecutiveFailures++;
                 LogBackgroundMetadataRefreshFailed(ex, consecutiveFailures);
 
-                var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
-                    _options.RetryBackoffMs,
-                    _options.RetryBackoffMaxMs,
-                    consecutiveFailures);
+                // Background refresh has a deliberately slower policy than individual request
+                // retries: preserve the existing 5-second step and 60-second outage cap.
+                var backoffMs = (int)Math.Min(consecutiveFailures * 5_000L, 60_000L);
                 try
                 {
                     await Task.Delay(backoffMs, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using Dekaf.Internal;
 using Dekaf.Protocol;
+using Dekaf.Retry;
 using Dekaf.Security.Sasl;
 using Dekaf.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -1093,18 +1094,12 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     {
         var minMs = _connectionOptions.ReconnectBackoff.TotalMilliseconds;
         var maxMs = _connectionOptions.ReconnectBackoffMax.TotalMilliseconds;
-        if (minMs <= 0 || maxMs <= 0)
-            return TimeSpan.Zero;
-
-        if (maxMs <= minMs)
-            return TimeSpan.FromMilliseconds(maxMs);
-
-        var exponent = Math.Min(failureCount - 1, 30);
-        var baseMs = Math.Min(maxMs, minMs * Math.Pow(2, exponent));
-        var randomValue = Math.Clamp(_randomDouble(), 0, 1);
-        var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));
-
-        return TimeSpan.FromMilliseconds(Math.Min(maxMs, jitteredMs));
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            minMs,
+            maxMs,
+            failureCount,
+            _randomDouble());
+        return TimeSpan.FromMilliseconds(delayMs);
     }
 
     private static long ToStopwatchTicks(TimeSpan delay)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -96,6 +96,8 @@ internal readonly record struct TransactionPartitionEnrollmentResult(
 /// </remarks>
 internal sealed partial class BrokerSender : IAsyncDisposable
 {
+    private static readonly double StopwatchTicksPerMillisecond = Stopwatch.Frequency / 1000.0;
+
     /// <summary>
     /// Timeout for SendCoalescedAsync which only does TCP write + response task wiring.
     /// Longer than this indicates a broken/stale connection. Reduced from 5000ms to 1500ms
@@ -3408,6 +3410,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (inlineLeaderApplied && batch.RetryFailureCount == 0)
             {
                 LogRetriableErrorWithoutBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
+                // The inline leader update is the first retry attempt, matching ApplyRetryBackoff's
+                // pre-increment convention. A later failure therefore starts at failure count 2.
                 batch.RetryFailureCount = 1;
                 batch.RetryNotBefore = 0;
             }
@@ -3978,8 +3982,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             _options.RetryBackoffMs,
             _options.RetryBackoffMaxMs,
             ++batch.RetryFailureCount);
-        batch.RetryNotBefore = _getTimestamp() +
-            (long)(delayMs * (Stopwatch.Frequency / 1000.0));
+        batch.RetryNotBefore = _getTimestamp() + (long)(delayMs * StopwatchTicksPerMillisecond);
         return delayMs;
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -14,6 +14,7 @@ using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Dekaf.Retry;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Producer;
@@ -3382,8 +3383,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
             // Apply backoff to prevent tight retry loops if the epoch bump doesn't
             // resolve the error (e.g., broker keeps rejecting with OOSN).
-            batch.RetryNotBefore = Stopwatch.GetTimestamp() +
-                _options.RetryBackoffTicks;
+            ApplyRetryBackoff(batch);
         }
         else if (isEpochBumpError && _bumpEpoch is null
             && batch.InflightEntry is not null
@@ -3396,26 +3396,31 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             try { CompleteInflightEntry(batch); }
             catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
             batch.InflightEntry = null;
+            ApplyRetryBackoff(batch);
         }
         else if (!networkRetryPrepared)
         {
-            if (TryApplyInlineLeader(batch.TopicPartition, errorCode, currentLeader, nodeEndpoints))
+            var inlineLeaderApplied = TryApplyInlineLeader(
+                batch.TopicPartition,
+                errorCode,
+                currentLeader,
+                nodeEndpoints);
+            if (inlineLeaderApplied && batch.RetryFailureCount == 0)
             {
                 LogRetriableErrorWithoutBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition);
+                batch.RetryFailureCount = 1;
                 batch.RetryNotBefore = 0;
             }
             else
             {
+                var delayMs = ApplyRetryBackoff(batch);
                 LogRetriableErrorWithBackoff(errorCode, batch.TopicPartition.Topic, batch.TopicPartition.Partition,
-                    _options.RetryBackoffMs);
+                    delayMs);
 
                 // Fire-and-forget metadata refresh for leader changes.
                 // Observe exceptions to prevent UnobservedTaskException on GC.
                 _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, cancellationToken);
 
-                // Set backoff via RetryNotBefore instead of Task.Delay
-                batch.RetryNotBefore = Stopwatch.GetTimestamp() +
-                    _options.RetryBackoffTicks;
             }
         }
 
@@ -3949,9 +3954,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         // sibling write cannot postpone metadata refresh or the start of retry backoff.
         if (!batch.IsLoopExitRedelivery)
             MutePartition(batch.TopicPartition);
+        var delayMs = ApplyRetryBackoff(batch);
         LogRetriableErrorWithBackoff(ErrorCode.NetworkException, batch.TopicPartition.Topic,
-            batch.TopicPartition.Partition, _options.RetryBackoffMs);
-        batch.RetryNotBefore = Stopwatch.GetTimestamp() + _options.RetryBackoffTicks;
+            batch.TopicPartition.Partition, delayMs);
 
         bool refreshMetadata;
         lock (metadataRefreshTopics)
@@ -3965,6 +3970,17 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             // lifetime token so recovery can still refresh metadata.
             _ = ObserveMetadataRefreshAsync(batch.TopicPartition.Topic, _cts.Token);
         }
+    }
+
+    private int ApplyRetryBackoff(ReadyBatch batch)
+    {
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs,
+            ++batch.RetryFailureCount);
+        batch.RetryNotBefore = _getTimestamp() +
+            (long)(delayMs * (Stopwatch.Frequency / 1000.0));
+        return delayMs;
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -277,6 +277,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             pipeMemoryBucketCapacity: sharedPoolSizes.PipeMemoryArraysPerBucket,
             telemetryMetricCollector: telemetryMetricCollector);
 
+        metadataOptions ??= new MetadataOptions
+        {
+            RetryBackoffMs = options.RetryBackoffMs,
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs,
+            InitTimeoutMs = options.MaxBlockMs
+        };
         var metadataManager = new MetadataManager(
             connectionPool,
             options.BootstrapServers,
@@ -296,6 +302,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         IDekafMemoryBudget memoryBudget,
         Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null)
     {
+        ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         _options = options;
         _addPartitionsToTransaction = addPartitionsToTransaction ?? AddPartitionsToTransactionAsync;
         _keySerializer = keySerializer;
@@ -2163,12 +2170,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
     }
 
+    private int CalculateRequestRetryBackoff(int zeroBasedAttempt)
+        => ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs,
+            zeroBasedAttempt + 1);
+
     internal async ValueTask ReinitializeProducerIdAsync(
         CancellationToken cancellationToken,
         bool keepPreparedTransaction = false)
     {
         const int maxRetries = 10;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -2199,12 +2211,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (classification == TransactionErrorClassification.Retriable)
                 {
+                    if (attempt == maxRetries - 1)
+                        break;
+
+                    var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                     if (response.ErrorCode == ErrorCode.NotCoordinator)
                     {
                         LogInitProducerIdNotCoordinator(attempt + 1, maxRetries);
 
                         await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                        retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                         await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                         continue;
                     }
@@ -2212,7 +2227,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
 
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                     continue;
                 }
 
@@ -2268,7 +2282,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
 
         const int maxRetries = 5;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -2291,10 +2304,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (errorCode is ErrorCode.CoordinatorNotAvailable or ErrorCode.NotCoordinator)
             {
+                if (attempt == maxRetries - 1)
+                    break;
+
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 LogTransactionCoordinatorNotAvailable(errorCode, attempt + 1, maxRetries, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 1000);
                 continue;
             }
 
@@ -2356,7 +2372,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
 
         const int maxRetries = 5;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -2415,10 +2430,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return; // Success
             }
 
+            if (attempt == maxRetries - 1)
+                break;
+
+            var retryDelayMs = CalculateRequestRetryBackoff(attempt);
             LogAddPartitionsToTxnRetriableError(attempt + 1, maxRetries, retryDelayMs);
 
             await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-            retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
         }
 
         throw new TransactionException(ErrorCode.ConcurrentTransactions,
@@ -2458,7 +2476,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         const int maxRetries = 5;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -2544,18 +2561,20 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             ThrowIfNonRetriableTransactionError(response.ErrorCode,
                 $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
 
+            if (attempt == maxRetries - 1)
+                break;
+
+            var retryDelayMs = CalculateRequestRetryBackoff(attempt);
             if (response.ErrorCode == ErrorCode.NotCoordinator)
             {
                 LogEndTxnNotCoordinator(attempt + 1, maxRetries);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                 continue;
             }
 
             LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
             await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-            retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
             continue;
         }
 
@@ -2577,7 +2596,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // TransactionErrorClassifier (the single source of retriability for transactional ops) rather
         // than RetryHelper, whose IsRetriable predicate does not cover codes like ConcurrentTransactions.
         const int maxRetries = 5;
-        var retryDelayMs = 100;
         var tv2 = _currentTransactionUsesTV2;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
@@ -2602,10 +2620,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 // Retriable -> back off and restart the sequence; fatal/abortable -> throws typed exception.
                 ThrowIfNonRetriableTransactionError(addOffsetsResponse.ErrorCode, "AddOffsetsToTxn", tv2);
+                if (attempt == maxRetries - 1)
+                    break;
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 if (addOffsetsResponse.ErrorCode == ErrorCode.NotCoordinator)
                     await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 continue;
             }
 
@@ -2626,8 +2646,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             if (findCoordResponse.Coordinators.Count == 0)
             {
                 // Treat an empty coordinator set as transiently unavailable and retry.
+                if (attempt == maxRetries - 1)
+                    break;
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 continue;
             }
 
@@ -2638,8 +2660,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 ThrowIfNonRetriableTransactionError(coord.ErrorCode,
                     $"FindCoordinator for consumer group '{consumerGroupId}'", tv2);
+                if (attempt == maxRetries - 1)
+                    break;
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 continue;
             }
 
@@ -2709,10 +2733,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             if (commitError.HasValue)
             {
                 ThrowIfNonRetriableTransactionError(commitError.Value, commitContext!, tv2);
+                if (attempt == maxRetries - 1)
+                    break;
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 if (commitError.Value == ErrorCode.NotCoordinator)
                     await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 continue;
             }
 
@@ -3286,7 +3312,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         const int maxRetries = 5;
-        var retryDelayMs = 100;
         var retryDeadline = Stopwatch.GetTimestamp() + _options.DeliveryTimeoutTicks;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
@@ -3300,12 +3325,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 && IsRetriablePartitionEnrollmentException(exception)
                 && Stopwatch.GetTimestamp() < retryDeadline)
             {
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 LogAddPartitionsToTxnTransportRetry(attempt + 1, retryDelayMs);
                 var remainingTicks = retryDeadline - Stopwatch.GetTimestamp();
                 var remainingMs = Math.Max(1, remainingTicks * 1000d / Stopwatch.Frequency);
                 await Task.Delay((int)Math.Min(retryDelayMs, remainingMs), cancellationToken)
                     .ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
             }
         }
     }
@@ -3767,7 +3792,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             }
 
             // Retry with backoff for retriable errors (e.g. CoordinatorLoadInProgress during broker startup)
-            var retryDelayMs = _options.RetryBackoffMs;
+            var consecutiveFailures = 0;
 
             while (true)
             {
@@ -3815,10 +3840,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         $"Failed to initialize idempotent producer: {response.ErrorCode}");
                 }
 
+                var retryDelayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    ++consecutiveFailures);
                 LogInitProducerIdRetriable(response.ErrorCode, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, _options.RetryBackoffMaxMs);
             }
         }
         finally
@@ -3888,7 +3916,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return (_producerId, _producerEpoch);
             }
 
-            var retryDelayMs = _options.RetryBackoffMs;
+            var consecutiveFailures = 0;
 
             while (true)
             {
@@ -3933,10 +3961,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         $"Failed to bump producer epoch: {response.ErrorCode}");
                 }
 
+                var retryDelayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                    _options.RetryBackoffMs,
+                    _options.RetryBackoffMaxMs,
+                    ++consecutiveFailures);
                 LogBumpEpochRetriable(response.ErrorCode, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, _options.RetryBackoffMaxMs);
             }
         }
         finally

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -336,15 +336,6 @@ public sealed class ProducerOptions
         : (_requestTimeoutTicks = (long)(RequestTimeoutMs * (Stopwatch.Frequency / 1000.0)));
 
     /// <summary>
-    /// <see cref="RetryBackoffMs"/> converted to <see cref="Stopwatch"/> ticks.
-    /// Cached on first access to avoid repeated floating-point multiply.
-    /// </summary>
-    private long _retryBackoffTicks;
-    internal long RetryBackoffTicks =>
-        _retryBackoffTicks != 0 ? _retryBackoffTicks
-        : (_retryBackoffTicks = (long)(RetryBackoffMs * (Stopwatch.Frequency / 1000.0)));
-
-    /// <summary>
     /// Enables idempotent producer mode, which ensures that messages are delivered exactly once
     /// to a particular topic partition during the lifetime of a single producer session.
     /// <para>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -8327,6 +8327,9 @@ internal sealed class ReadyBatch
     /// </summary>
     internal long RetryNotBefore { get; set; }
 
+    /// <summary>Number of consecutive failed requests for this batch.</summary>
+    internal int RetryFailureCount { get; set; }
+
     /// <summary>
     /// Stopwatch timestamp when the accumulator batch was created. Used for absolute delivery
     /// deadline computation in ProcessCompletedResponses (prevents infinite retries with relative
@@ -8619,6 +8622,7 @@ internal sealed class ReadyBatch
         Volatile.Write(ref _loopExitRecoveryRegistered, 0);
         LoopExitRedeliveryOrder = 0;
         RetryNotBefore = 0;
+        RetryFailureCount = 0;
         _diagTraceLen = 0;
 
         // NOTE: _cleanedUp, _completed, and _sendCompleted are NOT reset here. They stay

--- a/src/Dekaf/Retry/ExponentialRetryBackoff.cs
+++ b/src/Dekaf/Retry/ExponentialRetryBackoff.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+
+namespace Dekaf.Retry;
+
+/// <summary>
+/// Calculates the overflow-safe exponential backoff shared by Kafka client requests.
+/// </summary>
+internal static class ExponentialRetryBackoff
+{
+    private const double MinimumJitterFactor = 0.8;
+    private const double JitterFactorRange = 0.4;
+    private const int MaximumExponent = 62;
+
+    public static void Validate(int initialDelayMs, int maximumDelayMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(initialDelayMs);
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumDelayMs);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CalculateDelayMilliseconds(int initialDelayMs, int maximumDelayMs, int failureCount)
+        => (int)CalculateDelayMilliseconds(
+            initialDelayMs,
+            maximumDelayMs,
+            failureCount,
+            Random.Shared.NextDouble());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static double CalculateDelayMilliseconds(
+        double initialDelayMs,
+        double maximumDelayMs,
+        int failureCount,
+        double randomValue)
+    {
+        if (initialDelayMs <= 0 || maximumDelayMs <= 0)
+            return 0;
+
+        if (initialDelayMs >= maximumDelayMs)
+            return maximumDelayMs;
+
+        var exponent = Math.Min(Math.Max(failureCount - 1, 0), MaximumExponent);
+        var exponentialDelayMs = initialDelayMs * Math.Pow(2, exponent);
+        var unitRandom = double.IsNaN(randomValue) ? 0.5 : Math.Clamp(randomValue, 0, 1);
+        var jitteredDelayMs = exponentialDelayMs * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
+        return Math.Min(maximumDelayMs, jitteredDelayMs);
+    }
+}

--- a/src/Dekaf/Retry/ExponentialRetryBackoff.cs
+++ b/src/Dekaf/Retry/ExponentialRetryBackoff.cs
@@ -19,11 +19,13 @@ internal static class ExponentialRetryBackoff
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CalculateDelayMilliseconds(int initialDelayMs, int maximumDelayMs, int failureCount)
-        => (int)CalculateDelayMilliseconds(
-            initialDelayMs,
-            maximumDelayMs,
-            failureCount,
-            Random.Shared.NextDouble());
+        => (int)Math.Min(
+            int.MaxValue,
+            CalculateDelayMilliseconds(
+                initialDelayMs,
+                maximumDelayMs,
+                failureCount,
+                Random.Shared.NextDouble()));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static double CalculateDelayMilliseconds(
@@ -35,13 +37,10 @@ internal static class ExponentialRetryBackoff
         if (initialDelayMs <= 0 || maximumDelayMs <= 0)
             return 0;
 
-        if (initialDelayMs >= maximumDelayMs)
-            return maximumDelayMs;
-
         var exponent = Math.Min(Math.Max(failureCount - 1, 0), MaximumExponent);
         var exponentialDelayMs = initialDelayMs * Math.Pow(2, exponent);
+        var cappedDelayMs = Math.Min(maximumDelayMs, exponentialDelayMs);
         var unitRandom = double.IsNaN(randomValue) ? 0.5 : Math.Clamp(randomValue, 0, 1);
-        var jitteredDelayMs = exponentialDelayMs * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
-        return Math.Min(maximumDelayMs, jitteredDelayMs);
+        return cappedDelayMs * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
     }
 }

--- a/src/Dekaf/Retry/ExponentialRetryBackoff.cs
+++ b/src/Dekaf/Retry/ExponentialRetryBackoff.cs
@@ -37,9 +37,10 @@ internal static class ExponentialRetryBackoff
         if (initialDelayMs <= 0 || maximumDelayMs <= 0)
             return 0;
 
+        var effectiveMaximumDelayMs = Math.Max(initialDelayMs, maximumDelayMs);
         var exponent = Math.Min(Math.Max(failureCount - 1, 0), MaximumExponent);
         var exponentialDelayMs = initialDelayMs * Math.Pow(2, exponent);
-        var cappedDelayMs = Math.Min(maximumDelayMs, exponentialDelayMs);
+        var cappedDelayMs = Math.Min(effectiveMaximumDelayMs, exponentialDelayMs);
         var unitRandom = double.IsNaN(randomValue) ? 0.5 : Math.Clamp(randomValue, 0, 1);
         return cappedDelayMs * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
     }

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -24,8 +24,7 @@ internal static class RetryHelper
         int retryBackoffMs = 100,
         int retryBackoffMaxMs = 1000,
         Func<CancellationToken, ValueTask>? onRetry = null,
-        int maxRetries = MaxRetries,
-        Func<int, int, int, int>? calculateDelayMilliseconds = null)
+        int maxRetries = MaxRetries)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -41,11 +40,10 @@ internal static class RetryHelper
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var delayMs = CalculateDelayMilliseconds(
+                var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                     retryBackoffMs,
                     retryBackoffMaxMs,
-                    attempt + 1,
-                    calculateDelayMilliseconds);
+                    attempt + 1);
                 await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -68,8 +66,7 @@ internal static class RetryHelper
         int retryBackoffMaxMs = 1000,
         Func<CancellationToken, ValueTask>? onRetry = null,
         int maxRetries = MaxRetries,
-        Func<KafkaException, bool>? shouldRefreshMetadata = null,
-        Func<int, int, int, int>? calculateDelayMilliseconds = null)
+        Func<KafkaException, bool>? shouldRefreshMetadata = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -88,26 +85,14 @@ internal static class RetryHelper
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var delayMs = CalculateDelayMilliseconds(
+                var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                     retryBackoffMs,
                     retryBackoffMaxMs,
-                    attempt + 1,
-                    calculateDelayMilliseconds);
+                    attempt + 1);
                 await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
         }
     }
-
-    private static int CalculateDelayMilliseconds(
-        int retryBackoffMs,
-        int retryBackoffMaxMs,
-        int failureCount,
-        Func<int, int, int, int>? calculateDelayMilliseconds)
-        => calculateDelayMilliseconds?.Invoke(retryBackoffMs, retryBackoffMaxMs, failureCount)
-           ?? ExponentialRetryBackoff.CalculateDelayMilliseconds(
-               retryBackoffMs,
-               retryBackoffMaxMs,
-               failureCount);
 
     internal static bool IsRetriableRequestFailure(Exception exception)
         => exception is IOException or System.Net.Sockets.SocketException or TimeoutException

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -4,28 +4,28 @@ namespace Dekaf.Retry;
 
 /// <summary>
 /// Centralized retry logic for retriable Kafka errors.
-/// Catches <see cref="KafkaException"/> where <see cref="KafkaException.IsRetriable"/> is true,
-/// refreshes metadata, and retries up to <see cref="MaxRetries"/> times with a jittered delay.
-/// The effective delay per retry is <see cref="RetryDelayMs"/> + [0, 100)ms random jitter.
+/// Catches retriable Kafka and transport failures,
+/// refreshes metadata, and retries up to <see cref="MaxRetries"/> times with KIP-580 backoff.
 /// </summary>
 internal static class RetryHelper
 {
     internal const int MaxRetries = 3;
-    internal const int RetryDelayMs = 500;
 
     /// <summary>
     /// Executes an async operation with retry logic for retriable Kafka errors.
     /// On retriable failure, refreshes metadata, invokes the optional <paramref name="onRetry"/>
-    /// callback (e.g. to re-discover a coordinator), and retries after a jittered delay
-    /// of <see cref="RetryDelayMs"/> + [0, 100)ms.
+    /// callback (e.g. to re-discover a coordinator), and retries after KIP-580 backoff.
     /// </summary>
     /// <param name="maxRetries">Maximum number of retries. Defaults to <see cref="MaxRetries"/> (3).</param>
     internal static async ValueTask WithRetryAsync(
         Func<ValueTask> operation,
         MetadataManager metadataManager,
         CancellationToken cancellationToken,
+        int retryBackoffMs = 100,
+        int retryBackoffMaxMs = 1000,
         Func<CancellationToken, ValueTask>? onRetry = null,
-        int maxRetries = MaxRetries)
+        int maxRetries = MaxRetries,
+        Func<int, int, int, int>? calculateDelayMilliseconds = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -34,15 +34,19 @@ internal static class RetryHelper
                 await operation().ConfigureAwait(false);
                 return;
             }
-            catch (KafkaException ex) when (ex.IsRetriable && attempt < maxRetries)
+            catch (Exception ex) when (IsRetriableRequestFailure(ex) && attempt < maxRetries)
             {
                 await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
 
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var jitter = Random.Shared.Next(0, 100);
-                await Task.Delay(RetryDelayMs + jitter, cancellationToken).ConfigureAwait(false);
+                var delayMs = CalculateDelayMilliseconds(
+                    retryBackoffMs,
+                    retryBackoffMaxMs,
+                    attempt + 1,
+                    calculateDelayMilliseconds);
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
         }
     }
@@ -50,8 +54,7 @@ internal static class RetryHelper
     /// <summary>
     /// Executes an async operation with retry logic for retriable Kafka errors,
     /// returning a result on success. On retriable failure, refreshes metadata,
-    /// invokes the optional <paramref name="onRetry"/> callback, and retries after a jittered delay
-    /// of <see cref="RetryDelayMs"/> + [0, 100)ms.
+    /// invokes the optional <paramref name="onRetry"/> callback, and retries after KIP-580 backoff.
     /// </summary>
     /// <param name="maxRetries">Maximum number of retries. Defaults to <see cref="MaxRetries"/> (3).</param>
     /// <param name="shouldRefreshMetadata">
@@ -61,9 +64,12 @@ internal static class RetryHelper
         Func<ValueTask<T>> operation,
         MetadataManager metadataManager,
         CancellationToken cancellationToken,
+        int retryBackoffMs = 100,
+        int retryBackoffMaxMs = 1000,
         Func<CancellationToken, ValueTask>? onRetry = null,
         int maxRetries = MaxRetries,
-        Func<KafkaException, bool>? shouldRefreshMetadata = null)
+        Func<KafkaException, bool>? shouldRefreshMetadata = null,
+        Func<int, int, int, int>? calculateDelayMilliseconds = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -71,9 +77,10 @@ internal static class RetryHelper
             {
                 return await operation().ConfigureAwait(false);
             }
-            catch (KafkaException ex) when (ex.IsRetriable && attempt < maxRetries)
+            catch (Exception ex) when (IsRetriableRequestFailure(ex) && attempt < maxRetries)
             {
-                if (shouldRefreshMetadata?.Invoke(ex) ?? true)
+                if (ex is not KafkaException kafkaException ||
+                    shouldRefreshMetadata?.Invoke(kafkaException) != false)
                 {
                     await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
                 }
@@ -81,11 +88,30 @@ internal static class RetryHelper
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);
 
-                var jitter = Random.Shared.Next(0, 100);
-                await Task.Delay(RetryDelayMs + jitter, cancellationToken).ConfigureAwait(false);
+                var delayMs = CalculateDelayMilliseconds(
+                    retryBackoffMs,
+                    retryBackoffMaxMs,
+                    attempt + 1,
+                    calculateDelayMilliseconds);
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
         }
     }
+
+    private static int CalculateDelayMilliseconds(
+        int retryBackoffMs,
+        int retryBackoffMaxMs,
+        int failureCount,
+        Func<int, int, int, int>? calculateDelayMilliseconds)
+        => calculateDelayMilliseconds?.Invoke(retryBackoffMs, retryBackoffMaxMs, failureCount)
+           ?? ExponentialRetryBackoff.CalculateDelayMilliseconds(
+               retryBackoffMs,
+               retryBackoffMaxMs,
+               failureCount);
+
+    internal static bool IsRetriableRequestFailure(Exception exception)
+        => exception is IOException or System.Net.Sockets.SocketException or TimeoutException
+           || exception is KafkaException { IsRetriable: true };
 
     private static async ValueTask RefreshMetadataForRetryAsync(
         MetadataManager metadataManager,
@@ -101,6 +127,12 @@ internal static class RetryHelper
         {
             // Refresh is best-effort. Keep retrying the original operation so its typed
             // Kafka failure remains the final error when every broker is unavailable.
+        }
+        catch (Exception ex) when (
+            IsRetriableRequestFailure(ex)
+            && !cancellationToken.IsCancellationRequested)
+        {
+            // Same best-effort behavior for transient transport failures.
         }
     }
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -6,6 +6,7 @@ using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Dekaf.Retry;
 using Dekaf.Serialization;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
@@ -102,6 +103,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         var metadataManager = new MetadataManager(
             connectionPool,
             options.BootstrapServers,
+            new MetadataOptions
+            {
+                RetryBackoffMs = options.RetryBackoffMs,
+                RetryBackoffMaxMs = options.RetryBackoffMaxMs
+            },
             logger: loggerFactory?.CreateLogger<MetadataManager>());
 
         return (connectionPool, metadataManager);
@@ -127,6 +133,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         ILoggerFactory? loggerFactory,
         bool ownsInfrastructure)
     {
+        ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         _options = options;
         _keyDeserializer = keyDeserializer;
         _valueDeserializer = valueDeserializer;
@@ -547,40 +554,49 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? pendingAcks,
         CancellationToken cancellationToken)
     {
-        try
+        for (var attempt = 0; ; attempt++)
         {
-            using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
-                .ConfigureAwait(false);
-            var connection = connectionLease.Connection;
-            var version = _metadataManager.GetNegotiatedApiVersion(
-                connection,
-                ApiKey.ShareFetch,
-                ShareFetchRequest.LowestSupportedVersion,
-                ShareFetchRequest.HighestSupportedVersion);
-            var maxRecords = version >= 1 ? _options.MaxPollRecords : 0;
-            var request = new ShareFetchRequest
+            try
             {
-                GroupId = _options.GroupId,
-                MemberId = _coordinator.MemberId!,
-                ShareSessionEpoch = _sessionManager.GetSessionEpoch(brokerId),
-                MaxWaitMs = _options.FetchMaxWaitMs,
-                MinBytes = _options.FetchMinBytes,
-                MaxBytes = _options.FetchMaxBytes,
-                MaxRecords = maxRecords,
-                BatchSize = maxRecords,
-                ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
-                Topics = BuildShareFetchTopics(partitions, pendingAcks, version)
-            };
-            var response = (ShareFetchResponse)await connection
-                .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
-                .ConfigureAwait(false);
-            return (brokerId, response);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)
-        {
-            LogFetchFailed(brokerId, ex);
-            _sessionManager.ResetSession(brokerId);
-            return (brokerId, null);
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
+                    .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
+                var version = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.ShareFetch,
+                    ShareFetchRequest.LowestSupportedVersion,
+                    ShareFetchRequest.HighestSupportedVersion);
+                var maxRecords = version >= 1 ? _options.MaxPollRecords : 0;
+                var request = new ShareFetchRequest
+                {
+                    GroupId = _options.GroupId,
+                    MemberId = _coordinator.MemberId!,
+                    ShareSessionEpoch = _sessionManager.GetSessionEpoch(brokerId),
+                    MaxWaitMs = _options.FetchMaxWaitMs,
+                    MinBytes = _options.FetchMinBytes,
+                    MaxBytes = _options.FetchMaxBytes,
+                    MaxRecords = maxRecords,
+                    BatchSize = maxRecords,
+                    ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
+                    Topics = BuildShareFetchTopics(partitions, pendingAcks, version)
+                };
+                var response = (ShareFetchResponse)await connection
+                    .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
+                    .ConfigureAwait(false);
+                return (brokerId, response);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)
+            {
+                if (attempt < RetryHelper.MaxRetries && RetryHelper.IsRetriableRequestFailure(ex))
+                {
+                    await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                LogFetchFailed(brokerId, ex);
+                _sessionManager.ResetSession(brokerId);
+                return (brokerId, null);
+            }
         }
     }
 
@@ -656,25 +672,64 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             Topics = topics
         };
 
-        using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
-            .ConfigureAwait(false);
-        var connection = connectionLease.Connection;
-        var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
-            connection,
-            ApiKey.ShareAcknowledge,
-            ShareAcknowledgeRequest.LowestSupportedVersion,
-            ShareAcknowledgeRequest.HighestSupportedVersion);
-
-        var response = (ShareAcknowledgeResponse)await connection
-            .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
-                request, shareAckVersion, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (response.ErrorCode != ErrorCode.None)
+        for (var attempt = 0; ; attempt++)
         {
-            throw KafkaException.FromErrorCode(response.ErrorCode,
-                $"ShareAcknowledge failed for broker {brokerId}: {response.ErrorCode} - {response.ErrorMessage}");
+            try
+            {
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
+                    .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
+                var shareAckVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.ShareAcknowledge,
+                    ShareAcknowledgeRequest.LowestSupportedVersion,
+                    ShareAcknowledgeRequest.HighestSupportedVersion);
+
+                var response = (ShareAcknowledgeResponse)await connection
+                    .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
+                        request, shareAckVersion, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (response.ErrorCode != ErrorCode.None)
+                {
+                    throw KafkaException.FromErrorCode(response.ErrorCode,
+                        $"ShareAcknowledge failed for broker {brokerId}: {response.ErrorCode} - {response.ErrorMessage}");
+                }
+
+                return;
+            }
+            catch (Exception ex) when (attempt < RetryHelper.MaxRetries
+                                       && RetryHelper.IsRetriableRequestFailure(ex))
+            {
+                await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+            }
         }
+    }
+
+    private async ValueTask PrepareRequestRetryAsync(int zeroBasedAttempt, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _metadataManager.RefreshMetadataAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (
+            ex is not ObjectDisposedException
+            && !cancellationToken.IsCancellationRequested)
+        {
+            // Best-effort: preserve the original request failure if retries exhaust.
+        }
+        catch (Exception ex) when (
+            RetryHelper.IsRetriableRequestFailure(ex)
+            && !cancellationToken.IsCancellationRequested)
+        {
+            // Same best-effort behavior for transient transport failures.
+        }
+
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs,
+            zeroBasedAttempt + 1);
+        await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -583,6 +583,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 var response = (ShareFetchResponse)await connection
                     .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
                     .ConfigureAwait(false);
+
+                if (attempt < RetryHelper.MaxRetries && response.ErrorCode.IsRetriable())
+                {
+                    await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
                 return (brokerId, response);
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -382,7 +382,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         {
             try
             {
-                await SendAcknowledgeAsync(kvp.Key, kvp.Value, cancellationToken)
+                await SendAcknowledgeAsync(
+                        kvp.Key,
+                        kvp.Value,
+                        retryRetriableFailures: true,
+                        cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
                 return (Acks: kvp.Value, Error: (Exception?)null);
             }
@@ -537,7 +541,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 try
                 {
-                    await SendAcknowledgeAsync(brokerId, acks, CancellationToken.None)
+                    await SendAcknowledgeAsync(
+                            brokerId,
+                            acks,
+                            retryRetriableFailures: false,
+                            cancellationToken: CancellationToken.None)
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -666,6 +674,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private async Task SendAcknowledgeAsync(
         int brokerId,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> topicAcks,
+        bool retryRetriableFailures,
         CancellationToken cancellationToken)
     {
         var topics = BuildShareAcknowledgeTopics(topicAcks);
@@ -705,7 +714,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 return;
             }
-            catch (Exception ex) when (attempt < RetryHelper.MaxRetries
+            catch (Exception ex) when (retryRetriableFailures
+                                       && attempt < RetryHelper.MaxRetries
                                        && RetryHelper.IsRetriableRequestFailure(ex))
             {
                 await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -1,10 +1,11 @@
 using System.Diagnostics;
+using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
-using Dekaf.Consumer;
+using Dekaf.Retry;
 using Microsoft.Extensions.Logging;
 #if NETSTANDARD2_0
 using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
@@ -130,7 +131,6 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
         };
 
         const int maxRetries = 5;
-        var retryDelayMs = 100;
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
@@ -167,10 +167,10 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             if (errorCode == ErrorCode.CoordinatorNotAvailable ||
                 errorCode == ErrorCode.CoordinatorLoadInProgress)
             {
+                var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                retryDelayMs = Math.Min(retryDelayMs * 2, 1000);
                 continue;
             }
 
@@ -195,6 +195,12 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             GroupId = _options.GroupId
         };
     }
+
+    private int CalculateRequestRetryBackoff(int failureCount) =>
+        ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            _options.RetryBackoffMs,
+            _options.RetryBackoffMaxMs,
+            failureCount);
 
     /// <summary>
     /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
@@ -396,7 +402,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             // inactivity timeout (default 45s), not a dedicated join timeout — but it provides
             // a reasonable upper bound for how long we should wait for an assignment.
             var timeout = TimeSpan.FromMilliseconds(_options.SessionTimeoutMs);
-            var retryDelayMs = 200;
+            var retryFailureCount = 0;
 
             while (_state != CoordinatorState.Stable)
             {
@@ -433,6 +439,7 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                         // Broker accepted us but hasn't assigned partitions yet.
                         // Wait before re-sending heartbeat.
                         LogWaitingForAssignment();
+                        var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                         await Task.Delay(
                             GetWaitForAssignmentDelayMs(retryDelayMs, _heartbeatIntervalMs),
                             cancellationToken).ConfigureAwait(false);
@@ -453,8 +460,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 {
                     LogRetriableCoordinatorError(ex.ErrorCode);
                     MarkCoordinatorUnknown();
+                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
@@ -464,8 +471,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();
+                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    retryDelayMs = Math.Min(retryDelayMs * 2, 2000);
                 }
             }
         }

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -52,8 +52,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
     internal static int GetCoordinationConnectionIndex(int connectionsPerBroker)
         => connectionsPerBroker - 1;
 
-    internal static int GetWaitForAssignmentDelayMs(int retryDelayMs, int heartbeatIntervalMs)
-        => Math.Max(retryDelayMs, heartbeatIntervalMs);
+    internal static int GetWaitForAssignmentDelayMs(int heartbeatIntervalMs)
+        => Math.Max(heartbeatIntervalMs, 1);
 
     public ShareConsumerCoordinator(
         ShareConsumerOptions options,
@@ -167,6 +167,9 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             if (errorCode == ErrorCode.CoordinatorNotAvailable ||
                 errorCode == ErrorCode.CoordinatorLoadInProgress)
             {
+                if (attempt == maxRetries - 1)
+                    break;
+
                 var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
 
@@ -437,11 +440,11 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                     else
                     {
                         // Broker accepted us but hasn't assigned partitions yet.
-                        // Wait before re-sending heartbeat.
+                        // This is a successful heartbeat, so preserve the broker cadence.
                         LogWaitingForAssignment();
-                        var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
+                        retryFailureCount = 0;
                         await Task.Delay(
-                            GetWaitForAssignmentDelayMs(retryDelayMs, _heartbeatIntervalMs),
+                            GetWaitForAssignmentDelayMs(_heartbeatIntervalMs),
                             cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerCoordinator.cs
@@ -205,6 +205,29 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
             _options.RetryBackoffMaxMs,
             failureCount);
 
+    internal static TimeSpan GetJoinRetryDelay(
+        int retryDelayMs,
+        TimeSpan elapsed,
+        TimeSpan joinTimeout)
+    {
+        var remaining = joinTimeout - elapsed;
+        return remaining <= TimeSpan.Zero
+            ? TimeSpan.Zero
+            : TimeSpan.FromMilliseconds(Math.Min(retryDelayMs, remaining.TotalMilliseconds));
+    }
+
+    private Task DelayForJoinRetryAsync(
+        int failureCount,
+        long startedAt,
+        TimeSpan joinTimeout,
+        CancellationToken cancellationToken) =>
+        Task.Delay(
+            GetJoinRetryDelay(
+                CalculateRequestRetryBackoff(failureCount),
+                Stopwatch.GetElapsedTime(startedAt),
+                joinTimeout),
+            cancellationToken);
+
     /// <summary>
     /// Serializes heartbeat loop starts to prevent concurrent callers from orphaning a loop.
     /// </summary>
@@ -463,8 +486,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 {
                     LogRetriableCoordinatorError(ex.ErrorCode);
                     MarkCoordinatorUnknown();
-                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayForJoinRetryAsync(
+                        ++retryFailureCount, startedAt, timeout, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (
                     ex is ObjectDisposedException ||
@@ -474,8 +497,8 @@ internal sealed partial class ShareConsumerCoordinator : IAsyncDisposable
                 {
                     LogCoordinatorConnectionDisposed();
                     MarkCoordinatorUnknown();
-                    var retryDelayMs = CalculateRequestRetryBackoff(++retryFailureCount);
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    await DelayForJoinRetryAsync(
+                        ++retryFailureCount, startedAt, timeout, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -86,6 +86,18 @@ public sealed class ShareConsumerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Initial delay in milliseconds for retrying failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
+    /// </summary>
+    public int RetryBackoffMs { get; init; } = 100;
+
+    /// <summary>
+    /// Maximum delay in milliseconds for retrying repeatedly failed broker requests.
+    /// Equivalent to Kafka's <c>retry.backoff.max.ms</c>.
+    /// </summary>
+    public int RetryBackoffMaxMs { get; init; } = 1000;
+
+    /// <summary>
     /// Initial delay in milliseconds before reconnecting to a broker after a connection failure.
     /// Equivalent to Kafka's <c>reconnect.backoff.ms</c>. Set to 0 to disable the delay.
     /// </summary>

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -161,6 +161,41 @@ public sealed class ConnectionBuilderOptionsTests
     }
 
     [Test]
+    public async Task Builders_WithRetryBackoff_PreserveCommonSettings()
+    {
+        var initial = TimeSpan.FromMilliseconds(123);
+        var maximum = TimeSpan.FromMilliseconds(456);
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRetryBackoff(initial)
+            .WithRetryBackoffMax(maximum)
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("consumer-group")
+            .WithRetryBackoff(initial)
+            .WithRetryBackoffMax(maximum)
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("share-group")
+            .WithRetryBackoff(initial)
+            .WithRetryBackoffMax(maximum)
+            .Build();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092")
+            .WithRetryBackoff(initial)
+            .WithRetryBackoffMax(maximum)
+            .Build();
+
+        await AssertRetryBackoff(GetPrivateOptions<ProducerOptions>(producer));
+        await AssertRetryBackoff(GetPrivateOptions<ConsumerOptions>(consumer));
+        await AssertRetryBackoff(GetPrivateOptions<Dekaf.ShareConsumer.ShareConsumerOptions>(shareConsumer));
+        await AssertRetryBackoff(GetPrivateOptions<AdminClientOptions>(admin));
+    }
+
+    [Test]
     public async Task BuilderConnectionOptions_CanDisableTcpKeepAlive()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -216,5 +251,21 @@ public sealed class ConnectionBuilderOptionsTests
             ?? throw new InvalidOperationException($"Could not find _connectionPool on {client.GetType()}");
 
         return ((ConnectionPool)poolField.GetValue(client)!).EffectiveConnectionOptions;
+    }
+
+    private static TOptions GetPrivateOptions<TOptions>(object client)
+    {
+        var optionsField = client.GetType().GetField("_options", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Could not find _options on {client.GetType()}");
+        return (TOptions)optionsField.GetValue(client)!;
+    }
+
+    private static async Task AssertRetryBackoff(object options)
+    {
+        var optionsType = options.GetType();
+        var initial = (int)optionsType.GetProperty("RetryBackoffMs")!.GetValue(options)!;
+        var maximum = (int)optionsType.GetProperty("RetryBackoffMaxMs")!.GetValue(options)!;
+        await Assert.That(initial).IsEqualTo(123);
+        await Assert.That(maximum).IsEqualTo(456);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -150,6 +150,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithRetryBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
@@ -178,6 +180,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithRetryBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
@@ -198,6 +202,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsPerBroker(2))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithRetryBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
@@ -221,6 +227,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateAdminClient().WithMetadataMaxAge(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithReconnectBackoff(TimeSpan.FromMilliseconds(100)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithRetryBackoff(TimeSpan.FromMilliseconds(100)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
@@ -247,6 +255,24 @@ public sealed class KafkaClientBuilderTests
 
         await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoff).IsEqualTo(TimeSpan.FromMilliseconds(123));
         await Assert.That(pool.EffectiveConnectionOptions.ReconnectBackoffMax).IsEqualTo(TimeSpan.FromMilliseconds(456));
+    }
+
+    [Test]
+    public async Task RootClient_WithRetryBackoff_ConfiguresCreatedClients()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithRetryBackoff(TimeSpan.FromMilliseconds(123))
+            .WithRetryBackoffMax(TimeSpan.FromMilliseconds(456)));
+        await using var producer = client.CreateProducer<string, string>().Build();
+        await using var consumer = client.CreateConsumer<string, string>("group").Build();
+
+        var producerOptions = GetField<ProducerOptions>(producer, "_options");
+        var consumerOptions = GetField<ConsumerOptions>(consumer, "_options");
+
+        await Assert.That(producerOptions.RetryBackoffMs).IsEqualTo(123);
+        await Assert.That(producerOptions.RetryBackoffMaxMs).IsEqualTo(456);
+        await Assert.That(consumerOptions.RetryBackoffMs).IsEqualTo(123);
+        await Assert.That(consumerOptions.RetryBackoffMaxMs).IsEqualTo(456);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerBuilderTests.cs
@@ -116,6 +116,28 @@ public sealed class ConsumerBuilderTests
     }
 
     [Test]
+    public async Task Build_WithZeroRetryBackoff_Succeeds()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRetryBackoff(TimeSpan.Zero)
+            .Build();
+
+        await Assert.That(consumer).IsNotNull();
+    }
+
+    [Test]
+    public async Task Build_WithZeroRetryBackoffMax_Succeeds()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithRetryBackoffMax(TimeSpan.Zero)
+            .Build();
+
+        await Assert.That(consumer).IsNotNull();
+    }
+
+    [Test]
     public async Task SubscribeTo_SingleTopic_BuildsWithSubscription()
     {
         await using var consumer = Kafka.CreateConsumer<string, string>()

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3448,6 +3448,28 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task JoinRetryDelay_DoesNotExceedRemainingRebalanceTimeout()
+    {
+        var delay = ConsumerCoordinator.GetJoinRetryDelay(
+            retryDelayMs: 10_000,
+            elapsed: TimeSpan.FromMilliseconds(900),
+            rebalanceTimeout: TimeSpan.FromSeconds(1));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Test]
+    public async Task JoinRetryDelay_WhenDeadlinePassed_ReturnsZero()
+    {
+        var delay = ConsumerCoordinator.GetJoinRetryDelay(
+            retryDelayMs: 10_000,
+            elapsed: TimeSpan.FromSeconds(1),
+            rebalanceTimeout: TimeSpan.FromSeconds(1));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
     public async Task IsAssignmentSyncCurrent_PendingFatalHeartbeat_ReturnsFalse()
     {
         var options = CreateConsumerProtocolOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -153,6 +153,14 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task RetryBackoff_DefaultsTo_100And1000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.RetryBackoffMs).IsEqualTo(100);
+        await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
     public async Task ReconnectBackoffMs_DefaultsTo_50()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
@@ -85,13 +85,25 @@ public sealed class PrefetchFailureTrackerTests
     }
 
     [Test]
-    [Arguments(0, 100)]
-    [Arguments(100, 99)]
+    [Arguments(-1, 100)]
+    [Arguments(100, -1)]
     public async Task Constructor_InvalidBackoff_Throws(int initialDelayMs, int maxDelayMs)
     {
         var create = () => new PrefetchFailureTracker(3, initialDelayMs, maxDelayMs, NoJitter);
 
         await Assert.That(create).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [Arguments(0, 100)]
+    [Arguments(100, 0)]
+    public async Task Observe_DisabledBackoff_ReturnsZeroDelay(int initialDelayMs, int maxDelayMs)
+    {
+        var tracker = new PrefetchFailureTracker(3, initialDelayMs, maxDelayMs, NoJitter);
+
+        var decision = tracker.Observe(Key, Positions, deterministic: false);
+
+        await Assert.That(decision.DelayMs).IsEqualTo(0);
     }
 
     private static PrefetchFailureTracker CreateTracker()

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
@@ -84,6 +84,16 @@ public sealed class PrefetchFailureTrackerTests
         await Assert.That(decision.Count).IsEqualTo(1);
     }
 
+    [Test]
+    [Arguments(0, 100)]
+    [Arguments(100, 99)]
+    public async Task Constructor_InvalidBackoff_Throws(int initialDelayMs, int maxDelayMs)
+    {
+        var create = () => new PrefetchFailureTracker(3, initialDelayMs, maxDelayMs, NoJitter);
+
+        await Assert.That(create).Throws<ArgumentOutOfRangeException>();
+    }
+
     private static PrefetchFailureTracker CreateTracker()
         => new(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000, NoJitter);
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PrefetchFailureTrackerTests.cs
@@ -4,6 +4,7 @@ namespace Dekaf.Tests.Unit.Consumer;
 
 public sealed class PrefetchFailureTrackerTests
 {
+    private static readonly Func<double> NoJitter = static () => 0.5;
     private static readonly PrefetchFailureKey Key = new(BrokerId: 1, ConnectionIndex: 0);
     private static readonly PrefetchPosition[] Positions =
     [
@@ -14,7 +15,7 @@ public sealed class PrefetchFailureTrackerTests
     [Test]
     public async Task Observe_DeterministicFailureTripsAtThreshold()
     {
-        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        var tracker = CreateTracker();
 
         var first = tracker.Observe(Key, Positions, deterministic: true);
         var second = tracker.Observe(Key, Positions, deterministic: true);
@@ -28,7 +29,7 @@ public sealed class PrefetchFailureTrackerTests
     [Test]
     public async Task Observe_ChangedPositionRestartsFailureCount()
     {
-        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        var tracker = CreateTracker();
         tracker.Observe(Key, Positions, deterministic: true);
         tracker.Observe(Key, Positions, deterministic: true);
         PrefetchPosition[] advanced =
@@ -45,7 +46,7 @@ public sealed class PrefetchFailureTrackerTests
     [Test]
     public async Task Observe_ChangedFailureClassificationRestartsFailureCount()
     {
-        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        var tracker = CreateTracker();
         tracker.Observe(Key, Positions, deterministic: false);
         tracker.Observe(Key, Positions, deterministic: false);
 
@@ -57,7 +58,7 @@ public sealed class PrefetchFailureTrackerTests
     [Test]
     public async Task Observe_TransientFailureBacksOffWithoutBecomingTerminal()
     {
-        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 500);
+        var tracker = new PrefetchFailureTracker(3, 100, 500, NoJitter);
         PrefetchFailureDecision decision = default;
 
         for (var i = 0; i < 10; i++)
@@ -73,7 +74,7 @@ public sealed class PrefetchFailureTrackerTests
     [Test]
     public async Task Reset_RestartsFailureCount()
     {
-        var tracker = new PrefetchFailureTracker(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000);
+        var tracker = CreateTracker();
         tracker.Observe(Key, Positions, deterministic: true);
         tracker.Observe(Key, Positions, deterministic: true);
 
@@ -82,4 +83,7 @@ public sealed class PrefetchFailureTrackerTests
 
         await Assert.That(decision.Count).IsEqualTo(1);
     }
+
+    private static PrefetchFailureTracker CreateTracker()
+        => new(terminalThreshold: 3, initialDelayMs: 100, maxDelayMs: 5_000, NoJitter);
 }

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -197,6 +197,18 @@ public sealed class MetadataRecoveryStrategyTests
     }
 
     [Test]
+    public async Task AdminClientOptions_RetryBackoff_DefaultsTo100And1000()
+    {
+        var options = new Dekaf.Admin.AdminClientOptions
+        {
+            BootstrapServers = ["localhost:9092"]
+        };
+
+        await Assert.That(options.RetryBackoffMs).IsEqualTo(100);
+        await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
     public async Task AdminClientOptions_ReconnectBackoffMaxMs_DefaultsTo1000()
     {
         var options = new Dekaf.Admin.AdminClientOptions

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -820,10 +820,12 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    [Arguments(0.0)]
-    [Arguments(0.5)]
-    [Arguments(0.999999)]
-    public async Task CalculateReconnectBackoffDelay_FixedBackoffDoesNotApplyJitter(double randomValue)
+    [Arguments(0.0, 98.4)]
+    [Arguments(0.5, 123.0)]
+    [Arguments(0.999999, 147.5999508)]
+    public async Task CalculateReconnectBackoffDelay_FixedBackoffAppliesJitter(
+        double randomValue,
+        double expectedMilliseconds)
     {
         await using var pool = CreateReconnectBackoffPool(
             reconnectBackoffMs: 123,
@@ -832,7 +834,7 @@ public sealed class ConnectionPoolTests
 
         var delay = pool.CalculateReconnectBackoffDelay(failureCount: 10);
 
-        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(123));
+        await Assert.That(delay.TotalMilliseconds).IsEqualTo(expectedMilliseconds).Within(0.001);
     }
 
     [Test]
@@ -860,7 +862,7 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task CalculateReconnectBackoffDelay_CapsJitterAtConfiguredMaximum()
+    public async Task CalculateReconnectBackoffDelay_CapsBaseBeforeJitter()
     {
         await using var pool = CreateReconnectBackoffPool(
             reconnectBackoffMs: 100,
@@ -869,7 +871,7 @@ public sealed class ConnectionPoolTests
 
         var delay = pool.CalculateReconnectBackoffDelay(failureCount: 2);
 
-        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(150));
+        await Assert.That(delay.TotalMilliseconds).IsEqualTo(179.99994).Within(0.001);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -160,6 +160,10 @@ public sealed class AdaptiveScaleDownTests
 
         try
         {
+            // Keep the live loop in partition-limited state so it cannot independently
+            // end and flush the reflection-driven diagnostic window before disposal.
+            GetField<HashSet<TopicPartition>>(sender, "_knownPartitions")
+                .Add(new TopicPartition(Topic, 0));
             var observe = typeof(BrokerSender).GetMethod(
                 "ObservePartitionLimitedPressure",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;
@@ -1048,6 +1052,7 @@ public sealed class AdaptiveScaleDownTests
 
         try
         {
+            await StopSendLoopAsync(sender);
             SetField(sender, "_connectionCount", 3);
             SetField(sender, "_totalMaxInFlight", 300);
             SetField(sender, "_totalPendingResponseCount", 1);
@@ -1198,6 +1203,12 @@ public sealed class AdaptiveScaleDownTests
         instance.GetType().GetField(
             fieldName,
             BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+
+    private static async Task StopSendLoopAsync(BrokerSender sender)
+    {
+        GetField<CancellationTokenSource>(sender, "_cts").Cancel();
+        await GetField<Task>(sender, "_sendLoopTask").WaitAsync(TimeSpan.FromSeconds(5));
+    }
 
     [Test]
     public async Task FirstScaleUp_InvalidatesEndpointPinnedSingleton()

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -613,6 +613,15 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                     sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
             });
 
+        // EnqueueBulk publishes separate channel events. Seed the known wave width before
+        // publishing so the live sender cannot dispatch the first event before its sibling
+        // has been written and thereby turn setup timing into an extra request.
+        var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+            "_knownPartitions",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+        knownPartitions.Add(new TopicPartition("test-topic", 0));
+        knownPartitions.Add(new TopicPartition("test-topic", 1));
+
         try
         {
             sender.EnqueueBulk(

--- a/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
@@ -45,6 +45,23 @@ public sealed class ExponentialRetryBackoffTests
     }
 
     [Test]
+    [Arguments(0.0, 4000.0)]
+    [Arguments(0.5, 5000.0)]
+    [Arguments(1.0, 6000.0)]
+    public async Task MaximumBelowInitial_PreservesConfiguredInitialDelay(
+        double randomValue,
+        double expectedDelayMs)
+    {
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            initialDelayMs: 5000,
+            maximumDelayMs: 1000,
+            failureCount: 1,
+            randomValue);
+
+        await Assert.That(delayMs).IsEqualTo(expectedDelayMs).Within(0.001);
+    }
+
+    [Test]
     public async Task ExtremeFailureCount_CapsWithoutOverflow()
     {
         var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(

--- a/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
@@ -1,0 +1,71 @@
+using Dekaf.Retry;
+
+namespace Dekaf.Tests.Unit.Retry;
+
+public sealed class ExponentialRetryBackoffTests
+{
+    [Test]
+    [Arguments(0.0, 80.0)]
+    [Arguments(0.5, 100.0)]
+    [Arguments(1.0, 120.0)]
+    public async Task FirstFailure_AppliesUnbiasedTwentyPercentJitter(
+        double randomValue,
+        double expectedDelayMs)
+    {
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            initialDelayMs: 100,
+            maximumDelayMs: 1000,
+            failureCount: 1,
+            randomValue);
+
+        await Assert.That(delayMs).IsEqualTo(expectedDelayMs).Within(0.001);
+    }
+
+    [Test]
+    public async Task RepeatedFailures_DoubleBeforeJitterAndCap()
+    {
+        var secondFailure = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 2, 0.5);
+        var fourthFailureLowJitter = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 4, 0.0);
+        var fifthFailureLowJitter = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 5, 0.0);
+
+        await Assert.That(secondFailure).IsEqualTo(200);
+        await Assert.That(fourthFailureLowJitter).IsEqualTo(640);
+        await Assert.That(fifthFailureLowJitter).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task InitialAtOrAboveMaximum_UsesMaximumWithoutJitter()
+    {
+        var equal = ExponentialRetryBackoff.CalculateDelayMilliseconds(1000, 1000, 1, 0.0);
+        var above = ExponentialRetryBackoff.CalculateDelayMilliseconds(2000, 1000, 10, 1.0);
+
+        await Assert.That(equal).IsEqualTo(1000);
+        await Assert.That(above).IsEqualTo(1000);
+    }
+
+    [Test]
+    public async Task ExtremeFailureCount_CapsWithoutOverflow()
+    {
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            initialDelayMs: 1,
+            maximumDelayMs: int.MaxValue,
+            failureCount: int.MaxValue,
+            randomValue: 0.0);
+
+        await Assert.That(delayMs).IsEqualTo(int.MaxValue);
+    }
+
+    [Test]
+    [Arguments(0, 1000)]
+    [Arguments(100, 0)]
+    public async Task ZeroBound_DisablesDelay(int initialDelayMs, int maximumDelayMs)
+    {
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+            initialDelayMs,
+            maximumDelayMs,
+            failureCount: 10,
+            randomValue: 0.5);
+
+        await Assert.That(delayMs).IsEqualTo(0);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/ExponentialRetryBackoffTests.cs
@@ -22,7 +22,7 @@ public sealed class ExponentialRetryBackoffTests
     }
 
     [Test]
-    public async Task RepeatedFailures_DoubleBeforeJitterAndCap()
+    public async Task RepeatedFailures_DoubleAndCapBeforeJitter()
     {
         var secondFailure = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 2, 0.5);
         var fourthFailureLowJitter = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 4, 0.0);
@@ -30,17 +30,18 @@ public sealed class ExponentialRetryBackoffTests
 
         await Assert.That(secondFailure).IsEqualTo(200);
         await Assert.That(fourthFailureLowJitter).IsEqualTo(640);
-        await Assert.That(fifthFailureLowJitter).IsEqualTo(1000);
+        await Assert.That(fifthFailureLowJitter).IsEqualTo(800);
     }
 
     [Test]
-    public async Task InitialAtOrAboveMaximum_UsesMaximumWithoutJitter()
+    [Arguments(0.0, 800.0)]
+    [Arguments(0.5, 1000.0)]
+    [Arguments(1.0, 1200.0)]
+    public async Task AtMaximum_PreservesTwentyPercentJitter(double randomValue, double expectedDelayMs)
     {
-        var equal = ExponentialRetryBackoff.CalculateDelayMilliseconds(1000, 1000, 1, 0.0);
-        var above = ExponentialRetryBackoff.CalculateDelayMilliseconds(2000, 1000, 10, 1.0);
+        var delayMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(100, 1000, 10, randomValue);
 
-        await Assert.That(equal).IsEqualTo(1000);
-        await Assert.That(above).IsEqualTo(1000);
+        await Assert.That(delayMs).IsEqualTo(expectedDelayMs).Within(0.001);
     }
 
     [Test]
@@ -52,7 +53,7 @@ public sealed class ExponentialRetryBackoffTests
             failureCount: int.MaxValue,
             randomValue: 0.0);
 
-        await Assert.That(delayMs).IsEqualTo(int.MaxValue);
+        await Assert.That(delayMs).IsEqualTo(int.MaxValue * 0.8).Within(0.001);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -21,6 +21,8 @@ public sealed class RetryHelperTests
                 : ValueTask.FromResult(42),
             metadataManager,
             CancellationToken.None,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0,
             maxRetries: 1);
 
         await Assert.That(result).IsEqualTo(42);
@@ -42,10 +44,87 @@ public sealed class RetryHelperTests
                 },
                 metadataManager,
                 CancellationToken.None,
+                retryBackoffMs: 0,
+                retryBackoffMaxMs: 0,
                 maxRetries: 1));
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
         await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TransportFailure_RetriesOriginalOperation()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        var attempts = 0;
+
+        var result = await RetryHelper.WithRetryAsync(
+            () => Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<int>(new IOException("connection reset"))
+                : ValueTask.FromResult(42),
+            metadataManager,
+            CancellationToken.None,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0,
+            maxRetries: 1);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Success_ResetsFailureSequenceForNextOperation()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        var failureCounts = new List<int>();
+        var attempts = 0;
+        int CalculateDelay(int initialDelayMs, int maximumDelayMs, int failureCount)
+        {
+            _ = initialDelayMs;
+            _ = maximumDelayMs;
+            failureCounts.Add(failureCount);
+            return 0;
+        }
+
+        for (var invocation = 0; invocation < 2; invocation++)
+        {
+            attempts = 0;
+            await RetryHelper.WithRetryAsync(
+                () => Interlocked.Increment(ref attempts) == 1
+                    ? ValueTask.FromException(CreateRequestTimeout())
+                    : ValueTask.CompletedTask,
+                metadataManager,
+                CancellationToken.None,
+                retryBackoffMs: 100,
+                retryBackoffMaxMs: 1000,
+                maxRetries: 1,
+                calculateDelayMilliseconds: CalculateDelay);
+        }
+
+        await Assert.That(failureCounts).IsEquivalentTo([1, 1]);
+    }
+
+    [Test]
+    public async Task CancellationDuringBackoff_StopsRetrying()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await RetryHelper.WithRetryAsync(
+                () =>
+                {
+                    Interlocked.Increment(ref attempts);
+                    return ValueTask.FromException(CreateRequestTimeout());
+                },
+                metadataManager,
+                cancellation.Token,
+                retryBackoffMs: 1000,
+                retryBackoffMaxMs: 1000,
+                maxRetries: 3));
+
+        await Assert.That(attempts).IsEqualTo(1);
     }
 
     private static MetadataManager CreateUnavailableMetadataManager()

--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -73,38 +73,6 @@ public sealed class RetryHelperTests
     }
 
     [Test]
-    public async Task Success_ResetsFailureSequenceForNextOperation()
-    {
-        await using var metadataManager = CreateUnavailableMetadataManager();
-        var failureCounts = new List<int>();
-        var attempts = 0;
-        int CalculateDelay(int initialDelayMs, int maximumDelayMs, int failureCount)
-        {
-            _ = initialDelayMs;
-            _ = maximumDelayMs;
-            failureCounts.Add(failureCount);
-            return 0;
-        }
-
-        for (var invocation = 0; invocation < 2; invocation++)
-        {
-            attempts = 0;
-            await RetryHelper.WithRetryAsync(
-                () => Interlocked.Increment(ref attempts) == 1
-                    ? ValueTask.FromException(CreateRequestTimeout())
-                    : ValueTask.CompletedTask,
-                metadataManager,
-                CancellationToken.None,
-                retryBackoffMs: 100,
-                retryBackoffMaxMs: 1000,
-                maxRetries: 1,
-                calculateDelayMilliseconds: CalculateDelay);
-        }
-
-        await Assert.That(failureCounts).IsEquivalentTo([1, 1]);
-    }
-
-    [Test]
     public async Task CancellationDuringBackoff_StopsRetrying()
     {
         await using var metadataManager = CreateUnavailableMetadataManager();

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -99,6 +99,64 @@ public sealed class ShareConsumerConnectionOwnershipTests
         await Assert.That(connection.LeaseCount).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task SendShareFetchForPartitionsAsync_RetriesRetriableTopLevelError()
+    {
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-group",
+            ConnectionsPerBroker = 2,
+            RetryBackoffMs = 0,
+            RetryBackoffMaxMs = 0
+        };
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.ShareFetch,
+                ShareFetchRequest.LowestSupportedVersion,
+                ShareFetchRequest.HighestSupportedVersion),
+            new ApiVersion(
+                ApiKey.Metadata,
+                MetadataRequest.LowestSupportedVersion,
+                MetadataRequest.HighestSupportedVersion))
+        {
+            ShareFetchResponses = new Queue<ShareFetchResponse>(
+            [
+                new ShareFetchResponse
+                {
+                    ErrorCode = ErrorCode.CoordinatorLoadInProgress,
+                    Responses = [],
+                    NodeEndpoints = []
+                },
+                new ShareFetchResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    Responses = [],
+                    NodeEndpoints = []
+                }
+            ])
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        await using var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+        SetMemberId(consumer, "member-1");
+
+        var sendTask = InvokeSendShareFetchForPartitionsAsync(consumer);
+
+        await sendTask;
+
+        await Assert.That(connection.ShareFetchSendCount).IsEqualTo(2);
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
     private static Task InvokeSendShareFetchForPartitionsAsync(
         KafkaShareConsumer<string, string> consumer)
     {
@@ -154,6 +212,8 @@ public sealed class ShareConsumerConnectionOwnershipTests
             });
         public int LeaseCount => Volatile.Read(ref _leaseCount);
         public int LeaseCountDuringSend { get; private set; }
+        public int ShareFetchSendCount { get; private set; }
+        public Queue<ShareFetchResponse>? ShareFetchResponses { get; init; }
 
         int IRetirableKafkaConnection.LeaseCount => LeaseCount;
         int IRetirableKafkaConnection.ActiveOperationCount => 0;
@@ -193,15 +253,24 @@ public sealed class ShareConsumerConnectionOwnershipTests
                 {
                     ErrorCode = ErrorCode.None
                 },
-                ShareFetchRequest => new ShareFetchResponse
+                ShareFetchRequest => GetShareFetchResponse(),
+                MetadataRequest => new MetadataResponse { Brokers = [], Topics = [] },
+                _ => throw new NotSupportedException(typeof(TRequest).Name)
+            };
+            return new ValueTask<TResponse>((TResponse)response);
+        }
+
+        private ShareFetchResponse GetShareFetchResponse()
+        {
+            ShareFetchSendCount++;
+            return ShareFetchResponses is { Count: > 0 }
+                ? ShareFetchResponses.Dequeue()
+                : new ShareFetchResponse
                 {
                     ErrorCode = ErrorCode.None,
                     Responses = [],
                     NodeEndpoints = []
-                },
-                _ => throw new NotSupportedException(typeof(TRequest).Name)
-            };
-            return new ValueTask<TResponse>((TResponse)response);
+                };
         }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerConnectionOwnershipTests.cs
@@ -157,6 +157,76 @@ public sealed class ShareConsumerConnectionOwnershipTests
         await Assert.That(connection.LeaseCount).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task Unsubscribe_RetriableReleaseFailure_DoesNotRetry()
+    {
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-group",
+            ConnectionsPerBroker = 2,
+            RetryBackoffMs = 0,
+            RetryBackoffMaxMs = 0
+        };
+        var connection = new LeaseTrackingConnection(
+            new ApiVersion(
+                ApiKey.ShareAcknowledge,
+                ShareAcknowledgeRequest.LowestSupportedVersion,
+                ShareAcknowledgeRequest.HighestSupportedVersion))
+        {
+            ShareAcknowledgeResponse = new ShareAcknowledgeResponse
+            {
+                ErrorCode = ErrorCode.CoordinatorLoadInProgress,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        pool.GetConnectionAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "test-topic",
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+        var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+        var acknowledgementTracker = (AcknowledgementTracker)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_ackTracker", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        acknowledgementTracker.TrackDeliveredRecords(new TopicPartition("test-topic", 0), 1, 1);
+
+        consumer.Unsubscribe();
+        await consumer.DisposeAsync();
+
+        await Assert.That(connection.ShareAcknowledgeSendCount).IsEqualTo(1);
+        await Assert.That(connection.LeaseCount).IsEqualTo(0);
+    }
+
     private static Task InvokeSendShareFetchForPartitionsAsync(
         KafkaShareConsumer<string, string> consumer)
     {
@@ -213,7 +283,9 @@ public sealed class ShareConsumerConnectionOwnershipTests
         public int LeaseCount => Volatile.Read(ref _leaseCount);
         public int LeaseCountDuringSend { get; private set; }
         public int ShareFetchSendCount { get; private set; }
+        public int ShareAcknowledgeSendCount { get; private set; }
         public Queue<ShareFetchResponse>? ShareFetchResponses { get; init; }
+        public ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
 
         int IRetirableKafkaConnection.LeaseCount => LeaseCount;
         int IRetirableKafkaConnection.ActiveOperationCount => 0;
@@ -254,6 +326,7 @@ public sealed class ShareConsumerConnectionOwnershipTests
                     ErrorCode = ErrorCode.None
                 },
                 ShareFetchRequest => GetShareFetchResponse(),
+                ShareAcknowledgeRequest => GetShareAcknowledgeResponse(),
                 MetadataRequest => new MetadataResponse { Brokers = [], Topics = [] },
                 _ => throw new NotSupportedException(typeof(TRequest).Name)
             };
@@ -271,6 +344,17 @@ public sealed class ShareConsumerConnectionOwnershipTests
                     Responses = [],
                     NodeEndpoints = []
                 };
+        }
+
+        private ShareAcknowledgeResponse GetShareAcknowledgeResponse()
+        {
+            ShareAcknowledgeSendCount++;
+            return ShareAcknowledgeResponse ?? new ShareAcknowledgeResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            };
         }
 
         public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
@@ -5,22 +5,18 @@ namespace Dekaf.Tests.Unit.ShareConsumer;
 public sealed class ShareConsumerCoordinatorTests
 {
     [Test]
-    public async Task WaitForAssignmentDelay_UsesHeartbeatIntervalWhenLonger()
+    public async Task WaitForAssignmentDelay_UsesHeartbeatInterval()
     {
-        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(
-            retryDelayMs: 200,
-            heartbeatIntervalMs: 3000);
+        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(heartbeatIntervalMs: 3000);
 
         await Assert.That(delayMs).IsEqualTo(3000);
     }
 
     [Test]
-    public async Task WaitForAssignmentDelay_UsesRetryDelayWhenLonger()
+    public async Task WaitForAssignmentDelay_NormalizesNonPositiveInterval()
     {
-        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(
-            retryDelayMs: 1000,
-            heartbeatIntervalMs: 500);
+        var delayMs = ShareConsumerCoordinator.GetWaitForAssignmentDelayMs(heartbeatIntervalMs: 0);
 
-        await Assert.That(delayMs).IsEqualTo(1000);
+        await Assert.That(delayMs).IsEqualTo(1);
     }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerCoordinatorTests.cs
@@ -19,4 +19,37 @@ public sealed class ShareConsumerCoordinatorTests
 
         await Assert.That(delayMs).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task JoinRetryDelay_UsesCalculatedDelayWhenDeadlineIsFartherAway()
+    {
+        var delay = ShareConsumerCoordinator.GetJoinRetryDelay(
+            retryDelayMs: 500,
+            elapsed: TimeSpan.FromSeconds(1),
+            joinTimeout: TimeSpan.FromSeconds(5));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Test]
+    public async Task JoinRetryDelay_IsCappedToRemainingDeadline()
+    {
+        var delay = ShareConsumerCoordinator.GetJoinRetryDelay(
+            retryDelayMs: 5_000,
+            elapsed: TimeSpan.FromMilliseconds(4_750),
+            joinTimeout: TimeSpan.FromSeconds(5));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Test]
+    public async Task JoinRetryDelay_IsZeroAfterDeadline()
+    {
+        var delay = ShareConsumerCoordinator.GetJoinRetryDelay(
+            retryDelayMs: 500,
+            elapsed: TimeSpan.FromSeconds(6),
+            joinTimeout: TimeSpan.FromSeconds(5));
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.Zero);
+    }
 }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerOptionsDefaultsTests.cs
@@ -19,6 +19,14 @@ public sealed class ShareConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task RetryBackoff_DefaultsTo_100And1000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.RetryBackoffMs).IsEqualTo(100);
+        await Assert.That(options.RetryBackoffMaxMs).IsEqualTo(1000);
+    }
+
+    [Test]
     public async Task ReconnectBackoffMaxMs_DefaultsTo_1000()
     {
         var options = CreateOptions();


### PR DESCRIPTION
## Summary
- add one overflow-safe KIP-580 calculator with symmetric ±20% jitter and fixed/capped edge handling
- expose `retry.backoff.ms` / `retry.backoff.max.ms` (100 ms / 1000 ms defaults) across producer, consumer, share consumer, admin, root client, and DI binding
- apply consecutive-failure backoff to producer batches/transactions, metadata/background refresh, consumer prefetch/offset operations, share fetch/ack, and admin requests; reset on success
- leave group rebalance timing unchanged
- make three pre-existing producer concurrency tests deterministic after the full suite exposed live sender/setup races

## Verification
- unit after rebase: 5,721 passed, 0 failed
- consumer integration after rebase (Kafka 4.3.1): 125 passed, 0 failed
- full integration before rebase (Kafka 4.3.1): 820 passed, 0 failed
- `dotnet build`: 0 warnings, 0 errors

## Performance
Exact-parent comparison after rebase: `202eb7dd` → `e60a6756`.

`AccumulatorAppendBenchmarks` (`MemoryDiagnoser`, built-in throughput job):

| Case | Baseline | Candidate | Delta | Allocation |
|---|---:|---:|---:|---:|
| Hot, 100 B | 94.52 ns | 98.24 ns | +3.9% | 0 B → 4 B* |
| Multi, 100 B | 101.64 ns | 104.24 ns | +2.6% | 0 B → 0 B |
| Hot, 1000 B | 251.69 ns | 247.79 ns | -1.6% | 0 B → 0 B |
| Multi, 1000 B | 271.48 ns | 268.81 ns | -1.0% | 0 B → 0 B |

All confidence intervals overlap. The candidate keeps the three deterministic rows at `0 B`; Hot/100 hit the benchmark's known stochastic drainer-behind cold-path noise (`4 B`). The immediately preceding same-change run measured `0 B` for that row. Combined before/after evidence shows no protected regression signal.

Closes #2264