### PR TITLE
Support live SASL credential rotation

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -792,6 +792,16 @@ public sealed class AdminClientServiceBuilder
 
 internal static class DekafOptionsBinding
 {
+    private delegate TBuilder SaslOptionsApplier<TBuilder>(
+        SaslMechanism mechanism,
+        string? username,
+        string? password,
+        GssapiConfig? gssapiConfig,
+        OAuthBearerConfig? oauthConfig,
+        AwsMskIamConfig? awsMskIamConfig,
+        bool saslScramTokenAuth,
+        Func<CancellationToken, ValueTask<SaslCredentials>>? credentialProvider);
+
     public static void ApplyProducer<TKey, TValue>(
         ProducerOptions options,
         ProducerBuilder<TKey, TValue> builder)
@@ -857,6 +867,7 @@ internal static class DekafOptionsBinding
             options.OAuthBearerConfig,
             options.OAuthBearerTokenProvider,
             options.AwsMskIamConfig,
+            options.SaslCredentialProvider,
             builder.WithSaslOptions,
             builder.WithOAuthBearer);
         builder.WithSocketSendBufferBytes(options.SocketSendBufferBytes);
@@ -943,6 +954,7 @@ internal static class DekafOptionsBinding
             options.OAuthBearerConfig,
             options.OAuthBearerTokenProvider,
             options.AwsMskIamConfig,
+            options.SaslCredentialProvider,
             builder.WithSaslOptions,
             builder.WithOAuthBearer);
         if (options.RebalanceListener is not null)
@@ -1015,7 +1027,8 @@ internal static class DekafOptionsBinding
                 options.GssapiConfig,
                 options.OAuthBearerConfig,
                 options.AwsMskIamConfig,
-                options.SaslScramTokenAuth);
+                options.SaslScramTokenAuth,
+                options.SaslCredentialProvider);
         }
 
         builder.WithMetadataRecoveryStrategy(options.MetadataRecoveryStrategy);
@@ -1081,7 +1094,8 @@ internal static class DekafOptionsBinding
         OAuthBearerConfig? oauthConfig,
         Func<CancellationToken, ValueTask<OAuthBearerToken>>? oauthTokenProvider,
         AwsMskIamConfig? awsMskIamConfig,
-        Func<SaslMechanism, string?, string?, GssapiConfig?, OAuthBearerConfig?, AwsMskIamConfig?, bool, TBuilder> withSaslOptions,
+        Func<CancellationToken, ValueTask<SaslCredentials>>? credentialProvider,
+        SaslOptionsApplier<TBuilder> withSaslOptions,
         Func<Func<CancellationToken, ValueTask<OAuthBearerToken>>, TBuilder> withOAuthBearer)
     {
         if (oauthTokenProvider is not null)
@@ -1097,7 +1111,8 @@ internal static class DekafOptionsBinding
             gssapiConfig,
             oauthConfig,
             awsMskIamConfig,
-            saslScramTokenAuth);
+            saslScramTokenAuth,
+            credentialProvider);
     }
 
     private static void AddProducerInterceptors<TKey, TValue>(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -5419,12 +5419,14 @@ public sealed class AdminClientBuilder
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig,
         AwsMskIamConfig? awsMskIamConfig = null,
-        bool saslScramTokenAuth = false)
+        bool saslScramTokenAuth = false,
+        Func<CancellationToken, ValueTask<SaslCredentials>>? credentialProvider = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = credentialProvider;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
         _saslScramTokenAuth = saslScramTokenAuth;

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -66,6 +66,7 @@ public sealed class AdminClient : IAdminClient
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
+                SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,
@@ -4785,6 +4786,8 @@ public sealed class AdminClientOptions
     public SaslMechanism SaslMechanism { get; init; } = SaslMechanism.None;
     public string? SaslUsername { get; init; }
     public string? SaslPassword { get; init; }
+
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
     public bool SaslScramTokenAuth { get; init; }
 
     /// <summary>
@@ -4857,6 +4860,7 @@ public sealed class AdminClientBuilder
     private SaslMechanism _saslMechanism = SaslMechanism.None;
     private string? _saslUsername;
     private string? _saslPassword;
