### PR TITLE
Implement KIP-601 adaptive connection setup timeout

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -342,7 +342,7 @@ Set a larger maximum to enable KIP-601 adaptive setup deadlines. Consecutive fai
 .WithConnectionTimeoutMax(TimeSpan.FromSeconds(127))
 ```
 
-When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the logical `host:port`, so DNS address rotation retains it; a broker moving to a different advertised endpoint starts fresh.
+When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the broker ID plus advertised `host:port`. DNS address rotation for that broker and endpoint retains it; a different broker ID or advertised endpoint starts fresh.
 
 ### WithTcpKeepAlive
 

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -106,6 +106,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithPrefetchPipelineDepth(...)` | `PrefetchPipelineDepth` | Integer |
 | `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
 | `WithConnectionTimeout(...)` | `ConnectionTimeout` | TimeSpan |
+| `WithConnectionTimeoutMax(...)` | `ConnectionTimeoutMax` | TimeSpan; Kafka `socket.connection.setup.timeout.max.ms` |
 | `WithTcpKeepAlive(...)` | `EnableTcpKeepAlive`, `TcpKeepAliveTime`, `TcpKeepAliveInterval`, `TcpKeepAliveRetryCount` | Socket keepalive |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
@@ -334,6 +335,15 @@ Maximum time allowed for socket connection setup, including TLS and SASL handsha
 .WithConnectionTimeout(TimeSpan.FromSeconds(10))
 ```
 
+Set a larger maximum to enable KIP-601 adaptive setup deadlines. Consecutive failures grow the effective timeout exponentially with ±20% jitter, capped at the maximum. A successful setup resets it. Reconnect backoff remains separate.
+
+```csharp
+.WithConnectionTimeout(TimeSpan.FromSeconds(10))
+.WithConnectionTimeoutMax(TimeSpan.FromSeconds(127))
+```
+
+When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the logical `host:port`, so DNS address rotation retains it; a broker moving to a different advertised endpoint starts fresh.
+
 ### WithTcpKeepAlive
 
 Enable, disable, or tune TCP keepalive probes:
@@ -452,6 +462,7 @@ For transactional reads:
 | `WithConnectionsPerBroker` | 2 | TCP connections per broker |
 | `WithAdaptiveConnections` | enabled (max 4) | Auto-scale connections under load |
 | `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |
+| `WithConnectionTimeoutMax` | Same as initial | Maximum adaptive connection setup timeout |
 | `WithTcpKeepAlive` | enabled | TCP keepalive; 2m idle, 30s interval, 3 retries |
 | `UseTls` | false | Enable TLS |
 | `WithRemoteCertificateValidationCallback` | null | Custom TLS certificate validation |

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -313,7 +313,7 @@ Set a larger maximum to enable KIP-601 adaptive setup deadlines. Consecutive fai
 .WithConnectionTimeoutMax(TimeSpan.FromSeconds(127))
 ```
 
-When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the logical `host:port`, so DNS address rotation retains it; a broker moving to a different advertised endpoint starts fresh.
+When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the broker ID plus advertised `host:port`. DNS address rotation for that broker and endpoint retains it; a different broker ID or advertised endpoint starts fresh.
 
 ### WithTcpKeepAlive
 

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -84,6 +84,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithIdempotence(...)` | `EnableIdempotence` | Boolean |
 | `WithConnectionsMaxIdle(...)` | `ConnectionsMaxIdleMs` | Milliseconds; `-1` disables |
 | `WithConnectionTimeout(...)` | `ConnectionTimeout` | TimeSpan |
+| `WithConnectionTimeoutMax(...)` | `ConnectionTimeoutMax` | TimeSpan; Kafka `socket.connection.setup.timeout.max.ms` |
 | `WithTcpKeepAlive(...)` | `EnableTcpKeepAlive`, `TcpKeepAliveTime`, `TcpKeepAliveInterval`, `TcpKeepAliveRetryCount` | Socket keepalive |
 | `WithConnectionsPerBroker(...)` | `ConnectionsPerBroker` | Integer |
 | `WithAdaptiveConnections(...)` | `EnableAdaptiveConnections`, `MaxConnectionsPerBroker` | Set `EnableAdaptiveConnections` to `false` to disable |
@@ -305,6 +306,15 @@ Maximum time allowed for socket connection setup, including TLS and SASL handsha
 .WithConnectionTimeout(TimeSpan.FromSeconds(10))
 ```
 
+Set a larger maximum to enable KIP-601 adaptive setup deadlines. Consecutive failures grow the effective timeout exponentially with ±20% jitter, capped at the maximum. A successful setup resets it. Reconnect backoff remains a separate delay between attempts.
+
+```csharp
+.WithConnectionTimeout(TimeSpan.FromSeconds(10))
+.WithConnectionTimeoutMax(TimeSpan.FromSeconds(127))
+```
+
+When only `WithConnectionTimeout` is set, the maximum follows the initial value, preserving fixed-timeout behavior. Failure progression follows the logical `host:port`, so DNS address rotation retains it; a broker moving to a different advertised endpoint starts fresh.
+
 ### WithTcpKeepAlive
 
 Enable, disable, or tune TCP keepalive probes:
@@ -431,6 +441,7 @@ Enable logging:
 | `WithConnectionsPerBroker` | 1 | TCP connections per broker |
 | `WithConnectionsMaxIdle` | 540000ms | Close unused broker connections; `Timeout.InfiniteTimeSpan` disables |
 | `WithConnectionTimeout` | 30000ms | Socket connection setup timeout |
+| `WithConnectionTimeoutMax` | Same as initial | Maximum adaptive connection setup timeout |
 | `WithTcpKeepAlive` | enabled | TCP keepalive; 2m idle, 30s interval, 3 retries |
 | `WithAdaptiveConnections` | enabled (max 10) | Auto-scale connections under load |
 | `WithoutAdaptiveConnections` | - | Disable adaptive scaling |

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -843,6 +843,8 @@ internal static class DekafOptionsBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (options.IsConnectionTimeoutMaxConfigured)
+            builder.WithConnectionTimeoutMax(options.ConnectionTimeoutMax);
         builder.WithIdempotence(options.EnableIdempotence);
         builder.WithConnectionsPerBroker(options.ConnectionsPerBroker);
         if (options.TransactionalId is not null)
@@ -959,6 +961,8 @@ internal static class DekafOptionsBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (options.IsConnectionTimeoutMaxConfigured)
+            builder.WithConnectionTimeoutMax(options.ConnectionTimeoutMax);
         builder.WithCheckCrcs(options.CheckCrcs);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         ApplyRemoteCertificateValidationCallback(
@@ -1027,6 +1031,8 @@ internal static class DekafOptionsBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (options.IsConnectionTimeoutMaxConfigured)
+            builder.WithConnectionTimeoutMax(options.ConnectionTimeoutMax);
         ApplyTls(options.UseTls, options.TlsConfig, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         ApplyRemoteCertificateValidationCallback(
             options.RemoteCertificateValidationCallback,
@@ -1236,6 +1242,8 @@ internal static class DekafConfigurationBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (TryGetValue<TimeSpan>(configuration, nameof(ProducerOptions.ConnectionTimeoutMax), out var connectionTimeoutMax))
+            builder.WithConnectionTimeoutMax(connectionTimeoutMax);
         if (TryGetValue<bool>(configuration, nameof(ProducerOptions.EnableIdempotence), out var enableIdempotence))
             builder.WithIdempotence(enableIdempotence);
         if (TryGetValue<int>(configuration, nameof(ProducerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
@@ -1384,6 +1392,8 @@ internal static class DekafConfigurationBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (TryGetValue<TimeSpan>(configuration, nameof(ConsumerOptions.ConnectionTimeoutMax), out var connectionTimeoutMax))
+            builder.WithConnectionTimeoutMax(connectionTimeoutMax);
         if (TryGetValue<bool>(configuration, nameof(ConsumerOptions.CheckCrcs), out var checkCrcs))
             builder.WithCheckCrcs(checkCrcs);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
@@ -1443,6 +1453,8 @@ internal static class DekafConfigurationBinding
             builder.WithConnectionTimeout,
             enabled => builder.WithTcpKeepAlive(enabled),
             (time, interval, retryCount) => builder.WithTcpKeepAlive(time, interval, retryCount));
+        if (TryGetValue<TimeSpan>(configuration, nameof(AdminClientOptions.ConnectionTimeoutMax), out var connectionTimeoutMax))
+            builder.WithConnectionTimeoutMax(connectionTimeoutMax);
         ApplyTls(configuration, () => builder.UseTls(), tlsConfig => builder.UseTls(tlsConfig));
         if (TryReadSasl(configuration, out var mechanism, out var username, out var password, out var gssapi, out var oauth, out var awsMskIam, out var saslScramTokenAuth))
             builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIam, saslScramTokenAuth: saslScramTokenAuth);

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -55,6 +55,7 @@ public sealed class AdminClient : IAdminClient
                 TlsConfig = options.TlsConfig,
                 RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
                 ConnectionTimeout = options.ConnectionTimeout,
+                ConnectionTimeoutMax = options.ConnectionTimeoutMax,
                 EnableTcpKeepAlive = options.EnableTcpKeepAlive,
                 TcpKeepAliveTime = options.TcpKeepAliveTime,
                 TcpKeepAliveInterval = options.TcpKeepAliveInterval,
@@ -4733,6 +4734,7 @@ public sealed class AdminClient : IAdminClient
 /// </summary>
 public sealed class AdminClientOptions
 {
+    private TimeSpan? _connectionTimeoutMax;
     private int _reconnectBackoffMs = 50;
     private int _reconnectBackoffMaxMs = 1000;
     private bool _isReconnectBackoffMsConfigured;
@@ -4787,6 +4789,19 @@ public sealed class AdminClientOptions
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
     public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+
+    /// <summary>
+    /// Maximum connection setup timeout after consecutive failures. Defaults to
+    /// <see cref="ConnectionTimeout"/> to preserve fixed-timeout behavior.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
+
+    internal bool IsConnectionTimeoutMaxConfigured => _connectionTimeoutMax.HasValue;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.
@@ -4918,6 +4933,8 @@ public sealed class AdminClientBuilder
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _connectionTimeoutMaxConfigured;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -5441,6 +5458,23 @@ public sealed class AdminClientBuilder
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
+        if (!_connectionTimeoutMaxConfigured)
+            _connectionTimeoutMax = _connectionTimeout;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public AdminClientBuilder WithConnectionTimeoutMax(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeoutMax = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Maximum connection timeout must be positive");
+        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -5532,6 +5566,7 @@ public sealed class AdminClientBuilder
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
+            ConnectionTimeoutMax = _connectionTimeoutMax,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4933,8 +4933,7 @@ public sealed class AdminClientBuilder
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
-    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
-    private bool _connectionTimeoutMaxConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -5458,8 +5457,6 @@ public sealed class AdminClientBuilder
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
-        if (!_connectionTimeoutMaxConfigured)
-            _connectionTimeoutMax = _connectionTimeout;
         return this;
     }
 
@@ -5474,7 +5471,6 @@ public sealed class AdminClientBuilder
             timeout,
             nameof(timeout),
             "Maximum connection timeout must be positive");
-        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -5566,7 +5562,7 @@ public sealed class AdminClientBuilder
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
-            ConnectionTimeoutMax = _connectionTimeoutMax,
+            ConnectionTimeoutMax = _connectionTimeoutMax ?? _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -91,6 +91,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _connectionTimeoutMaxConfigured;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -388,6 +390,23 @@ public sealed class ProducerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
+        if (!_connectionTimeoutMaxConfigured)
+            _connectionTimeoutMax = _connectionTimeout;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithConnectionTimeoutMax(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeoutMax = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Maximum connection timeout must be positive");
+        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -1423,6 +1442,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
+            ConnectionTimeoutMax = _connectionTimeoutMax,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,
@@ -1669,6 +1689,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _connectionTimeoutMaxConfigured;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -2760,6 +2782,23 @@ public sealed class ConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
+        if (!_connectionTimeoutMaxConfigured)
+            _connectionTimeoutMax = _connectionTimeout;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithConnectionTimeoutMax(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeoutMax = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Maximum connection timeout must be positive");
+        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -3162,6 +3201,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
+            ConnectionTimeoutMax = _connectionTimeoutMax,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,
@@ -3342,6 +3382,8 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _connectionTimeoutMaxConfigured;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -3554,6 +3596,23 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
+        if (!_connectionTimeoutMaxConfigured)
+            _connectionTimeoutMax = _connectionTimeout;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithConnectionTimeoutMax(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _connectionTimeoutMax = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Maximum connection timeout must be positive");
+        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -3960,6 +4019,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
+            ConnectionTimeoutMax = _connectionTimeoutMax,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -91,8 +91,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
-    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
-    private bool _connectionTimeoutMaxConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -390,8 +389,6 @@ public sealed class ProducerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
-        if (!_connectionTimeoutMaxConfigured)
-            _connectionTimeoutMax = _connectionTimeout;
         return this;
     }
 
@@ -406,7 +403,6 @@ public sealed class ProducerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Maximum connection timeout must be positive");
-        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -1442,7 +1438,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
-            ConnectionTimeoutMax = _connectionTimeoutMax,
+            ConnectionTimeoutMax = _connectionTimeoutMax ?? _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,
@@ -1689,8 +1685,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
-    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
-    private bool _connectionTimeoutMaxConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -2782,8 +2777,6 @@ public sealed class ConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
-        if (!_connectionTimeoutMaxConfigured)
-            _connectionTimeoutMax = _connectionTimeout;
         return this;
     }
 
@@ -2798,7 +2791,6 @@ public sealed class ConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Maximum connection timeout must be positive");
-        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -3201,7 +3193,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
-            ConnectionTimeoutMax = _connectionTimeoutMax,
+            ConnectionTimeoutMax = _connectionTimeoutMax ?? _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,
@@ -3382,8 +3374,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private bool _reconnectBackoffMaxConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
-    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
-    private bool _connectionTimeoutMaxConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -3596,8 +3587,6 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
-        if (!_connectionTimeoutMaxConfigured)
-            _connectionTimeoutMax = _connectionTimeout;
         return this;
     }
 
@@ -3612,7 +3601,6 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             timeout,
             nameof(timeout),
             "Maximum connection timeout must be positive");
-        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -4019,7 +4007,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             ReconnectBackoffMaxMs = reconnectBackoffMaxMs,
             ConnectionsMaxIdleMs = _connectionsMaxIdleMs,
             ConnectionTimeout = _connectionTimeout,
-            ConnectionTimeoutMax = _connectionTimeoutMax,
+            ConnectionTimeoutMax = _connectionTimeoutMax ?? _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -61,6 +61,7 @@ public sealed class ConsumerOptions
     private int _reconnectBackoffMaxMs = 1000;
     private bool _isReconnectBackoffMsConfigured;
     private bool _isReconnectBackoffMaxMsConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     internal const int DefaultMaxConnectionsPerBroker = 4;
 
     /// <summary>
@@ -285,6 +286,19 @@ public sealed class ConsumerOptions
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
     public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+
+    /// <summary>
+    /// Maximum connection setup timeout after consecutive failures. Defaults to
+    /// <see cref="ConnectionTimeout"/> to preserve fixed-timeout behavior.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
+
+    internal bool IsConnectionTimeoutMaxConfigured => _connectionTimeoutMax.HasValue;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1198,6 +1198,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 TlsConfig = options.TlsConfig,
                 RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
                 ConnectionTimeout = options.ConnectionTimeout,
+                ConnectionTimeoutMax = options.ConnectionTimeoutMax,
                 EnableTcpKeepAlive = options.EnableTcpKeepAlive,
                 TcpKeepAliveTime = options.TcpKeepAliveTime,
                 TcpKeepAliveInterval = options.TcpKeepAliveInterval,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -107,6 +107,8 @@ public sealed class KafkaClientBuilder
     private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
+    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
+    private bool _connectionTimeoutMaxConfigured;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -230,6 +232,22 @@ public sealed class KafkaClientBuilder
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
+        if (!_connectionTimeoutMaxConfigured)
+            _connectionTimeoutMax = _connectionTimeout;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public KafkaClientBuilder WithConnectionTimeoutMax(TimeSpan timeout)
+    {
+        _connectionTimeoutMax = ConnectionOptionValidation.ValidatePositiveTimeout(
+            timeout,
+            nameof(timeout),
+            "Maximum connection timeout must be positive");
+        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -596,6 +614,7 @@ public sealed class KafkaClientBuilder
             TlsConfig = _tlsConfig,
             RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             ConnectionTimeout = _connectionTimeout,
+            ConnectionTimeoutMax = _connectionTimeoutMax,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,
@@ -631,6 +650,7 @@ public sealed class KafkaClientBuilder
 }
 internal sealed class KafkaClientOptions
 {
+    private TimeSpan? _connectionTimeoutMax;
     public required IReadOnlyList<string> BootstrapServers { get; init; }
     public string? ClientId { get; init; }
     public int RequestTimeoutMs { get; init; }
@@ -642,6 +662,12 @@ internal sealed class KafkaClientOptions
     public TlsConfig? TlsConfig { get; init; }
     public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; init; }
     public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
+
     public bool EnableTcpKeepAlive { get; init; } = ConnectionOptions.DefaultEnableTcpKeepAlive;
     public TimeSpan TcpKeepAliveTime { get; init; } = ConnectionOptions.DefaultTcpKeepAliveTime;
     public TimeSpan TcpKeepAliveInterval { get; init; } = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -793,6 +819,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         TlsConfig = options.TlsConfig,
         RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
         ConnectionTimeout = options.ConnectionTimeout,
+        ConnectionTimeoutMax = options.ConnectionTimeoutMax,
         EnableTcpKeepAlive = options.EnableTcpKeepAlive,
         TcpKeepAliveTime = options.TcpKeepAliveTime,
         TcpKeepAliveInterval = options.TcpKeepAliveInterval,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -107,8 +107,7 @@ public sealed class KafkaClientBuilder
     private bool _isMaxConnectionsPerBrokerConfigured;
     private int _connectionsMaxIdleMs = ConnectionOptions.DefaultConnectionsMaxIdleMs;
     private TimeSpan _connectionTimeout = ConnectionOptions.DefaultConnectionTimeout;
-    private TimeSpan _connectionTimeoutMax = ConnectionOptions.DefaultConnectionTimeout;
-    private bool _connectionTimeoutMaxConfigured;
+    private TimeSpan? _connectionTimeoutMax;
     private bool _enableTcpKeepAlive = ConnectionOptions.DefaultEnableTcpKeepAlive;
     private TimeSpan _tcpKeepAliveTime = ConnectionOptions.DefaultTcpKeepAliveTime;
     private TimeSpan _tcpKeepAliveInterval = ConnectionOptions.DefaultTcpKeepAliveInterval;
@@ -232,8 +231,6 @@ public sealed class KafkaClientBuilder
             timeout,
             nameof(timeout),
             "Connection timeout must be positive");
-        if (!_connectionTimeoutMaxConfigured)
-            _connectionTimeoutMax = _connectionTimeout;
         return this;
     }
 
@@ -247,7 +244,6 @@ public sealed class KafkaClientBuilder
             timeout,
             nameof(timeout),
             "Maximum connection timeout must be positive");
-        _connectionTimeoutMaxConfigured = true;
         return this;
     }
 
