### PR TITLE
fix(consumer): bound finite API operations

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -924,6 +924,7 @@ internal static class DekafOptionsBinding
         builder.WithHeartbeatInterval(TimeSpan.FromMilliseconds(options.HeartbeatIntervalMs));
         builder.WithRebalanceTimeout(TimeSpan.FromMilliseconds(options.RebalanceTimeoutMs));
         builder.WithRequestTimeout(TimeSpan.FromMilliseconds(options.RequestTimeoutMs));
+        builder.WithDefaultApiTimeout(TimeSpan.FromMilliseconds(options.DefaultApiTimeoutMs));
         builder.WithRetryBackoff(TimeSpan.FromMilliseconds(options.RetryBackoffMs));
         builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(options.RetryBackoffMaxMs));
         if (options.IsReconnectBackoffMsConfigured)
@@ -1321,6 +1322,8 @@ internal static class DekafConfigurationBinding
             builder.WithIsolationLevel(isolationLevel);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RequestTimeoutMs), out var requestTimeoutMs))
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.DefaultApiTimeoutMs), out var defaultApiTimeoutMs))
+            builder.WithDefaultApiTimeout(TimeSpan.FromMilliseconds(defaultApiTimeoutMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RetryBackoffMs), out var retryBackoffMs))
             builder.WithRetryBackoff(TimeSpan.FromMilliseconds(retryBackoffMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.RetryBackoffMaxMs), out var retryBackoffMaxMs))

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1536,6 +1536,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int? _heartbeatIntervalMs;
     private int _rebalanceTimeoutMs = 60000;
     private int _requestTimeoutMs = 30000;
+    private int _defaultApiTimeoutMs = 60000;
     private int _retryBackoffMs = 100;
     private int _retryBackoffMaxMs = 1000;
     private bool _checkCrcs = true;
@@ -1963,6 +1964,23 @@ public sealed class ConsumerBuilder<TKey, TValue>
     {
         ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
         _sessionTimeoutMs = (int)timeout.TotalMilliseconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the aggregate timeout for finite consumer API operations such as initialization,
+    /// commits, committed-offset lookup, watermark lookup, timestamp-offset lookup, and close.
+    /// Equivalent to Kafka's <c>default.api.timeout.ms</c>. Default is 60 seconds.
+    /// Streaming consume APIs remain long-lived and are controlled by their cancellation token.
+    /// </summary>
+    /// <param name="timeout">The aggregate API timeout. Must be at least one millisecond.</param>
+    public ConsumerBuilder<TKey, TValue> WithDefaultApiTimeout(TimeSpan timeout)
+    {
+        if (timeout < TimeSpan.FromMilliseconds(1))
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Default API timeout must be at least one millisecond");
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, nameof(timeout));
+
+        _defaultApiTimeoutMs = (int)timeout.TotalMilliseconds;
         return this;
     }
 
@@ -2947,6 +2965,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             HeartbeatIntervalMs = _heartbeatIntervalMs ?? 3000,
             RebalanceTimeoutMs = _rebalanceTimeoutMs,
             RequestTimeoutMs = _requestTimeoutMs,