+    private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
@@ -4972,6 +4976,19 @@ public sealed class AdminClientBuilder
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public AdminClientBuilder WithSaslPlain(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.Plain;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -4982,6 +4999,19 @@ public sealed class AdminClientBuilder
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public AdminClientBuilder WithSaslScramSha256(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -4992,6 +5022,19 @@ public sealed class AdminClientBuilder
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public AdminClientBuilder WithSaslScramSha512(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -5002,6 +5045,7 @@ public sealed class AdminClientBuilder
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -5012,6 +5056,7 @@ public sealed class AdminClientBuilder
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -5422,6 +5467,7 @@ public sealed class AdminClientBuilder
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
+            SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -113,6 +113,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _isMaxConnectionsPerBrokerConfigured = true;
         _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
         _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
+        _saslMechanism = clientInfrastructure.SaslMechanism;
     }
 
     public ProducerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -1382,6 +1383,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
             SaslCredentialProvider = _saslCredentialProvider,
+            UsesClientOwnedDynamicSaslCredentials =
+                _clientInfrastructure?.UsesDynamicSaslCredentials == true,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -57,6 +57,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private SaslMechanism _saslMechanism = SaslMechanism.None;
     private string? _saslUsername;
     private string? _saslPassword;
+    private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
@@ -605,6 +606,19 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ProducerBuilder<TKey, TValue> WithSaslPlain(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.Plain;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -615,6 +629,19 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ProducerBuilder<TKey, TValue> WithSaslScramSha256(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -625,6 +652,19 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ProducerBuilder<TKey, TValue> WithSaslScramSha512(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -635,6 +675,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -645,6 +686,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -1168,6 +1210,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
         _saslScramTokenAuth = saslScramTokenAuth;
@@ -1337,6 +1380,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
+            SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
@@ -1496,6 +1540,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private SaslMechanism _saslMechanism = SaslMechanism.None;
     private string? _saslUsername;
     private string? _saslPassword;
+    private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
@@ -1996,6 +2041,19 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ConsumerBuilder<TKey, TValue> WithSaslPlain(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.Plain;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -2006,6 +2064,19 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ConsumerBuilder<TKey, TValue> WithSaslScramSha256(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -2016,6 +2087,19 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ConsumerBuilder<TKey, TValue> WithSaslScramSha512(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -2026,6 +2110,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -2036,6 +2121,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -2751,6 +2837,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
         _saslScramTokenAuth = saslScramTokenAuth;
@@ -2871,6 +2958,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
+            SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
@@ -3008,6 +3096,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private SaslMechanism _saslMechanism = SaslMechanism.None;
     private string? _saslUsername;
     private string? _saslPassword;
+    private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
@@ -3299,6 +3388,19 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslPlain(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.Plain;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -3309,6 +3411,19 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScram256(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -3319,6 +3434,19 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public ShareConsumerBuilder<TKey, TValue> WithSaslScram512(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -3332,6 +3460,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -3345,6 +3474,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -3586,6 +3716,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
+            SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1204,13 +1204,14 @@ public sealed class ProducerBuilder<TKey, TValue>
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig,
         AwsMskIamConfig? awsMskIamConfig = null,
-        bool saslScramTokenAuth = false)
+        bool saslScramTokenAuth = false,
+        Func<CancellationToken, ValueTask<SaslCredentials>>? credentialProvider = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
-        _saslCredentialProvider = null;
+        _saslCredentialProvider = credentialProvider;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
         _saslScramTokenAuth = saslScramTokenAuth;
@@ -2831,13 +2832,14 @@ public sealed class ConsumerBuilder<TKey, TValue>
         GssapiConfig? gssapiConfig,
         OAuthBearerConfig? oauthConfig,
         AwsMskIamConfig? awsMskIamConfig = null,
-        bool saslScramTokenAuth = false)
+        bool saslScramTokenAuth = false,
+        Func<CancellationToken, ValueTask<SaslCredentials>>? credentialProvider = null)
     {
         ThrowIfClientOwnedConnectionSettings();
         _saslMechanism = mechanism;
         _saslUsername = username;
         _saslPassword = password;
-        _saslCredentialProvider = null;
+        _saslCredentialProvider = credentialProvider;
         _gssapiConfig = gssapiConfig;
         _oauthConfig = oauthConfig;
         _saslScramTokenAuth = saslScramTokenAuth;

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1322,7 +1322,8 @@ public sealed class ProducerBuilder<TKey, TValue>
             _acks = Acks.All;
         }
 
-        GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
+        if (_clientInfrastructure is null)
+            GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
         var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>("key", "WithKeySerializer");
         var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>("value", "WithValueSerializer");

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -319,6 +319,11 @@ public sealed class ConsumerOptions
     public string? SaslPassword { get; init; }
 
     /// <summary>
+    /// Dynamic credential provider for PLAIN and SCRAM authentication.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
+
+    /// <summary>
     /// Whether SCRAM authentication uses Kafka delegation token credentials.
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -803,6 +803,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     DeadLetter.IRawRecordAccessor,
     IBudgetedInstance
 {
+    internal ValueTask CloseConnectionsForTestingAsync() => _connectionPool.CloseAllAsync();
+
     /// <summary>
     /// Delay in milliseconds when all assigned partitions are paused, to prevent
     /// a tight spin loop that would starve CPU while still allowing responsive
@@ -1153,6 +1155,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
+                SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -662,7 +662,9 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         int maxConnectionsPerBroker,
         int producerMaxConnectionsPerBroker,
         int retryBackoffMs,
-        int retryBackoffMaxMs)
+        int retryBackoffMaxMs,
+        SaslMechanism saslMechanism,
+        bool usesDynamicSaslCredentials)
     {
         BootstrapServers = bootstrapServers;
         ConnectionPool = connectionPool;
@@ -675,6 +677,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ProducerMaxConnectionsPerBroker = producerMaxConnectionsPerBroker;
         RetryBackoffMs = retryBackoffMs;
         RetryBackoffMaxMs = retryBackoffMaxMs;
+        SaslMechanism = saslMechanism;
+        UsesDynamicSaslCredentials = usesDynamicSaslCredentials;
     }
 
     public IReadOnlyList<string> BootstrapServers { get; }
@@ -688,6 +692,8 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     public int ProducerMaxConnectionsPerBroker { get; }
     public int RetryBackoffMs { get; }
     public int RetryBackoffMaxMs { get; }
+    public SaslMechanism SaslMechanism { get; }
+    public bool UsesDynamicSaslCredentials { get; }
 
     public static KafkaClientInfrastructure Create(KafkaClientOptions options)
     {
@@ -743,7 +749,9 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.MaxConnectionsPerBroker,
             options.ProducerMaxConnectionsPerBroker,
             options.RetryBackoffMs,
-            options.RetryBackoffMaxMs);
+            options.RetryBackoffMaxMs,
+            options.SaslMechanism,
+            options.SaslCredentialProvider is not null);
     }
 
     private static ConnectionOptions CreateConnectionOptions(KafkaClientOptions options) => new()

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -92,6 +92,7 @@ public sealed class KafkaClientBuilder
     private SaslMechanism _saslMechanism = SaslMechanism.None;
     private string? _saslUsername;
     private string? _saslPassword;
+    private Func<CancellationToken, ValueTask<SaslCredentials>>? _saslCredentialProvider;
     private bool _saslScramTokenAuth;
     private GssapiConfig? _gssapiConfig;
     private OAuthBearerConfig? _oauthConfig;
@@ -272,6 +273,18 @@ public sealed class KafkaClientBuilder
         _saslMechanism = SaslMechanism.Plain;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslPlain(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        _saslMechanism = SaslMechanism.Plain;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -281,6 +294,18 @@ public sealed class KafkaClientBuilder
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslScramSha256(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        _saslMechanism = SaslMechanism.ScramSha256;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -290,6 +315,18 @@ public sealed class KafkaClientBuilder
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = username;
         _saslPassword = password;
+        _saslCredentialProvider = null;
+        _saslScramTokenAuth = false;
+        return this;
+    }
+
+    public KafkaClientBuilder WithSaslScramSha512(
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider)
+    {
+        _saslMechanism = SaslMechanism.ScramSha512;
+        _saslCredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+        _saslUsername = null;
+        _saslPassword = null;
         _saslScramTokenAuth = false;
         return this;
     }
@@ -299,6 +336,7 @@ public sealed class KafkaClientBuilder
         _saslMechanism = SaslMechanism.ScramSha256;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -308,6 +346,7 @@ public sealed class KafkaClientBuilder
         _saslMechanism = SaslMechanism.ScramSha512;
         _saslUsername = tokenId;
         _saslPassword = tokenHmac;
+        _saslCredentialProvider = null;
         _saslScramTokenAuth = true;
         return this;
     }
@@ -541,6 +580,7 @@ public sealed class KafkaClientBuilder
             SaslMechanism = _saslMechanism,
             SaslUsername = _saslUsername,
             SaslPassword = _saslPassword,
+            SaslCredentialProvider = _saslCredentialProvider,
             SaslScramTokenAuth = _saslScramTokenAuth,
             GssapiConfig = _gssapiConfig,
             OAuthBearerConfig = _oauthConfig,
@@ -584,6 +624,7 @@ internal sealed class KafkaClientOptions
     public SaslMechanism SaslMechanism { get; init; }
     public string? SaslUsername { get; init; }
     public string? SaslPassword { get; init; }
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
     public bool SaslScramTokenAuth { get; init; }
     public GssapiConfig? GssapiConfig { get; init; }
     public OAuthBearerConfig? OAuthBearerConfig { get; init; }
@@ -722,6 +763,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         SaslMechanism = options.SaslMechanism,
         SaslUsername = options.SaslUsername,
         SaslPassword = options.SaslPassword,
+        SaslCredentialProvider = options.SaslCredentialProvider,
         SaslScramTokenAuth = options.SaslScramTokenAuth,
         GssapiConfig = options.GssapiConfig,
         OAuthBearerConfig = options.OAuthBearerConfig,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -184,6 +184,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
             SaslMechanism = options.SaslMechanism,
             SaslUsername = options.SaslUsername,
             SaslPassword = options.SaslPassword,
+            SaslCredentialProvider = options.SaslCredentialProvider,
             SaslScramTokenAuth = options.SaslScramTokenAuth,
             GssapiConfig = options.GssapiConfig,
             OAuthBearerTokenProvider = sharedProvider.GetTokenAsync,

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3090,6 +3090,7 @@ public sealed partial class KafkaConnection :
                 if (authResponse.ErrorCode != ErrorCode.None)
                 {
                     throw new AuthenticationException(
+                        authResponse.ErrorCode,
                         $"SASL authentication failed: {authResponse.ErrorCode}" +
                         (authResponse.ErrorMessage is not null ? $" - {authResponse.ErrorMessage}" : ""));
                 }
@@ -3121,7 +3122,11 @@ public sealed partial class KafkaConnection :
 
     private ValueTask<ISaslAuthenticator> CreateSaslAuthenticatorAsync(CancellationToken cancellationToken)
     {
-        var provider = _options.SaslCredentialProvider;
+        var provider = _options.SaslMechanism is SaslMechanism.Plain
+            or SaslMechanism.ScramSha256
+            or SaslMechanism.ScramSha512
+            ? _options.SaslCredentialProvider
+            : null;
         return provider is null
             ? new ValueTask<ISaslAuthenticator>(CreateSaslAuthenticator(_options.SaslUsername, _options.SaslPassword))
             : CreateSaslAuthenticatorFromProviderAsync(provider, cancellationToken);
@@ -3132,6 +3137,13 @@ public sealed partial class KafkaConnection :
         CancellationToken cancellationToken)
     {
         var credentials = await provider(cancellationToken).ConfigureAwait(false);
+        if (credentials.Username is null || credentials.Password is null)
+        {
+            throw new AuthenticationException(
+                ErrorCode.SaslAuthenticationFailed,
+                "SASL credential provider returned invalid credentials");
+        }
+
         return CreateSaslAuthenticator(credentials.Username, credentials.Password);
     }
 
@@ -3327,6 +3339,7 @@ public sealed partial class KafkaConnection :
                 if (authResponse.ErrorCode != ErrorCode.None)
                 {
                     throw new AuthenticationException(
+                        authResponse.ErrorCode,
                         $"SASL re-authentication failed: {authResponse.ErrorCode}" +
                         (authResponse.ErrorMessage is not null ? $" - {authResponse.ErrorMessage}" : ""));
                 }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -3041,8 +3041,8 @@ public sealed partial class KafkaConnection :
     /// </summary>
     private async ValueTask<long> PerformSaslExchangeAsync(CancellationToken cancellationToken)
     {
-        // Create the appropriate authenticator
-        ISaslAuthenticator authenticator = CreateSaslAuthenticator();
+        // Resolve dynamic credentials once per authentication attempt, then create a fresh authenticator.
+        var authenticator = await CreateSaslAuthenticatorAsync(cancellationToken).ConfigureAwait(false);
 
         long sessionLifetimeMs = 0;
 
@@ -3119,20 +3119,36 @@ public sealed partial class KafkaConnection :
         return sessionLifetimeMs;
     }
 
-    private ISaslAuthenticator CreateSaslAuthenticator() => _options.SaslMechanism switch
+    private ValueTask<ISaslAuthenticator> CreateSaslAuthenticatorAsync(CancellationToken cancellationToken)
+    {
+        var provider = _options.SaslCredentialProvider;
+        return provider is null
+            ? new ValueTask<ISaslAuthenticator>(CreateSaslAuthenticator(_options.SaslUsername, _options.SaslPassword))
+            : CreateSaslAuthenticatorFromProviderAsync(provider, cancellationToken);
+    }
+
+    private async ValueTask<ISaslAuthenticator> CreateSaslAuthenticatorFromProviderAsync(
+        Func<CancellationToken, ValueTask<SaslCredentials>> provider,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await provider(cancellationToken).ConfigureAwait(false);
+        return CreateSaslAuthenticator(credentials.Username, credentials.Password);
+    }
+
+    private ISaslAuthenticator CreateSaslAuthenticator(string? username, string? password) => _options.SaslMechanism switch
     {
         SaslMechanism.Plain => new PlainAuthenticator(
-            _options.SaslUsername ?? throw new InvalidOperationException("SASL username not configured"),
-            _options.SaslPassword ?? throw new InvalidOperationException("SASL password not configured")),
+            username ?? throw new InvalidOperationException("SASL username not configured"),
+            password ?? throw new InvalidOperationException("SASL password not configured")),
         SaslMechanism.ScramSha256 => new ScramAuthenticator(
             SaslMechanism.ScramSha256,
-            _options.SaslUsername ?? throw new InvalidOperationException("SASL username not configured"),
-            _options.SaslPassword ?? throw new InvalidOperationException("SASL password not configured"),
+            username ?? throw new InvalidOperationException("SASL username not configured"),
+            password ?? throw new InvalidOperationException("SASL password not configured"),
             _options.SaslScramTokenAuth),
         SaslMechanism.ScramSha512 => new ScramAuthenticator(
             SaslMechanism.ScramSha512,
-            _options.SaslUsername ?? throw new InvalidOperationException("SASL username not configured"),
-            _options.SaslPassword ?? throw new InvalidOperationException("SASL password not configured"),
+            username ?? throw new InvalidOperationException("SASL username not configured"),
+            password ?? throw new InvalidOperationException("SASL password not configured"),
             _options.SaslScramTokenAuth),
         SaslMechanism.Gssapi => new GssapiAuthenticator(
             _options.GssapiConfig ?? throw new InvalidOperationException("GSSAPI configuration not provided"),
@@ -3265,8 +3281,8 @@ public sealed partial class KafkaConnection :
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
 
-        // Create the appropriate authenticator (fresh instance for each re-auth)
-        ISaslAuthenticator authenticator = CreateSaslAuthenticator();
+        // Resolve dynamic credentials once per re-authentication attempt.
+        var authenticator = await CreateSaslAuthenticatorAsync(cancellationToken).ConfigureAwait(false);
 
         long sessionLifetimeMs = 0;
 
@@ -3909,6 +3925,12 @@ public sealed class ConnectionOptions
     /// SASL password for PLAIN and SCRAM authentication.
     /// </summary>
     public string? SaslPassword { get; init; }
+
+    /// <summary>
+    /// Dynamic credential provider for PLAIN and SCRAM authentication.
+    /// Invoked once for each initial authentication and re-authentication attempt.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
 
     /// <summary>
     /// Whether SCRAM authentication uses Kafka delegation token credentials.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3878,6 +3878,29 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
         }
+        catch (AuthenticationException ex)
+        {
+            // Authentication failures are fatal for the configured credentials. Retrying the
+            // same credentials until delivery timeout hides the actionable exception and creates
+            // a reconnect storm.
+            _pinnedConnections[connectionIndex] = null;
+            LogResponseFailed(ex, _brokerId);
+            for (var i = 0; i < count; i++)
+            {
+                var batch = batches[i];
+                if (batch is null || !batch.IsCurrentIncarnation(generations[i]))
+                    continue;
+
+                UnmutePartition(batch.TopicPartition);
+                try { FailAndCleanupBatch(batch, ex); }
+                catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+            }
+
+            scratch.ClearReferences();
+
+            if (!pendingResponseAdded)
+                ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
+        }
         catch (Exception ex)
         {
             // Send failed (connection error, timeout, etc.) — retry batches instead of permanently failing.

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -15,6 +15,7 @@ using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
 using Dekaf.Retry;
+using Dekaf.Security.Sasl;
 using Microsoft.Extensions.Logging;
 
 namespace Dekaf.Producer;
@@ -3878,11 +3879,15 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
         }
-        catch (AuthenticationException ex)
+        catch (AuthenticationException ex) when (
+            ex.ErrorCode == ErrorCode.SaslAuthenticationFailed
+            && _options.SaslCredentialProvider is null
+            && _options.SaslMechanism is SaslMechanism.Plain
+                or SaslMechanism.ScramSha256
+                or SaslMechanism.ScramSha512)
         {
-            // Authentication failures are fatal for the configured credentials. Retrying the
-            // same credentials until delivery timeout hides the actionable exception and creates
-            // a reconnect storm.
+            // A broker-rejected static PLAIN/SCRAM credential is fatal. Dynamic credential
+            // providers and other authentication-adjacent failures follow the normal retry path.
             _pinnedConnections[connectionIndex] = null;
             LogResponseFailed(ex, _brokerId);
             for (var i = 0; i < count; i++)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3881,7 +3881,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
         catch (AuthenticationException ex) when (
             ex.ErrorCode == ErrorCode.SaslAuthenticationFailed
-            && _options.SaslCredentialProvider is null
+            && !_options.UsesDynamicSaslCredentials
             && _options.SaslMechanism is SaslMechanism.Plain
                 or SaslMechanism.ScramSha256
                 or SaslMechanism.ScramSha512)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -25,6 +25,8 @@ namespace Dekaf.Producer;
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerDiagnostics, IProducerFastPath<TKey, TValue>, IBudgetedInstance
 {
+    internal ValueTask CloseConnectionsForTestingAsync() => _connectionPool.CloseAllAsync();
+
     /// <summary>
     /// Sentinel return value from <see cref="TryProduceSyncCore"/> indicating that the
     /// buffer is full and the caller should fall back to the async path (ReserveMemoryAsync).
@@ -260,6 +262,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
+                SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -494,6 +494,11 @@ public sealed class ProducerOptions
     public string? SaslPassword { get; init; }
 
     /// <summary>
+    /// Dynamic credential provider for PLAIN and SCRAM authentication.
+    /// </summary>
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
+
+    /// <summary>
     /// Whether SCRAM authentication uses Kafka delegation token credentials.
     /// </summary>
     public bool SaslScramTokenAuth { get; init; }

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -498,6 +498,10 @@ public sealed class ProducerOptions
     /// </summary>
     public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
 
+    internal bool UsesClientOwnedDynamicSaslCredentials { get; init; }
+    internal bool UsesDynamicSaslCredentials =>
+        SaslCredentialProvider is not null || UsesClientOwnedDynamicSaslCredentials;
+
     /// <summary>
     /// Whether SCRAM authentication uses Kafka delegation token credentials.
     /// </summary>

--- a/src/Dekaf/Security/Sasl/SaslCredentials.cs
+++ b/src/Dekaf/Security/Sasl/SaslCredentials.cs
@@ -1,0 +1,19 @@
+namespace Dekaf.Security.Sasl;
+
+/// <summary>
+/// Username and password used for SASL/PLAIN or SASL/SCRAM authentication.
+/// </summary>
+public readonly struct SaslCredentials
+{
+    public SaslCredentials(string username, string password)
+    {
+        Username = username ?? throw new ArgumentNullException(nameof(username));
+        Password = password ?? throw new ArgumentNullException(nameof(password));
+    }
+
+    /// <summary>The SASL username.</summary>
+    public string Username { get; }
+
+    /// <summary>The SASL password.</summary>
+    public string Password { get; }
+}

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -88,6 +88,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 SaslMechanism = options.SaslMechanism,
                 SaslUsername = options.SaslUsername,
                 SaslPassword = options.SaslPassword,
+                SaslCredentialProvider = options.SaslCredentialProvider,
                 SaslScramTokenAuth = options.SaslScramTokenAuth,
                 GssapiConfig = options.GssapiConfig,
                 OAuthBearerConfig = options.OAuthBearerConfig,

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -172,6 +172,8 @@ public sealed class ShareConsumerOptions
     /// </summary>
     public string? SaslPassword { get; init; }
 
+    public Func<CancellationToken, ValueTask<SaslCredentials>>? SaslCredentialProvider { get; init; }
+
     /// <summary>
     /// Whether SCRAM authentication uses Kafka delegation token credentials.
     /// </summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslCredentialRotationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslCredentialRotationTests.cs
@@ -33,7 +33,7 @@ public sealed class SaslCredentialRotationTests(SaslKafkaContainer kafka)
         await ProduceAsync(producer, topic, "before-rotation").ConfigureAwait(false);
 
         await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
-        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
 
         // Revocation does not terminate an already-authenticated broker connection.
         await ProduceAsync(producer, topic, "existing-connection").ConfigureAwait(false);
@@ -72,7 +72,7 @@ public sealed class SaslCredentialRotationTests(SaslKafkaContainer kafka)
         await ProduceAsync(producer, topic, "before-rotation").ConfigureAwait(false);
 
         await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
-        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
         current.Value = new SaslCredentials(userB, passwordB);
 
         await ((KafkaProducer<string, string>)producer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
@@ -107,7 +107,7 @@ public sealed class SaslCredentialRotationTests(SaslKafkaContainer kafka)
         await ConsumeValueAsync(consumer, "before-rotation").ConfigureAwait(false);
 
         await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
-        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
         await ProduceWithPlainAsync(topic, "existing-connection").ConfigureAwait(false);
         await ConsumeValueAsync(consumer, "existing-connection").ConfigureAwait(false);
 
@@ -141,7 +141,7 @@ public sealed class SaslCredentialRotationTests(SaslKafkaContainer kafka)
         consumer.Subscribe(topic);
         await ConsumeValueAsync(consumer, "before-revocation").ConfigureAwait(false);
 
-        await kafka.DeleteScramSha256CredentialAsync(user).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(user, password).ConfigureAwait(false);
         await ProduceWithPlainAsync(topic, "existing-connection").ConfigureAwait(false);
         await ConsumeValueAsync(consumer, "existing-connection").ConfigureAwait(false);
 

--- a/tests/Dekaf.Tests.Integration/Security/SaslCredentialRotationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslCredentialRotationTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Security.Sasl;
+
+namespace Dekaf.Tests.Integration.Security;
+
+[Category("Authentication")]
+[ClassDataSource<SaslKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SaslCredentialRotationTests(SaslKafkaContainer kafka)
+{
+    [Test]
+    public async Task Producer_ReconnectWithRevokedCredential_ThrowsAuthenticationExceptionWithoutRetryStorm()
+    {
+        var userA = $"rotation-a-{Guid.NewGuid():N}";
+        var passwordA = $"password-a-{Guid.NewGuid():N}";
+        var userB = $"rotation-b-{Guid.NewGuid():N}";
+        var passwordB = $"password-b-{Guid.NewGuid():N}";
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+
+        await kafka.UpsertScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithSaslScramSha256(userA, passwordA)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+
+        await ProduceAsync(producer, topic, "before-rotation").ConfigureAwait(false);
+
+        await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+
+        // Revocation does not terminate an already-authenticated broker connection.
+        await ProduceAsync(producer, topic, "existing-connection").ConfigureAwait(false);
+
+        await ((KafkaProducer<string, string>)producer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = await Assert.ThrowsAsync<AuthenticationException>(async () =>
+            await ProduceAsync(producer, topic, "after-reconnect").ConfigureAwait(false));
+
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(10));
+    }
+
+    [Test]
+    public async Task Producer_CredentialProvider_UsesRotatedCredentialAfterReconnect()
+    {
+        var userA = $"provider-a-{Guid.NewGuid():N}";
+        var passwordA = $"password-a-{Guid.NewGuid():N}";
+        var userB = $"provider-b-{Guid.NewGuid():N}";
+        var passwordB = $"password-b-{Guid.NewGuid():N}";
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var current = new CredentialState(new SaslCredentials(userA, passwordA));
+
+        await kafka.UpsertScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithSaslScramSha256(current.GetAsync)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(15))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+
+        await ProduceAsync(producer, topic, "before-rotation").ConfigureAwait(false);
+
+        await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+        current.Value = new SaslCredentials(userB, passwordB);
+
+        await ((KafkaProducer<string, string>)producer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
+        await ProduceAsync(producer, topic, "after-reconnect").ConfigureAwait(false);
+
+        await Assert.That(current.InvocationCount).IsGreaterThanOrEqualTo(2);
+    }
+
+    [Test]
+    public async Task Consumer_CredentialProvider_UsesRotatedCredentialAfterReconnect()
+    {
+        var userA = $"consumer-a-{Guid.NewGuid():N}";
+        var passwordA = $"password-a-{Guid.NewGuid():N}";
+        var userB = $"consumer-b-{Guid.NewGuid():N}";
+        var passwordB = $"password-b-{Guid.NewGuid():N}";
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var current = new CredentialState(new SaslCredentials(userA, passwordA));
+
+        await kafka.UpsertScramSha256CredentialAsync(userA, passwordA).ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "before-rotation").ConfigureAwait(false);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithGroupId($"rotation-group-{Guid.NewGuid():N}")
+            .WithSaslScramSha256(current.GetAsync)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+
+        consumer.Subscribe(topic);
+        await ConsumeValueAsync(consumer, "before-rotation").ConfigureAwait(false);
+
+        await kafka.UpsertScramSha256CredentialAsync(userB, passwordB).ConfigureAwait(false);
+        await kafka.DeleteScramSha256CredentialAsync(userA).ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "existing-connection").ConfigureAwait(false);
+        await ConsumeValueAsync(consumer, "existing-connection").ConfigureAwait(false);
+
+        current.Value = new SaslCredentials(userB, passwordB);
+        await ((KafkaConsumer<string, string>)consumer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "after-reconnect").ConfigureAwait(false);
+        await ConsumeValueAsync(consumer, "after-reconnect").ConfigureAwait(false);
+
+        await Assert.That(current.InvocationCount).IsGreaterThanOrEqualTo(2);
+    }
+
+    [Test]
+    public async Task Consumer_ReconnectWithRevokedCredential_ThrowsAuthenticationException()
+    {
+        var user = $"revoked-consumer-{Guid.NewGuid():N}";
+        var password = $"password-{Guid.NewGuid():N}";
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+
+        await kafka.UpsertScramSha256CredentialAsync(user, password).ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "before-revocation").ConfigureAwait(false);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithGroupId($"revoked-group-{Guid.NewGuid():N}")
+            .WithSaslScramSha256(user, password)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+
+        consumer.Subscribe(topic);
+        await ConsumeValueAsync(consumer, "before-revocation").ConfigureAwait(false);
+
+        await kafka.DeleteScramSha256CredentialAsync(user).ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "existing-connection").ConfigureAwait(false);
+        await ConsumeValueAsync(consumer, "existing-connection").ConfigureAwait(false);
+
+        await ((KafkaConsumer<string, string>)consumer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
+        await ProduceWithPlainAsync(topic, "after-reconnect").ConfigureAwait(false);
+
+        var exception = await Assert.ThrowsAsync<AuthenticationException>(async () =>
+            await ConsumeValueAsync(consumer, "after-reconnect").ConfigureAwait(false));
+        await Assert.That(exception!.IsRetriable).IsFalse();
+    }
+
+    private static async Task ProduceAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        string value)
+    {
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = value,
+            Value = value
+        }, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private async Task ProduceWithPlainAsync(string topic, string value)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithSaslPlain(SaslKafkaContainer.SaslUsername, SaslKafkaContainer.SaslPassword)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        await ProduceAsync(producer, topic, value).ConfigureAwait(false);
+    }
+
+    private static async Task ConsumeValueAsync(IKafkaConsumer<string, string> consumer, string expected)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token).ConfigureAwait(false);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Value).IsEqualTo(expected);
+    }
+
+    private sealed class CredentialState(SaslCredentials value)
+    {
+        private int _invocationCount;
+
+        public SaslCredentials Value { get; set; } = value;
+        public int InvocationCount => Volatile.Read(ref _invocationCount);
+
+        public ValueTask<SaslCredentials> GetAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Interlocked.Increment(ref _invocationCount);
+            return ValueTask.FromResult(Value);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -1,4 +1,5 @@
 using Dekaf.Admin;
+using Dekaf.Errors;
 using Testcontainers.Kafka;
 
 namespace Dekaf.Tests.Integration.Security;
@@ -88,9 +89,13 @@ public class SaslKafkaContainer : KafkaTestContainer
                 Password = password
             }
         ]).ConfigureAwait(false);
