### PR TITLE
Test DNS re-resolution across IP changes

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1330,6 +1330,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            DnsResolver = _dnsResolver,
             // Java parity: initial metadata blocks up to max.block.ms, retrying throughout.
             InitTimeoutMs = options.MaxBlockMs
         };
@@ -1476,6 +1477,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private MetadataRecoveryStrategy _metadataRecoveryStrategy = MetadataRecoveryStrategy.Rebootstrap;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private ClientDnsEndpointResolver _dnsResolver = ClientDnsEndpointResolver.Default;
     private readonly List<string> _topicsToSubscribe = [];
     private string? _topicPatternToSubscribe;
     private TimeSpan? _metadataMaxAge;
@@ -2325,6 +2327,13 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    internal ConsumerBuilder<TKey, TValue> WithDnsResolver(ClientDnsEndpointResolver resolver)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _dnsResolver = resolver;
+        return this;
+    }
+
     /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
@@ -2807,6 +2816,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            DnsResolver = _dnsResolver,
             Interceptors = _interceptors?.Count > 0 ? _interceptors.ToArray() : null,
             RetryPolicy = _retryPolicy,
             PrefetchPipelineDepth = _prefetchPipelineDepth,
@@ -2823,7 +2833,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
             MetadataRefreshInterval = _metadataMaxAge ?? TimeSpan.FromMinutes(15),
             MetadataRecoveryStrategy = _metadataRecoveryStrategy,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
-            ClientDnsLookup = _clientDnsLookup
+            ClientDnsLookup = _clientDnsLookup,
+            DnsResolver = _dnsResolver
         };
 
         var consumer = _clientInfrastructure is null

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -428,6 +428,11 @@ public sealed class ConsumerOptions
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
     /// <summary>
+    /// DNS resolver used by connections. Internal for deterministic tests.
+    /// </summary>
+    internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
+
+    /// <summary>
     /// Application-level retry policy for message processing in hosted consumer services.
     /// When set, the consumer service will use this policy to determine delays between retries.
     /// When <c>null</c>, existing retry behavior is unchanged.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1166,7 +1166,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 AwsMskIamConfig = options.AwsMskIamConfig,
                 SendBufferSize = options.SocketSendBufferBytes,
                 ReceiveBufferSize = options.SocketReceiveBufferBytes,
-                ClientDnsLookup = options.ClientDnsLookup
+                ClientDnsLookup = options.ClientDnsLookup,
+                DnsResolver = options.DnsResolver
             },
             loggerFactory,
             connectionsPerBroker: options.ConnectionsPerBroker,

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -905,31 +905,25 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 // Apply a per-host timeout to prevent DNS hangs from blocking rebootstrap
                 using var dnsCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 dnsCts.CancelAfter(TimeSpan.FromSeconds(5));
-                IPAddress[] addresses;
+                var endpoints = await _options.DnsResolver
+                    .ResolveAsync(host, port, _options.ClientDnsLookup, dnsCts.Token)
+                    .ConfigureAwait(false);
                 if (_options.ClientDnsLookup == ClientDnsLookup.ResolveCanonicalBootstrapServersOnly)
                 {
-                    var entry = await Dns.GetHostEntryAsync(host, dnsCts.Token).ConfigureAwait(false);
-                    addresses = entry.AddressList;
-                    var canonicalHost = string.IsNullOrWhiteSpace(entry.HostName) ? host : entry.HostName;
-                    var canonicalEndpoint = (canonicalHost, port);
-                    if (seen.Add(canonicalEndpoint))
+                    if (endpoints.Count > 0)
                     {
-                        resolved.Add(canonicalEndpoint);
+                        var canonicalEndpoint = (endpoints[0].TargetHost, port);
+                        if (seen.Add(canonicalEndpoint))
+                            resolved.Add(canonicalEndpoint);
                     }
                 }
                 else
                 {
-                    addresses = await Dns.GetHostAddressesAsync(host, dnsCts.Token).ConfigureAwait(false);
-                    foreach (var address in addresses)
+                    foreach (var endpoint in endpoints)
                     {
-                        var endpoint = (address.ToString(), port);
-                        // Add resolved IP endpoints for rebootstrap fan-out. The original
-                        // hostname fallback below preserves TLS/SASL target names when direct
-                        // IP endpoints are unsuitable.
-                        if (seen.Add(endpoint))
-                        {
-                            resolved.Add(endpoint);
-                        }
+                        var resolvedEndpoint = (endpoint.Address.ToString(), port);
+                        if (seen.Add(resolvedEndpoint))
+                            resolved.Add(resolvedEndpoint);
                     }
                 }
 
