### PR TITLE
Add KIP-1123 rack-aware producer partitioning

### DIFF
--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -94,6 +94,8 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithAdaptivePartitioning(...)` | `EnableAdaptivePartitioning` | Boolean; Kafka `partitioner.adaptive.partitioning.enable` |
 | `WithPartitionerAvailabilityTimeout(...)` | `PartitionerAvailabilityTimeoutMs` | Milliseconds; Kafka `partitioner.availability.timeout.ms` |
 | `WithPartitionerIgnoreKeys(...)` | `IgnorePartitionerKeys` | Boolean; Kafka `partitioner.ignore.keys` |
+| `WithClientRack(...)` | `ClientRack` | String; Kafka `client.rack` |
+| `WithRackAwarePartitioning(...)` | `EnableRackAwarePartitioning` | Boolean; Kafka `partitioner.rack.aware` |
 | `UseTls(...)` | `UseTls`, `TlsConfig` | `TlsConfig` can bind certificate path fields |
 | `WithRemoteCertificateValidationCallback(...)` | Runtime callback | Custom TLS certificate validation |
 | `WithSaslPlain(...)` / `WithSaslScramSha512(...)` | `SaslMechanism`, `SaslUsername`, `SaslPassword` | `SaslMechanism` values match the enum names |
@@ -204,7 +206,7 @@ Control how messages are assigned to partitions:
 .WithPartitioner(PartitionerType.Fnv1ARandom)      // librdkafka/Sarama-compatible
 ```
 
-The built-in default and sticky partitioners use KIP-794 behavior for sticky records: they stay on a partition until at least `BatchSize` bytes have been produced to it. Adaptive partitioning is enabled by default and weights new sticky choices away from partitions with queued batches. Set `.WithAdaptivePartitioning(false)` for uniform switching, `.WithPartitionerAvailabilityTimeout(...)` to exclude backed-up partitions after a timeout, or `.WithPartitionerIgnoreKeys()` to use sticky partitioning even when records have keys.
+The built-in default and sticky partitioners use KIP-794 behavior for sticky records: they stay on a partition until at least `BatchSize` bytes have been produced to it. Adaptive partitioning is enabled by default and weights new sticky choices away from partitions with queued batches. Set `.WithAdaptivePartitioning(false)` for uniform switching, `.WithPartitionerAvailabilityTimeout(...)` to exclude backed-up partitions after a timeout, or `.WithPartitionerIgnoreKeys()` to use sticky partitioning even when records have keys. KIP-1123 rack-aware partitioning is opt-in with `.WithClientRack("rack-a").WithRackAwarePartitioning()`. It prefers local partition leaders and falls back to all leaders when none are usable; uneven rack placement can therefore produce an uneven partition distribution.
 
 ## Transactions
 
@@ -421,6 +423,8 @@ Enable logging:
 | `WithAdaptivePartitioning` | true | Adapt sticky partition choices to queued broker load |
 | `WithPartitionerAvailabilityTimeout` | 0ms | Exclude backed-up partitions after timeout; 0 disables |
 | `WithPartitionerIgnoreKeys` | false | Ignore keys for built-in sticky partitioning |
+| `WithClientRack` | null | Producer rack for rack-aware partitioning |
+| `WithRackAwarePartitioning` | false | Prefer partition leaders in the producer rack |
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
 | `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |

--- a/docs/docs/producer/partitioning.md
+++ b/docs/docs/producer/partitioning.md
@@ -120,6 +120,18 @@ var producer = await Kafka.CreateProducer<string, string>()
     .BuildAsync();
 ```
 
+To prefer partition leaders in the producer's rack for records using automatic partitioning, enable KIP-1123 rack awareness:
+
+```csharp
+var producer = await Kafka.CreateProducer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithClientRack("rack-a")
+    .WithRackAwarePartitioning()
+    .BuildAsync();
+```
+
+The built-in default and sticky partitioners fall back to all partitions when no local leader is usable. Explicit partitions, keyed records, and custom partitioners are unaffected unless `.WithPartitionerIgnoreKeys()` enables automatic partitioning for keyed records. Because only local leaders are preferred, uneven partition-leader placement across racks can create an uneven partition distribution.
+
 ## Partition Count Considerations
 
 The number of partitions affects:

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -841,6 +841,9 @@ internal static class DekafOptionsBinding
             builder.WithCustomPartitioner(options.CustomPartitioner);
         else
             builder.WithPartitioner(options.Partitioner);
