### PR TITLE
Implement KIP-1025 OAuth Basic URL encoding

### DIFF
--- a/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerConfig.cs
@@ -26,6 +26,13 @@ public sealed class OAuthBearerConfig
     public string? ClientSecret { get; init; }
 
     /// <summary>
+    /// Whether to form URL-encode the client ID and client secret independently before
+    /// constructing the HTTP Basic Authorization header. Defaults to <see langword="false"/>
+    /// for compatibility with OAuth providers that expect raw credentials.
+    /// </summary>
+    public bool UrlEncodeHeaderCredentials { get; init; }
+
+    /// <summary>
     /// The OAuth 2.0 scope(s) to request. Multiple scopes should be space-separated.
     /// </summary>
     public string? Scope { get; init; }

--- a/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
+++ b/src/Dekaf/Security/Sasl/OAuthBearerTokenProvider.cs
@@ -131,10 +131,20 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         };
 
         // If client secret is provided, use HTTP Basic authentication
-        if (_config.ClientAssertion is null && !string.IsNullOrEmpty(_config.ClientSecret))
+        if (_config.ClientAssertion is null
+            && _config.ClientSecret is { } clientSecret
+            // Preserve the legacy "empty means absent" behavior unless encoding is opted in.
+            && (clientSecret.Length > 0 || _config.UrlEncodeHeaderCredentials))
         {
+            var clientId = _config.ClientId;
+            if (_config.UrlEncodeHeaderCredentials)
+            {
+                clientId = FormUrlEncode(clientId);
+                clientSecret = FormUrlEncode(clientSecret);
+            }
+
             var credentials = Convert.ToBase64String(
-                Encoding.UTF8.GetBytes($"{_config.ClientId}:{_config.ClientSecret}"));
+                Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}"));
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
         }
 
@@ -151,6 +161,38 @@ public sealed class OAuthBearerTokenProvider : IDisposable
         }
 
         return ParseTokenResponse(responseContent);
+    }
+
+    private static string FormUrlEncode(string value)
+    {
+        if (value.Length == 0)
+            return string.Empty;
+
+        const string Hex = "0123456789ABCDEF";
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var encoded = new StringBuilder(bytes.Length);
+        foreach (var valueByte in bytes)
+        {
+            if (valueByte is >= (byte)'a' and <= (byte)'z'
+                or >= (byte)'A' and <= (byte)'Z'
+                or >= (byte)'0' and <= (byte)'9'
+                or (byte)'-' or (byte)'.' or (byte)'_' or (byte)'*')
+            {
+                encoded.Append((char)valueByte);
+            }
+            else if (valueByte == (byte)' ')
+            {
+                encoded.Append('+');
+            }
+            else
+            {
+                encoded.Append('%');
+                encoded.Append(Hex[valueByte >> 4]);
+                encoded.Append(Hex[valueByte & 0x0F]);
+            }
+        }
+
+        return encoded.ToString();
     }
 
     private async Task<OAuthBearerToken> FetchAzureImdsTokenAsync(CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
+++ b/tests/Dekaf.Tests.Unit/Security/Sasl/OAuthBearerTokenProviderTests.cs
@@ -342,6 +342,84 @@ public sealed class OAuthBearerTokenProviderTests
     }
 
     [Test]
