### PR TITLE
Stabilize LockFreeStack allocation probe

### DIFF
--- a/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
@@ -1,6 +1,7 @@
 using Dekaf.Internal;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Dekaf.Tests.Unit.Internal;
 
@@ -109,30 +110,40 @@ public class LockFreeStackTests
         // LockFreeStack's steady-state operations contribute to its allocation counter.
         using (ExecutionContext.SuppressFlow())
         {
-            allocationProbe = Task.Factory.StartNew(static () =>
-            {
-                var stack = new LockFreeStack<Item>(1);
-                var item = new Item { Value = 42 };
-
-                for (var i = 0; i < 100; i++)
-                {
-                    stack.TryPush(item);
-                    stack.TryPop(out _);
-                }
-
-                var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-                for (var i = 0; i < 10_000; i++)
-                {
-                    stack.TryPush(item);
-                    stack.TryPop(out _);
-                }
-
-                return GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
-            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            allocationProbe = Task.Factory.StartNew(
+                MeasureSteadyStateAllocations,
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
         }
 
         var allocated = await allocationProbe;
         await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    // Compile the complete probe at the optimized tier before it starts. Otherwise
+    // suite-wide JIT load can delay tier promotion until the measured loop and make
+    // runtime transition work look like a LockFreeStack allocation.
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    private static long MeasureSteadyStateAllocations()
+    {
+        var stack = new LockFreeStack<Item>(1);
+        var item = new Item { Value = 42 };
+
+        for (var i = 0; i < 100; i++)
+        {
+            stack.TryPush(item);
+            stack.TryPop(out _);
+        }
+
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 10_000; i++)
+        {
+            stack.TryPush(item);
+            stack.TryPop(out _);
+        }
+
+        return GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -1639,6 +1639,8 @@ public sealed class AdaptiveScaleDownTests
             return ValueTask.CompletedTask;
         });
         var sender = CreateSender(pool, options, accumulator, onAcknowledgement: null);
+        sender.RequestCancellation();
+        await GetField<Task>(sender, "_sendLoopTask");
 
         try
         {


### PR DESCRIPTION
## Summary
- move the exact LockFreeStack allocation probe into an `AggressiveOptimization` method so suite-wide JIT load cannot trigger tier promotion inside the measured interval
- preserve the dedicated thread, suppressed `ExecutionContext`, and exact `0 B` assertion
- quiesce the BrokerSender before the reflective `ApplyScaleDown` test invocation, fixing a separate live-loop race exposed during full-suite validation

## Verification
- Release build: 0 warnings, 0 errors
- exact allocation probe, fresh processes: net10 30/30; net8 20/20
- full Release net10 suite after fixes: 3 consecutive passes, 5,705/5,705 each
- full Release net8 suite after fixes: 2 consecutive passes, 5,578/5,578 each
- affected scale-down test: 1/1

Closes #2205