+        if (options.ClientRack is not null)
+            builder.WithClientRack(options.ClientRack);
+        builder.WithRackAwarePartitioning(options.EnableRackAwarePartitioning);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         ApplyRemoteCertificateValidationCallback(
             options.RemoteCertificateValidationCallback,
@@ -1209,6 +1212,10 @@ internal static class DekafConfigurationBinding
             builder.WithCompressionLevel(compressionLevel);
         if (TryGetValue<PartitionerType>(configuration, nameof(ProducerOptions.Partitioner), out var partitioner))
             builder.WithPartitioner(partitioner);
+        if (TryGetValue<string>(configuration, nameof(ProducerOptions.ClientRack), out var clientRack))
+            builder.WithClientRack(clientRack);
+        if (TryGetValue<bool>(configuration, nameof(ProducerOptions.EnableRackAwarePartitioning), out var enableRackAwarePartitioning))
+            builder.WithRackAwarePartitioning(enableRackAwarePartitioning);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -50,6 +50,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _enableAdaptivePartitioning = true;
     private int _partitionerAvailabilityTimeoutMs;
     private bool _ignorePartitionerKeys;
+    private string? _clientRack;
+    private bool _enableRackAwarePartitioning;
     private bool _useTls;
     private TlsConfig? _tlsConfig;
     private SaslMechanism _saslMechanism = SaslMechanism.None;
@@ -507,6 +509,24 @@ public sealed class ProducerBuilder<TKey, TValue>
     public ProducerBuilder<TKey, TValue> WithPartitionerIgnoreKeys(bool ignoreKeys = true)
     {
         _ignorePartitionerKeys = ignoreKeys;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the producer rack used by rack-aware built-in partitioning.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithClientRack(string clientRack)
+    {
+        _clientRack = clientRack ?? throw new ArgumentNullException(nameof(clientRack));
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables KIP-1123 rack-aware behavior for built-in default and sticky partitioners.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithRackAwarePartitioning(bool enable = true)
+    {
+        _enableRackAwarePartitioning = enable;
         return this;
     }
 
@@ -1296,6 +1316,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             EnableAdaptivePartitioning = _enableAdaptivePartitioning,
             PartitionerAvailabilityTimeoutMs = _partitionerAvailabilityTimeoutMs,
             IgnorePartitionerKeys = _ignorePartitionerKeys,
+            ClientRack = _clientRack,
+            EnableRackAwarePartitioning = _enableRackAwarePartitioning,
             UseTls = _useTls,
             TlsConfig = _tlsConfig,
             RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -4,6 +4,14 @@ using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Metadata;
 
+internal sealed class RackPartitionIndex(
+    int partitionCount,
+    Dictionary<string, int[]> partitionsByRack)
+{
+    public int PartitionCount { get; } = partitionCount;
+    public Dictionary<string, int[]> PartitionsByRack { get; } = partitionsByRack;
+}
+
 /// <summary>
 /// Immutable snapshot of cluster metadata.
 /// Using an immutable snapshot with volatile reference swap eliminates lock overhead on reads.
@@ -42,7 +50,7 @@ internal sealed class ClusterMetadataSnapshot
     /// Built with the metadata snapshot so rack-aware partitioning never scans topic
     /// partitions on the producer append path.
     /// </summary>
-    public Dictionary<string, Dictionary<string, int[]>> PartitionsByTopicRack { get; }
+    public Dictionary<string, RackPartitionIndex> PartitionsByTopicRack { get; }
 
     public ClusterMetadataSnapshot(
         string? clusterId,
@@ -116,11 +124,11 @@ internal sealed class ClusterMetadataSnapshot
         return result;
     }
 
-    private static Dictionary<string, Dictionary<string, int[]>> BuildPartitionsByTopicRack(
+    private static Dictionary<string, RackPartitionIndex> BuildPartitionsByTopicRack(
         Dictionary<int, BrokerNode> brokers,
         Dictionary<string, TopicInfo> topics)
     {
-        var result = new Dictionary<string, Dictionary<string, int[]>>(topics.Count);
+        var result = new Dictionary<string, RackPartitionIndex>(topics.Count);
         foreach (var topic in topics.Values)
         {
             var builders = new Dictionary<string, List<int>>(StringComparer.Ordinal);
@@ -145,7 +153,7 @@ internal sealed class ClusterMetadataSnapshot
             foreach (var (rack, partitions) in builders)
                 partitionsByRack[rack] = partitions.ToArray();
 
-            result[topic.Name] = partitionsByRack;
+            result[topic.Name] = new RackPartitionIndex(topic.PartitionCount, partitionsByRack);
         }
 
         return result;
@@ -231,11 +239,12 @@ public sealed class ClusterMetadata
     /// Gets the immutable partition-index cache for leaders in a rack.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int[] GetPartitionsForRack(string topicName, string rack)
+    internal int[] GetPartitionsForRack(string topicName, string rack, int partitionCount)
     {
         var snapshot = _snapshot;
-        return snapshot.PartitionsByTopicRack.TryGetValue(topicName, out var partitionsByRack)
-            && partitionsByRack.TryGetValue(rack, out var partitions)
+        return snapshot.PartitionsByTopicRack.TryGetValue(topicName, out var rackIndex)
+            && rackIndex.PartitionCount == partitionCount
+            && rackIndex.PartitionsByRack.TryGetValue(rack, out var partitions)
                 ? partitions
                 : Array.Empty<int>();
     }

--- a/src/Dekaf/Metadata/ClusterMetadata.cs
+++ b/src/Dekaf/Metadata/ClusterMetadata.cs
@@ -37,6 +37,13 @@ internal sealed class ClusterMetadataSnapshot
     /// </summary>
     public IReadOnlyDictionary<string, PartitionInfo?[]> PartitionsByTopicIndex { get; }
 
+    /// <summary>
+    /// Topic name → leader rack → partition indices.
+    /// Built with the metadata snapshot so rack-aware partitioning never scans topic
+    /// partitions on the producer append path.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, int[]>> PartitionsByTopicRack { get; }
+
     public ClusterMetadataSnapshot(
         string? clusterId,
         int controllerId,
@@ -53,6 +60,7 @@ internal sealed class ClusterMetadataSnapshot
         TopicsById = topicsById;
         PartitionsByBroker = BuildPartitionsByBroker(topics);
         PartitionsByTopicIndex = BuildPartitionsByTopicIndex(topics);
+        PartitionsByTopicRack = BuildPartitionsByTopicRack(brokers, topics);
     }
 
     private static Dictionary<int, IReadOnlyList<TopicPartition>> BuildPartitionsByBroker(
@@ -103,6 +111,41 @@ internal sealed class ClusterMetadataSnapshot
             }
 
             result[topic.Name] = partitionsByIndex;
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, Dictionary<string, int[]>> BuildPartitionsByTopicRack(
+        Dictionary<int, BrokerNode> brokers,
+        Dictionary<string, TopicInfo> topics)
+    {
+        var result = new Dictionary<string, Dictionary<string, int[]>>(topics.Count);
+        foreach (var topic in topics.Values)
+        {
+            var builders = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+            foreach (var partition in topic.Partitions)
+            {
+                if (!brokers.TryGetValue(partition.LeaderId, out var leader))
+                {
+                    continue;
+                }
+
+                var rack = leader.Rack;
+                if (rack is not { Length: > 0 })
+                    continue;
+
+                if (!builders.TryGetValue(rack, out var partitions))
+                    builders[rack] = partitions = [];
+
+                partitions.Add(partition.PartitionIndex);
+            }
+
+            var partitionsByRack = new Dictionary<string, int[]>(builders.Count, StringComparer.Ordinal);
+            foreach (var (rack, partitions) in builders)
+                partitionsByRack[rack] = partitions.ToArray();
+
+            result[topic.Name] = partitionsByRack;
         }
 
         return result;
@@ -182,6 +225,19 @@ public sealed class ClusterMetadata
         return _snapshot.PartitionsByBroker.TryGetValue(brokerId, out var partitions)
             ? partitions
             : Array.Empty<TopicPartition>();
+    }
+
+    /// <summary>
+    /// Gets the immutable partition-index cache for leaders in a rack.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int[] GetPartitionsForRack(string topicName, string rack)
+    {
+        var snapshot = _snapshot;
+        return snapshot.PartitionsByTopicRack.TryGetValue(topicName, out var partitionsByRack)
+            && partitionsByRack.TryGetValue(rack, out var partitions)
+                ? partitions
+                : Array.Empty<int>();
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -353,7 +353,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 options.BatchSize,
                 options.EnableAdaptivePartitioning,
                 options.PartitionerAvailabilityTimeoutMs,
-                options.IgnorePartitionerKeys),
+                options.IgnorePartitionerKeys,
+                options.EnableRackAwarePartitioning,
+                options.ClientRack),
             PartitionerType.RoundRobin => new RoundRobinPartitioner(),
             PartitionerType.Random => new RandomPartitioner(),
             PartitionerType.Consistent => new ConsistentPartitioner(),
@@ -366,7 +368,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 options.BatchSize,
                 options.EnableAdaptivePartitioning,
                 options.PartitionerAvailabilityTimeoutMs,
-                options.IgnorePartitionerKeys)
+                options.IgnorePartitionerKeys,
+                options.EnableRackAwarePartitioning,
+                options.ClientRack)
         };
         _uniformStickyPartitioner = _usesCustomPartitioner ? null : _partitioner as IUniformStickyPartitioner;
 
@@ -415,6 +419,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             recordAppendedCallback,
             ResolveLeaderIdForUnackedBudget);
         _uniformStickyPartitioner?.SetPartitionQueueByteProvider(_accumulator.GetPartitionQueueBytes);
+        _uniformStickyPartitioner?.SetPartitionLeaderRackProvider(
+            (topic, partition) => _metadataManager.Metadata.GetPartitionLeader(topic, partition)?.Rack);
 
         // Inflight tracker enables coordinated retry with multiple in-flight batches per partition.
         // The broker uses sequence numbers to guarantee ordering, so multiple batches can be

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -419,8 +419,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             recordAppendedCallback,
             ResolveLeaderIdForUnackedBudget);
         _uniformStickyPartitioner?.SetPartitionQueueByteProvider(_accumulator.GetPartitionQueueBytes);
-        _uniformStickyPartitioner?.SetPartitionLeaderRackProvider(
-            (topic, partition) => _metadataManager.Metadata.GetPartitionLeader(topic, partition)?.Rack);
+        _uniformStickyPartitioner?.SetRackLocalPartitionsProvider(
+            _metadataManager.Metadata.GetPartitionsForRack);
 
         // Inflight tracker enables coordinated retry with multiple in-flight batches per partition.
         // The broker uses sequence numbers to guarantee ordering, so multiple batches can be

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -271,12 +271,25 @@ internal sealed class StickyPartitionTracker
         if (localPartitionCount == 0)
             return null;
 
-        var start = NextSequentialPartition(partitionCount);
-        for (var offset = 0; offset < partitionCount; offset++)
+        if (currentPartition is { } current
+            && localPartitionCount > 1
+            && IsLocalPartition(topic, current))
         {
-            var partition = (start + offset) % partitionCount;
-            if (IsLocalPartition(topic, partition)
-                && (localPartitionCount == 1 || currentPartition != partition))
+            for (var offset = 1; offset < partitionCount; offset++)
+            {
+                var partition = (current + offset) % partitionCount;
+                if (IsLocalPartition(topic, partition))
+                    return partition;
+            }
+        }
+
+        var localOrdinal = NextSequentialPartition(localPartitionCount);
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            if (!IsLocalPartition(topic, partition))
+                continue;
+
+            if (localOrdinal-- == 0)
                 return partition;
         }
 

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -27,6 +27,7 @@ internal interface IUniformStickyPartitioner
     bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull);
     void OnRecordAppended(string topic, int partition, int bytes, int partitionCount);
     void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes);
+    void SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack);
 }
 
 internal sealed class StickyPartitionTracker
@@ -34,27 +35,41 @@ internal sealed class StickyPartitionTracker
     private readonly ConcurrentDictionary<string, StickyPartitionState> _partitions = new();
     private readonly bool _adaptivePartitioning;
     private readonly int _availabilityTimeoutMs;
+    private readonly bool _rackAwarePartitioning;
+    private readonly string? _clientRack;
     private readonly RandomPartitionSelector _randomPartitionSelector = new();
     private readonly ConcurrentDictionary<(string Topic, int Partition), PartitionAvailabilityState> _availability = new();
     private Func<string, int, long>? _partitionQueueBytes;
+    private Func<string, int, string?>? _partitionLeaderRack;
 #if NETSTANDARD2_0
     private int _counter;
 #else
     private uint _counter;
 #endif
 
-    public StickyPartitionTracker(bool adaptivePartitioning = false, int availabilityTimeoutMs = 0)
+    public StickyPartitionTracker(
+        bool adaptivePartitioning = false,
+        int availabilityTimeoutMs = 0,
+        bool rackAwarePartitioning = false,
+        string? clientRack = null)
     {
         if (availabilityTimeoutMs < 0)
             throw new ArgumentOutOfRangeException(nameof(availabilityTimeoutMs), "Availability timeout cannot be negative");
 
         _adaptivePartitioning = adaptivePartitioning;
         _availabilityTimeoutMs = availabilityTimeoutMs;
+        _rackAwarePartitioning = rackAwarePartitioning;
+        _clientRack = clientRack;
     }
 
     public void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes)
     {
         _partitionQueueBytes = partitionQueueBytes ?? throw new ArgumentNullException(nameof(partitionQueueBytes));
+    }
+
+    public void SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    {
+        _partitionLeaderRack = partitionLeaderRack ?? throw new ArgumentNullException(nameof(partitionLeaderRack));
     }
 
     public int GetOrAssign(string topic, int partitionCount)