@@ -614,7 +610,7 @@ public sealed class KafkaClientBuilder
             TlsConfig = _tlsConfig,
             RemoteCertificateValidationCallback = _remoteCertificateValidationCallback,
             ConnectionTimeout = _connectionTimeout,
-            ConnectionTimeoutMax = _connectionTimeoutMax,
+            ConnectionTimeoutMax = _connectionTimeoutMax ?? _connectionTimeout,
             EnableTcpKeepAlive = _enableTcpKeepAlive,
             TcpKeepAliveTime = _tcpKeepAliveTime,
             TcpKeepAliveInterval = _tcpKeepAliveInterval,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -62,6 +62,7 @@ public sealed partial class ConnectionPool :
     private Action<KafkaConnectionCapabilities>? _capabilityObserver;
     private readonly MetadataClusterIdentity _metadataClusterIdentity = new();
     private readonly Action? _brokerEndpointUpdated;
+    private readonly Action<TimeSpan>? _connectionSetupTimeoutObserver;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
@@ -71,6 +72,9 @@ public sealed partial class ConnectionPool :
     private readonly ConcurrentDictionary<EndpointKey, ReconnectBackoffState> _reconnectBackoffs = new();
     private readonly ConcurrentDictionary<int, BrokerThrottleState> _brokerThrottleStates = new();
     private readonly ConcurrentDictionary<EndpointKey, BrokerThrottleState> _bootstrapThrottleStates = new();
+    // Logical broker + host:port identity is deliberate: DNS IP rotation keeps failure
+    // progression, while brokers and changed advertised endpoints remain isolated.
+    private readonly ConcurrentDictionary<ConnectionSetupKey, ConnectionSetupTimeoutState> _connectionSetupTimeouts = new();
 
     // Multi-connection support: connection groups and round-robin index
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
@@ -119,6 +123,7 @@ public sealed partial class ConnectionPool :
             connectionOptions ?? new ConnectionOptions(),
             out _sharedOAuthBearerTokenProvider);
         ValidateReconnectBackoff(_connectionOptions);
+        ValidateConnectionSetupTimeouts(_connectionOptions);
         _loggerFactory = loggerFactory;
         _logger = loggerFactory?.CreateLogger<ConnectionPool>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -144,13 +149,15 @@ public sealed partial class ConnectionPool :
         Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>> connectionFactory,
         TimeSpan? idleReapDrainTimeout = null,
         Func<double>? randomDouble = null,
-        Action? brokerEndpointUpdated = null)
+        Action? brokerEndpointUpdated = null,
+        Action<TimeSpan>? connectionSetupTimeoutObserver = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
             connectionOptions ?? new ConnectionOptions(),
             out _sharedOAuthBearerTokenProvider);
         ValidateReconnectBackoff(_connectionOptions);
+        ValidateConnectionSetupTimeouts(_connectionOptions);
         _loggerFactory = null;
         _logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<ConnectionPool>.Instance;
         _connectionsPerBroker = Math.Max(1, connectionsPerBroker);
@@ -159,6 +166,7 @@ public sealed partial class ConnectionPool :
         _idleReapDrainTimeout = idleReapDrainTimeout ?? DefaultIdleReapDrainTimeout;
         _randomDouble = randomDouble ?? SharedRandomDouble;
         _brokerEndpointUpdated = brokerEndpointUpdated;
+        _connectionSetupTimeoutObserver = connectionSetupTimeoutObserver;
         // No shared pool needed: factory-created connections manage their own pools.
         StartIdleConnectionReaper();
     }
@@ -261,6 +269,7 @@ public sealed partial class ConnectionPool :
             TcpKeepAliveInterval = options.TcpKeepAliveInterval,
             TcpKeepAliveRetryCount = options.TcpKeepAliveRetryCount,
             ConnectionTimeout = options.ConnectionTimeout,
+            ConnectionTimeoutMax = options.ConnectionTimeoutMax,
             RequestTimeout = options.RequestTimeout,
             ReconnectBackoff = options.ReconnectBackoff,
             ReconnectBackoffMax = options.ReconnectBackoffMax,
@@ -283,6 +292,25 @@ public sealed partial class ConnectionPool :
             "Maximum reconnect backoff cannot be negative");
 
         ReconnectBackoffValidation.ValidateMilliseconds(reconnectBackoffMs, reconnectBackoffMaxMs);
+    }
+
+    private static void ValidateConnectionSetupTimeouts(ConnectionOptions options)
+    {
+        ConnectionOptionValidation.ValidatePositiveTimeout(
+            options.ConnectionTimeout,
+            nameof(options),
+            "Connection setup timeout must be positive");
+        ConnectionOptionValidation.ValidatePositiveTimeout(
+            options.ConnectionTimeoutMax,
+            nameof(options),
+            "Maximum connection setup timeout must be positive");
+
+        if (options.ConnectionTimeoutMax < options.ConnectionTimeout)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                "Maximum connection setup timeout must be greater than or equal to the initial timeout");
+        }
     }
 
     /// <summary>
@@ -329,6 +357,9 @@ public sealed partial class ConnectionPool :
             if (!_brokers.TryUpdate(brokerId, brokerInfo, previous))
                 continue;
 
+            _connectionSetupTimeouts.TryRemove(
+                new ConnectionSetupKey(brokerId, previous.Host, previous.Port),
+                out _);
             _brokerEndpointUpdated?.Invoke();
             RetireBrokerConnections(brokerId, previous);
             break;
@@ -518,13 +549,6 @@ public sealed partial class ConnectionPool :
         var connections = new IKafkaConnection[initialCount];
         var tasks = new Task<IKafkaConnection>[initialCount];
 
-        using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            timeoutCts.Token);
-
-        var token = linkedCts.Token;
-
         var success = false;
         try
         {
@@ -536,13 +560,13 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Host,
                     brokerInfo.Port,
                     index,
-                    token,
+                    cancellationToken,
                     cancellationToken).AsTask();
             }
 
-            // Add timeout to prevent indefinite hang if connection creation stalls
-            // Similar pattern to RecordAccumulator disposal fix (commit 8f26f05)
-            await Task.WhenAll(tasks).WaitAsync(_connectionOptions.ConnectionTimeout, cancellationToken).ConfigureAwait(false);
+            // Each setup task carries its own adaptive deadline, so the aggregate cannot
+            // hang even though lock and reconnect-backoff waits remain outside that deadline.
+            await Task.WhenAll(tasks).ConfigureAwait(false);
 
             for (var i = 0; i < initialCount; i++)
             {
@@ -551,24 +575,14 @@ public sealed partial class ConnectionPool :
 
             // Atomically set the connection group
             _connectionGroupsById[brokerId] = connections;
-            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
+            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
 
             LogCreatedConnectionGroup(initialCount, brokerId);
 
             success = true;
             return connections[0];
-        }
-        catch (TimeoutException)
-        {
-            throw new KafkaException(
-                ErrorCode.RequestTimedOut,
-                $"Connection group creation timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId}");
-        }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-        {
-            throw new KafkaException(
-                ErrorCode.RequestTimedOut,
-                $"Connection group creation timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId}");
         }
         finally
         {
@@ -617,10 +631,6 @@ public sealed partial class ConnectionPool :
             var existingCount = currentGroup?.Length ?? 0;
             var additionalCount = newCount - existingCount;
 
-            // Create additional connections in parallel with a single timeout mechanism
-            using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-
             var tasks = new Task<IKafkaConnection>[additionalCount];
 
             for (var i = 0; i < additionalCount; i++)
@@ -631,7 +641,7 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Host,
                     brokerInfo.Port,
                     index,
-                    linkedCts.Token,
+                    cancellationToken,
                     cancellationToken).AsTask();
             }
 
@@ -655,7 +665,9 @@ public sealed partial class ConnectionPool :
 
             // Atomically swap the connection group
             _connectionGroupsById[brokerId] = newGroup;
-            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
+            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
 
             LogScaledConnectionGroup(existingCount, newCount, brokerId);
             return newCount;
@@ -751,19 +763,13 @@ public sealed partial class ConnectionPool :
     {
         // Use a per-(broker,index) SemaphoreSlim instead of Lazy<ValueTask> to avoid
         // capturing a caller-scoped CancellationToken that gets disposed in the caller's finally block.
-        // Each caller creates its own timeout CTS, so no token outlives its CTS.
+        // The adaptive setup attempt creates its timeout CTS only after this lock is acquired,
+        // so lock contention does not consume the socket setup deadline.
         var replacementLock = _connectionReplacementLocks.GetOrAdd(
             (brokerId, index),
             static _ => new SemaphoreSlim(1, 1));
 
-        using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            timeoutCts.Token);
-
-        var token = linkedCts.Token;
-
-        await replacementLock.WaitAsync(token).ConfigureAwait(false);
+        await replacementLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             // Re-check: another caller may have already replaced this connection
@@ -780,14 +786,14 @@ public sealed partial class ConnectionPool :
                 brokerInfo.Host,
                 brokerInfo.Port,
                 index,
-                token,
+                cancellationToken,
                 cancellationToken).ConfigureAwait(false);
 
             // Acquire _scaleLock to protect the array write against concurrent
             // ShrinkConnectionGroupAsync, which may have swapped the array reference.
             bool stored = false;
             IKafkaConnection? oldConnection = null;
-            await _scaleLock.WaitAsync(token).ConfigureAwait(false);
+            await _scaleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (_connectionGroupsById.TryGetValue(brokerId, out var connections) && index < connections.Length)
@@ -819,15 +825,11 @@ public sealed partial class ConnectionPool :
                     $"Connection slot {index} for broker {brokerId} was removed by a concurrent shrink");
             }
 
-            ResetReconnectBackoff(new EndpointKey(brokerInfo.Host, brokerInfo.Port), brokerId, brokerInfo.Host, brokerInfo.Port);
+            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
 
             return connection;
-        }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-        {
-            throw new KafkaException(
-                ErrorCode.RequestTimedOut,
-                $"Connection replacement timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId} index {index}");
         }
         finally
         {
@@ -849,12 +851,18 @@ public sealed partial class ConnectionPool :
             brokerId,
             host,
             port,
-            () => CreateConnectionForGroupCoreAsync(
+            () => RunConnectionSetupAttemptAsync(
                 brokerId,
                 host,
                 port,
-                index,
-                cancellationToken,
+                (setupTimeout, setupCancellationToken) => CreateConnectionForGroupCoreAsync(
+                    brokerId,
+                    host,
+                    port,
+                    index,
+                    setupTimeout,
+                    setupCancellationToken,
+                    callerCancellationToken),
                 callerCancellationToken),
             cancellationToken).ConfigureAwait(false);
     }
@@ -864,6 +872,7 @@ public sealed partial class ConnectionPool :
         string host,
         int port,
         int index,
+        TimeSpan connectionSetupTimeout,
         CancellationToken cancellationToken,
         CancellationToken callerCancellationToken)
     {
@@ -891,7 +900,7 @@ public sealed partial class ConnectionPool :
                 Volatile.Read(ref _capabilityObserver),
                 _metadataClusterIdentity);
 
-            await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            await connection.ConnectAsync(connectionSetupTimeout, cancellationToken).ConfigureAwait(false);
 
             LogCreatedConnectionForGroup(index, brokerId, host, port);
 
@@ -944,19 +953,13 @@ public sealed partial class ConnectionPool :
         var endpoint = new EndpointKey(host, port);
 
         // Use a per-endpoint semaphore to deduplicate concurrent connection creation.
-        // Each caller creates its own timeout CTS, so no token outlives its CTS.
+        // The adaptive setup attempt creates its timeout CTS only after this lock is acquired,
+        // so lock contention does not consume the socket setup deadline.
         // This replaces the previous Lazy<ValueTask> pattern which violated the ValueTask
         // contract (multiple awaiters) and captured a caller-scoped CTS that could be disposed.
         var creationLock = _connectionCreationLocks.GetOrAdd(endpoint, static _ => new SemaphoreSlim(1, 1));
 
-        using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            timeoutCts.Token);
-
-        var token = linkedCts.Token;
-
-        await creationLock.WaitAsync(token).ConfigureAwait(false);
+        await creationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             for (var attempt = 0; attempt < MaxRetries; attempt++)
@@ -978,12 +981,13 @@ public sealed partial class ConnectionPool :
                     catch { /* best-effort cleanup */ }
                 }
 
-                var connection = await CreateConnectionAsync(brokerId, host, port, token, cancellationToken).ConfigureAwait(false);
+                var connection = await CreateConnectionAsync(brokerId, host, port, cancellationToken).ConfigureAwait(false);
 
                 // Verify connection is still valid
                 if (connection.IsConnected)
                 {
                     ResetReconnectBackoff(endpoint, brokerId, host, port);
+                    ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, host, port));
                     return connection;
                 }
 
@@ -1000,12 +1004,6 @@ public sealed partial class ConnectionPool :
 
             throw new InvalidOperationException($"Failed to create connection after {MaxRetries} retries");
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-        {
-            throw new KafkaException(
-                ErrorCode.RequestTimedOut,
-                $"Connection timeout after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
-        }
         finally
         {
             creationLock.Release();
@@ -1016,8 +1014,7 @@ public sealed partial class ConnectionPool :
         int brokerId,
         string host,
         int port,
-        CancellationToken cancellationToken,
-        CancellationToken callerCancellationToken)
+        CancellationToken cancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
         return await RunWithReconnectBackoffAsync(
@@ -1025,12 +1022,18 @@ public sealed partial class ConnectionPool :
             brokerId,
             host,
             port,
-            () => CreateConnectionCoreAsync(
+            () => RunConnectionSetupAttemptAsync(
                 brokerId,
                 host,
                 port,
-                cancellationToken,
-                callerCancellationToken),
+                (setupTimeout, setupCancellationToken) => CreateConnectionCoreAsync(
+                    brokerId,
+                    host,
+                    port,
+                    setupTimeout,
+                    setupCancellationToken,
+                    cancellationToken),
+                cancellationToken),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -1038,6 +1041,7 @@ public sealed partial class ConnectionPool :
         int brokerId,
         string host,
         int port,
+        TimeSpan connectionSetupTimeout,
         CancellationToken cancellationToken,
         CancellationToken callerCancellationToken)
     {
@@ -1074,7 +1078,7 @@ public sealed partial class ConnectionPool :
                 Volatile.Read(ref _capabilityObserver),
                 _metadataClusterIdentity);
 
-            await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+            await connection.ConnectAsync(connectionSetupTimeout, cancellationToken).ConfigureAwait(false);
 
             _connectionsByEndpoint[endpoint] = connection;
             if (brokerId >= 0)
@@ -1098,6 +1102,76 @@ public sealed partial class ConnectionPool :
                 RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
+    }
+
+    private async ValueTask<IKafkaConnection> RunConnectionSetupAttemptAsync(
+        int brokerId,
+        string host,
+        int port,
+        Func<TimeSpan, CancellationToken, ValueTask<IKafkaConnection>> createConnection,
+        CancellationToken callerCancellationToken)
+    {
+        var setupKey = new ConnectionSetupKey(brokerId, host, port);
+        var timeout = GetConnectionSetupTimeout(setupKey);
+        _connectionSetupTimeoutObserver?.Invoke(timeout);
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            callerCancellationToken,
+            timeoutCts.Token);
+
+        try
+        {
+            var connection = await createConnection(timeout, linkedCts.Token).ConfigureAwait(false);
+            if (!connection.IsConnected)
+                RecordConnectionSetupFailure(setupKey);
+            return connection;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
+        {
+            RecordConnectionSetupFailure(setupKey);
+            throw new KafkaException(
+                ErrorCode.RequestTimedOut,
+                $"Connection setup timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
+        }
+        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        {
+            RecordConnectionSetupFailure(setupKey);
+            throw;
+        }
+    }
+
+    private TimeSpan GetConnectionSetupTimeout(ConnectionSetupKey setupKey)
+    {
+        if (!_connectionSetupTimeouts.TryGetValue(setupKey, out var state))
+            return _connectionOptions.ConnectionTimeout;
+
+        lock (state.Sync)
+            return CalculateConnectionSetupTimeout(state.FailureCount);
+    }
+
+    private void RecordConnectionSetupFailure(ConnectionSetupKey setupKey)
+    {
+        var state = _connectionSetupTimeouts.GetOrAdd(setupKey, static _ => new ConnectionSetupTimeoutState());
+        lock (state.Sync)
+            state.FailureCount = Math.Min(state.FailureCount + 1, 30);
+    }
+
+    private void ResetConnectionSetupTimeout(ConnectionSetupKey setupKey)
+        => _connectionSetupTimeouts.TryRemove(setupKey, out _);
+
+    internal TimeSpan CalculateConnectionSetupTimeout(int failureCount)
+    {
+        var initialMs = _connectionOptions.ConnectionTimeout.TotalMilliseconds;
+        var maxMs = _connectionOptions.ConnectionTimeoutMax.TotalMilliseconds;
+        if (failureCount <= 0 || maxMs <= initialMs)
+            return TimeSpan.FromMilliseconds(initialMs);
+
+        var exponent = Math.Min(failureCount - 1, 30);
+        var baseMs = initialMs * Math.Pow(2, exponent);
+        var randomValue = Math.Clamp(_randomDouble(), 0, 1);
+        var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));
+
+        return TimeSpan.FromMilliseconds(Math.Min(maxMs, jitteredMs));
     }
 
     private async ValueTask<IKafkaConnection> RunWithReconnectBackoffAsync(
@@ -1724,6 +1798,7 @@ public sealed partial class ConnectionPool :
             _connectionsById.Clear();
             _connectionGroupsById.Clear();
             _reconnectBackoffs.Clear();
+            _connectionSetupTimeouts.Clear();
             _connectionCreationLocks.Clear();
             _connectionReplacementLocks.Clear();
             _groupCreationLocks.Clear();
@@ -1877,7 +1952,14 @@ public sealed partial class ConnectionPool :
         }
     }
 
+    private sealed class ConnectionSetupTimeoutState
+    {
+        public readonly object Sync = new();
+        public int FailureCount;
+    }
+
     private readonly record struct EndpointKey(string Host, int Port);
+    private readonly record struct ConnectionSetupKey(int BrokerId, string Host, int Port);
     private readonly record struct BrokerInfo(int BrokerId, string Host, int Port);
     private readonly record struct IdleConnectionDisposalResult(bool Reaped, bool CanRestore);
 }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1166,7 +1166,8 @@ public sealed partial class ConnectionPool :
         if (failureCount <= 0 || maxMs <= initialMs)
             return TimeSpan.FromMilliseconds(initialMs);
 
-        var exponent = Math.Min(failureCount - 1, 30);
+        // Zero is the initial attempt; after the first failed setup, failureCount is one.
+        var exponent = Math.Min(failureCount, 30);
         var baseMs = initialMs * Math.Pow(2, exponent);
         var randomValue = Math.Clamp(_randomDouble(), 0, 1);
         var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1180,7 +1180,16 @@ public sealed partial class ConnectionPool :
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
             timeoutCts.Token);
