### PR TITLE
fix(protocol): qualify finalized feature state

### DIFF
--- a/src/Dekaf/Metadata/FinalizedFeatureSnapshot.cs
+++ b/src/Dekaf/Metadata/FinalizedFeatureSnapshot.cs
@@ -1,0 +1,85 @@
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Metadata;
+
+internal enum FinalizedFeatureStatus
+{
+    Unavailable,
+    Absent,
+    Present
+}
+
+/// <summary>
+/// Immutable epoch-qualified cluster finalized-feature state.
+/// </summary>
+internal sealed class FinalizedFeatureSnapshot
+{
+    private readonly Dictionary<string, FeatureLevel> _features;
+
+    private FinalizedFeatureSnapshot(long epoch, Dictionary<string, FeatureLevel> features)
+    {
+        Epoch = epoch;
+        _features = features;
+    }
+
+    public long Epoch { get; }
+
+    public static FinalizedFeatureSnapshot? Create(
+        long epoch,
+        IReadOnlyList<FinalizedFeature>? features)
+    {
+        if (epoch < 0)
+            return null;
+
+        var featureMap = new Dictionary<string, FeatureLevel>(
+            features?.Count ?? 0,
+            StringComparer.Ordinal);
+        if (features is not null)
+        {
+            foreach (var feature in features)
+            {
+                var level = new FeatureLevel(feature.MinVersionLevel, feature.MaxVersionLevel);
+                if (!featureMap.TryAdd(feature.Name, level)
+                    && featureMap[feature.Name] != level)
+                {
+                    throw new KafkaException(
+                        Protocol.ErrorCode.FeatureUpdateFailed,
+                        $"Finalized feature '{feature.Name}' appeared more than once with conflicting levels");
+                }
+            }
+        }
+
+        return new FinalizedFeatureSnapshot(epoch, featureMap);
+    }
+
+    public FinalizedFeatureStatus GetFeatureStatus(string featureName, out short maxVersionLevel)
+    {
+        if (_features.TryGetValue(featureName, out var level))
+        {
+            maxVersionLevel = level.MaxVersionLevel;
+            return FinalizedFeatureStatus.Present;
+        }
+
+        maxVersionLevel = default;
+        return FinalizedFeatureStatus.Absent;
+    }
+
+    public bool HasSameContent(FinalizedFeatureSnapshot other)
+    {
+        if (_features.Count != other._features.Count)
+            return false;
+
+        foreach (var feature in _features)
+        {
+            if (!other._features.TryGetValue(feature.Key, out var level)
+                || level != feature.Value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private readonly record struct FeatureLevel(short MinVersionLevel, short MaxVersionLevel);
+}

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -31,7 +31,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private volatile short _metadataApiVersion = -1;
     private readonly ConcurrentDictionary<ApiKey, (short MinVersion, short MaxVersion)> _brokerApiVersions = new();
     private readonly ConcurrentDictionary<(ApiKey, short, short), short> _negotiatedVersionCache = new();
-    private volatile IReadOnlyList<FinalizedFeature>? _finalizedFeatures;
+    private readonly object _finalizedFeatureLock = new();
+    private FinalizedFeatureSnapshot? _finalizedFeatures;
+    private string? _finalizedFeatureClusterId;
     private readonly SemaphoreSlim _initializeLock = new(1, 1);
     private volatile bool _initialized;
     private volatile bool _hasSuccessfulRefresh;
@@ -120,6 +122,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _options = options ?? new MetadataOptions();
         ExponentialRetryBackoff.Validate(_options.RetryBackoffMs, _options.RetryBackoffMaxMs);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<MetadataManager>.Instance;
+        if (connectionPool is IConnectionCapabilityObserverPool observerPool)
+            observerPool.SetConnectionCapabilityObserver(ObserveConnectionCapabilities);
 
         // Pre-parse bootstrap servers to avoid allocation in hot path
         _bootstrapEndpoints = new List<(string Host, int Port)>();
@@ -153,6 +157,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
         {
             throw new InvalidOperationException("An additional broker registration target is already configured");
         }
+
+        if (connectionPool is IConnectionCapabilityObserverPool observerPool)
+            observerPool.SetConnectionCapabilityObserver(ObserveConnectionCapabilities);
     }
 
     /// <summary>
@@ -303,29 +310,103 @@ public sealed partial class MetadataManager : IAsyncDisposable
     }
 
     /// <summary>
-    /// Returns the max finalized version for a broker feature, or 0 if the feature is not present.
+    /// Returns whether finalized cluster state is unavailable, the feature is absent, or it is present.
     /// </summary>
-    internal short GetFinalizedFeatureVersion(string featureName)
+    internal FinalizedFeatureStatus GetFinalizedFeatureStatus(
+        string featureName,
+        out short maxVersionLevel)
     {
-        var features = _finalizedFeatures;
-        if (features is null)
-            return 0;
-
-        foreach (var feature in features)
+        var snapshot = Volatile.Read(ref _finalizedFeatures);
+        if (snapshot is null)
         {
-            if (feature.Name == featureName)
-                return feature.MaxVersionLevel;
+            maxVersionLevel = default;
+            return FinalizedFeatureStatus.Unavailable;
         }
 
-        return 0;
+        return snapshot.GetFeatureStatus(featureName, out maxVersionLevel);
     }
 
-    internal short GetFinalizedFeatureVersion(
-        IKafkaConnection connection,
-        string featureName) =>
-        connection is IKafkaCapabilityProvider provider
-            ? provider.Capabilities.GetFinalizedFeatureVersion(featureName)
-            : GetFinalizedFeatureVersion(featureName);
+    internal bool TryGetFinalizedFeatureVersion(string featureName, out short maxVersionLevel) =>
+        GetFinalizedFeatureStatus(featureName, out maxVersionLevel) == FinalizedFeatureStatus.Present;
+
+    private void ObserveConnectionCapabilities(KafkaConnectionCapabilities capabilities)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        var candidate = capabilities.FinalizedFeatureSnapshot;
+        if (candidate is null)
+            return;
+
+        lock (_finalizedFeatureLock)
+        {
+            if (_finalizedFeatureClusterId is null)
+                return;
+
+            PublishFinalizedFeatures(candidate);
+        }
+    }
+
+    private void ObserveClusterCapabilities(string? clusterId, IKafkaConnection connection)
+    {
+        if (connection is not IKafkaCapabilityProvider provider)
+            return;
+
+        ObserveClusterCapabilities(clusterId, provider.Capabilities);
+    }
+
+    internal void ObserveClusterCapabilities(
+        string? clusterId,
+        KafkaConnectionCapabilities capabilities)
+    {
+        lock (_finalizedFeatureLock)
+        {
+            if (!string.Equals(_finalizedFeatureClusterId, clusterId, StringComparison.Ordinal))
+            {
+                _finalizedFeatureClusterId = clusterId;
+                Volatile.Write(ref _finalizedFeatures, null);
+            }
+
+            if (clusterId is null)
+                return;
+
+            var candidate = capabilities.FinalizedFeatureSnapshot;
+            if (candidate is not null)
+                PublishFinalizedFeatures(candidate);
+        }
+    }
+
+    private void PublishFinalizedFeatures(FinalizedFeatureSnapshot candidate)
+    {
+        var current = Volatile.Read(ref _finalizedFeatures);
+        if (current is not null)
+        {
+            if (candidate.Epoch < current.Epoch)
+                return;
+
+            if (candidate.Epoch == current.Epoch)
+            {
+                if (current.HasSameContent(candidate))
+                    return;
+
+                LogConflictingFinalizedFeatures(candidate.Epoch);
+                throw new KafkaException(
+                    ErrorCode.FeatureUpdateFailed,
+                    $"Brokers returned conflicting finalized feature state for epoch {candidate.Epoch}");
+            }
+        }
+
+        Volatile.Write(ref _finalizedFeatures, candidate);
+    }
+
+    private void ResetFinalizedFeaturesForRebootstrap()
+    {
+        lock (_finalizedFeatureLock)
+        {
+            _finalizedFeatureClusterId = null;
+            Volatile.Write(ref _finalizedFeatures, null);
+        }
+    }
 
     /// <summary>
     /// Initializes the metadata manager by fetching initial metadata.
