### PR TITLE
fix(consumer): recover stale OffsetFetch membership

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -807,148 +807,114 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (string.IsNullOrEmpty(_options.GroupId))
             return new Dictionary<TopicPartition, TopicPartitionOffset>();
 
-        // Lock is intentionally held across retries to protect the shared _fetchTopicGroups dictionary,
-        // which is reused across calls to avoid allocations. With up to 3 retries x ~600ms each,
-        // the lock can be held for up to ~1.8 seconds. Concurrent callers will block for the full retry duration.
-        await _fetchLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var configuredTimeout = TimeSpan.FromMilliseconds(_options.RequestTimeoutMs);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(configuredTimeout);
+        var operationToken = timeout.Token;
+
         try
         {
-            return await RetryHelper.WithRetryAsync(async () =>
+            // Lock is intentionally held across retries to protect the shared _fetchTopicGroups dictionary,
+            // which is reused across calls to avoid allocations. The operation token bounds lock acquisition,
+            // membership recovery, retry delay, and every network request to one aggregate deadline.
+            await _fetchLock.WaitAsync(operationToken).ConfigureAwait(false);
+            try
             {
-                if (_coordinatorId < 0)
-                    await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
-
-                var coordinatorId = _coordinatorId;
-                if (coordinatorId < 0)
+                return await RetryHelper.WithRetryAsync(async () =>
                 {
-                    throw new Errors.GroupException(
-                        ErrorCode.CoordinatorNotAvailable,
-                        "Coordinator was invalidated during offset fetch discovery")
+                    if (_coordinatorId < 0)
+                        await FindCoordinatorAsync(operationToken).ConfigureAwait(false);
+
+                    var coordinatorId = _coordinatorId;
+                    if (coordinatorId < 0)
                     {
-                        GroupId = _options.GroupId
-                    };
-                }
-
-                using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-                    coordinatorId,
-                    _getCoordinationConnectionIndex(),
-                    cancellationToken)
-                    .ConfigureAwait(false);
-                var connection = connectionLease.Connection;
-
-                // Group partitions by topic using pooled dictionary to avoid allocations
-                // Clear existing Lists before clearing the dictionary to reuse List instances
-                foreach (var list in _fetchTopicGroups.Values)
-                {
-                    list.Clear();
-                }
-
-                foreach (var partition in partitions)
-                {
-                    if (!_fetchTopicGroups.TryGetValue(partition.Topic, out var indexes))
-                    {
-                        indexes = [];
-                        _fetchTopicGroups[partition.Topic] = indexes;
+                        throw new Errors.GroupException(
+                            ErrorCode.CoordinatorNotAvailable,
+                            "Coordinator was invalidated during offset fetch discovery")
+                        {
+                            GroupId = _options.GroupId
+                        };
                     }
-                    indexes.Add(partition.Partition);
-                }
 
-                RemoveEmptyTopicGroups(_fetchTopicGroups);
+                    using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                        coordinatorId,
+                        _getCoordinationConnectionIndex(),
+                        operationToken)
+                        .ConfigureAwait(false);
+                    var connection = connectionLease.Connection;
 
-                var topicPartitions = new List<OffsetFetchRequestTopic>(_fetchTopicGroups.Count);
-                foreach (var kvp in _fetchTopicGroups)
-                {
-                    topicPartitions.Add(new OffsetFetchRequestTopic
+                    // Group partitions by topic using pooled dictionary to avoid allocations
+                    // Clear existing Lists before clearing the dictionary to reuse List instances
+                    foreach (var list in _fetchTopicGroups.Values)
                     {
-                        Name = kvp.Key,
-                        PartitionIndexes = kvp.Value
-                    });
-                }
+                        list.Clear();
+                    }
 
-                var request = new OffsetFetchRequest
-                {
-                    GroupId = _options.GroupId!,
-                    Topics = topicPartitions,
-                    Groups =
-                    [
-                        new OffsetFetchRequestGroup
+                    foreach (var partition in partitions)
+                    {
+                        if (!_fetchTopicGroups.TryGetValue(partition.Topic, out var indexes))
+                        {
+                            indexes = [];
+                            _fetchTopicGroups[partition.Topic] = indexes;
+                        }
+                        indexes.Add(partition.Partition);
+                    }
+
+                    RemoveEmptyTopicGroups(_fetchTopicGroups);
+
+                    var topicPartitions = new List<OffsetFetchRequestTopic>(_fetchTopicGroups.Count);
+                    foreach (var kvp in _fetchTopicGroups)
+                    {
+                        topicPartitions.Add(new OffsetFetchRequestTopic
+                        {
+                            Name = kvp.Key,
+                            PartitionIndexes = kvp.Value
+                        });
+                    }
+
+                    var request = new OffsetFetchRequest
+                    {
+                        GroupId = _options.GroupId!,
+                        Topics = topicPartitions,
+                        Groups =
+                        [
+                            new OffsetFetchRequestGroup
                         {
                             GroupId = _options.GroupId!,
                             MemberId = _memberId,
                             MemberEpoch = _generationId,
                             Topics = topicPartitions
                         }
-                    ]
-                };
-
-                // Use negotiated API version
-                var offsetFetchVersion = _metadataManager.GetNegotiatedApiVersion(
-                    ApiKey.OffsetFetch,
-                    OffsetFetchRequest.LowestSupportedVersion,
-                    OffsetFetchRequest.HighestSupportedVersion);
-
-                var response = await connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
-                    request,
-                    offsetFetchVersion,
-                    cancellationToken).ConfigureAwait(false);
-
-                // Check top-level error (v6-v7)
-                if (response.ErrorCode != ErrorCode.None)
-                {
-                    throw new GroupException(response.ErrorCode,
-                        $"OffsetFetch failed: {response.ErrorCode}")
-                    {
-                        GroupId = _options.GroupId
+                        ]
                     };
-                }
 
-                var result = new Dictionary<TopicPartition, TopicPartitionOffset>();
+                    // Use negotiated API version
+                    var offsetFetchVersion = _metadataManager.GetNegotiatedApiVersion(
+                        ApiKey.OffsetFetch,
+                        OffsetFetchRequest.LowestSupportedVersion,
+                        OffsetFetchRequest.HighestSupportedVersion);
 
-                // v6-v7: Topics field
-                if (response.Topics is not null)
-                {
-                    foreach (var topic in response.Topics)
+                    var response = await connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                        request,
+                        offsetFetchVersion,
+                        operationToken).ConfigureAwait(false);
+
+                    // Check top-level error (v6-v7)
+                    if (response.ErrorCode != ErrorCode.None)
                     {
-                        foreach (var partition in topic.Partitions)
+                        throw new GroupException(response.ErrorCode,
+                            $"OffsetFetch failed: {response.ErrorCode}")
                         {
-                            if (partition.ErrorCode != ErrorCode.None)
-                            {
-                                throw new GroupException(partition.ErrorCode,
-                                    $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
-                                {
-                                    GroupId = _options.GroupId
-                                };
-                            }
-
-                            if (partition.CommittedOffset >= 0)
-                            {
-                                result[new TopicPartition(topic.Name, partition.PartitionIndex)] =
-                                    new TopicPartitionOffset(
-                                        topic.Name,
-                                        partition.PartitionIndex,
-                                        partition.CommittedOffset,
-                                        partition.CommittedLeaderEpoch);
-                            }
-                        }
+                            GroupId = _options.GroupId
+                        };
                     }
-                }
 
