### PR TITLE
fix(producer): flush disposal diagnostics

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -5117,7 +5117,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         LogWaitingForSendLoop(_brokerId);
         try
         {
-            await _sendLoopTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            await _sendLoopTask.WaitAsync(_disposalDrainTimeout).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -5126,7 +5126,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
         // The final loop iteration is not guaranteed to run the scale controller after
         // cancellation. Flush any partial diagnostic window explicitly once its writer exits.
-        EndPartitionLimitedDiagnosticState(MonotonicClock.GetMilliseconds());
+        // If the bounded wait timed out, the send loop still owns this state and must remain
+        // its only writer.
+        if (_sendLoopTask.IsCompleted)
+            EndPartitionLimitedDiagnosticState(MonotonicClock.GetMilliseconds());
 
         var deferredPendingCount = Volatile.Read(ref _totalPendingResponseCount);
         if (deferredPendingCount > 0 && !_sendLoopTask.IsCompleted)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -5124,6 +5124,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             LogBatchCleanupStepFailed(ex, _brokerId);
         }
 
+        // The final loop iteration is not guaranteed to run the scale controller after
+        // cancellation. Flush any partial diagnostic window explicitly once its writer exits.
+        EndPartitionLimitedDiagnosticState(MonotonicClock.GetMilliseconds());
+
         var deferredPendingCount = Volatile.Read(ref _totalPendingResponseCount);
         if (deferredPendingCount > 0 && !_sendLoopTask.IsCompleted)
         {

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -160,10 +160,9 @@ public sealed class AdaptiveScaleDownTests
 
         try
         {
-            // Keep the live loop in partition-limited state so it cannot independently
-            // end and flush the reflection-driven diagnostic window before disposal.
-            GetField<HashSet<TopicPartition>>(sender, "_knownPartitions")
-                .Add(new TopicPartition(Topic, 0));
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+
             var observe = typeof(BrokerSender).GetMethod(
                 "ObservePartitionLimitedPressure",
                 BindingFlags.Instance | BindingFlags.NonPublic)!;

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -186,6 +186,51 @@ public sealed class AdaptiveScaleDownTests
     }
 
     [Test]
+    public async Task PartitionLimitedPressure_DisposeTimeout_DoesNotFlushPartialWindow()
+    {
+        var options = CreateOptions(
+            idempotent: false,
+            scaleCooldownMs: 0,
+            enableDeliveryDiagnostics: true);
+        var accumulator = new RecordAccumulator(options);
+        var pool = Substitute.For<IConnectionPool>();
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            onAcknowledgement: null,
+            disposalDrainTimeout: TimeSpan.FromMilliseconds(25));
+        var incompleteSendLoop = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            sender.RequestCancellation();
+            await GetField<Task>(sender, "_sendLoopTask");
+
+            var observe = typeof(BrokerSender).GetMethod(
+                "ObservePartitionLimitedPressure",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var now = Dekaf.MonotonicClock.GetMilliseconds();
+            observe.Invoke(sender, [now, 0.5, 10L, 20L]);
+            observe.Invoke(sender, [now + 1, 0.6, 30L, 40L]);
+            SetField(sender, "_sendLoopTask", incompleteSendLoop.Task);
+
+            await sender.DisposeAsync();
+
+            var diagnostics = accumulator.GetDeliveryDiagnosticsSnapshot().ConnectionScaleEvents;
+            await Assert.That(diagnostics).HasSingleItem();
+            await Assert.That(diagnostics[0].ObservationCount).IsEqualTo(1);
+        }
+        finally
+        {
+            incompleteSendLoop.TrySetResult();
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task PartitionLimitedBufferPressure_RecordsCappedEventOncePerDelta()
     {
         var options = CreateOptions(


### PR DESCRIPTION
Closes #2304.

## What changed
- flush partial partition-limited diagnostics explicitly after the send loop exits during disposal
- stop and await the test sender loop before directly seeding diagnostic state

This removes the race where the live loop could split or overwrite the test window, and makes the production disposal guarantee explicit instead of depending on a final scale-controller pass.

## Validation
- `AdaptiveScaleDownTests`: net10 38/38, net8 38/38
- full unit: net10 5734/5734, net8 5607/5607
- build: 0 warnings, 0 errors

Performance: disposal-only cold path; no per-message or per-batch path changes.