+            DefaultApiTimeoutMs = _defaultApiTimeoutMs,
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs,
             ReconnectBackoffMs = _reconnectBackoffMs,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1915,7 +1915,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     {
         await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
 
-        await StopHeartbeatAsync().ConfigureAwait(false);
+        await StopHeartbeatAsyncCore(cancellationToken).ConfigureAwait(false);
 
         await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
         try
@@ -1992,7 +1992,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// <summary>
     /// Stops the heartbeat background task.
     /// </summary>
-    public async ValueTask StopHeartbeatAsync()
+    public ValueTask StopHeartbeatAsync() => StopHeartbeatAsyncCore(CancellationToken.None);
+
+    internal async ValueTask StopHeartbeatAsyncCore(CancellationToken cancellationToken)
     {
         CancellationTokenSource? cts;
         Task? task;
@@ -2014,7 +2016,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         {
             try
             {
-                await task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                await task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1917,7 +1917,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         await StopHeartbeatAsyncCore(cancellationToken).ConfigureAwait(false);
 
-        await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             ResetMemberState();

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -206,6 +206,17 @@ public sealed class ConsumerOptions
     public int RequestTimeoutMs { get; init; } = 30000;
 
     /// <summary>
+    /// Aggregate timeout in milliseconds for finite consumer API operations.
+    /// Equivalent to Kafka's <c>default.api.timeout.ms</c>. Default is 60 seconds.
+    /// </summary>
+    /// <remarks>
+    /// This bounds the complete operation across metadata lookup, coordinator discovery,
+    /// retries, and multi-broker fan-out. It does not apply to the long-lived
+    /// <c>ConsumeAsync</c>, <c>ConsumeBatchAsync</c>, or <c>ConsumeRawBatchAsync</c> streams.
+    /// </remarks>
+    public int DefaultApiTimeoutMs { get; init; } = 60000;
+
+    /// <summary>
     /// Initial delay in milliseconds for retrying failed broker requests.
     /// Equivalent to Kafka's <c>retry.backoff.ms</c>.
     /// </summary>

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -1,3 +1,4 @@
+using Dekaf.Errors;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 #if NETSTANDARD2_0
@@ -91,6 +92,10 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// <summary>
     /// Consumes messages as an async enumerable.
     /// </summary>
+    /// <remarks>
+    /// This is an intentionally long-lived stream. <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>
+    /// does not apply; use <paramref name="cancellationToken"/> to bound its lifetime.
+    /// </remarks>
     IAsyncEnumerable<ConsumeResult<TKey, TValue>> ConsumeAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -105,6 +110,10 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Position tracking is deferred to batch completion.
     /// Partition EOF events are not surfaced by this method; use <see cref="ConsumeAsync"/> for EOF notification.
     /// </summary>
+    /// <remarks>
+    /// This is an intentionally long-lived stream. <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>
+    /// does not apply; use <paramref name="cancellationToken"/> to bound its lifetime.
+    /// </remarks>
     IAsyncEnumerable<ConsumeBatch<TKey, TValue>> ConsumeBatchAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -113,6 +122,10 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// No deserialization, header copying, interceptors, or tracing overhead.
     /// Partition EOF events are not surfaced by this method; use <see cref="ConsumeAsync"/> for EOF notification.
     /// </summary>
+    /// <remarks>
+    /// This is an intentionally long-lived stream. <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>
+    /// does not apply; use <paramref name="cancellationToken"/> to bound its lifetime.
+    /// </remarks>
     IAsyncEnumerable<ConsumeRawBatch> ConsumeRawBatchAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -132,11 +145,17 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// Commits the offsets of all consumed messages.
     /// Use with OffsetCommitMode.Manual to control when offsets are committed.
     /// </summary>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     ValueTask CommitAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Commits specific offsets.
     /// </summary>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     ValueTask CommitAsync(IEnumerable<TopicPartitionOffset> offsets, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -170,6 +189,9 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// </remarks>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the asynchronous close operation.</returns>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     ValueTask CloseAsync(CancellationToken cancellationToken = default);
 }
 
@@ -205,6 +227,9 @@ public interface IConsumerPositions
     /// <summary>
     /// Gets the committed offset for a partition.
     /// </summary>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     ValueTask<long?> GetCommittedOffsetAsync(TopicPartition partition, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -299,6 +324,9 @@ public interface IConsumerOffsets
     /// If the input collection is empty, an empty dictionary is returned.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="timestampsToSearch"/> is null.</exception>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     /// <remarks>
     /// This method uses the Kafka ListOffsets API (API Key 2).
     /// Special timestamp values: -1 (latest offset), -2 (earliest offset).
@@ -324,6 +352,9 @@ public interface IConsumerOffsets
     /// <param name="topicPartition">The topic partition to query watermarks for.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The current watermark offsets from the cluster.</returns>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
     ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
         TopicPartition topicPartition,
         CancellationToken cancellationToken = default);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -7751,7 +7751,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Step 1: Stop heartbeat background task
         if (_coordinator is not null)
         {
-            await _coordinator.StopHeartbeatAsync().ConfigureAwait(false);
+            await _coordinator.StopHeartbeatAsyncCore(cancellationToken).ConfigureAwait(false);
         }
 
         // Step 2: Stop leader-refresh tasks before metadata dependencies are disposed

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -843,6 +843,43 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    private readonly struct ApiTimeoutScope : IDisposable
+    {
+        private readonly CancellationTokenSource _timeoutSource;
+        private readonly CancellationToken _callerToken;
+        private readonly long _startedAt;
+        private readonly int _timeoutMs;
+
+        public ApiTimeoutScope(int timeoutMs, CancellationToken callerToken)
+        {
+            _timeoutMs = timeoutMs;
+            _callerToken = callerToken;
+            _startedAt = Stopwatch.GetTimestamp();
+            _timeoutSource = callerToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(callerToken)
+                : new CancellationTokenSource();
+            _timeoutSource.CancelAfter(timeoutMs);
+        }
+
+        public CancellationToken Token => _timeoutSource.Token;
+
+        public bool DefaultTimeoutExpired =>
+            !_callerToken.IsCancellationRequested && _timeoutSource.IsCancellationRequested;
+
+        public KafkaTimeoutException CreateTimeoutException(string operation, Exception innerException)
+        {
+            var configured = TimeSpan.FromMilliseconds(_timeoutMs);
+            return new KafkaTimeoutException(
+                TimeoutKind.Api,
+                Stopwatch.GetElapsedTime(_startedAt),
+                configured,
+                $"Consumer API operation '{operation}' did not complete within default API timeout ({_timeoutMs}ms)",
+                innerException);
+        }
+
+        public void Dispose() => _timeoutSource.Dispose();
+    }
+
     void IBudgetedInstance.OnBudgetChanged(ulong newLimit)
     {
         Interlocked.Exchange(ref _currentQueuedMaxBytes, (long)newLimit);
@@ -1134,6 +1171,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             options.IsReconnectBackoffMsConfigured,
             options.IsReconnectBackoffMaxMsConfigured);
         ValidateFetchBufferMemory(options);
+        ValidateDefaultApiTimeout(options);
         var telemetryMetricCollector = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
         var fetchBufferMemoryPool = new FetchBufferMemoryPool(options.FetchBufferMemoryBytes);
         var connectionPool = new ConnectionPool(
@@ -1241,6 +1279,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
+    internal static void ValidateDefaultApiTimeout(ConsumerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.DefaultApiTimeoutMs, 1);
+    }
+
     private KafkaConsumer(
         ConsumerOptions options,
         IDeserializer<TKey> keyDeserializer,
@@ -1259,6 +1303,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollIntervalMs, 1);
         ValidateFetchBufferMemory(options);
+        ValidateDefaultApiTimeout(options);
         AutoOffsetResetStrategy.ValidateOptions(options);
 
         _options = options;
@@ -4274,10 +4319,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
-        // Explicit commit: the caller vouches for everything yielded so far, including
-        // a record still being processed.
-        FlushActiveConsumedPosition();
-        await CommitStoredOffsetsAsync(cancellationToken).ConfigureAwait(false);
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
+        {
+            // Explicit commit: the caller vouches for everything yielded so far, including
+            // a record still being processed.
+            FlushActiveConsumedPosition();
+            await CommitStoredOffsetsAsync(apiTimeout.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(CommitAsync), ex);
+        }
     }
 
     /// <summary>
@@ -4406,19 +4459,27 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_coordinator is null)
             return;
 
-        // Materialize to list to allow iteration for both commit tracking and interceptors
-        var offsetsList = offsets as IReadOnlyList<TopicPartitionOffset> ?? offsets.ToArray();
-
-        await _coordinator.CommitOffsetsAsync(offsetsList, cancellationToken).ConfigureAwait(false);
-
-        foreach (var offset in offsetsList)
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
         {
-            var partition = new TopicPartition(offset.Topic, offset.Partition);
-            MarkOffsetCommitted(partition, offset.Offset);
-        }
+            // Materialize to list to allow iteration for both commit tracking and interceptors
+            var offsetsList = offsets as IReadOnlyList<TopicPartitionOffset> ?? offsets.ToArray();
 