+
+        await WaitForAdminReadyAsync(
+            $"SCRAM-SHA-256 user '{user}'",
+            () => CreateScramAdminClient(ScramMechanism.ScramSha256, user, password)).ConfigureAwait(false);
     }
 
-    public async Task DeleteScramSha256CredentialAsync(string user)
+    public async Task DeleteScramSha256CredentialAsync(string user, string password)
     {
         await using var admin = CreateAdminClient();
         await admin.AlterUserScramCredentialsAsync(
@@ -101,6 +106,41 @@ public class SaslKafkaContainer : KafkaTestContainer
                 Mechanism = ScramMechanism.ScramSha256
             }
         ]).ConfigureAwait(false);
+
+        await WaitForScramRejectionAsync(user, password).ConfigureAwait(false);
+    }
+
+    private async Task WaitForScramRejectionAsync(string user, string password, int maxAttempts = 30)
+    {
+        Console.WriteLine($"[{GetType().Name}] Waiting for SCRAM-SHA-256 user '{user}' to be revoked...");
+        Exception? lastError = null;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            try
+            {
+                var admin = CreateScramAdminClient(ScramMechanism.ScramSha256, user, password);
+                await using (admin.ConfigureAwait(false))
+                {
+                    await admin.ListTopicsAsync().ConfigureAwait(false);
+                }
+            }
+            catch (AuthenticationException)
+            {
+                Console.WriteLine($"[{GetType().Name}] SCRAM-SHA-256 user '{user}' is revoked");
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex;
+            }
+
+            await Task.Delay(1000).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"SCRAM-SHA-256 user '{user}' remained usable after {maxAttempts} attempts. " +
+            $"Last client error: {lastError?.Message}.{await TryGetBrokerLogTailAsync().ConfigureAwait(false)}");
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/SaslKafkaContainer.cs
@@ -75,6 +75,34 @@ public class SaslKafkaContainer : KafkaTestContainer
             .Build();
     }
 