@@ -131,13 +146,20 @@ internal sealed class StickyPartitionTracker
 
     private int NextPartition(string topic, int partitionCount, int? currentPartition)
     {
-        var nextPartition = TryNextAdaptivePartition(topic, partitionCount, currentPartition) ?? NextSequentialPartition(partitionCount);
-        if (partitionCount > 1 && currentPartition == nextPartition)
+        var localPartitionCount = CountAvailableLocalPartitions(topic, partitionCount);
+        var nextPartition = TryNextAdaptivePartition(topic, partitionCount, currentPartition, localPartitionCount)
+            ?? TryNextLocalSequentialPartition(topic, partitionCount, currentPartition, localPartitionCount)
+            ?? NextSequentialPartition(partitionCount);
+        if (partitionCount > 1 && currentPartition == nextPartition && localPartitionCount != 1)
             nextPartition = (nextPartition + 1) % partitionCount;
         return nextPartition;
     }
 
-    private int? TryNextAdaptivePartition(string topic, int partitionCount, int? currentPartition)
+    private int? TryNextAdaptivePartition(
+        string topic,
+        int partitionCount,
+        int? currentPartition,
+        int localPartitionCount)
     {
         var partitionQueueBytes = _partitionQueueBytes;
         if (!_adaptivePartitioning || partitionQueueBytes is null || partitionCount < 2)
@@ -151,7 +173,13 @@ internal sealed class StickyPartitionTracker
 
         for (var partition = 0; partition < partitionCount; partition++)
         {
-            if (currentPartition == partition)
+            if (localPartitionCount > 0 && !IsLocalPartition(topic, partition))
+            {
+                queueSizes[partition] = -1;
+                continue;
+            }
+
+            if (currentPartition == partition && localPartitionCount != 1)
             {
                 queueSizes[partition] = -1;
                 continue;
@@ -173,7 +201,7 @@ internal sealed class StickyPartitionTracker
                 maxQueueSize = queueSize;
         }
 
-        if (eligibleCount == 0)
+        if (eligibleCount == 0 && localPartitionCount == 0)
         {
             // Every other partition has stayed backed up past the timeout. Fall back to
             // the weighted choice across all partitions; NextPartition still prevents a
@@ -199,7 +227,7 @@ internal sealed class StickyPartitionTracker
             eligibleCount = partitionCount;
         }
 
-        if (allEqual && eligibleCount == partitionCount)
+        if (allEqual && eligibleCount == partitionCount && localPartitionCount == 0)
             return null;
 
         var maxWeightSource = maxQueueSize == long.MaxValue ? long.MaxValue : maxQueueSize + 1;
@@ -233,6 +261,49 @@ internal sealed class StickyPartitionTracker
 
         return null;
     }
+
+    private int? TryNextLocalSequentialPartition(
+        string topic,
+        int partitionCount,
+        int? currentPartition,
+        int localPartitionCount)
+    {
+        if (localPartitionCount == 0)
+            return null;
+
+        var start = NextSequentialPartition(partitionCount);
+        for (var offset = 0; offset < partitionCount; offset++)
+        {
+            var partition = (start + offset) % partitionCount;
+            if (IsLocalPartition(topic, partition)
+                && (localPartitionCount == 1 || currentPartition != partition))
+                return partition;
+        }
+
+        return null;
+    }
+
+    private int CountAvailableLocalPartitions(string topic, int partitionCount)
+    {
+        if (!_rackAwarePartitioning || string.IsNullOrEmpty(_clientRack) || _partitionLeaderRack is null)
+            return 0;
+
+        var count = 0;
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            if (!IsLocalPartition(topic, partition))
+                continue;
+
+            var queueSize = Math.Max(0, _partitionQueueBytes?.Invoke(topic, partition) ?? 0);
+            if (!IsUnavailable(topic, partition, queueSize))
+                count++;
+        }
+
+        return count;
+    }
+
+    private bool IsLocalPartition(string topic, int partition)
+        => string.Equals(_partitionLeaderRack?.Invoke(topic, partition), _clientRack, StringComparison.Ordinal);
 
     private bool IsUnavailable(string topic, int partition, long queueSize)
     {
@@ -299,14 +370,20 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
         int stickyBatchSize = int.MaxValue,
         bool adaptivePartitioning = false,
         int availabilityTimeoutMs = 0,
-        bool ignoreKeys = false)
+        bool ignoreKeys = false,
+        bool rackAwarePartitioning = false,
+        string? clientRack = null)
     {
         if (stickyBatchSize < 1)
             throw new ArgumentOutOfRangeException(nameof(stickyBatchSize), "Sticky batch size must be at least 1 byte");
 
         _stickyBatchSize = stickyBatchSize;
         _ignoreKeys = ignoreKeys;
-        _stickyPartitionTracker = new StickyPartitionTracker(adaptivePartitioning, availabilityTimeoutMs);
+        _stickyPartitionTracker = new StickyPartitionTracker(
+            adaptivePartitioning,
+            availabilityTimeoutMs,
+            rackAwarePartitioning,
+            clientRack);
     }
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
@@ -341,6 +418,11 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
     }
 
+    void IUniformStickyPartitioner.SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    {
+        _stickyPartitionTracker.SetPartitionLeaderRackProvider(partitionLeaderRack);
+    }
+
     private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
         => _ignoreKeys || keyIsNull || key.Length == 0;
 }
@@ -358,14 +440,20 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         int stickyBatchSize = int.MaxValue,
         bool adaptivePartitioning = false,
         int availabilityTimeoutMs = 0,
-        bool ignoreKeys = false)
+        bool ignoreKeys = false,
+        bool rackAwarePartitioning = false,
+        string? clientRack = null)
     {
         if (stickyBatchSize < 1)
             throw new ArgumentOutOfRangeException(nameof(stickyBatchSize), "Sticky batch size must be at least 1 byte");
 
         _stickyBatchSize = stickyBatchSize;
         _ignoreKeys = ignoreKeys;
-        _stickyPartitionTracker = new StickyPartitionTracker(adaptivePartitioning, availabilityTimeoutMs);
+        _stickyPartitionTracker = new StickyPartitionTracker(
+            adaptivePartitioning,
+            availabilityTimeoutMs,
+            rackAwarePartitioning,
+            clientRack);
     }
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
@@ -397,6 +485,11 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
     void IUniformStickyPartitioner.SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes)
     {
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
+    }
+
+    void IUniformStickyPartitioner.SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    {
+        _stickyPartitionTracker.SetPartitionLeaderRackProvider(partitionLeaderRack);
     }
 
     private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -383,7 +383,16 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
         int stickyBatchSize = int.MaxValue,
         bool adaptivePartitioning = false,
         int availabilityTimeoutMs = 0,
-        bool ignoreKeys = false,
+        bool ignoreKeys = false)
+        : this(stickyBatchSize, adaptivePartitioning, availabilityTimeoutMs, ignoreKeys, false, null)
+    {
+    }
+
+    public DefaultPartitioner(
+        int stickyBatchSize,
+        bool adaptivePartitioning,
+        int availabilityTimeoutMs,
+        bool ignoreKeys,
         bool rackAwarePartitioning = false,
         string? clientRack = null)
     {
@@ -453,7 +462,16 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         int stickyBatchSize = int.MaxValue,
         bool adaptivePartitioning = false,
         int availabilityTimeoutMs = 0,
-        bool ignoreKeys = false,
+        bool ignoreKeys = false)
+        : this(stickyBatchSize, adaptivePartitioning, availabilityTimeoutMs, ignoreKeys, false, null)
+    {
+    }
+
+    public StickyPartitioner(
+        int stickyBatchSize,
+        bool adaptivePartitioning,
+        int availabilityTimeoutMs,
+        bool ignoreKeys,
         bool rackAwarePartitioning = false,
         string? clientRack = null)
     {

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -27,7 +28,7 @@ internal interface IUniformStickyPartitioner
     bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull);
     void OnRecordAppended(string topic, int partition, int bytes, int partitionCount);
     void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes);
-    void SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack);
+    void SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions);
 }
 
 internal sealed class StickyPartitionTracker
@@ -40,7 +41,7 @@ internal sealed class StickyPartitionTracker
     private readonly RandomPartitionSelector _randomPartitionSelector = new();
     private readonly ConcurrentDictionary<(string Topic, int Partition), PartitionAvailabilityState> _availability = new();
     private Func<string, int, long>? _partitionQueueBytes;
-    private Func<string, int, string?>? _partitionLeaderRack;
+    private Func<string, string, int[]>? _rackLocalPartitions;
 #if NETSTANDARD2_0
     private int _counter;
 #else
@@ -67,15 +68,14 @@ internal sealed class StickyPartitionTracker
         _partitionQueueBytes = partitionQueueBytes ?? throw new ArgumentNullException(nameof(partitionQueueBytes));
     }
 