-        // Invoke OnCommit interceptors
-        InvokeOnCommitInterceptors(offsetsList);
+            await _coordinator.CommitOffsetsAsync(offsetsList, apiTimeout.Token).ConfigureAwait(false);
+
+            foreach (var offset in offsetsList)
+            {
+                var partition = new TopicPartition(offset.Topic, offset.Partition);
+                MarkOffsetCommitted(partition, offset.Offset);
+            }
+
+            // Invoke OnCommit interceptors
+            InvokeOnCommitInterceptors(offsetsList);
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(CommitAsync), ex);
+        }
     }
 
     public void StoreOffset(ConsumeResult<TKey, TValue> result)
@@ -4443,9 +4504,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_committed.TryGetValue(partition, out var offset))
             return offset;
 
-        if (_coordinator is not null)
+        if (_coordinator is null)
+            return null;
+
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
         {
-            var offsets = await _coordinator.FetchOffsetsAsync([partition], cancellationToken).ConfigureAwait(false);
+            var offsets = await _coordinator.FetchOffsetsAsync([partition], apiTimeout.Token).ConfigureAwait(false);
             if (offsets.TryGetValue(partition, out var committedOffset))
             {
                 offset = committedOffset.Offset;
@@ -4456,6 +4521,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     ClearLastConsumedLeaderEpoch(partition);
                 return offset;
             }
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(GetCommittedOffsetAsync), ex);
         }
 
         return null;
@@ -5235,81 +5304,89 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         ThrowIfNotInitialized();
 
-        return await RetryHelper.WithRetryAsync(async () =>
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
         {
-            var connectionLease = await GetPartitionLeaderControlConnectionAsync(topicPartition, cancellationToken)
+            return await RetryHelper.WithRetryAsync(async () =>
+            {
+                var connectionLease = await GetPartitionLeaderControlConnectionAsync(topicPartition, apiTimeout.Token)
+                    .ConfigureAwait(false);
+                if (connectionLease is null)
+                    throw new KafkaException(ErrorCode.LeaderNotAvailable, $"No leader found for partition {topicPartition}");
+                using var lease = connectionLease.Value;
+                var connection = lease.Connection;
+
+                var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.ListOffsets,
+                    ListOffsetsRequest.LowestSupportedVersion,
+                    ListOffsetsRequest.HighestSupportedVersion);
+
+                var currentLeaderEpoch = GetCurrentLeaderEpoch(topicPartition);
+                var earliestRequest = CreateWatermarkListOffsetsRequest(
+                    topicPartition,
+                    _options.IsolationLevel,
+                    EarliestOffsetTimestamp,
+                    currentLeaderEpoch);
+                var latestRequest = CreateWatermarkListOffsetsRequest(
+                    topicPartition,
+                    _options.IsolationLevel,
+                    LatestOffsetTimestamp,
+                    currentLeaderEpoch);
+
+                var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                    earliestRequest,
+                    listOffsetsVersion,
+                    apiTimeout.Token).AsTask();
+
+                var latestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                    latestRequest,
+                    listOffsetsVersion,
+                    apiTimeout.Token).AsTask();
+
+                await Task.WhenAll(earliestResponseTask, latestResponseTask).ConfigureAwait(false);
+
+                var earliestPartitionResponse = FindListOffsetsPartition(earliestResponseTask.Result, topicPartition);
+
+                if (earliestPartitionResponse is null)
+                    throw new KafkaException(ErrorCode.UnknownServerError,
+                        $"Failed to query earliest offset for {topicPartition}: missing partition response");
+
+                if (earliestPartitionResponse.ErrorCode != ErrorCode.None)
+                {
+                    throw KafkaException.FromErrorCode(earliestPartitionResponse.ErrorCode,
+                        $"Failed to query earliest offset for {topicPartition}: {earliestPartitionResponse.ErrorCode}");
+                }
+
+                var lowWatermark = earliestPartitionResponse.Offset;
+
+                var latestPartitionResponse = FindListOffsetsPartition(latestResponseTask.Result, topicPartition);
+
+                if (latestPartitionResponse is null)
+                    throw new KafkaException(ErrorCode.UnknownServerError,
+                        $"Failed to query latest offset for {topicPartition}: missing partition response");
+
+                if (latestPartitionResponse.ErrorCode != ErrorCode.None)
+                {
+                    throw KafkaException.FromErrorCode(latestPartitionResponse.ErrorCode,
+                        $"Failed to query latest offset for {topicPartition}: {latestPartitionResponse.ErrorCode}");
+                }
+
+                var highWatermark = latestPartitionResponse.Offset;
+
+                var watermarks = new WatermarkOffsets(lowWatermark, highWatermark);
+
+                // Cache the result
+                _watermarks[topicPartition] = watermarks;
+
+                return watermarks;
+            }, _metadataManager, apiTimeout.Token, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
                 .ConfigureAwait(false);
