### PR TITLE
test(producer): synchronize coalescing waves

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1936,8 +1936,14 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             // Phase 1: enqueue A(p0) and B(p1) — coalesced into send 1
             var batchA = CreateTestBatch(vtPool, "test-topic", 0);
             var batchB = CreateTestBatch(vtPool, "test-topic", 1);
-            sender.Enqueue(batchA);
-            sender.Enqueue(batchB);
+            // Predeclare the complete first wave before publishing its separate channel
+            // events. Otherwise the live sender can dispatch A before B is available.
+            var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+                "_knownPartitions",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+            knownPartitions.Add(batchA.TopicPartition);
+            knownPartitions.Add(batchB.TopicPartition);
+            sender.EnqueueBulk([batchA, batchB]);
 
             await sendSignals[0].Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
@@ -1945,8 +1951,7 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             // (maxInFlight=1, so the send loop is waiting for the response)
             var batchC = CreateTestBatch(vtPool, "test-topic", 0);
             var batchD = CreateTestBatch(vtPool, "test-topic", 1);
-            sender.Enqueue(batchC);
-            sender.Enqueue(batchD);
+            sender.EnqueueBulk([batchC, batchD]);
 
             // Complete send 1: p0 fails, p1 succeeds
             // This triggers the muted partition filter on already-coalesced batches

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1906,8 +1906,15 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             var batch1 = CreateTestBatch(vtPool, "test-topic", 0);
             var batch2 = CreateTestBatch(vtPool, "test-topic", 1);
 
-            sender.Enqueue(batch1);
-            sender.Enqueue(batch2);
+            // The first batch teaches the live sender only one known partition. Predeclare
+            // the complete test wave so it waits for both separately queued bulk events
+            // instead of dispatching whichever event wins the startup race.
+            var knownPartitions = (HashSet<TopicPartition>)typeof(BrokerSender).GetField(
+                "_knownPartitions",
+                BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+            knownPartitions.Add(batch1.TopicPartition);
+            knownPartitions.Add(batch2.TopicPartition);
+            sender.EnqueueBulk([batch1, batch2]);
 
             // Wait for the send loop to send the coalesced request
             await requestSent.Task.WaitAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- publish both coalescing setup waves with `EnqueueBulk`
- predeclare the complete known-partition wave before the live sender can dispatch its first event
- remove startup races without delays or rerun-based mitigation

## Verification
- Release unit build: 0 warnings, 0 errors
- each affected test: 20/20 on net10.0 and 20/20 on net8.0 (80 focused runs total)
- full net10.0 unit suite: 5,809/5,809
- full net8.0 unit suite: 5,682/5,682

Prerequisite #2205 landed first via #2307.

Closes #2302