-    public void SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    public void SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
     {
-        _partitionLeaderRack = partitionLeaderRack ?? throw new ArgumentNullException(nameof(partitionLeaderRack));
+        _rackLocalPartitions = rackLocalPartitions ?? throw new ArgumentNullException(nameof(rackLocalPartitions));
     }
 
     public int GetOrAssign(string topic, int partitionCount)
     {
-        var state = _partitions.GetOrAdd(topic,
-            topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
+        var state = GetOrCreateAssignedState(topic, partitionCount);
 
         while (true)
         {
@@ -93,8 +93,7 @@ internal sealed class StickyPartitionTracker
 
     public void Rotate(string topic, int partitionCount)
     {
-        var state = _partitions.GetOrAdd(topic,
-            topicName => new StickyPartitionState(NextPartition(topicName, partitionCount, currentPartition: null)));
+        var state = GetOrCreateAssignedState(topic, partitionCount);
 
         while (true)
         {
@@ -112,7 +111,7 @@ internal sealed class StickyPartitionTracker
         if (bytes <= 0 || partitionCount <= 1)
             return;
 
-        var state = _partitions.GetOrAdd(topic, _ => new StickyPartitionState(partition));
+        var state = GetOrCreateStateWithPartition(topic, partition);
         while (true)
         {
             var packedState = Volatile.Read(ref state.PackedState);
@@ -146,12 +145,22 @@ internal sealed class StickyPartitionTracker
 
     private int NextPartition(string topic, int partitionCount, int? currentPartition)
     {
-        var localPartitionCount = CountAvailableLocalPartitions(topic, partitionCount);
-        var nextPartition = TryNextAdaptivePartition(topic, partitionCount, currentPartition, localPartitionCount)
-            ?? TryNextLocalSequentialPartition(topic, partitionCount, currentPartition, localPartitionCount)
+        var localPartitions = GetRackLocalPartitions(topic);
+        var nextPartition = TryNextAdaptivePartition(
+                topic,
+                partitionCount,
+                currentPartition,
+                localPartitions,
+                out var useLocalSequential)
+            ?? (useLocalSequential ? NextLocalSequentialPartition(localPartitions, currentPartition) : (int?)null)
             ?? NextSequentialPartition(partitionCount);
-        if (partitionCount > 1 && currentPartition == nextPartition && localPartitionCount != 1)
+        if (partitionCount > 1
+            && currentPartition == nextPartition
+            && !(useLocalSequential && localPartitions.Length == 1))
+        {
             nextPartition = (nextPartition + 1) % partitionCount;
+        }
+
         return nextPartition;
     }
 
@@ -159,49 +168,120 @@ internal sealed class StickyPartitionTracker
         string topic,
         int partitionCount,
         int? currentPartition,
-        int localPartitionCount)
+        int[] localPartitions,
+        out bool useLocalSequential)
     {
+        useLocalSequential = localPartitions.Length > 0;
         var partitionQueueBytes = _partitionQueueBytes;
         if (!_adaptivePartitioning || partitionQueueBytes is null || partitionCount < 2)
             return null;
 
-        Span<long> queueSizes = partitionCount <= 64 ? stackalloc long[partitionCount] : new long[partitionCount];
+        if (partitionCount <= 64)
+        {
+            Span<long> queueSizes = stackalloc long[partitionCount];
+            return TryNextAdaptivePartitionCore(
+                topic,
+                partitionCount,
+                currentPartition,
+                localPartitions,
+                partitionQueueBytes,
+                queueSizes,
+                out useLocalSequential);
+        }
+
+        var rentedQueueSizes = ArrayPool<long>.Shared.Rent(partitionCount);
+        try
+        {
+            return TryNextAdaptivePartitionCore(
+                topic,
+                partitionCount,
+                currentPartition,
+                localPartitions,
+                partitionQueueBytes,
+                rentedQueueSizes.AsSpan(0, partitionCount),
+                out useLocalSequential);
+        }
+        finally
+        {
+            ArrayPool<long>.Shared.Return(rentedQueueSizes);
+        }
+    }
+
+    private int? TryNextAdaptivePartitionCore(
+        string topic,
+        int partitionCount,
+        int? currentPartition,
+        int[] localPartitions,
+        Func<string, int, long> partitionQueueBytes,
+        Span<long> queueSizes,
+        out bool useLocalSequential)
+    {
+        useLocalSequential = localPartitions.Length > 0;
         var eligibleCount = 0;
         var allEqual = true;
         var maxQueueSize = 0L;
         long? firstQueueSize = null;
 
-        for (var partition = 0; partition < partitionCount; partition++)
+        if (localPartitions.Length > 0)
         {
-            if (localPartitionCount > 0 && !IsLocalPartition(topic, partition))
+            for (var i = 0; i < localPartitions.Length; i++)
             {
-                queueSizes[partition] = -1;
-                continue;
+                var partition = localPartitions[i];
+                EvaluateAdaptivePartition(
+                    topic,
+                    partition,
+                    currentPartition,
+                    localPartitions.Length,
+                    partitionQueueBytes,
+                    queueSizes,
+                    ref eligibleCount,
+                    ref allEqual,
+                    ref maxQueueSize,
+                    ref firstQueueSize);
             }
-
-            if (currentPartition == partition && localPartitionCount != 1)
+        }
+        else
+        {
+            for (var partition = 0; partition < partitionCount; partition++)
             {
-                queueSizes[partition] = -1;
-                continue;
+                EvaluateAdaptivePartition(
+                    topic,
+                    partition,
+                    currentPartition,
+                    localPartitions.Length,
+                    partitionQueueBytes,
+                    queueSizes,
+                    ref eligibleCount,
+                    ref allEqual,
+                    ref maxQueueSize,
+                    ref firstQueueSize);
             }
-
-            var queueSize = Math.Max(0, partitionQueueBytes(topic, partition));
-            if (IsUnavailable(topic, partition, queueSize))
-            {
-                queueSizes[partition] = -1;
-                continue;
-            }
-
-            queueSizes[partition] = queueSize;
-            eligibleCount++;
-            firstQueueSize ??= queueSize;
-            if (queueSize != firstQueueSize.Value)
-                allEqual = false;
-            if (queueSize > maxQueueSize)
-                maxQueueSize = queueSize;
         }
 
-        if (eligibleCount == 0 && localPartitionCount == 0)
+        if (eligibleCount == 0 && localPartitions.Length > 0)
+        {
+            useLocalSequential = false;
+            allEqual = true;
+            maxQueueSize = 0;
+            firstQueueSize = null;
+            queueSizes.Fill(-1);
+            for (var partition = 0; partition < partitionCount; partition++)
+            {
+                EvaluateAdaptivePartition(
+                    topic,
+                    partition,
+                    currentPartition,
+                    localPartitionCount: 0,
+                    partitionQueueBytes,
+                    queueSizes,
+                    ref eligibleCount,
+                    ref allEqual,
+                    ref maxQueueSize,
+                    ref firstQueueSize);
+            }
+        }
+
+        if (eligibleCount == 0)
         {
             // Every other partition has stayed backed up past the timeout. Fall back to
             // the weighted choice across all partitions; NextPartition still prevents a
@@ -227,19 +307,21 @@ internal sealed class StickyPartitionTracker
             eligibleCount = partitionCount;
         }
 
-        if (allEqual && eligibleCount == partitionCount && localPartitionCount == 0)
+        var candidateCount = useLocalSequential ? localPartitions.Length : partitionCount;
+        if (allEqual && eligibleCount == candidateCount)
             return null;
 
         var maxWeightSource = maxQueueSize == long.MaxValue ? long.MaxValue : maxQueueSize + 1;
         var totalWeight = 0L;
-        for (var partition = 0; partition < partitionCount; partition++)
+        if (useLocalSequential)
         {
-            var queueSize = queueSizes[partition];
-            if (queueSize < 0)
-                continue;
-
-            var weight = Math.Max(1L, maxWeightSource - queueSize);
-            totalWeight = SaturatingAdd(totalWeight, weight);
+            for (var i = 0; i < localPartitions.Length; i++)
+                AddAdaptiveWeight(localPartitions[i], queueSizes, maxWeightSource, ref totalWeight);
+        }
+        else
+        {
+            for (var partition = 0; partition < partitionCount; partition++)
+                AddAdaptiveWeight(partition, queueSizes, maxWeightSource, ref totalWeight);
         }
 
         if (totalWeight <= 0)
@@ -247,76 +329,130 @@ internal sealed class StickyPartitionTracker
 
         var target = PositiveRandomLong(totalWeight);
         var cumulative = 0L;
-        for (var partition = 0; partition < partitionCount; partition++)
+        if (useLocalSequential)
         {
-            var queueSize = queueSizes[partition];
-            if (queueSize < 0)
-                continue;
-
-            var weight = Math.Max(1L, maxWeightSource - queueSize);
-            cumulative = SaturatingAdd(cumulative, weight);
-            if (target < cumulative)
-                return partition;
-        }
-
-        return null;
-    }
-
-    private int? TryNextLocalSequentialPartition(
-        string topic,
-        int partitionCount,
-        int? currentPartition,
-        int localPartitionCount)
-    {
-        if (localPartitionCount == 0)
-            return null;
-
-        if (currentPartition is { } current
-            && localPartitionCount > 1
-            && IsLocalPartition(topic, current))
-        {
-            for (var offset = 1; offset < partitionCount; offset++)
+            for (var i = 0; i < localPartitions.Length; i++)
             {
-                var partition = (current + offset) % partitionCount;
-                if (IsLocalPartition(topic, partition))
-                    return partition;
+                var selected = TrySelectAdaptivePartition(
+                    localPartitions[i], queueSizes, maxWeightSource, target, ref cumulative);
+                if (selected is not null)
+                    return selected;
+            }
+        }
+        else
+        {
+            for (var partition = 0; partition < partitionCount; partition++)
+            {
+                var selected = TrySelectAdaptivePartition(
+                    partition, queueSizes, maxWeightSource, target, ref cumulative);
+                if (selected is not null)
+                    return selected;
             }
         }
 
-        var localOrdinal = NextSequentialPartition(localPartitionCount);
-        for (var partition = 0; partition < partitionCount; partition++)
-        {
-            if (!IsLocalPartition(topic, partition))
-                continue;
-
-            if (localOrdinal-- == 0)
-                return partition;
-        }
-
         return null;
     }
 
-    private int CountAvailableLocalPartitions(string topic, int partitionCount)
+    private static void AddAdaptiveWeight(
+        int partition,
+        ReadOnlySpan<long> queueSizes,
+        long maxWeightSource,
+        ref long totalWeight)
     {
-        if (!_rackAwarePartitioning || string.IsNullOrEmpty(_clientRack) || _partitionLeaderRack is null)
-            return 0;
+        var queueSize = queueSizes[partition];
+        if (queueSize < 0)
+            return;
 
-        var count = 0;
-        for (var partition = 0; partition < partitionCount; partition++)
-        {
-            if (!IsLocalPartition(topic, partition))
-                continue;
-
-            var queueSize = Math.Max(0, _partitionQueueBytes?.Invoke(topic, partition) ?? 0);
-            if (!IsUnavailable(topic, partition, queueSize))
-                count++;
-        }
-
-        return count;
+        var weight = Math.Max(1L, maxWeightSource - queueSize);
+        totalWeight = SaturatingAdd(totalWeight, weight);
     }
 
-    private bool IsLocalPartition(string topic, int partition)
-        => string.Equals(_partitionLeaderRack?.Invoke(topic, partition), _clientRack, StringComparison.Ordinal);
+    private static int? TrySelectAdaptivePartition(
+        int partition,
+        ReadOnlySpan<long> queueSizes,
+        long maxWeightSource,
+        long target,
+        ref long cumulative)
+    {
+        var queueSize = queueSizes[partition];
+        if (queueSize < 0)
+            return null;
+
+        var weight = Math.Max(1L, maxWeightSource - queueSize);
+        cumulative = SaturatingAdd(cumulative, weight);
+        return target < cumulative ? partition : null;
+    }
+
+    private void EvaluateAdaptivePartition(
+        string topic,
+        int partition,
+        int? currentPartition,
+        int localPartitionCount,
+        Func<string, int, long> partitionQueueBytes,
+        Span<long> queueSizes,
+        ref int eligibleCount,
+        ref bool allEqual,
+        ref long maxQueueSize,
+        ref long? firstQueueSize)
+    {
+        if (currentPartition == partition && localPartitionCount != 1)
+        {
+            queueSizes[partition] = -1;
+            return;
+        }
+
+        var queueSize = Math.Max(0, partitionQueueBytes(topic, partition));
+        if (IsUnavailable(topic, partition, queueSize))
+        {
+            queueSizes[partition] = -1;
+            return;
+        }
+
+        queueSizes[partition] = queueSize;
+        eligibleCount++;
+        firstQueueSize ??= queueSize;
+        if (queueSize != firstQueueSize.Value)
+            allEqual = false;
+        if (queueSize > maxQueueSize)
+            maxQueueSize = queueSize;
+    }
+
+    private int NextLocalSequentialPartition(int[] localPartitions, int? currentPartition)
+    {
+        var localOrdinal = NextSequentialPartition(localPartitions.Length);
+        var partition = localPartitions[localOrdinal];
+        return currentPartition == partition && localPartitions.Length > 1
+            ? localPartitions[(localOrdinal + 1) % localPartitions.Length]
+            : partition;
+    }
+
+    private int[] GetRackLocalPartitions(string topic)
+    {
+        var clientRack = _clientRack;
+        return _rackAwarePartitioning
+            && clientRack is { Length: > 0 }
+            && _rackLocalPartitions is not null
+                ? _rackLocalPartitions(topic, clientRack)
+                : Array.Empty<int>();
+    }
+
+    private StickyPartitionState GetOrCreateAssignedState(string topic, int partitionCount)
+    {
+        if (_partitions.TryGetValue(topic, out var state))
+            return state;
+
+        var created = new StickyPartitionState(NextPartition(topic, partitionCount, currentPartition: null));
+        return _partitions.GetOrAdd(topic, created);
+    }
+
+    private StickyPartitionState GetOrCreateStateWithPartition(string topic, int initialPartition)
+    {
+        if (_partitions.TryGetValue(topic, out var state))
+            return state;
+
+        var created = new StickyPartitionState(initialPartition);
+        return _partitions.GetOrAdd(topic, created);
+    }
 
     private bool IsUnavailable(string topic, int partition, long queueSize)
     {
@@ -440,9 +576,9 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
     }
 
-    void IUniformStickyPartitioner.SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
     {
-        _stickyPartitionTracker.SetPartitionLeaderRackProvider(partitionLeaderRack);
+        _stickyPartitionTracker.SetRackLocalPartitionsProvider(rackLocalPartitions);
     }
 
     private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)
@@ -518,9 +654,9 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
     }
 
-    void IUniformStickyPartitioner.SetPartitionLeaderRackProvider(Func<string, int, string?> partitionLeaderRack)
+    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
     {
-        _stickyPartitionTracker.SetPartitionLeaderRackProvider(partitionLeaderRack);
+        _stickyPartitionTracker.SetRackLocalPartitionsProvider(rackLocalPartitions);
     }
 
     private bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull)

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -28,7 +28,7 @@ internal interface IUniformStickyPartitioner
     bool UsesStickyPartition(ReadOnlySpan<byte> key, bool keyIsNull);
     void OnRecordAppended(string topic, int partition, int bytes, int partitionCount);
     void SetPartitionQueueByteProvider(Func<string, int, long> partitionQueueBytes);
-    void SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions);
+    void SetRackLocalPartitionsProvider(Func<string, string, int, int[]> rackLocalPartitions);
 }
 
 internal sealed class StickyPartitionTracker
