### PR TITLE
Test producer recovery below min ISR

### DIFF
--- a/tests/Dekaf.Tests.Integration/ProducerMinInSyncReplicasIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerMinInSyncReplicasIntegrationTests.cs
@@ -1,0 +1,288 @@
+using System.Diagnostics;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Microsoft.Extensions.Logging;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Producer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ProducerMinInSyncReplicasIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    private const int InitialMessageCount = 5;
+    private const int RecoveryMessageCount = 20;
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task Producer_AcksAll_IsrBelowMinInsync_RetriesUntilDeliveryTimeout(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync(minInSyncReplicas: 3).ConfigureAwait(false);
+        var stoppedBrokers = new List<int>(1);
+        using var logs = new CapturingLoggerProvider();
+        using var loggerFactory = CreateLoggerFactory(logs);
+
+        await using var producer = await CreateProducerAsync(
+                Acks.All,
+                enableIdempotence: true,
+                deliveryTimeout: TimeSpan.FromSeconds(4),
+                cancellationToken,
+                loggerFactory)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var initial = await ProduceAsync(producer, topic, 0, cancellationToken).ConfigureAwait(false);
+            await StopFollowerAsync(topic, stoppedBrokers, cancellationToken).ConfigureAwait(false);
+
+            ((IProducerDiagnostics)producer).ResetProduceRequestDiagnostics();
+            var stopwatch = Stopwatch.StartNew();
+            var exception = await Assert.ThrowsAsync<KafkaTimeoutException>(async () =>
+                await ProduceAsync(producer, topic, 1, cancellationToken).ConfigureAwait(false));
+            stopwatch.Stop();
+
+            var diagnostics = ((IProducerDiagnostics)producer).GetDeliveryDiagnosticsSnapshot();
+            var replicaError = GetReplicaError(logs);
+            await Assert.That(initial.Offset).IsEqualTo(0);
+            await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Delivery);
+            await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromSeconds(4));
+            await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(20));
+            await Assert.That(diagnostics.ProduceRequestCount).IsGreaterThan(1);
+            await Assert.That(replicaError).IsEqualTo(ErrorCode.NotEnoughReplicas);
+            await Assert.That(replicaError!.Value.IsRetriable()).IsTrue();
+        }
+        finally
+        {
+            await RestoreBrokersAsync(topic, stoppedBrokers).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task Producer_AcksAll_IsrRecovers_RetriesSucceedWithoutLossOrDuplicates(
+        CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync(minInSyncReplicas: 3).ConfigureAwait(false);
+        var stoppedBrokers = new List<int>(1);
+
+        await using var producer = await CreateProducerAsync(
+                Acks.All,
+                enableIdempotence: true,
+                deliveryTimeout: TimeSpan.FromSeconds(45),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var acknowledgements = new List<RecordMetadata>(InitialMessageCount + RecoveryMessageCount);
+            for (var value = 0; value < InitialMessageCount; value++)
+            {
+                acknowledgements.Add(
+                    await ProduceAsync(producer, topic, value, cancellationToken).ConfigureAwait(false));
+            }
+
+            await StopFollowerAsync(topic, stoppedBrokers, cancellationToken).ConfigureAwait(false);
+            var diagnostics = (IProducerDiagnostics)producer;
+            diagnostics.ResetProduceRequestDiagnostics();
+
+            var pending = new Task<RecordMetadata>[RecoveryMessageCount];
+            for (var index = 0; index < pending.Length; index++)
+            {
+                pending[index] = ProduceAsync(
+                        producer,
+                        topic,
+                        InitialMessageCount + index,
+                        cancellationToken)
+                    .AsTask();
+            }
+
+            await WaitUntilAsync(
+                    () => diagnostics.GetDeliveryDiagnosticsSnapshot().ProduceRequestCount > 0,
+                    TimeSpan.FromSeconds(15),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await Assert.That(pending.All(static task => !task.IsCompletedSuccessfully)).IsTrue();
+
+            await RestoreBrokersAsync(topic, stoppedBrokers).ConfigureAwait(false);
+            acknowledgements.AddRange(await Task.WhenAll(pending).ConfigureAwait(false));
+            await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            AssertAcknowledgementSequence(acknowledgements);
+            await AssertBrokerSequenceAsync(topic, acknowledgements.Count, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await RestoreBrokersAsync(topic, stoppedBrokers).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task Producer_AcksLeader_UnaffectedByIsrShrink(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateReplicatedTopicAsync(minInSyncReplicas: 3).ConfigureAwait(false);
+        var stoppedBrokers = new List<int>(1);
+
+        await using var producer = await CreateProducerAsync(
+                Acks.Leader,
+                enableIdempotence: false,
+                deliveryTimeout: TimeSpan.FromSeconds(15),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var initial = await ProduceAsync(producer, topic, 0, cancellationToken).ConfigureAwait(false);
+            await StopFollowerAsync(topic, stoppedBrokers, cancellationToken).ConfigureAwait(false);
+            var duringOutage = await ProduceAsync(producer, topic, 1, cancellationToken).ConfigureAwait(false);
+
+            await Assert.That(initial.Offset).IsEqualTo(0);
+            await Assert.That(duringOutage.Offset).IsEqualTo(1);
+        }
+        finally
+        {
+            await RestoreBrokersAsync(topic, stoppedBrokers).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask<IKafkaProducer<string, string>> CreateProducerAsync(
+        Acks acks,
+        bool enableIdempotence,
+        TimeSpan deliveryTimeout,
+        CancellationToken cancellationToken,
+        ILoggerFactory? loggerFactory = null)
+    {
+        return await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"min-isr-producer-{Guid.NewGuid():N}")
+            .WithAcks(acks)
+            .WithIdempotence(enableIdempotence)
+            .WithRequestTimeout(TimeSpan.FromSeconds(2))
+            .WithDeliveryTimeout(deliveryTimeout)
+            .WithReconnectBackoff(TimeSpan.FromMilliseconds(50))
+            .WithReconnectBackoffMax(TimeSpan.FromMilliseconds(250))
+            .WithDeliveryDiagnostics()
+            .WithLoggerFactory(loggerFactory ?? GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static ValueTask<RecordMetadata> ProduceAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        int value,
+        CancellationToken cancellationToken)
+    {
+        var payload = value.ToString();
+        return producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Partition = 0,
+            Key = payload,
+            Value = payload
+        }, cancellationToken);
+    }
+
+    private async Task StopFollowerAsync(
+        string topic,
+        List<int> stoppedBrokers,
+        CancellationToken cancellationToken)
+    {
+        const int followerId = 2;
+        await kafka.StopBrokerAsync(followerId, cancellationToken).ConfigureAwait(false);
+        stoppedBrokers.Add(followerId);
+        await kafka.WaitForInSyncReplicasAsync(topic, 2, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RestoreBrokersAsync(string topic, List<int> stoppedBrokers)
+    {
+        if (stoppedBrokers.Count == 0)
+            return;
+
+        var brokersToStart = stoppedBrokers.ToArray();
+        await kafka.StartBrokersAsync(brokersToStart, CancellationToken.None).ConfigureAwait(false);
+        stoppedBrokers.Clear();
+        await kafka.WaitForInSyncReplicasAsync(topic, 3, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> condition,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+        while (!condition())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Stopwatch.GetTimestamp() >= deadline)
+                throw new TimeoutException("Producer did not issue a request while ISR was below min.insync.replicas.");
+
+            await Task.Delay(25, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static ErrorCode? GetReplicaError(CapturingLoggerProvider logs)
+    {
+        foreach (var entry in logs.Entries)
+        {
+            if (entry.TryGetProperty<ErrorCode>("ErrorCode", out var errorCode)
+                && errorCode is ErrorCode.NotEnoughReplicas or ErrorCode.NotEnoughReplicasAfterAppend)
+            {
+                return errorCode;
+            }
+        }
+
+        return null;
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(CapturingLoggerProvider logs) =>
+        LoggerFactory.Create(builder => builder
+            .SetMinimumLevel(LogLevel.Debug)
+            .AddProvider(logs));
+
+    private static void AssertAcknowledgementSequence(IReadOnlyList<RecordMetadata> acknowledgements)
+    {
+        for (var index = 0; index < acknowledgements.Count; index++)
+        {
+            if (acknowledgements[index].Offset != index)
+            {
+                throw new InvalidOperationException(
+                    $"Acknowledgement offset mismatch at index {index}: {acknowledgements[index].Offset}.");
+            }
+        }
+    }
+
+    private async Task AssertBrokerSequenceAsync(
+        string topic,
+        int expectedCount,
+        CancellationToken cancellationToken)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"min-isr-oracle-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.Assign(new TopicPartition(topic, 0));
+
+        for (var index = 0; index < expectedCount; index++)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .ConfigureAwait(false);
+            if (result is null || result.Value.Offset != index || result.Value.Value != index.ToString())
+            {
+                throw new InvalidOperationException(
+                    $"Record mismatch at index {index}: {result?.Offset}/{result?.Value}.");
+            }
+        }
+
+        var extra = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+            .ConfigureAwait(false);
+        if (extra is not null)
+            throw new InvalidOperationException($"Unexpected duplicate at offset {extra.Value.Offset}.");
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -124,7 +124,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         return topic;
     }
 
-    public async Task<string> CreateReplicatedTopicAsync()
+    public async Task<string> CreateReplicatedTopicAsync(int minInSyncReplicas = 2)
     {
         var topic = $"replicated-{Guid.NewGuid():N}";
         await using var admin = CreateAdminClient();
@@ -141,7 +141,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
                 },
                 Configs = new Dictionary<string, string>
                 {
-                    ["min.insync.replicas"] = "2"
+                    ["min.insync.replicas"] = minInSyncReplicas.ToString()
                 }
             }
         ]).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -87,7 +87,10 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             cancellationToken,
             pollInterval: TimeSpan.FromMilliseconds(1));
 
-    private static ProduceResponse CreateRetriableErrorResponse(string topic, int partition) =>
+    private static ProduceResponse CreateRetriableErrorResponse(
+        string topic,
+        int partition,
+        ErrorCode errorCode = ErrorCode.NotLeaderOrFollower) =>
         new()
         {
             TopicCount = 1,
@@ -102,7 +105,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
                         new ProduceResponsePartitionData
                         {
                             Index = partition,
-                            ErrorCode = ErrorCode.NotLeaderOrFollower,
+                            ErrorCode = errorCode,
                             BaseOffset = -1
                         }
                     ]
@@ -1163,14 +1166,18 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
     /// Core muting test: a retriable error on partition 0 should mute it, blocking
     /// subsequent normal batches for partition 0 until the retry succeeds.
     ///
-    /// Flow: batch A (p0) → NotLeaderOrFollower → p0 muted → batch B (p0) enqueued
+    /// Flow: batch A (p0) → replica availability error → p0 muted → batch B (p0) enqueued
     /// but blocked → A retry succeeds → p0 unmuted → B proceeds.
     ///
     /// Verifies: batch A acknowledged before batch B (ordering preserved).
     /// </summary>
     [Test]
+    [Arguments(ErrorCode.NotEnoughReplicas)]
+    [Arguments(ErrorCode.NotEnoughReplicasAfterAppend)]
     [Timeout(60_000)]
-    public async Task RetriableError_MutesPartition_BlocksNormalBatchUntilRetrySucceeds(CancellationToken ct)
+    public async Task ReplicaAvailabilityError_MutesPartition_BlocksNormalBatchUntilRetrySucceeds(
+        ErrorCode errorCode,
+        CancellationToken ct)
     {
         // Send 1: batch A (p0) → retriable error
         // Send 2: batch A retry (p0) → success (batch B is blocked, not coalesced)
@@ -1224,7 +1231,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
             // Return retriable error → triggers HandleRetriableBatch → mutes p0
-            tcs1.SetResult(CreateRetriableErrorResponse("test-topic", 0));
+            tcs1.SetResult(CreateRetriableErrorResponse("test-topic", 0, errorCode));
 
             // Wait for send 2 (retry of batch A) — do this BEFORE enqueuing B to ensure
             // the send loop has processed the retriable error and started the retry.


### PR DESCRIPTION
Fixes #2252

## Summary
- cover acks=all delivery timeout when RF=3 ISR falls from 3 to 2 below min.insync.replicas=3
- capture the real broker NotEnoughReplicas response and verify retriable classification before delivery timeout
- prove idempotent retries recover with ordered acknowledgements and no broker-side loss/duplicates
- add the acks=1 control under the same ISR shrink
- exercise both NotEnoughReplicas and NotEnoughReplicasAfterAppend through the BrokerSender retry/ordering path

The test stops one combined broker/controller node instead of two: this crosses the min ISR threshold while retaining a 2/3 KRaft controller quorum, making recovery deterministic.

## Validation
- Release integration build: net8.0 + net10.0
- ProducerMinInSyncReplicasIntegrationTests: 3/3 net10.0; 3/3 net8.0
- exact captured-error timeout lane: 1/1 net10.0
- replica error-code retry lanes: 2/2 net10.0; 2/2 net8.0
- BrokerSenderMuteOrderingTests: 23/23 net10.0

## Performance
Test and test-infrastructure changes only; no src/ or hot-path changes. No benchmark required.