@@ -940,7 +934,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     resolved.Add(hostnameEndpoint);
                 }
 
-                LogRebootstrapDnsResolved(host, port, addresses.Length);
+                LogRebootstrapDnsResolved(host, port, endpoints.Count);
             }
             catch (Exception ex)
             {
@@ -1352,6 +1346,11 @@ public sealed class MetadataOptions
     /// Controls how bootstrap and broker hostnames are resolved before connecting.
     /// </summary>
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
+
+    /// <summary>
+    /// DNS resolver used when re-resolving bootstrap endpoints. Internal for deterministic tests.
+    /// </summary>
+    internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
 
     /// <summary>
     /// Initial retry backoff in milliseconds for metadata initialization.

--- a/tests/Dekaf.Tests.Integration/DnsReresolutionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/DnsReresolutionKafkaContainer.cs
@@ -1,0 +1,277 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Networking;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using TUnit.Core.Interfaces;
+
+namespace Dekaf.Tests.Integration;
+
+public sealed class DnsReresolutionKafkaContainer : IAsyncInitializer, IAsyncDisposable
+{
+    private const ushort KafkaClientPort = 19_092;
+    private const ushort KafkaBrokerPort = 19_093;
+    private const ushort KafkaControllerPort = 19_094;
+    private const string KafkaNetworkAlias = "dns-reresolution-kafka";
+
+    private IContainer? _kafka;
+    private TcpRelay? _primaryRelay;
+    private TcpRelay? _secondaryRelay;
+    private int _relayPort;
+    private string? _upstreamHost;
+    private int _upstreamPort;
+
+    public const string StableHost = "dns-reresolution.test";
+    public static IPAddress PrimaryAddress { get; } = IPAddress.Parse("127.0.0.2");
+    public static IPAddress SecondaryAddress { get; } = IPAddress.Parse("127.0.0.3");
+    public static IPAddress DeadAddress { get; } = IPAddress.Parse("127.0.0.4");
+
+    public string BootstrapServers => $"{StableHost}:{_relayPort}";
+    public int PrimaryAcceptedConnections => _primaryRelay?.AcceptedConnections ?? 0;
+    public int SecondaryAcceptedConnections => _secondaryRelay?.AcceptedConnections ?? 0;
+
+    public async Task InitializeAsync()
+    {
+        await StartRelaysAsync().ConfigureAwait(false);
+
+        _kafka = new ContainerBuilder($"apache/kafka:{KafkaContainerDefault.ImageTag}")
+            .WithNetworkAliases(KafkaNetworkAlias)
+            .WithPortBinding(KafkaClientPort, true)
+            .WithEnvironment("KAFKA_HEAP_OPTS", "-Xmx512m -Xms512m")
+            .WithEnvironment("KAFKA_NODE_ID", "1")
+            .WithEnvironment("KAFKA_PROCESS_ROLES", "broker,controller")
+            .WithEnvironment(
+                "KAFKA_LISTENERS",
+                $"CLIENT://0.0.0.0:{KafkaClientPort}," +
+                $"BROKER://0.0.0.0:{KafkaBrokerPort}," +
+                $"CONTROLLER://0.0.0.0:{KafkaControllerPort}")
+            .WithEnvironment(
+                "KAFKA_ADVERTISED_LISTENERS",
+                $"CLIENT://{StableHost}:{_relayPort}," +
+                $"BROKER://{KafkaNetworkAlias}:{KafkaBrokerPort}")
+            .WithEnvironment(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "CLIENT:PLAINTEXT,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")
+            .WithEnvironment("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")
+            .WithEnvironment("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER")
+            .WithEnvironment("KAFKA_CONTROLLER_QUORUM_VOTERS", $"1@localhost:{KafkaControllerPort}")
+            .WithEnvironment("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+            .WithEnvironment("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", "1")
+            .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+            .WithEnvironment("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+            .WithEnvironment("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+            .WithEnvironment("CLUSTER_ID", "4L6g3nShT-eMCtK--X86sw")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilMessageIsLogged(".*Transitioning from RECOVERY to RUNNING.*"))
+            .Build();
+
+        await _kafka.StartAsync().ConfigureAwait(false);
+        _upstreamHost = _kafka.Hostname;
+        _upstreamPort = _kafka.GetMappedPublicPort(KafkaClientPort);
+        SetRelayTargets();
+        await WaitForBrokerAsync().ConfigureAwait(false);
+    }
+
+    public async ValueTask ResetRelaysAsync()
+    {
+        await DisposeRelaysAsync().ConfigureAwait(false);
+        await StartRelaysAsync(_relayPort).ConfigureAwait(false);
+        SetRelayTargets();
+    }
+
+    public ValueTask StopPrimaryRelayAsync() => _primaryRelay?.DisposeAsync() ?? default;
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeRelaysAsync().ConfigureAwait(false);
+        if (_kafka is not null)
+            await _kafka.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async ValueTask StartRelaysAsync(int port = 0)
+    {
+        _primaryRelay = new TcpRelay(PrimaryAddress, port);
+        _relayPort = _primaryRelay.Port;
+        try
+        {
+            _secondaryRelay = new TcpRelay(SecondaryAddress, _relayPort);
+        }
+        catch
+        {
+            await _primaryRelay.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private void SetRelayTargets()
+    {
+        if (_upstreamHost is null)
+            return;
+
+        _primaryRelay?.SetTarget(_upstreamHost, _upstreamPort);
+        _secondaryRelay?.SetTarget(_upstreamHost, _upstreamPort);
+    }
+
+    private async ValueTask DisposeRelaysAsync()
+    {
+        if (_primaryRelay is not null)
+            await _primaryRelay.DisposeAsync().ConfigureAwait(false);
+        if (_secondaryRelay is not null)
+            await _secondaryRelay.DisposeAsync().ConfigureAwait(false);
+        _primaryRelay = null;
+        _secondaryRelay = null;
+    }
+
+    private async Task WaitForBrokerAsync()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (true)
+        {
+            try
+            {
+                using var client = new TcpClient();
+                await client.ConnectAsync(_upstreamHost!, _upstreamPort, timeout.Token).ConfigureAwait(false);
+                return;
+            }
+            catch (SocketException) when (!timeout.IsCancellationRequested)
+            {
+                await Task.Delay(100, timeout.Token).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class TcpRelay : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _stopping = new();
+        private readonly ConcurrentDictionary<long, TcpClient> _clients = new();
+        private readonly ConcurrentDictionary<long, Task> _connections = new();
+        private readonly Task _acceptTask;
+        private string? _targetHost;
+        private int _targetPort;
+        private long _nextConnectionId;
+        private int _acceptedConnections;
+        private int _disposeState;
+
+        public TcpRelay(IPAddress address, int port)
+        {
+            _listener = new TcpListener(address, port);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _acceptTask = AcceptAsync();
+        }
+
+        public int Port { get; }
+        public int AcceptedConnections => Volatile.Read(ref _acceptedConnections);
+
+        public void SetTarget(string host, int port)
+        {
+            _targetHost = host;
+            _targetPort = port;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+                return;
+
+            _stopping.Cancel();
+            _listener.Stop();
+            foreach (var client in _clients.Values)
+                client.Dispose();
+
+            await _acceptTask.ConfigureAwait(false);
+            if (!_connections.IsEmpty)
+                await Task.WhenAll(_connections.Values).ConfigureAwait(false);
+            _stopping.Dispose();
+        }
+
+        private async Task AcceptAsync()
+        {
+            try
+            {
+                while (!_stopping.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_stopping.Token).ConfigureAwait(false);
+                    var id = Interlocked.Increment(ref _nextConnectionId);
+                    _clients[id] = client;
+                    Interlocked.Increment(ref _acceptedConnections);
+                    var task = RelayAsync(id, client);
+                    _connections[id] = task;
+                }
+            }
+            catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (_stopping.IsCancellationRequested)
+            {
+            }
+        }
+
+        private async Task RelayAsync(long id, TcpClient inbound)
+        {
+            using (inbound)
+            using (var outbound = new TcpClient())
+            {
+                try
+                {
+                    var targetHost = _targetHost ?? throw new InvalidOperationException("Relay target not ready");
+                    await outbound.ConnectAsync(targetHost, _targetPort, _stopping.Token).ConfigureAwait(false);
+                    _clients[-id] = outbound;
+
+                    var inboundStream = inbound.GetStream();
+                    var outboundStream = outbound.GetStream();
+                    var upstream = inboundStream.CopyToAsync(outboundStream, _stopping.Token);
+                    var downstream = outboundStream.CopyToAsync(inboundStream, _stopping.Token);
+                    await Task.WhenAny(upstream, downstream).ConfigureAwait(false);
+                    inbound.Dispose();
+                    outbound.Dispose();
+                    await Task.WhenAll(upstream, downstream).ConfigureAwait(false);
+                }
+                catch (Exception) when (_stopping.IsCancellationRequested)
+                {
+                }
+                catch (IOException)
+                {
+                }
+                catch (SocketException)
+                {
+                }
+                finally
+                {
+                    _clients.TryRemove(id, out _);
+                    _clients.TryRemove(-id, out _);
+                    _connections.TryRemove(id, out _);
+                }
+            }
+        }
+    }
+}
+
+internal sealed class SwitchingDnsLookup(params IPAddress[] addresses) : IDnsLookup
+{
+    private IPAddress[] _addresses = addresses;
+    private int _invocationCount;
+
+    public int InvocationCount => Volatile.Read(ref _invocationCount);
+
+    public void Use(params IPAddress[] currentAddresses) => Volatile.Write(ref _addresses, currentAddresses);
+
+    public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _invocationCount);
+        return ValueTask.FromResult(Volatile.Read(ref _addresses));
+    }
+
+    public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _invocationCount);
+        return ValueTask.FromResult(new IPHostEntry
+        {
+            HostName = host,
+            AddressList = Volatile.Read(ref _addresses),
+            Aliases = []
+        });
+    }
+}

