### PR TITLE
test: isolate exact allocation probe

### DIFF
--- a/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
+++ b/tests/Dekaf.Tests.Unit/Internal/LockFreeStackTests.cs
@@ -101,7 +101,10 @@ public class LockFreeStackTests
         await Assert.That(stack.Count).IsEqualTo(1);
     }
 
+    // A dedicated thread isolates ExecutionContext, but not process-wide runtime work
+    // triggered by parallel tests. Give the exact allocation counter a quiet test window.
     [Test]
+    [NotInParallel]
     public async Task TryPush_TryPop_DoNotAllocateInSteadyState()
     {
         Task<long> allocationProbe;


### PR DESCRIPTION
## Summary
- serialize the exact LockFreeStack allocation probe against the parallel TUnit suite
- retain its dedicated thread, suppressed ExecutionContext, optimized probe body, and exact `0 B` assertion
- prevent process-wide runtime work triggered by parallel tests from contaminating the probe thread's counter

## Verification
- Release unit build: 0 warnings, 0 errors
- exact probe in fresh processes: net10.0 30/30; net8.0 20/20
- full Release net10.0 suite: 3 consecutive passes, 5,799/5,799 each
- full Release net8.0 suite: 3 consecutive passes, 5,672/5,672 each

Test-only change; no `src/` or hot-path benchmark impact.

Closes #2205
Unblocks #2302
