### PR TITLE
test(interop): synchronize Confluent fetch startup

### DIFF
--- a/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/CrossClientInteropTests.cs
@@ -55,10 +55,15 @@ public sealed class CrossClientInteropTests(KafkaTestContainer kafka) : KafkaInt
         }
 
         using var consumer = CreateConfluentConsumer();
+        var topicPartition = new ConfluentKafka.TopicPartition(topic, ExpectedPartition);
+        var watermarks = consumer.QueryWatermarkOffsets(
+            topicPartition,
+            TimeSpan.FromSeconds(30));
+        await Assert.That(watermarks.Low.Value).IsEqualTo(0);
+        await Assert.That(watermarks.High.Value).IsEqualTo(expectedRecords.Length);
         consumer.Assign(new ConfluentKafka.TopicPartitionOffset(
-            topic,
-            ExpectedPartition,
-            ConfluentKafka.Offset.Beginning));
+            topicPartition,
+            watermarks.Low));
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         foreach (var expected in expectedRecords)


### PR DESCRIPTION
## Summary
- query Confluent watermarks after Dekaf produce acknowledgements
- assert the broker-visible range matches the expected records
- assign the concrete low watermark instead of relying on symbolic offset resolution

## Validation
- Release net10.0 integration build: 0 warnings, 0 errors
- CrossClientInteropTests: 5/5 passed after rebase onto #2280
- focused flaky scenario: 6/6 passed before rebase
- full net10.0 integration suite: 824/825 passed; unrelated GetCommittedOffset_Uncommitted_ReturnsNull failed once with StaleMemberEpoch, then passed isolated 1/1

Closes #2279