@@ -41,7 +41,7 @@ internal sealed class StickyPartitionTracker
     private readonly RandomPartitionSelector _randomPartitionSelector = new();
     private readonly ConcurrentDictionary<(string Topic, int Partition), PartitionAvailabilityState> _availability = new();
     private Func<string, int, long>? _partitionQueueBytes;
-    private Func<string, string, int[]>? _rackLocalPartitions;
+    private Func<string, string, int, int[]>? _rackLocalPartitions;
 #if NETSTANDARD2_0
     private int _counter;
 #else
@@ -68,7 +68,7 @@ internal sealed class StickyPartitionTracker
         _partitionQueueBytes = partitionQueueBytes ?? throw new ArgumentNullException(nameof(partitionQueueBytes));
     }
 
-    public void SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
+    public void SetRackLocalPartitionsProvider(Func<string, string, int, int[]> rackLocalPartitions)
     {
         _rackLocalPartitions = rackLocalPartitions ?? throw new ArgumentNullException(nameof(rackLocalPartitions));
     }
@@ -145,7 +145,7 @@ internal sealed class StickyPartitionTracker
 
     private int NextPartition(string topic, int partitionCount, int? currentPartition)
     {
-        var localPartitions = GetRackLocalPartitions(topic);
+        var localPartitions = GetRackLocalPartitions(topic, partitionCount);
         var nextPartition = TryNextAdaptivePartition(
                 topic,
                 partitionCount,
@@ -426,13 +426,13 @@ internal sealed class StickyPartitionTracker
             : partition;
     }
 
-    private int[] GetRackLocalPartitions(string topic)
+    private int[] GetRackLocalPartitions(string topic, int partitionCount)
     {
         var clientRack = _clientRack;
         return _rackAwarePartitioning
             && clientRack is { Length: > 0 }
             && _rackLocalPartitions is not null
-                ? _rackLocalPartitions(topic, clientRack)
+                ? _rackLocalPartitions(topic, clientRack, partitionCount)
                 : Array.Empty<int>();
     }
 
@@ -576,7 +576,7 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
     }
 
-    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
+    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int, int[]> rackLocalPartitions)
     {
         _stickyPartitionTracker.SetRackLocalPartitionsProvider(rackLocalPartitions);
     }
@@ -654,7 +654,7 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
         _stickyPartitionTracker.SetPartitionQueueByteProvider(partitionQueueBytes);
     }
 
-    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int[]> rackLocalPartitions)
+    void IUniformStickyPartitioner.SetRackLocalPartitionsProvider(Func<string, string, int, int[]> rackLocalPartitions)
     {
         _stickyPartitionTracker.SetRackLocalPartitionsProvider(rackLocalPartitions);
     }

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -458,6 +458,20 @@ public sealed class ProducerOptions
     public bool IgnorePartitionerKeys { get; init; }
 
     /// <summary>