@@ -735,9 +816,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
                 // Production connections negotiate before becoming ready. Keep explicit
                 // negotiation only for injected test connections without a capability snapshot.
+                KafkaConnectionCapabilities? negotiatedCapabilities = null;
                 if (connection is not IKafkaCapabilityProvider && _metadataApiVersion < 0)
                 {
-                    await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
+                    negotiatedCapabilities = await NegotiateApiVersionsAsync(
+                        connection,
+                        cancellationToken).ConfigureAwait(false);
                 }
 
                 var metadataApiVersion = connection is IKafkaCapabilityProvider
@@ -774,6 +858,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     }
                     // Rebootstrap failed — fall through and apply the original response as best-effort fallback
                 }
+
+                if (negotiatedCapabilities is not null)
+                    ObserveClusterCapabilities(response.ClusterId, negotiatedCapabilities);
+                else
+                    ObserveClusterCapabilities(response.ClusterId, connection);
 
                 // Topic-specific requests merge into the existing snapshot to preserve
                 // metadata for other topics. Full-cluster requests replace the snapshot.
@@ -869,6 +958,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     private async ValueTask<bool> ExecuteRebootstrapAsync(IEnumerable<string>? topics, CancellationToken cancellationToken)
     {
+        ResetFinalizedFeaturesForRebootstrap();
+
         // Re-resolve DNS for each original bootstrap server
         var newEndpoints = await ResolveBootstrapEndpointsAsync(cancellationToken).ConfigureAwait(false);
 
@@ -888,8 +979,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
 
+                KafkaConnectionCapabilities? negotiatedCapabilities = null;
                 if (connection is not IKafkaCapabilityProvider)
-                    await NegotiateApiVersionsAsync(connection, cancellationToken).ConfigureAwait(false);
+                {
+                    negotiatedCapabilities = await NegotiateApiVersionsAsync(
+                        connection,
+                        cancellationToken).ConfigureAwait(false);
+                }
 
                 var metadataApiVersion = connection is IKafkaCapabilityProvider
                     ? GetNegotiatedApiVersion(
@@ -912,6 +1008,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     connection,
                     metadataApiVersion,
                     replaceExisting: true);
+
+                if (negotiatedCapabilities is not null)
+                    ObserveClusterCapabilities(response.ClusterId, negotiatedCapabilities);
+                else
+                    ObserveClusterCapabilities(response.ClusterId, connection);
 
                 _metadata.Update(response, mergeTopics: topics is not null);
 
@@ -1027,7 +1128,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
         Interlocked.Exchange(ref _allBrokersUnavailableSince, 0);
     }
 
