### PR TITLE
fix(networking): honor KIP-219 broker throttles

### DIFF
--- a/src/Dekaf/Networking/BrokerThrottleState.cs
+++ b/src/Dekaf/Networking/BrokerThrottleState.cs
@@ -1,0 +1,182 @@
+using System.Runtime.CompilerServices;
+using Dekaf.Protocol;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Networking;
+
+/// <summary>
+/// Shared KIP-219 throttle deadline for every physical connection to one broker.
+/// </summary>
+internal sealed class BrokerThrottleState(ClientTelemetryMetricCollector? telemetryMetricCollector = null)
+{
+    private long _throttleUntilMs;
+    private int _maxObservedThrottleTimeMs;
+
+    public int MaxObservedThrottleTimeMs => Volatile.Read(ref _maxObservedThrottleTimeMs);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int GetRemainingMilliseconds()
+    {
+        var throttleUntilMs = Volatile.Read(ref _throttleUntilMs);
+        if (throttleUntilMs == 0)
+            return 0;
+
+        var remainingMs = throttleUntilMs - MonotonicClock.GetMilliseconds();
+        if (remainingMs <= 0)
+        {
+            Interlocked.CompareExchange(ref _throttleUntilMs, 0, throttleUntilMs);
+            return 0;
+        }
+
+        return (int)Math.Min(remainingMs, int.MaxValue);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask WaitAsync(
+        CancellationToken cancellationToken,
+        CancellationToken connectionShutdownToken)
+    {
+        var remainingMs = GetRemainingMilliseconds();
+        return remainingMs == 0
+            ? ValueTask.CompletedTask
+            : WaitSlowAsync(remainingMs, cancellationToken, connectionShutdownToken);
+    }
+
+    public void Observe(int throttleTimeMs)
+    {
+        telemetryMetricCollector?.RecordBrokerThrottle(throttleTimeMs);
+
+        if (throttleTimeMs <= 0)
+            return;
+
+        var observedMaximum = Volatile.Read(ref _maxObservedThrottleTimeMs);
+        while (throttleTimeMs > observedMaximum)
+        {
+            var previous = Interlocked.CompareExchange(
+                ref _maxObservedThrottleTimeMs,
+                throttleTimeMs,
+                observedMaximum);
+            if (previous == observedMaximum)
+                break;
+
+            observedMaximum = previous;
+        }
+
+        var nowMs = MonotonicClock.GetMilliseconds();
+        var throttleUntilMs = throttleTimeMs >= long.MaxValue - nowMs
+            ? long.MaxValue
+            : nowMs + throttleTimeMs;
+        var current = Volatile.Read(ref _throttleUntilMs);
+
+        while (throttleUntilMs > current)
+        {
+            var observed = Interlocked.CompareExchange(
+                ref _throttleUntilMs,
+                throttleUntilMs,
+                current);
+            if (observed == current)
+                return;
+
+            current = observed;
+        }
+    }
+
+    private async ValueTask WaitSlowAsync(
+        int initialDelayMs,
+        CancellationToken cancellationToken,
+        CancellationToken connectionShutdownToken)
+    {
+        CancellationTokenSource? linkedCts = null;
+        var effectiveToken = cancellationToken;
+        if (connectionShutdownToken.CanBeCanceled && connectionShutdownToken != cancellationToken)
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    connectionShutdownToken);
+                effectiveToken = linkedCts.Token;
+            }
+            else
+            {
+                effectiveToken = connectionShutdownToken;
+            }
+        }
+
+        try
+        {
+            var delayMs = initialDelayMs;
+            while (delayMs > 0)
+            {
+                await Task.Delay(delayMs, effectiveToken).ConfigureAwait(false);
+                delayMs = GetRemainingMilliseconds();
+            }
+        }
+        finally
+        {
+            linkedCts?.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// Mirrors Apache Kafka's <c>AbstractResponse.shouldClientThrottle(version)</c>
+/// gates. Older response versions were already delayed by the broker.
+/// </summary>
+internal static class BrokerThrottlePolicy
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool ShouldClientThrottle(ApiKey apiKey, short version) => apiKey switch
+    {
+        ApiKey.Produce => version >= 6,
+        ApiKey.Fetch => version >= 8,
+        ApiKey.ListOffsets => version >= 3,
+        ApiKey.Metadata => version >= 6,
+        ApiKey.OffsetCommit => version >= 4,
+        ApiKey.OffsetFetch => version >= 4,
+        ApiKey.FindCoordinator => version >= 2,
+        ApiKey.JoinGroup => version >= 3,
+        ApiKey.Heartbeat => version >= 2,
+        ApiKey.LeaveGroup => version >= 2,
+        ApiKey.SyncGroup => version >= 2,
+        ApiKey.DescribeGroups => version >= 2,
+        ApiKey.ListGroups => version >= 2,
+        ApiKey.ApiVersions => version >= 2,
+        ApiKey.CreateTopics => version >= 3,
+        ApiKey.DeleteTopics => version >= 2,
+        ApiKey.DeleteRecords => version >= 1,
+        ApiKey.InitProducerId => version >= 1,
+        ApiKey.AddPartitionsToTxn => version >= 1,
+        ApiKey.AddOffsetsToTxn => version >= 1,
+        ApiKey.EndTxn => version >= 1,
+        ApiKey.TxnOffsetCommit => version >= 1,
+        ApiKey.DescribeAcls => version >= 1,
+        ApiKey.CreateAcls => version >= 1,
+        ApiKey.DeleteAcls => version >= 1,
+        ApiKey.DescribeConfigs => version >= 2,
+        ApiKey.AlterConfigs => version >= 1,
+        ApiKey.AlterReplicaLogDirs => version >= 1,
+        ApiKey.DescribeLogDirs => version >= 1,
+        ApiKey.CreatePartitions => version >= 1,
+        ApiKey.CreateDelegationToken => version >= 1,
+        ApiKey.RenewDelegationToken => version >= 1,
+        ApiKey.ExpireDelegationToken => version >= 1,
+        ApiKey.DescribeDelegationToken => version >= 1,
+        ApiKey.DeleteGroups => version >= 1,
+        ApiKey.ElectLeaders => true,
+        ApiKey.IncrementalAlterConfigs => true,
+        ApiKey.AlterPartitionReassignments => true,
+        ApiKey.ListPartitionReassignments => true,
+        ApiKey.OffsetDelete => true,
+        ApiKey.DescribeUserScramCredentials => true,
+        ApiKey.AlterUserScramCredentials => true,
+        ApiKey.UnregisterBroker => true,
+        ApiKey.DescribeTopicPartitions => true,
+        _ => false
+    };
+}
+
+internal interface IBrokerThrottleProvider
+{
+    int GetRemainingBrokerThrottleMilliseconds(int brokerId);
+}

--- a/src/Dekaf/Networking/BrokerThrottleState.cs
+++ b/src/Dekaf/Networking/BrokerThrottleState.cs
@@ -81,6 +81,40 @@ internal sealed class BrokerThrottleState(ClientTelemetryMetricCollector? teleme
         }
     }
 