-            if (connectionLease is null)
-                throw new KafkaException(ErrorCode.LeaderNotAvailable, $"No leader found for partition {topicPartition}");
-            using var lease = connectionLease.Value;
-            var connection = lease.Connection;
-
-            var listOffsetsVersion = _metadataManager.GetNegotiatedApiVersion(
-                connection,
-                ApiKey.ListOffsets,
-                ListOffsetsRequest.LowestSupportedVersion,
-                ListOffsetsRequest.HighestSupportedVersion);
-
-            var currentLeaderEpoch = GetCurrentLeaderEpoch(topicPartition);
-            var earliestRequest = CreateWatermarkListOffsetsRequest(
-                topicPartition,
-                _options.IsolationLevel,
-                EarliestOffsetTimestamp,
-                currentLeaderEpoch);
-            var latestRequest = CreateWatermarkListOffsetsRequest(
-                topicPartition,
-                _options.IsolationLevel,
-                LatestOffsetTimestamp,
-                currentLeaderEpoch);
-
-            var earliestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-                earliestRequest,
-                listOffsetsVersion,
-                cancellationToken).AsTask();
-
-            var latestResponseTask = connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
-                latestRequest,
-                listOffsetsVersion,
-                cancellationToken).AsTask();
-
-            await Task.WhenAll(earliestResponseTask, latestResponseTask).ConfigureAwait(false);
-
-            var earliestPartitionResponse = FindListOffsetsPartition(earliestResponseTask.Result, topicPartition);
-
-            if (earliestPartitionResponse is null)
-                throw new KafkaException(ErrorCode.UnknownServerError,
-                    $"Failed to query earliest offset for {topicPartition}: missing partition response");
-
-            if (earliestPartitionResponse.ErrorCode != ErrorCode.None)
-            {
-                throw KafkaException.FromErrorCode(earliestPartitionResponse.ErrorCode,
-                    $"Failed to query earliest offset for {topicPartition}: {earliestPartitionResponse.ErrorCode}");
-            }
-
-            var lowWatermark = earliestPartitionResponse.Offset;
-
-            var latestPartitionResponse = FindListOffsetsPartition(latestResponseTask.Result, topicPartition);
-
-            if (latestPartitionResponse is null)
-                throw new KafkaException(ErrorCode.UnknownServerError,
-                    $"Failed to query latest offset for {topicPartition}: missing partition response");
-
-            if (latestPartitionResponse.ErrorCode != ErrorCode.None)
-            {
-                throw KafkaException.FromErrorCode(latestPartitionResponse.ErrorCode,
-                    $"Failed to query latest offset for {topicPartition}: {latestPartitionResponse.ErrorCode}");
-            }
-
-            var highWatermark = latestPartitionResponse.Offset;
-
-            var watermarks = new WatermarkOffsets(lowWatermark, highWatermark);
-
-            // Cache the result
-            _watermarks[topicPartition] = watermarks;
-
-            return watermarks;
-        }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
-            .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(QueryWatermarkOffsetsAsync), ex);
+        }
     }
 
     /// <inheritdoc />
@@ -5322,20 +5399,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (_initialized)
             return;
 
-        await SemaphoreHelper.AcquireOrThrowDisposedAsync(_initLock, nameof(KafkaConsumer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
         try
         {
-            // Double-check after acquiring lock
-            if (_initialized)
-                return;
+            await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                _initLock,
+                nameof(KafkaConsumer<TKey, TValue>),
+                apiTimeout.Token).ConfigureAwait(false);
+            try
+            {
+                // Double-check after acquiring lock
+                if (_initialized)
+                    return;
 
-            await _metadataManager.InitializeAsync(cancellationToken).ConfigureAwait(false);
-            await _telemetryManager.StartAsync(cancellationToken).ConfigureAwait(false);
-            _initialized = true;
+                await _metadataManager.InitializeAsync(apiTimeout.Token).ConfigureAwait(false);
+                await _telemetryManager.StartAsync(apiTimeout.Token).ConfigureAwait(false);
+                _initialized = true;
+            }
+            finally
+            {
+                SemaphoreHelper.ReleaseSafely(_initLock);
+            }
         }
-        finally
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
         {
-            SemaphoreHelper.ReleaseSafely(_initLock);
+            throw apiTimeout.CreateTimeoutException(nameof(InitializeAsync), ex);
         }
     }
 
@@ -7640,7 +7728,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Interlocked.Exchange(ref _closed, 1) != 0 || Volatile.Read(ref _consumerDisposed) != 0)
             return;
 
-        await CloseAsyncCore(cancellationToken).ConfigureAwait(false);
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
+        {
+            await CloseAsyncCore(apiTimeout.Token).ConfigureAwait(false);
+            apiTimeout.Token.ThrowIfCancellationRequested();
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(CloseAsync), ex);
+        }
     }
 
     /// <summary>
@@ -7834,51 +7931,63 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         ThrowIfNotInitialized();
 
-        var timestamps = timestampsToSearch as IReadOnlyList<TopicPartitionTimestamp>
-            ?? [.. timestampsToSearch];
-
-        return await RetryHelper.WithRetryAsync<IReadOnlyDictionary<TopicPartition, long>>(async () =>
+        using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
+        try
         {
-            // Group partitions by broker leader for efficient batch requests.
-            // Retrying the whole operation re-groups after metadata refreshes.
-            var partitionsByBroker = new Dictionary<int, List<TopicPartitionTimestamp>>();
-            foreach (var tpt in timestamps)
+            var timestamps = timestampsToSearch as IReadOnlyList<TopicPartitionTimestamp>
+                ?? [.. timestampsToSearch];
+
+            return await RetryHelper.WithRetryAsync<IReadOnlyDictionary<TopicPartition, long>>(async () =>
             {
-                var leader = await _metadataManager.GetPartitionLeaderAsync(tpt.Topic, tpt.Partition, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (leader is null)
+                // Group partitions by broker leader for efficient batch requests.
+                // Retrying the whole operation re-groups after metadata refreshes.
+                var partitionsByBroker = new Dictionary<int, List<TopicPartitionTimestamp>>();
+                foreach (var tpt in timestamps)
                 {
-                    LogNoLeaderFound(tpt.Topic, tpt.Partition);
-                    continue;
+                    var leader = await _metadataManager.GetPartitionLeaderAsync(
+                        tpt.Topic,
+                        tpt.Partition,
+                        apiTimeout.Token).ConfigureAwait(false);
+
+                    if (leader is null)
+                    {
+                        LogNoLeaderFound(tpt.Topic, tpt.Partition);
+                        continue;
+                    }
+
+                    if (!partitionsByBroker.TryGetValue(leader.NodeId, out var list))
+                    {
+                        list = [];
+                        partitionsByBroker[leader.NodeId] = list;
+                    }
+
+                    list.Add(tpt);
                 }
 
-                if (!partitionsByBroker.TryGetValue(leader.NodeId, out var list))
+                var results = new Dictionary<TopicPartition, long>();
+
+                // Send ListOffsets requests to each broker
+                foreach (var (brokerId, partitions) in partitionsByBroker)
                 {
-                    list = [];
-                    partitionsByBroker[leader.NodeId] = list;
+                    var brokerResults = await GetOffsetsForTimesFromBrokerAsync(
+                        brokerId,
+                        partitions,
+                        apiTimeout.Token).ConfigureAwait(false);
+
+                    foreach (var kvp in brokerResults)
+                    {
+                        results[kvp.Key] = kvp.Value;
+                    }
                 }
 
-                list.Add(tpt);
-            }
-
-            var results = new Dictionary<TopicPartition, long>();
-
-            // Send ListOffsets requests to each broker
-            foreach (var (brokerId, partitions) in partitionsByBroker)
-            {
-                var brokerResults = await GetOffsetsForTimesFromBrokerAsync(brokerId, partitions, cancellationToken)
-                    .ConfigureAwait(false);
-
-                foreach (var kvp in brokerResults)
-                {
-                    results[kvp.Key] = kvp.Value;
-                }
-            }
-
-            return results;
-        }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
-            .ConfigureAwait(false);
+                return results;
+            }, _metadataManager, apiTimeout.Token, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        {
+            throw apiTimeout.CreateTimeoutException(nameof(GetOffsetsForTimesAsync), ex);
+        }
     }
 
     private async ValueTask<Dictionary<TopicPartition, long>> GetOffsetsForTimesFromBrokerAsync(
@@ -7980,14 +8089,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Diagnostics.DekafMetrics.UnregisterConsumerFetchBufferState(_fetchBufferMetricSource);
 
         // If not already closed, perform graceful close first
-        // Use 30 seconds to allow CommitAsync (which may take up to RequestTimeoutMs=30s) to complete
+        // Preserve the existing 30-second disposal cap while honoring a shorter configured API timeout.
         // Interlocked.Exchange prevents the TOCTOU gap where both CloseAsync and DisposeAsync
         // could race to run teardown concurrently when using Volatile.Read + separate CloseAsync CAS.
         if (Interlocked.Exchange(ref _closed, 1) == 0)
         {
             try
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                using var cts = new CancellationTokenSource(
+                    Math.Min(_options.DefaultApiTimeoutMs, 30_000));
                 await CloseAsyncCore(cts.Token).ConfigureAwait(false);
             }
             catch

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4319,15 +4319,19 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
     {
+        // Explicit commit: the caller vouches for everything yielded so far, including
+        // a record still being processed.
+        FlushActiveConsumedPosition();
+
+        if (_coordinator is null)
+            return;
+
         using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
         try
         {
-            // Explicit commit: the caller vouches for everything yielded so far, including
-            // a record still being processed.
-            FlushActiveConsumedPosition();
             await CommitStoredOffsetsAsync(apiTimeout.Token).ConfigureAwait(false);
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(CommitAsync), ex);
         }
@@ -4476,7 +4480,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             // Invoke OnCommit interceptors
             InvokeOnCommitInterceptors(offsetsList);
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(CommitAsync), ex);
         }