-    private async ValueTask NegotiateApiVersionsAsync(IKafkaConnection connection, CancellationToken cancellationToken)
+    private async ValueTask<KafkaConnectionCapabilities> NegotiateApiVersionsAsync(
+        IKafkaConnection connection,
+        CancellationToken cancellationToken)
     {
         const short versionlessConnectionApiVersionsVersion = 3;
 
@@ -1087,9 +1190,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
         // Set metadata version last (acts as a signal that negotiation is complete)
         _metadataApiVersion = newMetadataVersion;
 
-        _finalizedFeatures = response.FinalizedFeatures;
-
         LogNegotiatedApiVersion(_metadataApiVersion);
+        return KafkaConnectionCapabilities.Create(response);
     }
 
     private void UpdateVersionlessCapabilities(
@@ -1113,7 +1215,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
         }
 
         _negotiatedVersionCache.Clear();
-        _finalizedFeatures = capabilities.FinalizedFeatures;
         _metadataApiVersion = metadataApiVersion;
     }
 
@@ -1377,6 +1478,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Negotiated Metadata API version: {Version}")]
     private partial void LogNegotiatedApiVersion(short version);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Brokers returned conflicting finalized feature state for epoch {Epoch}")]
+    private partial void LogConflictingFinalizedFeatures(long epoch);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Background metadata refresh failed (attempt {Attempt}), continuing with existing metadata")]
     private partial void LogBackgroundMetadataRefreshFailed(Exception exception, int attempt);

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -13,7 +13,11 @@ namespace Dekaf.Networking;
 /// Connection pool for managing connections to Kafka brokers.
 /// Supports multiple connections per broker for parallel request handling.
 /// </summary>
-public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDiagnostics, IBrokerThrottleProvider
+public sealed partial class ConnectionPool :
+    IConnectionPool,
+    IConnectionPoolDiagnostics,
+    IBrokerThrottleProvider,
+    IConnectionCapabilityObserverPool
 {
     private const int MaxConnectionReapDiagnosticEvents = 256;
     private static readonly TimeSpan DefaultIdleReapDrainTimeout = TimeSpan.FromSeconds(5);
@@ -54,6 +58,7 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
     /// </summary>
     private readonly Func<int, string, int, int, CancellationToken, ValueTask<IKafkaConnection>>? _connectionFactory;
     private readonly Func<double> _randomDouble;
+    private Action<KafkaConnectionCapabilities>? _capabilityObserver;
 
     private readonly ConcurrentDictionary<int, BrokerInfo> _brokers = new();
     private readonly ConcurrentDictionary<EndpointKey, IKafkaConnection> _connectionsByEndpoint = new();
@@ -191,6 +196,13 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
 
     internal BrokerThrottleState GetBrokerThrottleStateForTest(int brokerId, string host, int port) =>
         GetBrokerThrottleState(brokerId, new EndpointKey(host, port));
+
+    void IConnectionCapabilityObserverPool.SetConnectionCapabilityObserver(
+        Action<KafkaConnectionCapabilities> observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+        Volatile.Write(ref _capabilityObserver, observer);
+    }
 
     private static ConnectionOptions ConfigureSharedOAuthBearerProvider(
         ConnectionOptions options,
@@ -841,7 +853,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
                 _responseMemoryAdmissionsEnabled,
-                GetBrokerThrottleState(brokerId, endpoint));
+                GetBrokerThrottleState(brokerId, endpoint),
+                Volatile.Read(ref _capabilityObserver));
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1022,7 +1035,8 @@ public sealed partial class ConnectionPool : IConnectionPool, IConnectionPoolDia
                 _sharedPipeMemoryPool,
                 _telemetryMetricCollector,
                 _responseMemoryAdmissionsEnabled,
-                GetBrokerThrottleState(brokerId, endpoint));
+                GetBrokerThrottleState(brokerId, endpoint),
+                Volatile.Read(ref _capabilityObserver));
 
             await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Dekaf/Networking/IConnectionPool.cs
+++ b/src/Dekaf/Networking/IConnectionPool.cs
@@ -70,3 +70,8 @@ internal interface IConnectionPoolDiagnostics
 
     int GetMaxObservedBrokerThrottleTimeMs();
 }
+
+internal interface IConnectionCapabilityObserverPool
+{
+    void SetConnectionCapabilityObserver(Action<KafkaConnectionCapabilities> observer);
+}

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -155,6 +155,7 @@ public sealed partial class KafkaConnection :
     private int _disposed;
     private int _connected;
     private KafkaConnectionCapabilities? _capabilities;
+    private readonly Action<KafkaConnectionCapabilities>? _capabilitiesObserver;
     private bool _hasReceivedResponse;
     private long _lastUsedTimestampMs = Dekaf.MonotonicClock.GetMilliseconds();
     private readonly SemaphoreSlim _connectLock = new(1, 1);
@@ -249,7 +250,8 @@ public sealed partial class KafkaConnection :
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
         Func<Task, TimeSpan, Task>? waitForAbandonedWriteAsync = null,
         bool responseMemoryAdmissionsEnabled = false,
-        BrokerThrottleState? brokerThrottleState = null)
+        BrokerThrottleState? brokerThrottleState = null,
+        Action<KafkaConnectionCapabilities>? capabilitiesObserver = null)
     {
         _host = host;
         _port = port;
@@ -267,6 +269,7 @@ public sealed partial class KafkaConnection :
         _telemetryMetricCollector = telemetryMetricCollector;
         _brokerThrottleState = brokerThrottleState ?? new BrokerThrottleState(telemetryMetricCollector);
         _waitForAbandonedWriteAsync = waitForAbandonedWriteAsync ?? WaitForAbandonedWriteAsync;
+        _capabilitiesObserver = capabilitiesObserver;
         _receiveTimeoutStopwatchTicks =
             (long)(_options.RequestTimeout.Ticks * (double)Stopwatch.Frequency / TimeSpan.TicksPerSecond);
     }