+    public void MergeFrom(BrokerThrottleState source)
+    {
+        if (ReferenceEquals(this, source))
+            return;
+
+        var sourceMaximum = Volatile.Read(ref source._maxObservedThrottleTimeMs);
+        var observedMaximum = Volatile.Read(ref _maxObservedThrottleTimeMs);
+        while (sourceMaximum > observedMaximum)
+        {
+            var previous = Interlocked.CompareExchange(
+                ref _maxObservedThrottleTimeMs,
+                sourceMaximum,
+                observedMaximum);
+            if (previous == observedMaximum)
+                break;
+
+            observedMaximum = previous;
+        }
+
+        var sourceDeadline = Volatile.Read(ref source._throttleUntilMs);
+        var currentDeadline = Volatile.Read(ref _throttleUntilMs);
+        while (sourceDeadline > currentDeadline)
+        {
+            var previous = Interlocked.CompareExchange(
+                ref _throttleUntilMs,
+                sourceDeadline,
+                currentDeadline);
+            if (previous == currentDeadline)
+                break;
+
+            currentDeadline = previous;
+        }
+    }
+
     private async ValueTask WaitSlowAsync(
         int initialDelayMs,
         CancellationToken cancellationToken,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -170,17 +170,16 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
             ? state.GetRemainingMilliseconds()
             : 0;
 
-    private BrokerThrottleState GetBrokerThrottleState(
-        int brokerId,
-        EndpointKey endpoint) => brokerId >= 0
-            ? _brokerThrottleStates.GetOrAdd(
-                brokerId,
-                static (_, collector) => new BrokerThrottleState(collector),
-                _telemetryMetricCollector)
-            : _bootstrapThrottleStates.GetOrAdd(
-                endpoint,
-                static (_, collector) => new BrokerThrottleState(collector),
-                _telemetryMetricCollector);
+    private BrokerThrottleState GetBrokerThrottleState(int brokerId, EndpointKey endpoint)
+    {
+        var endpointState = _bootstrapThrottleStates.GetOrAdd(
+            endpoint,
+            static (_, collector) => new BrokerThrottleState(collector),
+            _telemetryMetricCollector);
+        return brokerId >= 0
+            ? _brokerThrottleStates.GetOrAdd(brokerId, endpointState)
+            : endpointState;
+    }
 
     private static ConnectionOptions ConfigureSharedOAuthBearerProvider(
         ConnectionOptions options,
@@ -270,6 +269,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     public void RegisterBroker(int brokerId, string host, int port)
     {
         _brokers[brokerId] = new BrokerInfo(brokerId, host, port);
+        GetBrokerThrottleState(brokerId, new EndpointKey(host, port));
         LogRegisteredBroker(brokerId, host, port);
     }
 

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -13,7 +13,7 @@ namespace Dekaf.Networking;
 /// Connection pool for managing connections to Kafka brokers.
 /// Supports multiple connections per broker for parallel request handling.
 /// </summary>
-public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDiagnostics
+public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDiagnostics, IBrokerThrottleProvider
 {
     private const int MaxConnectionReapDiagnosticEvents = 256;
     private static readonly TimeSpan DefaultIdleReapDrainTimeout = TimeSpan.FromSeconds(5);
@@ -61,6 +61,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     // Per-endpoint semaphores to deduplicate concurrent single-connection creation
     private readonly ConcurrentDictionary<EndpointKey, SemaphoreSlim> _connectionCreationLocks = new();
     private readonly ConcurrentDictionary<EndpointKey, ReconnectBackoffState> _reconnectBackoffs = new();
+    private readonly ConcurrentDictionary<int, BrokerThrottleState> _brokerThrottleStates = new();
+    private readonly ConcurrentDictionary<EndpointKey, BrokerThrottleState> _bootstrapThrottleStates = new();
 
     // Multi-connection support: connection groups and round-robin index
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
@@ -79,6 +81,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
 
     private readonly SemaphoreSlim _disposeLock = new(1, 1);
     private readonly SemaphoreSlim _scaleLock = new(1, 1);
+    private readonly CancellationTokenSource _disposeCts = new();
     private int _disposed;
 
     public ConnectionPool(
@@ -161,6 +164,23 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     internal ConnectionOptions EffectiveConnectionOptions => _connectionOptions;
 
     internal bool HasSharedOAuthBearerTokenProvider => _sharedOAuthBearerTokenProvider is not null;
+
+    int IBrokerThrottleProvider.GetRemainingBrokerThrottleMilliseconds(int brokerId) =>
+        _brokerThrottleStates.TryGetValue(brokerId, out var state)
+            ? state.GetRemainingMilliseconds()
+            : 0;
+
+    private BrokerThrottleState GetBrokerThrottleState(
+        int brokerId,
+        EndpointKey endpoint) => brokerId >= 0
+            ? _brokerThrottleStates.GetOrAdd(
+                brokerId,
+                static (_, collector) => new BrokerThrottleState(collector),
+                _telemetryMetricCollector)
+            : _bootstrapThrottleStates.GetOrAdd(
+                endpoint,
+                static (_, collector) => new BrokerThrottleState(collector),
+                _telemetryMetricCollector);
 
     private static ConnectionOptions ConfigureSharedOAuthBearerProvider(
         ConnectionOptions options,
@@ -258,6 +278,12 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(ConnectionPool));
 
+        if (_brokerThrottleStates.TryGetValue(brokerId, out var throttleState))
+        {
+            await throttleState.WaitAsync(cancellationToken, _disposeCts.Token)
+                .ConfigureAwait(false);
+        }
+
         // Multi-connection path: use connection groups with round-robin selection
         if (_connectionsPerBroker > 1)
         {
@@ -323,6 +349,12 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(ConnectionPool));
+
+        if (_brokerThrottleStates.TryGetValue(brokerId, out var throttleState))
+        {
+            await throttleState.WaitAsync(cancellationToken, _disposeCts.Token)
+                .ConfigureAwait(false);
+        }
 
         ArgumentOutOfRangeException.ThrowIfNegative(index);
         ArgumentOutOfRangeException.ThrowIfEqual(index, int.MaxValue);
@@ -797,7 +829,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _responseBufferPool,
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
-                _responseMemoryAdmissionsEnabled);
+                _responseMemoryAdmissionsEnabled,
+                GetBrokerThrottleState(brokerId, endpoint));
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
@@ -825,6 +858,11 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
             throw new ObjectDisposedException(nameof(ConnectionPool));
 
         var endpoint = new EndpointKey(host, port);
+        if (_bootstrapThrottleStates.TryGetValue(endpoint, out var throttleState))
+        {
+            await throttleState.WaitAsync(cancellationToken, _disposeCts.Token)
+                .ConfigureAwait(false);
+        }
 
         // Try to get existing connection
         if (_connectionsByEndpoint.TryGetValue(endpoint, out var existing) && existing.IsConnected)
@@ -972,7 +1010,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _responseBufferPool,
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
-                _responseMemoryAdmissionsEnabled);
+                _responseMemoryAdmissionsEnabled,
+                GetBrokerThrottleState(brokerId, endpoint));
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1318,6 +1357,16 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     IReadOnlyList<ConnectionReapDiagnostic> IConnectionPoolDiagnostics.GetConnectionReapDiagnosticsSnapshot() =>
         GetConnectionReapDiagnosticsSnapshot();
 
+    int IConnectionPoolDiagnostics.GetMaxObservedBrokerThrottleTimeMs()
+    {
+        var maximum = 0;
+        foreach (var state in _brokerThrottleStates.Values)
+            maximum = Math.Max(maximum, state.MaxObservedThrottleTimeMs);
+        foreach (var state in _bootstrapThrottleStates.Values)
+            maximum = Math.Max(maximum, state.MaxObservedThrottleTimeMs);
+        return maximum;
+    }
+
     private void RecordConnectionReapDiagnostic(int brokerId, int connectionIndex, long idleDurationMs)
     {
         lock (_connectionReapDiagnosticsLock)
@@ -1533,6 +1582,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        _disposeCts.Cancel();
         _idleReaperCts?.Cancel();
         if (_idleReaperTask is not null)
             await _idleReaperTask.ConfigureAwait(false);
@@ -1541,6 +1591,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
         await CloseAllAsync().ConfigureAwait(false);
 
         _sharedOAuthBearerTokenProvider?.Dispose();
+        _disposeCts.Dispose();
         _disposeLock.Dispose();
         _scaleLock.Dispose();
     }

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -176,10 +176,21 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
             endpoint,
             static (_, collector) => new BrokerThrottleState(collector),
             _telemetryMetricCollector);
-        return brokerId >= 0
-            ? _brokerThrottleStates.GetOrAdd(brokerId, endpointState)
-            : endpointState;
+        if (brokerId < 0)
+            return endpointState;
+
+        var brokerState = _brokerThrottleStates.GetOrAdd(brokerId, endpointState);
+        if (!ReferenceEquals(brokerState, endpointState))
+        {
+            brokerState.MergeFrom(endpointState);
+            _bootstrapThrottleStates[endpoint] = brokerState;
+        }
+
+        return brokerState;
     }