-                // v8+: Groups field
-                if (response.Groups is not null)
-                {
-                    foreach (var group in response.Groups)
+                    var result = new Dictionary<TopicPartition, TopicPartitionOffset>();
+
+                    // v6-v7: Topics field
+                    if (response.Topics is not null)
                     {
-                        if (group.ErrorCode != ErrorCode.None)
-                        {
-                            HandleOffsetFetchMembershipError(group.ErrorCode);
-                            throw new GroupException(group.ErrorCode,
-                                $"OffsetFetch failed for group: {group.ErrorCode}")
-                            {
-                                GroupId = _options.GroupId
-                            };
-                        }
-
-                        foreach (var topic in group.Topics)
+                        foreach (var topic in response.Topics)
                         {
                             foreach (var partition in topic.Partitions)
                             {
@@ -973,28 +939,106 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                             }
                         }
                     }
-                }
 
-                return result;
-            }, _metadataManager, cancellationToken, onRetry: FindCoordinatorAsync).ConfigureAwait(false);
+                    // v8+: Groups field
+                    if (response.Groups is not null)
+                    {
+                        foreach (var group in response.Groups)
+                        {
+                            if (group.ErrorCode != ErrorCode.None)
+                            {
+                                var isRetriable = HandleOffsetFetchMembershipError(group.ErrorCode);
+                                throw new GroupException(
+                                    group.ErrorCode,
+                                    $"OffsetFetch failed for group: {group.ErrorCode}",
+                                    isRetriable)
+                                {
+                                    GroupId = _options.GroupId
+                                };
+                            }
+
+                            foreach (var topic in group.Topics)
+                            {
+                                foreach (var partition in topic.Partitions)
+                                {
+                                    if (partition.ErrorCode != ErrorCode.None)
+                                    {
+                                        throw new GroupException(partition.ErrorCode,
+                                            $"OffsetFetch failed for {topic.Name}-{partition.PartitionIndex}: {partition.ErrorCode}")
+                                        {
+                                            GroupId = _options.GroupId
+                                        };
+                                    }
+
+                                    if (partition.CommittedOffset >= 0)
+                                    {
+                                        result[new TopicPartition(topic.Name, partition.PartitionIndex)] =
+                                            new TopicPartitionOffset(
+                                                topic.Name,
+                                                partition.PartitionIndex,
+                                                partition.CommittedOffset,
+                                                partition.CommittedLeaderEpoch);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    return result;
+                },
+                _metadataManager,
+                operationToken,
+                onRetry: RecoverOffsetFetchAsync,
+                shouldRefreshMetadata: ShouldRefreshMetadataForOffsetFetchRetry).ConfigureAwait(false);
+            }
+            finally
+            {
+                _fetchLock.Release();
+            }
         }
-        finally
+        catch (OperationCanceledException ex) when (
+            !cancellationToken.IsCancellationRequested
+            && timeout.IsCancellationRequested)
         {
-            _fetchLock.Release();
+            throw new KafkaTimeoutException(
+                $"OffsetFetch for group '{_options.GroupId}' did not complete within request timeout " +
+                $"({_options.RequestTimeoutMs}ms)",
+                ex);
         }
     }
 