@@ -305,7 +308,8 @@ public sealed partial class KafkaConnection :
         PipeMemoryPool? sharedPipeMemoryPool = null,
         ClientTelemetryMetricCollector? telemetryMetricCollector = null,
         bool responseMemoryAdmissionsEnabled = false,
-        BrokerThrottleState? brokerThrottleState = null)
+        BrokerThrottleState? brokerThrottleState = null,
+        Action<KafkaConnectionCapabilities>? capabilitiesObserver = null)
         : this(
             host,
             port,
@@ -315,7 +319,8 @@ public sealed partial class KafkaConnection :
             responseBufferPool,
             telemetryMetricCollector,
             responseMemoryAdmissionsEnabled: responseMemoryAdmissionsEnabled,
-            brokerThrottleState: brokerThrottleState)
+            brokerThrottleState: brokerThrottleState,
+            capabilitiesObserver: capabilitiesObserver)
     {
         BrokerId = brokerId;
         _sharedPipeMemoryPool = sharedPipeMemoryPool;
@@ -463,6 +468,7 @@ public sealed partial class KafkaConnection :
         _receiveTask = ReceiveLoopAsync(_receiveCts.Token);
 
         var capabilities = await NegotiateCapabilitiesAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+        _capabilitiesObserver?.Invoke(capabilities);
         Volatile.Write(ref _capabilities, capabilities);
 
         Touch();

--- a/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
+++ b/src/Dekaf/Networking/KafkaConnectionCapabilities.cs
@@ -19,14 +19,14 @@ internal sealed class KafkaConnectionCapabilities
     private const int MissingRange = -1;
 
     private readonly int[] _apiRanges;
-    private readonly SupportedFeature[] _supportedFeatures;
-    private readonly FinalizedFeature[] _finalizedFeatures;
+    private readonly Dictionary<string, SupportedFeature> _supportedFeatures;
+    private readonly FinalizedFeatureSnapshot? _finalizedFeatures;
 
     private KafkaConnectionCapabilities(
         int[] apiRanges,
-        SupportedFeature[] supportedFeatures,
+        Dictionary<string, SupportedFeature> supportedFeatures,
         long finalizedFeaturesEpoch,
-        FinalizedFeature[] finalizedFeatures,
+        FinalizedFeatureSnapshot? finalizedFeatures,
         bool zkMigrationReady)
     {
         _apiRanges = apiRanges;
@@ -56,8 +56,10 @@ internal sealed class KafkaConnectionCapabilities
             ranges[key] = Pack(version.MinVersion, version.MaxVersion);
         }
 
-        var supportedFeatures = CopyFeatures(response.SupportedFeatures);
-        var finalizedFeatures = CopyFeatures(response.FinalizedFeatures);
+        var supportedFeatures = CopySupportedFeatures(response.SupportedFeatures);
+        var finalizedFeatures = FinalizedFeatureSnapshot.Create(
+            response.FinalizedFeaturesEpoch,
+            response.FinalizedFeatures);
 
         return new KafkaConnectionCapabilities(
             ranges,
@@ -140,15 +142,16 @@ internal sealed class KafkaConnectionCapabilities
             out negotiatedVersion);
     }
 
-    public short GetFinalizedFeatureVersion(string featureName)
+    public bool TryGetFinalizedFeatureVersion(string featureName, out short maxVersionLevel)
     {
-        foreach (var feature in _finalizedFeatures)
+        if (_finalizedFeatures is null)
         {
-            if (string.Equals(feature.Name, featureName, StringComparison.Ordinal))
-                return feature.MaxVersionLevel;
+            maxVersionLevel = default;
+            return false;
         }
 
-        return 0;
+        return _finalizedFeatures.GetFeatureStatus(featureName, out maxVersionLevel)
+            == FinalizedFeatureStatus.Present;
     }
 
     public bool TryGetSupportedFeatureRange(
@@ -156,14 +159,11 @@ internal sealed class KafkaConnectionCapabilities
         out short minVersion,
         out short maxVersion)
     {
-        foreach (var feature in _supportedFeatures)
+        if (_supportedFeatures.TryGetValue(featureName, out var feature))
         {
-            if (string.Equals(feature.Name, featureName, StringComparison.Ordinal))
-            {
-                minVersion = feature.MinVersion;
-                maxVersion = feature.MaxVersion;
-                return true;
-            }
+            minVersion = feature.MinVersion;
+            maxVersion = feature.MaxVersion;
+            return true;
         }
 
         minVersion = default;
@@ -190,7 +190,7 @@ internal sealed class KafkaConnectionCapabilities
         return true;
     }
 
-    internal IReadOnlyList<FinalizedFeature> FinalizedFeatures => _finalizedFeatures;
+    internal FinalizedFeatureSnapshot? FinalizedFeatureSnapshot => _finalizedFeatures;
     internal int ApiRangeCount => _apiRanges.Length;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -204,14 +204,17 @@ internal sealed class KafkaConnectionCapabilities
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static short UnpackMax(int range) => (short)range;
 
-    private static T[] CopyFeatures<T>(IReadOnlyList<T>? source)
+    private static Dictionary<string, SupportedFeature> CopySupportedFeatures(
+        IReadOnlyList<SupportedFeature>? source)
     {
-        if (source is null || source.Count == 0)
-            return [];
+        var copy = new Dictionary<string, SupportedFeature>(
+            source?.Count ?? 0,
+            StringComparer.Ordinal);
+        if (source is null)
+            return copy;
 
-        var copy = new T[source.Count];
-        for (var i = 0; i < copy.Length; i++)
-            copy[i] = source[i];
+        foreach (var feature in source)
+            copy.TryAdd(feature.Name, feature);
 
         return copy;
     }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1885,6 +1885,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 $"Cannot begin transaction in state: {_transactionState}");
         }
 