-        await connectionLock.WaitAsync(linkedCts.Token).ConfigureAwait(false);
+        try
+        {
+            await connectionLock.WaitAsync(linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new KafkaException(
+                ErrorCode.RequestTimedOut,
+                $"Timed out after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms waiting for a connection lock");
+        }
     }
 
     private static KafkaException CreateConnectionSetupTimeoutException(

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1018,7 +1018,7 @@ public sealed partial class ConnectionPool :
         CancellationToken cancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
-        return await RunWithReconnectBackoffAsync(
+        var connection = await RunWithReconnectBackoffAsync(
             endpoint,
             brokerId,
             host,
@@ -1036,6 +1036,14 @@ public sealed partial class ConnectionPool :
                     cancellationToken),
                 cancellationToken),
             cancellationToken).ConfigureAwait(false);
+
+        // Publish only after the hard setup deadline has accepted the result. A factory
+        // that ignores cancellation may finish late, but that connection is never visible.
+        _connectionsByEndpoint[endpoint] = connection;
+        if (brokerId >= 0)
+            _connectionsById[brokerId] = connection;
+
+        return connection;
     }
 
     private async ValueTask<IKafkaConnection> CreateConnectionCoreAsync(
@@ -1057,12 +1065,6 @@ public sealed partial class ConnectionPool :
             if (_connectionFactory is not null)
             {
                 var factoryConnection = await _connectionFactory(brokerId, host, port, 0, cancellationToken).ConfigureAwait(false);
-                _connectionsByEndpoint[endpoint] = factoryConnection;
-                if (brokerId >= 0)
-                {
-                    _connectionsById[brokerId] = factoryConnection;
-                }
-
                 LogCreatedConnection(brokerId, host, port);
                 return factoryConnection;
             }
@@ -1080,12 +1082,6 @@ public sealed partial class ConnectionPool :
                 _metadataClusterIdentity);
 
             await connection.ConnectAsync(connectionSetupTimeout, cancellationToken).ConfigureAwait(false);
-
-            _connectionsByEndpoint[endpoint] = connection;
-            if (brokerId >= 0)
-            {
-                _connectionsById[brokerId] = connection;
-            }
 
             LogCreatedConnection(brokerId, host, port);
 
@@ -1206,11 +1202,13 @@ public sealed partial class ConnectionPool :
     {
         var initialMs = _connectionOptions.ConnectionTimeout.TotalMilliseconds;
         var maxMs = _connectionOptions.ConnectionTimeoutMax.TotalMilliseconds;
-        if (failureCount <= 0 || maxMs <= initialMs)
+        if (maxMs <= initialMs)
             return TimeSpan.FromMilliseconds(initialMs);
 
-        // Zero is the initial attempt; after the first failed setup, failureCount is one.
-        var exponent = Math.Min(failureCount, 30);
+        // KIP-601 applies jitter from attempt zero. Cap the exponent before jitter so a
+        // low random factor can still produce a value below max at the saturation point.
+        var maxExponent = Math.Log(maxMs / initialMs, 2);
+        var exponent = Math.Min(Math.Max(failureCount, 0), Math.Min(maxExponent, 30));
         var baseMs = initialMs * Math.Pow(2, exponent);
         var randomValue = Math.Clamp(_randomDouble(), 0, 1);
         var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -789,7 +789,7 @@ public sealed partial class ConnectionPool :
             (brokerId, index),
             static _ => new SemaphoreSlim(1, 1));
 
-        await replacementLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForConnectionLockAsync(replacementLock, cancellationToken).ConfigureAwait(false);
         try
         {
             // Re-check: another caller may have already replaced this connection
@@ -978,7 +978,7 @@ public sealed partial class ConnectionPool :
         // contract (multiple awaiters) and captured a caller-scoped CTS that could be disposed.
         var creationLock = _connectionCreationLocks.GetOrAdd(endpoint, static _ => new SemaphoreSlim(1, 1));
 
-        await creationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForConnectionLockAsync(creationLock, cancellationToken).ConfigureAwait(false);
         try
         {
             for (var attempt = 0; attempt < MaxRetries; attempt++)
@@ -1143,7 +1143,7 @@ public sealed partial class ConnectionPool :
                 RecordConnectionSetupFailure(setupKey);
             return connection;
         }
-        catch (TimeoutException) when (!callerCancellationToken.IsCancellationRequested)
+        catch (TimeoutException)
         {
             timeoutCts.Cancel();
             ObserveLateConnectionSetup(connectionTask);
@@ -1153,6 +1153,7 @@ public sealed partial class ConnectionPool :
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
+            ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
                 RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
@@ -1162,12 +1163,24 @@ public sealed partial class ConnectionPool :
             ObserveLateConnectionSetup(connectionTask);
             throw;
         }
-        catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
+        catch (Exception)
         {
+            ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
                 RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
             throw;
         }
+    }
+
+    private async ValueTask WaitForConnectionLockAsync(
+        SemaphoreSlim connectionLock,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+        await connectionLock.WaitAsync(linkedCts.Token).ConfigureAwait(false);
     }
 
     private static KafkaException CreateConnectionSetupTimeoutException(

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1320,7 +1320,9 @@ public sealed partial class ConnectionPool :
         }
         catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
         {
-            ObserveLateConnectionSetup(connectionTask);
+            // A caller-scoped factory may ignore cancellation indefinitely. Observe and
+            // clean up any eventual result without making pool disposal depend on it.
+            ObserveLateConnectionSetup(connectionTask, trackDisposal: false);
             throw;
         }
         catch (Exception)
@@ -1371,10 +1373,16 @@ public sealed partial class ConnectionPool :
             ErrorCode.RequestTimedOut,
             $"Connection operation timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
 
-    private static void ObserveLateConnectionSetup(Task<IKafkaConnection>? connectionTask)
+    private void ObserveLateConnectionSetup(
+        Task<IKafkaConnection>? connectionTask,
+        bool trackDisposal = true)
     {
-        if (connectionTask is not null)
-            _ = DisposeLateConnectionSetupAsync(connectionTask);
+        if (connectionTask is null)
+            return;
+
+        var disposalTask = DisposeLateConnectionSetupAsync(connectionTask);
+        if (trackDisposal)
+            TrackConnectionDisposal(disposalTask);
     }
 
     private static async Task DisposeLateConnectionSetupAsync(Task<IKafkaConnection> connectionTask)
@@ -1878,9 +1886,13 @@ public sealed partial class ConnectionPool :
     private void RetireConnection(IKafkaConnection connection)
     {
         BeginConnectionRetirement(connection);
-        var drainTask = DrainRetiredConnectionAsync(connection);
-        _retiredConnectionDisposalTasks.TryAdd(drainTask, 0);
-        _ = drainTask.ContinueWith(
+        TrackConnectionDisposal(DrainRetiredConnectionAsync(connection));
+    }
+
+    private void TrackConnectionDisposal(Task disposalTask)
+    {
+        _retiredConnectionDisposalTasks.TryAdd(disposalTask, 0);
+        _ = disposalTask.ContinueWith(
             static (task, state) => ((ConnectionPool)state!).ObserveRetiredConnectionDisposal(task),
             this,
             CancellationToken.None,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1209,7 +1209,8 @@ public sealed partial class ConnectionPool :
         SemaphoreSlim connectionLock,
         CancellationToken cancellationToken)
     {
-        using var timeoutCts = new CancellationTokenSource(_connectionOptions.ConnectionTimeout);
+        var lockTimeout = _connectionOptions.ConnectionTimeoutMax;
+        using var timeoutCts = new CancellationTokenSource(lockTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
             timeoutCts.Token);
@@ -1221,7 +1222,7 @@ public sealed partial class ConnectionPool :
         {
             throw new KafkaException(
                 ErrorCode.RequestTimedOut,
-                $"Timed out after {(int)_connectionOptions.ConnectionTimeout.TotalMilliseconds}ms waiting for a connection lock");
+                $"Timed out after {(int)lockTimeout.TotalMilliseconds}ms waiting for a connection lock");
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -579,6 +579,7 @@ public sealed partial class ConnectionPool :
             for (var i = 0; i < initialCount; i++)
             {
                 connections[i] = await tasks[i].ConfigureAwait(false);
+                ThrowIfGroupConnectionDisconnected(connections[i], brokerId);
             }
 
             // Atomically set the connection group
@@ -619,6 +620,19 @@ public sealed partial class ConnectionPool :
             }
         }
     }
+
+    private static void ThrowIfGroupConnectionDisconnected(
+        IKafkaConnection connection,
+        int brokerId)
+    {
+        if (!connection.IsConnected)
+            throw CreateDisconnectedGroupConnectionException(brokerId);
+    }
+
+    private static KafkaException CreateDisconnectedGroupConnectionException(int brokerId) =>
+        new(
+            ErrorCode.NetworkException,
+            $"Broker {brokerId} disconnected during connection group setup.");
 
     public async ValueTask<int> ScaleConnectionGroupAsync(int brokerId, int newCount, CancellationToken cancellationToken = default)
     {
@@ -666,6 +680,11 @@ public sealed partial class ConnectionPool :
             try
             {
                 await Task.WhenAll(tasks).ConfigureAwait(false);
+                for (var i = 0; i < additionalCount; i++)
+                {
+                    var connection = await tasks[i].ConfigureAwait(false);
+                    ThrowIfGroupConnectionDisconnected(connection, brokerId);
+                }
             }
             catch
             {
@@ -808,6 +827,20 @@ public sealed partial class ConnectionPool :
                 index,
                 cancellationToken,
                 cancellationToken).ConfigureAwait(false);
+
+            if (!connection.IsConnected)
+            {
+                try { await connection.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort cleanup of a disconnected replacement */ }
+
+                var disconnectedEndpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+                RecordReconnectFailure(
+                    disconnectedEndpoint,
+                    brokerId,
+                    brokerInfo.Host,
+                    brokerInfo.Port);
+                throw CreateDisconnectedGroupConnectionException(brokerId);
+            }
 
             // Acquire _scaleLock to protect the array write against concurrent
             // ShrinkConnectionGroupAsync, which may have swapped the array reference.

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -581,7 +581,7 @@ public sealed partial class ConnectionPool :
 
             await WaitForConnectionGroupSetupAsync(
                     tasks,
-                    setupTimeout,
+                    _connectionOptions.ConnectionTimeoutMax,
                     setupRoundCts,
                     brokerId,
                     brokerInfo.Host,
@@ -636,7 +636,7 @@ public sealed partial class ConnectionPool :
 
     private static async ValueTask WaitForConnectionGroupSetupAsync(
         Task<IKafkaConnection>[] tasks,
-        TimeSpan setupTimeout,
+        TimeSpan operationTimeout,
         CancellationTokenSource setupRoundCts,
         int brokerId,
         string host,
@@ -646,13 +646,13 @@ public sealed partial class ConnectionPool :
         try
         {
             await Task.WhenAll(tasks)
-                .WaitAsync(setupTimeout, cancellationToken)
+                .WaitAsync(operationTimeout, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (TimeoutException)
         {
             setupRoundCts.Cancel();
-            throw CreateConnectionSetupTimeoutException(setupTimeout, brokerId, host, port);
+            throw CreateConnectionSetupTimeoutException(operationTimeout, brokerId, host, port);
         }
     }
 
@@ -717,7 +717,7 @@ public sealed partial class ConnectionPool :
             {
                 await WaitForConnectionGroupSetupAsync(
                         tasks,
-                        setupTimeout,
+                        _connectionOptions.ConnectionTimeoutMax,
                         setupRoundCts,
                         brokerId,
                         brokerInfo.Host,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -63,6 +63,8 @@ public sealed partial class ConnectionPool :
     private readonly MetadataClusterIdentity _metadataClusterIdentity = new();
     private readonly Action? _brokerEndpointUpdated;
     private readonly Action<TimeSpan>? _connectionSetupTimeoutObserver;
+    private readonly Func<TimeSpan, CancellationToken, ValueTask>? _reconnectBackoffDelay;
+    private readonly Func<long>? _timestampProvider;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
@@ -150,7 +152,9 @@ public sealed partial class ConnectionPool :
         TimeSpan? idleReapDrainTimeout = null,
         Func<double>? randomDouble = null,
         Action? brokerEndpointUpdated = null,
-        Action<TimeSpan>? connectionSetupTimeoutObserver = null)
+        Action<TimeSpan>? connectionSetupTimeoutObserver = null,
+        Func<TimeSpan, CancellationToken, ValueTask>? reconnectBackoffDelay = null,
+        Func<long>? timestampProvider = null)
     {
         _clientId = clientId;
         _connectionOptions = ConfigureSharedOAuthBearerProvider(
@@ -167,6 +171,8 @@ public sealed partial class ConnectionPool :
         _randomDouble = randomDouble ?? SharedRandomDouble;
         _brokerEndpointUpdated = brokerEndpointUpdated;
         _connectionSetupTimeoutObserver = connectionSetupTimeoutObserver;
+        _reconnectBackoffDelay = reconnectBackoffDelay;
+        _timestampProvider = timestampProvider;
         // No shared pool needed: factory-created connections manage their own pools.
         StartIdleConnectionReaper();
     }
@@ -999,7 +1005,7 @@ public sealed partial class ConnectionPool :
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
                 _responseMemoryAdmissionsEnabled,
-                GetBrokerThrottleState(brokerId, endpoint),
+                GetBrokerThrottleState(brokerId, new EndpointKey(host, port)),
                 Volatile.Read(ref _capabilityObserver),
                 _metadataClusterIdentity);
 
@@ -1174,7 +1180,7 @@ public sealed partial class ConnectionPool :
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
                 _responseMemoryAdmissionsEnabled,
-                GetBrokerThrottleState(brokerId, endpoint),
+                GetBrokerThrottleState(brokerId, new EndpointKey(host, port)),
                 Volatile.Read(ref _capabilityObserver),
                 _metadataClusterIdentity);
 
@@ -1398,7 +1404,7 @@ public sealed partial class ConnectionPool :
             int failureCount;
             lock (state.Sync)
             {
-                var retryAfterTicks = state.NextAttemptTimestamp - Stopwatch.GetTimestamp();
+                var retryAfterTicks = state.NextAttemptTimestamp - GetTimestamp();
                 if (state.FailureCount == 0 || retryAfterTicks <= 0)
                     return;
 
@@ -1407,7 +1413,14 @@ public sealed partial class ConnectionPool :
             }
 
             LogReconnectBackoffDelay(delay.TotalMilliseconds, brokerId, host, port, failureCount);
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            if (_reconnectBackoffDelay is null)
+            {
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _reconnectBackoffDelay(delay, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 
@@ -1422,7 +1435,7 @@ public sealed partial class ConnectionPool :
             state.FailureCount = Math.Min(state.FailureCount + 1, 30);
             failureCount = state.FailureCount;
             delay = CalculateReconnectBackoffDelay(failureCount);
-            state.NextAttemptTimestamp = Stopwatch.GetTimestamp() + ToStopwatchTicks(delay);
+            state.NextAttemptTimestamp = GetTimestamp() + ToStopwatchTicks(delay);
         }
 
         LogReconnectBackoffScheduled(delay.TotalMilliseconds, brokerId, host, port, failureCount);
@@ -1461,6 +1474,8 @@ public sealed partial class ConnectionPool :
 
         return (long)(delay.TotalSeconds * Stopwatch.Frequency);
     }
+
+    private long GetTimestamp() => _timestampProvider?.Invoke() ?? Stopwatch.GetTimestamp();
 
     internal async ValueTask<int> ReapIdleConnectionsAsync()
     {

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -548,6 +548,11 @@ public sealed partial class ConnectionPool :
 
         var connections = new IKafkaConnection[initialCount];
         var tasks = new Task<IKafkaConnection>[initialCount];
+        var setupKey = new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port);
+        var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+        // KIP-601 progression is per broker setup round, not per physical connection.
+        // Every sibling uses one jittered snapshot; the outer catch advances it once.
+        var setupTimeout = GetConnectionSetupTimeout(setupKey);
 
         var success = false;
         try
@@ -561,7 +566,9 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Port,
                     index,
                     cancellationToken,
-                    cancellationToken).AsTask();
+                    cancellationToken,
+                    setupTimeout,
+                    recordFailure: false).AsTask();
             }
 
             // RunConnectionSetupAttemptAsync applies a hard Task.WaitAsync deadline around
@@ -576,14 +583,18 @@ public sealed partial class ConnectionPool :
 
             // Atomically set the connection group
             _connectionGroupsById[brokerId] = connections;
-            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
             ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
-            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
+            ResetConnectionSetupTimeout(setupKey);
 
             LogCreatedConnectionGroup(initialCount, brokerId);
 
             success = true;
             return connections[0];
+        }
+        catch when (!cancellationToken.IsCancellationRequested)
+        {
+            RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            throw;
         }
         finally
         {
@@ -631,6 +642,10 @@ public sealed partial class ConnectionPool :
 
             var existingCount = currentGroup?.Length ?? 0;
             var additionalCount = newCount - existingCount;
+            var setupKey = new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port);
+            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
+            // Scale-up is one logical setup round even when it creates several siblings.
+            var setupTimeout = GetConnectionSetupTimeout(setupKey);
 
             var tasks = new Task<IKafkaConnection>[additionalCount];
 
@@ -643,7 +658,9 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Port,
                     index,
                     cancellationToken,
-                    cancellationToken).AsTask();
+                    cancellationToken,
+                    setupTimeout,
+                    recordFailure: false).AsTask();
             }
 
             try
@@ -654,6 +671,9 @@ public sealed partial class ConnectionPool :
             {
                 // Close any successfully created connections to avoid leaking TCP handles.
                 await DisposeCompletedTaskConnectionsAsync(tasks).ConfigureAwait(false);
+                if (!cancellationToken.IsCancellationRequested)
+                    RecordConnectionAttemptFailure(
+                        setupKey, endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
                 throw;
             }
 
@@ -666,9 +686,8 @@ public sealed partial class ConnectionPool :
 
             // Atomically swap the connection group
             _connectionGroupsById[brokerId] = newGroup;
-            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
             ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
-            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
+            ResetConnectionSetupTimeout(setupKey);
 
             LogScaledConnectionGroup(existingCount, newCount, brokerId);
             return newCount;
@@ -844,7 +863,9 @@ public sealed partial class ConnectionPool :
         int port,
         int index,
         CancellationToken cancellationToken,
-        CancellationToken callerCancellationToken)
+        CancellationToken callerCancellationToken,
+        TimeSpan? setupTimeoutOverride = null,
+        bool recordFailure = true)
     {
         var endpoint = new EndpointKey(host, port);
         return await RunWithReconnectBackoffAsync(
@@ -863,7 +884,9 @@ public sealed partial class ConnectionPool :
                     index,
                     setupTimeout,
                     setupCancellationToken),
-                callerCancellationToken),
+                callerCancellationToken,
+                setupTimeoutOverride,
+                recordFailure),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -1096,11 +1119,13 @@ public sealed partial class ConnectionPool :
         string host,
         int port,
         Func<TimeSpan, CancellationToken, ValueTask<IKafkaConnection>> createConnection,
-        CancellationToken callerCancellationToken)
+        CancellationToken callerCancellationToken,
+        TimeSpan? setupTimeoutOverride = null,
+        bool recordFailure = true)
     {
         var setupKey = new ConnectionSetupKey(brokerId, host, port);
         var endpoint = new EndpointKey(host, port);
-        var timeout = GetConnectionSetupTimeout(setupKey);
+        var timeout = setupTimeoutOverride ?? GetConnectionSetupTimeout(setupKey);
         _connectionSetupTimeoutObserver?.Invoke(timeout);
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
@@ -1114,7 +1139,7 @@ public sealed partial class ConnectionPool :
             var connection = await connectionTask
                 .WaitAsync(timeout, callerCancellationToken)
                 .ConfigureAwait(false);
-            if (!connection.IsConnected)
+            if (!connection.IsConnected && recordFailure)
                 RecordConnectionSetupFailure(setupKey);
             return connection;
         }