+
+    internal BrokerThrottleState GetBrokerThrottleStateForTest(int brokerId, string host, int port) =>
+        GetBrokerThrottleState(brokerId, new EndpointKey(host, port));
 
     private static ConnectionOptions ConfigureSharedOAuthBearerProvider(
         ConnectionOptions options,

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -67,4 +67,6 @@ public interface IConnectionPool : IAsyncDisposable
 internal interface IConnectionPoolDiagnostics
 {
     IReadOnlyList<ConnectionReapDiagnostic> GetConnectionReapDiagnosticsSnapshot();
+
+    int GetMaxObservedBrokerThrottleTimeMs();
 }

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -89,6 +89,7 @@ public sealed partial class KafkaConnection :
     private readonly bool _responseMemoryAdmissionsEnabled;
     private readonly Func<int, ResponseFrameAdmission> _responseFrameAdmission;
     private readonly Func<Task, TimeSpan, Task> _waitForAbandonedWriteAsync;
+    private readonly BrokerThrottleState _brokerThrottleState;
 
     private Socket? _socket;
     private string? _resolvedTargetHost;
@@ -246,7 +247,8 @@ public sealed partial class KafkaConnection :
         ResponseBufferPool responseBufferPool,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
         Func<Task, TimeSpan, Task>? waitForAbandonedWriteAsync = null,
-        bool responseMemoryAdmissionsEnabled = false)
+        bool responseMemoryAdmissionsEnabled = false,
+        BrokerThrottleState? brokerThrottleState = null)
     {
         _host = host;
         _port = port;
@@ -262,6 +264,7 @@ public sealed partial class KafkaConnection :
         _responseMemoryAdmissionsEnabled = responseMemoryAdmissionsEnabled;
         _responseFrameAdmission = GetResponseFrameAdmission;
         _telemetryMetricCollector = telemetryMetricCollector;
+        _brokerThrottleState = brokerThrottleState ?? new BrokerThrottleState(telemetryMetricCollector);
         _waitForAbandonedWriteAsync = waitForAbandonedWriteAsync ?? WaitForAbandonedWriteAsync;
         _receiveTimeoutStopwatchTicks =
             (long)(_options.RequestTimeout.Ticks * (double)Stopwatch.Frequency / TimeSpan.TicksPerSecond);
@@ -300,7 +303,8 @@ public sealed partial class KafkaConnection :
         ResponseBufferPool responseBufferPool,
         PipeMemoryPool? sharedPipeMemoryPool = null,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
-        bool responseMemoryAdmissionsEnabled = false)
+        bool responseMemoryAdmissionsEnabled = false,
+        BrokerThrottleState? brokerThrottleState = null)
         : this(
             host,
             port,
@@ -309,7 +313,8 @@ public sealed partial class KafkaConnection :
             logger,
             responseBufferPool,
             telemetryMetricCollector,
-            responseMemoryAdmissionsEnabled: responseMemoryAdmissionsEnabled)
+            responseMemoryAdmissionsEnabled: responseMemoryAdmissionsEnabled,
+            brokerThrottleState: brokerThrottleState)
     {
         BrokerId = brokerId;
         _sharedPipeMemoryPool = sharedPipeMemoryPool;
@@ -539,10 +544,18 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        using var operation = TrackOperation();
-
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
+        if (Volatile.Read(ref _retirementState) >= 2)
+            throw new ObjectDisposedException(nameof(KafkaConnection), "Connection has been retired");
+
+        if (requireReady ? !IsConnected : !(_socket?.Connected ?? false))
+            throw new InvalidOperationException("Not connected");
+
+        await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
+            .ConfigureAwait(false);
+
+        using var operation = TrackOperation();
 
         if (requireReady ? !IsConnected : !(_socket?.Connected ?? false))
             throw new InvalidOperationException("Not connected");
@@ -673,10 +686,18 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        using var operation = TrackOperation();
-
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
+        if (Volatile.Read(ref _retirementState) >= 2)
+            throw new ObjectDisposedException(nameof(KafkaConnection), "Connection has been retired");
+
+        if (!IsConnected)
+            throw new InvalidOperationException("Not connected");
+
+        await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
+            .ConfigureAwait(false);
+
+        using var operation = TrackOperation();
 
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
@@ -777,10 +798,18 @@ public sealed partial class KafkaConnection :
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
-        using var operation = TrackOperation();
-
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(KafkaConnection));
+        if (Volatile.Read(ref _retirementState) >= 2)
+            throw new ObjectDisposedException(nameof(KafkaConnection), "Connection has been retired");
+
+        if (!IsConnected)
+            throw new InvalidOperationException("Not connected");
+
+        await _brokerThrottleState.WaitAsync(cancellationToken, _pendingRequestSlotCts.Token)
+            .ConfigureAwait(false);
+
+        using var operation = TrackOperation();
 
         if (!IsConnected)
             throw new InvalidOperationException("Not connected");
@@ -1004,6 +1033,7 @@ public sealed partial class KafkaConnection :
                     _apiVersion,
                     pending.CheckCrcs,
                     pending.TakeResponseMemoryReservation());