-    private void HandleOffsetFetchMembershipError(ErrorCode errorCode)
+    private async ValueTask RecoverOffsetFetchAsync(CancellationToken cancellationToken)
+    {
+        var subscribedTopics = _subscribedTopics;
+        if (_state == CoordinatorState.Unjoined && subscribedTopics is not null)
+        {
+            await EnsureActiveGroupAsync(
+                subscribedTopics,
+                _subscribedTopicRegex,
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool ShouldRefreshMetadataForOffsetFetchRetry(KafkaException exception) =>
+        exception.ErrorCode is not ErrorCode.StaleMemberEpoch and not ErrorCode.UnknownMemberId;
+
+    private bool HandleOffsetFetchMembershipError(ErrorCode errorCode)
     {
         switch (errorCode)
         {
             case ErrorCode.StaleMemberEpoch:
                 RequestRejoin();
-                break;
+                return true;
 
             case ErrorCode.UnknownMemberId:
                 ResetMemberState();
-                break;
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -947,7 +947,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                         {
                             if (group.ErrorCode != ErrorCode.None)
                             {
-                                var isRetriable = HandleOffsetFetchMembershipError(group.ErrorCode);
+                                var isRetriable = HandleOffsetFetchMembershipError(group.ErrorCode)
+                                    || group.ErrorCode.IsRetriable();
                                 throw new GroupException(
                                     group.ErrorCode,
                                     $"OffsetFetch failed for group: {group.ErrorCode}",

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -5479,145 +5479,158 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // concurrently. Without synchronization, concurrent access to non-thread-safe
         // _assignment HashSet causes NullReferenceException during enumeration.
         // Readers use the volatile _assignmentSnapshot instead of acquiring this lock.
-        await SemaphoreHelper.AcquireOrThrowDisposedAsync(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
-        (ConsumerCoordinator Coordinator, HashSet<TopicPartition> Partitions)? unacknowledgedCoordinatorRevocations = null;
-        try
+        while (true)
         {
-            coordinator = _coordinator;
-            if ((!_subscription.IsEmpty || topicPattern is not null) && coordinator is not null)
+            await SemaphoreHelper.AcquireOrThrowDisposedAsync(_assignmentLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
+            (ConsumerCoordinator Coordinator, HashSet<TopicPartition> Partitions)? unacknowledgedCoordinatorRevocations = null;
+            try
             {
-                BeforeCoordinatorAssignmentSnapshotForTest?.Invoke();
-                var (coordinatorAssignment, coordinatorAssignmentVersion, coordinatorRevocations) =
-                    await coordinator.GetAssignmentSnapshotAndDrainRevocationsAsync(cancellationToken)
-                        .ConfigureAwait(false);
-                if (coordinatorRevocations is not null)
+                coordinator = _coordinator;
+                if ((!_subscription.IsEmpty || topicPattern is not null) && coordinator is not null)
                 {
-                    unacknowledgedCoordinatorRevocations = (coordinator, coordinatorRevocations);
-                }
-
-                // Set equality alone is insufficient: the assignment can change away and back
-                // between polls. Unseen revocations require stale-fetch cleanup and position reset.
-                if (_assignment.SetEquals(coordinatorAssignment)
-                    && coordinatorRevocations is null
-                    && HasInitializedFetchPositions(coordinatorAssignment))
-                {
-                    Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
-                    coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
-                    return;
-                }
-
-                // Check for new partitions that need initialization
-                List<TopicPartition>? newPartitions = null;
-                foreach (var partition in coordinatorAssignment)
-                {
-                    if (!_assignment.Contains(partition) || !_fetchPositions.ContainsKey(partition))
+                    BeforeCoordinatorAssignmentSnapshotForTest?.Invoke();
+                    var (coordinatorAssignment, coordinatorAssignmentVersion, coordinatorRevocations) =
+                        await coordinator.GetAssignmentSnapshotAndDrainRevocationsAsync(cancellationToken)
+                            .ConfigureAwait(false);
+                    if (coordinatorRevocations is not null)
                     {
-                        newPartitions ??= new List<TopicPartition>();
-                        newPartitions.Add(partition);
+                        unacknowledgedCoordinatorRevocations = (coordinator, coordinatorRevocations);
                     }
-                }
 
-                // Check for partitions that were removed (for EOF state cleanup)
-                List<TopicPartition>? removedPartitions = null;
-                foreach (var partition in _assignment)
-                {
-                    if (!coordinatorAssignment.Contains(partition))
+                    // Set equality alone is insufficient: the assignment can change away and back
+                    // between polls. Unseen revocations require stale-fetch cleanup and position reset.
+                    if (_assignment.SetEquals(coordinatorAssignment)
+                        && coordinatorRevocations is null
+                        && HasInitializedFetchPositions(coordinatorAssignment))
                     {
-                        removedPartitions ??= new List<TopicPartition>();
-                        removedPartitions.Add(partition);
-                    }
-                }
-
-                if (coordinatorRevocations is not null)
-                {
-                    foreach (var partition in coordinatorRevocations)
-                    {
-                        if (removedPartitions is null || !removedPartitions.Contains(partition))
-                            (removedPartitions ??= []).Add(partition);
-
-                        if (!coordinatorAssignment.Contains(partition))
+                        if (coordinator.AssignmentVersion != coordinatorAssignmentVersion)
                             continue;
 
-                        if (newPartitions is null || !newPartitions.Contains(partition))
-                            (newPartitions ??= []).Add(partition);
+                        Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+                        coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
+                        return;
                     }
-                }
 
-                if (newPartitions is { Count: > 0 })
-                    LogPartitionsAdded(newPartitions.Count);
-                if (removedPartitions is { Count: > 0 })
-                    LogPartitionsRemoved(removedPartitions.Count);
-
-                // Invalidate in-flight fetches before publishing an ABA reassignment or
-                // reinitializing its position. The consume loop owns the actual buffer drain.
-                if (removedPartitions is not null)
-                    QueueCoordinatorRevokedPartitionsForFetchClear(removedPartitions);
-
-                // Update assignment from coordinator
-                _assignment.Clear();
-                foreach (var partition in coordinatorAssignment)
-                {
-                    _assignment.Add(partition);
-                }
-                PublishAssignmentSnapshot();
-                InvalidatePartitionCache();
-                InvalidateFetchRequestCache();
-
-                // Ratchet pool sizes based on actual partition count
-                RatchetConsumerPoolSizes(_assignment.Count);
-
-                // Clean up state for removed partitions
-                if (removedPartitions is not null)
-                {
-                    if (RemovePartitionState(removedPartitions))
-                        PublishPausedSnapshot();
-                }
-
-                // Initialize positions for new partitions
-                if (newPartitions is { Count: > 0 })
-                {
-                    await InitializePositionsAsync(newPartitions, cancellationToken).ConfigureAwait(false);
-                }
-
-                Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
-                coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
-                unacknowledgedCoordinatorRevocations = null;
-            }
-            else
-            {
-                if (_assignment.Count > 0)
-                {
-                    // Ratchet pool sizes based on actual partition count (manual assignment)
-                    RatchetConsumerPoolSizes(_assignment.Count);
-
-                    // Manual assignment - initialize positions for partitions that don't have positions yet
-                    List<TopicPartition>? uninitializedPartitions = null;
-                    foreach (var p in _assignment)
+                    // Check for new partitions that need initialization
+                    List<TopicPartition>? newPartitions = null;
+                    foreach (var partition in coordinatorAssignment)
                     {
-                        if (!_fetchPositions.ContainsKey(p))
+                        if (!_assignment.Contains(partition) || !_fetchPositions.ContainsKey(partition))
                         {
-                            uninitializedPartitions ??= new List<TopicPartition>();
-                            uninitializedPartitions.Add(p);
+                            newPartitions ??= new List<TopicPartition>();
+                            newPartitions.Add(partition);
                         }
                     }
 
-                    if (uninitializedPartitions is not null)
+                    // Check for partitions that were removed (for EOF state cleanup)
+                    List<TopicPartition>? removedPartitions = null;
+                    foreach (var partition in _assignment)
                     {
-                        await InitializeManualAssignmentPositionsAsync(uninitializedPartitions, cancellationToken).ConfigureAwait(false);
+                        if (!coordinatorAssignment.Contains(partition))
+                        {
+                            removedPartitions ??= new List<TopicPartition>();
+                            removedPartitions.Add(partition);
+                        }
                     }
+
+                    if (coordinatorRevocations is not null)
+                    {
+                        foreach (var partition in coordinatorRevocations)
+                        {
+                            if (removedPartitions is null || !removedPartitions.Contains(partition))
+                                (removedPartitions ??= []).Add(partition);
+
+                            if (!coordinatorAssignment.Contains(partition))
+                                continue;
+
+                            if (newPartitions is null || !newPartitions.Contains(partition))
+                                (newPartitions ??= []).Add(partition);
+                        }
+                    }
+
+                    if (newPartitions is { Count: > 0 })
+                        LogPartitionsAdded(newPartitions.Count);
+                    if (removedPartitions is { Count: > 0 })
+                        LogPartitionsRemoved(removedPartitions.Count);
+
+                    // Invalidate in-flight fetches before publishing an ABA reassignment or
+                    // reinitializing its position. The consume loop owns the actual buffer drain.
+                    if (removedPartitions is not null)
+                        QueueCoordinatorRevokedPartitionsForFetchClear(removedPartitions);
+
+                    // Update assignment from coordinator
+                    _assignment.Clear();
+                    foreach (var partition in coordinatorAssignment)
+                    {
+                        _assignment.Add(partition);
+                    }
+                    PublishAssignmentSnapshot();
+                    InvalidatePartitionCache();
+                    InvalidateFetchRequestCache();
+
+                    // Ratchet pool sizes based on actual partition count
+                    RatchetConsumerPoolSizes(_assignment.Count);
+
+                    // Clean up state for removed partitions
+                    if (removedPartitions is not null)
+                    {
+                        if (RemovePartitionState(removedPartitions))
+                            PublishPausedSnapshot();
+                    }
+
+                    // Initialize positions for new partitions
+                    if (newPartitions is { Count: > 0 })
+                    {
+                        await InitializePositionsAsync(newPartitions, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // OffsetFetch recovery can rejoin the group. If that produced a new assignment,
+                    // synchronize the latest snapshot before publishing this pass as current.
+                    if (coordinator.AssignmentVersion != coordinatorAssignmentVersion)
+                        continue;
+
+                    Volatile.Write(ref _lastCoordinatorAssignmentVersion, coordinatorAssignmentVersion);
+                    coordinator.AcknowledgeAssignmentSync(coordinatorAssignmentVersion);
+                    unacknowledgedCoordinatorRevocations = null;
                 }
+                else
+                {
+                    if (_assignment.Count > 0)
+                    {
+                        // Ratchet pool sizes based on actual partition count (manual assignment)
+                        RatchetConsumerPoolSizes(_assignment.Count);
 
-                Volatile.Write(ref _lastManualAssignmentEnsureVersion, Volatile.Read(ref _assignmentEnsureVersion));
+                        // Manual assignment - initialize positions for partitions that don't have positions yet
+                        List<TopicPartition>? uninitializedPartitions = null;
+                        foreach (var p in _assignment)
+                        {
+                            if (!_fetchPositions.ContainsKey(p))
+                            {
+                                uninitializedPartitions ??= new List<TopicPartition>();
+                                uninitializedPartitions.Add(p);
+                            }
+                        }
+
+                        if (uninitializedPartitions is not null)
+                        {
+                            await InitializeManualAssignmentPositionsAsync(uninitializedPartitions, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+
+                    Volatile.Write(ref _lastManualAssignmentEnsureVersion, Volatile.Read(ref _assignmentEnsureVersion));
+                }
             }
-        }
-        finally
-        {
-            // Position initialization and assignment-version publication acknowledge the drain.
-            // Restore on failure so the next sync repeats revocation cleanup and initialization.
-            if (unacknowledgedCoordinatorRevocations is { } revocations)
-                revocations.Coordinator.RestoreRevokedPartitionsSinceLastSync(revocations.Partitions);
+            finally
+            {
+                // Position initialization and assignment-version publication acknowledge the drain.
+                // Restore on failure so the next sync repeats revocation cleanup and initialization.
+                if (unacknowledgedCoordinatorRevocations is { } revocations)
+                    revocations.Coordinator.RestoreRevokedPartitionsSinceLastSync(revocations.Partitions);
 
-            SemaphoreHelper.ReleaseSafely(_assignmentLock);
+                SemaphoreHelper.ReleaseSafely(_assignmentLock);
+            }
+
+            return;
         }
     }
 

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -372,6 +372,11 @@ public sealed class GroupException : KafkaException
     {
     }
 
+    internal GroupException(ErrorCode errorCode, string message, bool isRetriable)
+        : base(errorCode, message, isRetriable)
+    {
+    }
+
     /// <summary>
     /// The group ID.
     /// </summary>

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -54,12 +54,16 @@ internal static class RetryHelper
     /// of <see cref="RetryDelayMs"/> + [0, 100)ms.
     /// </summary>
     /// <param name="maxRetries">Maximum number of retries. Defaults to <see cref="MaxRetries"/> (3).</param>
+    /// <param name="shouldRefreshMetadata">
+    /// Optional predicate that suppresses metadata refresh for errors recovered by <paramref name="onRetry"/>.
+    /// </param>
     internal static async ValueTask<T> WithRetryAsync<T>(
         Func<ValueTask<T>> operation,
         MetadataManager metadataManager,
         CancellationToken cancellationToken,
         Func<CancellationToken, ValueTask>? onRetry = null,
-        int maxRetries = MaxRetries)
+        int maxRetries = MaxRetries,
+        Func<KafkaException, bool>? shouldRefreshMetadata = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -69,7 +73,10 @@ internal static class RetryHelper
             }
             catch (KafkaException ex) when (ex.IsRetriable && attempt < maxRetries)
             {
-                await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
+                if (shouldRefreshMetadata?.Invoke(ex) ?? true)
+                {
+                    await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
+                }
 
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -440,7 +440,7 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
-    public async Task EnsureAssignmentAsync_AbaInitializationFailure_RetriesRevocationRecovery()
+    public async Task EnsureAssignmentAsync_AbaStaleMemberEpoch_RetriesRevocationRecovery()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -462,20 +462,13 @@ public sealed class ConsumerAssignmentFastPathTests
         coordinator.RequestRejoin();
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
 
-        var exception = await Assert.That(async () =>
-                await consumer.EnsureAssignmentAsync(CancellationToken.None))
-            .Throws<GroupException>();
-
-        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.StaleMemberEpoch);
-        await Assert.That(GetFetchPositions(consumer).ContainsKey(reassignedPartition)).IsFalse();
-
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         await Assert.That(GetFetchPositions(consumer)[reassignedPartition]).IsEqualTo(20L);
     }
 
     [Test]
-    public async Task EnsureAssignmentAsync_InitialPositionFailure_RetriesUnchangedAssignment()
+    public async Task EnsureAssignmentAsync_InitialPositionStaleMemberEpoch_RetriesUnchangedAssignment()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -489,17 +482,89 @@ public sealed class ConsumerAssignmentFastPathTests
         await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
         consumer.Subscribe("test-topic");
 
-        _ = await Assert.That(async () =>
-                await consumer.EnsureAssignmentAsync(CancellationToken.None))
-            .Throws<GroupException>();
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
         var partition = new TopicPartition("test-topic", 0);
         await Assert.That(consumer.Assignment).Contains(partition);
-        await Assert.That(GetFetchPositions(consumer).ContainsKey(partition)).IsFalse();
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(10L);
+    }
 
+    [Test]
+    public async Task GetCommittedOffsetAsync_StaleMemberEpoch_RejoinsAndRetriesWithUpdatedEpoch()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupIncrementingConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        var requestedEpochs = new ConcurrentQueue<int>();
+        SetupOffsetFetchStaleAfterInitialSuccess(connection, requestedEpochs);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
         await consumer.EnsureAssignmentAsync(CancellationToken.None);
 
-        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(10L);
+        var committed = await consumer.GetCommittedOffsetAsync(
+            new TopicPartition("test-topic", 1),
+            CancellationToken.None);
+
+        await Assert.That(committed).IsEqualTo(20L);
+        await Assert.That(requestedEpochs).IsEquivalentTo([1, 1, 2]);
+    }
+
+    [Test]
+    public async Task GetCommittedOffsetAsync_StaleMemberEpoch_UsesAggregateRequestTimeout()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        var rejoinStarted = SetupBlockingRejoinConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetchStaleAfterInitialSuccess(connection, new ConcurrentQueue<int>());
+
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            requestTimeoutMs: 100);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        _ = await Assert.That(async () => await consumer.GetCommittedOffsetAsync(
+                new TopicPartition("test-topic", 1),
+                CancellationToken.None))
+            .Throws<KafkaTimeoutException>();
+        await Assert.That(rejoinStarted.Task.IsCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task GetCommittedOffsetAsync_StaleMemberEpoch_PreservesCallerCancellation()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        var rejoinStarted = SetupBlockingRejoinConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetchStaleAfterInitialSuccess(connection, new ConcurrentQueue<int>());
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+        using var cancellation = new CancellationTokenSource();
+
+        var committed = consumer.GetCommittedOffsetAsync(
+            new TopicPartition("test-topic", 1),
+            cancellation.Token).AsTask();
+        await rejoinStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellation.Cancel();
+
+        _ = await Assert.That(async () => await committed)
+            .Throws<OperationCanceledException>();
     }
 
     [Test]
@@ -972,7 +1037,8 @@ public sealed class ConsumerAssignmentFastPathTests
         MetadataManager metadataManager,
         int queuedMinMessages = 1,
         int maxPollIntervalMs = 300_000,
-        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual)
+        OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
+        int requestTimeoutMs = 30_000)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -981,7 +1047,8 @@ public sealed class ConsumerAssignmentFastPathTests
                 GroupId = "group-a",
                 OffsetCommitMode = offsetCommitMode,
                 QueuedMinMessages = queuedMinMessages,
-                MaxPollIntervalMs = maxPollIntervalMs
+                MaxPollIntervalMs = maxPollIntervalMs,
+                RequestTimeoutMs = requestTimeoutMs
             },
             Serializers.String,
             Serializers.String,
@@ -1103,6 +1170,62 @@ public sealed class ConsumerAssignmentFastPathTests
             });
     }
 
+    private static void SetupIncrementingConsumerGroupHeartbeat(
+        IKafkaConnection connection,
+        ConsumerGroupHeartbeatAssignment assignment)
+    {
+        var callCount = 0;
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(CreateHeartbeatResponse(
+                assignment,
+                Interlocked.Increment(ref callCount))));
+    }
+
+    private static TaskCompletionSource SetupBlockingRejoinConsumerGroupHeartbeat(
+        IKafkaConnection connection,
+        ConsumerGroupHeartbeatAssignment assignment)
+    {
+        var callCount = 0;
+        var rejoinStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return count == 2
+                    ? WaitForRejoinCancellationAsync(
+                        rejoinStarted,
+                        call.ArgAt<CancellationToken>(2))
+                    : ValueTask.FromResult(CreateHeartbeatResponse(assignment, count));
+            });
+        return rejoinStarted;
+    }
+
+    private static ConsumerGroupHeartbeatResponse CreateHeartbeatResponse(
+        ConsumerGroupHeartbeatAssignment assignment,
+        int memberEpoch) => new()
+        {
+            ErrorCode = ErrorCode.None,
+            MemberId = "member-1",
+            MemberEpoch = memberEpoch,
+            HeartbeatIntervalMs = 60000,
+            Assignment = assignment
+        };
+
+    private static async ValueTask<ConsumerGroupHeartbeatResponse> WaitForRejoinCancellationAsync(
+        TaskCompletionSource rejoinStarted,
+        CancellationToken cancellationToken)
+    {
+        rejoinStarted.TrySetResult();
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("Cancellation wait completed without cancellation");
+    }
+
     private static void SetupRevokingConsumerGroupHeartbeat(IKafkaConnection connection)
     {
         var callCount = 0;
@@ -1214,6 +1337,36 @@ public sealed class ConsumerAssignmentFastPathTests
                     ]
                 })
                 : ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse()));