@@ -4522,7 +4526,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 return offset;
             }
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(GetCommittedOffsetAsync), ex);
         }
@@ -5383,7 +5387,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }, _metadataManager, apiTimeout.Token, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
                 .ConfigureAwait(false);
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(QueryWatermarkOffsetsAsync), ex);
         }
@@ -5421,7 +5425,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 SemaphoreHelper.ReleaseSafely(_initLock);
             }
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(InitializeAsync), ex);
         }
@@ -7734,7 +7738,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             await CloseAsyncCore(apiTimeout.Token).ConfigureAwait(false);
             apiTimeout.Token.ThrowIfCancellationRequested();
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(CloseAsync), ex);
         }
@@ -7984,7 +7988,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }, _metadataManager, apiTimeout.Token, _options.RetryBackoffMs, _options.RetryBackoffMaxMs)
                 .ConfigureAwait(false);
         }
-        catch (Exception ex) when (apiTimeout.DefaultTimeoutExpired)
+        catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
         {
             throw apiTimeout.CreateTimeoutException(nameof(GetOffsetsForTimesAsync), ex);
         }

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -179,6 +179,11 @@ public enum TimeoutKind
     /// A consumer group rebalance operation timed out waiting to join or sync with the group.
     /// </summary>
     Rebalance,