+                connection.ObserveBrokerThrottle<TRequest, TResponse>(response, _apiVersion);
 
                 connection.Touch();
                 connection._telemetryMetricCollector?.RecordRequestLatency(
@@ -1247,11 +1277,13 @@ public sealed partial class KafkaConnection :
 
             LogResponseReceived(correlationId);
 
-            return ParsePipelinedResponse<TRequest, TResponse>(
+            var response = ParsePipelinedResponse<TRequest, TResponse>(
                 pooledBuffer,
                 apiVersion,
                 pending.CheckCrcs,
                 pending.TakeResponseMemoryReservation());
+            ObserveBrokerThrottle<TRequest, TResponse>(response, apiVersion);
+            return response;
         }
         finally
         {
@@ -1283,6 +1315,22 @@ public sealed partial class KafkaConnection :
         {
             pooledBuffer.Dispose();
             reservation?.Dispose();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ObserveBrokerThrottle<TRequest, TResponse>(
+        TResponse response,
+        short apiVersion)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse
+    {
+        if (BrokerThrottlePolicy.ShouldClientThrottle(
+                KafkaMessageMetadata<TRequest, TResponse>.ApiKey,
+                apiVersion))
+        {
+            _brokerThrottleState.Observe(
+                KafkaMessageMetadata<TRequest, TResponse>.GetThrottleTimeMs(response));
         }
     }
 

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -683,10 +683,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
     private long _lastUnackedBlockObserved;
     private long _lastUnackedBlockObservedMs;
 
-    // Broker quota throttling is scoped per broker, not per connection. A positive
-    // ProduceResponse.ThrottleTimeMs pauses every connection owned by this BrokerSender.
-    // Zero is the common fast path and leaves this sentinel at zero.
-    private long _brokerThrottleUntilTimestamp;
+    // Compatibility fallback for custom IConnectionPool implementations that do not expose
+    // the shared networking throttle state. Dekaf's ConnectionPool always uses the shared path.
+    private long _fallbackBrokerThrottleUntilTimestamp;
 
     // Tracks distinct partitions this broker has seen, used to skip MicroLinger when all
     // known partitions are already coalesced (e.g., single-partition topics).
@@ -2692,8 +2691,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         UnmutePartition(batch.TopicPartition);
     }
 
-    private void ObserveBrokerThrottle(int throttleTimeMs)
+    private void ObserveBrokerThrottleFallback(int throttleTimeMs)
     {
+        if (_connectionPool is IBrokerThrottleProvider)
+            return;
+
         _onBrokerThrottle?.Invoke(throttleTimeMs);
 
         if (throttleTimeMs <= 0)
@@ -2706,19 +2708,22 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             ? long.MaxValue
             : now + delayTicks;
 
-        if (throttleUntil > _brokerThrottleUntilTimestamp)
-            _brokerThrottleUntilTimestamp = throttleUntil;
+        if (throttleUntil > _fallbackBrokerThrottleUntilTimestamp)
+            _fallbackBrokerThrottleUntilTimestamp = throttleUntil;
     }
 
     private int GetRemainingBrokerThrottleMs()
     {
-        if (_brokerThrottleUntilTimestamp == 0)
+        if (_connectionPool is IBrokerThrottleProvider throttleProvider)
+            return throttleProvider.GetRemainingBrokerThrottleMilliseconds(_brokerId);
+
+        if (_fallbackBrokerThrottleUntilTimestamp == 0)
             return 0;
 
-        var remainingTicks = _brokerThrottleUntilTimestamp - _getTimestamp();
+        var remainingTicks = _fallbackBrokerThrottleUntilTimestamp - _getTimestamp();
         if (remainingTicks <= 0)
         {
-            _brokerThrottleUntilTimestamp = 0;
+            _fallbackBrokerThrottleUntilTimestamp = 0;
             return 0;
         }
 
@@ -2809,7 +2814,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
                     var response = task.GetResult();
                     responseToReturn = response;
-                    ObserveBrokerThrottle(response.ThrottleTimeMs);
+                    ObserveBrokerThrottleFallback(response.ThrottleTimeMs);
                     var allPartitionsSucceeded = true;
                     var anyPartitionSucceeded = false;
                     ProduceResponsePartitionData? directResponse = null;

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -82,7 +82,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly SemaphoreSlim _initLock = new(1, 1);
 
     private volatile int _produceApiVersion = -1;
-    private int _maxObservedBrokerThrottleTimeMs;
     private int _disposed;
 
     internal bool IsDisposed => Volatile.Read(ref _disposed) != 0;
@@ -2785,23 +2784,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         _accumulator.ResetProduceRequestDiagnostics();
 
     int IProducerDiagnostics.MaxObservedBrokerThrottleTimeMs =>
-        Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);
-
-    private void ObserveBrokerThrottle(int throttleTimeMs)
-    {
-        var observedMaximum = Volatile.Read(ref _maxObservedBrokerThrottleTimeMs);
-        while (throttleTimeMs > observedMaximum)
-        {
-            var previous = Interlocked.CompareExchange(
-                ref _maxObservedBrokerThrottleTimeMs,
-                throttleTimeMs,
-                observedMaximum);
-            if (previous == observedMaximum)
-                return;
-
-            observedMaximum = previous;
-        }
-    }
+        _connectionPool is IConnectionPoolDiagnostics diagnostics
+            ? diagnostics.GetMaxObservedBrokerThrottleTimeMs()
+            : _telemetryMetricCollector.MaxObservedBrokerThrottleTimeMs;
 
     private async Task SenderLoopAsync(CancellationToken cancellationToken)
     {
@@ -3090,7 +3075,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _interceptors is not null ? InvokeOnAcknowledgementForBatch : null,
             _logger,
             canPhysicallyShrinkConnections: _ownsInfrastructure,
-            onBrokerThrottle: _options.EnableDeliveryDiagnostics ? ObserveBrokerThrottle : null,
+            onBrokerThrottle: _options.EnableDeliveryDiagnostics
+                ? _telemetryMetricCollector.RecordBrokerThrottle
+                : null,
             unackedBudget: _accumulator.GetBrokerUnackedBudget(brokerId),
             usesTransactionV2: () => _currentTransactionUsesTV2);
     }

--- a/src/Dekaf/Protocol/IKafkaMessage.cs
+++ b/src/Dekaf/Protocol/IKafkaMessage.cs
@@ -70,6 +70,12 @@ public interface IKafkaResponse : IKafkaMessage
 {
 #if !NETSTANDARD2_0
     /// <summary>
+    /// Gets the broker-reported throttle time in milliseconds, or zero when this
+    /// response type does not carry quota throttle information.
+    /// </summary>
+    int ThrottleTimeMs => 0;
+
+    /// <summary>
     /// Reads the response body from the protocol reader.
     /// </summary>
     static abstract IKafkaResponse Read(ref KafkaProtocolReader reader, short version);

--- a/src/Dekaf/Protocol/KafkaMessageMetadata.cs
+++ b/src/Dekaf/Protocol/KafkaMessageMetadata.cs
@@ -19,6 +19,8 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
 
     public static TResponse ReadResponse(ref KafkaProtocolReader reader, short version)
         => (TResponse)TResponse.Read(ref reader, version);
+
+    public static int GetThrottleTimeMs(TResponse response) => response.ThrottleTimeMs;
 #else
     private delegate short HeaderVersionDelegate(short version);
     private delegate IKafkaResponse ReadResponseDelegate(ref KafkaProtocolReader reader, short version);
@@ -28,6 +30,7 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
     private static readonly HeaderVersionDelegate? s_getResponseHeaderVersion =
         CreateHeaderVersionDelegate(nameof(GetResponseHeaderVersion));
     private static readonly ReadResponseDelegate s_readResponse = CreateReadResponseDelegate();
+    private static readonly Func<TResponse, int> s_getThrottleTimeMs = CreateThrottleTimeDelegate();
 
     public static ApiKey ApiKey { get; } = ReadApiKey();
 
@@ -43,6 +46,8 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
 
     public static TResponse ReadResponse(ref KafkaProtocolReader reader, short version)
         => (TResponse)s_readResponse(ref reader, version);
+
+    public static int GetThrottleTimeMs(TResponse response) => s_getThrottleTimeMs(response);
 
     private static ApiKey ReadApiKey()
     {
@@ -101,6 +106,17 @@ internal static class KafkaMessageMetadata<TRequest, TResponse>
         }
 
         return (ReadResponseDelegate)Delegate.CreateDelegate(typeof(ReadResponseDelegate), method);
+    }
+
+    private static Func<TResponse, int> CreateThrottleTimeDelegate()
+    {
+        var getter = typeof(TResponse).GetProperty(
+            "ThrottleTimeMs",
+            BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
+
+        return getter is null
+            ? static _ => 0
+            : (Func<TResponse, int>)Delegate.CreateDelegate(typeof(Func<TResponse, int>), getter);
     }
 #endif
 }

--- a/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
+++ b/src/Dekaf/Telemetry/ClientTelemetryMetricCollector.cs
@@ -40,10 +40,14 @@ internal static class ClientTelemetryMetricNames
     public const string ProducerConnectionCreationTotal = "org.apache.kafka.producer.connection.creation.total";
     public const string ProducerNodeRequestLatencyAvg = "org.apache.kafka.producer.node.request.latency.avg";
     public const string ProducerNodeRequestLatencyMax = "org.apache.kafka.producer.node.request.latency.max";
+    public const string ProducerProduceThrottleTimeAvg = "org.apache.kafka.producer.produce.throttle.time.avg";
+    public const string ProducerProduceThrottleTimeMax = "org.apache.kafka.producer.produce.throttle.time.max";
 
     public const string ConsumerConnectionCreationTotal = "org.apache.kafka.consumer.connection.creation.total";
     public const string ConsumerNodeRequestLatencyAvg = "org.apache.kafka.consumer.node.request.latency.avg";
     public const string ConsumerNodeRequestLatencyMax = "org.apache.kafka.consumer.node.request.latency.max";
+    public const string ConsumerFetchThrottleTimeAvg = "org.apache.kafka.consumer.fetch.manager.fetch.throttle.time.avg";
+    public const string ConsumerFetchThrottleTimeMax = "org.apache.kafka.consumer.fetch.manager.fetch.throttle.time.max";
 }
 
 internal sealed class ClientTelemetryMetricCollector
@@ -58,23 +62,34 @@ internal sealed class ClientTelemetryMetricCollector
     private readonly string? _connectionCreationTotalName;
     private readonly string? _nodeRequestLatencyAvgName;
     private readonly string? _nodeRequestLatencyMaxName;
+    private readonly string? _brokerThrottleTimeAvgName;
+    private readonly string? _brokerThrottleTimeMaxName;
+    private readonly BrokerThrottleMeasurements _brokerThrottleMeasurements = new();
 
     private long _connectionCreationTotal;
     private long _connectionCreationDelta;
 
     public ClientTelemetryMetricCollector(ClientTelemetryClientRole role)
     {
-        (_connectionCreationTotalName, _nodeRequestLatencyAvgName, _nodeRequestLatencyMaxName) = role switch
+        (_connectionCreationTotalName,
+            _nodeRequestLatencyAvgName,
+            _nodeRequestLatencyMaxName,
+            _brokerThrottleTimeAvgName,
+            _brokerThrottleTimeMaxName) = role switch
         {
             ClientTelemetryClientRole.Producer => (
                 ClientTelemetryMetricNames.ProducerConnectionCreationTotal,
                 ClientTelemetryMetricNames.ProducerNodeRequestLatencyAvg,
-                ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax),
+                ClientTelemetryMetricNames.ProducerNodeRequestLatencyMax,
+                ClientTelemetryMetricNames.ProducerProduceThrottleTimeAvg,
+                ClientTelemetryMetricNames.ProducerProduceThrottleTimeMax),
             ClientTelemetryClientRole.Consumer => (
                 ClientTelemetryMetricNames.ConsumerConnectionCreationTotal,
                 ClientTelemetryMetricNames.ConsumerNodeRequestLatencyAvg,
-                ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax),
-            ClientTelemetryClientRole.Admin => (null, null, null),
+                ClientTelemetryMetricNames.ConsumerNodeRequestLatencyMax,
+                ClientTelemetryMetricNames.ConsumerFetchThrottleTimeAvg,
+                ClientTelemetryMetricNames.ConsumerFetchThrottleTimeMax),
+            ClientTelemetryClientRole.Admin => (null, null, null, null, null),
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unsupported telemetry client role")
         };
     }