+    public async Task UpsertScramSha256CredentialAsync(string user, string password)
+    {
+        await using var admin = CreateAdminClient();
+        await admin.AlterUserScramCredentialsAsync(
+        [
+            new UserScramCredentialUpsertion
+            {
+                User = user,
+                Mechanism = ScramMechanism.ScramSha256,
+                Iterations = 4096,
+                Password = password
+            }
+        ]).ConfigureAwait(false);
+    }
+
+    public async Task DeleteScramSha256CredentialAsync(string user)
+    {
+        await using var admin = CreateAdminClient();
+        await admin.AlterUserScramCredentialsAsync(
+        [
+            new UserScramCredentialDeletion
+            {
+                User = user,
+                Mechanism = ScramMechanism.ScramSha256
+            }
+        ]).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// After the base container is started and TCP-ready, verify SASL/PLAIN authentication
     /// works, create SCRAM credentials, and wait for each mechanism to propagate.

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -4,6 +4,7 @@ using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Consumer;
 using Dekaf.Producer;
+using Dekaf.Security.Sasl;
 
 namespace Dekaf.Tests.Unit.Builder;
 
@@ -43,6 +44,35 @@ public sealed class KafkaClientBuilderTests
         var options = GetField<ProducerOptions>(producer, "_options");
 
         await Assert.That(options.MaxConnectionsPerBroker).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task RootClient_StaticSasl_CopiesProducerAuthModeWithoutCredentials()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithSaslScramSha256("user", "password"));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha256);