+    }
+
+    private static void SetupOffsetFetchStaleAfterInitialSuccess(
+        IKafkaConnection connection,
+        ConcurrentQueue<int> requestedEpochs)
+    {
+        var callCount = 0;
+        connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
+                Arg.Any<OffsetFetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var request = call.ArgAt<OffsetFetchRequest>(0);
+                requestedEpochs.Enqueue(request.Groups![0].MemberEpoch);
+                return Interlocked.Increment(ref callCount) == 2
+                    ? ValueTask.FromResult(new OffsetFetchResponse
+                    {
+                        Groups =
+                        [
+                            new OffsetFetchResponseGroup
+                            {
+                                GroupId = "group-a",
+                                Topics = [],
+                                ErrorCode = ErrorCode.StaleMemberEpoch
+                            }
+                        ]
+                    })
+                    : ValueTask.FromResult(CreateSuccessfulOffsetFetchResponse());
+            });
     }
 
     private static OffsetFetchResponse CreateSuccessfulOffsetFetchResponse() => new()

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -490,6 +490,31 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task EnsureAssignmentAsync_InitialPositionRejoinRestartsChangedAssignment()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupChangingConsumerGroupHeartbeat(connection);
+        SetupOffsetFetchFailureThenSuccess(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var initialPartition = new TopicPartition("test-topic", 0);
+        var addedPartition = new TopicPartition("test-topic", 1);
+        await Assert.That(consumer.Assignment).Contains(initialPartition);
+        await Assert.That(consumer.Assignment).Contains(addedPartition);
+        await Assert.That(GetFetchPositions(consumer)[initialPartition]).IsEqualTo(10L);
+        await Assert.That(GetFetchPositions(consumer)[addedPartition]).IsEqualTo(20L);
+    }
+
+    [Test]
     public async Task GetCommittedOffsetAsync_StaleMemberEpoch_RejoinsAndRetriesWithUpdatedEpoch()
     {
         var connectionPool = Substitute.For<IConnectionPool>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -2423,7 +2423,10 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     [Test]
     [Arguments(ErrorCode.StaleMemberEpoch)]
     [Arguments(ErrorCode.UnknownMemberId)]
-    public async Task FetchOffsetsAsync_MembershipGroupError_RejoinsAndRetries(ErrorCode errorCode)
+    [Arguments(ErrorCode.CoordinatorLoadInProgress)]
+    [Arguments(ErrorCode.CoordinatorNotAvailable)]
+    [Arguments(ErrorCode.NotCoordinator)]
+    public async Task FetchOffsetsAsync_RetriableGroupError_RecoversAndRetries(ErrorCode errorCode)
     {
         _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
         SetupFindCoordinator();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -2423,18 +2423,21 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     [Test]
     [Arguments(ErrorCode.StaleMemberEpoch)]
     [Arguments(ErrorCode.UnknownMemberId)]
-    public async Task FetchOffsetsAsync_MembershipGroupError_ThrowsAndRequestsRejoin(ErrorCode errorCode)
+    public async Task FetchOffsetsAsync_MembershipGroupError_RejoinsAndRetries(ErrorCode errorCode)
     {
         _metadataManager.SetApiVersion(ApiKey.OffsetFetch, 9, 9);
-        SetupSuccessfulConsumerProtocolJoin();
+        SetupFindCoordinator();
+        SetupConsumerGroupHeartbeat(heartbeatIntervalMs: 60_000);
 
+        var requestCount = 0;
         _connection.SendAsync<OffsetFetchRequest, OffsetFetchResponse>(
                 Arg.Any<OffsetFetchRequest>(),
                 Arg.Any<short>(),
                 Arg.Any<CancellationToken>())
-            .Returns(ValueTask.FromResult(new OffsetFetchResponse
-            {
-                Groups =
+            .Returns(_ => ValueTask.FromResult(Interlocked.Increment(ref requestCount) == 1
+                ? new OffsetFetchResponse
+                {
+                    Groups =
                 [
                     new OffsetFetchResponseGroup
                     {
@@ -2443,28 +2446,33 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                         ErrorCode = errorCode
                     }
                 ]
-            }));
+                }
+                : new OffsetFetchResponse
+                {
+                    Groups =
+                    [
+                        new OffsetFetchResponseGroup
+                        {
+                            GroupId = "test-group",
+                            Topics = [],
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+                }));
 
         var options = CreateConsumerProtocolOptions();
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         var topics = new HashSet<string> { "test-topic" };
         await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
 
-        var exception = await Assert.That(async () =>
-                await coordinator.FetchOffsetsAsync([new TopicPartition("test-topic", 0)], CancellationToken.None))
-            .Throws<GroupException>();
+        var result = await coordinator.FetchOffsetsAsync(
+            [new TopicPartition("test-topic", 0)],
+            CancellationToken.None);
 
-        await Assert.That(exception!.ErrorCode).IsEqualTo(errorCode);
-        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
-        await Assert.That(coordinator.MemberId).IsEqualTo(
-            errorCode == ErrorCode.UnknownMemberId ? null : "member-1");
-
-        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
-
-        await _connection.Received(2).SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
-            Arg.Any<ConsumerGroupHeartbeatRequest>(),
-            Arg.Any<short>(),
-            Arg.Any<CancellationToken>());
+        await Assert.That(result).IsEmpty();
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.MemberId).IsEqualTo("member-1");
+        await Assert.That(requestCount).IsEqualTo(2);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- recover `StaleMemberEpoch` and `UnknownMemberId` OffsetFetch failures by rejoining before retry
- retry with the refreshed member epoch under one aggregate `RequestTimeoutMs` deadline
- preserve caller cancellation and keep retries finite
- update assignment recovery expectations and add deterministic epoch, timeout, and cancellation coverage

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore` — both TFMs, 0 warnings
- `ConsumerAssignmentFastPathTests` — net10: 33/33; net8: 33/33
- full unit suite net10 — 5708/5708
- `OffsetManagementEdgeCaseTests.GetCommittedOffset_Uncommitted_ReturnsNull` — 1/1 integration

A full net8 run reached 5543/5546; unrelated pre-existing synchronization failures were diagnosed and filed as #2284 and #2285. A separate producer assertion race exposed by parallel TFM execution was filed as #2283.

## Performance

OffsetFetch and group rejoin are control-plane operations, not per-message produce/consume hot paths. No hot-path code or per-message allocation behavior changes; a benchmark lane is not applicable.

Closes #2278