+        RefreshTransactionFeaturesAtBoundary();
+
         _transactionState = TransactionState.InTransaction;
         _preparedTransactionState = PreparedTransactionState.Empty;
         _lastTransactionError = ErrorCode.None;
@@ -2128,9 +2130,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             cancellationToken).ConfigureAwait(false);
         var connection = connectionLease.Connection;
         if (captureTransactionFeatures)
-            CaptureTransactionFeatures(connection, keepPreparedTransaction);
+            CaptureTransactionFeatures(keepPreparedTransaction);
         else if (requireTransactionFeatureMatch)
-            EnsureTransactionFeatureMatch(connection);
+            EnsureTransactionFeatureMatch();
 
         var apiVersion = _metadataManager.GetNegotiatedApiVersion(
             connection,
@@ -2150,23 +2152,46 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             cancellationToken).ConfigureAwait(false);
     }
 
-    private void CaptureTransactionFeatures(
-        IKafkaConnection connection,
-        bool keepPreparedTransaction)
+    private void CaptureTransactionFeatures(bool keepPreparedTransaction)
     {
-        var featureVersion = _metadataManager.GetFinalizedFeatureVersion(
-            connection,
-            TransactionVersionFeature);
+        var status = _metadataManager.GetFinalizedFeatureStatus(
+            TransactionVersionFeature,
+            out var featureVersion);
+        if (status != FinalizedFeatureStatus.Present)
+            featureVersion = 0;
+
         _currentTransactionFeatureVersion = featureVersion;
         _currentTransactionUsesTV2 = featureVersion >= 2;
         ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction);
     }
 
-    private void EnsureTransactionFeatureMatch(IKafkaConnection connection)
+    private void RefreshTransactionFeaturesAtBoundary()
     {
-        var featureVersion = _metadataManager.GetFinalizedFeatureVersion(
-            connection,
-            TransactionVersionFeature);
+        var status = _metadataManager.GetFinalizedFeatureStatus(
+            TransactionVersionFeature,
+            out var featureVersion);
+        if (status == FinalizedFeatureStatus.Unavailable)
+            return;
+
+        if (status == FinalizedFeatureStatus.Absent)
+            featureVersion = 0;
+
+        _currentTransactionFeatureVersion = featureVersion;
+        _currentTransactionUsesTV2 = featureVersion >= 2;
+        ThrowIfTwoPhaseCommitUnsupported(keepPreparedTransaction: false);
+    }
+
+    private void EnsureTransactionFeatureMatch()
+    {
+        var status = _metadataManager.GetFinalizedFeatureStatus(
+            TransactionVersionFeature,
+            out var featureVersion);
+        if (status == FinalizedFeatureStatus.Unavailable)
+            return;
+
+        if (status == FinalizedFeatureStatus.Absent)
+            featureVersion = 0;
+
         if (featureVersion != _currentTransactionFeatureVersion)
         {
             _transactionState = TransactionState.FatalError;
@@ -2501,7 +2526,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                        cancellationToken).ConfigureAwait(false))
             {
                 var connection = connectionLease.Connection;
-                EnsureTransactionFeatureMatch(connection);
+                EnsureTransactionFeatureMatch();
                 var apiVersion = _metadataManager.GetNegotiatedApiVersion(
                     connection,
                     ApiKey.EndTxn,

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -84,9 +84,106 @@ public class KafkaConnectionCapabilitiesTests
         await Assert.That(maxVersion).IsEqualTo((short)1);
         await Assert.That(capabilities.TryGetSupportedFeatureRange("missing", out _, out _)).IsFalse();
         await Assert.That(capabilities.FinalizedFeaturesEpoch).IsEqualTo(42);
-        await Assert.That(capabilities.GetFinalizedFeatureVersion("transaction.version")).IsEqualTo((short)2);
-        await Assert.That(capabilities.GetFinalizedFeatureVersion("missing")).IsEqualTo((short)0);
+        await Assert.That(capabilities.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var transactionVersion)).IsTrue();
+        await Assert.That(transactionVersion).IsEqualTo((short)2);
+        await Assert.That(capabilities.TryGetFinalizedFeatureVersion("missing", out _)).IsFalse();
         await Assert.That(capabilities.ZkMigrationReady).IsTrue();
+    }
+
+    [Test]
+    public async Task ClusterFinalizedFeatures_DistinguishesUnavailableAbsentAndZero()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["unused:9092"]);
+
+        await Assert.That(metadata.GetFinalizedFeatureStatus(
+            "transaction.version",
+            out _)).IsEqualTo(FinalizedFeatureStatus.Unavailable);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(-1, new FinalizedFeature("transaction.version", 2, 0)));
+        await Assert.That(metadata.GetFinalizedFeatureStatus(
+            "transaction.version",
+            out _)).IsEqualTo(FinalizedFeatureStatus.Unavailable);
+
+        metadata.ObserveClusterCapabilities("cluster-a", CreateFeatureCapabilities(1));
+        await Assert.That(metadata.GetFinalizedFeatureStatus(
+            "transaction.version",
+            out _)).IsEqualTo(FinalizedFeatureStatus.Absent);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(2, new FinalizedFeature("transaction.version", 0, 0)));
+        await Assert.That(metadata.GetFinalizedFeatureStatus(
+            "transaction.version",
+            out var featureVersion)).IsEqualTo(FinalizedFeatureStatus.Present);
+        await Assert.That(featureVersion).IsEqualTo((short)0);
+    }
+
+    [Test]
+    public async Task ClusterFinalizedFeatures_RejectsRegressionAndEqualEpochConflict()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["unused:9092"]);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(2, new FinalizedFeature("transaction.version", 2, 0)));
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(1, new FinalizedFeature("transaction.version", 1, 0)));
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(2, new FinalizedFeature("transaction.version", 2, 0)));
+
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var featureVersion)).IsTrue();
+        await Assert.That(featureVersion).IsEqualTo((short)2);
+
+        var exception = await Assert.That(() => metadata.ObserveClusterCapabilities(
+                "cluster-a",
+                CreateFeatureCapabilities(2, new FinalizedFeature("transaction.version", 3, 0))))
+            .Throws<KafkaException>();
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.FeatureUpdateFailed);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(3, new FinalizedFeature("transaction.version", 3, 0)));
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out featureVersion)).IsTrue();
+        await Assert.That(featureVersion).IsEqualTo((short)3);
+    }
+
+    [Test]
+    public async Task ClusterFinalizedFeatures_ClusterChangeCannotLeakPreviousSnapshot()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["unused:9092"]);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            CreateFeatureCapabilities(5, new FinalizedFeature("transaction.version", 2, 0)));
+        metadata.ObserveClusterCapabilities("cluster-b", CreateFeatureCapabilities(-1));
+
+        await Assert.That(metadata.GetFinalizedFeatureStatus(
+            "transaction.version",
+            out _)).IsEqualTo(FinalizedFeatureStatus.Unavailable);
+
+        metadata.ObserveClusterCapabilities(
+            "cluster-b",
+            CreateFeatureCapabilities(1, new FinalizedFeature("transaction.version", 1, 0)));
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var featureVersion)).IsTrue();
+        await Assert.That(featureVersion).IsEqualTo((short)1);
     }
 
     [Test]