+    /// Logical rack ID of this producer. Used by rack-aware built-in partitioning.
+    /// Equivalent to Kafka's <c>client.rack</c> configuration.
+    /// </summary>
+    public string? ClientRack { get; init; }
+
+    /// <summary>
+    /// Whether built-in default and sticky partitioners prefer partitions whose leaders
+    /// are in <see cref="ClientRack"/>. Falls back to all partitions when no local leader is usable.
+    /// Equivalent to Kafka's <c>partitioner.rack.aware</c>. Default is false.
+    /// Has no effect when <see cref="CustomPartitioner"/> is set.
+    /// </summary>
+    public bool EnableRackAwarePartitioning { get; init; }
+
+    /// <summary>
     /// Use TLS.
     /// </summary>
     public bool UseTls { get; init; }

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -355,6 +355,29 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithClientRackAndRackAwarePartitioning_SetOptions()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientRack("rack-a")
+            .WithRackAwarePartitioning()
+            .Build();
+
+        var options = GetOptions(producer);
+
+        await Assert.That(options.ClientRack).IsEqualTo("rack-a");
+        await Assert.That(options.EnableRackAwarePartitioning).IsTrue();
+    }
+
+    [Test]
+    public async Task WithClientRack_WhenNull_ThrowsArgumentNullException()
+    {
+        var builder = Kafka.CreateProducer<string, string>();
+
+        await Assert.That(() => builder.WithClientRack(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
     public async Task UseTls_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateProducer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -167,6 +167,8 @@ public class DependencyInjectionTests
             LingerMs = 7,
             DeliveryLatencyTargetMs = 23,
             EnableAdaptiveConnections = false,
+            ClientRack = "rack-a",
+            EnableRackAwarePartitioning = true,
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha512,
             SaslUsername = "producer-user",
@@ -188,6 +190,8 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.LingerMs).IsEqualTo(7);
         await Assert.That(boundOptions.DeliveryLatencyTargetMs).IsEqualTo(23);
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
+        await Assert.That(boundOptions.ClientRack).IsEqualTo("rack-a");
+        await Assert.That(boundOptions.EnableRackAwarePartitioning).IsTrue();
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("producer-user");
@@ -637,6 +641,8 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:CompressionType"] = "Gzip",
             ["Kafka:Producers:Orders:CompressionLevel"] = "4",
             ["Kafka:Producers:Orders:Partitioner"] = "RoundRobin",
+            ["Kafka:Producers:Orders:ClientRack"] = "rack-a",
+            ["Kafka:Producers:Orders:EnableRackAwarePartitioning"] = "true",
             ["Kafka:Producers:Orders:UseTls"] = "true",
             ["Kafka:Producers:Orders:SaslMechanism"] = "ScramSha512",
             ["Kafka:Producers:Orders:SaslUsername"] = "user",
@@ -687,6 +693,8 @@ public class DependencyInjectionTests
         await Assert.That(options.CompressionType).IsEqualTo(CompressionType.Gzip);
         await Assert.That(options.CompressionLevel).IsEqualTo(4);
         await Assert.That(options.Partitioner).IsEqualTo(PartitionerType.RoundRobin);
+        await Assert.That(options.ClientRack).IsEqualTo("rack-a");
+        await Assert.That(options.EnableRackAwarePartitioning).IsTrue();
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(options.SaslUsername).IsEqualTo("user");

--- a/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
@@ -498,6 +498,63 @@ public sealed class ClusterMetadataTests
         await Assert.That(metadata.GetPartitionsForBroker(2)).Count().IsEqualTo(0);
     }
 
+    [Test]
+    public async Task GetPartitionsForRack_UpdateRefreshesIndex()
+    {
+        var metadata = new ClusterMetadata();
+        metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092, Rack = "rack-a" },
+                new BrokerMetadata { NodeId = 2, Host = "broker2", Port = 9092, Rack = "rack-b" },
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "rack-topic",
+                    Partitions =
+                    [
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 2, ReplicaNodes = [2], IsrNodes = [2] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 2, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
+                    ]
+                }
+            ]
+        });
+
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a")).IsEquivalentTo([0, 2]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b")).IsEquivalentTo([1]);
+
+        metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker1", Port = 9092, Rack = "rack-b" },
+                new BrokerMetadata { NodeId = 2, Host = "broker2", Port = 9092, Rack = "rack-a" },
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "rack-topic",
+                    Partitions =
+                    [
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 1, LeaderId = 2, ReplicaNodes = [2], IsrNodes = [2] },
+                        new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 2, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] },
+                    ]
+                }
+            ]
+        });
+
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a")).IsEquivalentTo([1]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b")).IsEquivalentTo([0, 2]);
+    }
+
     #endregion
 
     #region Update Replaces Previous State

--- a/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/ClusterMetadataTests.cs
@@ -525,8 +525,9 @@ public sealed class ClusterMetadataTests
             ]
         });
 
-        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a")).IsEquivalentTo([0, 2]);
-        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b")).IsEquivalentTo([1]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a", 3)).IsEquivalentTo([0, 2]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b", 3)).IsEquivalentTo([1]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a", 2)).IsEmpty();
 
         metadata.Update(new MetadataResponse
         {
@@ -551,8 +552,8 @@ public sealed class ClusterMetadataTests
             ]
         });
 