+        await Assert.That(options.UsesDynamicSaslCredentials).IsFalse();
+        await Assert.That(options.SaslUsername).IsNull();
+        await Assert.That(options.SaslPassword).IsNull();
+    }
+
+    [Test]
+    public async Task RootClient_DynamicSasl_CopiesProducerAuthModeWithoutProvider()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithSaslPlain(static _ => ValueTask.FromResult(new SaslCredentials("user", "password"))));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Plain);
+        await Assert.That(options.UsesDynamicSaslCredentials).IsTrue();
+        await Assert.That(options.SaslCredentialProvider is null).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/KafkaClientBuilderTests.cs
@@ -76,6 +76,19 @@ public sealed class KafkaClientBuilderTests
     }
 
     [Test]
+    public async Task RootClient_Gssapi_CreatesProducerUsingSharedConfiguration()
+    {
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithGssapi(new GssapiConfig()));
+        await using var producer = client.CreateProducer<string, string>().Build();
+
+        var options = GetField<ProducerOptions>(producer, "_options");
+
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.Gssapi);
+        await Assert.That(options.GssapiConfig).IsNull();
+    }
+
+    [Test]
     public async Task RootClient_CreatedConsumer_UsesDefaultAdaptiveMaximumOf4()
     {
         await using var client = Kafka.Connect("localhost:9092");

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -160,6 +160,8 @@ public class DependencyInjectionTests
     public async Task AddProducer_WithTypedOptions_BindsOptions()
     {
         var services = new ServiceCollection();
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider =
+            _ => ValueTask.FromResult(new SaslCredentials("rotated-user", "rotated-password"));
         var options = new ProducerOptions
         {
             BootstrapServers = ["broker1:9092"],
@@ -173,7 +175,8 @@ public class DependencyInjectionTests
             SaslMechanism = SaslMechanism.ScramSha512,
             SaslUsername = "producer-user",
             SaslPassword = "producer-password",
-            SaslScramTokenAuth = true
+            SaslScramTokenAuth = true,
+            SaslCredentialProvider = credentialProvider
         };
 
         services.AddDekaf(builder =>
@@ -197,6 +200,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("producer-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("producer-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
     [Test]
@@ -368,6 +372,8 @@ public class DependencyInjectionTests
     public async Task AddConsumer_WithTypedOptions_BindsOptions()
     {
         var services = new ServiceCollection();
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider =
+            _ => ValueTask.FromResult(new SaslCredentials("rotated-user", "rotated-password"));
         var options = new ConsumerOptions
         {
             BootstrapServers = ["broker1:9092"],
@@ -380,7 +386,8 @@ public class DependencyInjectionTests
             SaslMechanism = SaslMechanism.ScramSha256,
             SaslUsername = "consumer-user",
             SaslPassword = "consumer-password",
-            SaslScramTokenAuth = true
+            SaslScramTokenAuth = true,
+            SaslCredentialProvider = credentialProvider
         };
 
         services.AddDekaf(builder =>
@@ -403,6 +410,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("consumer-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("consumer-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
     [Test]
@@ -472,6 +480,8 @@ public class DependencyInjectionTests
     public async Task AddAdminClient_WithTypedOptions_BindsOptions()
     {
         var services = new ServiceCollection();
+        Func<CancellationToken, ValueTask<SaslCredentials>> credentialProvider =
+            _ => ValueTask.FromResult(new SaslCredentials("rotated-user", "rotated-password"));
         var options = new AdminClientOptions
         {
             BootstrapServers = ["broker1:9092"],
@@ -481,7 +491,8 @@ public class DependencyInjectionTests
             SaslMechanism = SaslMechanism.ScramSha512,
             SaslUsername = "admin-user",
             SaslPassword = "admin-password",
-            SaslScramTokenAuth = true
+            SaslScramTokenAuth = true,
+            SaslCredentialProvider = credentialProvider
         };
 
         services.AddDekaf(builder =>
@@ -501,6 +512,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.SaslUsername).IsEqualTo("admin-user");
         await Assert.That(boundOptions.SaslPassword).IsEqualTo("admin-password");
         await Assert.That(boundOptions.SaslScramTokenAuth).IsTrue();
+        await Assert.That((object?)boundOptions.SaslCredentialProvider).IsSameReferenceAs(credentialProvider);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1409,8 +1409,10 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
                 CreateMultiPartitionResponse("test-topic", partitions.ToArray())));
         };
         var pool = Substitute.For<IConnectionPool>();
+        var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(connection);
+            .Returns(_ => new ValueTask<IKafkaConnection>(connectionAvailable.Task));
         var options = CreateOptions();
         var accumulator = new RecordAccumulator(options);
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
@@ -1440,6 +1442,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             sender.Enqueue(batchA);
             sender.Enqueue(batchB);
             sender.Enqueue(batchC);
+            connectionAvailable.SetResult(connection);
 
             await firstSend.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -13,6 +13,7 @@ using Dekaf.Protocol;
 using Dekaf.Producer;
 using Dekaf.Protocol.Messages;
 using Dekaf.Protocol.Records;
+using Dekaf.Security.Sasl;
 
 using NSubstitute;
 
@@ -35,7 +36,9 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     public async Task SendLoop_AuthenticationFailure_FailsBatchWithoutRetry(
         CancellationToken cancellationToken)
     {
-        var authenticationFailure = new AuthenticationException("revoked credential");
+        var authenticationFailure = new AuthenticationException(
+            ErrorCode.SaslAuthenticationFailed,
+            "revoked credential");
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns<ValueTask<IKafkaConnection>>(_ =>
@@ -44,7 +47,10 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             .Returns<ValueTask<IKafkaConnection>>(_ =>
                 ValueTask.FromException<IKafkaConnection>(authenticationFailure));
 
-        var options = CreateOptions(deliveryTimeoutMs: 20_000, requestTimeoutMs: 5_000);
+        var options = CreateOptions(
+            deliveryTimeoutMs: 20_000,
+            requestTimeoutMs: 5_000,
+            saslMechanism: SaslMechanism.ScramSha256);
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var acknowledgement = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -705,7 +711,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         bool enableIdempotence = true, int batchSize = 1_048_576,
         long? unackedByteBudgetCapOverride = null, long? scaleCooldownMsOverride = null,
         string? transactionalId = null, int lingerMs = 0,
-        bool enableDeliveryDiagnostics = false) => new()
+        bool enableDeliveryDiagnostics = false,
+        SaslMechanism saslMechanism = SaslMechanism.None) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -722,7 +729,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             EnableDeliveryDiagnostics = enableDeliveryDiagnostics,
             UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride,
             ScaleCooldownMsOverride = scaleCooldownMsOverride,
-            TransactionalId = transactionalId
+            TransactionalId = transactionalId,
+            SaslMechanism = saslMechanism
         };
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -31,6 +31,46 @@ namespace Dekaf.Tests.Unit.Producer;
 public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 {
     [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_AuthenticationFailure_FailsBatchWithoutRetry(
+        CancellationToken cancellationToken)
+    {
+        var authenticationFailure = new AuthenticationException("revoked credential");
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                ValueTask.FromException<IKafkaConnection>(authenticationFailure));
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                ValueTask.FromException<IKafkaConnection>(authenticationFailure));
+
+        var options = CreateOptions(deliveryTimeoutMs: 20_000, requestTimeoutMs: 5_000);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledgement = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) => acknowledgement.TrySetResult(error));
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+
+            var observed = await acknowledgement.Task.WaitAsync(cancellationToken);
+            await Assert.That(observed).IsSameReferenceAs(authenticationFailure);
+            await pool.Received(1).GetConnectionAsync(1, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task DeliveryLatencyOrigin_SealWithinLinger_UsesSealNotCreation()
     {
         // Sealing within the configured linger: the origin stays the seal, so opted-in


### PR DESCRIPTION
Closes #2251

## Summary
- add dynamic `SaslCredentials` providers for PLAIN/SCRAM across producer, consumer, share consumer, admin, and shared `KafkaClient` builders
- resolve credentials once per initial authentication or KIP-368 re-authentication attempt
- surface revoked producer credentials as non-retriable `AuthenticationException` instead of retrying until delivery timeout
- add reusable SCRAM upsert/delete fixture helpers and live producer/consumer rotation coverage

## Validation
- `dotnet build --configuration Release --no-restore` — passed, 0 warnings
- `BrokerSenderSendLoopTests/SendLoop_AuthenticationFailure_FailsBatchWithoutRetry` — net10 1/1, net8 1/1
- `SaslCredentialRotationTests` — net10 4/4, net8 4/4

## Performance
`ProducerFireHotPathBenchmarks` (`MemoryDiagnoser`, 1 KB messages, same machine/runtime):

| delivery target | baseline `01d45cd1` | candidate `c8b8a013` repeat | delta | allocated |
|---|---:|---:|---:|---:|
| 0 ms | 318.3 ns | 315.1 ns | -1.0% | 0 B → 0 B |
| 10 ms | 932.4 ns | 928.7 ns | -0.4% | 0 B → 0 B |

The first candidate sample for the 0 ms case was inconclusive (377.4 ns, 155% CI, stochastic 1 B report). One exact repeat returned 315.1 ns and 0 B; the 10 ms control was stable in both candidate samples (935.4 ns then 928.7 ns) and remained 0 B. Provider invocation and fatal-auth handling are connection/authentication error paths; no per-message success-path work was added.