+
+    /// <summary>
+    /// A finite client API operation exceeded its aggregate configured timeout.
+    /// </summary>
+    Api,
 }
 
 /// <summary>

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -800,6 +800,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 return;
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex) when (IsFatalMetadataError(ex))
             {
                 throw; // No other broker will resolve this — surface the real cause.
@@ -935,6 +939,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 ResetAllBrokersUnavailableTimestamp();
 
                 return true;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex) when (IsFatalMetadataError(ex))
             {

--- a/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
+++ b/tests/Dekaf.Tests.Integration/NetworkPartition/ConsumerNetworkPartitionTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Producer;
@@ -13,6 +14,146 @@ namespace Dekaf.Tests.Integration.NetworkPartition;
 [ClassDataSource<NetworkPartitionKafkaContainer>(Shared = SharedType.PerTestSession)]
 public class ConsumerNetworkPartitionTests(NetworkPartitionKafkaContainer kafka)
 {
+    [Test]
+    [Timeout(30_000)]
+    public async Task InitializeAsync_PausedBroker_UsesAggregateApiTimeout(
+        CancellationToken cancellationToken)
+    {
+        var configuredTimeout = TimeSpan.FromMilliseconds(750);
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("api-timeout-initialize-consumer")
+            .WithDefaultApiTimeout(configuredTimeout)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(10))
+            .Build();
+
+        await kafka.PauseAsync();
+        try
+        {
+            var startedAt = Stopwatch.GetTimestamp();
+            var exception = await Assert.That(async () =>
+                    await consumer.InitializeAsync(cancellationToken))
+                .Throws<KafkaTimeoutException>();
+            var elapsed = Stopwatch.GetElapsedTime(startedAt);
+
+            await AssertApiTimeoutAsync(exception, configuredTimeout, elapsed);
+        }
+        finally
+        {
+            await kafka.TryUnpauseAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task CommitAsync_PausedBroker_UsesAggregateApiTimeout(
+        CancellationToken cancellationToken)
+    {
+        var configuredTimeout = TimeSpan.FromMilliseconds(750);
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("api-timeout-commit-consumer")
+            .WithGroupId($"api-timeout-{Guid.NewGuid():N}")
+            .WithDefaultApiTimeout(configuredTimeout)
+            .WithRequestTimeout(TimeSpan.FromSeconds(10))
+            .BuildAsync(cancellationToken);
+
+        await kafka.PauseAsync();
+        try
+        {
+            var startedAt = Stopwatch.GetTimestamp();
+            var exception = await Assert.That(async () =>
+                    await consumer.CommitAsync([new TopicPartitionOffset(topic, 0, 0)], cancellationToken))
+                .Throws<KafkaTimeoutException>();
+            var elapsed = Stopwatch.GetElapsedTime(startedAt);
+
+            await AssertApiTimeoutAsync(exception, configuredTimeout, elapsed);
+        }
+        finally
+        {
+            await kafka.TryUnpauseAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task QueryWatermarkOffsetsAsync_PausedBroker_UsesAggregateApiTimeout(
+        CancellationToken cancellationToken)
+    {
+        var configuredTimeout = TimeSpan.FromMilliseconds(750);
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("api-timeout-consumer")
+            .WithDefaultApiTimeout(configuredTimeout)
+            .WithRequestTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        await kafka.PauseAsync();
+        try
+        {
+            var startedAt = Stopwatch.GetTimestamp();
+            var exception = await Assert.That(async () =>
+                    await consumer.QueryWatermarkOffsetsAsync(new TopicPartition(topic, 0), cancellationToken))
+                .Throws<KafkaTimeoutException>();
+            var elapsed = Stopwatch.GetElapsedTime(startedAt);
+
+            await AssertApiTimeoutAsync(exception, configuredTimeout, elapsed);
+        }
+        finally
+        {
+            await kafka.TryUnpauseAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task GetOffsetsForTimesAsync_PausedBroker_UsesAggregateApiTimeout(
+        CancellationToken cancellationToken)
+    {
+        var configuredTimeout = TimeSpan.FromMilliseconds(750);
+        var topic = await kafka.CreateTestTopicAsync();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("api-timeout-offsets-consumer")
+            .WithDefaultApiTimeout(configuredTimeout)
+            .WithRequestTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        await kafka.PauseAsync();
+        try
+        {
+            var startedAt = Stopwatch.GetTimestamp();
+            var exception = await Assert.That(async () =>
+                    await consumer.GetOffsetsForTimesAsync(
+                        [new TopicPartitionTimestamp(topic, 0, TopicPartitionTimestamp.Earliest)],
+                        cancellationToken))
+                .Throws<KafkaTimeoutException>();
+            var elapsed = Stopwatch.GetElapsedTime(startedAt);
+
+            await AssertApiTimeoutAsync(exception, configuredTimeout, elapsed);
+        }
+        finally
+        {
+            await kafka.TryUnpauseAsync();
+        }
+    }
+
+    private static async Task AssertApiTimeoutAsync(
+        KafkaTimeoutException? exception,
+        TimeSpan configuredTimeout,
+        TimeSpan elapsed)
+    {
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception.Configured).IsEqualTo(configuredTimeout);
+        await Assert.That(elapsed).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(500));
+        await Assert.That(elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+    }
+
     [Test]
     [Timeout(60_000)]
     public async Task Consumer_LatestOffsetResolutionFailure_DoesNotReplayFromZero(

--- a/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConsumerBuilderValidationTests.cs
@@ -390,6 +390,33 @@ public class ConsumerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithDefaultApiTimeout_SetsOptions()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithDefaultApiTimeout(TimeSpan.FromSeconds(12))
+            .Build();
+
+        var options = GetConsumerOptions(consumer);
+        await Assert.That(options.DefaultApiTimeoutMs).IsEqualTo(12000);
+    }
+
+    [Test]
+    public async Task WithDefaultApiTimeout_OutsideMillisecondRange_ThrowsArgumentOutOfRangeException()
+    {
+        var builder = Kafka.CreateConsumer<string, string>();
+
+        await Assert.That(() => builder.WithDefaultApiTimeout(TimeSpan.Zero))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithDefaultApiTimeout(TimeSpan.FromMilliseconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithDefaultApiTimeout(TimeSpan.FromTicks(1)))
+            .Throws<ArgumentOutOfRangeException>();
+        await Assert.That(() => builder.WithDefaultApiTimeout(TimeSpan.FromMilliseconds((double)int.MaxValue + 1)))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     public async Task UseTls_ReturnsSameBuilder()
     {
         var builder = Kafka.CreateConsumer<string, string>();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -566,6 +566,36 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task GetCommittedOffsetAsync_StaleMemberEpoch_UsesDefaultApiTimeout()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        var rejoinStarted = SetupBlockingRejoinConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetchStaleAfterInitialSuccess(connection, new ConcurrentQueue<int>());
+
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            requestTimeoutMs: 5000,
+            defaultApiTimeoutMs: 100);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var exception = await Assert.That(async () => await consumer.GetCommittedOffsetAsync(
+                new TopicPartition("test-topic", 1),
+                CancellationToken.None))
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(100));
+        await Assert.That(rejoinStarted.Task.IsCompleted).IsTrue();
+    }
+
+    [Test]
     public async Task GetCommittedOffsetAsync_StaleMemberEpoch_PreservesCallerCancellation()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -1063,7 +1093,8 @@ public sealed class ConsumerAssignmentFastPathTests
         int queuedMinMessages = 1,
         int maxPollIntervalMs = 300_000,
         OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
-        int requestTimeoutMs = 30_000)
+        int requestTimeoutMs = 30_000,
+        int defaultApiTimeoutMs = 60_000)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -1073,7 +1104,8 @@ public sealed class ConsumerAssignmentFastPathTests
                 OffsetCommitMode = offsetCommitMode,
                 QueuedMinMessages = queuedMinMessages,
                 MaxPollIntervalMs = maxPollIntervalMs,
-                RequestTimeoutMs = requestTimeoutMs
+                RequestTimeoutMs = requestTimeoutMs,
+                DefaultApiTimeoutMs = defaultApiTimeoutMs
             },
             Serializers.String,
             Serializers.String,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -2650,6 +2650,32 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(coordinator.GenerationId).IsEqualTo(-1);
     }
 
+    [Test]
+    public async Task ConsumerProtocol_LeaveGroup_ObservesCancellationWhileWaitingForStateLock()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        await using var coordinator = new ConsumerCoordinator(
+            CreateConsumerProtocolOptions(), _connectionPool, _metadataManager);
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+        SetupConsumerGroupHeartbeat();
+        var coordinatorLock = (SemaphoreSlim)typeof(ConsumerCoordinator).GetField(
+            "_lock",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(coordinator)!;
+
+        await coordinatorLock.WaitAsync(CancellationToken.None);
+        try
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+            await Assert.That(async () => await coordinator.LeaveGroupAsync(cancellation.Token))
+                .Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            coordinatorLock.Release();
+        }
+    }
+
     #endregion
 
     #region Remote Assignor Tests

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerDirtyCommitTests.cs
@@ -79,6 +79,54 @@ public sealed class ConsumerDirtyCommitTests
     }
 
     [Test]