@@ -126,6 +223,7 @@ public class KafkaConnectionCapabilitiesTests
                 new ApiVersion(ApiKey.Metadata, 9, 13),
                 new ApiVersion(ApiKey.Fetch, 12, 16)
             ],
+            FinalizedFeaturesEpoch = 1,
             FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
         });
         var connection = new CapabilityConnection(capabilities);
@@ -143,8 +241,10 @@ public class KafkaConnectionCapabilitiesTests
         await Assert.That(metadata.HasApiKey(ApiKey.Fetch)).IsTrue();
         await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
             .IsEqualTo((short)16);
-        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
-            .IsEqualTo((short)2);
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var initializedTransactionVersion)).IsTrue();
+        await Assert.That(initializedTransactionVersion).IsEqualTo((short)2);
     }
 
     [Test]
@@ -159,6 +259,7 @@ public class KafkaConnectionCapabilitiesTests
                 new ApiVersion(ApiKey.Fetch, 12, 14),
                 new ApiVersion(ApiKey.Produce, 0, 11)
             ],
+            FinalizedFeaturesEpoch = 1,
             FinalizedFeatures = [new FinalizedFeature("transaction.version", 1, 0)]
         });
         var replacementCapabilities = KafkaConnectionCapabilities.Create(new ApiVersionsResponse
@@ -169,6 +270,7 @@ public class KafkaConnectionCapabilitiesTests
                 new ApiVersion(ApiKey.Metadata, 9, 13),
                 new ApiVersion(ApiKey.Fetch, 12, 16)
             ],
+            FinalizedFeaturesEpoch = 2,
             FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
         });
         var initialConnection = new CapabilityConnection(initialCapabilities);
@@ -188,8 +290,10 @@ public class KafkaConnectionCapabilitiesTests
         await metadata.InitializeAsync();
         await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
             .IsEqualTo((short)14);
-        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
-            .IsEqualTo((short)1);
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var initialTransactionVersion)).IsTrue();
+        await Assert.That(initialTransactionVersion).IsEqualTo((short)1);
         await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsTrue();
 
         var rebootstrapped = await metadata.TryRebootstrapImmediateAsync(null, CancellationToken.None);
@@ -198,8 +302,10 @@ public class KafkaConnectionCapabilitiesTests
         await Assert.That(replacementConnection.ObservedApiVersion).IsEqualTo((short)13);
         await Assert.That(metadata.GetNegotiatedApiVersion(ApiKey.Fetch, 12, 18))
             .IsEqualTo((short)16);
-        await Assert.That(metadata.GetFinalizedFeatureVersion("transaction.version"))
-            .IsEqualTo((short)2);
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var replacementTransactionVersion)).IsTrue();
+        await Assert.That(replacementTransactionVersion).IsEqualTo((short)2);
         await Assert.That(metadata.HasApiKey(ApiKey.Produce)).IsFalse();
     }
 
@@ -250,6 +356,17 @@ public class KafkaConnectionCapabilitiesTests
     private static KafkaConnectionCapabilities CreateCapabilities(params ApiVersion[] versions)
         => KafkaConnectionCapabilities.Create(CreateResponse(versions));
 
+    private static KafkaConnectionCapabilities CreateFeatureCapabilities(
+        long epoch,
+        params FinalizedFeature[] features)
+        => KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys = [],
+            FinalizedFeaturesEpoch = epoch,
+            FinalizedFeatures = features
+        });
+
     private static IKafkaConnection CreateConnection(KafkaConnectionCapabilities capabilities)
         => new CapabilityConnection(capabilities);
 