@@ -1122,14 +1147,14 @@ public sealed partial class ConnectionPool :
         {
             timeoutCts.Cancel();
             ObserveLateConnectionSetup(connectionTask);
-            RecordConnectionSetupFailure(setupKey);
-            RecordReconnectFailure(endpoint, brokerId, host, port);
+            if (recordFailure)
+                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
-            RecordConnectionSetupFailure(setupKey);
-            RecordReconnectFailure(endpoint, brokerId, host, port);
+            if (recordFailure)
+                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
         }
         catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
@@ -1139,8 +1164,8 @@ public sealed partial class ConnectionPool :
         }
         catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
         {
-            RecordConnectionSetupFailure(setupKey);
-            RecordReconnectFailure(endpoint, brokerId, host, port);
+            if (recordFailure)
+                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
             throw;
         }
     }
@@ -1176,7 +1201,7 @@ public sealed partial class ConnectionPool :
     private TimeSpan GetConnectionSetupTimeout(ConnectionSetupKey setupKey)
     {
         if (!_connectionSetupTimeouts.TryGetValue(setupKey, out var state))
-            return _connectionOptions.ConnectionTimeout;
+            return CalculateConnectionSetupTimeout(failureCount: 0);
 
         lock (state.Sync)
             return CalculateConnectionSetupTimeout(state.FailureCount);
@@ -1187,6 +1212,17 @@ public sealed partial class ConnectionPool :
         var state = _connectionSetupTimeouts.GetOrAdd(setupKey, static _ => new ConnectionSetupTimeoutState());
         lock (state.Sync)
             state.FailureCount = Math.Min(state.FailureCount + 1, 30);
+    }
+
+    private void RecordConnectionAttemptFailure(
+        ConnectionSetupKey setupKey,
+        EndpointKey endpoint,
+        int brokerId,
+        string host,
+        int port)
+    {
+        RecordConnectionSetupFailure(setupKey);
+        RecordReconnectFailure(endpoint, brokerId, host, port);
     }
 
     private void ResetConnectionSetupTimeout(ConnectionSetupKey setupKey)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -846,7 +846,17 @@ public sealed partial class ConnectionPool :
             // ShrinkConnectionGroupAsync, which may have swapped the array reference.
             bool stored = false;
             IKafkaConnection? oldConnection = null;
-            await _scaleLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await WaitForConnectionLockAsync(_scaleLock, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                try { await connection.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort cleanup of an unpublished replacement */ }
+                throw;
+            }
+
             try
             {
                 if (_connectionGroupsById.TryGetValue(brokerId, out var connections) && index < connections.Length)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -1118,25 +1118,67 @@ public sealed partial class ConnectionPool :
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
             callerCancellationToken,
             timeoutCts.Token);
+        Task<IKafkaConnection>? connectionTask = null;
 
         try
         {
-            var connection = await createConnection(timeout, linkedCts.Token).ConfigureAwait(false);
+            connectionTask = createConnection(timeout, linkedCts.Token).AsTask();
+            var connection = await connectionTask
+                .WaitAsync(timeout, callerCancellationToken)
+                .ConfigureAwait(false);
             if (!connection.IsConnected)
                 RecordConnectionSetupFailure(setupKey);
             return connection;
         }
+        catch (TimeoutException) when (!callerCancellationToken.IsCancellationRequested)
+        {
+            timeoutCts.Cancel();
+            ObserveLateConnectionSetup(connectionTask);
+            RecordConnectionSetupFailure(setupKey);
+            throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
+        }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
             RecordConnectionSetupFailure(setupKey);
-            throw new KafkaException(
-                ErrorCode.RequestTimedOut,
-                $"Connection setup timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
+            throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
+        }
+        catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
+        {
+            ObserveLateConnectionSetup(connectionTask);
+            throw;
         }
         catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
         {
             RecordConnectionSetupFailure(setupKey);
             throw;
+        }
+    }
+
+    private static KafkaException CreateConnectionSetupTimeoutException(
+        TimeSpan timeout,
+        int brokerId,
+        string host,
+        int port)
+        => new(
+            ErrorCode.RequestTimedOut,
+            $"Connection setup timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
+
+    private static void ObserveLateConnectionSetup(Task<IKafkaConnection>? connectionTask)
+    {
+        if (connectionTask is not null)
+            _ = DisposeLateConnectionSetupAsync(connectionTask);
+    }
+
+    private static async Task DisposeLateConnectionSetupAsync(Task<IKafkaConnection> connectionTask)
+    {
+        try
+        {
+            var connection = await connectionTask.ConfigureAwait(false);
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // The caller already received cancellation/timeout; only observe late failure.
         }
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -564,8 +564,9 @@ public sealed partial class ConnectionPool :
                     cancellationToken).AsTask();
             }
 
-            // Each setup task carries its own adaptive deadline, so the aggregate cannot
-            // hang even though lock and reconnect-backoff waits remain outside that deadline.
+            // RunConnectionSetupAttemptAsync applies a hard Task.WaitAsync deadline around
+            // each setup, so factory/auth code that ignores cancellation cannot stall the
+            // aggregate. Deadlines stay per attempt so lock and reconnect waits remain outside.
             await Task.WhenAll(tasks).ConfigureAwait(false);
 
             for (var i = 0; i < initialCount; i++)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -553,6 +553,8 @@ public sealed partial class ConnectionPool :
         // KIP-601 progression is per broker setup round, not per physical connection.
         // Every sibling uses one jittered snapshot; the outer catch advances it once.
         var setupTimeout = GetConnectionSetupTimeout(setupKey);
+        using var setupRoundCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var setupRoundToken = setupRoundCts.Token;
 
         var success = false;
         try
@@ -565,16 +567,21 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Host,
                     brokerInfo.Port,
                     index,
-                    cancellationToken,
-                    cancellationToken,
+                    setupRoundToken,
+                    setupRoundToken,
                     setupTimeout,
                     recordFailure: false).AsTask();
             }
 
-            // RunConnectionSetupAttemptAsync applies a hard Task.WaitAsync deadline around
-            // each setup, so factory/auth code that ignores cancellation cannot stall the
-            // aggregate. Deadlines stay per attempt so lock and reconnect waits remain outside.
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await WaitForConnectionGroupSetupAsync(
+                    tasks,
+                    setupTimeout,
+                    setupRoundCts,
+                    brokerId,
+                    brokerInfo.Host,
+                    brokerInfo.Port,
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             for (var i = 0; i < initialCount; i++)
             {
@@ -621,6 +628,28 @@ public sealed partial class ConnectionPool :
         }
     }
 
+    private static async ValueTask WaitForConnectionGroupSetupAsync(
+        Task<IKafkaConnection>[] tasks,
+        TimeSpan setupTimeout,
+        CancellationTokenSource setupRoundCts,
+        int brokerId,
+        string host,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.WhenAll(tasks)
+                .WaitAsync(setupTimeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            setupRoundCts.Cancel();
+            throw CreateConnectionSetupTimeoutException(setupTimeout, brokerId, host, port);
+        }
+    }
+
     private static void ThrowIfGroupConnectionDisconnected(
         IKafkaConnection connection,
         int brokerId)
@@ -660,6 +689,8 @@ public sealed partial class ConnectionPool :
             var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
             // Scale-up is one logical setup round even when it creates several siblings.
             var setupTimeout = GetConnectionSetupTimeout(setupKey);
+            using var setupRoundCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var setupRoundToken = setupRoundCts.Token;
 
             var tasks = new Task<IKafkaConnection>[additionalCount];
 
@@ -671,15 +702,23 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Host,
                     brokerInfo.Port,
                     index,
-                    cancellationToken,
-                    cancellationToken,
+                    setupRoundToken,
+                    setupRoundToken,
                     setupTimeout,
                     recordFailure: false).AsTask();
             }
 
             try
             {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                await WaitForConnectionGroupSetupAsync(
+                        tasks,
+                        setupTimeout,
+                        setupRoundCts,
+                        brokerId,
+                        brokerInfo.Host,
+                        brokerInfo.Port,
+                        cancellationToken)
+                    .ConfigureAwait(false);
                 for (var i = 0; i < additionalCount; i++)
                 {
                     var connection = await tasks[i].ConfigureAwait(false);

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -71,7 +71,8 @@ public sealed partial class ConnectionPool :
     private readonly ConcurrentDictionary<int, IKafkaConnection> _connectionsById = new();
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
     private readonly ConcurrentDictionary<EndpointKey, SemaphoreSlim> _connectionCreationLocks = new();
-    private readonly ConcurrentDictionary<EndpointKey, ReconnectBackoffState> _reconnectBackoffs = new();
+    // Reconnect backoff and setup-timeout progression share the same logical identity.
+    private readonly ConcurrentDictionary<ConnectionSetupKey, ReconnectBackoffState> _reconnectBackoffs = new();
     private readonly ConcurrentDictionary<int, BrokerThrottleState> _brokerThrottleStates = new();
     private readonly ConcurrentDictionary<EndpointKey, BrokerThrottleState> _bootstrapThrottleStates = new();
     // Logical broker + host:port identity is deliberate: DNS IP rotation keeps failure
@@ -363,9 +364,9 @@ public sealed partial class ConnectionPool :
             if (!_brokers.TryUpdate(brokerId, brokerInfo, previous))
                 continue;
 
-            _connectionSetupTimeouts.TryRemove(
-                new ConnectionSetupKey(brokerId, previous.Host, previous.Port),
-                out _);
+            var previousKey = new ConnectionSetupKey(brokerId, previous.Host, previous.Port);
+            _connectionSetupTimeouts.TryRemove(previousKey, out _);
+            RemoveReconnectBackoff(previousKey);
             _brokerEndpointUpdated?.Invoke();
             RetireBrokerConnections(brokerId, previous);
             break;
@@ -555,7 +556,6 @@ public sealed partial class ConnectionPool :
         var connections = new IKafkaConnection[initialCount];
         var tasks = new Task<IKafkaConnection>[initialCount];
         var setupKey = new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port);
-        var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
         // KIP-601 progression is per broker setup round, not per physical connection.
         // Every sibling uses one jittered snapshot; the outer catch advances it once.
         var setupTimeout = GetConnectionSetupTimeout(setupKey);
@@ -574,7 +574,7 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Port,
                     index,
                     setupRoundToken,
-                    setupRoundToken,
+                    cancellationToken,
                     setupTimeout,
                     recordFailure: false).AsTask();
             }
@@ -597,7 +597,7 @@ public sealed partial class ConnectionPool :
 
             // Atomically set the connection group
             _connectionGroupsById[brokerId] = connections;
-            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
             ResetConnectionSetupTimeout(setupKey);
 
             LogCreatedConnectionGroup(initialCount, brokerId);
@@ -607,7 +607,7 @@ public sealed partial class ConnectionPool :
         }
         catch when (!cancellationToken.IsCancellationRequested)
         {
-            RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            RecordConnectionAttemptFailure(setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
             throw;
         }
         finally
@@ -692,7 +692,6 @@ public sealed partial class ConnectionPool :
             var existingCount = currentGroup?.Length ?? 0;
             var additionalCount = newCount - existingCount;
             var setupKey = new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port);
-            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
             // Scale-up is one logical setup round even when it creates several siblings.
             var setupTimeout = GetConnectionSetupTimeout(setupKey);
             using var setupRoundCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -709,7 +708,7 @@ public sealed partial class ConnectionPool :
                     brokerInfo.Port,
                     index,
                     setupRoundToken,
-                    setupRoundToken,
+                    cancellationToken,
                     setupTimeout,
                     recordFailure: false).AsTask();
             }
@@ -737,7 +736,7 @@ public sealed partial class ConnectionPool :
                 await DisposeCompletedTaskConnectionsAsync(tasks).ConfigureAwait(false);
                 if (!cancellationToken.IsCancellationRequested)
                     RecordConnectionAttemptFailure(
-                        setupKey, endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+                        setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
                 throw;
             }
 
@@ -750,7 +749,7 @@ public sealed partial class ConnectionPool :
 
             // Atomically swap the connection group
             _connectionGroupsById[brokerId] = newGroup;
-            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
             ResetConnectionSetupTimeout(setupKey);
 
             LogScaledConnectionGroup(existingCount, newCount, brokerId);
@@ -845,6 +844,34 @@ public sealed partial class ConnectionPool :
 
     private async ValueTask<IKafkaConnection> ReplaceConnectionInGroupAsync(int brokerId, BrokerInfo brokerInfo, int index, CancellationToken cancellationToken)
     {
+        var timeout = _connectionOptions.ConnectionTimeoutMax;
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+        try
+        {
+            return await ReplaceConnectionInGroupCoreAsync(
+                    brokerId,
+                    brokerInfo,
+                    index,
+                    linkedCts.Token,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateConnectionOperationTimeoutException(timeout, brokerId, brokerInfo.Host, brokerInfo.Port);
+        }
+    }
+
+    private async ValueTask<IKafkaConnection> ReplaceConnectionInGroupCoreAsync(
+        int brokerId,
+        BrokerInfo brokerInfo,
+        int index,
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
+    {
         // Use a per-(broker,index) SemaphoreSlim instead of Lazy<ValueTask> to avoid
         // capturing a caller-scoped CancellationToken that gets disposed in the caller's finally block.
         // The adaptive setup attempt creates its timeout CTS only after this lock is acquired,
@@ -871,16 +898,15 @@ public sealed partial class ConnectionPool :
                 brokerInfo.Port,
                 index,
                 cancellationToken,
-                cancellationToken).ConfigureAwait(false);
+                callerCancellationToken).ConfigureAwait(false);
 
             if (!connection.IsConnected)
             {
                 try { await connection.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup of a disconnected replacement */ }
 
-                var disconnectedEndpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
                 RecordReconnectFailure(
-                    disconnectedEndpoint,
+                    new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port),
                     brokerId,
                     brokerInfo.Host,
                     brokerInfo.Port);
@@ -933,9 +959,9 @@ public sealed partial class ConnectionPool :
                     $"Connection slot {index} for broker {brokerId} was removed by a concurrent shrink");
             }
 
-            var endpoint = new EndpointKey(brokerInfo.Host, brokerInfo.Port);
-            ResetReconnectBackoff(endpoint, brokerId, brokerInfo.Host, brokerInfo.Port);
-            ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port));
+            var setupKey = new ConnectionSetupKey(brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetReconnectBackoff(setupKey, brokerId, brokerInfo.Host, brokerInfo.Port);
+            ResetConnectionSetupTimeout(setupKey);
 
             return connection;
         }
@@ -955,9 +981,9 @@ public sealed partial class ConnectionPool :
         TimeSpan? setupTimeoutOverride = null,
         bool recordFailure = true)
     {
-        var endpoint = new EndpointKey(host, port);
+        var setupKey = new ConnectionSetupKey(brokerId, host, port);
         return await RunWithReconnectBackoffAsync(
-            endpoint,
+            setupKey,
             brokerId,
             host,
             port,
@@ -972,6 +998,7 @@ public sealed partial class ConnectionPool :
                     index,
                     setupTimeout,
                     setupCancellationToken),
+                cancellationToken,
                 callerCancellationToken,
                 setupTimeoutOverride,
                 recordFailure),
@@ -1055,9 +1082,38 @@ public sealed partial class ConnectionPool :
         int port,
         CancellationToken cancellationToken)
     {
+        var timeout = _connectionOptions.ConnectionTimeoutMax;
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
+        try
+        {
+            return await GetOrCreateConnectionCoreAsync(
+                    brokerId,
+                    host,
+                    port,
+                    linkedCts.Token,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateConnectionOperationTimeoutException(timeout, brokerId, host, port);
+        }
+    }
+
+    private async ValueTask<IKafkaConnection> GetOrCreateConnectionCoreAsync(
+        int brokerId,
+        string host,
+        int port,
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
+    {
         const int MaxRetries = 3;
 
         var endpoint = new EndpointKey(host, port);
+        var setupKey = new ConnectionSetupKey(brokerId, host, port);
 
         // Use a per-endpoint semaphore to deduplicate concurrent connection creation.
         // The adaptive setup attempt creates its timeout CTS only after this lock is acquired,
@@ -1088,13 +1144,19 @@ public sealed partial class ConnectionPool :
                     catch { /* best-effort cleanup */ }
                 }
 
-                var connection = await CreateConnectionAsync(brokerId, host, port, cancellationToken).ConfigureAwait(false);
+                var connection = await CreateConnectionAsync(
+                        brokerId,
+                        host,
+                        port,
+                        cancellationToken,
+                        callerCancellationToken)
+                    .ConfigureAwait(false);
 
                 // Verify connection is still valid
                 if (connection.IsConnected)
                 {
-                    ResetReconnectBackoff(endpoint, brokerId, host, port);
-                    ResetConnectionSetupTimeout(new ConnectionSetupKey(brokerId, host, port));
+                    ResetReconnectBackoff(setupKey, brokerId, host, port);
+                    ResetConnectionSetupTimeout(setupKey);
                     return connection;
                 }
 
@@ -1106,7 +1168,7 @@ public sealed partial class ConnectionPool :
                 try { await connection.DisposeAsync().ConfigureAwait(false); }
                 catch { /* best-effort cleanup */ }
 
-                RecordReconnectFailure(endpoint, brokerId, host, port);
+                RecordReconnectFailure(setupKey, brokerId, host, port);
             }
 
             throw new InvalidOperationException($"Failed to create connection after {MaxRetries} retries");
@@ -1121,11 +1183,13 @@ public sealed partial class ConnectionPool :
         int brokerId,
         string host,
         int port,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        CancellationToken callerCancellationToken)
     {
         var endpoint = new EndpointKey(host, port);
+        var setupKey = new ConnectionSetupKey(brokerId, host, port);
         var connection = await RunWithReconnectBackoffAsync(
-            endpoint,
+            setupKey,
             brokerId,
             host,
             port,
@@ -1139,7 +1203,8 @@ public sealed partial class ConnectionPool :
                     port,
                     setupTimeout,
                     setupCancellationToken),
-                cancellationToken),
+                cancellationToken,
+                callerCancellationToken),
             cancellationToken).ConfigureAwait(false);
 
         // Publish only after the hard setup deadline has accepted the result. A factory
@@ -1207,17 +1272,17 @@ public sealed partial class ConnectionPool :
         string host,
         int port,
         Func<TimeSpan, CancellationToken, ValueTask<IKafkaConnection>> createConnection,
+        CancellationToken operationCancellationToken,
         CancellationToken callerCancellationToken,
         TimeSpan? setupTimeoutOverride = null,
         bool recordFailure = true)
     {
         var setupKey = new ConnectionSetupKey(brokerId, host, port);
-        var endpoint = new EndpointKey(host, port);
         var timeout = setupTimeoutOverride ?? GetConnectionSetupTimeout(setupKey);
         _connectionSetupTimeoutObserver?.Invoke(timeout);
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            callerCancellationToken,
+            operationCancellationToken,
             timeoutCts.Token);
         Task<IKafkaConnection>? connectionTask = null;
 