@@ -120,6 +135,17 @@ internal sealed class ClientTelemetryMetricCollector
         RecordRequestLatencyTicks(brokerId, elapsedTimestampTicks);
     }
 
+    public void RecordBrokerThrottle(int throttleTimeMs)
+    {
+        if (throttleTimeMs < 0)
+            return;
+
+        _brokerThrottleMeasurements.Record(throttleTimeMs);
+    }
+
+    internal int MaxObservedBrokerThrottleTimeMs =>
+        (int)Math.Min(_brokerThrottleMeasurements.MaxObserved, int.MaxValue);
+
     internal void RecordRequestLatency(int brokerId, TimeSpan elapsed)
     {
         if (brokerId < 0)
@@ -145,10 +171,16 @@ internal sealed class ClientTelemetryMetricCollector
             IsRequested(_nodeRequestLatencyAvgName, requestedMetrics);
         var includeRequestLatencyMax = _nodeRequestLatencyMaxName is not null &&
             IsRequested(_nodeRequestLatencyMaxName, requestedMetrics);
+        var includeBrokerThrottleTimeAvg = _brokerThrottleTimeAvgName is not null &&
+            IsRequested(_brokerThrottleTimeAvgName, requestedMetrics);
+        var includeBrokerThrottleTimeMax = _brokerThrottleTimeMaxName is not null &&
+            IsRequested(_brokerThrottleTimeMaxName, requestedMetrics);
 
         var capacity = (includeConnectionCreationTotal ? 1 : 0) +
             ((includeRequestLatencyAvg ? 1 : 0) + (includeRequestLatencyMax ? 1 : 0)) *
             Math.Max(1, _nodeRequestLatencies.Count) +
+            (includeBrokerThrottleTimeAvg ? 1 : 0) +
+            (includeBrokerThrottleTimeMax ? 1 : 0) +
             _applicationMetrics.Count;
         var metrics = new List<ClientTelemetryMetric>(capacity);
 
@@ -202,6 +234,34 @@ internal sealed class ClientTelemetryMetricCollector
                         ClientTelemetryMetricKind.Gauge,
                         StopwatchTicksToMilliseconds(snapshot.MaxTimestampTicks),
                         attributes));
+                }
+            }
+        }
+
+        if (includeBrokerThrottleTimeAvg || includeBrokerThrottleTimeMax)
+        {
+            var snapshot = subscription.DeltaTemporality
+                ? _brokerThrottleMeasurements.CollectDelta()
+                : _brokerThrottleMeasurements.CollectCumulative();
+
+            if (snapshot.Count != 0)
+            {
+                if (includeBrokerThrottleTimeAvg)
+                {
+                    metrics.Add(new ClientTelemetryMetric(
+                        _brokerThrottleTimeAvgName!,
+                        ClientTelemetryMetricKind.Gauge,
+                        snapshot.Total / (double)snapshot.Count,
+                        EmptyAttributes));
+                }
+
+                if (includeBrokerThrottleTimeMax)
+                {
+                    metrics.Add(new ClientTelemetryMetric(
+                        _brokerThrottleTimeMaxName!,
+                        ClientTelemetryMetricKind.Gauge,
+                        snapshot.Max,
+                        EmptyAttributes));
                 }
             }
         }
@@ -334,6 +394,56 @@ internal sealed class ClientTelemetryMetricCollector
         long Count,
         long TotalTimestampTicks,
         long MaxTimestampTicks);