@@ -286,6 +403,7 @@ public class KafkaConnectionCapabilitiesTests
             ObservedApiVersion = apiVersion;
             return ValueTask.FromResult((TResponse)(IKafkaResponse)new MetadataResponse
             {
+                ClusterId = "cluster-a",
                 Brokers = [],
                 Topics = []
             });

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Errors;
 using Dekaf.Protocol;
@@ -317,17 +318,23 @@ public class KafkaConnectionCapabilityHandshakeTests
 
         var serverTask = Task.Run(async () =>
         {
-            await ServeGenerationAsync(
+            await ServeFeatureGenerationAsync(
                 listener,
                 releaseFirstGeneration.Task,
-                cancellationToken,
-                new ApiVersion(ApiKey.Metadata, 9, 12),
-                new ApiVersion(ApiKey.Produce, 3, 7));
-            await ServeGenerationAsync(
+                finalizedFeaturesEpoch: 1,
+                transactionVersion: 1,
+                [
+                    new ApiVersion(ApiKey.Metadata, 9, 12),
+                    new ApiVersion(ApiKey.Produce, 3, 7)
+                ],
+                cancellationToken);
+            await ServeFeatureGenerationAsync(
                 listener,
                 releaseSecondGeneration.Task,
-                cancellationToken,
-                new ApiVersion(ApiKey.Metadata, 9, 13));
+                finalizedFeaturesEpoch: 2,
+                transactionVersion: 2,
+                [new ApiVersion(ApiKey.Metadata, 9, 13)],
+                cancellationToken);
         }, cancellationToken);
 
         await using var pool = new ConnectionPool(connectionOptions: new ConnectionOptions
@@ -335,10 +342,27 @@ public class KafkaConnectionCapabilityHandshakeTests
             ReconnectBackoff = TimeSpan.Zero,
             ReconnectBackoffMax = TimeSpan.Zero
         });
+        await using var metadata = new MetadataManager(
+            pool,
+            [$"127.0.0.1:{port}"],
+            new MetadataOptions { EnableBackgroundRefresh = false });
+        metadata.ObserveClusterCapabilities(
+            "cluster-a",
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = [],
+                FinalizedFeaturesEpoch = 0,
+                FinalizedFeatures = [new FinalizedFeature("transaction.version", 0, 0)]
+            }));
 
         var firstConnection = await pool.GetConnectionAsync("127.0.0.1", port, cancellationToken);
         var firstCapabilities = ((IKafkaCapabilityProvider)firstConnection).Capabilities;
         await Assert.That(firstCapabilities.NegotiateVersion(ApiKey.Produce, 3, 13)).IsEqualTo((short)7);
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var firstFeatureVersion)).IsTrue();
+        await Assert.That(firstFeatureVersion).IsEqualTo((short)1);
 
         releaseFirstGeneration.SetResult();
         await WaitUntilAsync(() => !firstConnection.IsConnected, cancellationToken);
@@ -350,6 +374,10 @@ public class KafkaConnectionCapabilityHandshakeTests
         await Assert.That(secondCapabilities.NegotiateVersion(ApiKey.Metadata, 9, 13)).IsEqualTo((short)13);
         await Assert.That(() => secondCapabilities.NegotiateVersion(ApiKey.Produce, 3, 13))
             .Throws<BrokerVersionException>();
+        await Assert.That(metadata.TryGetFinalizedFeatureVersion(
+            "transaction.version",
+            out var secondFeatureVersion)).IsTrue();
+        await Assert.That(secondFeatureVersion).IsEqualTo((short)2);
 
         Parallel.For(0, 10_000, _ =>
         {
@@ -425,6 +453,28 @@ public class KafkaConnectionCapabilityHandshakeTests
         await releaseConnection.WaitAsync(cancellationToken);
     }
 
+    private static async Task ServeFeatureGenerationAsync(
+        TcpListener listener,
+        Task releaseConnection,
+        long finalizedFeaturesEpoch,
+        short transactionVersion,
+        IReadOnlyList<ApiVersion> versions,
+        CancellationToken cancellationToken)
+    {
+        using var socket = await listener.AcceptSocketAsync(cancellationToken);
+        await using var stream = new NetworkStream(socket, ownsSocket: false);
+        var request = await ReadFrameAsync(stream, cancellationToken);
+        var correlationId = BinaryPrimitives.ReadInt32BigEndian(request.AsSpan(4));
+        await stream.WriteAsync(
+            BuildFeatureResponse(
+                correlationId,
+                finalizedFeaturesEpoch,
+                transactionVersion,
+                versions),
+            cancellationToken);
+        await releaseConnection.WaitAsync(cancellationToken);
+    }
+
     private static async Task WaitUntilAsync(
         Func<bool> predicate,
         CancellationToken cancellationToken)
@@ -451,11 +501,31 @@ public class KafkaConnectionCapabilityHandshakeTests
         int correlationId,
         ErrorCode errorCode,
         params ApiVersion[] versions)