-        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a")).IsEquivalentTo([1]);
-        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b")).IsEquivalentTo([0, 2]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-a", 3)).IsEquivalentTo([1]);
+        await Assert.That(metadata.GetPartitionsForRack("rack-topic", "rack-b", 3)).IsEquivalentTo([0, 2]);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -31,6 +31,8 @@ internal static class StickyPartitionerTestHelpers
 
 public class DefaultPartitionerTests
 {
+    private const string Topic = "test-topic";
+
     [Test]
     public async Task Partition_WithNullKey_ReturnsValidPartition()
     {
@@ -134,6 +136,146 @@ public class DefaultPartitionerTests
     }
 
     [Test]
+    public async Task RackAwarePartitioning_SelectsOnlyLocalLeaders()
+    {
+        var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider(
+            (_, partition) => partition is 0 or 2 ? "rack-a" : "rack-b");
+
+        var selected = new HashSet<int>();
+        for (var i = 0; i < 20; i++)
+        {
+            var partition = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 4);
+            selected.Add(partition);
+            uniform.OnRecordAppended(Topic, partition, bytes: 1, partitionCount: 4);
+        }
+
+        await Assert.That(selected).Contains(0);
+        await Assert.That(selected).Contains(2);
+        await Assert.That(selected).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_PreservesKeyHashing()
+    {
+        var partitioner = CreateRackAwarePartitioner();
+        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
+            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        var key = "keyed-record"u8;
+
+        var partition = partitioner.Partition(Topic, key, keyIsNull: false, partitionCount: 4);
+
+        await Assert.That(partition).IsEqualTo(Murmur2.Partition(key, 4));
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_WhenIgnoreKeys_SelectsLocalLeader()
+    {
+        var partitioner = CreateRackAwarePartitioner(ignoreKeys: true);
+        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
+            (_, partition) => partition == 2 ? "rack-a" : "rack-b");
+
+        var partition = partitioner.Partition(Topic, "keyed-record"u8, keyIsNull: false, partitionCount: 4);
+
+        await Assert.That(partition).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_WithoutLocalMetadata_FallsBackToAllPartitions()
+    {
+        var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider(static (_, _) => null);
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
+
+        var selected = new HashSet<int>();
+        for (var i = 0; i < 3; i++)
+        {
+            var partition = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+            selected.Add(partition);
+            uniform.OnRecordAppended(Topic, partition, bytes: 1, partitionCount: 3);
+        }
+
+        await Assert.That(selected).Count().IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_WhenLocalLeaderUnavailable_FallsBackGlobally()
+    {
+        var partitioner = CreateRackAwarePartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: true,
+            availabilityTimeoutMs: 1);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider(
+            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        var localLeaderBackedUp = false;
+        uniform.SetPartitionQueueByteProvider(
+            (_, partition) => partition == 0 && localLeaderBackedUp ? 1024 : 0);
+
+        var initial = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+        await Assert.That(initial).IsEqualTo(0);
+        localLeaderBackedUp = true;
+        uniform.OnRecordAppended(Topic, initial, bytes: 1, partitionCount: 3);
+        Thread.Sleep(5);
+        uniform.OnRecordAppended(Topic, initial, bytes: 1, partitionCount: 3);
+
+        var fallback = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+
+        await Assert.That(fallback).IsNotEqualTo(0);
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_LeaderRackChangeUpdatesEligiblePartition()
+    {
+        var racks = new[] { "rack-a", "rack-b" };
+        var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider((_, partition) => racks[partition]);
+
+        var initial = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 2);
+        await Assert.That(initial).IsEqualTo(0);
+        racks[0] = "rack-b";
+        racks[1] = "rack-a";
+        uniform.OnRecordAppended(Topic, initial, bytes: 1, partitionCount: 2);
+
+        var updated = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 2);
+
+        await Assert.That(updated).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task RackAwarePartitioning_WhenDisabled_DoesNotFilterPartitions()
+    {
+        var partitioner = new DefaultPartitioner(stickyBatchSize: 1, rackAwarePartitioning: false, clientRack: "rack-a");
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider(
+            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
+
+        var first = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+        uniform.OnRecordAppended(Topic, first, bytes: 1, partitionCount: 3);
+        var second = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+
+        await Assert.That(first).IsEqualTo(0);
+        await Assert.That(second).IsEqualTo(1);
+    }
+
+    private static DefaultPartitioner CreateRackAwarePartitioner(
+        int stickyBatchSize = int.MaxValue,
+        bool adaptivePartitioning = false,
+        int availabilityTimeoutMs = 0,
+        bool ignoreKeys = false) =>
+        new(
+            stickyBatchSize,
+            adaptivePartitioning,
+            availabilityTimeoutMs,
+            ignoreKeys,
+            rackAwarePartitioning: true,
+            clientRack: "rack-a");
+
+    [Test]
     public async Task Partition_NearUIntMaxValue_NeverReturnsNegative()
     {
         var partitioner = new DefaultPartitioner();
@@ -173,6 +315,21 @@ public class DefaultPartitionerTests
 
 public class StickyPartitionerTests
 {
+    [Test]
+    public async Task RackAwarePartitioning_SelectsLocalLeader()
+    {
+        const string topic = "test-topic";
+        var partitioner = new StickyPartitioner(
+            rackAwarePartitioning: true,
+            clientRack: "rack-a");
+        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
+            (_, partition) => partition == 1 ? "rack-a" : "rack-b");
+
+        var partition = partitioner.Partition(topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
+
+        await Assert.That(partition).IsEqualTo(1);
+    }
+
     [Test]
     public async Task Partition_WithNullKey_ReturnsValidPartition()
     {

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -157,6 +157,26 @@ public class DefaultPartitionerTests
     }
 
     [Test]
+    public async Task RackAwarePartitioning_UnevenLocalLeadersRotateUniformly()
+    {
+        var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetPartitionLeaderRackProvider(
+            (_, partition) => partition is 0 or 9 ? "rack-a" : "rack-b");
+        var selections = new int[10];
+
+        for (var i = 0; i < 100; i++)
+        {
+            var partition = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 10);
+            selections[partition]++;
+            uniform.OnRecordAppended(Topic, partition, bytes: 1, partitionCount: 10);
+        }
+
+        await Assert.That(selections[0]).IsEqualTo(50);
+        await Assert.That(selections[9]).IsEqualTo(50);
+    }
+
+    [Test]
     public async Task RackAwarePartitioning_PreservesKeyHashing()
     {
         var partitioner = CreateRackAwarePartitioner();

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -149,8 +149,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider(
-            (_, partition) => partition is 0 or 2 ? "rack-a" : "rack-b");
+        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0, 2]);
 
         var selected = new HashSet<int>();
         for (var i = 0; i < 20; i++)
@@ -170,8 +169,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider(
-            (_, partition) => partition is 0 or 9 ? "rack-a" : "rack-b");
+        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0, 9]);
         var selections = new int[10];
 
         for (var i = 0; i < 100; i++)
@@ -189,8 +187,7 @@ public class DefaultPartitionerTests
     public async Task RackAwarePartitioning_PreservesKeyHashing()
     {
         var partitioner = CreateRackAwarePartitioner();
-        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
-            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [0]);
         var key = "keyed-record"u8;
 
         var partition = partitioner.Partition(Topic, key, keyIsNull: false, partitionCount: 4);
@@ -202,8 +199,7 @@ public class DefaultPartitionerTests
     public async Task RackAwarePartitioning_WhenIgnoreKeys_SelectsLocalLeader()
     {
         var partitioner = CreateRackAwarePartitioner(ignoreKeys: true);
-        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
-            (_, partition) => partition == 2 ? "rack-a" : "rack-b");
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [2]);
 
         var partition = partitioner.Partition(Topic, "keyed-record"u8, keyIsNull: false, partitionCount: 4);
 
@@ -215,7 +211,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider(static (_, _) => null);
+        uniform.SetRackLocalPartitionsProvider(static (_, _) => []);
         StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
 
         var selected = new HashSet<int>();
@@ -237,8 +233,7 @@ public class DefaultPartitionerTests
             adaptivePartitioning: true,
             availabilityTimeoutMs: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider(
-            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0]);
         var localLeaderBackedUp = false;
         uniform.SetPartitionQueueByteProvider(
             (_, partition) => partition == 0 && localLeaderBackedUp ? 1024 : 0);
@@ -261,7 +256,10 @@ public class DefaultPartitionerTests
         var racks = new[] { "rack-a", "rack-b" };
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider((_, partition) => racks[partition]);
+        var initialLocalPartitions = new[] { 0 };
+        var updatedLocalPartitions = new[] { 1 };
+        uniform.SetRackLocalPartitionsProvider(
+            (_, _) => racks[0] == "rack-a" ? initialLocalPartitions : updatedLocalPartitions);
 
         var initial = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 2);
         await Assert.That(initial).IsEqualTo(0);
@@ -285,8 +283,7 @@ public class DefaultPartitionerTests
             rackAwarePartitioning: false,
             clientRack: "rack-a");
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetPartitionLeaderRackProvider(
-            (_, partition) => partition == 0 ? "rack-a" : "rack-b");
+        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0]);
         StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
 
         var first = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
@@ -361,8 +358,7 @@ public class StickyPartitionerTests
             ignoreKeys: false,
             rackAwarePartitioning: true,
             clientRack: "rack-a");
-        ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(
-            (_, partition) => partition == 1 ? "rack-a" : "rack-b");
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [1]);
 
         var partition = partitioner.Partition(topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
 

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -149,7 +149,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0, 2]);
+        uniform.SetRackLocalPartitionsProvider(static (_, _, _) => [0, 2]);
 
         var selected = new HashSet<int>();
         for (var i = 0; i < 20; i++)
@@ -169,7 +169,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0, 9]);
+        uniform.SetRackLocalPartitionsProvider(static (_, _, _) => [0, 9]);
         var selections = new int[10];
 
         for (var i = 0; i < 100; i++)
@@ -184,10 +184,30 @@ public class DefaultPartitionerTests
     }
 
     [Test]
+    public async Task RackAwarePartitioning_StaleRackSnapshotFallsBackSafely()
+    {
+        var partitioner = CreateRackAwarePartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: true);
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        uniform.SetRackLocalPartitionsProvider(static (_, _, partitionCount) =>
+            partitionCount == 3 ? [0, 2] : []);
+        uniform.SetPartitionQueueByteProvider(static (_, _) => 0);
+
+        var partition = partitioner.Partition(
+            Topic,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            partitionCount: 2);
+
+        await Assert.That(partition).IsIn(0, 1);
+    }
+
+    [Test]
     public async Task RackAwarePartitioning_PreservesKeyHashing()
     {
         var partitioner = CreateRackAwarePartitioner();
-        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [0]);
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _, _) => [0]);
         var key = "keyed-record"u8;
 
         var partition = partitioner.Partition(Topic, key, keyIsNull: false, partitionCount: 4);
@@ -199,7 +219,7 @@ public class DefaultPartitionerTests
     public async Task RackAwarePartitioning_WhenIgnoreKeys_SelectsLocalLeader()
     {
         var partitioner = CreateRackAwarePartitioner(ignoreKeys: true);
-        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [2]);
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _, _) => [2]);
 
         var partition = partitioner.Partition(Topic, "keyed-record"u8, keyIsNull: false, partitionCount: 4);
 
@@ -211,7 +231,7 @@ public class DefaultPartitionerTests
     {
         var partitioner = CreateRackAwarePartitioner(stickyBatchSize: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetRackLocalPartitionsProvider(static (_, _) => []);
+        uniform.SetRackLocalPartitionsProvider(static (_, _, _) => []);
         StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
 
         var selected = new HashSet<int>();
@@ -233,7 +253,7 @@ public class DefaultPartitionerTests
             adaptivePartitioning: true,
             availabilityTimeoutMs: 1);
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0]);
+        uniform.SetRackLocalPartitionsProvider(static (_, _, _) => [0]);
         var localLeaderBackedUp = false;
         uniform.SetPartitionQueueByteProvider(
             (_, partition) => partition == 0 && localLeaderBackedUp ? 1024 : 0);
@@ -259,7 +279,7 @@ public class DefaultPartitionerTests
         var initialLocalPartitions = new[] { 0 };
         var updatedLocalPartitions = new[] { 1 };
         uniform.SetRackLocalPartitionsProvider(
-            (_, _) => racks[0] == "rack-a" ? initialLocalPartitions : updatedLocalPartitions);
+            (_, _, _) => racks[0] == "rack-a" ? initialLocalPartitions : updatedLocalPartitions);
 
         var initial = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 2);
         await Assert.That(initial).IsEqualTo(0);
@@ -283,7 +303,7 @@ public class DefaultPartitionerTests
             rackAwarePartitioning: false,
             clientRack: "rack-a");
         var uniform = (IUniformStickyPartitioner)partitioner;