+
+    private readonly record struct BrokerThrottleSnapshot(long Count, long Total, long Max);
+
+    private sealed class BrokerThrottleMeasurements
+    {
+        private long _count;
+        private long _total;
+        private long _max;
+        private long _deltaCount;
+        private long _deltaTotal;
+        private long _deltaMax;
+
+        public long MaxObserved => Volatile.Read(ref _max);
+
+        public void Record(int throttleTimeMs)
+        {
+            Interlocked.Increment(ref _count);
+            Interlocked.Add(ref _total, throttleTimeMs);
+            AtomicMax(ref _max, throttleTimeMs);
+
+            Interlocked.Increment(ref _deltaCount);
+            Interlocked.Add(ref _deltaTotal, throttleTimeMs);
+            AtomicMax(ref _deltaMax, throttleTimeMs);
+        }
+
+        public BrokerThrottleSnapshot CollectCumulative() =>
+            new(
+                Volatile.Read(ref _count),
+                Volatile.Read(ref _total),
+                Volatile.Read(ref _max));
+
+        public BrokerThrottleSnapshot CollectDelta() =>
+            new(
+                Interlocked.Exchange(ref _deltaCount, 0),
+                Interlocked.Exchange(ref _deltaTotal, 0),
+                Interlocked.Exchange(ref _deltaMax, 0));
+
+        private static void AtomicMax(ref long target, long value)
+        {
+            var current = Volatile.Read(ref target);
+            while (value > current)
+            {
+                var original = Interlocked.CompareExchange(ref target, value, current);
+                if (original == current)
+                    return;
+
+                current = original;
+            }
+        }
+    }
 
     private sealed class NodeRequestLatency
     {

--- a/tests/Dekaf.Tests.Unit/Networking/BrokerThrottleStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/BrokerThrottleStateTests.cs
@@ -1,0 +1,182 @@
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class BrokerThrottleStateTests
+{
+    [Test]
+    [Arguments(ApiKey.Produce, 5, false)]
+    [Arguments(ApiKey.Produce, 6, true)]
+    [Arguments(ApiKey.Fetch, 7, false)]
+    [Arguments(ApiKey.Fetch, 8, true)]
+    [Arguments(ApiKey.Metadata, 5, false)]
+    [Arguments(ApiKey.Metadata, 6, true)]
+    [Arguments(ApiKey.FindCoordinator, 1, false)]
+    [Arguments(ApiKey.FindCoordinator, 2, true)]
+    [Arguments(ApiKey.OffsetCommit, 3, false)]
+    [Arguments(ApiKey.OffsetCommit, 4, true)]
+    [Arguments(ApiKey.CreateTopics, 2, false)]
+    [Arguments(ApiKey.CreateTopics, 3, true)]
+    [Arguments(ApiKey.DescribeConfigs, 1, false)]
+    [Arguments(ApiKey.DescribeConfigs, 2, true)]
+    [Arguments(ApiKey.AlterPartitionReassignments, 0, true)]
+    [Arguments(ApiKey.DescribeTopicPartitions, 0, true)]
+    [Arguments(ApiKey.ConsumerGroupHeartbeat, 1, false)]
+    [Arguments(ApiKey.ShareFetch, 2, false)]
+    public async Task ShouldClientThrottle_MatchesBrokerDelayVersionBoundary(
+        ApiKey apiKey,
+        short version,
+        bool expected)
+    {
+        await Assert.That(BrokerThrottlePolicy.ShouldClientThrottle(apiKey, version))
+            .IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ShouldClientThrottle_CoversEverySupportedKip219Response()
+    {
+        (ApiKey ApiKey, short FirstClientThrottledVersion)[] expected =
+        [
+            (ApiKey.Produce, 6),
+            (ApiKey.Fetch, 8),
+            (ApiKey.ListOffsets, 3),
+            (ApiKey.Metadata, 6),
+            (ApiKey.OffsetCommit, 4),
+            (ApiKey.OffsetFetch, 4),
+            (ApiKey.FindCoordinator, 2),
+            (ApiKey.JoinGroup, 3),
+            (ApiKey.Heartbeat, 2),
+            (ApiKey.LeaveGroup, 2),
+            (ApiKey.SyncGroup, 2),
+            (ApiKey.DescribeGroups, 2),
+            (ApiKey.ListGroups, 2),
+            (ApiKey.ApiVersions, 2),
+            (ApiKey.CreateTopics, 3),
+            (ApiKey.DeleteTopics, 2),
+            (ApiKey.DeleteRecords, 1),
+            (ApiKey.InitProducerId, 1),
+            (ApiKey.AddPartitionsToTxn, 1),
+            (ApiKey.AddOffsetsToTxn, 1),
+            (ApiKey.EndTxn, 1),
+            (ApiKey.TxnOffsetCommit, 1),
+            (ApiKey.DescribeAcls, 1),
+            (ApiKey.CreateAcls, 1),
+            (ApiKey.DeleteAcls, 1),
+            (ApiKey.DescribeConfigs, 2),
+            (ApiKey.AlterConfigs, 1),
+            (ApiKey.AlterReplicaLogDirs, 1),
+            (ApiKey.DescribeLogDirs, 1),
+            (ApiKey.CreatePartitions, 1),
+            (ApiKey.CreateDelegationToken, 1),
+            (ApiKey.RenewDelegationToken, 1),
+            (ApiKey.ExpireDelegationToken, 1),
+            (ApiKey.DescribeDelegationToken, 1),
+            (ApiKey.DeleteGroups, 1),
+            (ApiKey.ElectLeaders, 0),
+            (ApiKey.IncrementalAlterConfigs, 0),
+            (ApiKey.AlterPartitionReassignments, 0),
+            (ApiKey.ListPartitionReassignments, 0),
+            (ApiKey.OffsetDelete, 0),
+            (ApiKey.DescribeUserScramCredentials, 0),
+            (ApiKey.AlterUserScramCredentials, 0),
+            (ApiKey.UnregisterBroker, 0),
+            (ApiKey.DescribeTopicPartitions, 0)
+        ];
+
+        var actual = Enum.GetValues<ApiKey>()
+            .Where(apiKey => BrokerThrottlePolicy.ShouldClientThrottle(apiKey, short.MaxValue))
+            .ToArray();
+        await Assert.That(actual).IsEquivalentTo(expected.Select(entry => entry.ApiKey));
+
+        foreach (var (apiKey, firstVersion) in expected)
+        {
+            await Assert.That(BrokerThrottlePolicy.ShouldClientThrottle(apiKey, firstVersion)).IsTrue();
+            if (firstVersion > 0)
+            {
+                await Assert.That(BrokerThrottlePolicy.ShouldClientThrottle(apiKey, (short)(firstVersion - 1)))
+                    .IsFalse();
+            }
+        }
+    }
+
+    [Test]
+    public async Task Observe_ConcurrentResponsesKeepLatestDeadline()
+    {
+        var state = new BrokerThrottleState();
+
+        Parallel.Invoke(
+            () => state.Observe(250),
+            () => state.Observe(2_000),
+            () => state.Observe(500));
+
+        await Assert.That(state.GetRemainingMilliseconds()).IsGreaterThan(1_500);
+    }
+
+    [Test]
+    public async Task WaitAsync_UnthrottledFastPathCompletesSynchronously()
+    {
+        var state = new BrokerThrottleState();
+
+        var wait = state.WaitAsync(CancellationToken.None, CancellationToken.None);
+
+        await Assert.That(wait.IsCompletedSuccessfully).IsTrue();
+        await wait;
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task WaitAsync_CancellationInterruptsThrottle(CancellationToken cancellationToken)
+    {
+        var state = new BrokerThrottleState();
+        state.Observe(10_000);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var wait = state.WaitAsync(cts.Token, CancellationToken.None);
+        cts.Cancel();
+
+        await Assert.That(async () => await wait).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task RecordBrokerThrottle_ExposesProducerAndConsumerTelemetry()
+    {
+        var producer = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Producer);
+        var consumer = new ClientTelemetryMetricCollector(ClientTelemetryClientRole.Consumer);
+        producer.RecordBrokerThrottle(10);
+        producer.RecordBrokerThrottle(30);
+        consumer.RecordBrokerThrottle(20);
+
+        var producerSnapshot = producer.Collect(new ClientTelemetrySubscription(
+            ClientInstanceId: Guid.Empty,
+            SubscriptionId: 1,
+            CompressionType: 0,
+            PushIntervalMs: 1_000,
+            TelemetryMaxBytes: 1024,
+            DeltaTemporality: false,
+            RequestedMetrics: ["org.apache.kafka.producer.produce.throttle.time"]));
+        var consumerSnapshot = consumer.Collect(new ClientTelemetrySubscription(
+            ClientInstanceId: Guid.Empty,
+            SubscriptionId: 1,
+            CompressionType: 0,
+            PushIntervalMs: 1_000,
+            TelemetryMaxBytes: 1024,
+            DeltaTemporality: false,
+            RequestedMetrics: ["org.apache.kafka.consumer.fetch.manager.fetch.throttle.time"]));
+
+        await Assert.That(Metric(producerSnapshot, ClientTelemetryMetricNames.ProducerProduceThrottleTimeAvg).Value)
+            .IsEqualTo(20);
+        await Assert.That(Metric(producerSnapshot, ClientTelemetryMetricNames.ProducerProduceThrottleTimeMax).Value)
+            .IsEqualTo(30);
+        await Assert.That(producer.MaxObservedBrokerThrottleTimeMs).IsEqualTo(30);
+        await Assert.That(Metric(consumerSnapshot, ClientTelemetryMetricNames.ConsumerFetchThrottleTimeAvg).Value)
+            .IsEqualTo(20);
+        await Assert.That(Metric(consumerSnapshot, ClientTelemetryMetricNames.ConsumerFetchThrottleTimeMax).Value)
+            .IsEqualTo(20);
+    }
+
+    private static ClientTelemetryMetric Metric(
+        ClientTelemetryMetricSnapshot snapshot,
+        string name) => snapshot.Metrics.Single(metric => metric.Name == name);
+}

--- a/tests/Dekaf.Tests.Unit/Networking/BrokerThrottleStateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/BrokerThrottleStateTests.cs
@@ -176,7 +176,26 @@ public sealed class BrokerThrottleStateTests
             .IsEqualTo(20);
     }
 
+    [Test]
+    public async Task RegisterBroker_ChangedEndpointAliasesCanonicalStateAndMergesDeadline()
+    {
+        await using var pool = new ConnectionPool();
+        pool.RegisterBroker(1, "old-host", 9092);
+
+        var canonicalState = pool.GetBrokerThrottleStateForTest(1, "old-host", 9092);
+        canonicalState.Observe(5_000);
+        var changedEndpointState = pool.GetBrokerThrottleStateForTest(-1, "new-host", 9093);
+        changedEndpointState.Observe(10_000);
+
+        pool.RegisterBroker(1, "new-host", 9093);
+
+        var aliasedEndpointState = pool.GetBrokerThrottleStateForTest(-1, "new-host", 9093);
+        await Assert.That(ReferenceEquals(aliasedEndpointState, canonicalState)).IsTrue();
+        await Assert.That(canonicalState.GetRemainingMilliseconds()).IsGreaterThan(9_000);
+    }
+
     private static ClientTelemetryMetric Metric(
         ClientTelemetryMetricSnapshot snapshot,
         string name) => snapshot.Metrics.Single(metric => metric.Name == name);
+
 }

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
@@ -46,13 +46,13 @@ public sealed class KafkaConnectionBrokerThrottleTests
         await second.ConnectAsync(cancellationToken);
 
         _ = await first.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-            new ApiVersionsRequest(),
+            CreateApiVersionsRequest(),
             3,
             cancellationToken);
 
         var followUpStarted = Stopwatch.GetTimestamp();
         var followUpTask = second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-            new ApiVersionsRequest(),
+            CreateApiVersionsRequest(),
             3,
             cancellationToken);
 
