### PR TITLE
feat(serialization): introduce IAsyncSerde for per-message async serdes (#2309)

### DIFF
--- a/docs/docs/serialization/custom.md
+++ b/docs/docs/serialization/custom.md
@@ -186,3 +186,60 @@ var consumer = await Kafka.CreateConsumer<string, Order>()
     .WithValueDeserializer(codec)
     .BuildAsync();
 ```
+
+## Async Serializers (IAsyncSerde)
+
+When serialization itself requires I/O — for example an encryption stack that fetches short-lived
+keys per message — implement `IAsyncSerializer<T>` / `IAsyncDeserializer<T>` (or the combined
+`IAsyncSerde<T>`):
+
+```csharp
+using Dekaf;
+using Dekaf.Serialization;
+
+public class EncryptingSerde : IAsyncSerde<Order>
+{
+    public async ValueTask SerializeAsync(
+        Order value, IBufferWriter<byte> destination,
+        SerializationContext context, CancellationToken cancellationToken = default)
+    {
+        var key = await FetchEncryptionKeyAsync(cancellationToken);
+        var payload = Encrypt(JsonSerializer.SerializeToUtf8Bytes(value), key);
+        destination.Write(payload);
+    }
+
+    public async ValueTask<Order> DeserializeAsync(
+        ReadOnlyMemory<byte> data,
+        SerializationContext context, CancellationToken cancellationToken = default)
+    {
+        var key = await FetchEncryptionKeyAsync(cancellationToken);
+        // `data` is pooled memory — only valid until this method's task completes.
+        return JsonSerializer.Deserialize<Order>(Decrypt(data.Span, key))!;
+    }
+}
+
+// Same builder methods — the async overload is picked by type
+var producer = await Kafka.CreateProducer<string, Order>()
+    .WithValueSerializer(new EncryptingSerde())
+    .BuildAsync();
+
+var consumer = await Kafka.CreateConsumer<string, Order>()
+    .WithValueDeserializer(new EncryptingSerde())
+    .BuildAsync();
+```
+
+Behavior and trade-offs:
+
+- **Prefer synchronous serializers** unless you genuinely need per-message async work. Async
+  serdes route every message through a slower pooled-buffer path with async state-machine
+  overhead; the synchronous zero-allocation fast path is unaffected when they are not configured.
+- For a **one-time async setup** (like a Schema Registry fetch) keep a synchronous serializer and
+  implement `IAsyncSerializerPreparer<T>` instead.
+- Producer: `ProduceAsync`, `ProduceAllAsync`, and `FireAsync` all work. Fire-and-forget delivery
+  errors go to the delivery handler (or the log) as usual.
+- Consumer: records are delivered via `ConsumeAsync` and `ConsumeOneAsync`. `ConsumeBatchAsync`
+  iterates records synchronously and throws `NotSupportedException` when an async deserializer is
+  configured.
+- Mixed configurations are fine — e.g. a synchronous key serializer with an async value serializer.
+- Configuring both a synchronous and an asynchronous serializer for the same component fails at
+  `Build()` with `InvalidOperationException`.

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -65,6 +65,8 @@ public sealed class ProducerBuilder<TKey, TValue>
     private AwsMskIamConfig? _awsMskIamConfig;
     private ISerializer<TKey>? _keySerializer;
     private ISerializer<TValue>? _valueSerializer;
+    private IAsyncSerializer<TKey>? _asyncKeySerializer;
+    private IAsyncSerializer<TValue>? _asyncValueSerializer;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private ulong? _bufferMemory;
     private int? _maxBlockMs;
@@ -836,6 +838,30 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Configures an asynchronous key serializer for serializers that perform per-message I/O
+    /// (e.g. envelope encryption with short-lived keys). Messages are serialized on the
+    /// asynchronous produce path instead of the synchronous zero-allocation fast path — prefer
+    /// <see cref="WithKeySerializer(ISerializer{TKey})"/> when serialization can run synchronously.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithKeySerializer(IAsyncSerializer<TKey> serializer)
+    {
+        _asyncKeySerializer = serializer;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures an asynchronous value serializer for serializers that perform per-message I/O
+    /// (e.g. envelope encryption with short-lived keys). Messages are serialized on the
+    /// asynchronous produce path instead of the synchronous zero-allocation fast path — prefer
+    /// <see cref="WithValueSerializer(ISerializer{TValue})"/> when serialization can run synchronously.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithValueSerializer(IAsyncSerializer<TValue> serializer)
+    {
+        _asyncValueSerializer = serializer;
+        return this;
+    }
+
     public ProducerBuilder<TKey, TValue> WithLoggerFactory(Microsoft.Extensions.Logging.ILoggerFactory loggerFactory)
     {
         _loggerFactory = loggerFactory;
@@ -1325,8 +1351,23 @@ public sealed class ProducerBuilder<TKey, TValue>
         if (_clientInfrastructure is null)
             GssapiConfig.ValidateForBuild(_saslMechanism, _gssapiConfig);
 
-        var keySerializer = _keySerializer ?? GetDefaultSerializer<TKey>("key", "WithKeySerializer");
-        var valueSerializer = _valueSerializer ?? GetDefaultSerializer<TValue>("value", "WithValueSerializer");
+        if (_keySerializer is not null && _asyncKeySerializer is not null)
+            throw new InvalidOperationException(
+                "Both a synchronous and an asynchronous key serializer are configured. Configure only one of " +
+                "WithKeySerializer(ISerializer<TKey>) or WithKeySerializer(IAsyncSerializer<TKey>).");
+        if (_valueSerializer is not null && _asyncValueSerializer is not null)
+            throw new InvalidOperationException(
+                "Both a synchronous and an asynchronous value serializer are configured. Configure only one of " +
+                "WithValueSerializer(ISerializer<TValue>) or WithValueSerializer(IAsyncSerializer<TValue>).");
+
+        // A component with an async serializer never reaches the synchronous serialize path;
+        // its sync slot holds a throwing placeholder as defense in depth.
+        var keySerializer = _asyncKeySerializer is not null
+            ? AsyncOnlySerializerPlaceholder<TKey>.Instance
+            : _keySerializer ?? GetDefaultSerializer<TKey>("key", "WithKeySerializer");
+        var valueSerializer = _asyncValueSerializer is not null
+            ? AsyncOnlySerializerPlaceholder<TValue>.Instance
+            : _valueSerializer ?? GetDefaultSerializer<TValue>("value", "WithValueSerializer");
 
         var memoryBudget = _clientInfrastructure?.MemoryBudget ?? DekafMemoryBudget.Global;
 
@@ -1422,7 +1463,14 @@ public sealed class ProducerBuilder<TKey, TValue>
         };
 
         var producer = _clientInfrastructure is null
-            ? new KafkaProducer<TKey, TValue>(options, keySerializer, valueSerializer, _loggerFactory, metadataOptions)
+            ? new KafkaProducer<TKey, TValue>(
+                options,
+                keySerializer,
+                valueSerializer,
+                _loggerFactory,
+                metadataOptions,
+                asyncKeySerializer: _asyncKeySerializer,
+                asyncValueSerializer: _asyncValueSerializer)
             : new KafkaProducer<TKey, TValue>(
                 options,
                 keySerializer,
@@ -1430,7 +1478,9 @@ public sealed class ProducerBuilder<TKey, TValue>
                 _clientInfrastructure.ConnectionPool,
                 _clientInfrastructure.MetadataManager,
                 memoryBudget,
-                _loggerFactory);
+                _loggerFactory,
+                asyncKeySerializer: _asyncKeySerializer,
+                asyncValueSerializer: _asyncValueSerializer);
 
         // The BufferMemory above is seeded from PreviewProducerLimit(), which assumes N producers.
         // RegisterProducer rebalances to N+1 and synchronously fires OnBudgetChanged on every
@@ -1554,6 +1604,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private AwsMskIamConfig? _awsMskIamConfig;
     private IDeserializer<TKey>? _keyDeserializer;
     private IDeserializer<TValue>? _valueDeserializer;
+    private IAsyncDeserializer<TKey>? _asyncKeyDeserializer;
+    private IAsyncDeserializer<TValue>? _asyncValueDeserializer;
     private bool _cacheStringValues;
     private int _maxCachedStringValueBytes = DefaultMaxCachedStringValueBytes;
     private int _maxCachedStringValueEntries = DefaultMaxCachedStringValueEntries;
@@ -2294,6 +2346,32 @@ public sealed class ConsumerBuilder<TKey, TValue>
     }
 
     /// <summary>
+    /// Configures an asynchronous key deserializer for deserializers that perform per-record I/O
+    /// (e.g. envelope decryption with short-lived keys). Records are delivered via ConsumeAsync
+    /// and ConsumeOneAsync; ConsumeBatchAsync throws <see cref="NotSupportedException"/> because
+    /// batch records are deserialized during synchronous iteration. Prefer
+    /// <see cref="WithKeyDeserializer(IDeserializer{TKey})"/> when decoding can run synchronously.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithKeyDeserializer(IAsyncDeserializer<TKey> deserializer)
+    {
+        _asyncKeyDeserializer = deserializer;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures an asynchronous value deserializer for deserializers that perform per-record I/O
+    /// (e.g. envelope decryption with short-lived keys). Records are delivered via ConsumeAsync
+    /// and ConsumeOneAsync; ConsumeBatchAsync throws <see cref="NotSupportedException"/> because
+    /// batch records are deserialized during synchronous iteration. Prefer
+    /// <see cref="WithValueDeserializer(IDeserializer{TValue})"/> when decoding can run synchronously.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithValueDeserializer(IAsyncDeserializer<TValue> deserializer)
+    {
+        _asyncValueDeserializer = deserializer;
+        return this;
+    }
+
+    /// <summary>
     /// Enables bounded caching for repeated built-in string values.
     /// </summary>
     /// <remarks>
@@ -2900,8 +2978,23 @@ public sealed class ConsumerBuilder<TKey, TValue>
         if (_topicPatternToSubscribe is not null && string.IsNullOrWhiteSpace(_groupId))
             throw new InvalidOperationException("SubscribeToPattern requires WithGroupId(...) to be called before Build().");
 
-        var keyDeserializer = _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
-        var valueDeserializer = _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
+        if (_keyDeserializer is not null && _asyncKeyDeserializer is not null)
+            throw new InvalidOperationException(
+                "Both a synchronous and an asynchronous key deserializer are configured. Configure only one of " +
+                "WithKeyDeserializer(IDeserializer<TKey>) or WithKeyDeserializer(IAsyncDeserializer<TKey>).");
+        if (_valueDeserializer is not null && _asyncValueDeserializer is not null)
+            throw new InvalidOperationException(
+                "Both a synchronous and an asynchronous value deserializer are configured. Configure only one of " +
+                "WithValueDeserializer(IDeserializer<TValue>) or WithValueDeserializer(IAsyncDeserializer<TValue>).");
+
+        // A component with an async deserializer never reaches the synchronous deserialize path;
+        // its sync slot holds a throwing placeholder as defense in depth.
+        var keyDeserializer = _asyncKeyDeserializer is not null
+            ? AsyncOnlyDeserializerPlaceholder<TKey>.Instance
+            : _keyDeserializer ?? GetDefaultDeserializer<TKey>("key", "WithKeyDeserializer");
+        var valueDeserializer = _asyncValueDeserializer is not null
+            ? AsyncOnlyDeserializerPlaceholder<TValue>.Instance
+            : _valueDeserializer ?? GetDefaultDeserializer<TValue>("value", "WithValueDeserializer");
 
         // Wrap the built-in string key deserializer with caching to avoid per-message string
         // allocation for repeated keys. Kafka workloads typically reuse a bounded set of key
@@ -3025,7 +3118,14 @@ public sealed class ConsumerBuilder<TKey, TValue>
         };
 
         var consumer = _clientInfrastructure is null
-            ? new KafkaConsumer<TKey, TValue>(options, keyDeserializer, valueDeserializer, _loggerFactory, metadataOptions)
+            ? new KafkaConsumer<TKey, TValue>(
+                options,
+                keyDeserializer,
+                valueDeserializer,
+                _loggerFactory,
+                metadataOptions,
+                asyncKeyDeserializer: _asyncKeyDeserializer,
+                asyncValueDeserializer: _asyncValueDeserializer)
             : new KafkaConsumer<TKey, TValue>(
                 options,
                 keyDeserializer,
@@ -3033,7 +3133,9 @@ public sealed class ConsumerBuilder<TKey, TValue>
                 _clientInfrastructure.ConsumerConnectionPool,
                 _clientInfrastructure.MetadataManager,
                 memoryBudget,
-                _loggerFactory);
+                _loggerFactory,
+                asyncKeyDeserializer: _asyncKeyDeserializer,
+                asyncValueDeserializer: _asyncValueDeserializer);
 
         // QueuedMaxMessagesKbytes above is seeded from PreviewConsumerLimit() assuming N consumers.
         // RegisterConsumer rebalances to N+1 and synchronously dispatches OnBudgetChanged on every

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -470,6 +470,49 @@ public readonly struct ConsumeResult<TKey, TValue>
     {
     }
 
+    /// <summary>
+    /// Creates a ConsumeResult from already-deserialized key and value. Used by the asynchronous
+    /// deserialization path (<see cref="IAsyncDeserializer{T}"/>), where deserialization is awaited
+    /// before the result is constructed and therefore cannot run in this eager constructor.
+    /// </summary>
+    internal ConsumeResult(
+        string topic,
+        int partition,
+        long offset,
+        TKey? key,
+        TValue value,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        PendingFetchData headerOwner,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch)
+        : this(
+            topic,
+            partition,
+            offset,
+            keyData: default,
+            isKeyNull: true,
+            valueData: default,
+            isValueNull: true,
+            headers: null,
+            pooledHeaders,
+            pooledHeaderCount,
+            headerOwner,
+            headerOwner.HeaderGeneration,
+            timestampMs,
+            timestampType,
+            leaderEpoch,
+            keyDeserializer: null,
+            valueDeserializer: null,
+            isPartitionEof: false)
+    {
+        // The chained call above leaves Key/Value at default (both deserializers are null);
+        // the awaited async deserialization already produced the real values.
+        Key = key;
+        Value = value;
+    }
+
     private ConsumeResult(
         string topic,
         int partition,

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -888,6 +888,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private readonly IDeserializer<TKey> _keyDeserializer;
     private readonly IDeserializer<TValue> _valueDeserializer;
+    // Non-null when the user configured an IAsyncDeserializer for that component (issue #2309:
+    // deserializers that perform per-record I/O, e.g. envelope decryption with short-lived keys).
+    // When either is set, ConsumeAsync/ConsumeOneAsync await deserialization per record before
+    // constructing the ConsumeResult; the corresponding sync slot holds a throwing
+    // AsyncOnlyDeserializerPlaceholder and ConsumeBatchAsync (synchronous iteration) throws.
+    private readonly IAsyncDeserializer<TKey>? _asyncKeyDeserializer;
+    private readonly IAsyncDeserializer<TValue>? _asyncValueDeserializer;
+    private readonly bool _hasAsyncDeserializers;
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly ClientTelemetryMetricCollector _telemetryMetricCollector;
@@ -1106,12 +1114,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
         ILoggerFactory? loggerFactory = null,
-        MetadataOptions? metadataOptions = null)
+        MetadataOptions? metadataOptions = null,
+        IAsyncDeserializer<TKey>? asyncKeyDeserializer = null,
+        IAsyncDeserializer<TValue>? asyncValueDeserializer = null)
         : this(options, keyDeserializer, valueDeserializer,
             CreateInfrastructure(options, loggerFactory, metadataOptions),
             loggerFactory,
             ownsInfrastructure: true,
-            DekafMemoryBudget.Global)
+            DekafMemoryBudget.Global,
+            asyncKeyDeserializer,
+            asyncValueDeserializer)
     {
     }
 
@@ -1145,7 +1157,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         IConnectionPool connectionPool,
         MetadataManager metadataManager,
         IDekafMemoryBudget memoryBudget,
-        ILoggerFactory? loggerFactory = null)
+        ILoggerFactory? loggerFactory = null,
+        IAsyncDeserializer<TKey>? asyncKeyDeserializer = null,
+        IAsyncDeserializer<TValue>? asyncValueDeserializer = null)
         : this(options, keyDeserializer, valueDeserializer,
             (
                 connectionPool,
@@ -1154,7 +1168,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 new FetchBufferMemoryPool(options.FetchBufferMemoryBytes)),
             loggerFactory,
             ownsInfrastructure: false,
-            memoryBudget)
+            memoryBudget,
+            asyncKeyDeserializer,
+            asyncValueDeserializer)
     {
     }
 
@@ -1296,7 +1312,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             FetchBufferMemoryPool FetchBufferMemoryPool) infrastructure,
         ILoggerFactory? loggerFactory,
         bool ownsInfrastructure,
-        IDekafMemoryBudget memoryBudget)
+        IDekafMemoryBudget memoryBudget,
+        IAsyncDeserializer<TKey>? asyncKeyDeserializer = null,
+        IAsyncDeserializer<TValue>? asyncValueDeserializer = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(options.ConnectionsPerBroker, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(options.ConnectionsPerBroker, options.MaxConnectionsPerBroker);
@@ -1318,8 +1336,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             options.RetryBackoffMs,
             options.RetryBackoffMaxMs);
         _currentQueuedMaxBytes = (long)((ulong)options.QueuedMaxMessagesKbytes * 1024UL);
-        _keyDeserializer = keyDeserializer;
-        _valueDeserializer = valueDeserializer;
+        // When an async deserializer is configured for a component, its sync slot is forced to
+        // the throwing placeholder here — by construction, not by builder convention — so a
+        // direct constructor caller can never pair an async deserializer with a live sync one.
+        _keyDeserializer = asyncKeyDeserializer is null ? keyDeserializer : AsyncOnlyDeserializerPlaceholder<TKey>.Instance;
+        _valueDeserializer = asyncValueDeserializer is null ? valueDeserializer : AsyncOnlyDeserializerPlaceholder<TValue>.Instance;
+        _asyncKeyDeserializer = asyncKeyDeserializer;
+        _asyncValueDeserializer = asyncValueDeserializer;
+        _hasAsyncDeserializers = asyncKeyDeserializer is not null || asyncValueDeserializer is not null;
 
         // Derive consumer pool sizes from configuration
         // Use 64 as default partition count estimate — covers most workloads.
@@ -1992,6 +2016,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
                 var hasInterceptors = _interceptors is not null;
                 var rawTrackingEnabled = _rawRecordTrackingEnabled;
+                var hasAsyncDeserializers = _hasAsyncDeserializers;
                 const int pollRefreshRecordInterval = 32;
                 var recordsUntilPollRefresh = pollRefreshRecordInterval;
 
@@ -2067,25 +2092,43 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     previousActivity = activity;
                             }
 
-                            // Create result - deserialization happens eagerly in the constructor.
+                            // Create result - deserialization happens eagerly in the constructor,
+                            // or is awaited here when async deserializers are configured. The record
+                            // memory referenced by `record` stays valid across the await: no user
+                            // code other than the deserializer itself runs on this consumer until
+                            // the result is yielded (see IAsyncDeserializer memory contract).
                             // Exceptions from user deserializers must never be classified as wire corruption.
                             readingProtocolData = false;
-                            nextResult = new ConsumeResult<TKey, TValue>(
-                                topic: pending.Topic,
-                                partition: pending.PartitionIndex,
-                                offset: offset,
-                                keyData: record.Key,
-                                isKeyNull: record.IsKeyNull,
-                                valueData: record.Value,
-                                isValueNull: record.IsValueNull,
-                                pooledHeaders: record.Headers,
-                                pooledHeaderCount: record.HeaderCount,
-                                headerOwner: pending,
-                                timestampMs: timestampMs,
-                                timestampType: timestampType,
-                                leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
-                                keyDeserializer: _keyDeserializer,
-                                valueDeserializer: _valueDeserializer);
+                            nextResult = hasAsyncDeserializers
+                                ? await CreateResultWithAsyncDeserializationAsync(
+                                    pending,
+                                    offset,
+                                    record.Key,
+                                    record.IsKeyNull,
+                                    record.Value,
+                                    record.IsValueNull,
+                                    record.Headers,
+                                    record.HeaderCount,
+                                    timestampMs,
+                                    timestampType,
+                                    pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
+                                    cancellationToken).ConfigureAwait(false)
+                                : new ConsumeResult<TKey, TValue>(
+                                    topic: pending.Topic,
+                                    partition: pending.PartitionIndex,
+                                    offset: offset,
+                                    keyData: record.Key,
+                                    isKeyNull: record.IsKeyNull,
+                                    valueData: record.Value,
+                                    isValueNull: record.IsValueNull,
+                                    pooledHeaders: record.Headers,
+                                    pooledHeaderCount: record.HeaderCount,
+                                    headerOwner: pending,
+                                    timestampMs: timestampMs,
+                                    timestampType: timestampType,
+                                    leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
+                                    keyDeserializer: _keyDeserializer,
+                                    valueDeserializer: _valueDeserializer);
 
                             if (HasPendingFetchClear(pending.TopicPartition))
                                 break;
@@ -2224,6 +2267,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (Volatile.Read(ref _consumerDisposed) != 0)
         {
             throw new ObjectDisposedException(nameof(KafkaConsumer<TKey, TValue>));
+        }
+
+        if (_hasAsyncDeserializers)
+        {
+            throw new NotSupportedException(
+                "ConsumeBatchAsync does not support asynchronous deserializers because batch records " +
+                "are deserialized during synchronous iteration. Use ConsumeAsync or ConsumeOneAsync, " +
+                "or configure synchronous IDeserializer implementations.");
         }
 
         ThrowIfNotInitialized();
@@ -3860,7 +3911,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // the returned ValueTask — the standard idiom for a sync-completing ValueTask method.
         var pollRecorded = false;
         long? bufferedDrainStarted = null;
-        if (!RequiresRuntimeTimeoutValidation(timeoutMilliseconds)
+        // Async deserializers cannot run on the synchronous buffered fast path — the async
+        // drain inside ConsumeOneCoreAsync handles them.
+        if (!_hasAsyncDeserializers
+            && !RequiresRuntimeTimeoutValidation(timeoutMilliseconds)
             && CanUseBufferedConsumeOneFastPath(cancellationToken))
         {
             long pollTimestamp = 0;
@@ -4061,8 +4115,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 }
             }
 
-            if (TryConsumeOneFromPendingFetches(out var result))
+            if (_hasAsyncDeserializers)
+            {
+                var asyncResult = await ConsumeOneFromPendingFetchesAsync(cancellationToken).ConfigureAwait(false);
+                if (asyncResult is not null)
+                    return asyncResult;
+            }
+            else if (TryConsumeOneFromPendingFetches(out var result))
+            {
                 return result;
+            }
 
             if (TryDequeuePendingEofResult(out var eofResult))
                 return eofResult;
@@ -4293,6 +4355,217 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Asynchronous-deserialization sibling of <see cref="TryConsumeOneFromPendingFetches"/>,
+    /// used only when an <see cref="IAsyncDeserializer{T}"/> is configured. Keep the drain
+    /// bookkeeping (poll contract, fetch-clear checks, rewind, metrics, disposal) in sync with
+    /// the synchronous method — the only intended difference is that deserialization is awaited
+    /// before the result is constructed, and interceptors therefore run after that await.
+    /// Returns null when no record is buffered.
+    /// </summary>
+    private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneFromPendingFetchesAsync(
+        CancellationToken cancellationToken)
+    {
+        var metricsEnabled = Diagnostics.DekafMetrics.MessagesReceived.Enabled
+                             || Diagnostics.DekafMetrics.BytesReceived.Enabled;
+        var hasTraceListeners = Diagnostics.DekafDiagnostics.Source.HasListeners();
+        var hasInterceptors = _interceptors is not null;
+        var rawTrackingEnabled = _rawRecordTrackingEnabled;
+
+        // A new consume call proves the record returned by the previous call was processed
+        // (poll contract), so everything yielded from the head fetch becomes committable.
+        if (_pendingFetches.Count > 0)
+            _pendingFetches.Peek().MarkYieldedProcessed();
+
+        while (_pendingFetches.Count > 0)
+        {
+            if (ClearFetchBufferForPendingCoordinatorRevocations())
+                continue;
+
+            var pending = _pendingFetches.Peek();
+            long? batchProcessingStarted = _adaptiveFetchSizer is not null
+                ? Stopwatch.GetTimestamp() : null;
+
+            EagerParsePendingOrRemove(pending);
+
+            System.Diagnostics.Activity? activity = null;
+            try
+            {
+                while (true)
+                {
+                    var readingProtocolData = true;
+                    var offset = -1L;
+                    try
+                    {
+                        if (!pending.MoveNext())
+                            break;
+
+                        var record = pending.CurrentRecord;
+                        offset = pending.CurrentBaseOffset + record.OffsetDelta;
+                        var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
+                        var timestampType = pending.CurrentTimestampType;
+                        // Hoist every record field used below into locals before the await:
+                        // `record` references pooled batch storage, and the deserializer or an
+                        // interceptor can run user code that Seeks/Assigns and recycles it.
+                        var keyData = record.Key;
+                        var valueData = record.Value;
+                        var isKeyNull = record.IsKeyNull;
+                        var isValueNull = record.IsValueNull;
+                        var pooledHeaders = record.Headers;
+                        var pooledHeaderCount = record.HeaderCount;
+                        var messageBytes = (isKeyNull ? 0 : keyData.Length) +
+                                           (isValueNull ? 0 : valueData.Length);
+
+                        if (hasTraceListeners)
+                        {
+                            var headers = LazyConsumeHeaders.Create(
+                                pooledHeaders,
+                                pooledHeaderCount,
+                                pending,
+                                pending.HeaderGeneration);
+                            activity = StartConsumeActivity(pending, headers, offset, messageBytes);
+                        }
+
+                        // User deserialization begins in this await. Its exceptions must
+                        // propagate even when their type also occurs in protocol codecs.
+                        readingProtocolData = false;
+                        var result = await CreateResultWithAsyncDeserializationAsync(
+                            pending,
+                            offset,
+                            keyData,
+                            isKeyNull,
+                            valueData,
+                            isValueNull,
+                            pooledHeaders,
+                            pooledHeaderCount,
+                            timestampMs,
+                            timestampType,
+                            pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
+                            cancellationToken).ConfigureAwait(false);
+
+                        if (HasPendingFetchClear(pending.TopicPartition))
+                            break;
+
+                        if (hasInterceptors)
+                        {
+                            result = ApplyOnConsumeInterceptors(result);
+
+                            if (HasPendingFetchClear(pending.TopicPartition))
+                                break;
+                        }
+
+                        TrackConsumedPosition(pending, offset, messageBytes);
+
+                        if (rawTrackingEnabled)
+                        {
+                            _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
+                            _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
+                        }
+
+                        return result;
+                    }
+                    catch (OperationCanceledException) when (readingProtocolData)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex) when (
+                        readingProtocolData && ProtocolDataErrorClassifier.IsProtocolDataError(ex))
+                    {
+                        LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
+                        break;
+                    }
+                    catch (Exception) when (!readingProtocolData)
+                    {
+                        RewindAfterDeliveryFailure(pending, offset);
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                activity?.Dispose();
+            }
+
+            FlushConsumedPositions(pending);
+
+            if (metricsEnabled && pending.MessageCount > 0)
+                EmitFetchMetrics(pending);
+
+            if (batchProcessingStarted.HasValue)
+            {
+                var processingDuration = Stopwatch.GetElapsedTime(batchProcessingStarted.Value);
+                ReportAdaptiveProcessingComplete(processingDuration);
+            }
+
+            DequeuePendingFetch().Dispose();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Deserializes a record via the configured <see cref="IAsyncDeserializer{T}"/> implementations
+    /// (falling back to the synchronous deserializer for a component without one in mixed
+    /// configurations) and constructs the result from the pre-deserialized values. Null-ness
+    /// semantics mirror the eager ConsumeResult constructor: null keys skip the deserializer,
+    /// null values invoke it with empty data and <c>IsNull = true</c>.
+    /// </summary>
+    private async ValueTask<ConsumeResult<TKey, TValue>> CreateResultWithAsyncDeserializationAsync(
+        PendingFetchData pending,
+        long offset,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch,
+        CancellationToken cancellationToken)
+    {
+        var topic = pending.Topic;
+        var partition = pending.PartitionIndex;
+
+        TKey? key = default;
+        if (!isKeyNull)
+        {
+            var keyContext = new SerializationContext
+            {
+                Topic = topic,
+                Component = SerializationComponent.Key,
+                IsNull = false
+            };
+            key = _asyncKeyDeserializer is not null
+                ? await _asyncKeyDeserializer.DeserializeAsync(keyData, keyContext, cancellationToken).ConfigureAwait(false)
+                : _keyDeserializer.Deserialize(keyData, keyContext);
+        }
+
+        var valueContext = new SerializationContext
+        {
+            Topic = topic,
+            Component = SerializationComponent.Value,
+            IsNull = isValueNull
+        };
+        var valueBytes = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
+        var value = _asyncValueDeserializer is not null
+            ? await _asyncValueDeserializer.DeserializeAsync(valueBytes, valueContext, cancellationToken).ConfigureAwait(false)
+            : _valueDeserializer.Deserialize(valueBytes, valueContext);
+
+        return new ConsumeResult<TKey, TValue>(
+            topic,
+            partition,
+            offset,
+            key,
+            value,
+            pooledHeaders,
+            pooledHeaderCount,
+            pending,
+            timestampMs,
+            timestampType,
+            leaderEpoch);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/AsyncSerializationBufferWriter.cs
+++ b/src/Dekaf/Producer/AsyncSerializationBufferWriter.cs
@@ -1,0 +1,143 @@
+using System.Buffers;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Heap-allocated <see cref="IBufferWriter{T}"/> backed by <see cref="ProducerDataPool.BytePool"/>
+/// for the asynchronous serialization path. <see cref="PooledBufferWriter"/> is a ref struct and
+/// cannot cross an <c>await</c>, so async serializers write into this class instead.
+/// </summary>
+/// <remarks>
+/// Instances are cached per thread via <see cref="Rent"/>/<see cref="Return"/> so the steady state
+/// allocates neither the writer nor its backing array. The writer is used by a single logical
+/// produce flow at a time; the thread-local slot is only touched synchronously inside
+/// <see cref="Rent"/> and <see cref="Return"/>, so continuations resuming on a different thread
+/// simply return the instance to that thread's slot.
+/// </remarks>
+internal sealed class AsyncSerializationBufferWriter : IBufferWriter<byte>
+{
+    // Matches KafkaProducer.DefaultValueBufferSize — sized for typical message payloads.
+    private const int InitialCapacity = 2048;
+
+    [ThreadStatic]
+    private static AsyncSerializationBufferWriter? t_cached;
+
+    private byte[]? _buffer;
+    private int _written;
+
+    private AsyncSerializationBufferWriter()
+    {
+    }
+
+    public static AsyncSerializationBufferWriter Rent()
+    {
+        var writer = t_cached;
+        if (writer is not null)
+        {
+            t_cached = null;
+            return writer;
+        }
+
+        return new AsyncSerializationBufferWriter();
+    }
+
+    /// <summary>
+    /// Resets the writer and caches it on the current thread. Safe to call after
+    /// <see cref="DetachWrittenMemory"/> (the detached array is not returned to the pool here).
+    /// </summary>
+    public static void Return(AsyncSerializationBufferWriter writer)
+    {
+        writer.Reset();
+        t_cached = writer;
+    }
+
+    // Keep small buffers warm across messages (skips a pool round-trip per message); return
+    // oversized ones so a single large message doesn't pin pool memory on this thread forever.
+    private const int MaxRetainedBufferBytes = 64 * 1024;
+
+    private void Reset()
+    {
+        if (_buffer is not null && _buffer.Length > MaxRetainedBufferBytes)
+        {
+            // clearArray: false — serialized Kafka payload bytes, no credential material;
+            // consistent with PooledBufferWriter.Dispose.
+            ProducerDataPool.BytePool.Return(_buffer, clearArray: false);
+            _buffer = null;
+        }
+
+        _written = 0;
+    }
+
+    public void Advance(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        if (_buffer is null || _written + count > _buffer.Length)
+            throw new InvalidOperationException("Cannot advance past the end of the buffer");
+
+        _written += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsMemory(_written);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsSpan(_written);
+    }
+
+    /// <summary>
+    /// Transfers ownership of the written bytes to the caller as a <see cref="PooledMemory"/>
+    /// (returned to <see cref="ProducerDataPool.BytePool"/> when the batch completes). The writer
+    /// itself stays reusable via <see cref="Return"/>.
+    /// </summary>
+    public PooledMemory DetachWrittenMemory()
+    {
+        if (_written == 0)
+        {
+            // Empty payloads use the shared (null, 0) representation; keep the rented buffer
+            // for the next serialization. Mirrors ReusableBufferWriter.ToPooledMemory.
+            return new PooledMemory(null, 0, isNull: false);
+        }
+
+        var result = new PooledMemory(_buffer, _written);
+        _buffer = null;
+        _written = 0;
+        return result;
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 1)
+            sizeHint = 1;
+
+        if (_buffer is null)
+        {
+            _buffer = ProducerDataPool.BytePool.Rent(Math.Max(InitialCapacity, sizeHint));
+            return;
+        }
+
+        if (_buffer.Length - _written < sizeHint)
+            Grow(sizeHint);
+    }
+
+    private void Grow(int sizeHint)
+    {
+        // Clamp like DetachableBufferWriter.Grow so doubling can never overflow past Array.MaxLength.
+        var doubled = Math.Min((long)_buffer!.Length * 2, Array.MaxLength);
+        var required = Math.Min((long)_written + sizeHint, Array.MaxLength);
+        var newSize = (int)Math.Max(doubled, required);
+
+        if (newSize <= _buffer.Length)
+            throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
+
+        var newBuffer = ProducerDataPool.BytePool.Rent(newSize);
+        _buffer.AsSpan(0, _written).CopyTo(newBuffer);
+        ProducerDataPool.BytePool.Return(_buffer, clearArray: false);
+        _buffer = newBuffer;
+    }
+}

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -46,6 +46,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     // synchronous Serialize can run without blocking. Null for the common case (built-in serializers).
     private readonly IAsyncSerializerPreparer<TKey>? _keyPreparer;
     private readonly IAsyncSerializerPreparer<TValue>? _valuePreparer;
+    // Non-null when the user configured an IAsyncSerializer for that component (issue #2309:
+    // serializers that perform per-message I/O, e.g. envelope encryption with short-lived keys).
+    // When either is set, every produce entry point routes to the asynchronous serialization path
+    // before the synchronous fast path is reached; the corresponding sync slot holds a throwing
+    // AsyncOnlySerializerPlaceholder. Null for the common case, costing the fast path one
+    // readonly-bool branch (same shape as the _keyPreparer check above).
+    private readonly IAsyncSerializer<TKey>? _asyncKeySerializer;
+    private readonly IAsyncSerializer<TValue>? _asyncValueSerializer;
+    private readonly bool _hasAsyncSerializers;
     private readonly IPartitioner _partitioner;
     private readonly bool _usesCustomPartitioner;
     private readonly IUniformStickyPartitioner? _uniformStickyPartitioner;
@@ -193,7 +202,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ISerializer<TKey> keySerializer,
         ISerializer<TValue> valueSerializer,
         ILoggerFactory? loggerFactory = null,
-        MetadataOptions? metadataOptions = null)
+        MetadataOptions? metadataOptions = null,
+        IAsyncSerializer<TKey>? asyncKeySerializer = null,
+        IAsyncSerializer<TValue>? asyncValueSerializer = null)
         : this(
             options,
             keySerializer,
@@ -201,7 +212,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             CreateInfrastructure(options, loggerFactory, metadataOptions),
             loggerFactory,
             ownsInfrastructure: true,
-            DekafMemoryBudget.Global)
+            DekafMemoryBudget.Global,
+            asyncKeySerializer: asyncKeySerializer,
+            asyncValueSerializer: asyncValueSerializer)
     {
     }
 
@@ -213,7 +226,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         MetadataManager metadataManager,
         IDekafMemoryBudget memoryBudget,
         ILoggerFactory? loggerFactory = null,
-        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null)
+        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null,
+        IAsyncSerializer<TKey>? asyncKeySerializer = null,
+        IAsyncSerializer<TValue>? asyncValueSerializer = null)
         : this(
             options,
             keySerializer,
@@ -222,7 +237,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             loggerFactory,
             ownsInfrastructure: false,
             memoryBudget,
-            addPartitionsToTransaction)
+            addPartitionsToTransaction,
+            asyncKeySerializer,
+            asyncValueSerializer)
     {
     }
 
@@ -303,15 +320,24 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ILoggerFactory? loggerFactory,
         bool ownsInfrastructure,
         IDekafMemoryBudget memoryBudget,
-        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null)
+        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? addPartitionsToTransaction = null,
+        IAsyncSerializer<TKey>? asyncKeySerializer = null,
+        IAsyncSerializer<TValue>? asyncValueSerializer = null)
     {
         ExponentialRetryBackoff.Validate(options.RetryBackoffMs, options.RetryBackoffMaxMs);
         _options = options;
         _addPartitionsToTransaction = addPartitionsToTransaction ?? AddPartitionsToTransactionAsync;
-        _keySerializer = keySerializer;
-        _valueSerializer = valueSerializer;
-        _keyPreparer = keySerializer as IAsyncSerializerPreparer<TKey>;
-        _valuePreparer = valueSerializer as IAsyncSerializerPreparer<TValue>;
+        // When an async serializer is configured for a component, its sync slot is forced to the
+        // throwing placeholder here — by construction, not by builder convention — so a direct
+        // constructor caller can never pair an async serializer with a live sync one that would
+        // silently serialize on the sync path.
+        _keySerializer = asyncKeySerializer is null ? keySerializer : AsyncOnlySerializerPlaceholder<TKey>.Instance;
+        _valueSerializer = asyncValueSerializer is null ? valueSerializer : AsyncOnlySerializerPlaceholder<TValue>.Instance;
+        _keyPreparer = _keySerializer as IAsyncSerializerPreparer<TKey>;
+        _valuePreparer = _valueSerializer as IAsyncSerializerPreparer<TValue>;
+        _asyncKeySerializer = asyncKeySerializer;
+        _asyncValueSerializer = asyncValueSerializer;
+        _hasAsyncSerializers = asyncKeySerializer is not null || asyncValueSerializer is not null;
         _memoryBudget = memoryBudget;
         _ownsInfrastructure = ownsInfrastructure;
         _logger = loggerFactory?.CreateLogger<KafkaProducer<TKey, TValue>>() ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KafkaProducer<TKey, TValue>>.Instance;
@@ -561,6 +587,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         var activity = StartPublishActivity(ref message);
 
+        // Async serializers (per-message I/O, issue #2309) cannot run on the synchronous fast
+        // path — divert to the dedicated async-serialization path before any sync serialize.
+        if (_hasAsyncSerializers)
+            return ProduceWithAsyncSerializationAsync(message, activity, continuationMode, cancellationToken);
+
         // If a serializer needs async setup (e.g. a one-time Schema Registry fetch), do it here on the
         // async path so the synchronous serialize never blocks on it. After the first message for a
         // subject this completes synchronously and falls straight through to the fast path below.
@@ -759,6 +790,25 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Check cancellation upfront before any work
         cancellationToken.ThrowIfCancellationRequested();
+
+        // See ProduceAsyncCore(ProducerMessage): async serializers divert before any sync serialize.
+        // This overload is only reached without interceptors/retry/tracing, so no activity exists.
+        if (_hasAsyncSerializers)
+        {
+            return ProduceWithAsyncSerializationAsync(
+                new ProducerMessage<TKey, TValue>
+                {
+                    Topic = topic,
+                    Key = key,
+                    Value = value,
+                    Headers = headers,
+                    Partition = partition,
+                    Timestamp = timestamp
+                },
+                activity: null,
+                continuationMode,
+                cancellationToken);
+        }
 
         // See ProduceAsyncCore(ProducerMessage): resolve any async serializer prerequisite before the
         // synchronous serialize so it never blocks. Steady state completes synchronously and falls through.
@@ -1080,19 +1130,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Retry fast path - metadata should already be initialized via InitializeAsync()
         if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var fastCompletion))
         {
-            if (activity is not null)
-            {
-                return await AwaitWithActivity(fastCompletion!, activity, message.Topic, cancellationToken).ConfigureAwait(false);
-            }
-            if (metricsEnabled)
-            {
-                return await AwaitWithMetrics(fastCompletion!, message.Topic, cancellationToken).ConfigureAwait(false);
-            }
-            if (cancellationToken.CanBeCanceled)
-            {
-                return await AwaitWithCancellation(fastCompletion!, cancellationToken).ConfigureAwait(false);
-            }
-            return await fastCompletion!.Task.ConfigureAwait(false);
+            return await AwaitProduceCompletionAsync(fastCompletion!, activity, metricsEnabled, message.Topic, cancellationToken).ConfigureAwait(false);
         }
 
         // Topic cache miss — fetch topic metadata inline and produce
@@ -1110,19 +1148,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             completion.TrySetException(ex);
         }
 
-        if (activity is not null)
-        {
-            return await AwaitWithActivity(completion, activity, message.Topic, cancellationToken).ConfigureAwait(false);
-        }
-        if (metricsEnabled)
-        {
-            return await AwaitWithMetrics(completion, message.Topic, cancellationToken).ConfigureAwait(false);
-        }
-        if (cancellationToken.CanBeCanceled)
-        {
-            return await AwaitWithCancellation(completion, cancellationToken).ConfigureAwait(false);
-        }
-        return await completion.Task.ConfigureAwait(false);
+        return await AwaitProduceCompletionAsync(completion, activity, metricsEnabled, message.Topic, cancellationToken).ConfigureAwait(false);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1146,6 +1172,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         message = ApplyOnSendInterceptors(message);
 
         var activity = StartPublishActivity(ref message);
+
+        // Async serializers cannot run on the synchronous append path — serialize on the async
+        // path, then enqueue. Delivery errors are observed and logged (fire-and-forget contract).
+        if (_hasAsyncSerializers)
+            return FireWithAsyncSerializationAsync(message, activity, deliveryHandler: null);
 
         // Fast path: try thread-local cached topic metadata first
         var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
@@ -1204,6 +1235,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // so interceptors can inspect/modify the message before serialization.
         if (_interceptors is not null)
             return FireAsync(new ProducerMessage<TKey, TValue> { Topic = topic, Key = key, Value = value });
+
+        // Async serializers divert before the synchronous append path (see FireAsync(message)).
+        if (_hasAsyncSerializers)
+        {
+            return FireWithAsyncSerializationAsync(
+                new ProducerMessage<TKey, TValue> { Topic = topic, Key = key, Value = value },
+                activity: null,
+                deliveryHandler: null);
+        }
 
         // Fast path: no ProducerMessage allocation, no interceptors, no activity tracing
         var inThreadLocalCache = TryGetCachedTopicInfo(topic, out var topicInfo);
@@ -1568,6 +1608,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Apply OnSend interceptors before serialization
         message = ApplyOnSendInterceptors(message);
 
+        // Async serializers divert before the synchronous append path; the delivery handler is
+        // invoked from a background observer when the batch completes (see FireAsync(message)).
+        if (_hasAsyncSerializers)
+            return FireWithAsyncSerializationAsync(message, activity: null, deliveryHandler);
+
         // Fast path: try thread-local cached topic metadata first
         var inThreadLocalCache = TryGetCachedTopicInfo(message.Topic, out var topicInfo);
         if (inThreadLocalCache ||
@@ -1609,10 +1654,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         PooledValueTaskSource<RecordMetadata> completion,
         CancellationToken cancellationToken)
     {
-        // Fast path: try to get topic metadata from cache synchronously
-        // This avoids async state machine overhead for 99%+ of calls
+        // Fast path: thread-local topic cache (three reference compares), then the metadata
+        // manager's cache; async fetch only on a true miss. The thread-local hit matters for
+        // the async-serialization path (issue #2309), which routes every message through here.
         TopicInfo? topicInfo;
-        if (!_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
+        if (!TryGetCachedTopicInfo(message.Topic, out topicInfo) &&
+            !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
         {
             // Slow path: cache miss, need async refresh with MaxBlockMs timeout
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -1642,43 +1689,77 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             throw NoUsablePartitionsException(message.Topic, topicInfo);
         }
 
-        // Serialize key and value to pooled memory (returned to pool when batch completes)
+        UpdateCachedTopicInfo(message.Topic, topicInfo);
+
+        // Serialize key and value to pooled memory (returned to pool when batch completes).
+        // Async serializers (issue #2309) are awaited per component; a mixed configuration uses
+        // the thread-local sync path for the other component. Key then value sequentially — a
+        // both-async configuration pays two serde round trips per message (accepted; the common
+        // mixed configuration is unaffected).
         var keyIsNull = message.Key is null;
-        var key = keyIsNull ? PooledMemory.Null : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
         var valueIsNull = message.Value is null;
-        var value = valueIsNull ? PooledMemory.Null : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
-
-        // Determine partition
-        var partition = message.Partition
-            ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
-        var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
-            message.Partition, key.Span, keyIsNull, topicInfo.PartitionCount);
-
-        // Get timestamp
-        var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
-        var timestampMs = timestamp.ToUnixTimeMilliseconds();
-
-        // Convert headers with minimal allocations
-        Header[]? pooledHeaderArray = null;
-        var headerCount = 0;
-        if (message.Headers is not null && message.Headers.Count > 0)
+        var key = PooledMemory.Null;
+        var value = PooledMemory.Null;
+        try
         {
-            RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
-        }
+            if (!keyIsNull)
+            {
+                key = _asyncKeySerializer is not null
+                    ? await SerializeToPooledAsync(
+                        _asyncKeySerializer, message.Key!, message.Topic,
+                        SerializationComponent.Key, message.Headers, cancellationToken).ConfigureAwait(false)
+                    : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+            }
 
-        // Enqueue to per-partition-affine worker instead of calling AppendAsync inline.
-        // The worker will call AppendAsync and set the completion source on success/failure.
-        _accumulator.EnqueueAppend(
-            message.Topic,
-            partition,
-            timestampMs,
-            key,
-            value,
-            pooledHeaderArray,
-            headerCount,
-            completion,
-            cancellationToken,
-            batchCompletionPartitionCount);
+            if (!valueIsNull)
+            {
+                value = _asyncValueSerializer is not null
+                    ? await SerializeToPooledAsync(
+                        _asyncValueSerializer, message.Value!, message.Topic,
+                        SerializationComponent.Value, message.Headers, cancellationToken).ConfigureAwait(false)
+                    : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+            }
+
+            // Determine partition
+            var partition = message.Partition
+                ?? _partitioner.Partition(message.Topic, key.Span, keyIsNull, topicInfo.PartitionCount);
+            var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
+                message.Partition, key.Span, keyIsNull, topicInfo.PartitionCount);
+
+            // Get timestamp
+            var timestamp = message.Timestamp ?? DateTimeOffset.UtcNow;
+            var timestampMs = timestamp.ToUnixTimeMilliseconds();
+
+            // Convert headers with minimal allocations
+            Header[]? pooledHeaderArray = null;
+            var headerCount = 0;
+            if (message.Headers is not null && message.Headers.Count > 0)
+            {
+                RentAndFillHeaders(message.Headers, out pooledHeaderArray, out headerCount);
+            }
+
+            // Enqueue to per-partition-affine worker instead of calling AppendAsync inline.
+            // The worker will call AppendAsync and set the completion source on success/failure.
+            _accumulator.EnqueueAppend(
+                message.Topic,
+                partition,
+                timestampMs,
+                key,
+                value,
+                pooledHeaderArray,
+                headerCount,
+                completion,
+                cancellationToken,
+                batchCompletionPartitionCount);
+        }
+        catch
+        {
+            // EnqueueAppend transfers ownership of the pooled arrays; any failure before that
+            // must return them here.
+            key.Return();
+            value.Return();
+            throw;
+        }
     }
 
     public ValueTask<RecordMetadata> ProduceAsync(
@@ -4033,6 +4114,253 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Copy to right-sized pooled buffer for batch storage
         return writer.ToPooledMemory();
+    }
+
+    /// <summary>
+    /// Produce path used when an <see cref="IAsyncSerializer{T}"/> is configured (issue #2309).
+    /// Reuses <see cref="ProduceInternalAsync"/> (which awaits async serializers per component)
+    /// and ProduceAsyncSlow's completion/instrumentation handling.
+    /// </summary>
+    private async ValueTask<RecordMetadata> ProduceWithAsyncSerializationAsync(
+        ProducerMessage<TKey, TValue> message,
+        Activity? activity,
+        ProduceContinuationMode continuationMode,
+        CancellationToken cancellationToken)
+    {
+        // See ProduceAfterPrepare: instrumented awaits interpose a state machine that must not
+        // run inline on the broker ack thread.
+        var metricsEnabled = ProducerMetricsEnabled();
+        if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
+            continuationMode = ProduceContinuationMode.Async;
+        var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
+
+        var completion = RentCompletion(runContinuationsAsynchronously);
+        try
+        {
+            await ProduceInternalAsync(message, completion, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            completion.TrySetCanceled(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+
+        return await AwaitProduceCompletionAsync(completion, activity, metricsEnabled, message.Topic, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Shared cold-path tail for awaiting a produce completion with the correct instrumentation
+    /// wrapper. Branch order is load-bearing: activity, then metrics, then bare cancellation.
+    /// </summary>
+    private ValueTask<RecordMetadata> AwaitProduceCompletionAsync(
+        PooledValueTaskSource<RecordMetadata> completion,
+        Activity? activity,
+        bool metricsEnabled,
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        if (activity is not null)
+        {
+            return AwaitWithActivity(completion, activity, topic, cancellationToken);
+        }
+        if (metricsEnabled)
+        {
+            return AwaitWithMetrics(completion, topic, cancellationToken);
+        }
+        if (cancellationToken.CanBeCanceled)
+        {
+            return AwaitWithCancellation(completion, cancellationToken);
+        }
+        return completion.Task;
+    }
+
+    /// <summary>
+    /// Runs an async serializer against a pooled, heap-safe buffer writer and detaches the result
+    /// as <see cref="PooledMemory"/> (returned to the pool when the batch completes).
+    /// </summary>
+    private static async ValueTask<PooledMemory> SerializeToPooledAsync<T>(
+        IAsyncSerializer<T> serializer,
+        T value,
+        string topic,
+        SerializationComponent component,
+        Headers? headers,
+        CancellationToken cancellationToken)
+    {
+        var writer = AsyncSerializationBufferWriter.Rent();
+        try
+        {
+            var context = new SerializationContext
+            {
+                Topic = topic,
+                Component = component,
+                Headers = headers
+            };
+            await serializer.SerializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
+            return writer.DetachWrittenMemory();
+        }
+        finally
+        {
+            AsyncSerializationBufferWriter.Return(writer);
+        }
+    }
+
+    /// <summary>
+    /// Fire-and-forget path with async serializers. Serializes on the async path, then appends
+    /// through the accumulator's span/callback machinery — the same delivery-callback mechanism
+    /// the synchronous fire-and-forget path uses, so handler dispatch, backpressure, and
+    /// delivery-error accounting stay unified. The returned ValueTask completes when the message
+    /// is appended (parity with FireAsync's append semantics).
+    /// </summary>
+    private async ValueTask FireWithAsyncSerializationAsync(
+        ProducerMessage<TKey, TValue> message,
+        Activity? activity,
+        Action<RecordMetadata, Exception?>? deliveryHandler)
+    {
+        try
+        {
+            // Metadata: thread-local cache, then manager cache, then bounded fetch
+            // (mirrors FireAsyncSlow).
+            TopicInfo? topicInfo;
+            if (!TryGetCachedTopicInfo(message.Topic, out topicInfo) &&
+                !_metadataManager.TryGetCachedTopicMetadata(message.Topic, out topicInfo))
+            {
+                using var timeoutCts = new CancellationTokenSource(_options.MaxBlockMs);
+                try
+                {
+                    topicInfo = await _metadataManager.GetTopicMetadataAsync(message.Topic, timeoutCts.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new KafkaTimeoutException(
+                        $"Failed to fetch metadata for topic '{message.Topic}' within max.block.ms ({_options.MaxBlockMs}ms).");
+                }
+            }
+
+            if (topicInfo is null || topicInfo.PartitionCount == 0)
+            {
+                var metadataException = NoUsablePartitionsException(message.Topic, topicInfo);
+                if (deliveryHandler is null)
+                {
+                    // Parity with FireAsyncSlow: log and drop rather than throw.
+                    LogFireAndForgetMetadataFetchFailed(metadataException, message.Topic);
+                    return;
+                }
+
+                throw metadataException;
+            }
+
+            UpdateCachedTopicInfo(message.Topic, topicInfo);
+
+            var keyIsNull = message.Key is null;
+            var valueIsNull = message.Value is null;
+            var key = PooledMemory.Null;
+            var value = PooledMemory.Null;
+            try
+            {
+                if (!keyIsNull)
+                {
+                    key = _asyncKeySerializer is not null
+                        ? await SerializeToPooledAsync(
+                            _asyncKeySerializer, message.Key!, message.Topic,
+                            SerializationComponent.Key, message.Headers, CancellationToken.None).ConfigureAwait(false)
+                        : SerializeKeyToPooled(message.Key!, message.Topic, message.Headers);
+                }
+
+                if (!valueIsNull)
+                {
+                    value = _asyncValueSerializer is not null
+                        ? await SerializeToPooledAsync(
+                            _asyncValueSerializer, message.Value!, message.Topic,
+                            SerializationComponent.Value, message.Headers, CancellationToken.None).ConfigureAwait(false)
+                        : SerializeValueToPooled(message.Value!, message.Topic, message.Headers);
+                }
+
+                var appendResult = await AppendSerializedToAccumulatorAsync(
+                    message.Topic, key, keyIsNull, value, valueIsNull,
+                    message.Headers, message.Partition, message.Timestamp,
+                    topicInfo, deliveryHandler).ConfigureAwait(false);
+
+                if (!appendResult)
+                    throw new ObjectDisposedException(nameof(KafkaProducer<TKey, TValue>));
+            }
+            finally
+            {
+                // AppendFromSpansAsync copies the record data before any await, so the pooled
+                // serialization arrays are no longer referenced once the append completes.
+                key.Return();
+                value.Return();
+            }
+
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (KafkaTimeoutException ex) when (deliveryHandler is null)
+        {
+            // Metadata/BufferMemory backpressure timeout must propagate (parity with FireAsync).
+            if (activity is not null) Diagnostics.DekafDiagnostics.RecordException(activity, ex);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (activity is not null) Diagnostics.DekafDiagnostics.RecordException(activity, ex);
+            if (deliveryHandler is not null)
+            {
+                // Pre-append failure: deliver to the callback (parity with ProduceAsyncWithCallbackSlow).
+                try { deliveryHandler(default, ex); } catch (Exception cbEx) { LogBatchCleanupStepFailed(cbEx); }
+            }
+            else
+            {
+                LogFireAndForgetProduceFailed(ex, message.Topic);
+            }
+        }
+        finally
+        {
+            activity?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Appends already-serialized key/value bytes to the accumulator with an optional delivery
+    /// callback. Non-async so the spans never enter an async frame; AppendFromSpansAsync copies
+    /// the data before any await, so the caller may return the pooled arrays once the returned
+    /// ValueTask completes.
+    /// </summary>
+    private ValueTask<bool> AppendSerializedToAccumulatorAsync(
+        string topic,
+        in PooledMemory key,
+        bool keyIsNull,
+        in PooledMemory value,
+        bool valueIsNull,
+        Headers? headers,
+        int? explicitPartition,
+        DateTimeOffset? timestamp,
+        TopicInfo topicInfo,
+        Action<RecordMetadata, Exception?>? callback)
+    {
+        var keySpan = key.Span;
+        var partition = explicitPartition
+            ?? _partitioner.Partition(topic, keySpan, keyIsNull, topicInfo.PartitionCount);
+        var batchCompletionPartitionCount = GetUniformStickyPartitionCount(
+            explicitPartition, keySpan, keyIsNull, topicInfo.PartitionCount);
+        var timestampMs = timestamp?.ToUnixTimeMilliseconds() ?? GetFastTimestampMs();
+
+        Header[]? pooledHeaderArray = null;
+        var headerCount = 0;
+        if (headers is not null && headers.Count > 0)
+        {
+            RentAndFillHeaders(headers, out pooledHeaderArray, out headerCount);
+        }
+
+        // CancellationToken.None is intentional: fire-and-forget callers have no per-call token.
+        // Backpressure is bounded by MaxBlockMs inside ReserveMemoryAsync.
+        return _accumulator.AppendFromSpansAsync(
+            topic, partition, timestampMs,
+            keySpan, keyIsNull,
+            value.Span, valueIsNull,
+            pooledHeaderArray, headerCount, callback, CancellationToken.None, batchCompletionPartitionCount);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dekaf/Serialization/AsyncOnlySerdePlaceholders.cs
+++ b/src/Dekaf/Serialization/AsyncOnlySerdePlaceholders.cs
@@ -1,0 +1,47 @@
+using System.Buffers;
+
+namespace Dekaf.Serialization;
+
+/// <summary>
+/// Placeholder occupying the synchronous serializer slot when only an
+/// <see cref="IAsyncSerializer{T}"/> is configured. The producer routes every message through the
+/// asynchronous serialization path in that mode, so this is never invoked; reaching it means a
+/// produce path bypassed the async-serializer routing and must fail loudly rather than encode
+/// nothing.
+/// </summary>
+internal sealed class AsyncOnlySerializerPlaceholder<T> : ISerializer<T>
+{
+    public static readonly AsyncOnlySerializerPlaceholder<T> Instance = new();
+
+    private AsyncOnlySerializerPlaceholder()
+    {
+    }
+
+    public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
+        where TWriter : IBufferWriter<byte>
+#if !NETSTANDARD2_0
+        , allows ref struct
+#endif
+        => throw new InvalidOperationException(
+            "An asynchronous serializer is configured for this component, so the synchronous " +
+            "serialization path must not be reached. This is a bug in Dekaf — please report it.");
+}
+
+/// <summary>
+/// Placeholder occupying the synchronous deserializer slot when only an
+/// <see cref="IAsyncDeserializer{T}"/> is configured. See
+/// <see cref="AsyncOnlySerializerPlaceholder{T}"/> for the rationale.
+/// </summary>
+internal sealed class AsyncOnlyDeserializerPlaceholder<T> : IDeserializer<T>
+{
+    public static readonly AsyncOnlyDeserializerPlaceholder<T> Instance = new();
+
+    private AsyncOnlyDeserializerPlaceholder()
+    {
+    }
+
+    public T Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        => throw new InvalidOperationException(
+            "An asynchronous deserializer is configured for this component, so the synchronous " +
+            "deserialization path must not be reached. This is a bug in Dekaf — please report it.");
+}

--- a/src/Dekaf/Serialization/IAsyncSerializer.cs
+++ b/src/Dekaf/Serialization/IAsyncSerializer.cs
@@ -1,0 +1,86 @@
+using System.Buffers;
+
+namespace Dekaf.Serialization;
+
+/// <summary>
+/// Interface for serializers that need to perform asynchronous work per value — for example an
+/// encryption stack that fetches short-lived keys, or any serializer whose encoding requires I/O.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prefer <see cref="ISerializer{T}"/> whenever the serializer can encode synchronously:
+/// synchronous serializers run on the producer's zero-allocation fast path, while asynchronous
+/// serializers route every message through a slower pooled-buffer path that carries async
+/// state-machine overhead. When the asynchronous work is a one-time cached setup (such as a
+/// Schema Registry fetch), implement <see cref="IAsyncSerializerPreparer{T}"/> on a synchronous
+/// serializer instead — that keeps the steady-state encode on the fast path.
+/// </para>
+/// <para>
+/// When an asynchronous serializer is configured (via
+/// <c>ProducerBuilder.WithKeySerializer(IAsyncSerializer&lt;TKey&gt;)</c> or
+/// <c>WithValueSerializer(IAsyncSerializer&lt;TValue&gt;)</c>), the producer awaits
+/// <see cref="SerializeAsync"/> on its asynchronous produce path before appending the serialized
+/// bytes to the batch. Fire-and-forget (<c>FireAsync</c>) is still supported: serialization is
+/// awaited, and delivery errors are routed to the delivery handler or logged.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type to serialize.</typeparam>
+public interface IAsyncSerializer<in T>
+{
+    /// <summary>
+    /// Serializes a value to the output buffer, awaiting any required asynchronous work.
+    /// </summary>
+    /// <param name="value">The value to serialize.</param>
+    /// <param name="destination">
+    /// The buffer to write serialized bytes to. The buffer is only valid until the returned task
+    /// completes; implementations must not retain it.
+    /// </param>
+    /// <param name="context">Serialization context with topic and header information.</param>
+    /// <param name="cancellationToken">A token to cancel the serialization.</param>
+    ValueTask SerializeAsync(
+        T value,
+        IBufferWriter<byte> destination,
+        SerializationContext context,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Interface for deserializers that need to perform asynchronous work per value — for example a
+/// decryption stack that fetches short-lived keys, or any decoding that requires I/O.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prefer <see cref="IDeserializer{T}"/> whenever decoding can run synchronously: synchronous
+/// deserializers run inline on the consumer's poll path, while asynchronous deserializers are
+/// awaited per record. When an asynchronous deserializer is configured, records are delivered via
+/// <c>ConsumeAsync</c> and <c>ConsumeOneAsync</c>; the batch API (<c>ConsumeBatchAsync</c>)
+/// iterates records synchronously and therefore throws <see cref="NotSupportedException"/>.
+/// </para>
+/// <para>
+/// The <c>data</c> memory passed to <see cref="DeserializeAsync"/> references pooled fetch
+/// buffers and is only valid until the returned task completes; implementations must copy the
+/// bytes if they need them afterwards.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type to deserialize.</typeparam>
+public interface IAsyncDeserializer<T>
+{
+    /// <summary>
+    /// Deserializes a value from the input data, awaiting any required asynchronous work.
+    /// </summary>
+    /// <param name="data">
+    /// The serialized bytes. Only valid until the returned task completes — copy if retained.
+    /// </param>
+    /// <param name="context">Serialization context with topic and null-ness information.</param>
+    /// <param name="cancellationToken">A token to cancel the deserialization.</param>
+    ValueTask<T> DeserializeAsync(
+        ReadOnlyMemory<byte> data,
+        SerializationContext context,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Combined asynchronous serializer and deserializer interface.
+/// </summary>
+/// <typeparam name="T">The type to serialize/deserialize.</typeparam>
+public interface IAsyncSerde<T> : IAsyncSerializer<T>, IAsyncDeserializer<T>;

--- a/tests/Dekaf.Tests.Integration/AsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Integration/AsyncSerdeTests.cs
@@ -1,0 +1,292 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage for <see cref="IAsyncSerializer{T}"/>/<see cref="IAsyncDeserializer{T}"/>
+/// (issue #2309): serdes that perform per-message asynchronous work, e.g. an encryption stack
+/// fetching short-lived keys. The test serde XORs the payload with a "key" that is only obtainable
+/// asynchronously, so a sync-only path would either fail or produce unreadable bytes.
+/// </summary>
+[Category("Serialization")]
+public class AsyncSerdeTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    /// <summary>
+    /// Simulates an IO-dependent envelope-encryption serde: every operation awaits an async "key
+    /// fetch" before transforming the payload. Also counts invocations so tests can prove the
+    /// async path (not a sync fallback) ran.
+    /// </summary>
+    private sealed class XorEncryptionStringSerde : IAsyncSerde<string>
+    {
+        private const byte Key = 0x5A;
+        private int _serializeCalls;
+        private int _deserializeCalls;
+
+        public int SerializeCalls => Volatile.Read(ref _serializeCalls);
+        public int DeserializeCalls => Volatile.Read(ref _deserializeCalls);
+
+        private static async ValueTask<byte> FetchKeyAsync(CancellationToken cancellationToken)
+        {
+            // Force a real asynchronous hop, as a short-lived-key fetch would.
+            await Task.Delay(1, cancellationToken);
+            return Key;
+        }
+
+        public async ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _serializeCalls);
+            var key = await FetchKeyAsync(cancellationToken);
+            var bytes = Encoding.UTF8.GetBytes(value);
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] ^= key;
+            destination.Write(bytes);
+        }
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _deserializeCalls);
+            var key = await FetchKeyAsync(cancellationToken);
+            var bytes = data.ToArray();
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] ^= key;
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+
+    [Test]
+    public async Task AsyncSerde_ProduceAsyncAndConsumeAsync_RoundTrips()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+        var producerSerde = new XorEncryptionStringSerde();
+        var consumerSerde = new XorEncryptionStringSerde();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithKeySerializer(producerSerde)
+            .WithValueSerializer(producerSerde)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var metadata = await producer.ProduceAsync(topic, "secret-key", "secret-value");
+        await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(0);
+        await Assert.That(producerSerde.SerializeCalls).IsEqualTo(2);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithKeyDeserializer(consumerSerde)
+            .WithValueDeserializer(consumerSerde)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var result in consumer.ConsumeAsync(cts.Token))
+        {
+            await Assert.That(result.Key).IsEqualTo("secret-key");
+            await Assert.That(result.Value).IsEqualTo("secret-value");
+            break;
+        }
+
+        await Assert.That(consumerSerde.DeserializeCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AsyncSerde_ConsumeOneAsync_RoundTrips()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithValueSerializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(topic, "k1", "consume-one-value");
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        // Mixed configuration: key uses the built-in sync string deserializer, value the async serde.
+        await Assert.That(result!.Value.Key).IsEqualTo("k1");
+        await Assert.That(result.Value.Value).IsEqualTo("consume-one-value");
+    }
+
+    [Test]
+    public async Task AsyncSerde_ProduceAllAsync_DeliversAllMessages()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+        const int messageCount = 50;
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithValueSerializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var messages = Enumerable.Range(0, messageCount)
+            .Select(i => new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            })
+            .ToList();
+
+        var results = await producer.ProduceAllAsync(messages);
+        await Assert.That(results.Length).IsEqualTo(messageCount);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        var seen = new HashSet<string>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await foreach (var result in consumer.ConsumeAsync(cts.Token))
+        {
+            seen.Add(result.Value);
+            if (seen.Count == messageCount)
+                break;
+        }
+
+        await Assert.That(seen.Count).IsEqualTo(messageCount);
+        for (var i = 0; i < messageCount; i++)
+        {
+            await Assert.That(seen.Contains($"value-{i}")).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task AsyncSerde_FireAsync_DeliversMessage()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithValueSerializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.FireAsync(topic, "fire-key", "fire-value");
+        await producer.FlushAsync();
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Value).IsEqualTo("fire-value");
+    }
+
+    [Test]
+    public async Task AsyncSerde_FireAsyncWithDeliveryHandler_InvokesHandler()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithValueSerializer(new XorEncryptionStringSerde())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var delivered = new TaskCompletionSource<(RecordMetadata Metadata, Exception? Error)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await producer.FireAsync(
+            new ProducerMessage<string, string> { Topic = topic, Key = "k", Value = "handler-value" },
+            (metadata, error) => delivered.TrySetResult((metadata, error)));
+        await producer.FlushAsync();
+
+        var (recordMetadata, exception) = await delivered.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await Assert.That(exception).IsNull();
+        await Assert.That(recordMetadata.Offset).IsGreaterThanOrEqualTo(0);
+        await Assert.That(recordMetadata.Topic).IsEqualTo(topic);
+    }
+
+    [Test]
+    public async Task AsyncSerde_NullValue_RoundTripsAsTombstone()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"test-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithValueSerializer(new XorEncryptionStringSerde()!)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.ProduceAsync(topic, "tombstone-key", null);
+
+        await using var consumer = await Kafka.CreateConsumer<string, string?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithValueDeserializer(new NullTolerantAsyncStringDeserializer())
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("tombstone-key");
+        await Assert.That(result.Value.Value).IsNull();
+    }
+
+    private sealed class NullTolerantAsyncStringDeserializer : IAsyncDeserializer<string?>
+    {
+        public async ValueTask<string?> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            return context.IsNull ? null : Encoding.UTF8.GetString(data.Span);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Serialization/AsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Serialization/AsyncSerdeTests.cs
@@ -1,0 +1,212 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Serialization;
+
+public class AsyncSerdeTests
+{
+    private sealed class YieldingStringSerde : IAsyncSerde<string>
+    {
+        public async ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            destination.Write(Encoding.UTF8.GetBytes(value));
+        }
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            return Encoding.UTF8.GetString(data.Span);
+        }
+    }
+
+    [Test]
+    public async Task ProducerBuilder_SyncAndAsyncKeySerializer_Throws()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithKeySerializer(Serializers.String)
+            .WithKeySerializer(new YieldingStringSerde());
+
+        await Assert.That(() => builder.Build()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ProducerBuilder_SyncAndAsyncValueSerializer_Throws()
+    {
+        var builder = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithValueSerializer(Serializers.String)
+            .WithValueSerializer(new YieldingStringSerde());
+
+        await Assert.That(() => builder.Build()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_SyncAndAsyncKeyDeserializer_Throws()
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithKeyDeserializer(Serializers.String)
+            .WithKeyDeserializer(new YieldingStringSerde());
+
+        await Assert.That(() => builder.Build()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ConsumerBuilder_SyncAndAsyncValueDeserializer_Throws()
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithValueDeserializer(Serializers.String)
+            .WithValueDeserializer(new YieldingStringSerde());
+
+        await Assert.That(() => builder.Build()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ProducerBuilder_AsyncSerializers_Builds()
+    {
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithKeySerializer(new YieldingStringSerde())
+            .WithValueSerializer(new YieldingStringSerde())
+            .Build();
+
+        await Assert.That(producer).IsNotNull();
+    }
+
+    [Test]
+    public async Task ConsumeBatchAsync_WithAsyncDeserializer_ThrowsNotSupported()
+    {
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("async-serde-batch-guard")
+            .WithValueDeserializer(new YieldingStringSerde())
+            .Build();
+
+        await Assert.That(async () =>
+        {
+            await foreach (var _ in consumer.ConsumeBatchAsync(CancellationToken.None))
+            {
+                break;
+            }
+        }).Throws<NotSupportedException>();
+    }
+
+    [Test]
+    public async Task AsyncOnlySerializerPlaceholder_Throws()
+    {
+        await Assert.That(() =>
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var context = new SerializationContext { Topic = "t", Component = SerializationComponent.Value };
+            AsyncOnlySerializerPlaceholder<string>.Instance.Serialize("x", ref buffer, context);
+        }).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AsyncOnlyDeserializerPlaceholder_Throws()
+    {
+        var context = new SerializationContext { Topic = "t", Component = SerializationComponent.Value };
+
+        await Assert.That(() =>
+            AsyncOnlyDeserializerPlaceholder<string>.Instance.Deserialize(ReadOnlyMemory<byte>.Empty, context))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AsyncSerializationBufferWriter_WriteAndDetach_RoundTrips()
+    {
+        var writer = AsyncSerializationBufferWriter.Rent();
+        try
+        {
+            var payload = Encoding.UTF8.GetBytes("async serde payload");
+            writer.Write(payload);
+
+            var pooled = writer.DetachWrittenMemory();
+            try
+            {
+                await Assert.That(pooled.IsNull).IsFalse();
+                await Assert.That(pooled.Memory.ToArray().SequenceEqual(payload)).IsTrue();
+            }
+            finally
+            {
+                pooled.Return();
+            }
+        }
+        finally
+        {
+            AsyncSerializationBufferWriter.Return(writer);
+        }
+    }
+
+    [Test]
+    public async Task AsyncSerializationBufferWriter_EmptyDetach_IsEmptyNonNull()
+    {
+        var writer = AsyncSerializationBufferWriter.Rent();
+        try
+        {
+            var pooled = writer.DetachWrittenMemory();
+            await Assert.That(pooled.IsNull).IsFalse();
+            await Assert.That(pooled.Length).IsEqualTo(0);
+            pooled.Return();
+        }
+        finally
+        {
+            AsyncSerializationBufferWriter.Return(writer);
+        }
+    }
+
+    [Test]
+    public async Task AsyncSerializationBufferWriter_GrowsPastInitialCapacity()
+    {
+        var writer = AsyncSerializationBufferWriter.Rent();
+        try
+        {
+            var payload = new byte[16 * 1024];
+            new Random(42).NextBytes(payload);
+            writer.Write(payload);
+
+            var pooled = writer.DetachWrittenMemory();
+            try
+            {
+                await Assert.That(pooled.Length).IsEqualTo(payload.Length);
+                await Assert.That(pooled.Memory.ToArray().SequenceEqual(payload)).IsTrue();
+            }
+            finally
+            {
+                pooled.Return();
+            }
+        }
+        finally
+        {
+            AsyncSerializationBufferWriter.Return(writer);
+        }
+    }
+
+    [Test]
+    public async Task AsyncSerializationBufferWriter_AdvancePastEnd_Throws()
+    {
+        var writer = AsyncSerializationBufferWriter.Rent();
+        try
+        {
+            writer.GetSpan(1);
+            await Assert.That(() => writer.Advance(1024 * 1024)).Throws<InvalidOperationException>();
+        }
+        finally
+        {
+            AsyncSerializationBufferWriter.Return(writer);
+        }
+    }
+}


### PR DESCRIPTION
Closes #2309.

## What

Introduces first-class asynchronous serde support for serializers/deserializers that must perform per-message I/O — the issue's driving use case is a Confluent.Kafka migration whose custom encryption/compression serde stack fetches short-lived keys:

- **New interfaces** (`Dekaf.Serialization`): `IAsyncSerializer<T>` (writes into an `IBufferWriter<byte>`), `IAsyncDeserializer<T>`, and combined `IAsyncSerde<T>`. Both carry a `CancellationToken` and document the pooled-memory validity contract (inputs/outputs only valid until the returned task completes).
- **Builder API**: overloads of the existing methods — `WithKeySerializer(IAsyncSerializer<TKey>)`, `WithValueSerializer(IAsyncSerializer<TValue>)`, `WithKeyDeserializer(IAsyncDeserializer<TKey>)`, `WithValueDeserializer(IAsyncDeserializer<TValue>)` — mirroring Confluent's same-name sync/async overload pattern for easy migration. Configuring both sync and async for the same component fails at `Build()`.
- **Producer**: when an async serializer is configured, every produce entry point (`ProduceAsync` ×3 incl. transactions/retry, `ProduceAllAsync` ×2, `FireAsync` ×3) diverts to a dedicated async path *before* any synchronous serialize: serialize into a pooled heap-safe buffer writer (`AsyncSerializationBufferWriter`, thread-cached, backed by `ProducerDataPool.BytePool`), then enqueue via the existing `EnqueueAppend` pooled-memory worker path (same machinery as the metadata-miss slow path). Fire-and-forget observes delivery in the background: errors reach the delivery handler or the FnF log, and the pooled completion source is always harvested. Mixed configurations (sync key + async value) use the existing thread-local sync pooled path for the sync component.
- **Consumer**: when an async deserializer is configured, `ConsumeAsync` and `ConsumeOneAsync` await deserialization per record before constructing the `ConsumeResult` (new internal pre-deserialized ctor; record fields are hoisted before the await because they reference pooled batch storage). `ConsumeBatchAsync` throws `NotSupportedException` (batch records are deserialized during synchronous iteration) with guidance to use `ConsumeAsync`/`ConsumeOneAsync`. Null semantics mirror the eager path exactly (null key skips the deserializer; null value invokes it with empty data + `IsNull = true`).
- Defense in depth: with an async serde configured, the sync serializer/deserializer slot holds a throwing placeholder, so any path that bypassed the async routing fails loudly instead of producing garbage.
- Docs: new "Async Serializers (IAsyncSerde)" section in `docs/serialization/custom.md`.

## Hot-path impact (Rule 1 / Rule 8)

The synchronous fast path is untouched except for **one readonly-bool branch per produce/consume entry point** (`_hasAsyncSerializers` / `_hasAsyncDeserializers`), the same shape and placement as the existing `_keyPreparer is not null` check. In `ConsumeAsync` the flag is hoisted once per stream like `hasInterceptors`. No allocations, no virtual dispatch, no async machinery added to the sync path.

Before/after `[MemoryDiagnoser]` numbers (broker-free, `--inProcess`, same machine):

`ProducerFireHotPathBenchmarks.FireBatch` (broker-free sync fire fast path — covers the exact entry point that gained the routing branch; sync serializers configured, so the branch is the only delta). Both runs `--inProcess` on the same machine (out-of-process BDN boilerplate build fails locally — pre-existing toolchain issue):

| Config | main (baseline) | this PR | Allocated |
|---|---|---|---|
| MessageSize=1000, DeliveryLatencyTargetMs=0 | 377.2 ns (median 370.1) | 334.2 ns (median 332.5) | 0 B → 0 B |
| MessageSize=1000, DeliveryLatencyTargetMs=10 | 888.3 ns (median 934.4) | 900.3 ns (median 930.7) | 0 B → 0 B |

Medians agree within ~1% (target-10) and the target-0 delta favors the candidate — parity within run-to-run noise, and the Allocated column stays `0 B`. The consumer-side `ConsumeOneBufferedFastPathBenchmarks` could not produce usable numbers locally (the in-process toolchain forces InvocationCount=1, yielding μs-scale noise); the consumer sync-path delta is one readonly-bool added to the existing `ConsumeOneAsync` fast-path condition plus a hoisted local in the `ConsumeAsync` loop — the same shape as the existing `hasInterceptors` hoist.

## Semantics notes

- With async serializers, `FireAsync`'s returned `ValueTask` still completes at append/enqueue (not delivery). BufferMemory backpressure surfaces via the background delivery observer (handler/log) rather than synchronously — same model the `ProduceAsync` metadata-miss slow path already uses.
- `IAsyncSerializerPreparer<T>` is unchanged and remains the right tool for one-time async setup (Schema Registry); the new interfaces are for genuinely per-message async work.

## Not in scope (follow-ups)

- `ConsumeBatchAsync` async-deserialization support (would need per-batch eager async materialization).
- ShareConsumer async serdes (builder intentionally has no async overloads yet).
- A Confluent-style `AsSyncOverAsync()` bridge wrapper.
- SchemaRegistry serializers implementing `IAsyncSerializer` natively.

## /simplify pass (applied)

Four parallel review agents (reuse / simplification / efficiency / altitude) ran on the diff; applied: the async path now reuses `ProduceInternalAsync` directly (per-component async branch at its serialize lines — the parallel ~90-line method was deleted), a shared `AwaitProduceCompletionAsync` tail replaces three copies of the instrumented-await ladder (adopted by `ProduceAsyncSlow` too), fire-and-forget appends via the accumulator's existing span/callback machinery instead of a per-message observer task + completion source, `ProduceInternalAsync` now checks the thread-local topic cache first (matters when every async-serde message routes through it), the new `ConsumeResult` ctor chains to the master ctor instead of hand-assigning 14 fields, the buffer writer got the `Array.MaxLength` growth clamp (drift from `DetachableBufferWriter`) and warm-buffer retention on reset, and the placeholder invariant is now enforced in the client constructors (not just the builder). Skipped deliberately: the `ConsumeOne` async sibling stays a documented mirror of the sync method (no zero-hot-path-cost sharing found), the `ProducerMessage` wrapper allocation in the arg-based async diverts (removing it would re-duplicate the produce path to save ~72 B on an already-allocating opt-in path), and a builder slot-union redesign (behavior-changing; the Build-time conflict throw covers it).

## Testing

- Unit (12 tests, all green): builder conflict validation ×4, async-serde build, `ConsumeBatchAsync` guard, placeholder throws ×2, `AsyncSerializationBufferWriter` round-trip/empty/growth/advance-past-end.
- Integration (6 tests, all green vs real Kafka via Testcontainers): XOR "encryption" serde with a forced async hop — `ProduceAsync`+`ConsumeAsync` round-trip (key+value, call-count-verified), `ConsumeOneAsync` (mixed sync/async), `ProduceAllAsync` ×50, `FireAsync`, `FireAsync` with delivery handler, null-value tombstone round-trip.
- Full solution builds clean (net10.0 + netstandard2.0), 0 warnings.
- Full unit suite run 6× total post-change: one run had a single failure whose identity was lost before the report was captured (overwritten by the subsequent run); 5 consecutive full-suite runs after it were 5873/5873 green, including 4 back-to-back capture runs that produced no failure to attribute. Flagging per the flaky-test rule rather than hiding it — if CI reproduces it, the name will pin it down.