+        => BuildResponseCore(correlationId, errorCode, null, null, versions);
+
+    private static byte[] BuildFeatureResponse(
+        int correlationId,
+        long finalizedFeaturesEpoch,
+        short transactionVersion,
+        IReadOnlyList<ApiVersion> versions)
+        => BuildResponseCore(
+            correlationId,
+            ErrorCode.None,
+            finalizedFeaturesEpoch,
+            transactionVersion,
+            versions);
+
+    private static byte[] BuildResponseCore(
+        int correlationId,
+        ErrorCode errorCode,
+        long? finalizedFeaturesEpoch,
+        short? transactionVersion,
+        IReadOnlyList<ApiVersion> versions)
     {
         var body = new ArrayBufferWriter<byte>();
         var writer = new KafkaProtocolWriter(body);
         writer.WriteInt16((short)errorCode);
-        writer.WriteUnsignedVarInt(versions.Length + 1);
+        writer.WriteUnsignedVarInt(versions.Count + 1);
         foreach (var version in versions)
         {
             writer.WriteInt16((short)version.ApiKey);
@@ -465,7 +535,29 @@ public class KafkaConnectionCapabilityHandshakeTests
         }
 
         writer.WriteInt32(0);
-        writer.WriteEmptyTaggedFields();
+        if (finalizedFeaturesEpoch is null)
+        {
+            writer.WriteEmptyTaggedFields();
+        }
+        else
+        {
+            writer.WriteUnsignedVarInt(2);
+            writer.WriteUnsignedVarInt(1);
+            writer.WriteUnsignedVarInt(sizeof(long));
+            writer.WriteInt64(finalizedFeaturesEpoch.Value);
+
+            var features = new ArrayBufferWriter<byte>();
+            var featureWriter = new KafkaProtocolWriter(features);
+            featureWriter.WriteUnsignedVarInt(2);
+            featureWriter.WriteCompactString("transaction.version");
+            featureWriter.WriteInt16(transactionVersion!.Value);
+            featureWriter.WriteInt16(0);
+            featureWriter.WriteEmptyTaggedFields();
+
+            writer.WriteUnsignedVarInt(2);
+            writer.WriteUnsignedVarInt(features.WrittenCount);
+            writer.WriteRawBytes(features.WrittenSpan);
+        }
 
         var frame = new byte[sizeof(int) + sizeof(int) + body.WrittenCount];
         BinaryPrimitives.WriteInt32BigEndian(frame, frame.Length - sizeof(int));

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -901,7 +901,7 @@ public sealed class TransactionTests
     [Test]
     [Arguments(false, (short)2)]
     [Arguments(true, (short)1)]
-    public async Task BeginTransaction_GlobalFeatureVersionChanged_DoesNotOverrideConnectionSnapshot(
+    public async Task BeginTransaction_FeatureVersionChangedBetweenTransactions_UsesNewSnapshot(
         bool initializedWithTV2,
         short finalizedVersion)
     {
@@ -921,6 +921,11 @@ public sealed class TransactionTests
         var transaction = producer.BeginTransaction();
 
         await Assert.That(kafkaProducer._transactionState).IsEqualTo(TransactionState.InTransaction);
+        await Assert.That(kafkaProducer._currentTransactionUsesTV2)
+            .IsEqualTo(finalizedVersion >= 2);
+        await Assert.That(GetInstanceField<short>(
+            kafkaProducer,
+            "_currentTransactionFeatureVersion")).IsEqualTo(finalizedVersion);
         kafkaProducer._transactionState = TransactionState.Ready;
         await transaction.DisposeAsync();
     }
@@ -987,13 +992,7 @@ public sealed class TransactionTests
             ApiKey.InitProducerId,
             InitProducerIdRequest.LowestSupportedVersion,
             InitProducerIdRequest.HighestSupportedVersion);
-        SetInstanceField<IReadOnlyList<FinalizedFeature>>(
-            metadataManager,
-            "_finalizedFeatures",
-            [new FinalizedFeature(
-                "transaction.version",
-                transactionFeatureVersion,
-                transactionFeatureVersion)]);
+        PublishFinalizedTransactionVersion(metadataManager, transactionFeatureVersion);
 
         var producer = new KafkaProducer<string, string>(
             new ProducerOptions
@@ -1023,11 +1022,28 @@ public sealed class TransactionTests
 
     private static void SetFinalizedTransactionVersion(KafkaProducer<string, string> producer, short version)
     {
-        var metadataManager = GetInstanceField<object>(producer, "_metadataManager");
-        SetInstanceField<IReadOnlyList<FinalizedFeature>>(
-            metadataManager,
-            "_finalizedFeatures",
-            [new FinalizedFeature("transaction.version", version, version)]);
+        var metadataManager = GetInstanceField<MetadataManager>(producer, "_metadataManager");
+        PublishFinalizedTransactionVersion(metadataManager, version);
+    }
+
+    private static long s_finalizedFeatureEpoch;
+
+    private static void PublishFinalizedTransactionVersion(
+        MetadataManager metadataManager,
+        short version)
+    {
+        metadataManager.ObserveClusterCapabilities(
+            "cluster-a",
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = [],
+                FinalizedFeaturesEpoch = Interlocked.Increment(ref s_finalizedFeatureEpoch),
+                FinalizedFeatures =
+                [
+                    new FinalizedFeature("transaction.version", version, version)
+                ]
+            }));
     }
 
     private static void SetInstanceField<T>(object target, string name, T value)


### PR DESCRIPTION
Closes #2230

## Summary
- publish immutable, epoch-qualified finalized-feature snapshots per cluster identity
- refresh finalized features after every successful physical ApiVersions handshake without allowing epoch regression
- keep supported features connection-scoped with allocation-free O(1) lookup
- apply transaction-version changes only at safe transaction boundaries and fail active transactions on drift

## Validation
- `dotnet build Dekaf.sln --no-restore --nologo` (0 warnings)
- net10 unit suite: 5928 passed
- net8 unit suite: 5801 passed
- post-rebase focused capability/handshake/transaction suites: 70 passed