### PR TITLE
perf(consumer): bypass low-yield string key cache

### DIFF
--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -97,6 +97,13 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private string DeserializeWhileBypassing(ReadOnlyMemory<byte> data, SerializationContext context)
     {
+        ObserveBypassLookup();
+        return _configuredInner.Deserialize(data, context);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ObserveBypassLookup()
+    {
         var remaining = _bypassRemaining - 1;
         if (remaining <= 0)
         {
@@ -107,8 +114,6 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         {
             _bypassRemaining = remaining;
         }
-
-        return _configuredInner.Deserialize(data, context);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -248,7 +253,10 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
         {
             if (data.Length == 0 || data.Length > owner._configuredMaxCachedBytes)
+            {
+                owner.ObserveProbeLookup(hit: false);
                 return owner._configuredInner.Deserialize(data, context);
+            }
 
             return owner.DeserializeWhileProbing(data, context);
         }
@@ -268,7 +276,10 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
         {
             if (data.Length == 0 || data.Length > owner._configuredMaxCachedBytes)
+            {
+                owner.ObserveBypassLookup();
                 return owner._configuredInner.Deserialize(data, context);
+            }
 
             return owner.DeserializeWhileBypassing(data, context);
         }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -19,7 +19,9 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     internal const int AdmissionProbeLimit = 256;
     internal const int ProbeLookupCount = 1_024;
     internal const int MinimumProbeHits = (ProbeLookupCount + 9) / 10;
-    internal const int BypassInterval = 64 * 1_024;
+    // The default cache's threshold-safe reuse scan can reach ~164K lookups. A 512K
+    // bypass gives sustained unique traffic a greater than 3:1 bypass/probe duty cycle.
+    internal const int BypassInterval = 512 * 1_024;
 
     private readonly ISerde<string> _configuredInner;
     // Swapping the existing cold-path target keeps Deserialize's cached-hit JIT shape unchanged.
@@ -200,14 +202,21 @@ internal sealed class CachingStringDeserializer : ISerde<string>
 
     private void StartReuseProbe()
     {
-        // The primary probe may consume the beginning of a near-capacity cycle before
-        // reuse observation starts. Include that window so the probe can reach entries
-        // cached before the primary probe instead of retiring a high-yield generation.
-        _probeRemaining = _maxCachedEntries > int.MaxValue - ProbeLookupCount
-            ? int.MaxValue
-            : _maxCachedEntries + ProbeLookupCount;
+        // A cache with the minimum accepted hit rate can take cache capacity divided by
+        // that rate lookups to repeat. Observe that full cycle, plus the primary-probe
+        // prefix, before declaring the retained generation cold.
+        _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
         _isReuseProbe = true;
+    }
+
+    internal static int CalculateReuseProbeLookupCount(int maxCachedEntries)
+    {
+        var maximumUsefulCycleLength =
+            ((long)maxCachedEntries * ProbeLookupCount + MinimumProbeHits - 1)
+            / MinimumProbeHits;
+        var lookupCount = maximumUsefulCycleLength + ProbeLookupCount;
+        return lookupCount >= int.MaxValue ? int.MaxValue : (int)lookupCount;
     }
 
     private void StartBypass()

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -16,18 +16,30 @@ namespace Dekaf.Serialization;
 /// </remarks>
 internal sealed class CachingStringDeserializer : ISerde<string>
 {
-    private readonly ISerde<string> _inner;
-    private readonly int _maxCachedBytes;
+    internal const int AdmissionProbeLimit = 256;
+    internal const int BypassInterval = 64 * 1_024;
+
+    private readonly ISerde<string> _configuredInner;
+    // Swapping the existing cold-path target keeps Deserialize's cached-hit JIT shape unchanged.
+    private readonly ISerde<string> _bypassSerde;
+    private readonly int _configuredMaxCachedBytes;
     private readonly int _maxCachedEntries;
     private readonly ConcurrentDictionary<Hash128Key, string> _cache = new();
+    private ISerde<string> _inner;
+    private int _maxCachedBytes;
     private int _cacheCount;
+    private int _admissionsRemaining = AdmissionProbeLimit;
+    private int _bypassRemaining;
 
     internal CachingStringDeserializer(
         ISerde<string> inner,
         int maxCachedBytes,
         int maxCachedEntries)
     {
+        _configuredInner = inner;
         _inner = inner;
+        _bypassSerde = new BypassSerde(this);
+        _configuredMaxCachedBytes = maxCachedBytes;
         _maxCachedBytes = maxCachedBytes;
         _maxCachedEntries = maxCachedEntries;
     }
@@ -57,9 +69,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         var hash = ComputeHash(span);
 
         if (_cache.TryGetValue(hash, out var cachedValue))
-        {
             return cachedValue;
-        }
 
         var result = _inner.Deserialize(data, context);
 
@@ -70,10 +80,47 @@ internal sealed class CachingStringDeserializer : ISerde<string>
             if (_cache.TryAdd(hash, result))
             {
                 Interlocked.Increment(ref _cacheCount);
+                ObserveAdmission();
             }
         }
 
         return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string DeserializeWhileBypassing(ReadOnlyMemory<byte> data, SerializationContext context)
+    {
+        var remaining = _bypassRemaining - 1;
+        if (remaining <= 0)
+        {
+            _bypassRemaining = 0;
+            _inner = _configuredInner;
+            _maxCachedBytes = _configuredMaxCachedBytes;
+        }
+        else
+        {
+            _bypassRemaining = remaining;
+        }
+
+        return _configuredInner.Deserialize(data, context);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ObserveAdmission()
+    {
+        // Approximate by design: racing callers may slightly shift the probe and
+        // bypass boundaries, but no synchronization belongs on this hot path.
+        var remaining = _admissionsRemaining - 1;
+        if (remaining <= 0)
+        {
+            _admissionsRemaining = AdmissionProbeLimit;
+            _bypassRemaining = BypassInterval;
+            _inner = _bypassSerde;
+            _maxCachedBytes = -1;
+            return;
+        }
+
+        _admissionsRemaining = remaining;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -87,4 +134,24 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     }
 
     private readonly record struct Hash128Key(ulong Low, ulong High);
+
+    private sealed class BypassSerde(CachingStringDeserializer owner) : ISerde<string>
+    {
+        public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
+            where TWriter : System.Buffers.IBufferWriter<byte>
+#if !NETSTANDARD2_0
+            , allows ref struct
+#endif
+        {
+            owner._configuredInner.Serialize(value, ref destination, context);
+        }
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (data.Length == 0 || data.Length > owner._configuredMaxCachedBytes)
+                return owner._configuredInner.Deserialize(data, context);
+
+            return owner.DeserializeWhileBypassing(data, context);
+        }
+    }
 }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -34,7 +34,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private int _admissionsRemaining = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
-    private bool _probeAllowsAdmission;
+    private bool _isReuseProbe;
     private int _bypassRemaining;
 
     internal CachingStringDeserializer(
@@ -122,7 +122,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         }
 
         var result = _configuredInner.Deserialize(data, context);
-        if (_probeAllowsAdmission && Volatile.Read(ref _cacheCount) < _maxCachedEntries)
+        if (Volatile.Read(ref _cacheCount) < _maxCachedEntries)
         {
             if (_cache.TryAdd(hash, result))
                 Interlocked.Increment(ref _cacheCount);
@@ -138,7 +138,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         if (hit)
         {
             _probeHits++;
-            if (!_probeAllowsAdmission)
+            if (_isReuseProbe)
             {
                 RestoreCache();
                 return;
@@ -152,7 +152,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
             return;
         }
 
-        if (_probeAllowsAdmission)
+        if (!_isReuseProbe)
         {
             if (_probeHits >= MinimumProbeHits)
                 RestoreCache();
@@ -184,7 +184,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     {
         _probeRemaining = ProbeLookupCount;
         _probeHits = 0;
-        _probeAllowsAdmission = true;
+        _isReuseProbe = false;
         // These mode fields are deliberately lock-free. Racing callers may observe one
         // transition late, but every combination still deserializes correctly and the
         // next probe/bypass cycle self-corrects the approximate counters.
@@ -196,11 +196,15 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     {
         _probeRemaining = _maxCachedEntries;
         _probeHits = 0;
-        _probeAllowsAdmission = false;
+        _isReuseProbe = true;
     }
 
     private void StartBypass()
     {
+        // A full reuse window without a hit means the retained entries are cold. Drop them
+        // before bypassing so the next probe has capacity to learn a new repetitive set.
+        _cache.Clear();
+        Volatile.Write(ref _cacheCount, 0);
         _bypassRemaining = BypassInterval;
         _inner = _bypassSerde;
     }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -30,7 +30,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private CacheGeneration _cache = new();
     private ISerde<string> _inner;
     private int _maxCachedBytes;
-    private int _admissionsRemaining = AdmissionProbeLimit;
+    private int _missesUntilProbe = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
     private bool _isReuseProbe;
@@ -85,12 +85,11 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         if (Volatile.Read(ref cache.Count) < _maxCachedEntries)
         {
             if (cache.Entries.TryAdd(hash, result))
-            {
                 Interlocked.Increment(ref cache.Count);
-                if (ReferenceEquals(cache, Volatile.Read(ref _cache)))
-                    ObserveAdmission();
-            }
         }
+
+        if (ReferenceEquals(cache, Volatile.Read(ref _cache)))
+            ObserveCacheMiss();
 
         return result;
     }
@@ -167,19 +166,19 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ObserveAdmission()
+    private void ObserveCacheMiss()
     {
         // Approximate by design: racing callers may slightly shift the probe and
         // bypass boundaries, but no synchronization belongs on this hot path.
-        var remaining = _admissionsRemaining - 1;
+        var remaining = _missesUntilProbe - 1;
         if (remaining <= 0)
         {
-            _admissionsRemaining = AdmissionProbeLimit;
+            _missesUntilProbe = AdmissionProbeLimit;
             StartPrimaryProbe();
             return;
         }
 
-        _admissionsRemaining = remaining;
+        _missesUntilProbe = remaining;
     }
 
     private void StartPrimaryProbe()
@@ -212,7 +211,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
 
     private void RestoreCache()
     {
-        _admissionsRemaining = AdmissionProbeLimit;
+        _missesUntilProbe = AdmissionProbeLimit;
         _inner = _configuredInner;
         _maxCachedBytes = _configuredMaxCachedBytes;
     }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -35,6 +35,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private int _missesUntilProbe = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
+    private int _minimumReuseProbeHits;
     private bool _isReuseProbe;
     private int _bypassRemaining;
 
@@ -146,7 +147,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         if (hit)
         {
             _probeHits++;
-            if (_isReuseProbe)
+            if (_isReuseProbe && _probeHits >= _minimumReuseProbeHits)
             {
                 RestoreCache();
                 return;
@@ -207,6 +208,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         // prefix, before declaring the retained generation cold.
         _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
+        _minimumReuseProbeHits = CalculateMinimumReuseProbeHits(_probeRemaining);
         _isReuseProbe = true;
     }
 
@@ -217,6 +219,14 @@ internal sealed class CachingStringDeserializer : ISerde<string>
             / MinimumProbeHits;
         var lookupCount = maximumUsefulCycleLength + ProbeLookupCount;
         return lookupCount >= int.MaxValue ? int.MaxValue : (int)lookupCount;
+    }
+
+    private static int CalculateMinimumReuseProbeHits(int lookupCount)
+    {
+        var minimumHits =
+            ((long)lookupCount * MinimumProbeHits + ProbeLookupCount - 1)
+            / ProbeLookupCount;
+        return minimumHits >= int.MaxValue ? int.MaxValue : (int)minimumHits;
     }
 
     private void StartBypass()

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -35,6 +35,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private int _missesUntilProbe = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
+    private int _reuseProbeAdmissions;
     private int _minimumReuseProbeHits;
     private bool _isReuseProbe;
     private int _bypassRemaining;
@@ -131,27 +132,35 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         }
 
         var result = _configuredInner.Deserialize(data, context);
+        var admitted = false;
         if (Volatile.Read(ref cache.Count) < _maxCachedEntries)
         {
             if (cache.Entries.TryAdd(hash, result))
+            {
                 Interlocked.Increment(ref cache.Count);
+                admitted = true;
+            }
         }
 
-        ObserveProbeLookup(hit: false);
+        ObserveProbeLookup(hit: false, admitted);
         return result;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ObserveProbeLookup(bool hit)
+    private void ObserveProbeLookup(bool hit, bool admitted = false)
     {
         if (hit)
-        {
             _probeHits++;
-            if (_isReuseProbe && _probeHits >= _minimumReuseProbeHits)
-            {
-                RestoreCache();
-                return;
-            }
+        else if (_isReuseProbe && admitted)
+            _reuseProbeAdmissions++;
+
+        // A newly admitted entry could not hit on its first occurrence. Count that fill
+        // once when evaluating a reuse window, without letting primary-probe fills pass.
+        if (_isReuseProbe
+            && (long)_probeHits + _reuseProbeAdmissions >= _minimumReuseProbeHits)
+        {
+            RestoreCache();
+            return;
         }
 
         var remaining = _probeRemaining - 1;
@@ -208,6 +217,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         // prefix, before declaring the retained generation cold.
         _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
+        _reuseProbeAdmissions = 0;
         _minimumReuseProbeHits = CalculateMinimumReuseProbeHits(_probeRemaining);
         _isReuseProbe = true;
     }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -17,10 +17,13 @@ namespace Dekaf.Serialization;
 internal sealed class CachingStringDeserializer : ISerde<string>
 {
     internal const int AdmissionProbeLimit = 256;
+    internal const int ProbeLookupCount = 1_024;
+    internal const int MinimumProbeHits = (ProbeLookupCount + 9) / 10;
     internal const int BypassInterval = 64 * 1_024;
 
     private readonly ISerde<string> _configuredInner;
     // Swapping the existing cold-path target keeps Deserialize's cached-hit JIT shape unchanged.
+    private readonly ISerde<string> _probeSerde;
     private readonly ISerde<string> _bypassSerde;
     private readonly int _configuredMaxCachedBytes;
     private readonly int _maxCachedEntries;
@@ -29,6 +32,9 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private int _maxCachedBytes;
     private int _cacheCount;
     private int _admissionsRemaining = AdmissionProbeLimit;
+    private int _probeRemaining;
+    private int _probeHits;
+    private bool _probeAllowsAdmission;
     private int _bypassRemaining;
 
     internal CachingStringDeserializer(
@@ -38,6 +44,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     {
         _configuredInner = inner;
         _inner = inner;
+        _probeSerde = new ProbeSerde(this);
         _bypassSerde = new BypassSerde(this);
         _configuredMaxCachedBytes = maxCachedBytes;
         _maxCachedBytes = maxCachedBytes;
@@ -94,8 +101,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         if (remaining <= 0)
         {
             _bypassRemaining = 0;
-            _inner = _configuredInner;
-            _maxCachedBytes = _configuredMaxCachedBytes;
+            StartPrimaryProbe();
         }
         else
         {
@@ -103,6 +109,59 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         }
 
         return _configuredInner.Deserialize(data, context);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private string DeserializeWhileProbing(ReadOnlyMemory<byte> data, SerializationContext context)
+    {
+        var hash = ComputeHash(data.Span);
+        if (_cache.TryGetValue(hash, out var cachedValue))
+        {
+            ObserveProbeLookup(hit: true);
+            return cachedValue;
+        }
+
+        var result = _configuredInner.Deserialize(data, context);
+        if (_probeAllowsAdmission && Volatile.Read(ref _cacheCount) < _maxCachedEntries)
+        {
+            if (_cache.TryAdd(hash, result))
+                Interlocked.Increment(ref _cacheCount);
+        }
+
+        ObserveProbeLookup(hit: false);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ObserveProbeLookup(bool hit)
+    {
+        if (hit)
+        {
+            _probeHits++;
+            if (!_probeAllowsAdmission)
+            {
+                RestoreCache();
+                return;
+            }
+        }
+
+        var remaining = _probeRemaining - 1;
+        if (remaining > 0)
+        {
+            _probeRemaining = remaining;
+            return;
+        }
+
+        if (_probeAllowsAdmission)
+        {
+            if (_probeHits >= MinimumProbeHits)
+                RestoreCache();
+            else
+                StartReuseProbe();
+            return;
+        }
+
+        StartBypass();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -114,13 +173,43 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         if (remaining <= 0)
         {
             _admissionsRemaining = AdmissionProbeLimit;
-            _bypassRemaining = BypassInterval;
-            _inner = _bypassSerde;
-            _maxCachedBytes = -1;
+            StartPrimaryProbe();
             return;
         }
 
         _admissionsRemaining = remaining;
+    }
+
+    private void StartPrimaryProbe()
+    {
+        _probeRemaining = ProbeLookupCount;
+        _probeHits = 0;
+        _probeAllowsAdmission = true;
+        // These mode fields are deliberately lock-free. Racing callers may observe one
+        // transition late, but every combination still deserializes correctly and the
+        // next probe/bypass cycle self-corrects the approximate counters.
+        _inner = _probeSerde;
+        _maxCachedBytes = -1;
+    }
+
+    private void StartReuseProbe()
+    {
+        _probeRemaining = _maxCachedEntries;
+        _probeHits = 0;
+        _probeAllowsAdmission = false;
+    }
+
+    private void StartBypass()
+    {
+        _bypassRemaining = BypassInterval;
+        _inner = _bypassSerde;
+    }
+
+    private void RestoreCache()
+    {
+        _admissionsRemaining = AdmissionProbeLimit;
+        _inner = _configuredInner;
+        _maxCachedBytes = _configuredMaxCachedBytes;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,6 +223,26 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     }
 
     private readonly record struct Hash128Key(ulong Low, ulong High);
+
+    private sealed class ProbeSerde(CachingStringDeserializer owner) : ISerde<string>
+    {
+        public void Serialize<TWriter>(string value, ref TWriter destination, SerializationContext context)
+            where TWriter : System.Buffers.IBufferWriter<byte>
+#if !NETSTANDARD2_0
+            , allows ref struct
+#endif
+        {
+            owner._configuredInner.Serialize(value, ref destination, context);
+        }
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            if (data.Length == 0 || data.Length > owner._configuredMaxCachedBytes)
+                return owner._configuredInner.Deserialize(data, context);
+
+            return owner.DeserializeWhileProbing(data, context);
+        }
+    }
 
     private sealed class BypassSerde(CachingStringDeserializer owner) : ISerde<string>
     {

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -218,7 +218,10 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
         _reuseProbeAdmissions = 0;
-        _minimumReuseProbeHits = CalculateMinimumReuseProbeHits(_probeRemaining);
+        // The extra primary-probe prefix in the lookup window is phase-alignment slack,
+        // not additional traffic that should raise the evidence threshold. Requiring one
+        // cache capacity of hits/admissions keeps the threshold attainable after saturation.
+        _minimumReuseProbeHits = _maxCachedEntries;
         _isReuseProbe = true;
     }
 
@@ -229,14 +232,6 @@ internal sealed class CachingStringDeserializer : ISerde<string>
             / MinimumProbeHits;
         var lookupCount = maximumUsefulCycleLength + ProbeLookupCount;
         return lookupCount >= int.MaxValue ? int.MaxValue : (int)lookupCount;
-    }
-
-    private static int CalculateMinimumReuseProbeHits(int lookupCount)
-    {
-        var minimumHits =
-            ((long)lookupCount * MinimumProbeHits + ProbeLookupCount - 1)
-            / ProbeLookupCount;
-        return minimumHits >= int.MaxValue ? int.MaxValue : (int)minimumHits;
     }
 
     private void StartBypass()

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -200,7 +200,12 @@ internal sealed class CachingStringDeserializer : ISerde<string>
 
     private void StartReuseProbe()
     {
-        _probeRemaining = _maxCachedEntries;
+        // The primary probe may consume the beginning of a near-capacity cycle before
+        // reuse observation starts. Include that window so the probe can reach entries
+        // cached before the primary probe instead of retiring a high-yield generation.
+        _probeRemaining = _maxCachedEntries > int.MaxValue - ProbeLookupCount
+            ? int.MaxValue
+            : _maxCachedEntries + ProbeLookupCount;
         _probeHits = 0;
         _isReuseProbe = true;
     }

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -218,11 +218,15 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
         _reuseProbeFillCredit = 0;
+        var exactMinimumHits = CalculateMinimumReuseProbeHits(_probeRemaining);
+        var samplingTolerance = (exactMinimumHits + 99) / 100;
         _minimumReuseProbeHits = Math.Max(
             _maxCachedEntries,
-            CalculateMinimumReuseProbeHits(_probeRemaining));
+            exactMinimumHits - samplingTolerance);
         // First-seen values cannot hit in this window. Credit only the fixed
         // phase-alignment slack, never the full cache fill, toward the 10% gate.
+        // A 1% evidence tolerance prevents a finite window from rejecting a high-yield
+        // cache solely because its clustered hit run straddles the window boundary.
         _isReuseProbe = true;
     }
 

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -27,10 +27,9 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private readonly ISerde<string> _bypassSerde;
     private readonly int _configuredMaxCachedBytes;
     private readonly int _maxCachedEntries;
-    private readonly ConcurrentDictionary<Hash128Key, string> _cache = new();
+    private CacheGeneration _cache = new();
     private ISerde<string> _inner;
     private int _maxCachedBytes;
-    private int _cacheCount;
     private int _admissionsRemaining = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
@@ -74,20 +73,22 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     {
         var span = data.Span;
         var hash = ComputeHash(span);
+        var cache = Volatile.Read(ref _cache);
 
-        if (_cache.TryGetValue(hash, out var cachedValue))
+        if (cache.Entries.TryGetValue(hash, out var cachedValue))
             return cachedValue;
 
         var result = _inner.Deserialize(data, context);
 
         // Soft cap: concurrent threads may each read count < max and add simultaneously,
         // transiently overshooting by the number of racing threads. Bounded and acceptable.
-        if (Volatile.Read(ref _cacheCount) < _maxCachedEntries)
+        if (Volatile.Read(ref cache.Count) < _maxCachedEntries)
         {
-            if (_cache.TryAdd(hash, result))
+            if (cache.Entries.TryAdd(hash, result))
             {
-                Interlocked.Increment(ref _cacheCount);
-                ObserveAdmission();
+                Interlocked.Increment(ref cache.Count);
+                if (ReferenceEquals(cache, Volatile.Read(ref _cache)))
+                    ObserveAdmission();
             }
         }
 
@@ -115,17 +116,18 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private string DeserializeWhileProbing(ReadOnlyMemory<byte> data, SerializationContext context)
     {
         var hash = ComputeHash(data.Span);
-        if (_cache.TryGetValue(hash, out var cachedValue))
+        var cache = Volatile.Read(ref _cache);
+        if (cache.Entries.TryGetValue(hash, out var cachedValue))
         {
             ObserveProbeLookup(hit: true);
             return cachedValue;
         }
 
         var result = _configuredInner.Deserialize(data, context);
-        if (Volatile.Read(ref _cacheCount) < _maxCachedEntries)
+        if (Volatile.Read(ref cache.Count) < _maxCachedEntries)
         {
-            if (_cache.TryAdd(hash, result))
-                Interlocked.Increment(ref _cacheCount);
+            if (cache.Entries.TryAdd(hash, result))
+                Interlocked.Increment(ref cache.Count);
         }
 
         ObserveProbeLookup(hit: false);
@@ -201,10 +203,9 @@ internal sealed class CachingStringDeserializer : ISerde<string>
 
     private void StartBypass()
     {
-        // A full reuse window without a hit means the retained entries are cold. Drop them
-        // before bypassing so the next probe has capacity to learn a new repetitive set.
-        _cache.Clear();
-        Volatile.Write(ref _cacheCount, 0);
+        // A full reuse window without a hit means the retained entries are cold. Retire
+        // the generation in O(1); clearing every entry here would stall Deserialize.
+        Interlocked.Exchange(ref _cache, new CacheGeneration());
         _bypassRemaining = BypassInterval;
         _inner = _bypassSerde;
     }
@@ -227,6 +228,12 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     }
 
     private readonly record struct Hash128Key(ulong Low, ulong High);
+
+    private sealed class CacheGeneration
+    {
+        public readonly ConcurrentDictionary<Hash128Key, string> Entries = new();
+        public int Count;
+    }
 
     private sealed class ProbeSerde(CachingStringDeserializer owner) : ISerde<string>
     {

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -35,7 +35,7 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     private int _missesUntilProbe = AdmissionProbeLimit;
     private int _probeRemaining;
     private int _probeHits;
-    private int _reuseProbeAdmissions;
+    private int _reuseProbeFillCredit;
     private int _minimumReuseProbeHits;
     private bool _isReuseProbe;
     private int _bypassRemaining;
@@ -151,13 +151,13 @@ internal sealed class CachingStringDeserializer : ISerde<string>
     {
         if (hit)
             _probeHits++;
-        else if (_isReuseProbe && admitted)
-            _reuseProbeAdmissions++;
+        else if (_isReuseProbe
+                 && admitted
+                 && _reuseProbeFillCredit < _minimumReuseProbeHits - _maxCachedEntries)
+            _reuseProbeFillCredit++;
 
-        // A newly admitted entry could not hit on its first occurrence. Count that fill
-        // once when evaluating a reuse window, without letting primary-probe fills pass.
         if (_isReuseProbe
-            && (long)_probeHits + _reuseProbeAdmissions >= _minimumReuseProbeHits)
+            && (long)_probeHits + _reuseProbeFillCredit >= _minimumReuseProbeHits)
         {
             RestoreCache();
             return;
@@ -217,11 +217,12 @@ internal sealed class CachingStringDeserializer : ISerde<string>
         // prefix, before declaring the retained generation cold.
         _probeRemaining = CalculateReuseProbeLookupCount(_maxCachedEntries);
         _probeHits = 0;
-        _reuseProbeAdmissions = 0;
-        // The extra primary-probe prefix in the lookup window is phase-alignment slack,
-        // not additional traffic that should raise the evidence threshold. Requiring one
-        // cache capacity of hits/admissions keeps the threshold attainable after saturation.
-        _minimumReuseProbeHits = _maxCachedEntries;
+        _reuseProbeFillCredit = 0;
+        _minimumReuseProbeHits = Math.Max(
+            _maxCachedEntries,
+            CalculateMinimumReuseProbeHits(_probeRemaining));
+        // First-seen values cannot hit in this window. Credit only the fixed
+        // phase-alignment slack, never the full cache fill, toward the 10% gate.
         _isReuseProbe = true;
     }
 
@@ -232,6 +233,14 @@ internal sealed class CachingStringDeserializer : ISerde<string>
             / MinimumProbeHits;
         var lookupCount = maximumUsefulCycleLength + ProbeLookupCount;
         return lookupCount >= int.MaxValue ? int.MaxValue : (int)lookupCount;
+    }
+
+    private static int CalculateMinimumReuseProbeHits(int lookupCount)
+    {
+        var minimumHits =
+            ((long)lookupCount * MinimumProbeHits + ProbeLookupCount - 1)
+            / ProbeLookupCount;
+        return minimumHits >= int.MaxValue ? int.MaxValue : (int)minimumHits;
     }
 
     private void StartBypass()

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -53,8 +53,12 @@ public class CachingStringDeserializerTests
             "_cache",
             BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("_cache field not found.");
+        var entriesField = cacheField.FieldType.GetField(
+            "Entries",
+            BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Cache entries field not found.");
 
-        var keyType = cacheField.FieldType.GetGenericArguments()[0];
+        var keyType = entriesField.FieldType.GetGenericArguments()[0];
 
         var keyWords = keyType
             .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -277,6 +277,9 @@ public class CachingStringDeserializerTests
         for (var i = KeyCacheMaxEntries; i < keyCount + KeyCacheMaxEntries; i++)
             sut.Deserialize(ToUtf8($"fill-window-{i % keyCount}"), context);
 
+        for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
+            sut.Deserialize(ToUtf8($"fill-window-{i % keyCount}"), context);
+
         await Assert.That(GetInnerModeName(sut)).IsNotEqualTo("BypassSerde");
         await Assert.That(ReferenceEquals(firstReference, sut.Deserialize(firstKey, context))).IsTrue();
     }

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -37,6 +37,9 @@ public class CachingStringDeserializerTests
     private static CachingStringDeserializer CreateValueCache() =>
         new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: ValueCacheMaxEntries);
 
+    private static CachingStringDeserializer CreateSmallKeyCache() =>
+        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: ValueCacheMaxEntries);
+
     private static IDeserializer<string> GetValueDeserializer(IKafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>).GetField(
@@ -45,6 +48,16 @@ public class CachingStringDeserializerTests
             ?? throw new InvalidOperationException("_valueDeserializer field not found.");
 
         return (IDeserializer<string>)field.GetValue(consumer)!;
+    }
+
+    private static string GetInnerModeName(CachingStringDeserializer deserializer)
+    {
+        var field = typeof(CachingStringDeserializer).GetField(
+            "_inner",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_inner field not found.");
+
+        return field.GetValue(deserializer)!.GetType().Name;
     }
 
     [Test]
@@ -248,6 +261,44 @@ public class CachingStringDeserializerTests
         var secondProbe = sut.Deserialize(repeated, context);
 
         await Assert.That(ReferenceEquals(firstProbe, secondProbe)).IsTrue();
+    }
+
+    [Test]
+    public async Task Probe_OversizedPayloadsAdvanceToBypass()
+    {
+        var sut = CreateSmallKeyCache();
+        var context = KeyContext();
+
+        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
+            sut.Deserialize(ToUtf8($"probe-start-{i}"), context);
+
+        var oversized = ToUtf8(new string('x', 129));
+        var lookupsUntilBypass = CachingStringDeserializer.ProbeLookupCount + ValueCacheMaxEntries;
+        for (var i = 0; i < lookupsUntilBypass; i++)
+            sut.Deserialize(oversized, context);
+
+        await Assert.That(GetInnerModeName(sut)).IsEqualTo("BypassSerde");
+    }
+
+    [Test]
+    public async Task Bypass_EmptyPayloadsAdvanceToRecoveryProbe()
+    {
+        var sut = CreateSmallKeyCache();
+        var context = KeyContext();
+        var lookupsUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
+            + CachingStringDeserializer.ProbeLookupCount
+            + ValueCacheMaxEntries;
+        for (var i = 0; i < lookupsUntilBypass; i++)
+            sut.Deserialize(ToUtf8($"bypass-start-{i}"), context);
+
+        for (var i = 0; i < CachingStringDeserializer.BypassInterval; i++)
+            sut.Deserialize(ReadOnlyMemory<byte>.Empty, context);
+
+        var eligible = ToUtf8("eligible-after-empty-bypass");
+        var first = sut.Deserialize(eligible, context);
+        var second = sut.Deserialize(eligible, context);
+
+        await Assert.That(ReferenceEquals(first, second)).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -84,13 +84,18 @@ public class CachingStringDeserializerTests
     [Test]
     public async Task MaxCachedEntries_StopsNewEntries()
     {
-        var sut = CreateKeyCache();
+        const int maxEntries = 16;
+        var sut = new CachingStringDeserializer(
+            Serializers.String,
+            maxCachedBytes: 128,
+            maxCachedEntries: maxEntries);
         var context = KeyContext();
 
-        // Fill the cache to capacity (16,384 entries).
-        for (var i = 0; i < 16_384; i++)
+        for (var i = 0; i < maxEntries; i++)
         {
-            sut.Deserialize(ToUtf8($"key-{i}"), context);
+            var data = ToUtf8($"key-{i}");
+            sut.Deserialize(data, context);
+            sut.Deserialize(data, context);
         }
 
         // The next unique key should still return the correct value but not be cached.
@@ -102,6 +107,57 @@ public class CachingStringDeserializerTests
         await Assert.That(second).IsEqualTo("overflow-key");
         // Not cached — different string instances from the inner deserializer.
         await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task HighCardinalityKeys_BypassCacheAfterAdmissionProbeLimit()
+    {
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+
+        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
+            sut.Deserialize(ToUtf8($"unique-{i}"), context);
+
+        var data = ToUtf8("bypassed");
+        var first = sut.Deserialize(data, context);
+        var second = sut.Deserialize(data, context);
+
+        await Assert.That(first).IsEqualTo("bypassed");
+        await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task LowCardinalityKeys_RemainCachedPastAdmissionProbeLimit()
+    {
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var data = ToUtf8("repeated");
+        var first = sut.Deserialize(data, context);
+        var allReferencesCached = true;
+
+        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit * 2; i++)
+            allReferencesCached &= ReferenceEquals(first, sut.Deserialize(data, context));
+
+        await Assert.That(allReferencesCached).IsTrue();
+    }
+
+    [Test]
+    public async Task Bypass_ReprobesAndRecoversWhenKeysBecomeRepetitive()
+    {
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+
+        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
+            sut.Deserialize(ToUtf8($"unique-{i}"), context);
+
+        var repeated = ToUtf8("new-repeated-key");
+        for (var i = 0; i < CachingStringDeserializer.BypassInterval; i++)
+            sut.Deserialize(repeated, context);
+
+        var firstProbe = sut.Deserialize(repeated, context);
+        var secondProbe = sut.Deserialize(repeated, context);
+
+        await Assert.That(ReferenceEquals(firstProbe, secondProbe)).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -177,6 +177,7 @@ public class CachingStringDeserializerTests
         var first = sut.Deserialize(data, context);
         var second = sut.Deserialize(data, context);
 
+        await Assert.That(GetInnerModeName(sut)).IsEqualTo("BypassSerde");
         await Assert.That(ReferenceEquals(first, second)).IsFalse();
     }
 

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -7,6 +7,8 @@ namespace Dekaf.Tests.Unit.Serialization;
 
 public class CachingStringDeserializerTests
 {
+    private const int KeyCacheMaxEntries = 16_384;
+
     private static SerializationContext KeyContext(string topic = "test") =>
         new() { Topic = topic, Component = SerializationComponent.Key };
 
@@ -17,7 +19,19 @@ public class CachingStringDeserializerTests
         Encoding.UTF8.GetBytes(value);
 
     private static CachingStringDeserializer CreateKeyCache() =>
-        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: KeyCacheMaxEntries);
+
+    private static void EnterHighCardinalityBypass(
+        CachingStringDeserializer deserializer,
+        SerializationContext context)
+    {
+        var lookupCount = CachingStringDeserializer.AdmissionProbeLimit
+            + CachingStringDeserializer.ProbeLookupCount
+            + KeyCacheMaxEntries;
+
+        for (var uniqueKey = 0; uniqueKey < lookupCount; uniqueKey++)
+            deserializer.Deserialize(ToUtf8($"unique-{uniqueKey}"), context);
+    }
 
     private static CachingStringDeserializer CreateValueCache() =>
         new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
@@ -110,13 +124,12 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
-    public async Task HighCardinalityKeys_BypassCacheAfterAdmissionProbeLimit()
+    public async Task HighCardinalityKeys_BypassCacheAfterLowHitRateProbe()
     {
         var sut = CreateKeyCache();
         var context = KeyContext();
 
-        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
-            sut.Deserialize(ToUtf8($"unique-{i}"), context);
+        EnterHighCardinalityBypass(sut, context);
 
         var data = ToUtf8("bypassed");
         var first = sut.Deserialize(data, context);
@@ -124,6 +137,34 @@ public class CachingStringDeserializerTests
 
         await Assert.That(first).IsEqualTo("bypassed");
         await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task BoundedReusableKeys_RemainCachedAfterHitRateProbe()
+    {
+        const int keyCount = 1_000;
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var data = new ReadOnlyMemory<byte>[keyCount];
+        var references = new string[keyCount];
+
+        for (var i = 0; i < keyCount; i++)
+        {
+            data[i] = ToUtf8($"bounded-{i}");
+            references[i] = sut.Deserialize(data[i], context);
+        }
+
+        // Complete the 1,024-lookup probe with enough reuse to exceed its 10% hit gate.
+        var repeatedLookups = CachingStringDeserializer.ProbeLookupCount
+            - (keyCount - CachingStringDeserializer.AdmissionProbeLimit);
+        for (var i = 0; i < repeatedLookups; i++)
+            sut.Deserialize(data[i], context);
+
+        var allReferencesCached = true;
+        for (var i = 0; i < keyCount; i++)
+            allReferencesCached &= ReferenceEquals(references[i], sut.Deserialize(data[i], context));
+
+        await Assert.That(allReferencesCached).IsTrue();
     }
 
     [Test]
@@ -147,8 +188,7 @@ public class CachingStringDeserializerTests
         var sut = CreateKeyCache();
         var context = KeyContext();
 
-        for (var i = 0; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
-            sut.Deserialize(ToUtf8($"unique-{i}"), context);
+        EnterHighCardinalityBypass(sut, context);
 
         var repeated = ToUtf8("new-repeated-key");
         for (var i = 0; i < CachingStringDeserializer.BypassInterval; i++)

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -168,6 +168,28 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
+    public async Task BoundedReusableKeys_LargerThanPrimaryProbe_AreAdmittedDuringReuseProbe()
+    {
+        const int keyCount = 5_000;
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var data = new ReadOnlyMemory<byte>[keyCount];
+        var references = new string[keyCount];
+
+        for (var i = 0; i < keyCount; i++)
+        {
+            data[i] = ToUtf8($"bounded-reuse-{i}");
+            references[i] = sut.Deserialize(data[i], context);
+        }
+
+        var allReferencesCached = true;
+        for (var i = 0; i < keyCount; i++)
+            allReferencesCached &= ReferenceEquals(references[i], sut.Deserialize(data[i], context));
+
+        await Assert.That(allReferencesCached).IsTrue();
+    }
+
+    [Test]
     public async Task LowCardinalityKeys_RemainCachedPastAdmissionProbeLimit()
     {
         var sut = CreateKeyCache();

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -257,6 +257,28 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
+    public async Task ReuseProbe_CacheFilledDuringWindow_CountsAdmissionsAsReuseEvidence()
+    {
+        const int keyCount = 100_000;
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var firstKey = ToUtf8("fill-window-0");
+        var firstReference = sut.Deserialize(firstKey, context);
+
+        for (var i = 1; i < keyCount; i++)
+            sut.Deserialize(ToUtf8($"fill-window-{i}"), context);
+
+        var reuseLookupLimit = CachingStringDeserializer.CalculateReuseProbeLookupCount(KeyCacheMaxEntries);
+        for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
+            sut.Deserialize(ToUtf8($"fill-window-{i % keyCount}"), context);
+
+        var reusedReference = sut.Deserialize(firstKey, context);
+
+        await Assert.That(GetInnerModeName(sut)).IsNotEqualTo("BypassSerde");
+        await Assert.That(ReferenceEquals(firstReference, reusedReference)).IsTrue();
+    }
+
+    [Test]
     public async Task ReuseProbe_OneCoincidentalHit_DoesNotRestoreCache()
     {
         var sut = CreateSmallKeyCache();

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -27,8 +27,8 @@ public class CachingStringDeserializerTests
         SerializationContext context)
     {
         var lookupCount = CachingStringDeserializer.AdmissionProbeLimit
-            + (CachingStringDeserializer.ProbeLookupCount * 2)
-            + KeyCacheMaxEntries;
+            + CachingStringDeserializer.ProbeLookupCount
+            + CachingStringDeserializer.CalculateReuseProbeLookupCount(KeyCacheMaxEntries);
 
         for (var uniqueKey = 0; uniqueKey < lookupCount; uniqueKey++)
             deserializer.Deserialize(ToUtf8($"unique-{uniqueKey}"), context);
@@ -168,8 +168,8 @@ public class CachingStringDeserializerTests
 
         var missesUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
             - ValueCacheMaxEntries
-            + (CachingStringDeserializer.ProbeLookupCount * 2)
-            + ValueCacheMaxEntries;
+            + CachingStringDeserializer.ProbeLookupCount
+            + CachingStringDeserializer.CalculateReuseProbeLookupCount(ValueCacheMaxEntries);
         for (var i = 0; i < missesUntilBypass; i++)
             sut.Deserialize(ToUtf8($"saturated-miss-{i}"), context);
 
@@ -232,16 +232,16 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
-    public async Task NearCapacityCyclicKeys_ReachCachedReuseBeforeBypass()
+    public async Task HighYieldCyclicKeys_ReachCachedReuseBeforeBypass()
     {
-        const int keyCount = 18_000;
+        const int keyCount = 20_000;
         var sut = CreateKeyCache();
         var context = KeyContext();
-        var firstKey = ToUtf8("near-capacity-0");
+        var firstKey = ToUtf8("high-yield-0");
         var firstReference = sut.Deserialize(firstKey, context);
 
         for (var i = 1; i < keyCount; i++)
-            sut.Deserialize(ToUtf8($"near-capacity-{i}"), context);
+            sut.Deserialize(ToUtf8($"high-yield-{i}"), context);
 
         var reusedReference = sut.Deserialize(firstKey, context);
 
@@ -291,7 +291,8 @@ public class CachingStringDeserializerTests
             sut.Deserialize(ToUtf8($"probe-start-{i}"), context);
 
         var oversized = ToUtf8(new string('x', 129));
-        var lookupsUntilBypass = (CachingStringDeserializer.ProbeLookupCount * 2) + ValueCacheMaxEntries;
+        var lookupsUntilBypass = CachingStringDeserializer.ProbeLookupCount
+            + CachingStringDeserializer.CalculateReuseProbeLookupCount(ValueCacheMaxEntries);
         for (var i = 0; i < lookupsUntilBypass; i++)
             sut.Deserialize(oversized, context);
 
@@ -304,8 +305,8 @@ public class CachingStringDeserializerTests
         var sut = CreateSmallKeyCache();
         var context = KeyContext();
         var lookupsUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
-            + (CachingStringDeserializer.ProbeLookupCount * 2)
-            + ValueCacheMaxEntries;
+            + CachingStringDeserializer.ProbeLookupCount
+            + CachingStringDeserializer.CalculateReuseProbeLookupCount(ValueCacheMaxEntries);
         for (var i = 0; i < lookupsUntilBypass; i++)
             sut.Deserialize(ToUtf8($"bypass-start-{i}"), context);
 

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -257,7 +257,7 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
-    public async Task ReuseProbe_CacheFilledDuringWindow_CountsAdmissionsAsReuseEvidence()
+    public async Task ReuseProbe_PreservesFilledCacheAcrossSubsequentSaturatedProbe()
     {
         const int keyCount = 100_000;
         var sut = CreateKeyCache();
@@ -272,10 +272,13 @@ public class CachingStringDeserializerTests
         for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
             sut.Deserialize(ToUtf8($"fill-window-{i % keyCount}"), context);
 
-        var reusedReference = sut.Deserialize(firstKey, context);
+        // Continue the stable cycle through another probe. This time the cache is already
+        // saturated, so preservation must be attainable from hits without admission evidence.
+        for (var i = KeyCacheMaxEntries; i < keyCount + KeyCacheMaxEntries; i++)
+            sut.Deserialize(ToUtf8($"fill-window-{i % keyCount}"), context);
 
         await Assert.That(GetInnerModeName(sut)).IsNotEqualTo("BypassSerde");
-        await Assert.That(ReferenceEquals(firstReference, reusedReference)).IsTrue();
+        await Assert.That(ReferenceEquals(firstReference, sut.Deserialize(firstKey, context))).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -8,6 +8,7 @@ namespace Dekaf.Tests.Unit.Serialization;
 public class CachingStringDeserializerTests
 {
     private const int KeyCacheMaxEntries = 16_384;
+    private const int ValueCacheMaxEntries = 128;
 
     private static SerializationContext KeyContext(string topic = "test") =>
         new() { Topic = topic, Component = SerializationComponent.Key };
@@ -34,7 +35,7 @@ public class CachingStringDeserializerTests
     }
 
     private static CachingStringDeserializer CreateValueCache() =>
-        new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: 128);
+        new(Serializers.String, maxCachedBytes: 4 * 1024, maxCachedEntries: ValueCacheMaxEntries);
 
     private static IDeserializer<string> GetValueDeserializer(IKafkaConsumer<string, string> consumer)
     {
@@ -140,6 +141,29 @@ public class CachingStringDeserializerTests
         var second = sut.Deserialize(data, context);
 
         await Assert.That(first).IsEqualTo("bypassed");
+        await Assert.That(ReferenceEquals(first, second)).IsFalse();
+    }
+
+    [Test]
+    public async Task SaturatedCache_MissesStillTriggerHighCardinalityBypass()
+    {
+        var sut = CreateValueCache();
+        var context = ValueContext();
+
+        for (var i = 0; i < ValueCacheMaxEntries; i++)
+            sut.Deserialize(ToUtf8($"cached-{i}"), context);
+
+        var missesUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
+            - ValueCacheMaxEntries
+            + CachingStringDeserializer.ProbeLookupCount
+            + ValueCacheMaxEntries;
+        for (var i = 0; i < missesUntilBypass; i++)
+            sut.Deserialize(ToUtf8($"saturated-miss-{i}"), context);
+
+        var data = ToUtf8("bypassed-after-saturation");
+        var first = sut.Deserialize(data, context);
+        var second = sut.Deserialize(data, context);
+
         await Assert.That(ReferenceEquals(first, second)).IsFalse();
     }
 

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -303,6 +303,49 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
+    public async Task ReuseProbe_SmallCacheBelowTenPercentYield_EntersBypass()
+    {
+        const int keyCount = 2_000;
+        var sut = CreateSmallKeyCache();
+        var context = KeyContext();
+
+        for (var i = 0; i < keyCount; i++)
+            sut.Deserialize(ToUtf8($"low-yield-{i}"), context);
+
+        var reuseLookupLimit = CachingStringDeserializer.CalculateReuseProbeLookupCount(ValueCacheMaxEntries);
+        for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
+            sut.Deserialize(ToUtf8($"low-yield-{i % keyCount}"), context);
+
+        await Assert.That(GetInnerModeName(sut)).IsEqualTo("BypassSerde");
+    }
+
+    [Test]
+    public async Task ReuseProbe_CacheFillAndSparseHits_DoNotRestoreCache()
+    {
+        const int sparseHitInterval = 64;
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var retained = ToUtf8("sparse-retained");
+        sut.Deserialize(retained, context);
+
+        for (var i = 1; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
+            sut.Deserialize(ToUtf8($"sparse-admission-{i}"), context);
+        for (var i = 0; i < CachingStringDeserializer.ProbeLookupCount; i++)
+            sut.Deserialize(ToUtf8($"sparse-primary-{i}"), context);
+
+        var reuseLookups = CachingStringDeserializer.CalculateReuseProbeLookupCount(KeyCacheMaxEntries);
+        for (var i = 0; i < reuseLookups; i++)
+        {
+            var data = i % sparseHitInterval == 0
+                ? retained
+                : ToUtf8($"sparse-reuse-{i}");
+            sut.Deserialize(data, context);
+        }
+
+        await Assert.That(GetInnerModeName(sut)).IsEqualTo("BypassSerde");
+    }
+
+    [Test]
     public async Task LowCardinalityKeys_RemainCachedPastAdmissionProbeLimit()
     {
         var sut = CreateKeyCache();

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -27,7 +27,7 @@ public class CachingStringDeserializerTests
         SerializationContext context)
     {
         var lookupCount = CachingStringDeserializer.AdmissionProbeLimit
-            + CachingStringDeserializer.ProbeLookupCount
+            + (CachingStringDeserializer.ProbeLookupCount * 2)
             + KeyCacheMaxEntries;
 
         for (var uniqueKey = 0; uniqueKey < lookupCount; uniqueKey++)
@@ -168,7 +168,7 @@ public class CachingStringDeserializerTests
 
         var missesUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
             - ValueCacheMaxEntries
-            + CachingStringDeserializer.ProbeLookupCount
+            + (CachingStringDeserializer.ProbeLookupCount * 2)
             + ValueCacheMaxEntries;
         for (var i = 0; i < missesUntilBypass; i++)
             sut.Deserialize(ToUtf8($"saturated-miss-{i}"), context);
@@ -232,6 +232,23 @@ public class CachingStringDeserializerTests
     }
 
     [Test]
+    public async Task NearCapacityCyclicKeys_ReachCachedReuseBeforeBypass()
+    {
+        const int keyCount = 18_000;
+        var sut = CreateKeyCache();
+        var context = KeyContext();
+        var firstKey = ToUtf8("near-capacity-0");
+        var firstReference = sut.Deserialize(firstKey, context);
+
+        for (var i = 1; i < keyCount; i++)
+            sut.Deserialize(ToUtf8($"near-capacity-{i}"), context);
+
+        var reusedReference = sut.Deserialize(firstKey, context);
+
+        await Assert.That(ReferenceEquals(firstReference, reusedReference)).IsTrue();
+    }
+
+    [Test]
     public async Task LowCardinalityKeys_RemainCachedPastAdmissionProbeLimit()
     {
         var sut = CreateKeyCache();
@@ -274,7 +291,7 @@ public class CachingStringDeserializerTests
             sut.Deserialize(ToUtf8($"probe-start-{i}"), context);
 
         var oversized = ToUtf8(new string('x', 129));
-        var lookupsUntilBypass = CachingStringDeserializer.ProbeLookupCount + ValueCacheMaxEntries;
+        var lookupsUntilBypass = (CachingStringDeserializer.ProbeLookupCount * 2) + ValueCacheMaxEntries;
         for (var i = 0; i < lookupsUntilBypass; i++)
             sut.Deserialize(oversized, context);
 
@@ -287,7 +304,7 @@ public class CachingStringDeserializerTests
         var sut = CreateSmallKeyCache();
         var context = KeyContext();
         var lookupsUntilBypass = CachingStringDeserializer.AdmissionProbeLimit
-            + CachingStringDeserializer.ProbeLookupCount
+            + (CachingStringDeserializer.ProbeLookupCount * 2)
             + ValueCacheMaxEntries;
         for (var i = 0; i < lookupsUntilBypass; i++)
             sut.Deserialize(ToUtf8($"bypass-start-{i}"), context);

--- a/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/CachingStringDeserializerTests.cs
@@ -224,6 +224,10 @@ public class CachingStringDeserializerTests
             references[i] = sut.Deserialize(data[i], context);
         }
 
+        var reuseLookupLimit = CachingStringDeserializer.CalculateReuseProbeLookupCount(KeyCacheMaxEntries);
+        for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
+            sut.Deserialize(data[i % keyCount], context);
+
         var allReferencesCached = true;
         for (var i = 0; i < keyCount; i++)
             allReferencesCached &= ReferenceEquals(references[i], sut.Deserialize(data[i], context));
@@ -243,9 +247,34 @@ public class CachingStringDeserializerTests
         for (var i = 1; i < keyCount; i++)
             sut.Deserialize(ToUtf8($"high-yield-{i}"), context);
 
+        var reuseLookupLimit = CachingStringDeserializer.CalculateReuseProbeLookupCount(KeyCacheMaxEntries);
+        for (var i = 0; i < reuseLookupLimit && GetInnerModeName(sut) == "ProbeSerde"; i++)
+            sut.Deserialize(ToUtf8($"high-yield-{i % keyCount}"), context);
+
         var reusedReference = sut.Deserialize(firstKey, context);
 
         await Assert.That(ReferenceEquals(firstReference, reusedReference)).IsTrue();
+    }
+
+    [Test]
+    public async Task ReuseProbe_OneCoincidentalHit_DoesNotRestoreCache()
+    {
+        var sut = CreateSmallKeyCache();
+        var context = KeyContext();
+        var retained = ToUtf8("retained");
+        sut.Deserialize(retained, context);
+
+        for (var i = 1; i < CachingStringDeserializer.AdmissionProbeLimit; i++)
+            sut.Deserialize(ToUtf8($"admission-{i}"), context);
+        for (var i = 0; i < CachingStringDeserializer.ProbeLookupCount; i++)
+            sut.Deserialize(ToUtf8($"primary-{i}"), context);
+
+        sut.Deserialize(retained, context);
+        var reuseLookups = CachingStringDeserializer.CalculateReuseProbeLookupCount(ValueCacheMaxEntries);
+        for (var i = 1; i < reuseLookups; i++)
+            sut.Deserialize(ToUtf8($"reuse-{i}"), context);
+
+        await Assert.That(GetInnerModeName(sut)).IsEqualTo("BypassSerde");
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
@@ -9,8 +9,9 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 10, iterationCount: 10)]
 public class CachingStringDeserializerBenchmarks
 {
-    private const int UniqueKeyCount = 10_000;
-    private const int UniquePassCount = 50;
+    private const int UniqueKeyCount = 65_536;
+    private const int UniquePassCount = 10;
+    private const int BoundedKeyCount = 1_000;
 
     private readonly SerializationContext _context = new()
     {
@@ -19,7 +20,10 @@ public class CachingStringDeserializerBenchmarks
     };
     private readonly CachingStringDeserializer _repeatedDeserializer =
         new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+    private readonly CachingStringDeserializer _boundedDeserializer =
+        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
     private ReadOnlyMemory<byte>[] _uniqueKeys = null!;
+    private ReadOnlyMemory<byte>[] _boundedKeys = null!;
     private ReadOnlyMemory<byte> _repeatedKey;
 
     [GlobalSetup]
@@ -28,6 +32,17 @@ public class CachingStringDeserializerBenchmarks
         _uniqueKeys = new ReadOnlyMemory<byte>[UniqueKeyCount];
         for (var i = 0; i < _uniqueKeys.Length; i++)
             _uniqueKeys[i] = Encoding.UTF8.GetBytes($"unique-key-{i}");
+
+        _boundedKeys = new ReadOnlyMemory<byte>[BoundedKeyCount];
+        for (var i = 0; i < _boundedKeys.Length; i++)
+        {
+            _boundedKeys[i] = Encoding.UTF8.GetBytes($"bounded-key-{i}");
+            _boundedDeserializer.Deserialize(_boundedKeys[i], _context);
+        }
+
+        // Let the adaptive implementation complete its first hit-rate probe.
+        for (var i = 0; i < BoundedKeyCount; i++)
+            _boundedDeserializer.Deserialize(_boundedKeys[i], _context);
 
         _repeatedKey = Encoding.UTF8.GetBytes("repeated-key");
         _repeatedDeserializer.Deserialize(_repeatedKey, _context);
@@ -44,6 +59,16 @@ public class CachingStringDeserializerBenchmarks
             for (var i = 0; i < _uniqueKeys.Length; i++)
                 characters += deserializer.Deserialize(_uniqueKeys[i], _context).Length;
         }
+
+        return characters;
+    }
+
+    [Benchmark(OperationsPerInvoke = BoundedKeyCount)]
+    public int BoundedReusableKeys()
+    {
+        var characters = 0;
+        for (var i = 0; i < _boundedKeys.Length; i++)
+            characters += _boundedDeserializer.Deserialize(_boundedKeys[i], _context).Length;
 
         return characters;
     }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 10, iterationCount: 10)]
+public class CachingStringDeserializerBenchmarks
+{
+    private const int UniqueKeyCount = 10_000;
+    private const int UniquePassCount = 50;
+
+    private readonly SerializationContext _context = new()
+    {
+        Topic = "cache-benchmark",
+        Component = SerializationComponent.Key
+    };
+    private readonly CachingStringDeserializer _repeatedDeserializer =
+        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+    private ReadOnlyMemory<byte>[] _uniqueKeys = null!;
+    private ReadOnlyMemory<byte> _repeatedKey;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _uniqueKeys = new ReadOnlyMemory<byte>[UniqueKeyCount];
+        for (var i = 0; i < _uniqueKeys.Length; i++)
+            _uniqueKeys[i] = Encoding.UTF8.GetBytes($"unique-key-{i}");
+
+        _repeatedKey = Encoding.UTF8.GetBytes("repeated-key");
+        _repeatedDeserializer.Deserialize(_repeatedKey, _context);
+    }
+
+    [Benchmark(OperationsPerInvoke = UniqueKeyCount * UniquePassCount)]
+    public int UniqueKeys()
+    {
+        var characters = 0;
+        for (var pass = 0; pass < UniquePassCount; pass++)
+        {
+            var deserializer =
+                new CachingStringDeserializer(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+            for (var i = 0; i < _uniqueKeys.Length; i++)
+                characters += deserializer.Deserialize(_uniqueKeys[i], _context).Length;
+        }
+
+        return characters;
+    }
+
+    [Benchmark]
+    public string RepeatedKey() => _repeatedDeserializer.Deserialize(_repeatedKey, _context);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
@@ -9,8 +9,10 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 10, iterationCount: 10)]
 public class CachingStringDeserializerBenchmarks
 {
-    private const int UniqueKeyCount = 65_536;
-    private const int UniquePassCount = 10;
+    // Long enough to include the threshold-derived reuse probe and a sustained bypass
+    // phase, while keeping total operations per invocation close to the original harness.
+    private const int UniqueKeyCount = 512 * 1_024;
+    private const int UniquePassCount = 2;
     private const int BoundedKeyCount = 1_000;
 
     private readonly SerializationContext _context = new()


### PR DESCRIPTION
Closes #2213.

## What changed

- After 256 misses, measure 1,024 eligible cache lookups and retain caching when at least 10% hit.
- If the primary probe is low-hit, size the reuse scan from the same 10% threshold: cache capacity divided by the accepted hit rate, plus the primary-probe prefix. Cyclic workloads that the existing cache serves at >=10% therefore reach a cached reuse before bypass.
- Bypass hashing and dictionary insertion for 524,288 lookups, then automatically re-probe. This gives the default threshold-safe reuse scan a greater than 3:1 bypass/probe duty cycle on sustained unique traffic.
- Retire cache generations in O(1), keep transition counters approximate and lock-free, and preserve the cached-hit JIT shape through preallocated probe/bypass adapters.
- Cover saturated caches, oversized/empty payload transitions, bounded 1,000/5,000-key sets, and a 20,000-key high-yield cycle.
- Extend the unique-key benchmark to 512K keys so it measures both the threshold-derived probe and a sustained bypass phase.

## Performance

Exact parent: `68c94dd901e223642c249eb7634ab3acbc460aaf`
Candidate: `a91f65a4`

.NET 10.0.10, BenchmarkDotNet 0.15.8, 10 warmups / 10 measured iterations, same machine and identical updated harness.

| Workload | Baseline | Candidate | Delta | Baseline alloc | Candidate alloc |
|---|---:|---:|---:|---:|---:|
| Sustained unique keys | 44.763 ns | 32.935 ns | -26.4% | 60 B | 60 B |
| Bounded reusable keys | 8.303 ns | 8.224 ns | -1.0%; CIs overlap | 0 B | 0 B |
| Repeated key, ambiguity-control pair | 7.253 ns | 7.120 ns | -1.8%; broad CIs overlap | 0 B | 0 B |

The full-run repeated-key samples were multimodal, so one exact control pair was run as permitted by the benchmark rules; both control samples remained multimodal and statistically overlapping. No cached-workload allocation or statistically supported throughput regression was accepted.

## Verification

- Release solution build: 0 warnings, 0 errors
- Focused `CachingStringDeserializerTests`: 20/20
- Full unit suite net10.0: 5714/5714
- Full unit suite net8.0: 5587/5587
- Exact-parent `[MemoryDiagnoser]` benchmark pair above

Integration tests were not run because this changes only internal deterministic string-deserializer cache policy; Kafka protocol I/O and client-visible behavior are unchanged.