+    public async Task CommitAsync_Parameterless_UsesDefaultApiTimeout()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            onOffsetCommitAsync: static async token => await Task.Delay(Timeout.InfiniteTimeSpan, token),
+            defaultApiTimeoutMs: 100);
+        consumer.StoreOffset(new TopicPartitionOffset("topic-a", 0, 10));
+
+        var exception = await Assert.That(async () => await consumer.CommitAsync())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Test]
+    public async Task CommitAsync_WhenOperationFailsAfterDeadline_PreservesOriginalException()
+    {
+        var requests = new List<OffsetCommitRequest>();
+        await using var consumer = CreateConsumer(
+            requests,
+            ErrorCode.None,
+            onOffsetCommitAsync: static async token =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new KafkaException(ErrorCode.InvalidCommitOffsetSize, "commit failed");
+                }
+            },
+            defaultApiTimeoutMs: 100);
+        consumer.StoreOffset(new TopicPartitionOffset("topic-a", 0, 10));
+
+        var exception = await Assert.That(async () => await consumer.CommitAsync())
+            .Throws<KafkaException>()
+            .WithMessage("commit failed");
+
+        await Assert.That(exception).IsTypeOf<KafkaException>();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.InvalidCommitOffsetSize);
+        await Assert.That(exception.IsRetriable).IsFalse();
+    }
+
+    [Test]
     public async Task CommitAsync_AfterNonDirtyPositionReset_DoesNotCommitStaleDirtyOffset()
     {
         var requests = new List<OffsetCommitRequest>();
@@ -474,7 +522,8 @@ public sealed class ConsumerDirtyCommitTests
         bool enableAutoOffsetStore = true,
         Action<CancellationToken>? onOffsetCommit = null,
         int rebalanceTimeoutMs = 60_000,
-        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null)
+        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null,
+        int defaultApiTimeoutMs = 60_000)
         => CreateConsumer(
             requests,
             new Queue<ErrorCode>([responseError]),
@@ -482,7 +531,8 @@ public sealed class ConsumerDirtyCommitTests
             enableAutoOffsetStore,
             onOffsetCommit,
             rebalanceTimeoutMs,
-            onOffsetCommitAsync);
+            onOffsetCommitAsync,
+            defaultApiTimeoutMs);
 
     private static KafkaConsumer<string, string> CreateConsumer(
         List<OffsetCommitRequest> requests,
@@ -491,7 +541,8 @@ public sealed class ConsumerDirtyCommitTests
         bool enableAutoOffsetStore = true,
         Action<CancellationToken>? onOffsetCommit = null,
         int rebalanceTimeoutMs = 60_000,
-        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null)
+        Func<CancellationToken, ValueTask>? onOffsetCommitAsync = null,
+        int defaultApiTimeoutMs = 60_000)
     {
         var connectionPool = Substitute.For<IConnectionPool>();
         var connection = Substitute.For<IKafkaConnection>();
@@ -557,7 +608,8 @@ public sealed class ConsumerDirtyCommitTests
                 GroupId = "group-a",
                 OffsetCommitMode = offsetCommitMode,
                 EnableAutoOffsetStore = enableAutoOffsetStore,
-                RebalanceTimeoutMs = rebalanceTimeoutMs
+                RebalanceTimeoutMs = rebalanceTimeoutMs,
+                DefaultApiTimeoutMs = defaultApiTimeoutMs
             },
             Serializers.String,
             Serializers.String,

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -153,6 +153,13 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task DefaultApiTimeoutMs_DefaultsTo_60000()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.DefaultApiTimeoutMs).IsEqualTo(60000);
+    }
+
+    [Test]
     public async Task RetryBackoff_DefaultsTo_100And1000()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer;
@@ -59,6 +60,41 @@ public sealed class ConsumerPartitionStopListenerTests
     }
 
     [Test]
+    public async Task CloseAsync_BlockingPartitionStopListener_UsesDefaultApiTimeout()
+    {
+        var listener = new TrackingPartitionStopListener
+        {
+            OnStopped = static async (_, cancellationToken) =>
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false)
+        };
+        await using var consumer = CreateConsumer(listener, defaultApiTimeoutMs: 100);
+        consumer.Assign(new TopicPartition("topic-a", 0));
+
+        var exception = await Assert.That(async () => await consumer.CloseAsync())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Api);
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(100));
+        await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
+    public async Task DisposeAsync_BlockingPartitionStopListener_UsesShorterDefaultApiTimeout()
+    {
+        var listener = new TrackingPartitionStopListener
+        {
+            OnStopped = static async (_, cancellationToken) =>
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false)
+        };
+        var consumer = CreateConsumer(listener, defaultApiTimeoutMs: 100);
+        consumer.Assign(new TopicPartition("topic-a", 0));
+
+        await consumer.DisposeAsync();
+
+        await Assert.That(listener.CancellationTokens[0].IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
     public async Task CloseAsync_SuppressesPartitionStopListenerNonCancellationException()
     {
         var listener = new TrackingPartitionStopListener
@@ -74,7 +110,9 @@ public sealed class ConsumerPartitionStopListenerTests
         await Assert.That(consumer.Assignment).IsEmpty();
     }
 
-    private static KafkaConsumer<string, string> CreateConsumer(IRebalanceListener listener)
+    private static KafkaConsumer<string, string> CreateConsumer(
+        IRebalanceListener listener,
+        int defaultApiTimeoutMs = 60_000)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -82,7 +120,8 @@ public sealed class ConsumerPartitionStopListenerTests
                 BootstrapServers = ["localhost:9092"],
                 OffsetCommitMode = OffsetCommitMode.Manual,
                 QueuedMinMessages = 1,
-                RebalanceListener = listener
+                RebalanceListener = listener,
+                DefaultApiTimeoutMs = defaultApiTimeoutMs
             },
             Serializers.String,
             Serializers.String);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerPartitionStopListenerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
 using Dekaf.Serialization;