@@ -1225,7 +1290,7 @@ public sealed partial class ConnectionPool :
         {
             connectionTask = createConnection(timeout, linkedCts.Token).AsTask();
             var connection = await connectionTask
-                .WaitAsync(timeout, callerCancellationToken)
+                .WaitAsync(timeout, operationCancellationToken)
                 .ConfigureAwait(false);
             if (!connection.IsConnected && recordFailure)
                 RecordConnectionSetupFailure(setupKey);
@@ -1236,15 +1301,22 @@ public sealed partial class ConnectionPool :
             timeoutCts.Cancel();
             ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
             ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
+        }
+        catch (OperationCanceledException) when (operationCancellationToken.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
+        {
+            ObserveLateConnectionSetup(connectionTask);
+            if (recordFailure)
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
+            throw;
         }
         catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
         {
@@ -1255,7 +1327,7 @@ public sealed partial class ConnectionPool :
         {
             ObserveLateConnectionSetup(connectionTask);
             if (recordFailure)
-                RecordConnectionAttemptFailure(setupKey, endpoint, brokerId, host, port);
+                RecordConnectionAttemptFailure(setupKey, brokerId, host, port);
             throw;
         }
     }
@@ -1289,6 +1361,15 @@ public sealed partial class ConnectionPool :
         => new(
             ErrorCode.RequestTimedOut,
             $"Connection setup timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
+
+    private static KafkaException CreateConnectionOperationTimeoutException(
+        TimeSpan timeout,
+        int brokerId,
+        string host,
+        int port)
+        => new(
+            ErrorCode.RequestTimedOut,
+            $"Connection operation timeout after {(int)timeout.TotalMilliseconds}ms to broker {brokerId} ({host}:{port})");
 
     private static void ObserveLateConnectionSetup(Task<IKafkaConnection>? connectionTask)
     {
@@ -1327,13 +1408,12 @@ public sealed partial class ConnectionPool :
 
     private void RecordConnectionAttemptFailure(
         ConnectionSetupKey setupKey,
-        EndpointKey endpoint,
         int brokerId,
         string host,
         int port)
     {
         RecordConnectionSetupFailure(setupKey);
-        RecordReconnectFailure(endpoint, brokerId, host, port);
+        RecordReconnectFailure(setupKey, brokerId, host, port);
     }
 
     private void ResetConnectionSetupTimeout(ConnectionSetupKey setupKey)
@@ -1346,33 +1426,31 @@ public sealed partial class ConnectionPool :
         if (maxMs <= initialMs)
             return TimeSpan.FromMilliseconds(initialMs);
 
-        // KIP-601 applies jitter from attempt zero. Cap the exponent before jitter so a
-        // low random factor can still produce a value below max at the saturation point.
-        var maxExponent = Math.Log(maxMs / initialMs, 2);
-        var exponent = Math.Min(Math.Max(failureCount, 0), Math.Min(maxExponent, 30));
-        var baseMs = initialMs * Math.Pow(2, exponent);
-        var randomValue = Math.Clamp(_randomDouble(), 0, 1);
-        var jitteredMs = baseMs * (0.8 + (randomValue * 0.4));
-
-        return TimeSpan.FromMilliseconds(Math.Min(maxMs, jitteredMs));
+        // KIP-601 applies jitter from attempt zero and hard-caps the final timeout.
+        var timeoutMs = ExponentialRetryBackoff.CalculateHardCappedDelayMilliseconds(
+            initialMs,
+            maxMs,
+            failureCount,
+            _randomDouble());
+        return TimeSpan.FromMilliseconds(timeoutMs);
     }
 
     private async ValueTask<IKafkaConnection> RunWithReconnectBackoffAsync(
-        EndpointKey endpoint,
+        ConnectionSetupKey setupKey,
         int brokerId,
         string host,
         int port,
         Func<ValueTask<IKafkaConnection>> createConnection,
         CancellationToken cancellationToken)
     {
-        if (_reconnectBackoffs.TryGetValue(endpoint, out var state) && state.TryAddRef())
+        if (_reconnectBackoffs.TryGetValue(setupKey, out var state) && state.TryAddRef())
         {
             try
             {
                 await state.AttemptGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    await WaitForReconnectBackoffAsync(endpoint, state, brokerId, host, port, cancellationToken).ConfigureAwait(false);
+                    await WaitForReconnectBackoffAsync(setupKey, state, brokerId, host, port, cancellationToken).ConfigureAwait(false);
                     return await createConnection().ConfigureAwait(false);
                 }
                 finally
@@ -1390,14 +1468,14 @@ public sealed partial class ConnectionPool :
     }
 
     private async ValueTask WaitForReconnectBackoffAsync(
-        EndpointKey endpoint,
+        ConnectionSetupKey setupKey,
         ReconnectBackoffState state,
         int brokerId,
         string host,
         int port,
         CancellationToken cancellationToken)
     {
-        while (_reconnectBackoffs.TryGetValue(endpoint, out var currentState)
+        while (_reconnectBackoffs.TryGetValue(setupKey, out var currentState)
                && ReferenceEquals(currentState, state))
         {
             TimeSpan delay;
@@ -1424,9 +1502,9 @@ public sealed partial class ConnectionPool :
         }
     }
 
-    private void RecordReconnectFailure(EndpointKey endpoint, int brokerId, string host, int port)
+    private void RecordReconnectFailure(ConnectionSetupKey setupKey, int brokerId, string host, int port)
     {
-        var state = _reconnectBackoffs.GetOrAdd(endpoint, static _ => new ReconnectBackoffState());
+        var state = _reconnectBackoffs.GetOrAdd(setupKey, static _ => new ReconnectBackoffState());
 
         TimeSpan delay;
         int failureCount;
@@ -1441,10 +1519,16 @@ public sealed partial class ConnectionPool :
         LogReconnectBackoffScheduled(delay.TotalMilliseconds, brokerId, host, port, failureCount);
     }
 
-    private void ResetReconnectBackoff(EndpointKey endpoint, int brokerId, string host, int port)
+    private void ResetReconnectBackoff(ConnectionSetupKey setupKey, int brokerId, string host, int port)
     {
-        if (!_reconnectBackoffs.TryRemove(endpoint, out var state))
-            return;
+        if (RemoveReconnectBackoff(setupKey))
+            LogReconnectBackoffReset(brokerId, host, port);
+    }
+
+    private bool RemoveReconnectBackoff(ConnectionSetupKey setupKey)
+    {
+        if (!_reconnectBackoffs.TryRemove(setupKey, out var state))
+            return false;
 
         lock (state.Sync)
         {
@@ -1452,7 +1536,7 @@ public sealed partial class ConnectionPool :
             state.NextAttemptTimestamp = 0;
         }
         state.MarkRemoved();
-        LogReconnectBackoffReset(brokerId, host, port);
+        return true;
     }
 
     internal TimeSpan CalculateReconnectBackoffDelay(int failureCount)

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -862,8 +862,7 @@ public sealed partial class ConnectionPool :
                     port,
                     index,
                     setupTimeout,
-                    setupCancellationToken,
-                    callerCancellationToken),
+                    setupCancellationToken),
                 callerCancellationToken),
             cancellationToken).ConfigureAwait(false);
     }
@@ -874,10 +873,8 @@ public sealed partial class ConnectionPool :
         int port,
         int index,
         TimeSpan connectionSetupTimeout,
-        CancellationToken cancellationToken,
-        CancellationToken callerCancellationToken)
+        CancellationToken cancellationToken)
     {
-        var endpoint = new EndpointKey(host, port);
         KafkaConnection? connection = null;
 
         try
@@ -915,8 +912,6 @@ public sealed partial class ConnectionPool :
                 catch { /* best-effort cleanup of a failed connection attempt */ }
             }
 
-            if (!callerCancellationToken.IsCancellationRequested)
-                RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
     }
@@ -1032,8 +1027,7 @@ public sealed partial class ConnectionPool :
                     host,
                     port,
                     setupTimeout,
-                    setupCancellationToken,
-                    cancellationToken),
+                    setupCancellationToken),
                 cancellationToken),
             cancellationToken).ConfigureAwait(false);
 
@@ -1051,10 +1045,8 @@ public sealed partial class ConnectionPool :
         string host,
         int port,
         TimeSpan connectionSetupTimeout,
-        CancellationToken cancellationToken,
-        CancellationToken callerCancellationToken)
+        CancellationToken cancellationToken)
     {
-        var endpoint = new EndpointKey(host, port);
         KafkaConnection? connection = null;
 
         // Note: Stale connection cleanup is handled by the caller (GetOrCreateConnectionAsync)
@@ -1095,8 +1087,6 @@ public sealed partial class ConnectionPool :
                 catch { /* best-effort cleanup of a failed connection attempt */ }
             }
 
-            if (!callerCancellationToken.IsCancellationRequested)
-                RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
     }
@@ -1109,6 +1099,7 @@ public sealed partial class ConnectionPool :
         CancellationToken callerCancellationToken)
     {
         var setupKey = new ConnectionSetupKey(brokerId, host, port);
+        var endpoint = new EndpointKey(host, port);
         var timeout = GetConnectionSetupTimeout(setupKey);
         _connectionSetupTimeoutObserver?.Invoke(timeout);
         using var timeoutCts = new CancellationTokenSource(timeout);
@@ -1132,11 +1123,13 @@ public sealed partial class ConnectionPool :
             timeoutCts.Cancel();
             ObserveLateConnectionSetup(connectionTask);
             RecordConnectionSetupFailure(setupKey);
+            RecordReconnectFailure(endpoint, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
         }
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !callerCancellationToken.IsCancellationRequested)
         {
             RecordConnectionSetupFailure(setupKey);
+            RecordReconnectFailure(endpoint, brokerId, host, port);
             throw CreateConnectionSetupTimeoutException(timeout, brokerId, host, port);
         }
         catch (OperationCanceledException) when (callerCancellationToken.IsCancellationRequested)
@@ -1147,6 +1140,7 @@ public sealed partial class ConnectionPool :
         catch (Exception) when (!callerCancellationToken.IsCancellationRequested)
         {
             RecordConnectionSetupFailure(setupKey);
+            RecordReconnectFailure(endpoint, brokerId, host, port);
             throw;
         }
     }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -421,8 +421,13 @@ public sealed partial class KafkaConnection :
                 await sslStream.AuthenticateAsClientAsync(sslOptions, setupCancellationToken).ConfigureAwait(false);
 #endif
             }
-            catch (System.Security.Authentication.AuthenticationException ex)
+            catch (Exception ex)
             {
+                await DisposeFailedTlsStreamAsync(sslStream).ConfigureAwait(false);
+
+                if (ex is not System.Security.Authentication.AuthenticationException authenticationException)
+                    throw;
+
                 // TLS handshake failures surface here — primarily a rejected certificate, but .NET
                 // also throws this type for negotiation/protocol mismatches. We deliberately treat
                 // them all as fatal: TLS configuration is cluster-wide, so the same failure would
@@ -430,8 +435,9 @@ public sealed partial class KafkaConnection :
                 // Wrap as a Dekaf AuthenticationException (a KafkaException) so callers can catch it
                 // and metadata refresh treats it as fatal instead of masking it behind a generic
                 // "failed to refresh metadata" error.
-                await sslStream.DisposeAsync().ConfigureAwait(false);
-                throw new AuthenticationException($"TLS handshake failed: {ex.Message}", ex);
+                throw new AuthenticationException(
+                    $"TLS handshake failed: {authenticationException.Message}",
+                    authenticationException);
             }
             networkStream = sslStream;
             _isTls = true;
@@ -496,6 +502,9 @@ public sealed partial class KafkaConnection :
 
         LogConnected(_host, _port);
     }
+
+    internal static ValueTask DisposeFailedTlsStreamAsync(SslStream sslStream)
+        => sslStream.DisposeAsync();
 
     private async ValueTask<(Socket Socket, string TargetHost)> ConnectSocketAsync(CancellationToken cancellationToken)
     {

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -347,7 +347,10 @@ public sealed partial class KafkaConnection :
     private PendingRequestShard GetPendingRequestShard(int correlationId)
         => _pendingRequestShards[(int)((uint)correlationId % (uint)_pendingRequestShards.Length)];
 
-    public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+    public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+        => ConnectAsync(_options.ConnectionTimeout, cancellationToken);
+
+    internal async ValueTask ConnectAsync(TimeSpan connectionTimeout, CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
@@ -365,7 +368,7 @@ public sealed partial class KafkaConnection :
             if (IsConnected)
                 return;
 
-            await ConnectCoreAsync(cancellationToken).ConfigureAwait(false);
+            await ConnectCoreAsync(connectionTimeout, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -373,18 +376,19 @@ public sealed partial class KafkaConnection :
         }
     }
 
-    private async ValueTask ConnectCoreAsync(CancellationToken cancellationToken)
+    private async ValueTask ConnectCoreAsync(TimeSpan connectionTimeout, CancellationToken cancellationToken)
     {
         LogConnecting(_host, _port);
 
         Volatile.Write(ref _capabilities, null);
 
         using var connectTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        connectTimeoutCts.CancelAfter(_options.ConnectionTimeout);
+        connectTimeoutCts.CancelAfter(connectionTimeout);
+        var setupCancellationToken = connectTimeoutCts.Token;
         (Socket socket, string targetHost) socketResult;
         try
         {
-            socketResult = await ConnectSocketAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+            socketResult = await ConnectSocketAsync(setupCancellationToken).ConfigureAwait(false);
         }
         catch (DnsResolutionException ex) when (cancellationToken.IsCancellationRequested)
         {
@@ -410,11 +414,11 @@ public sealed partial class KafkaConnection :
             try
             {
 #if NETSTANDARD2_0
-                await AuthenticateAsClientNetStandardAsync(sslStream, targetHost, cancellationToken)
+                await AuthenticateAsClientNetStandardAsync(sslStream, targetHost, setupCancellationToken)
                     .ConfigureAwait(false);
 #else
                 var sslOptions = BuildSslClientAuthenticationOptions(targetHost);
-                await sslStream.AuthenticateAsClientAsync(sslOptions, cancellationToken).ConfigureAwait(false);
+                await sslStream.AuthenticateAsClientAsync(sslOptions, setupCancellationToken).ConfigureAwait(false);
 #endif
             }
             catch (System.Security.Authentication.AuthenticationException ex)
@@ -438,7 +442,7 @@ public sealed partial class KafkaConnection :
         // Perform SASL authentication if configured
         if (_options.SaslMechanism != SaslMechanism.None)
         {
-            await PerformSaslAuthenticationAsync(cancellationToken).ConfigureAwait(false);
+            await PerformSaslAuthenticationAsync(setupCancellationToken).ConfigureAwait(false);
         }
 
         // Release the previous reader's buffer (reconnect path) before its source pool
@@ -4197,9 +4201,21 @@ public sealed class ConnectionOptions
     public int MinimumReadSize { get; init; } = 256;
 
     /// <summary>
-    /// Connection timeout.
+    /// Initial socket connection setup timeout.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.ms</c>.
     /// </summary>
     public TimeSpan ConnectionTimeout { get; init; } = DefaultConnectionTimeout;
+
+    /// <summary>
+    /// Maximum socket connection setup timeout after consecutive failures.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// Defaults to <see cref="ConnectionTimeout"/> to preserve fixed-timeout behavior.
+    /// </summary>
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
 
     /// <summary>
     /// Request timeout.
@@ -4272,6 +4288,7 @@ public sealed class ConnectionOptions
     }
 
     private readonly int _connectionsMaxIdleMs = DefaultConnectionsMaxIdleMs;
+    private readonly TimeSpan? _connectionTimeoutMax;
 }
 
 /// <summary>

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -503,8 +503,17 @@ public sealed partial class KafkaConnection :
         LogConnected(_host, _port);
     }
 
-    internal static ValueTask DisposeFailedTlsStreamAsync(SslStream sslStream)
-        => sslStream.DisposeAsync();
+    internal static async ValueTask DisposeFailedTlsStreamAsync(SslStream sslStream)
+    {
+        try
+        {
+            await sslStream.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort cleanup must not replace the TLS handshake exception.
+        }
+    }
 
     private async ValueTask<(Socket Socket, string TargetHost)> ConnectSocketAsync(CancellationToken cancellationToken)
     {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -268,6 +268,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 TlsConfig = options.TlsConfig,
                 RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
                 ConnectionTimeout = options.ConnectionTimeout,
+                ConnectionTimeoutMax = options.ConnectionTimeoutMax,
                 EnableTcpKeepAlive = options.EnableTcpKeepAlive,
                 TcpKeepAliveTime = options.TcpKeepAliveTime,
                 TcpKeepAliveInterval = options.TcpKeepAliveInterval,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -35,6 +35,7 @@ public sealed class ProducerOptions
     private int _reconnectBackoffMaxMs = 1000;
     private bool _isReconnectBackoffMsConfigured;
     private bool _isReconnectBackoffMaxMsConfigured;
+    private TimeSpan? _connectionTimeoutMax;
 
     internal static bool IsBufferMemoryAllocationStrategyDefined(
         BufferMemoryAllocationStrategy strategy)
@@ -109,6 +110,19 @@ public sealed class ProducerOptions
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
     public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+
+    /// <summary>
+    /// Maximum connection setup timeout after consecutive failures. Defaults to
+    /// <see cref="ConnectionTimeout"/> to preserve fixed-timeout behavior.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
+
+    internal bool IsConnectionTimeoutMaxConfigured => _connectionTimeoutMax.HasValue;
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.

--- a/src/Dekaf/Retry/ExponentialRetryBackoff.cs
+++ b/src/Dekaf/Retry/ExponentialRetryBackoff.cs
@@ -44,4 +44,26 @@ internal static class ExponentialRetryBackoff
         var unitRandom = double.IsNaN(randomValue) ? 0.5 : Math.Clamp(randomValue, 0, 1);
         return cappedDelayMs * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static double CalculateHardCappedDelayMilliseconds(
+        double initialDelayMs,
+        double maximumDelayMs,
+        int exponent,
+        double randomValue)
+    {
+        if (initialDelayMs <= 0 || maximumDelayMs <= 0)
+            return 0;
+
+        var effectiveMaximumDelayMs = Math.Max(initialDelayMs, maximumDelayMs);
+        var maximumExponent = Math.Min(
+            Math.Log(effectiveMaximumDelayMs / initialDelayMs, 2),
+            MaximumExponent);
+        var boundedExponent = Math.Min(Math.Max(exponent, 0), maximumExponent);
+        var exponentialDelayMs = initialDelayMs * Math.Pow(2, boundedExponent);
+        var unitRandom = double.IsNaN(randomValue) ? 0.5 : Math.Clamp(randomValue, 0, 1);
+        var jitteredDelayMs = exponentialDelayMs
+            * (MinimumJitterFactor + (unitRandom * JitterFactorRange));
+        return Math.Min(effectiveMaximumDelayMs, jitteredDelayMs);
+    }
 }

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -77,6 +77,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 TlsConfig = options.TlsConfig,
                 RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
                 ConnectionTimeout = options.ConnectionTimeout,