@@ -92,7 +92,7 @@ public sealed class KafkaConnectionBrokerThrottleTests
         throttleState.Observe(10_000);
 
         var sendTask = connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-            new ApiVersionsRequest(),
+            CreateApiVersionsRequest(),
             3,
             CancellationToken.None);
         await Task.Delay(50, cancellationToken);
@@ -143,7 +143,7 @@ public sealed class KafkaConnectionBrokerThrottleTests
         pool.RegisterBroker(1, "127.0.0.1", port);
         var firstConnection = await pool.GetConnectionAsync(1, cancellationToken);
         _ = await firstConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-            new ApiVersionsRequest(),
+            CreateApiVersionsRequest(),
             3,
             cancellationToken);
 
@@ -204,7 +204,7 @@ public sealed class KafkaConnectionBrokerThrottleTests
             });
         var bootstrapConnection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
         _ = await bootstrapConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
-            new ApiVersionsRequest(),
+            CreateApiVersionsRequest(),
             3,
             cancellationToken);
         await Assert.That(await pool.ReapIdleConnectionsAsync()).IsEqualTo(1);
@@ -321,6 +321,12 @@ public sealed class KafkaConnectionBrokerThrottleTests
         await Assert.That(unrelatedWait.IsCompletedSuccessfully).IsTrue();
         await unrelatedWait;
     }
+
+    private static ApiVersionsRequest CreateApiVersionsRequest() => new()
+    {
+        ClientSoftwareName = "dekaf-tests",
+        ClientSoftwareVersion = "1.0"
+    };
 
     private static KafkaConnection CreateConnection(int port, BrokerThrottleState throttleState) =>
         new(

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
@@ -1,0 +1,336 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Dekaf.Errors;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Networking;
+
+public sealed class KafkaConnectionBrokerThrottleTests
+{
+    [Test]
+    [Timeout(10_000)]
+    public async Task ApplicableResponse_DelaysFollowUpAcrossPhysicalConnections(
+        CancellationToken cancellationToken)
+    {
+        const int throttleTimeMs = 300;
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var followUpReceived = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var firstSocket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var firstStream = new NetworkStream(firstSocket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(firstStream, throttleTimeMs: 0, cancellationToken);
+
+            using var secondSocket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var secondStream = new NetworkStream(secondSocket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(secondStream, throttleTimeMs: 0, cancellationToken);
+
+            await CompleteApiVersionsRequestAsync(firstStream, throttleTimeMs, cancellationToken);
+            var secondRequest = await ReadFrameAsync(secondStream, cancellationToken);
+            followUpReceived.TrySetResult(Stopwatch.GetTimestamp());
+            await WriteApiVersionsResponseAsync(secondStream, secondRequest, 0, cancellationToken);
+        }, cancellationToken);
+
+        var throttleState = new BrokerThrottleState();
+        await using var first = CreateConnection(port, throttleState);
+        await using var second = CreateConnection(port, throttleState);
+        await first.ConnectAsync(cancellationToken);
+        await second.ConnectAsync(cancellationToken);
+
+        _ = await first.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest(),
+            3,
+            cancellationToken);
+
+        var followUpStarted = Stopwatch.GetTimestamp();
+        var followUpTask = second.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest(),
+            3,
+            cancellationToken);
+
+        var earlyProgress = await Task.WhenAny(
+            followUpReceived.Task,
+            Task.Delay(100, cancellationToken));
+        await Assert.That(earlyProgress).IsNotSameReferenceAs(followUpReceived.Task);
+
+        _ = await followUpTask;
+        var receivedAt = await followUpReceived.Task;
+        var elapsedMs = (receivedAt - followUpStarted) * 1000d / Stopwatch.Frequency;
+        await Assert.That(elapsedMs).IsGreaterThanOrEqualTo(200);
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task ThrottledWait_RemainsIdleReapableAndShutdownResponsive(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(stream, throttleTimeMs: 0, cancellationToken);
+            await releaseServer.Task.WaitAsync(cancellationToken);
+        }, cancellationToken);
+
+        var throttleState = new BrokerThrottleState();
+        var connection = CreateConnection(port, throttleState);
+        await connection.ConnectAsync(cancellationToken);
+        throttleState.Observe(10_000);
+
+        var sendTask = connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest(),
+            3,
+            CancellationToken.None);
+        await Task.Delay(50, cancellationToken);
+
+        await Assert.That(((IIdleTrackedKafkaConnection)connection).PendingRequestCount).IsEqualTo(0);
+        await Assert.That(((IRetirableKafkaConnection)connection).ActiveOperationCount).IsEqualTo(0);
+
+        await connection.DisposeAsync();
+        await Assert.That(async () => await sendTask.AsTask().WaitAsync(cancellationToken))
+            .Throws<OperationCanceledException>();
+
+        releaseServer.TrySetResult();
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task PoolThrottleWait_AllowsIdleCloseAndSurvivesReconnect(
+        CancellationToken cancellationToken)
+    {
+        const int throttleTimeMs = 300;
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var releaseSecondConnection = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var firstSocket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var firstStream = new NetworkStream(firstSocket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(firstStream, 0, cancellationToken);
+            await CompleteApiVersionsRequestAsync(firstStream, throttleTimeMs, cancellationToken);
+
+            using var secondSocket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var secondStream = new NetworkStream(secondSocket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(secondStream, 0, cancellationToken);
+            await releaseSecondConnection.Task.WaitAsync(cancellationToken);
+        }, cancellationToken);
+
+        await using var pool = new ConnectionPool(
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionsMaxIdleMs = 0,
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            });
+        pool.RegisterBroker(1, "127.0.0.1", port);
+        var firstConnection = await pool.GetConnectionAsync(1, cancellationToken);
+        _ = await firstConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest(),
+            3,
+            cancellationToken);
+
+        var leaseTask = pool.LeaseConnectionAsync(1, cancellationToken).AsTask();
+        var earlyProgress = await Task.WhenAny(leaseTask, Task.Delay(100, cancellationToken));
+        await Assert.That(earlyProgress).IsNotSameReferenceAs(leaseTask);
+
+        await Assert.That(await pool.ReapIdleConnectionsAsync()).IsEqualTo(1);
+        using var lease = await leaseTask;
+        await Assert.That(lease.Connection).IsNotSameReferenceAs(firstConnection);
+        await Assert.That(lease.Connection.IsConnected).IsTrue();
+        releaseSecondConnection.TrySetResult();
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SharedThrottle_BlocksEveryClientRequestPathBeforeWrite(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var acceptedSocket = new TaskCompletionSource<Socket>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseServer = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(stream, 0, cancellationToken);
+            acceptedSocket.TrySetResult(socket);
+            await releaseServer.Task.WaitAsync(cancellationToken);
+        }, cancellationToken);
+
+        var throttleState = new BrokerThrottleState();
+        await using var connection = CreateConnection(port, throttleState);
+        await connection.ConnectAsync(cancellationToken);
+        var serverSocket = await acceptedSocket.Task.WaitAsync(cancellationToken);
+        throttleState.Observe(10_000);
+
+        await AssertBlockedBeforeWriteAsync(
+            token => connection.SendPipelinedAsync<ProduceRequest, ProduceResponse>(
+                new ProduceRequest(), 9, token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<FetchRequest, FetchResponse>(
+                new FetchRequest(), 16, token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                new ConsumerGroupHeartbeatRequest
+                {
+                    GroupId = "group",
+                    MemberId = "member",
+                    MemberEpoch = 1
+                },
+                1,
+                token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<ShareFetchRequest, ShareFetchResponse>(
+                new ShareFetchRequest
+                {
+                    GroupId = "group",
+                    MemberId = "member",
+                    Topics = []
+                },
+                2,
+                token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<CreateTopicsRequest, CreateTopicsResponse>(
+                new CreateTopicsRequest { Topics = [] }, 7, token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+                MetadataRequest.ForAllTopics(), 13, token),
+            serverSocket,
+            cancellationToken);
+        await AssertBlockedBeforeWriteAsync(
+            async token => _ = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                new FindCoordinatorRequest { Key = "group" }, 5, token),
+            serverSocket,
+            cancellationToken);
+
+        releaseServer.TrySetResult();
+        await serverTask;
+    }
+
+    [Test]
+    public async Task DifferentBrokerState_IsNotPaused()
+    {
+        var throttledBroker = new BrokerThrottleState();
+        var unrelatedBroker = new BrokerThrottleState();
+        throttledBroker.Observe(10_000);
+
+        var unrelatedWait = unrelatedBroker.WaitAsync(
+            CancellationToken.None,
+            CancellationToken.None);
+
+        await Assert.That(unrelatedWait.IsCompletedSuccessfully).IsTrue();
+        await unrelatedWait;
+    }
+
+    private static KafkaConnection CreateConnection(int port, BrokerThrottleState throttleState) =>
+        new(
+            brokerId: 1,
+            host: "127.0.0.1",
+            port,
+            clientId: null,
+            options: null,
+            logger: null,
+            responseBufferPool: ResponseBufferPool.Default,
+            sharedPipeMemoryPool: null,
+            telemetryMetricCollector: null,
+            responseMemoryAdmissionsEnabled: false,
+            brokerThrottleState: throttleState);
+
+    private static async Task AssertBlockedBeforeWriteAsync(
+        Func<CancellationToken, Task> send,
+        Socket serverSocket,
+        CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(25);
+
+        await Assert.That(async () => await send(cts.Token)).Throws<OperationCanceledException>();
+        await Task.Yield();
+        await Assert.That(serverSocket.Available).IsEqualTo(0);
+    }
+
+    private static async Task CompleteApiVersionsRequestAsync(
+        NetworkStream stream,
+        int throttleTimeMs,
+        CancellationToken cancellationToken)
+    {
+        var request = await ReadFrameAsync(stream, cancellationToken);
+        await WriteApiVersionsResponseAsync(stream, request, throttleTimeMs, cancellationToken);
+    }
+
+    private static async Task WriteApiVersionsResponseAsync(
+        NetworkStream stream,
+        byte[] request,
+        int throttleTimeMs,
+        CancellationToken cancellationToken)
+    {
+        await Assert.That(BinaryPrimitives.ReadInt16BigEndian(request)).IsEqualTo((short)ApiKey.ApiVersions);
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+        await stream.WriteAsync(BuildApiVersionsResponse(correlationId, throttleTimeMs), cancellationToken);
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(
+        NetworkStream stream,
+        CancellationToken cancellationToken)
+    {
+        var length = new byte[sizeof(int)];
+        await stream.ReadExactlyAsync(length, cancellationToken);
+        var frame = new byte[BinaryPrimitives.ReadInt32BigEndian(length)];
+        await stream.ReadExactlyAsync(frame, cancellationToken);
+        return frame;
+    }
+
+    private static byte[] BuildApiVersionsResponse(int correlationId, int throttleTimeMs)
+    {
+        var body = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(body);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ApiKey.ApiVersions);
+        writer.WriteInt16(3);
+        writer.WriteInt16(3);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt32(throttleTimeMs);
+        writer.WriteEmptyTaggedFields();
+
+        var frame = new byte[sizeof(int) + sizeof(int) + body.WrittenCount];
+        BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - sizeof(int));
+        BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(sizeof(int)), correlationId);
+        body.WrittenSpan.CopyTo(frame.AsSpan(sizeof(int) * 2));
+        return frame;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionBrokerThrottleTests.cs
@@ -161,6 +161,72 @@ public sealed class KafkaConnectionBrokerThrottleTests
 
     [Test]
     [Timeout(10_000)]