--- a/tests/Dekaf.Tests.Integration/DnsReresolutionTests.cs
+++ b/tests/Dekaf.Tests.Integration/DnsReresolutionTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using Dekaf.Consumer;
+using Dekaf.Networking;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("NetworkPartition")]
+[NotInParallel("DnsReresolutionKafkaContainer")]
+[ClassDataSource<DnsReresolutionKafkaContainer>(Shared = SharedType.PerTestSession)]
+public class DnsReresolutionTests(DnsReresolutionKafkaContainer kafka)
+{
+    [Test]
+    public async Task Producer_Reconnect_ReresolvesStableBrokerHostnameAfterIpChange()
+    {
+        await kafka.ResetRelaysAsync();
+        var lookup = new SwitchingDnsLookup(DnsReresolutionKafkaContainer.PrimaryAddress);
+        var topic = NewTopic();
+
+        await using var producer = await CreateProducerAsync(lookup);
+        var first = await producer.ProduceAsync(topic, "key-0", "value-0");
+        var callsBeforeIpChange = lookup.InvocationCount;
+
+        lookup.Use(DnsReresolutionKafkaContainer.SecondaryAddress);
+        await kafka.StopPrimaryRelayAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var second = await producer.ProduceAsync(topic, "key-1", "value-1", timeout.Token);
+
+        await Assert.That(first.Offset).IsEqualTo(0);
+        await Assert.That(second.Offset).IsEqualTo(1);
+        await Assert.That(lookup.InvocationCount).IsGreaterThan(callsBeforeIpChange);
+        await Assert.That(kafka.SecondaryAcceptedConnections).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Consumer_Reconnect_ReresolvesWithoutSkippingOrDuplicatingRecords()
+    {
+        await kafka.ResetRelaysAsync();
+        var producerLookup = new SwitchingDnsLookup(DnsReresolutionKafkaContainer.PrimaryAddress);
+        var consumerLookup = new SwitchingDnsLookup(DnsReresolutionKafkaContainer.PrimaryAddress);
+        var topic = NewTopic();
+
+        await using var producer = await CreateProducerAsync(producerLookup);
+        await producer.ProduceAsync(topic, "key-0", "value-0");
+
+        await using var consumer = await CreateConsumerAsync(consumerLookup);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        var values = new List<string>();
+        using (var firstTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
+        {
+            await foreach (var message in consumer.ConsumeAsync(firstTimeout.Token))
+            {
+                values.Add(message.Value!);
+                break;
+            }
+        }
+
+        var callsBeforeIpChange = consumerLookup.InvocationCount;
+        producerLookup.Use(DnsReresolutionKafkaContainer.SecondaryAddress);
+        consumerLookup.Use(DnsReresolutionKafkaContainer.SecondaryAddress);
+        await kafka.StopPrimaryRelayAsync();
+
+        for (var i = 1; i < 10; i++)
+            await producer.ProduceAsync(topic, $"key-{i}", $"value-{i}");
+
+        using (var remainingTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+        {
+            await foreach (var message in consumer.ConsumeAsync(remainingTimeout.Token))
+            {
+                values.Add(message.Value!);
+                if (values.Count == 10)
+                    break;
+            }
+        }
+
+        var expectedValues = Enumerable.Range(0, 10).Select(static i => $"value-{i}");
+        await Assert.That(values.SequenceEqual(expectedValues)).IsTrue();
+        await Assert.That(consumerLookup.InvocationCount).IsGreaterThan(callsBeforeIpChange);
+        await Assert.That(kafka.SecondaryAcceptedConnections).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task BootstrapReresolution_RecoversWhenCachedIpIsDead()
+    {
+        await kafka.ResetRelaysAsync();
+        var lookup = new SwitchingDnsLookup(DnsReresolutionKafkaContainer.PrimaryAddress);
+        var topic = NewTopic();
+
+        await using var producer = await CreateProducerAsync(lookup, rebootstrapImmediately: true);
+        await producer.ProduceAsync(topic, "key-0", "value-0");
+        var callsBeforeFailure = lookup.InvocationCount;
+
+        lookup.Use(DnsReresolutionKafkaContainer.SecondaryAddress);
+        await kafka.StopPrimaryRelayAsync();
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await producer.ProduceAsync(topic, "key-1", "value-1", timeout.Token);
+
+        await Assert.That(result.Offset).IsEqualTo(1);
+        await Assert.That(lookup.InvocationCount).IsGreaterThan(callsBeforeFailure);
+    }
+
+    [Test]
+    public async Task MultipleARecords_ConnectsThroughNextAddressWhenFirstIsDead()
+    {
+        await kafka.ResetRelaysAsync();
+        var lookup = new SwitchingDnsLookup(
+            DnsReresolutionKafkaContainer.DeadAddress,
+            DnsReresolutionKafkaContainer.SecondaryAddress);
+
+        await using var producer = await CreateProducerAsync(lookup);
+        var result = await producer.ProduceAsync(NewTopic(), "key", "value");
+
+        await Assert.That(result.Offset).IsEqualTo(0);
+        await Assert.That(lookup.InvocationCount).IsGreaterThan(0);
+        await Assert.That(kafka.SecondaryAcceptedConnections).IsGreaterThan(0);
+    }
+
+    private async ValueTask<IKafkaProducer<string, string>> CreateProducerAsync(
+        SwitchingDnsLookup lookup,
+        bool rebootstrapImmediately = false)
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithDnsResolver(new ClientDnsEndpointResolver(lookup))
+            .WithAcks(Acks.All)
+            .WithRequestTimeout(TimeSpan.FromSeconds(3))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(30))
+            .WithReconnectBackoff(TimeSpan.FromMilliseconds(20))
+            .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory());
+
+        if (rebootstrapImmediately)
+            builder = builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.Zero);
+
+        return await builder.BuildAsync();
+    }
+
+    private async ValueTask<IKafkaConsumer<string, string>> CreateConsumerAsync(SwitchingDnsLookup lookup)
+    {
+        return await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithDnsResolver(new ClientDnsEndpointResolver(lookup))
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithMaxPollRecords(1)
+            .WithFetchMaxWait(TimeSpan.FromMilliseconds(100))
+            .WithReconnectBackoff(TimeSpan.FromMilliseconds(20))
+            .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(100))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+    }
+
+    private static string NewTopic() => $"dns-reresolution-{Guid.NewGuid():N}";
+}

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataRecoveryStrategyTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Reflection;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -592,6 +593,24 @@ public sealed class MetadataRecoveryStrategyTests
         await Assert.That(distinctCount).IsEqualTo(endpoints.Count);
     }
 