+                ConnectionTimeoutMax = options.ConnectionTimeoutMax,
                 EnableTcpKeepAlive = options.EnableTcpKeepAlive,
                 TcpKeepAliveTime = options.TcpKeepAliveTime,
                 TcpKeepAliveInterval = options.TcpKeepAliveInterval,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -12,6 +12,8 @@ namespace Dekaf.ShareConsumer;
 /// </summary>
 public sealed class ShareConsumerOptions
 {
+    private TimeSpan? _connectionTimeoutMax;
+
     /// <summary>
     /// Bootstrap servers (host:port,host:port).
     /// </summary>
@@ -120,6 +122,17 @@ public sealed class ShareConsumerOptions
     /// Maximum time allowed for socket connection setup, including TLS/SASL handshakes.
     /// </summary>
     public TimeSpan ConnectionTimeout { get; init; } = ConnectionOptions.DefaultConnectionTimeout;
+
+    /// <summary>
+    /// Maximum connection setup timeout after consecutive failures. Defaults to
+    /// <see cref="ConnectionTimeout"/> to preserve fixed-timeout behavior.
+    /// Equivalent to Kafka's <c>socket.connection.setup.timeout.max.ms</c>.
+    /// </summary>
+    public TimeSpan ConnectionTimeoutMax
+    {
+        get => _connectionTimeoutMax ?? ConnectionTimeout;
+        init => _connectionTimeoutMax = value;
+    }
 
     /// <summary>
     /// Whether to enable TCP keepalive on broker sockets.

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -113,6 +113,53 @@ public sealed class ConnectionBuilderOptionsTests
     }
 
     [Test]
+    public async Task Builders_WithConnectionTimeoutMax_ConfigureAdaptiveRange()
+    {
+        var initial = TimeSpan.FromSeconds(7);
+        var maximum = TimeSpan.FromSeconds(21);
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionTimeout(initial)
+            .WithConnectionTimeoutMax(maximum)
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("consumer-group")
+            .WithConnectionTimeout(initial)
+            .WithConnectionTimeoutMax(maximum)
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("share-group")
+            .WithConnectionTimeout(initial)
+            .WithConnectionTimeoutMax(maximum)
+            .Build();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092")
+            .WithConnectionTimeout(initial)
+            .WithConnectionTimeoutMax(maximum)
+            .Build();
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithConnectionTimeout(initial)
+            .WithConnectionTimeoutMax(maximum));
+        await using var clientProducer = client.CreateProducer<string, string>().Build();
+
+        foreach (var options in new[]
+                 {
+                     GetConnectionOptions(producer),
+                     GetConnectionOptions(consumer),
+                     GetConnectionOptions(shareConsumer),
+                     GetConnectionOptions(admin),
+                     GetConnectionOptions(clientProducer)
+                 })
+        {
+            await Assert.That(options.ConnectionTimeout).IsEqualTo(initial);
+            await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(maximum);
+        }
+    }
+
+    [Test]
     public async Task DirectClientOptions_WithOnlyReconnectBackoff_UseFixedBackoff()
     {
         var expected = TimeSpan.FromMilliseconds(123);
@@ -264,6 +311,14 @@ public sealed class ConnectionBuilderOptionsTests
 
         await Assert.That(() => builder.WithConnectionTimeout(TimeSpan.Zero))
             .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithConnectionTimeoutMax(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder
+                .WithBootstrapServers("localhost:9092")
+                .WithConnectionTimeout(TimeSpan.FromSeconds(2))
+                .WithConnectionTimeoutMax(TimeSpan.FromSeconds(1))
+                .Build())
+            .Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => builder.WithTcpKeepAlive(TimeSpan.Zero, TimeSpan.FromSeconds(1)))
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => builder.WithTcpKeepAlive(TimeSpan.FromSeconds(1), TimeSpan.Zero))
@@ -284,6 +339,7 @@ public sealed class ConnectionBuilderOptionsTests
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That((object?)options.RemoteCertificateValidationCallback).IsSameReferenceAs(callback);
         await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(7));
         await Assert.That(options.EnableTcpKeepAlive).IsEqualTo(keepAliveEnabled);
         await Assert.That(options.TcpKeepAliveTime).IsEqualTo(TimeSpan.FromSeconds(11));
         await Assert.That(options.TcpKeepAliveInterval).IsEqualTo(TimeSpan.FromSeconds(3));

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -216,6 +216,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateProducer<string, string>().WithConnectionTimeoutMax(TimeSpan.FromSeconds(2)))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithTcpKeepAlive(false))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateProducer<string, string>().WithRemoteCertificateValidationCallback(AcceptCertificate))
@@ -248,6 +250,8 @@ public sealed class KafkaClientBuilderTests
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
             .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateConsumer<string, string>().WithConnectionTimeoutMax(TimeSpan.FromSeconds(2)))
+            .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithTcpKeepAlive(false))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateConsumer<string, string>().WithRemoteCertificateValidationCallback(AcceptCertificate))
@@ -272,6 +276,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateShareConsumer<string, string>().WithConnectionTimeoutMax(TimeSpan.FromSeconds(2)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateShareConsumer<string, string>().WithTcpKeepAlive(false))
             .Throws<InvalidOperationException>();
@@ -299,6 +305,8 @@ public sealed class KafkaClientBuilderTests
         await Assert.That(() => client.CreateAdminClient().WithConnectionsMaxIdle(TimeSpan.FromMinutes(1)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithConnectionTimeout(TimeSpan.FromSeconds(1)))
+            .Throws<InvalidOperationException>();
+        await Assert.That(() => client.CreateAdminClient().WithConnectionTimeoutMax(TimeSpan.FromSeconds(2)))
             .Throws<InvalidOperationException>();
         await Assert.That(() => client.CreateAdminClient().WithTcpKeepAlive(false))
             .Throws<InvalidOperationException>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -197,6 +197,18 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task ConnectionTimeoutMax_WithoutExplicitMaximum_FollowsInitialTimeout()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ConnectionTimeout = TimeSpan.FromSeconds(7)
+        };
+
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(7));
+    }
+
+    [Test]
     public async Task CheckCrcs_DefaultsTo_True()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -421,6 +421,8 @@ public class DependencyInjectionTests
             FetchMinBytes = 4096,
             DefaultApiTimeoutMs = 12_345,
             EnableAdaptiveConnections = false,
+            ConnectionTimeout = TimeSpan.FromSeconds(8),
+            ConnectionTimeoutMax = TimeSpan.FromSeconds(24),
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha256,
             SaslUsername = "consumer-user",
@@ -445,6 +447,8 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.FetchMinBytes).IsEqualTo(4096);
         await Assert.That(boundOptions.DefaultApiTimeoutMs).IsEqualTo(12_345);
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
+        await Assert.That(boundOptions.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(8));
+        await Assert.That(boundOptions.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(24));
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha256);
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("consumer-user");
@@ -546,6 +550,8 @@ public class DependencyInjectionTests
             BootstrapServers = ["broker1:9092"],
             ClientId = "typed-admin",
             RequestTimeoutMs = 12345,
+            ConnectionTimeout = TimeSpan.FromSeconds(9),
+            ConnectionTimeoutMax = TimeSpan.FromSeconds(27),
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha512,
             SaslUsername = "admin-user",
@@ -566,6 +572,8 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.BootstrapServers[0]).IsEqualTo("broker1:9092");
         await Assert.That(boundOptions.ClientId).IsEqualTo("override-admin");
         await Assert.That(boundOptions.RequestTimeoutMs).IsEqualTo(12345);
+        await Assert.That(boundOptions.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(9));
+        await Assert.That(boundOptions.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(27));
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("admin-user");
@@ -955,6 +963,8 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:DefaultApiTimeoutMs"] = "25000",
             ["Kafka:Consumers:Orders:ReconnectBackoffMs"] = "80",
             ["Kafka:Consumers:Orders:ReconnectBackoffMaxMs"] = "800",
+            ["Kafka:Consumers:Orders:ConnectionTimeout"] = "00:00:08",
+            ["Kafka:Consumers:Orders:ConnectionTimeoutMax"] = "00:00:24",
             ["Kafka:Consumers:Orders:CheckCrcs"] = "true",
             ["Kafka:Consumers:Orders:UseTls"] = "true",
             ["Kafka:Consumers:Orders:SaslMechanism"] = "ScramSha256",
@@ -1018,6 +1028,8 @@ public class DependencyInjectionTests
         await Assert.That(options.DefaultApiTimeoutMs).IsEqualTo(25000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(80);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(800);
+        await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(8));
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(24));
         await Assert.That(options.CheckCrcs).IsTrue();
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha256);
@@ -1148,6 +1160,8 @@ public class DependencyInjectionTests
             ["Kafka:Admin:RequestTimeoutMs"] = "45000",
             ["Kafka:Admin:ReconnectBackoffMs"] = "90",
             ["Kafka:Admin:ReconnectBackoffMaxMs"] = "900",
+            ["Kafka:Admin:ConnectionTimeout"] = "00:00:09",
+            ["Kafka:Admin:ConnectionTimeoutMax"] = "00:00:27",
             ["Kafka:Admin:UseTls"] = "true",
             ["Kafka:Admin:SaslMechanism"] = "ScramSha512",
             ["Kafka:Admin:SaslUsername"] = "admin",
@@ -1175,6 +1189,8 @@ public class DependencyInjectionTests
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(45000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(90);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(900);
+        await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(9));
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(27));
         await Assert.That(options.UseTls).IsTrue();
         await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(options.SaslUsername).IsEqualTo("admin");

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -171,6 +171,8 @@ public class DependencyInjectionTests
             EnableAdaptiveConnections = false,
             ClientRack = "rack-a",
             EnableRackAwarePartitioning = true,
+            ConnectionTimeout = TimeSpan.FromSeconds(7),
+            ConnectionTimeoutMax = TimeSpan.FromSeconds(21),
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha512,
             SaslUsername = "producer-user",
@@ -195,6 +197,8 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
         await Assert.That(boundOptions.ClientRack).IsEqualTo("rack-a");
         await Assert.That(boundOptions.EnableRackAwarePartitioning).IsTrue();
+        await Assert.That(boundOptions.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(boundOptions.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(21));
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("producer-user");
@@ -702,6 +706,8 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:RequestTimeoutMs"] = "3000",
             ["Kafka:Producers:Orders:ReconnectBackoffMs"] = "75",
             ["Kafka:Producers:Orders:ReconnectBackoffMaxMs"] = "750",
+            ["Kafka:Producers:Orders:ConnectionTimeout"] = "00:00:07",
+            ["Kafka:Producers:Orders:ConnectionTimeoutMax"] = "00:00:21",
             ["Kafka:Producers:Orders:EnableIdempotence"] = "false",
             ["Kafka:Producers:Orders:ConnectionsPerBroker"] = "3",
             ["Kafka:Producers:Orders:MaxConnectionsPerBroker"] = "6",
@@ -756,6 +762,8 @@ public class DependencyInjectionTests
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(3000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(75);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(750);
+        await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(21));
         await Assert.That(options.EnableIdempotence).IsFalse();
         await Assert.That(options.ConnectionsPerBroker).IsEqualTo(3);
         await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(6);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1319,9 +1319,11 @@ public sealed class ConnectionPoolTests
     {
         var releaseFactory = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var secondFactoryStarted = new TaskCompletionSource(
+        var observedBackoff = new TaskCompletionSource<TimeSpan>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBackoff = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var attempts = 0;
+        long timestamp = 0;
         await using var pool = new ConnectionPool(
             clientId: "test-client",
             connectionOptions: new ConnectionOptions
@@ -1335,14 +1337,19 @@ public sealed class ConnectionPoolTests
             connectionFactory: async (brokerId, host, port, _, _) =>
             {
                 if (Interlocked.Increment(ref attempts) == 2)
-                {
-                    secondFactoryStarted.TrySetResult();
                     return CreateConnectedConnection(brokerId, host, port);
-                }
 
                 await releaseFactory.Task;
                 return CreateConnectedConnection(brokerId, host, port);
-            });
+            },
+            randomDouble: static () => 0.5,
+            reconnectBackoffDelay: async (delay, cancellationToken) =>
+            {
+                observedBackoff.TrySetResult(delay);
+                await releaseBackoff.Task.WaitAsync(cancellationToken);
+                Interlocked.Add(ref timestamp, (long)(delay.TotalSeconds * Stopwatch.Frequency));
+            },
+            timestampProvider: () => Volatile.Read(ref timestamp));
 
         try
         {
@@ -1350,17 +1357,19 @@ public sealed class ConnectionPoolTests
             await Assert.That(firstAttempt).Throws<KafkaException>()
                 .WithMessageContaining("Connection setup timeout after 20ms");
 
-            var stopwatch = Stopwatch.StartNew();
             var secondAttempt = pool.GetConnectionAsync("broker-a", 9092).AsTask();
-            await secondFactoryStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            stopwatch.Stop();
+            var delay = await observedBackoff.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
+            await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(80));
+            await Assert.That(attempts).IsEqualTo(1);
+
+            releaseBackoff.SetResult();
             await secondAttempt;
-
-            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(60));
+            await Assert.That(attempts).IsEqualTo(2);
         }
         finally
         {
+            releaseBackoff.TrySetResult();
             releaseFactory.TrySetResult();
         }
     }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1437,6 +1437,50 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task DisposeAsync_WaitsForLateConnectionSetupDisposal()
+    {
+        var releaseFactory = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disposalStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDisposal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateConnection = CreateConnectedConnection(-1, "broker-a", 9092);
+        lateConnection.DisposeAsync().Returns(_ =>
+        {
+            disposalStarted.TrySetResult();
+            return new ValueTask(releaseDisposal.Task);
+        });
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromSeconds(1),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: async (_, _, _, _, _) =>
+            {
+                await releaseFactory.Task;
+                return lateConnection;
+            },
+            randomDouble: static () => 0.5);
+
+        Func<Task> connect = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await Assert.That(connect).Throws<KafkaException>()
+            .WithMessageContaining("Connection setup timeout after 20ms");
+
+        var disposeTask = pool.DisposeAsync().AsTask();
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+        releaseFactory.TrySetResult();
+        await disposalStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+
+        releaseDisposal.TrySetResult();
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_SuccessResetsFailureProgression()
     {
         var attempts = 0;

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1160,6 +1160,55 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionSetupTimeout_HardTimeoutPreservesReconnectBackoff()
+    {
+        var releaseFactory = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondFactoryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(80),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(80)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: async (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 2)
+                    secondFactoryStarted.TrySetResult();
+
+                await releaseFactory.Task;
+                return CreateConnectedConnection(brokerId, host, port);
+            });
+
+        try
+        {
+            Func<Task> firstAttempt = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+            await Assert.That(firstAttempt).Throws<KafkaException>()
+                .WithMessageContaining("Connection setup timeout after 20ms");
+
+            var stopwatch = Stopwatch.StartNew();
+            var secondAttempt = pool.GetConnectionAsync("broker-a", 9092).AsTask();
+            await secondFactoryStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            stopwatch.Stop();
+
+            releaseFactory.TrySetResult();
+            await secondAttempt;
+
+            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(60));
+        }
+        finally
+        {
+            releaseFactory.TrySetResult();
+        }
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_LateSuccessIsNeverPublished()
     {
         var releaseFirstFactory = new TaskCompletionSource(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1517,6 +1517,82 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [NotInParallel]
+    public async Task ConnectionSetupTimeout_GroupBackoffLongerThanRoundStillAttempts()
+    {
+        const int connectionsPerBroker = 2;
+        var attempts = 0;
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(500),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(100),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(100)
+            },
+            connectionsPerBroker,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) <= connectionsPerBroker)
+                    throw new InvalidOperationException("broker down");
+
+                return ValueTask.FromResult(CreateConnectedConnection(brokerId, host, port));
+            },
+            randomDouble: static () => 0.5);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        Func<Task> firstRound = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(firstRound).Throws<InvalidOperationException>();
+
+        var connection = await pool.GetConnectionAsync(1);
+
+        await Assert.That(connection.IsConnected).IsTrue();
+        await Assert.That(attempts).IsEqualTo(4);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ConnectionSetupTimeout_ScaleBackoffLongerThanRoundStillAttempts()
+    {
+        const int initialConnections = 2;
+        var scaling = 0;
+        var scaleAttempts = 0;
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(500),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(100),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(100)
+            },
+            connectionsPerBroker: initialConnections,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Volatile.Read(ref scaling) != 0
+                    && Interlocked.Increment(ref scaleAttempts) <= initialConnections)
+                {
+                    throw new InvalidOperationException("broker down");
+                }
+
+                return ValueTask.FromResult(CreateConnectedConnection(brokerId, host, port));
+            },
+            randomDouble: static () => 0.5);
+        pool.RegisterBroker(1, "broker-a", 9092);
+        _ = await pool.GetConnectionAsync(1);
+        Volatile.Write(ref scaling, 1);
+
+        Func<Task> firstRound = () => pool.ScaleConnectionGroupAsync(1, newCount: 4).AsTask();
+        await Assert.That(firstRound).Throws<InvalidOperationException>();
+
+        var count = await pool.ScaleConnectionGroupAsync(1, newCount: 4);
+
+        await Assert.That(count).IsEqualTo(4);
+        await Assert.That(scaleAttempts).IsEqualTo(4);
+    }
+
+    [Test]
     public async Task ReconnectBackoff_FailureStateIsIsolatedByBrokerAtSharedEndpoint()
     {
         var observedBackoffs = new List<TimeSpan>();

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1191,6 +1191,27 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionLockWait_CallerCancellationRemainsOperationCanceled()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(100)
+            });
+        using var connectionLock = new SemaphoreSlim(0, 1);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var waitForLock = typeof(ConnectionPool).GetMethod(
+            "WaitForConnectionLockAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await Assert.That(() =>
+                ((ValueTask)waitForLock.Invoke(pool, [connectionLock, cancellation.Token])!).AsTask())
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_GroupHardStopsFactoryThatIgnoresCancellation()
     {
         var releaseFactory = new TaskCompletionSource(
@@ -1542,7 +1563,10 @@ public sealed class ConnectionPoolTests
         await factoryStarted.Task;
 
         var contender = pool.GetConnectionAsync("broker-a", 9092).AsTask();
-        await Assert.That(async () => await contender).Throws<OperationCanceledException>();
+        var exception = await Assert.That(async () => await contender).Throws<KafkaException>();
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
 
         try { await lockHolder; }
         catch { /* Only the contending caller's bounded wait is under test. */ }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1056,9 +1056,9 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    [Arguments(0.0, 80.0)]
-    [Arguments(0.5, 100.0)]
-    [Arguments(0.999999, 119.99996)]
+    [Arguments(0.0, 160.0)]
+    [Arguments(0.5, 200.0)]
+    [Arguments(0.999999, 239.99992)]
     public async Task CalculateConnectionSetupTimeout_UsesSymmetricTwentyPercentJitter(
         double randomValue,
         double expectedMilliseconds)
@@ -1082,10 +1082,10 @@ public sealed class ConnectionPoolTests
         await Assert.That(timeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
             TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(400),
             TimeSpan.FromMilliseconds(800),
+            TimeSpan.FromMilliseconds(1000),
             TimeSpan.FromMilliseconds(1000),
             TimeSpan.FromMilliseconds(1000)
         });
@@ -1142,7 +1142,7 @@ public sealed class ConnectionPoolTests
         await Assert.That(observedTimeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(100)
         });
     }