+    public async Task BootstrapThrottle_SurvivesBrokerRegistrationAndReconnect(
+        CancellationToken cancellationToken)
+    {
+        const int throttleTimeMs = 300;
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var secondConnectionAccepted = new TaskCompletionSource<long>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSecondConnection = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var firstSocket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var firstStream = new NetworkStream(firstSocket, ownsSocket: false);
+            await CompleteApiVersionsRequestAsync(firstStream, 0, cancellationToken);
+            await CompleteApiVersionsRequestAsync(firstStream, throttleTimeMs, cancellationToken);
+
+            using var secondSocket = await listener.AcceptSocketAsync(cancellationToken);
+            secondConnectionAccepted.TrySetResult(Stopwatch.GetTimestamp());
+            await using var secondStream = new NetworkStream(secondSocket, ownsSocket: false);
+            using var handshakeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var handshakeTask = CompleteApiVersionsRequestAsync(secondStream, 0, handshakeCts.Token);
+            var completed = await Task.WhenAny(handshakeTask, releaseSecondConnection.Task);
+            if (completed == handshakeTask)
+                await handshakeTask;
+
+            await releaseSecondConnection.Task.WaitAsync(cancellationToken);
+            handshakeCts.Cancel();
+            try { await handshakeTask; }
+            catch (OperationCanceledException) when (handshakeCts.IsCancellationRequested) { }
+        }, cancellationToken);
+
+        await using var pool = new ConnectionPool(
+            connectionOptions: new ConnectionOptions
+            {
+                ConnectionsMaxIdleMs = 0,
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            });
+        var bootstrapConnection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
+        _ = await bootstrapConnection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+            new ApiVersionsRequest(),
+            3,
+            cancellationToken);
+        await Assert.That(await pool.ReapIdleConnectionsAsync()).IsEqualTo(1);
+
+        pool.RegisterBroker(1, "127.0.0.1", port);
+        var reconnectStarted = Stopwatch.GetTimestamp();
+        var leaseTask = pool.LeaseConnectionAsync(1, cancellationToken).AsTask();
+        var earlyProgress = await Task.WhenAny(
+            secondConnectionAccepted.Task,
+            Task.Delay(100, cancellationToken));
+        await Assert.That(earlyProgress).IsNotSameReferenceAs(secondConnectionAccepted.Task);
+
+        using var lease = await leaseTask;
+        var acceptedAt = await secondConnectionAccepted.Task;
+        var elapsedMs = (acceptedAt - reconnectStarted) * 1000d / Stopwatch.Frequency;
+        await Assert.That(elapsedMs).IsGreaterThanOrEqualTo(200);
+        releaseSecondConnection.TrySetResult();
+        await serverTask;
+    }
+
+    [Test]
+    [Timeout(10_000)]
     public async Task SharedThrottle_BlocksEveryClientRequestPathBeforeWrite(
         CancellationToken cancellationToken)
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerThrottleBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerThrottleBenchmarks.cs
@@ -1,0 +1,25 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Networking;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class BrokerThrottleBenchmarks
+{
+    private readonly BrokerThrottleState _unthrottled = new();
+    private readonly ConcurrentDictionary<int, BrokerThrottleState> _states =
+        new() { [1] = new BrokerThrottleState() };
+
+    [Benchmark(Baseline = true)]
+    public bool ExistingCompletedValueTaskCheck() => ValueTask.CompletedTask.IsCompletedSuccessfully;
+
+    [Benchmark]
+    public bool SharedBrokerThrottleFastPath() =>
+        _unthrottled.WaitAsync(CancellationToken.None, CancellationToken.None).IsCompletedSuccessfully;
+
+    [Benchmark]
+    public bool SharedBrokerLookupFastPath() =>
+        _states.TryGetValue(1, out var state) &&
+        state.WaitAsync(CancellationToken.None, CancellationToken.None).IsCompletedSuccessfully;
+}


### PR DESCRIPTION
## Summary

- move KIP-219 throttle tracking into shared per-broker networking state
- apply Apache Kafka's version-specific `shouldClientThrottle` gates across producer, fetch, metadata, coordinator, admin, and transactional responses
- preserve deadlines across physical connections/reconnects, keep unrelated brokers independent, and retain idle-reap/shutdown responsiveness
- route producer scheduling through the shared absolute deadline without double-throttling
- expose producer/consumer throttle average/max telemetry

Prerequisite #2228 landed before this work began.

## Verification

- Release build: 0 warnings
- Unit tests: 5,837/5,837 net10.0; 5,710/5,710 net8.0
- Focused networking tests: 10 repeated passes on each target
- Integration: producer quota + consumer quota tests, 2/2
- `[MemoryDiagnoser]` exact-head results:
  - completed `ValueTask` baseline: 0.0016 ns, 0 B
  - shared throttle state fast path: 0.1336 ns, 0 B
  - broker dictionary lookup + fast path: 0.8378 ns, 0 B

Closes #2263