-        uniform.SetRackLocalPartitionsProvider(static (_, _) => [0]);
+        uniform.SetRackLocalPartitionsProvider(static (_, _, _) => [0]);
         StickyPartitionerTestHelpers.SetCounter(partitioner, uint.MaxValue);
 
         var first = partitioner.Partition(Topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
@@ -358,7 +378,7 @@ public class StickyPartitionerTests
             ignoreKeys: false,
             rackAwarePartitioning: true,
             clientRack: "rack-a");
-        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _) => [1]);
+        ((IUniformStickyPartitioner)partitioner).SetRackLocalPartitionsProvider(static (_, _, _) => [1]);
 
         var partition = partitioner.Partition(topic, ReadOnlySpan<byte>.Empty, keyIsNull: true, partitionCount: 3);
 

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -34,6 +34,15 @@ public class DefaultPartitionerTests
     private const string Topic = "test-topic";
 
     [Test]
+    public async Task BuiltInPartitioners_PreserveLegacyConstructorSignatures()
+    {
+        var parameterTypes = new[] { typeof(int), typeof(bool), typeof(int), typeof(bool) };
+
+        await Assert.That(typeof(DefaultPartitioner).GetConstructor(parameterTypes)).IsNotNull();
+        await Assert.That(typeof(StickyPartitioner).GetConstructor(parameterTypes)).IsNotNull();
+    }
+
+    [Test]
     public async Task Partition_WithNullKey_ReturnsValidPartition()
     {
         var partitioner = new DefaultPartitioner();
@@ -268,7 +277,13 @@ public class DefaultPartitionerTests
     [Test]
     public async Task RackAwarePartitioning_WhenDisabled_DoesNotFilterPartitions()
     {
-        var partitioner = new DefaultPartitioner(stickyBatchSize: 1, rackAwarePartitioning: false, clientRack: "rack-a");
+        var partitioner = new DefaultPartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: false,
+            availabilityTimeoutMs: 0,
+            ignoreKeys: false,
+            rackAwarePartitioning: false,
+            clientRack: "rack-a");
         var uniform = (IUniformStickyPartitioner)partitioner;
         uniform.SetPartitionLeaderRackProvider(
             (_, partition) => partition == 0 ? "rack-a" : "rack-b");
@@ -340,6 +355,10 @@ public class StickyPartitionerTests
     {
         const string topic = "test-topic";
         var partitioner = new StickyPartitioner(
+            stickyBatchSize: int.MaxValue,
+            adaptivePartitioning: false,
+            availabilityTimeoutMs: 0,
+            ignoreKeys: false,
             rackAwarePartitioning: true,
             clientRack: "rack-a");
         ((IUniformStickyPartitioner)partitioner).SetPartitionLeaderRackProvider(

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -181,6 +181,15 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task RackAwarePartitioning_DefaultsToDisabledWithoutClientRack()
+    {
+        var options = CreateOptions();
+
+        await Assert.That(options.EnableRackAwarePartitioning).IsFalse();
+        await Assert.That(options.ClientRack).IsNull();
+    }
+
+    [Test]
     public async Task UseTls_DefaultsTo_False()
     {
         var options = CreateOptions();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
@@ -30,7 +30,7 @@ public class RackAwarePartitionerBenchmarks
         var localPartitions = new int[PartitionCount / 10];
         for (var i = 0; i < localPartitions.Length; i++)
             localPartitions[i] = i * 10;
-        _uniformPartitioner.SetRackLocalPartitionsProvider((_, _) => localPartitions);
+        _uniformPartitioner.SetRackLocalPartitionsProvider((_, _, _) => localPartitions);
     }
 
     [Benchmark(OperationsPerInvoke = 1_000)]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
@@ -12,8 +12,6 @@ public class RackAwarePartitionerBenchmarks
 
     private DefaultPartitioner _partitioner = null!;
     private IUniformStickyPartitioner _uniformPartitioner = null!;
-    private DefaultPartitioner _adaptivePartitioner = null!;
-    private IUniformStickyPartitioner _uniformAdaptivePartitioner = null!;
 
     [Params(10, 10_000)]
     public int PartitionCount { get; set; }
@@ -33,17 +31,6 @@ public class RackAwarePartitionerBenchmarks
         for (var i = 0; i < localPartitions.Length; i++)
             localPartitions[i] = i * 10;
         _uniformPartitioner.SetRackLocalPartitionsProvider((_, _) => localPartitions);
-
-        _adaptivePartitioner = new DefaultPartitioner(
-            stickyBatchSize: 1,
-            adaptivePartitioning: true,
-            availabilityTimeoutMs: 0,
-            ignoreKeys: false,
-            rackAwarePartitioning: true,
-            clientRack: "rack-a");
-        _uniformAdaptivePartitioner = _adaptivePartitioner;
-        _uniformAdaptivePartitioner.SetRackLocalPartitionsProvider((_, _) => localPartitions);
-        _uniformAdaptivePartitioner.SetPartitionQueueByteProvider(static (_, _) => 0);
     }
 
     [Benchmark(OperationsPerInvoke = 1_000)]
@@ -58,23 +45,6 @@ public class RackAwarePartitionerBenchmarks
                 keyIsNull: true,
                 PartitionCount);
             _uniformPartitioner.OnRecordAppended(Topic, partition, bytes: 1, PartitionCount);
-        }
-
-        return partition;
-    }
-
-    [Benchmark(OperationsPerInvoke = 1_000)]
-    public int RotateAdaptiveBatch()
-    {
-        var partition = 0;
-        for (var i = 0; i < 1_000; i++)
-        {
-            partition = _adaptivePartitioner.Partition(
-                Topic,
-                ReadOnlySpan<byte>.Empty,
-                keyIsNull: true,
-                PartitionCount);
-            _uniformAdaptivePartitioner.OnRecordAppended(Topic, partition, bytes: 1, PartitionCount);
         }
 
         return partition;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/RackAwarePartitionerBenchmarks.cs
@@ -1,0 +1,82 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class RackAwarePartitionerBenchmarks
+{
+    private const string Topic = "rack-aware-partitioner";
+
+    private DefaultPartitioner _partitioner = null!;
+    private IUniformStickyPartitioner _uniformPartitioner = null!;
+    private DefaultPartitioner _adaptivePartitioner = null!;
+    private IUniformStickyPartitioner _uniformAdaptivePartitioner = null!;
+
+    [Params(10, 10_000)]
+    public int PartitionCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _partitioner = new DefaultPartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: false,
+            availabilityTimeoutMs: 0,
+            ignoreKeys: false,
+            rackAwarePartitioning: true,
+            clientRack: "rack-a");
+        _uniformPartitioner = _partitioner;
+        var localPartitions = new int[PartitionCount / 10];
+        for (var i = 0; i < localPartitions.Length; i++)
+            localPartitions[i] = i * 10;
+        _uniformPartitioner.SetRackLocalPartitionsProvider((_, _) => localPartitions);
+
+        _adaptivePartitioner = new DefaultPartitioner(
+            stickyBatchSize: 1,
+            adaptivePartitioning: true,
+            availabilityTimeoutMs: 0,
+            ignoreKeys: false,
+            rackAwarePartitioning: true,
+            clientRack: "rack-a");
+        _uniformAdaptivePartitioner = _adaptivePartitioner;
+        _uniformAdaptivePartitioner.SetRackLocalPartitionsProvider((_, _) => localPartitions);
+        _uniformAdaptivePartitioner.SetPartitionQueueByteProvider(static (_, _) => 0);
+    }
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public int RotateBatch()
+    {
+        var partition = 0;
+        for (var i = 0; i < 1_000; i++)
+        {
+            partition = _partitioner.Partition(
+                Topic,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                PartitionCount);
+            _uniformPartitioner.OnRecordAppended(Topic, partition, bytes: 1, PartitionCount);
+        }
+
+        return partition;
+    }
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public int RotateAdaptiveBatch()
+    {
+        var partition = 0;
+        for (var i = 0; i < 1_000; i++)
+        {
+            partition = _adaptivePartitioner.Partition(
+                Topic,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                PartitionCount);
+            _uniformAdaptivePartitioner.OnRecordAppended(Topic, partition, bytes: 1, PartitionCount);
+        }
+
+        return partition;
+    }
+}


### PR DESCRIPTION
## Summary - add KIP-1123 rack-aware selection to built-in default and sticky partitioners - fall back to all usable partitions when no local leader is available - expose builder/options/DI configuration and document distribution tradeoffs  ## Validation - net10 unit suite: 5716 passed - net8 unit suite: 5589 passed - availability regression: 20/20 fresh runs  Closes #2223 
## Rack-aware rotation benchmark

`RackAwarePartitionerBenchmarks` (`[MemoryDiagnoser]`, .NET 10.0.10, i7-12700K):

| Partitions | Before (84f84910) | After (c1f1478d) | Delta | Allocated |
|---:|---:|---:|---:|---:|
| 10 | 66.91 ns | 25.14 ns | -62.4% | 184 B -> 0 B |
| 10,000 | 21,215.62 ns | 26.07 ns | -99.88% (~814x faster) | 184 B -> 0 B |

The metadata snapshot now builds immutable rack-local partition arrays. Uniform sticky rotation indexes the cached local set directly, so cost no longer scales with total topic partitions. Full solution build passed with 0 warnings; unit tests passed 5719/5719 on net10.0 and 5592/5592 on net8.0.