@@ -79,6 +80,21 @@ public sealed class ConsumerPartitionStopListenerTests
     }
 
     [Test]
+    public async Task CloseAsync_BlockingHeartbeatShutdown_ObservesAggregateCancellation()
+    {
+        await using var consumer = CreateGroupConsumer(defaultApiTimeoutMs: 60_000);
+        var coordinator = GetCoordinator(consumer);
+        SetField(coordinator, "_heartbeatTask", new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously).Task);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var close = consumer.CloseAsync(cts.Token);
+
+        await Assert.That(close.IsCompleted).IsTrue();
+        await Assert.That(async () => await close).Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task DisposeAsync_BlockingPartitionStopListener_UsesShorterDefaultApiTimeout()
     {
         var listener = new TrackingPartitionStopListener
@@ -125,6 +141,35 @@ public sealed class ConsumerPartitionStopListenerTests
             },
             Serializers.String,
             Serializers.String);
+    }
+
+    private static KafkaConsumer<string, string> CreateGroupConsumer(int defaultApiTimeoutMs)
+    {
+        return new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "group-a",
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1,
+                DefaultApiTimeoutMs = defaultApiTimeoutMs
+            },
+            Serializers.String,
+            Serializers.String);
+    }
+
+    private static ConsumerCoordinator GetCoordinator(KafkaConsumer<string, string> consumer) =>
+        (ConsumerCoordinator)GetField(consumer, "_coordinator");
+
+    private static object GetField(object instance, string fieldName) =>
+        instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(instance)
+        ?? throw new InvalidOperationException($"{fieldName} field not found.");
+
+    private static void SetField(object instance, string fieldName, object value)
+    {
+        var field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        field.SetValue(instance, value);
     }
 
     private sealed class TrackingPartitionStopListener : IRebalanceListener, IPartitionStopListener

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -381,6 +381,7 @@ public class DependencyInjectionTests
             GroupId = "typed-group",
             OffsetStoreTiming = OffsetStoreTiming.OnDelivery,
             FetchMinBytes = 4096,
+            DefaultApiTimeoutMs = 12_345,
             EnableAdaptiveConnections = false,
             UseTls = true,
             SaslMechanism = SaslMechanism.ScramSha256,
@@ -404,6 +405,7 @@ public class DependencyInjectionTests
         await Assert.That(boundOptions.GroupId).IsEqualTo("override-group");
         await Assert.That(boundOptions.OffsetStoreTiming).IsEqualTo(OffsetStoreTiming.OnDelivery);
         await Assert.That(boundOptions.FetchMinBytes).IsEqualTo(4096);
+        await Assert.That(boundOptions.DefaultApiTimeoutMs).IsEqualTo(12_345);
         await Assert.That(boundOptions.EnableAdaptiveConnections).IsFalse();
         await Assert.That(boundOptions.UseTls).IsTrue();
         await Assert.That(boundOptions.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha256);
@@ -885,6 +887,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:RebalanceTimeoutMs"] = "45000",
             ["Kafka:Consumers:Orders:IsolationLevel"] = "ReadCommitted",
             ["Kafka:Consumers:Orders:RequestTimeoutMs"] = "15000",
+            ["Kafka:Consumers:Orders:DefaultApiTimeoutMs"] = "25000",
             ["Kafka:Consumers:Orders:ReconnectBackoffMs"] = "80",
             ["Kafka:Consumers:Orders:ReconnectBackoffMaxMs"] = "800",
             ["Kafka:Consumers:Orders:CheckCrcs"] = "true",
@@ -945,6 +948,7 @@ public class DependencyInjectionTests
         await Assert.That(options.RebalanceTimeoutMs).IsEqualTo(45000);
         await Assert.That(options.IsolationLevel).IsEqualTo(IsolationLevel.ReadCommitted);
         await Assert.That(options.RequestTimeoutMs).IsEqualTo(15000);
+        await Assert.That(options.DefaultApiTimeoutMs).IsEqualTo(25000);
         await Assert.That(options.ReconnectBackoffMs).IsEqualTo(80);
         await Assert.That(options.ReconnectBackoffMaxMs).IsEqualTo(800);
         await Assert.That(options.CheckCrcs).IsTrue();

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -700,6 +700,32 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task RefreshMetadataAsync_CallerCancellation_PreservesOperationCanceledException()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        using var cts = new CancellationTokenSource();
+        pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                cts.Cancel();
+                return ValueTask.FromException<IKafkaConnection>(
+                    new OperationCanceledException(call.Arg<CancellationToken>()));
+            });
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["localhost:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                MetadataRecoveryStrategy = MetadataRecoveryStrategy.None
+            });
+
+        await Assert.That(async () => await manager.RefreshMetadataAsync(cts.Token))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task BackgroundRefreshLoop_ObjectDisposedConnection_DoesNotResetInitialized()
     {
         var pool = Substitute.For<IConnectionPool>();


### PR DESCRIPTION
## Summary
- add `default.api.timeout.ms`-equivalent consumer configuration with a 60-second default
- carry one linked deadline through initialization, commits, committed-offset lookup, watermark lookup, timestamp lookup, retries, fan-out, and close
- preserve shorter caller cancellation, expose `TimeoutKind.Api`, bound disposal's graceful-close phase, and document long-lived streaming exclusions

## Validation
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- unit net10: 5815 passed
- unit net8: 5688 passed
- `dotnet build tests/Dekaf.Tests.Integration --configuration Release`
- paused-broker integration: initialize, commit, watermark lookup, and timestamp lookup all passed

## Performance
Finite control-plane APIs only. Message production, consumption, serialization, fetch parsing, and streaming loops are unchanged. Existing cached committed-offset and already-initialized fast paths return before timeout-source creation.

Closes #2265