+    [Test]
+    public async Task ResolveBootstrapEndpointsAsync_UsesConfiguredDnsResolver()
+    {
+        var lookup = new RecordingDnsLookup(IPAddress.Parse("192.0.2.10"));
+        var manager = CreateTestManager(
+            new MetadataOptions
+            {
+                DnsResolver = new ClientDnsEndpointResolver(lookup)
+            },
+            ["broker.example:9092"]);
+
+        var endpoints = await manager.ResolveBootstrapEndpointsAsync(CancellationToken.None);
+
+        await Assert.That(lookup.InvocationCount).IsEqualTo(1);
+        await Assert.That(endpoints).Contains(("192.0.2.10", 9092));
+        await Assert.That(endpoints).Contains(("broker.example", 9092));
+    }
+
     #endregion
 
     #region MetadataManager Integration with Recovery Strategy
@@ -752,6 +771,27 @@ public sealed class MetadataRecoveryStrategyTests
     {
         var metadataManager = GetField<MetadataManager>(client, "_metadataManager");
         return GetField<MetadataOptions>(metadataManager, "_options");
+    }
+
+    private sealed class RecordingDnsLookup(IPAddress address) : IDnsLookup
+    {
+        public int InvocationCount { get; private set; }
+
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+        {
+            InvocationCount++;
+            return ValueTask.FromResult<IPAddress[]>([address]);
+        }
+
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+        {
+            InvocationCount++;
+            return ValueTask.FromResult(new IPHostEntry
+            {
+                HostName = host,
+                AddressList = [address]
+            });
+        }
     }
 
     private static T GetField<T>(object instance, string name)


### PR DESCRIPTION
Fixes #2253

## Summary
- add deterministic producer and consumer DNS IP-change integration coverage through dual loopback TCP relays
- verify dead cached-IP recovery and multiple-A-record endpoint failover
- route consumer connections and metadata rebootstrap through the configured DNS resolver
- assert metadata rebootstrap resolver injection with a unit test

## Validation
- Release build: integration project, net8.0 + net10.0
- MetadataRecoveryStrategyTests: 57/57 on net8.0 and 57/57 on net10.0
- DnsReresolutionTests: 4/4 on net8.0 and 4/4 on net10.0
- final net10.0 relay-teardown validation: 4/4

## Performance
No benchmark required: product changes are builder construction and failure-only DNS/rebootstrap paths; serialization, produce, consume, batch, and receive hot paths are unchanged.