@@ -1170,9 +1170,9 @@ public sealed class ConnectionPoolTests
         await Assert.That(observedTimeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(200)
+            TimeSpan.FromMilliseconds(400)
         });
     }
 
@@ -1201,9 +1201,9 @@ public sealed class ConnectionPoolTests
         await Assert.That(observedTimeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(200)
+            TimeSpan.FromMilliseconds(400)
         });
     }
 
@@ -1230,7 +1230,7 @@ public sealed class ConnectionPoolTests
         await Assert.That(observedTimeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(100)
         });
         await Assert.That(GetConnectionSetupTimeoutStateCount(pool)).IsEqualTo(1);
@@ -1272,7 +1272,7 @@ public sealed class ConnectionPoolTests
         {
             TimeSpan.FromMilliseconds(100),
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100)
+            TimeSpan.FromMilliseconds(200)
         });
     }
 
@@ -1298,9 +1298,9 @@ public sealed class ConnectionPoolTests
         await Assert.That(observedTimeouts).IsEquivalentTo(new[]
         {
             TimeSpan.FromMilliseconds(100),
-            TimeSpan.FromMilliseconds(100),
             TimeSpan.FromMilliseconds(200),
-            TimeSpan.FromMilliseconds(400)
+            TimeSpan.FromMilliseconds(400),
+            TimeSpan.FromMilliseconds(800)
         });
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -946,6 +946,9 @@ public sealed class ConnectionPoolTests
     {
         const int connectionsPerBroker = 2;
         var attempts = 0;
+        var observedBackoff = new TaskCompletionSource<TimeSpan>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        long timestamp = 0;
         var options = new ConnectionOptions
         {
             ConnectionTimeout = TimeSpan.FromSeconds(30),
@@ -964,7 +967,15 @@ public sealed class ConnectionPoolTests
                         new InvalidOperationException("broker down")));
 
                 return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
-            });
+            },
+            randomDouble: static () => 0.5,
+            reconnectBackoffDelay: (delay, _) =>
+            {
+                observedBackoff.TrySetResult(delay);
+                Interlocked.Add(ref timestamp, (long)(delay.TotalSeconds * Stopwatch.Frequency));
+                return ValueTask.CompletedTask;
+            },
+            timestampProvider: () => Volatile.Read(ref timestamp));
 
         await using (pool)
         {
@@ -973,12 +984,11 @@ public sealed class ConnectionPoolTests
             Func<Task> firstAttempt = () => pool.GetConnectionAsync(1).AsTask();
             await Assert.That(firstAttempt).Throws<InvalidOperationException>();
 
-            var stopwatch = Stopwatch.StartNew();
             var connection = await pool.GetConnectionAsync(1);
-            stopwatch.Stop();
+            var backoff = await observedBackoff.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(connection.IsConnected).IsTrue();
-            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(25));
+            await Assert.That(backoff).IsEqualTo(options.ReconnectBackoff);
             await Assert.That(attempts).IsEqualTo(4);
         }
     }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1493,6 +1493,40 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionCreationLock_ContentionRemainsBoundedByInitialTimeout()
+    {
+        var factoryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(100),
+            ConnectionTimeoutMax = TimeSpan.FromMilliseconds(100),
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        };
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: 1,
+            connectionFactory: async (brokerId, host, port, _, cancellationToken) =>
+            {
+                factoryStarted.TrySetResult();
+                await Task.Delay(TimeSpan.FromMilliseconds(80), cancellationToken);
+                var connection = CreateConnectedConnection(brokerId, host, port);
+                connection.IsConnected.Returns(false);
+                return connection;
+            });
+
+        var lockHolder = pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await factoryStarted.Task;
+
+        var contender = pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await Assert.That(async () => await contender).Throws<OperationCanceledException>();
+
+        try { await lockHolder; }
+        catch { /* Only the contending caller's bounded wait is under test. */ }
+    }
+
+    [Test]
     [NotInParallel]
     public async Task ReplaceConnectionInGroup_ReconnectBackoffDoesNotConsumeSetupTimeout()
     {

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1536,6 +1536,38 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionSetupTimeout_DisconnectedGroupAdvancesOncePerRound()
+    {
+        var observedTimeouts = new ConcurrentQueue<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: static (brokerId, host, port, _, _) =>
+            {
+                var connection = CreateConnectedConnection(brokerId, host, port);
+                connection.IsConnected.Returns(false);
+                return new ValueTask<IKafkaConnection>(connection);
+            },
+            timeoutObserver: observedTimeouts.Enqueue,
+            connectionsPerBroker: 2);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        for (var round = 0; round < 2; round++)
+        {
+            Func<Task> connect = () => pool.GetConnectionAsync(1).AsTask();
+            var exception = await Assert.That(connect).Throws<KafkaException>();
+            await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.NetworkException);
+        }
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(200)
+        });
+    }
+
+    [Test]
     public async Task ConnectionCreationLock_ContentionRemainsBoundedByInitialTimeout()
     {
         var factoryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1570,6 +1602,65 @@ public sealed class ConnectionPoolTests
 
         try { await lockHolder; }
         catch { /* Only the contending caller's bounded wait is under test. */ }
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ReplaceConnectionInGroup_DisconnectedReplacementPreservesSetupBackoff()
+    {
+        const int connectionsPerBroker = 2;
+        var observedTimeouts = new ConcurrentQueue<TimeSpan>();
+        var initialConnectionsRemaining = connectionsPerBroker;
+        var replacementAttempts = 0;
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(100),
+            ConnectionTimeoutMax = TimeSpan.FromMilliseconds(400),
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        };
+
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: connectionsPerBroker,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                var connection = CreateConnectedConnection(brokerId, host, port);
+                if (Interlocked.Decrement(ref initialConnectionsRemaining) < 0
+                    && Interlocked.Increment(ref replacementAttempts) == 1)
+                {
+                    connection.IsConnected.Returns(false);
+                }
+
+                return new ValueTask<IKafkaConnection>(connection);
+            },
+            randomDouble: static () => 0.5,
+            connectionSetupTimeoutObserver: observedTimeouts.Enqueue);
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+
+            await pool.GetConnectionAsync(1);
+            var oldConnection = await pool.GetConnectionByIndexAsync(1, 0);
+            oldConnection.IsConnected.Returns(false);
+
+            Func<Task> failedReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
+            var exception = await Assert.That(failedReplacement).Throws<KafkaException>();
+            await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.NetworkException);
+
+            var replacement = await pool.GetConnectionByIndexAsync(1, 0);
+            await Assert.That(replacement.IsConnected).IsTrue();
+        }
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200)
+        });
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1169,6 +1169,28 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionLockTimeout_IsReportedAsRequestTimeout()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20)
+            });
+        using var connectionLock = new SemaphoreSlim(0, 1);
+        var waitForLock = typeof(ConnectionPool).GetMethod(
+            "WaitForConnectionLockAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        var exception = await Assert.That(() =>
+                ((ValueTask)waitForLock.Invoke(pool, [connectionLock, CancellationToken.None])!).AsTask())
+            .Throws<KafkaException>();
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_GroupHardStopsFactoryThatIgnoresCancellation()
     {
         var releaseFactory = new TaskCompletionSource(

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1147,19 +1147,18 @@ public sealed class ConnectionPoolTests
                 return ValueTask.FromResult(CreateConnectedConnection(brokerId, host, port));
             });
 
-        Func<Task> establishReconnectState = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        pool.RegisterBroker(1, "broker-a", 9092);
+        Func<Task> establishReconnectState = () => pool.GetConnectionAsync(1).AsTask();
         await Assert.That(establishReconnectState).Throws<InvalidOperationException>();
         var attemptGate = await AssertSingleReconnectBackoffGate(pool);
         await attemptGate.WaitAsync(cancellationToken);
         try
         {
-            pool.RegisterBroker(1, "broker-a", 9092);
-
             Func<Task> createGroup = () => pool.GetConnectionAsync(1, cancellationToken).AsTask();
             var exception = await Assert.That(createGroup).Throws<KafkaException>();
 
             await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
-            await Assert.That(attempts).IsEqualTo(1);
+            await Assert.That(attempts).IsEqualTo(3);
         }
         finally
         {
@@ -1315,7 +1314,7 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task ConnectionSetupTimeout_HardTimeoutPreservesReconnectBackoff()
+    public async Task ConnectionSetupTimeout_OverallDeadlineIncludesReconnectBackoff()
     {
         var releaseFactory = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1355,7 +1354,7 @@ public sealed class ConnectionPoolTests
         {
             Func<Task> firstAttempt = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
             await Assert.That(firstAttempt).Throws<KafkaException>()
-                .WithMessageContaining("Connection setup timeout after 20ms");
+                .WithMessageContaining("timeout after 20ms");
 
             var secondAttempt = pool.GetConnectionAsync("broker-a", 9092).AsTask();
             var delay = await observedBackoff.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -1363,9 +1362,9 @@ public sealed class ConnectionPoolTests
             await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(80));
             await Assert.That(attempts).IsEqualTo(1);
 
-            releaseBackoff.SetResult();
-            await secondAttempt;
-            await Assert.That(attempts).IsEqualTo(2);
+            await Assert.That(async () => await secondAttempt).Throws<KafkaException>()
+                .WithMessageContaining("Connection operation timeout after 20ms");
+            await Assert.That(attempts).IsEqualTo(1);
         }
         finally
         {
@@ -1515,6 +1514,43 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ReconnectBackoff_FailureStateIsIsolatedByBrokerAtSharedEndpoint()
+    {
+        var observedBackoffs = new List<TimeSpan>();
+        long timestamp = 0;
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromSeconds(1),
+                ReconnectBackoff = TimeSpan.FromMilliseconds(100),
+                ReconnectBackoffMax = TimeSpan.FromMilliseconds(100)
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: static (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            randomDouble: static () => 0.5,
+            reconnectBackoffDelay: (delay, _) =>
+            {
+                observedBackoffs.Add(delay);
+                Interlocked.Add(ref timestamp, (long)(delay.TotalSeconds * Stopwatch.Frequency));
+                return ValueTask.CompletedTask;
+            },
+            timestampProvider: () => Volatile.Read(ref timestamp));
+        pool.RegisterBroker(1, "shared-endpoint", 9092);
+        pool.RegisterBroker(2, "shared-endpoint", 9092);
+
+        Func<Task> failBrokerOne = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(failBrokerOne).Throws<InvalidOperationException>();
+        Func<Task> failBrokerTwo = () => pool.GetConnectionAsync(2).AsTask();
+        await Assert.That(failBrokerTwo).Throws<InvalidOperationException>();
+
+        await Assert.That(observedBackoffs).IsEmpty();
+
+        await Assert.That(failBrokerOne).Throws<InvalidOperationException>();
+        await Assert.That(observedBackoffs).IsEquivalentTo([TimeSpan.FromMilliseconds(100)]);
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_BrokerEndpointChangeDropsOldState()
     {
         var observedTimeouts = new List<TimeSpan>();
@@ -1530,7 +1566,9 @@ public sealed class ConnectionPoolTests
             await Assert.That(fail).Throws<InvalidOperationException>();
         }
 
+        var oldReconnectGate = await AssertSingleReconnectBackoffGate(pool);
         pool.RegisterBroker(1, "broker-b", 9092);
+        await Assert.That(() => oldReconnectGate.Wait(0)).Throws<ObjectDisposedException>();
         Func<Task> failAfterMove = () => pool.GetConnectionAsync(1).AsTask();
         await Assert.That(failAfterMove).Throws<InvalidOperationException>();
 
@@ -1704,7 +1742,7 @@ public sealed class ConnectionPoolTests
 
     [Test]
     [NotInParallel]
-    public async Task ReplaceConnectionInGroup_ReconnectBackoffDoesNotConsumeSetupTimeout()
+    public async Task ReplaceConnectionInGroup_ReconnectBackoffRespectsOverallDeadline()
     {
         const int connectionsPerBroker = 2;
         var initialCreationDone = 0;
@@ -1712,8 +1750,8 @@ public sealed class ConnectionPoolTests
         var options = new ConnectionOptions
         {
             ConnectionTimeout = TimeSpan.FromMilliseconds(100),
-            ReconnectBackoff = TimeSpan.FromMilliseconds(40),
-            ReconnectBackoffMax = TimeSpan.FromMilliseconds(40)
+            ReconnectBackoff = TimeSpan.FromMilliseconds(200),
+            ReconnectBackoffMax = TimeSpan.FromMilliseconds(200)
         };
 
         var pool = new ConnectionPool(
@@ -1730,7 +1768,8 @@ public sealed class ConnectionPoolTests
                 }
 
                 return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
-            });
+            },
+            randomDouble: static () => 0.5);
 
         await using (pool)
         {
@@ -1745,12 +1784,10 @@ public sealed class ConnectionPoolTests
             Func<Task> failedReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
             await Assert.That(failedReplacement).Throws<InvalidOperationException>();
 
-            var stopwatch = Stopwatch.StartNew();
-            var replacement = await pool.GetConnectionByIndexAsync(1, 0);
-            stopwatch.Stop();
-
-            await Assert.That(replacement.IsConnected).IsTrue();
-            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(25));
+            Func<Task> replacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
+            await Assert.That(replacement).Throws<KafkaException>()
+                .WithMessageContaining("Connection operation timeout after 100ms");
+            await Assert.That(replacementAttempts).IsEqualTo(1);
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Errors;
@@ -1077,6 +1078,50 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionSetupTimeout_FirstAttemptAppliesJitter()
+    {
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0,
+            connectionFactory: static (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: observedTimeouts.Add);
+
+        Func<Task> connect = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+
+        await Assert.That(connect).Throws<InvalidOperationException>();
+        await Assert.That(observedTimeouts).IsEquivalentTo(
+            [TimeSpan.FromMilliseconds(80)]);
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_GroupFailureAdvancesOncePerRound()
+    {
+        var observedTimeouts = new ConcurrentQueue<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: static (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: observedTimeouts.Enqueue,
+            connectionsPerBroker: 3);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        for (var round = 0; round < 2; round++)
+        {
+            Func<Task> connect = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(connect).Throws<InvalidOperationException>();
+        }
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(200)
+        });
+    }
+
+    [Test]
     public async Task CalculateConnectionSetupTimeout_GrowsExponentiallyAndCapsAtMaximum()
     {
         await using var pool = CreateConnectionSetupTimeoutPool(randomValue: 0.5);
@@ -1180,7 +1225,10 @@ public sealed class ConnectionPoolTests
             connectionFactory: async (brokerId, host, port, _, _) =>
             {
                 if (Interlocked.Increment(ref attempts) == 2)
+                {
                     secondFactoryStarted.TrySetResult();
+                    return CreateConnectedConnection(brokerId, host, port);
+                }
 
                 await releaseFactory.Task;
                 return CreateConnectedConnection(brokerId, host, port);
@@ -1197,7 +1245,6 @@ public sealed class ConnectionPoolTests
             await secondFactoryStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
             stopwatch.Stop();
 
-            releaseFactory.TrySetResult();
             await secondAttempt;
 
             await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(60));
@@ -1603,7 +1650,8 @@ public sealed class ConnectionPoolTests
     private static ConnectionPool CreateConnectionSetupTimeoutPool(
         double randomValue,
         Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>>? connectionFactory = null,
-        Action<TimeSpan>? timeoutObserver = null)
+        Action<TimeSpan>? timeoutObserver = null,
+        int connectionsPerBroker = 1)
         => new(
             clientId: "test-client",
             connectionOptions: new ConnectionOptions
@@ -1613,7 +1661,7 @@ public sealed class ConnectionPoolTests
                 ReconnectBackoff = TimeSpan.Zero,
                 ReconnectBackoffMax = TimeSpan.Zero
             },
-            connectionsPerBroker: 1,
+            connectionsPerBroker,
             connectionFactory: connectionFactory
                 ?? ((_, _, _, _, _) => throw new InvalidOperationException("Connection not expected")),
             randomDouble: () => randomValue,

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1056,16 +1056,22 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    [Arguments(0.0, 160.0)]
-    [Arguments(0.5, 200.0)]
-    [Arguments(0.999999, 239.99992)]
+    [Arguments(0, 0.0, 80.0)]
+    [Arguments(0, 0.5, 100.0)]
+    [Arguments(0, 0.999999, 119.99996)]
+    [Arguments(1, 0.0, 160.0)]
+    [Arguments(1, 0.5, 200.0)]
+    [Arguments(1, 0.999999, 239.99992)]
+    [Arguments(6, 0.0, 800.0)]
+    [Arguments(6, 0.999999, 1000.0)]
     public async Task CalculateConnectionSetupTimeout_UsesSymmetricTwentyPercentJitter(
+        int failureCount,
         double randomValue,
         double expectedMilliseconds)
     {
         await using var pool = CreateConnectionSetupTimeoutPool(randomValue: randomValue);
 
-        var timeout = pool.CalculateConnectionSetupTimeout(failureCount: 1);
+        var timeout = pool.CalculateConnectionSetupTimeout(failureCount);
 
         await Assert.That(timeout.TotalMilliseconds).IsEqualTo(expectedMilliseconds).Within(0.001);
     }
@@ -1151,6 +1157,56 @@ public sealed class ConnectionPoolTests
         {
             releaseFactory.TrySetResult();
         }
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_LateSuccessIsNeverPublished()
+    {
+        var releaseFirstFactory = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateConnectionDisposed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateConnection = CreateConnectedConnection(-1, "broker-a", 9092);
+        lateConnection.DisposeAsync().Returns(_ =>
+        {
+            lateConnectionDisposed.TrySetResult();
+            return ValueTask.CompletedTask;
+        });
+        var freshConnection = CreateConnectedConnection(-1, "broker-a", 9092);
+        var attempts = 0;
+
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: async (_, _, _, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                {
+                    await releaseFirstFactory.Task;
+                    return lateConnection;
+                }
+
+                return freshConnection;
+            });
+
+        Func<Task> firstAttempt = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await Assert.That(firstAttempt).Throws<KafkaException>()
+            .WithMessageContaining("Connection setup timeout after 20ms");
+
+        releaseFirstFactory.TrySetResult();
+        await lateConnectionDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var acquired = await pool.GetConnectionAsync("broker-a", 9092);
+
+        await Assert.That(acquired).IsSameReferenceAs(freshConnection);
+        await Assert.That(attempts).IsEqualTo(2);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1191,6 +1191,27 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionLockTimeout_UsesConfiguredMaximum()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(10),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(40)
+            });
+        using var connectionLock = new SemaphoreSlim(0, 1);
+        var waitForLock = typeof(ConnectionPool).GetMethod(
+            "WaitForConnectionLockAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await Assert.That(() =>
+                ((ValueTask)waitForLock.Invoke(pool, [connectionLock, CancellationToken.None])!).AsTask())
+            .Throws<KafkaException>()
+            .WithMessageContaining("Timed out after 40ms");
+    }
+
+    [Test]
     public async Task ConnectionLockWait_CallerCancellationRemainsOperationCanceled()
     {
         await using var pool = new ConnectionPool(
@@ -1565,43 +1586,6 @@ public sealed class ConnectionPoolTests
             TimeSpan.FromMilliseconds(200),
             TimeSpan.FromMilliseconds(200)
         });