+    public async Task GetTokenAsync_WithUrlEncodingDisabled_PreservesRawBasicHeaderBytes()
+    {
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = "client id+:%",
+            ClientSecret = "sëcret +:%"
+        }, new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        await Assert.That(handler.AuthorizationParameters.Single())
+            .IsEqualTo("Y2xpZW50IGlkKzolOnPDq2NyZXQgKzol");
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithUrlEncodingEnabled_EncodesBasicHeaderComponents()
+    {
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = "client id+:%",
+            ClientSecret = "sëcret +:%",
+            UrlEncodeHeaderCredentials = true
+        }, new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        await Assert.That(handler.AuthorizationParameters.Single())
+            .IsEqualTo("Y2xpZW50K2lkJTJCJTNBJTI1OnMlQzMlQUJjcmV0KyUyQiUzQSUyNQ==");
+        await Assert.That(handler.Requests.Single()["client_id"]).IsEqualTo("client id+:%");
+    }
+
+    [Test]
+    [Arguments("", "secret", "OnNlY3JldA==")]
+    [Arguments("client", "", "Y2xpZW50Og==")]
+    public async Task GetTokenAsync_WithUrlEncodingEnabled_HandlesEmptyComponents(
+        string clientId,
+        string clientSecret,
+        string expectedHeader)
+    {
+        var handler = new CapturingTokenEndpointHandler();
+        using var provider = new OAuthBearerTokenProvider(new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+            UrlEncodeHeaderCredentials = true
+        }, new HttpClient(handler));
+
+        _ = await provider.GetTokenAsync();
+
+        await Assert.That(handler.AuthorizationParameters.Single()).IsEqualTo(expectedHeader);
+    }
+
+    [Test]
+    public async Task GetTokenAsync_WithUrlEncodingEnabled_RoundTripsAtRfcCompliantEndpoint()
+    {
+        const string ClientId = "client id+:%";
+        const string ClientSecret = "sëcret +:%";
+        var handler = new RfcCompliantTokenEndpointHandler(ClientId, ClientSecret);
+        using var provider = new OAuthBearerTokenProvider(new OAuthBearerConfig
+        {
+            TokenEndpointUrl = "https://auth.example.test/token",
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            UrlEncodeHeaderCredentials = true
+        }, new HttpClient(handler));
+
+        var token = await provider.GetTokenAsync();
+
+        await Assert.That(token.TokenValue).IsEqualTo("access-token");
+        await Assert.That(handler.CredentialsMatched).IsTrue();
+    }
+
+    [Test]
     public async Task GetTokenAsync_WhenClientAssertionIsRejected_DoesNotFallBackToSecret()
     {
         using var rsa = RSA.Create(2048);
@@ -560,6 +638,7 @@ public sealed class OAuthBearerTokenProviderTests
     {
         public List<IReadOnlyDictionary<string, string>> Requests { get; } = [];
         public List<string?> AuthorizationSchemes { get; } = [];
+        public List<string?> AuthorizationParameters { get; } = [];
         public int ExpiresInSeconds { get; init; } = 3600;
         public HttpStatusCode ResponseStatusCode { get; init; } = HttpStatusCode.OK;
 
@@ -570,6 +649,7 @@ public sealed class OAuthBearerTokenProviderTests
             var body = await request.Content!.ReadAsStringAsync(cancellationToken);
             Requests.Add(ParseForm(body));
             AuthorizationSchemes.Add(request.Headers.Authorization?.Scheme);
+            AuthorizationParameters.Add(request.Headers.Authorization?.Parameter);
 
             var count = Requests.Count;
             var json = $$"""{"access_token":"access-token-{{count}}","expires_in":{{ExpiresInSeconds}},"sub":"principal-{{count}}"}""";
@@ -591,6 +671,42 @@ public sealed class OAuthBearerTokenProviderTests
             }
 
             return result;
+        }
+
+        private static string DecodeFormValue(string value) =>
+            Uri.UnescapeDataString(value.Replace('+', ' '));
+    }
+
+    private sealed class RfcCompliantTokenEndpointHandler(
+        string expectedClientId,
+        string expectedClientSecret) : HttpMessageHandler
+    {
+        public bool CredentialsMatched { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var parameter = request.Headers.Authorization?.Parameter
+                ?? throw new InvalidOperationException("Basic Authorization header missing.");
+            var credentialBytes = Convert.FromBase64String(parameter);
+            var encodedCredentials = Encoding.UTF8.GetString(credentialBytes);
+            var components = encodedCredentials.Split(':', 2);
+            if (components.Length != 2)
+                throw new InvalidOperationException("Basic credentials separator missing.");
+
+            var clientId = DecodeFormValue(components[0]);
+            var clientSecret = DecodeFormValue(components[1]);
+            CredentialsMatched = clientId == expectedClientId && clientSecret == expectedClientSecret;
+
+            var statusCode = CredentialsMatched ? HttpStatusCode.OK : HttpStatusCode.Unauthorized;
+            return Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(
+                    """{"access_token":"access-token","expires_in":3600,"sub":"principal"}""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
         }
 
         private static string DecodeFormValue(string value) =>


### PR DESCRIPTION
Closes #2245.

## What changed
- add `OAuthBearerConfig.UrlEncodeHeaderCredentials`, default `false`
- when enabled, form URL-encode client ID and secret independently before joining with the unencoded `:` separator and Base64-encoding the HTTP Basic credentials
- match Kafka/Java `URLEncoder` UTF-8 semantics (`space` → `+`, other bytes → uppercase `%HH`)
- preserve the token request body, JWT client assertion, Azure IMDS, SASL payload, and default raw-header behavior
- preserve legacy empty-secret behavior unless the new option is explicitly enabled

## Validation
- deterministic raw and encoded Authorization header byte tests
- spaces, plus, colon, percent, non-ASCII, and empty component coverage
- RFC-compliant token endpoint decoder round-trip
- OAuth provider tests: 31/31
- full unit: net10 5739/5739; net8 5612/5612
- build: 0 warnings, 0 errors

Performance: token acquisition is a cold network path. Encoding only runs when explicitly enabled; no producer/consumer message hot path changes.