-    }
-
-    [Test]
-    public async Task ConnectionCreationLock_ContentionRemainsBoundedByInitialTimeout()
-    {
-        var factoryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var options = new ConnectionOptions
-        {
-            ConnectionTimeout = TimeSpan.FromMilliseconds(100),
-            ConnectionTimeoutMax = TimeSpan.FromMilliseconds(100),
-            ReconnectBackoff = TimeSpan.Zero,
-            ReconnectBackoffMax = TimeSpan.Zero
-        };
-        await using var pool = new ConnectionPool(
-            clientId: "test-client",
-            connectionOptions: options,
-            connectionsPerBroker: 1,
-            connectionFactory: async (brokerId, host, port, _, cancellationToken) =>
-            {
-                factoryStarted.TrySetResult();
-                await Task.Delay(TimeSpan.FromMilliseconds(80), cancellationToken);
-                var connection = CreateConnectedConnection(brokerId, host, port);
-                connection.IsConnected.Returns(false);
-                return connection;
-            });
-
-        var lockHolder = pool.GetConnectionAsync("broker-a", 9092).AsTask();
-        await factoryStarted.Task;
-
-        var contender = pool.GetConnectionAsync("broker-a", 9092).AsTask();
-        var exception = await Assert.That(async () => await contender).Throws<KafkaException>();
-
-        await Assert.That(exception).IsNotNull();
-        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
-
-        try { await lockHolder; }
-        catch { /* Only the contending caller's bounded wait is under test. */ }
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1056,8 +1056,257 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [Arguments(0.0, 80.0)]
+    [Arguments(0.5, 100.0)]
+    [Arguments(0.999999, 119.99996)]
+    public async Task CalculateConnectionSetupTimeout_UsesSymmetricTwentyPercentJitter(
+        double randomValue,
+        double expectedMilliseconds)
+    {
+        await using var pool = CreateConnectionSetupTimeoutPool(randomValue: randomValue);
+
+        var timeout = pool.CalculateConnectionSetupTimeout(failureCount: 1);
+
+        await Assert.That(timeout.TotalMilliseconds).IsEqualTo(expectedMilliseconds).Within(0.001);
+    }
+
+    [Test]
+    public async Task CalculateConnectionSetupTimeout_GrowsExponentiallyAndCapsAtMaximum()
+    {
+        await using var pool = CreateConnectionSetupTimeoutPool(randomValue: 0.5);
+
+        var timeouts = Enumerable.Range(0, 7)
+            .Select(pool.CalculateConnectionSetupTimeout)
+            .ToArray();
+
+        await Assert.That(timeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(400),
+            TimeSpan.FromMilliseconds(800),
+            TimeSpan.FromMilliseconds(1000),
+            TimeSpan.FromMilliseconds(1000)
+        });
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_CancelsStalledAttemptAtEffectiveDeadline()
+    {
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(40),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: async (_, _, _, _, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("unreachable");
+            },
+            randomDouble: static () => 0.5);
+
+        Func<Task> connect = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+
+        await Assert.That(connect).Throws<KafkaException>()
+            .WithMessageContaining("Connection setup timeout after 20ms");
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_SuccessResetsFailureProgression()
+    {
+        var attempts = 0;
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new InvalidOperationException("broker down");
+                return new ValueTask<IKafkaConnection>(CreateConnectedConnection(brokerId, host, port));
+            },
+            timeoutObserver: observedTimeouts.Add);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        Func<Task> firstAttempt = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(firstAttempt).Throws<InvalidOperationException>();
+        await pool.GetConnectionAsync(1);
+        await pool.RemoveConnectionAsync(1);
+        await pool.GetConnectionAsync(1);
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100)
+        });
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_FailureStateIsIsolatedByEndpoint()
+    {
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: observedTimeouts.Add);
+
+        for (var i = 0; i < 2; i++)
+        {
+            Func<Task> failA = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+            await Assert.That(failA).Throws<InvalidOperationException>();
+        }
+
+        Func<Task> failB = () => pool.GetConnectionAsync("broker-b", 9092).AsTask();
+        await Assert.That(failB).Throws<InvalidOperationException>();
+        Func<Task> failAAgain = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await Assert.That(failAAgain).Throws<InvalidOperationException>();
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200)
+        });
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_FailureStateIsIsolatedByBrokerAtSharedEndpoint()
+    {
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: observedTimeouts.Add);
+        pool.RegisterBroker(1, "shared-endpoint", 9092);
+        pool.RegisterBroker(2, "shared-endpoint", 9092);
+
+        for (var i = 0; i < 2; i++)
+        {
+            Func<Task> failBrokerOne = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(failBrokerOne).Throws<InvalidOperationException>();
+        }
+
+        Func<Task> failBrokerTwo = () => pool.GetConnectionAsync(2).AsTask();
+        await Assert.That(failBrokerTwo).Throws<InvalidOperationException>();
+        Func<Task> failBrokerOneAgain = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(failBrokerOneAgain).Throws<InvalidOperationException>();
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200)
+        });
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_BrokerEndpointChangeDropsOldState()
+    {
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: observedTimeouts.Add);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        for (var i = 0; i < 2; i++)
+        {
+            Func<Task> fail = () => pool.GetConnectionAsync(1).AsTask();
+            await Assert.That(fail).Throws<InvalidOperationException>();
+        }
+
+        pool.RegisterBroker(1, "broker-b", 9092);
+        Func<Task> failAfterMove = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(failAfterMove).Throws<InvalidOperationException>();
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100)
+        });
+        await Assert.That(GetConnectionSetupTimeoutStateCount(pool)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_CallerCancellationDoesNotAdvanceFailures()
+    {
+        var attempts = 0;
+        var factoryEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedTimeouts = new List<TimeSpan>();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: async (brokerId, host, port, _, cancellationToken) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                if (attempt == 1)
+                {
+                    factoryEntered.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                if (attempt == 2)
+                    throw new InvalidOperationException("broker down");
+                return CreateConnectedConnection(brokerId, host, port);
+            },
+            timeoutObserver: observedTimeouts.Add);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        using var cancellation = new CancellationTokenSource();
+        var canceledAttempt = pool.GetConnectionAsync(1, cancellation.Token).AsTask();
+        await factoryEntered.Task;
+        cancellation.Cancel();
+        await Assert.That(async () => await canceledAttempt).Throws<OperationCanceledException>();
+        Func<Task> failedAttempt = () => pool.GetConnectionAsync(1).AsTask();
+        await Assert.That(failedAttempt).Throws<InvalidOperationException>();
+        await pool.GetConnectionAsync(1);
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100)
+        });
+    }
+
+    [Test]
+    public async Task ConnectionSetupTimeout_ConcurrentFailuresAdvanceAtomically()
+    {
+        var observedTimeouts = new List<TimeSpan>();
+        var observerLock = new object();
+        await using var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("broker down"),
+            timeoutObserver: timeout =>
+            {
+                lock (observerLock)
+                    observedTimeouts.Add(timeout);
+            });
+
+        var attempts = Enumerable.Range(0, 4)
+            .Select(_ => pool.GetConnectionAsync("broker-a", 9092).AsTask())
+            .ToArray();
+        await Assert.That(async () => await Task.WhenAll(attempts)).Throws<InvalidOperationException>();
+
+        await Assert.That(observedTimeouts).IsEquivalentTo(new[]
+        {
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(400)
+        });
+    }
+
+    [Test]
     [NotInParallel]
-    public async Task ReplaceConnectionInGroup_DuringReconnectBackoff_RespectsConnectionTimeout()
+    public async Task ReplaceConnectionInGroup_ReconnectBackoffDoesNotConsumeSetupTimeout()
     {
         const int connectionsPerBroker = 2;
         var initialCreationDone = 0;
@@ -1065,8 +1314,8 @@ public sealed class ConnectionPoolTests
         var options = new ConnectionOptions
         {
             ConnectionTimeout = TimeSpan.FromMilliseconds(100),
-            ReconnectBackoff = TimeSpan.FromSeconds(1),
-            ReconnectBackoffMax = TimeSpan.FromSeconds(1)
+            ReconnectBackoff = TimeSpan.FromMilliseconds(40),
+            ReconnectBackoffMax = TimeSpan.FromMilliseconds(40)
         };
 
         var pool = new ConnectionPool(
@@ -1098,9 +1347,12 @@ public sealed class ConnectionPoolTests
             Func<Task> failedReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
             await Assert.That(failedReplacement).Throws<InvalidOperationException>();
 
-            Func<Task> timedOutReplacement = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
-            await Assert.That(timedOutReplacement).Throws<KafkaException>()
-                .WithMessageContaining("Connection replacement timeout");
+            var stopwatch = Stopwatch.StartNew();
+            var replacement = await pool.GetConnectionByIndexAsync(1, 0);
+            stopwatch.Stop();
+
+            await Assert.That(replacement.IsConnected).IsTrue();
+            await Assert.That(stopwatch.Elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(25));
         }
     }
 
@@ -1167,6 +1419,24 @@ public sealed class ConnectionPoolTests
         }
     }
 
+    [Test]
+    public async Task CloseAllAsync_ClearsConnectionSetupFailureState()
+    {
+        var pool = CreateConnectionSetupTimeoutPool(
+            randomValue: 0.5,
+            connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("broker down"));
+        await using (pool)
+        {
+            Func<Task> failedConnection = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+            await Assert.That(failedConnection).Throws<InvalidOperationException>();
+            await Assert.That(GetConnectionSetupTimeoutStateCount(pool)).IsEqualTo(1);
+
+            await pool.CloseAllAsync();
+
+            await Assert.That(GetConnectionSetupTimeoutStateCount(pool)).IsEqualTo(0);
+        }
+    }
+
     private static OAuthBearerConfig CreateOAuthBearerConfig() => new()
     {
         TokenEndpointUrl = "https://auth.example.invalid/token",
@@ -1188,6 +1458,25 @@ public sealed class ConnectionPoolTests
             connectionsPerBroker: 1,
             connectionFactory: (_, _, _, _, _) => throw new InvalidOperationException("Connection not expected"),
             randomDouble: () => randomValue);
+
+    private static ConnectionPool CreateConnectionSetupTimeoutPool(
+        double randomValue,
+        Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>>? connectionFactory = null,
+        Action<TimeSpan>? timeoutObserver = null)
+        => new(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(100),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(1000),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: connectionFactory
+                ?? ((_, _, _, _, _) => throw new InvalidOperationException("Connection not expected")),
+            randomDouble: () => randomValue,
+            connectionSetupTimeoutObserver: timeoutObserver);
 
     private static OAuthBearerToken CreateOAuthBearerToken() => new()
     {
@@ -1224,6 +1513,15 @@ public sealed class ConnectionPoolTests
 
         await Assert.That(gates).Count().IsEqualTo(1);
         return gates[0];
+    }
+
+    private static int GetConnectionSetupTimeoutStateCount(ConnectionPool pool)
+    {
+        var field = typeof(ConnectionPool).GetField(
+            "_connectionSetupTimeouts",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var states = field!.GetValue(pool)!;
+        return (int)states.GetType().GetProperty("Count")!.GetValue(states)!;
     }
 
     private static IKafkaConnection CreateConnectedConnection(int brokerId, string host, int port)

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1122,6 +1122,52 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [NotInParallel]
+    [Timeout(5_000)]
+    public async Task ConnectionSetupTimeout_GroupRoundBoundsReconnectGateWait(
+        CancellationToken cancellationToken)
+    {
+        var attempts = 0;
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+            ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        };
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: 3,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                if (Interlocked.Increment(ref attempts) == 1)
+                    throw new InvalidOperationException("broker down");
+
+                return ValueTask.FromResult(CreateConnectedConnection(brokerId, host, port));
+            });
+
+        Func<Task> establishReconnectState = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        await Assert.That(establishReconnectState).Throws<InvalidOperationException>();
+        var attemptGate = await AssertSingleReconnectBackoffGate(pool);
+        await attemptGate.WaitAsync(cancellationToken);
+        try
+        {
+            pool.RegisterBroker(1, "broker-a", 9092);
+
+            Func<Task> createGroup = () => pool.GetConnectionAsync(1, cancellationToken).AsTask();
+            var exception = await Assert.That(createGroup).Throws<KafkaException>();
+
+            await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+            await Assert.That(attempts).IsEqualTo(1);
+        }
+        finally
+        {
+            attemptGate.Release();
+        }
+    }
+
+    [Test]
     public async Task CalculateConnectionSetupTimeout_GrowsExponentiallyAndCapsAtMaximum()
     {
         await using var pool = CreateConnectionSetupTimeoutPool(randomValue: 0.5);

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1701,6 +1701,59 @@ public sealed class ConnectionPoolTests
 
     [Test]
     [NotInParallel]
+    public async Task ReplaceConnectionInGroup_ScaleLockWaitIsBoundedAndDisposesReplacement()
+    {
+        var created = new List<IKafkaConnection>();
+        var options = new ConnectionOptions
+        {
+            ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+            ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+            ReconnectBackoff = TimeSpan.Zero,
+            ReconnectBackoffMax = TimeSpan.Zero
+        };
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: options,
+            connectionsPerBroker: 2,
+            connectionFactory: (brokerId, host, port, _, _) =>
+            {
+                var connection = CreateConnectedConnection(brokerId, host, port);
+                created.Add(connection);
+                return new ValueTask<IKafkaConnection>(connection);
+            });
+
+        await using (pool)
+        {
+            pool.RegisterBroker(1, "localhost", 9092);
+            await pool.GetConnectionAsync(1);
+            await Assert.That(created).Count().IsEqualTo(2);
+            created[0].IsConnected.Returns(false);
+            await Assert.That(created[0].IsConnected).IsFalse();
+
+            var scaleLock = (SemaphoreSlim)typeof(ConnectionPool).GetField(
+                "_scaleLock",
+                BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(pool)!;
+            await scaleLock.WaitAsync();
+            await Assert.That(scaleLock.CurrentCount).IsEqualTo(0);
+            try
+            {
+                Func<Task> replaceConnection = () => pool.GetConnectionByIndexAsync(1, 0).AsTask();
+                var exception = await Assert.That(replaceConnection).Throws<KafkaException>();
+
+                await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RequestTimedOut);
+            }
+            finally
+            {
+                scaleLock.Release();
+            }
+
+            await Assert.That(created).Count().IsEqualTo(3);
+            await created[2].Received(1).DisposeAsync();
+        }
+    }
+
+    [Test]
+    [NotInParallel]
     public async Task GetConnectionAsync_AfterReconnectBackoffReset_DisposesAttemptGate()
     {
         var attempts = 0;

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1118,6 +1118,42 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    public async Task ConnectionSetupTimeout_GroupHardStopsFactoryThatIgnoresCancellation()
+    {
+        var releaseFactory = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(20),
+                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 2,
+            connectionFactory: async (brokerId, host, port, _, _) =>
+            {
+                await releaseFactory.Task;
+                return CreateConnectedConnection(brokerId, host, port);
+            },
+            randomDouble: static () => 0.5);
+        pool.RegisterBroker(1, "broker-a", 9092);
+
+        try
+        {
+            Func<Task> connect = () => pool.GetConnectionAsync(1).AsTask();
+
+            await Assert.That(connect).Throws<KafkaException>()
+                .WithMessageContaining("Connection setup timeout after 20ms");
+        }
+        finally
+        {
+            releaseFactory.TrySetResult();
+        }
+    }
+
+    [Test]
     public async Task ConnectionSetupTimeout_SuccessResetsFailureProgression()
     {
         var attempts = 0;

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1394,7 +1394,9 @@ public sealed class ConnectionPoolTests
             connectionOptions: new ConnectionOptions
             {
                 ConnectionTimeout = TimeSpan.FromMilliseconds(20),
-                ConnectionTimeoutMax = TimeSpan.FromMilliseconds(20),
+                // Keep the overall operation deadline distinct so this test exercises
+                // disposal of a connection that completes after the per-attempt timeout.
+                ConnectionTimeoutMax = TimeSpan.FromSeconds(1),
                 ReconnectBackoff = TimeSpan.Zero,
                 ReconnectBackoffMax = TimeSpan.Zero
             },
@@ -1408,7 +1410,8 @@ public sealed class ConnectionPoolTests
                 }
 
                 return freshConnection;
-            });
+            },
+            randomDouble: static () => 0.5);
 
         Func<Task> firstAttempt = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
         await Assert.That(firstAttempt).Throws<KafkaException>()

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1272,6 +1272,17 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task DisposeFailedTlsStreamAsync_DisposalFailureDoesNotReplaceHandshakeFailure()
+    {
+        var innerStream = new ThrowingDisposeStream();
+        var sslStream = new SslStream(innerStream, leaveInnerStreamOpen: false);
+
+        await KafkaConnection.DisposeFailedTlsStreamAsync(sslStream);
+
+        await Assert.That(innerStream.DisposeAttempted).IsTrue();
+    }
+
+    [Test]
     public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationEnabledWithoutCustomPolicy_ReturnsNull()
     {
         await using var connection = new KafkaConnection(
@@ -1707,6 +1718,28 @@ public sealed class KafkaConnectionTests
                 DisposeCount++;
 
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class ThrowingDisposeStream : MemoryStream
+    {
+        public bool DisposeAttempted { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                DisposeAttempted = true;
+                throw new IOException("dispose failed");
+            }
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeAttempted = true;
+            await base.DisposeAsync();
+            throw new IOException("dispose failed");
         }
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -1261,6 +1261,17 @@ public sealed class KafkaConnectionTests
     }
 
     [Test]
+    public async Task DisposeFailedTlsStreamAsync_DisposesTlsAndInnerStreams()
+    {
+        var innerStream = new DisposeTrackingStream();
+        var sslStream = new SslStream(innerStream, leaveInnerStreamOpen: false);
+
+        await KafkaConnection.DisposeFailedTlsStreamAsync(sslStream);
+
+        await Assert.That(innerStream.DisposeCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task BuildRemoteCertificateValidationCallback_WhenHostNameValidationEnabledWithoutCustomPolicy_ReturnsNull()
     {
         await using var connection = new KafkaConnection(
@@ -1681,6 +1692,19 @@ public sealed class KafkaConnectionTests
                 _pendingWrite.TrySetException(new IOException("write aborted"));
                 _disposed.TrySetResult();
             }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class DisposeTrackingStream : MemoryStream
+    {
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                DisposeCount++;
 
             base.Dispose(disposing);
         }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerOptionsDefaultsTests.cs
@@ -55,6 +55,18 @@ public class ProducerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task ConnectionTimeoutMax_WithoutExplicitMaximum_FollowsInitialTimeout()
+    {
+        var options = new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ConnectionTimeout = TimeSpan.FromSeconds(7)
+        };
+
+        await Assert.That(options.ConnectionTimeoutMax).IsEqualTo(TimeSpan.FromSeconds(7));
+    }
+
+    [Test]
     public async Task LingerMs_DefaultsTo_0()
     {
         var options = CreateOptions();


### PR DESCRIPTION
## Summary
- add KIP-601 adaptive connection setup timeouts with exponential growth, ±20% jitter, and a configured cap
- scope failure progression by broker and logical endpoint, reset on success, and keep reconnect backoff outside the setup deadline
- expose initial/max settings across producer, consumer, share consumer, admin, root client, DI binding, and docs

## Validation
- net10 unit suite: 5720 passed
- net8 unit suite: 5593 passed
- focused post-rebase ConnectionPool tests: 66 passed

Closes #2225