### PR TITLE
feat(networking): defer bootstrap DNS failure

### DIFF
--- a/docs/docs/configuration/client-dns-lookup.md
+++ b/docs/docs/configuration/client-dns-lookup.md
@@ -32,9 +32,22 @@ var consumer = new ConsumerBuilder<string, string>()
 
 DNS is resolved on every reconnect, so changes in broker DNS records are picked up without recreating the client.
 
+## Bootstrap resolution deadline
+
+KIP-909 gives initial bootstrap DNS failures a separate retry budget. A transient host-not-found response does not consume the metadata initialization retry cap or timeout. Dekaf retries with the configured reconnect backoff until one bootstrap name resolves, cancellation/disposal occurs, or the bootstrap deadline expires.
+
+```csharp
+var producer = new ProducerBuilder<string, string>()
+    .WithBootstrapServers("kafka.example.com:9092")
+    .WithBootstrapResolveTimeout(TimeSpan.FromMinutes(2))
+    .Build();
+```
+
+The default is 120000ms (2 minutes). Expiry throws the non-retriable `BootstrapResolutionException`, whose `UnresolvedBootstrapServers` property identifies the failed bootstrap endpoints. One resolvable name is sufficient when multiple bootstrap names are configured. `Build()` remains network-free; `BuildAsync()` and `InitializeAsync()` perform and retry the first network bootstrap.
+
 ## Configuration
 
-`ClientDnsLookup` can be configured on root clients, producers, consumers, share consumers, and admin clients. It also binds from `appsettings.json` by enum name:
+`ClientDnsLookup` and `BootstrapResolveTimeoutMs` can be configured on root clients, producers, consumers, share consumers, and admin clients. Producer, consumer, and admin options also bind from `appsettings.json`:
 
 ```json
 {
@@ -42,7 +55,8 @@ DNS is resolved on every reconnect, so changes in broker DNS records are picked 
     "Producers": {
       "Orders": {
         "BootstrapServers": "kafka.example.com:9092",
-        "ClientDnsLookup": "UseAllDnsIps"
+        "ClientDnsLookup": "UseAllDnsIps",
+        "BootstrapResolveTimeoutMs": 120000
       }
     }
   }

--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -78,6 +78,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
 | `WithClientDnsLookup(...)` | `ClientDnsLookup` | `UseAllDnsIps` or `ResolveCanonicalBootstrapServersOnly` |
+| `WithBootstrapResolveTimeout(...)` | `BootstrapResolveTimeoutMs` | Milliseconds; default 120000 |
 | `WithGroupId(...)` | `GroupId` | String |
 | `WithGroupInstanceId(...)` | `GroupInstanceId` | String |
 | `WithGroupRemoteAssignor(...)` | `GroupRemoteAssignor` | Common values: `uniform`, `range` |
@@ -423,6 +424,7 @@ For transactional reads:
 | `WithBootstrapServers` | (required) | Broker addresses |
 | `WithClientId` | "dekaf-consumer" | Client identifier |
 | `WithClientDnsLookup` | UseAllDnsIps | DNS lookup mode |
+| `WithBootstrapResolveTimeout` | 120000ms | Initial bootstrap DNS retry deadline |
 | `WithGroupId` | null | Consumer group ID |
 | `WithGroupInstanceId` | null | Static membership ID |
 | `WithOffsetCommitMode` | Auto | Offset management mode |

--- a/docs/docs/configuration/producer-options.md
+++ b/docs/docs/configuration/producer-options.md
@@ -71,6 +71,7 @@ Configuration is applied before the optional fluent callback, so fluent calls ca
 | `WithBootstrapServers(...)` | `BootstrapServers` | Server list (prefer `params string[]` in code; comma-separated string and JSON arrays are also supported) |
 | `WithClientId(...)` | `ClientId` | String |
 | `WithClientDnsLookup(...)` | `ClientDnsLookup` | `UseAllDnsIps` or `ResolveCanonicalBootstrapServersOnly` |
+| `WithBootstrapResolveTimeout(...)` | `BootstrapResolveTimeoutMs` | Milliseconds; default 120000 |
 | `WithAcks(...)` | `Acks` | `None`, `Leader`, `All` |
 | `WithLinger(...)` | `LingerMs` | Milliseconds |
 | `WithBatchSize(...)` | `BatchSize` | Bytes |
@@ -412,6 +413,7 @@ Enable logging:
 | `WithBootstrapServers` | (required) | Broker addresses |
 | `WithClientId` | "dekaf-producer" | Client identifier |
 | `WithClientDnsLookup` | UseAllDnsIps | DNS lookup mode |
+| `WithBootstrapResolveTimeout` | 120000ms | Initial bootstrap DNS retry deadline |
 | `WithAcks` | All | Acknowledgment mode |
 | `WithLinger` | 0ms | Batch wait time |
 | `WithBatchSize` | 1048576 | Max batch size in bytes |

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -754,6 +754,12 @@ public sealed class AdminClientServiceBuilder
         return this;
     }
 
+    public AdminClientServiceBuilder WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        _builder.WithBootstrapResolveTimeout(timeout);
+        return this;
+    }
+
     public AdminClientServiceBuilder RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
     {
         _builder.RegisterMetricForSubscription(metric);
@@ -879,6 +885,7 @@ internal static class DekafOptionsBinding
         builder.WithMetadataClusterCheck(options.MetadataClusterCheckEnabled);
         builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(options.MetadataRecoveryRebootstrapTriggerMs));
         builder.WithClientDnsLookup(options.ClientDnsLookup);
+        builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(options.BootstrapResolveTimeoutMs));
         if (options.EnableAdaptiveConnections)
             builder.WithAdaptiveConnections(options.MaxConnectionsPerBroker);
         else
@@ -981,6 +988,7 @@ internal static class DekafOptionsBinding
         builder.WithMetadataClusterCheck(options.MetadataClusterCheckEnabled);
         builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(options.MetadataRecoveryRebootstrapTriggerMs));
         builder.WithClientDnsLookup(options.ClientDnsLookup);
+        builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(options.BootstrapResolveTimeoutMs));
         builder.WithPrefetchPipelineDepth(options.PrefetchPipelineDepth);
         builder.WithConnectionsPerBroker(options.ConnectionsPerBroker);
         if (options.EnableAdaptiveConnections)
@@ -1048,6 +1056,7 @@ internal static class DekafOptionsBinding
         builder.WithMetadataClusterCheck(options.MetadataClusterCheckEnabled);
         builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(options.MetadataRecoveryRebootstrapTriggerMs));
         builder.WithClientDnsLookup(options.ClientDnsLookup);
+        builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(options.BootstrapResolveTimeoutMs));
         foreach (var metric in options.ApplicationMetrics)
             builder.RegisterMetricForSubscription(metric);
     }
@@ -1272,6 +1281,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
         if (TryGetValue<ClientDnsLookup>(configuration, nameof(ProducerOptions.ClientDnsLookup), out var clientDnsLookup))
             builder.WithClientDnsLookup(clientDnsLookup);
+        if (TryGetValue<int>(configuration, nameof(ProducerOptions.BootstrapResolveTimeoutMs), out var bootstrapResolveTimeoutMs))
+            builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(bootstrapResolveTimeoutMs));
         ApplyAdaptiveConnections(
             configuration,
             nameof(ProducerOptions.EnableAdaptiveConnections),
@@ -1396,6 +1407,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
         if (TryGetValue<ClientDnsLookup>(configuration, nameof(ConsumerOptions.ClientDnsLookup), out var clientDnsLookup))
             builder.WithClientDnsLookup(clientDnsLookup);
+        if (TryGetValue<int>(configuration, nameof(ConsumerOptions.BootstrapResolveTimeoutMs), out var bootstrapResolveTimeoutMs))
+            builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(bootstrapResolveTimeoutMs));
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.PrefetchPipelineDepth), out var prefetchPipelineDepth))
             builder.WithPrefetchPipelineDepth(prefetchPipelineDepth);
         if (TryGetValue<int>(configuration, nameof(ConsumerOptions.ConnectionsPerBroker), out var connectionsPerBroker))
@@ -1441,6 +1454,8 @@ internal static class DekafConfigurationBinding
             builder.WithMetadataRecoveryRebootstrapTrigger(TimeSpan.FromMilliseconds(rebootstrapMs));
         if (TryGetValue<ClientDnsLookup>(configuration, nameof(AdminClientOptions.ClientDnsLookup), out var clientDnsLookup))
             builder.WithClientDnsLookup(clientDnsLookup);
+        if (TryGetValue<int>(configuration, nameof(AdminClientOptions.BootstrapResolveTimeoutMs), out var bootstrapResolveTimeoutMs))
+            builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(bootstrapResolveTimeoutMs));
     }
 
     private static void ApplyTls<TBuilder>(

--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -82,7 +82,8 @@ public sealed class AdminClient : IAdminClient
             MetadataRecoveryStrategy = options.MetadataRecoveryStrategy,
             MetadataClusterCheckEnabled = options.MetadataClusterCheckEnabled,
             RetryBackoffMs = options.RetryBackoffMs,
-            RetryBackoffMaxMs = options.RetryBackoffMaxMs
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs,
+            BootstrapResolveTimeoutMs = options.BootstrapResolveTimeoutMs
         };
         _metadataManager = new MetadataManager(
             _connectionPool,
@@ -4877,6 +4878,12 @@ public sealed class AdminClientOptions
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
     /// <summary>
+    /// Maximum time in milliseconds spent retrying initial bootstrap DNS resolution.
+    /// Equivalent to Kafka's <c>bootstrap.resolve.timeout.ms</c>. Default is 120000.
+    /// </summary>
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
+
+    /// <summary>
     /// Application metrics registered for broker telemetry subscriptions.
     /// </summary>
     public IReadOnlyList<ApplicationTelemetryMetric> ApplicationMetrics { get; init; } = [];
@@ -4920,6 +4927,7 @@ public sealed class AdminClientBuilder
     private bool _metadataClusterCheckEnabled = true;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private int _bootstrapResolveTimeoutMs = 120000;
     private TimeSpan? _metadataMaxAge;
     private readonly Dictionary<string, ApplicationTelemetryMetric> _applicationMetrics = new(StringComparer.Ordinal);
 
@@ -4934,6 +4942,7 @@ public sealed class AdminClientBuilder
         _loggerFactory = clientInfrastructure.LoggerFactory;
         _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
         _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
+        _bootstrapResolveTimeoutMs = clientInfrastructure.BootstrapResolveTimeoutMs;
     }
 
     public AdminClientBuilder WithBootstrapServers(string servers)
@@ -5305,6 +5314,19 @@ public sealed class AdminClientBuilder
     }
 
     /// <summary>
+    /// Sets the KIP-909 deadline for resolving an initial bootstrap server DNS name.
+    /// </summary>
+    public AdminClientBuilder WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _bootstrapResolveTimeoutMs = ConnectionOptionValidation.ToNonNegativeMilliseconds(
+            timeout,
+            nameof(timeout),
+            "Bootstrap resolution timeout cannot be negative");
+        return this;
+    }
+
+    /// <summary>
     /// Sets the maximum age of metadata before it is refreshed.
     /// This controls how frequently the client refreshes its view of the cluster topology.
     /// Equivalent to Kafka's <c>metadata.max.age.ms</c> configuration.
@@ -5528,6 +5550,7 @@ public sealed class AdminClientBuilder
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             ApplicationMetrics = _applicationMetrics.Count > 0 ? _applicationMetrics.Values.ToArray() : []
         };
 
@@ -5538,6 +5561,7 @@ public sealed class AdminClientBuilder
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs
         };

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -75,6 +75,7 @@ public sealed class ProducerBuilder<TKey, TValue>
     private bool _metadataClusterCheckEnabled = true;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private int _bootstrapResolveTimeoutMs = 120000;
     private ClientDnsEndpointResolver _dnsResolver = ClientDnsEndpointResolver.Default;
     private bool _enableIdempotence = true;
     private int _connectionsPerBroker = 1;
@@ -116,6 +117,7 @@ public sealed class ProducerBuilder<TKey, TValue>
         _isMaxConnectionsPerBrokerConfigured = true;
         _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
         _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
+        _bootstrapResolveTimeoutMs = clientInfrastructure.BootstrapResolveTimeoutMs;
         _saslMechanism = clientInfrastructure.SaslMechanism;
     }
 
@@ -913,6 +915,19 @@ public sealed class ProducerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Sets the KIP-909 deadline for resolving an initial bootstrap server DNS name.
+    /// </summary>
+    public ProducerBuilder<TKey, TValue> WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _bootstrapResolveTimeoutMs = ConnectionOptionValidation.ToNonNegativeMilliseconds(
+            timeout,
+            nameof(timeout),
+            "Bootstrap resolution timeout cannot be negative");
+        return this;
+    }
+
     internal ProducerBuilder<TKey, TValue> WithDnsResolver(ClientDnsEndpointResolver resolver)
     {
         ThrowIfClientOwnedConnectionSettings();
@@ -1447,6 +1462,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             DnsResolver = _dnsResolver,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,
@@ -1468,6 +1484,7 @@ public sealed class ProducerBuilder<TKey, TValue>
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             DnsResolver = _dnsResolver,
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs,
@@ -1635,6 +1652,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private bool _metadataClusterCheckEnabled = true;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private int _bootstrapResolveTimeoutMs = 120000;
     private ClientDnsEndpointResolver _dnsResolver = ClientDnsEndpointResolver.Default;
     private readonly List<string> _topicsToSubscribe = [];
     private string? _topicPatternToSubscribe;
@@ -1675,6 +1693,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
         _maxConnectionsPerBroker = clientInfrastructure.MaxConnectionsPerBroker;
         _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
         _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
+        _bootstrapResolveTimeoutMs = clientInfrastructure.BootstrapResolveTimeoutMs;
     }
 
     public ConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -2618,6 +2637,19 @@ public sealed class ConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Sets the KIP-909 deadline for resolving an initial bootstrap server DNS name.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _bootstrapResolveTimeoutMs = ConnectionOptionValidation.ToNonNegativeMilliseconds(
+            timeout,
+            nameof(timeout),
+            "Bootstrap resolution timeout cannot be negative");
+        return this;
+    }
+
     internal ConsumerBuilder<TKey, TValue> WithDnsResolver(ClientDnsEndpointResolver resolver)
     {
         ThrowIfClientOwnedConnectionSettings();
@@ -3160,6 +3192,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             DnsResolver = _dnsResolver,
             Interceptors = _interceptors?.Count > 0 ? _interceptors.ToArray() : null,
             RetryPolicy = _retryPolicy,
@@ -3179,6 +3212,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             DnsResolver = _dnsResolver,
             RetryBackoffMs = _retryBackoffMs,
             RetryBackoffMaxMs = _retryBackoffMaxMs
@@ -3315,6 +3349,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
     private RemoteCertificateValidationCallback? _remoteCertificateValidationCallback;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
     private bool _metadataClusterCheckEnabled = true;
+    private int _bootstrapResolveTimeoutMs = 120000;
     private IRetryPolicy? _retryPolicy;
     private readonly List<string> _topicsToSubscribe = [];
 
@@ -3330,6 +3365,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         _connectionsPerBroker = clientInfrastructure.ConnectionsPerBroker;
         _retryBackoffMs = clientInfrastructure.RetryBackoffMs;
         _retryBackoffMaxMs = clientInfrastructure.RetryBackoffMaxMs;
+        _bootstrapResolveTimeoutMs = clientInfrastructure.BootstrapResolveTimeoutMs;
     }
 
     public ShareConsumerBuilder<TKey, TValue> WithBootstrapServers(string servers)
@@ -3832,6 +3868,19 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
         return this;
     }
 
+    /// <summary>
+    /// Sets the KIP-909 deadline for resolving an initial bootstrap server DNS name.
+    /// </summary>
+    public ShareConsumerBuilder<TKey, TValue> WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        ThrowIfClientOwnedConnectionSettings();
+        _bootstrapResolveTimeoutMs = ConnectionOptionValidation.ToNonNegativeMilliseconds(
+            timeout,
+            nameof(timeout),
+            "Bootstrap resolution timeout cannot be negative");
+        return this;
+    }
+
     public ShareConsumerBuilder<TKey, TValue> WithRetryPolicy(IRetryPolicy retryPolicy)
     {
         _retryPolicy = retryPolicy;
@@ -3932,6 +3981,7 @@ public sealed class ShareConsumerBuilder<TKey, TValue>
             ConnectionsPerBroker = _connectionsPerBroker,
             ClientDnsLookup = _clientDnsLookup,
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             RetryPolicy = _retryPolicy
         };
 

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -477,6 +477,12 @@ public sealed class ConsumerOptions
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
     /// <summary>
+    /// Maximum time in milliseconds spent retrying initial bootstrap DNS resolution.
+    /// Equivalent to Kafka's <c>bootstrap.resolve.timeout.ms</c>. Default is 120000.
+    /// </summary>
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
+
+    /// <summary>
     /// DNS resolver used by connections. Internal for deterministic tests.
     /// </summary>
     internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1231,7 +1231,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             MetadataRecoveryStrategy = options.MetadataRecoveryStrategy,
             MetadataClusterCheckEnabled = options.MetadataClusterCheckEnabled,
             RetryBackoffMs = options.RetryBackoffMs,
-            RetryBackoffMaxMs = options.RetryBackoffMaxMs
+            RetryBackoffMaxMs = options.RetryBackoffMaxMs,
+            BootstrapResolveTimeoutMs = options.BootstrapResolveTimeoutMs
         };
         var metadataManager = new MetadataManager(
             connectionPool,

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -187,6 +187,63 @@ public enum TimeoutKind
 }
 
 /// <summary>
+/// Exception thrown when no bootstrap server name can be resolved before the configured
+/// KIP-909 bootstrap resolution deadline. This error is non-retriable.
+/// </summary>
+public sealed class BootstrapResolutionException : KafkaException
+{
+    /// <summary>
+    /// Creates a bootstrap resolution exception.
+    /// </summary>
+    public BootstrapResolutionException(
+        IReadOnlyList<string> unresolvedBootstrapServers,
+        TimeSpan timeout)
+        : base(CreateMessage(unresolvedBootstrapServers, timeout))
+    {
+        UnresolvedBootstrapServers = CopyServers(unresolvedBootstrapServers);
+        Timeout = timeout;
+    }
+
+    /// <summary>
+    /// Creates a bootstrap resolution exception with the last DNS failure.
+    /// </summary>
+    public BootstrapResolutionException(
+        IReadOnlyList<string> unresolvedBootstrapServers,
+        TimeSpan timeout,
+        Exception innerException)
+        : base(CreateMessage(unresolvedBootstrapServers, timeout), innerException)
+    {
+        UnresolvedBootstrapServers = CopyServers(unresolvedBootstrapServers);
+        Timeout = timeout;
+    }
+
+    /// <summary>
+    /// Bootstrap server endpoints that remained unresolved.
+    /// </summary>
+    public IReadOnlyList<string> UnresolvedBootstrapServers { get; }
+
+    /// <summary>
+    /// Configured bootstrap DNS resolution timeout.
+    /// </summary>
+    public TimeSpan Timeout { get; }
+
+    private static ReadOnlyCollection<string> CopyServers(IReadOnlyList<string> unresolvedBootstrapServers)
+        => new(unresolvedBootstrapServers.ToArray());
+
+    private static string CreateMessage(IReadOnlyList<string> unresolvedBootstrapServers, TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(unresolvedBootstrapServers);
+        if (unresolvedBootstrapServers.Count == 0)
+            throw new ArgumentException("At least one unresolved bootstrap server is required.", nameof(unresolvedBootstrapServers));
+        if (timeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Bootstrap resolution timeout cannot be negative.");
+
+        return $"Could not resolve bootstrap server DNS within {timeout.TotalMilliseconds}ms: " +
+               string.Join(", ", unresolvedBootstrapServers);
+    }
+}
+
+/// <summary>
 /// Exception thrown when a Kafka operation times out.
 /// Provides structured context about the kind of timeout, how long elapsed,
 /// and what the configured timeout was.

--- a/src/Dekaf/Internal/ConnectionOptionValidation.cs
+++ b/src/Dekaf/Internal/ConnectionOptionValidation.cs
@@ -11,6 +11,15 @@ internal static class ConnectionOptionValidation
         return timeout;
     }
 
+    public static int ToNonNegativeMilliseconds(TimeSpan timeout, string paramName, string message)
+    {
+        if (timeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(paramName, message);
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(timeout.TotalMilliseconds, int.MaxValue, paramName);
+        return (int)timeout.TotalMilliseconds;
+    }
+
     public static void ValidateTcpKeepAlive(TimeSpan time, TimeSpan interval, int retryCount)
     {
         ValidatePositiveTimeout(time, nameof(time), "TCP keepalive time must be positive");

--- a/src/Dekaf/KafkaClient.cs
+++ b/src/Dekaf/KafkaClient.cs
@@ -117,6 +117,7 @@ public sealed class KafkaClientBuilder
     private bool _metadataClusterCheckEnabled = true;
     private int _metadataRecoveryRebootstrapTriggerMs = 300000;
     private ClientDnsLookup _clientDnsLookup = ClientDnsLookup.UseAllDnsIps;
+    private int _bootstrapResolveTimeoutMs = 120000;
     private ulong? _memoryBudgetBytes;
     private ILoggerFactory? _loggerFactory;
 
@@ -541,6 +542,18 @@ public sealed class KafkaClientBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the KIP-909 deadline for resolving an initial bootstrap server DNS name.
+    /// </summary>
+    public KafkaClientBuilder WithBootstrapResolveTimeout(TimeSpan timeout)
+    {
+        _bootstrapResolveTimeoutMs = ConnectionOptionValidation.ToNonNegativeMilliseconds(
+            timeout,
+            nameof(timeout),
+            "Bootstrap resolution timeout cannot be negative");
+        return this;
+    }
+
     public KafkaClientBuilder WithMemoryBudget(ulong bytes)
     {
         ArgumentOutOfRangeException.ThrowIfZero(bytes);
@@ -608,6 +621,7 @@ public sealed class KafkaClientBuilder
             MetadataClusterCheckEnabled = _metadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = _metadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = _clientDnsLookup,
+            BootstrapResolveTimeoutMs = _bootstrapResolveTimeoutMs,
             MemoryBudgetBytes = _memoryBudgetBytes,
             LoggerFactory = _loggerFactory
         };
@@ -653,6 +667,7 @@ internal sealed class KafkaClientOptions
     public bool MetadataClusterCheckEnabled { get; init; } = true;
     public int MetadataRecoveryRebootstrapTriggerMs { get; init; }
     public ClientDnsLookup ClientDnsLookup { get; init; }
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
     public ulong? MemoryBudgetBytes { get; init; }
     public ILoggerFactory? LoggerFactory { get; init; }
 }
@@ -675,6 +690,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         int producerMaxConnectionsPerBroker,
         int retryBackoffMs,
         int retryBackoffMaxMs,
+        int bootstrapResolveTimeoutMs,
         SaslMechanism saslMechanism,
         bool usesDynamicSaslCredentials)
     {
@@ -689,6 +705,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
         ProducerMaxConnectionsPerBroker = producerMaxConnectionsPerBroker;
         RetryBackoffMs = retryBackoffMs;
         RetryBackoffMaxMs = retryBackoffMaxMs;
+        BootstrapResolveTimeoutMs = bootstrapResolveTimeoutMs;
         SaslMechanism = saslMechanism;
         UsesDynamicSaslCredentials = usesDynamicSaslCredentials;
     }
@@ -704,6 +721,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
     public int ProducerMaxConnectionsPerBroker { get; }
     public int RetryBackoffMs { get; }
     public int RetryBackoffMaxMs { get; }
+    public int BootstrapResolveTimeoutMs { get; }
     public SaslMechanism SaslMechanism { get; }
     public bool UsesDynamicSaslCredentials { get; }
 
@@ -740,6 +758,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             MetadataClusterCheckEnabled = options.MetadataClusterCheckEnabled,
             MetadataRecoveryRebootstrapTriggerMs = options.MetadataRecoveryRebootstrapTriggerMs,
             ClientDnsLookup = options.ClientDnsLookup,
+            BootstrapResolveTimeoutMs = options.BootstrapResolveTimeoutMs,
             RetryBackoffMs = options.RetryBackoffMs,
             RetryBackoffMaxMs = options.RetryBackoffMaxMs
         };
@@ -763,6 +782,7 @@ internal sealed class KafkaClientInfrastructure : IAsyncDisposable
             options.ProducerMaxConnectionsPerBroker,
             options.RetryBackoffMs,
             options.RetryBackoffMaxMs,
+            options.BootstrapResolveTimeoutMs,
             options.SaslMechanism,
             options.SaslCredentialProvider is not null);
     }

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -39,7 +39,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private volatile bool _initialized;
     private volatile bool _hasSuccessfulRefresh;
     private int _initializationAttempt;
-    private long _bootstrapResolutionStartedAt;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
     private readonly object _backgroundRefreshGate = new();
@@ -512,8 +511,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
             var initializationToken = linkedCts.Token;
-            var metadataStartedAt = Stopwatch.GetTimestamp();
-            var bootstrapStartedAt = GetOrStartBootstrapResolutionTimer();
+            var bootstrapStartedAt = Stopwatch.GetTimestamp();
+            var metadataStartedAt = 0L;
             var bootstrapResolutionCompleted = false;
             var metadataFailureCount = 0;
             var bootstrapFailureCount = 0;
@@ -529,16 +528,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     {
                         if (bootstrapResolutionCompleted)
                         {
-                            await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
+                            await RefreshMetadataForInitializationAsync(initializationToken).ConfigureAwait(false);
                         }
                         else
                         {
                             var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs
                                 - Stopwatch.GetElapsedTime(bootstrapStartedAt).TotalMilliseconds;
-                            var metadataRemainingMs = _options.InitTimeoutMs
-                                - Stopwatch.GetElapsedTime(metadataStartedAt).TotalMilliseconds;
                             await RefreshMetadataWithinBootstrapDeadlineAsync(
-                                    Math.Max(0, Math.Min(bootstrapRemainingMs, metadataRemainingMs)),
+                                    Math.Max(0, bootstrapRemainingMs),
                                     initializationToken)
                                 .ConfigureAwait(false);
                         }
@@ -548,18 +545,11 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     {
                         var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
                         var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
-                        var metadataElapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
-                        var metadataRemainingMs = _options.InitTimeoutMs - metadataElapsed.TotalMilliseconds;
-                        var remainingMs = Math.Min(bootstrapRemainingMs, metadataRemainingMs);
-                        if (remainingMs <= 0)
+                        if (bootstrapRemainingMs <= 0)
                             throw CreateBootstrapDeadlineException(
                                 ex.UnresolvedBootstrapServers,
                                 ex,
-                                bootstrapElapsed,
-                                bootstrapRemainingMs,
-                                metadataElapsed,
-                                metadataRemainingMs,
-                                metadataFailureCount + bootstrapFailureCount + 1);
+                                bootstrapElapsed);
 
                         var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                             _options.RetryBackoffMs,
@@ -567,12 +557,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
                             ++bootstrapFailureCount);
                         LogBootstrapResolutionRetry(ex, bootstrapFailureCount, backoffMs);
                         await Task.Delay(
-                                (int)Math.Min(backoffMs, remainingMs),
+                                (int)Math.Min(backoffMs, bootstrapRemainingMs),
                                 initializationToken)
                             .ConfigureAwait(false);
 
-                        // DNS failures do not consume the normal retry count, but the caller's
-                        // overall initialization deadline (for example max.block.ms) still applies.
+                        // DNS failures do not consume the normal retry count or its independent
+                        // metadata initialization budget.
                         metadataFailureCount = 0;
                     }
                     catch (OperationCanceledException ex) when (
@@ -581,23 +571,20 @@ public sealed partial class MetadataManager : IAsyncDisposable
                         && IsDnsResolutionFailure(ex))
                     {
                         var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
-                        var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
-                        var metadataElapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
-                        var metadataRemainingMs = _options.InitTimeoutMs - metadataElapsed.TotalMilliseconds;
                         throw CreateBootstrapDeadlineException(
                             _originalBootstrapHostnames,
                             ex,
-                            bootstrapElapsed,
-                            bootstrapRemainingMs,
-                            metadataElapsed,
-                            metadataRemainingMs,
-                            metadataFailureCount + bootstrapFailureCount + 1);
+                            bootstrapElapsed);
                     }
                     catch (Exception ex) when (!IsFatalMetadataError(ex) && !initializationToken.IsCancellationRequested)
                     {
                         // Any non-DNS failure proves resolution completed. Stop applying the
                         // bootstrap DNS deadline to connection, authentication, and metadata work.
-                        bootstrapResolutionCompleted = true;
+                        if (!bootstrapResolutionCompleted)
+                        {
+                            bootstrapResolutionCompleted = true;
+                            metadataStartedAt = Stopwatch.GetTimestamp();
+                        }
                         if (metadataFailureCount >= _options.MaxInitRetries)
                         {
                             LogMetadataInitializationAbandoned(ex, metadataFailureCount + 1);
@@ -891,7 +878,28 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// <summary>
     /// Refreshes metadata for specific topics.
     /// </summary>
-    public async ValueTask RefreshMetadataAsync(IEnumerable<string>? topics, bool forceRefresh = false, CancellationToken cancellationToken = default)
+    public ValueTask RefreshMetadataAsync(
+        IEnumerable<string>? topics,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default) =>
+        RefreshMetadataAsyncCore(
+            topics,
+            forceRefresh,
+            allowBootstrapResolutionPending: false,
+            cancellationToken);
+
+    private ValueTask RefreshMetadataForInitializationAsync(CancellationToken cancellationToken) =>
+        RefreshMetadataAsyncCore(
+            topics: null,
+            forceRefresh: false,
+            allowBootstrapResolutionPending: true,
+            cancellationToken);
+
+    private async ValueTask RefreshMetadataAsyncCore(
+        IEnumerable<string>? topics,
+        bool forceRefresh,
+        bool allowBootstrapResolutionPending,
+        CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
             throw new ObjectDisposedException(nameof(MetadataManager));
@@ -911,7 +919,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 return;
             }
 
-            await RefreshMetadataInternalAsync(topics, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await RefreshMetadataInternalAsync(topics, cancellationToken).ConfigureAwait(false);
+            }
+            catch (BootstrapResolutionPendingException ex) when (!allowBootstrapResolutionPending)
+            {
+                throw CreateBootstrapResolutionException(ex.UnresolvedBootstrapServers, ex);
+            }
         }
         finally
         {
@@ -1087,17 +1102,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
         throw new InvalidOperationException("Failed to refresh metadata from any broker", lastException);
     }
 
-    private long GetOrStartBootstrapResolutionTimer()
-    {
-        var startedAt = Volatile.Read(ref _bootstrapResolutionStartedAt);
-        if (startedAt != 0)
-            return startedAt;
-
-        var now = Stopwatch.GetTimestamp();
-        var existing = Interlocked.CompareExchange(ref _bootstrapResolutionStartedAt, now, 0);
-        return existing == 0 ? now : existing;
-    }
-
     private async ValueTask RefreshMetadataWithinBootstrapDeadlineAsync(
         double remainingMs,
         CancellationToken cancellationToken)
@@ -1106,7 +1110,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
         deadlineCts.CancelAfter(TimeSpan.FromMilliseconds(remainingMs));
         try
         {
-            await RefreshMetadataAsync(deadlineCts.Token).ConfigureAwait(false);
+            await RefreshMetadataForInitializationAsync(deadlineCts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException ex) when (
             !cancellationToken.IsCancellationRequested
@@ -1119,28 +1123,19 @@ public sealed partial class MetadataManager : IAsyncDisposable
         }
     }
 
-    private Exception CreateBootstrapDeadlineException(
+    private BootstrapResolutionException CreateBootstrapDeadlineException(
         IReadOnlyList<string> unresolvedBootstrapServers,
         Exception innerException,
-        TimeSpan bootstrapElapsed,
-        double bootstrapRemainingMs,
-        TimeSpan metadataElapsed,
-        double metadataRemainingMs,
-        int attemptCount)
+        TimeSpan bootstrapElapsed)
     {
-        if (metadataRemainingMs <= bootstrapRemainingMs)
-        {
-            LogMetadataInitializationAbandoned(innerException, attemptCount);
-            return new KafkaTimeoutException(
-                TimeoutKind.Metadata,
-                metadataElapsed,
-                TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
-                $"Failed to fetch initial metadata within {_options.InitTimeoutMs}ms. " +
-                "Ensure the Kafka cluster is reachable and the bootstrap servers are correct.",
-                innerException);
-        }
-
         LogBootstrapResolutionExpired(bootstrapElapsed.TotalMilliseconds);
+        return CreateBootstrapResolutionException(unresolvedBootstrapServers, innerException);
+    }
+
+    private BootstrapResolutionException CreateBootstrapResolutionException(
+        IReadOnlyList<string> unresolvedBootstrapServers,
+        Exception innerException)
+    {
         return new BootstrapResolutionException(
             unresolvedBootstrapServers,
             TimeSpan.FromMilliseconds(_options.BootstrapResolveTimeoutMs),

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -39,6 +39,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
     private volatile bool _initialized;
     private volatile bool _hasSuccessfulRefresh;
     private int _initializationAttempt;
+    private long _bootstrapResolutionStartedAt;
     private int _disposed;
     private readonly CancellationTokenSource _disposalCts = new();
     private readonly object _backgroundRefreshGate = new();
@@ -122,6 +123,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
         _connectionPool = connectionPool;
         _options = options ?? new MetadataOptions();
         ConfigureMetadataClusterCheck(_connectionPool);
+        ArgumentOutOfRangeException.ThrowIfNegative(_options.BootstrapResolveTimeoutMs);
         ExponentialRetryBackoff.Validate(_options.RetryBackoffMs, _options.RetryBackoffMaxMs);
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<MetadataManager>.Instance;
         if (connectionPool is IConnectionCapabilityObserverPool observerPool)
@@ -479,7 +481,10 @@ public sealed partial class MetadataManager : IAsyncDisposable
     /// </summary>
     private bool IsFatalMetadataError(Exception ex)
     {
-        if (ex is BrokerVersionException or AuthenticationException or AuthorizationException)
+        if (ex is BrokerVersionException
+            or AuthenticationException
+            or AuthorizationException
+            or BootstrapResolutionException)
             return true;
 
         // KafkaConnection instances can be disposed independently during pool churn. Only the
@@ -507,31 +512,62 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
             var initializationToken = linkedCts.Token;
-            var startedAt = Stopwatch.GetTimestamp();
+            var metadataStartedAt = Stopwatch.GetTimestamp();
+            var metadataFailureCount = 0;
+            var bootstrapFailureCount = 0;
 
             try
             {
-                for (var attempt = 0; ; attempt++)
+                while (true)
                 {
-                    Volatile.Write(ref _initializationAttempt, attempt + 1);
+                    Volatile.Write(
+                        ref _initializationAttempt,
+                        metadataFailureCount + bootstrapFailureCount + 1);
                     try
                     {
                         await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
                         break;
                     }
+                    catch (BootstrapResolutionPendingException ex) when (!initializationToken.IsCancellationRequested)
+                    {
+                        var bootstrapStartedAt = GetOrStartBootstrapResolutionTimer();
+                        var elapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
+                        var remainingMs = _options.BootstrapResolveTimeoutMs - elapsed.TotalMilliseconds;
+                        if (remainingMs <= 0)
+                        {
+                            LogBootstrapResolutionExpired(elapsed.TotalMilliseconds);
+                            throw new BootstrapResolutionException(
+                                ex.UnresolvedBootstrapServers,
+                                TimeSpan.FromMilliseconds(_options.BootstrapResolveTimeoutMs),
+                                ex.InnerException ?? ex);
+                        }
+
+                        var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
+                            _options.RetryBackoffMs,
+                            _options.RetryBackoffMaxMs,
+                            ++bootstrapFailureCount);
+                        LogBootstrapResolutionRetry(ex, bootstrapFailureCount, backoffMs);
+                        await Task.Delay((int)Math.Min(backoffMs, remainingMs), initializationToken)
+                            .ConfigureAwait(false);
+
+                        // DNS resolution has its own KIP-909 budget. Once it recovers, connection,
+                        // authentication, and metadata failures receive their full normal budget.
+                        metadataFailureCount = 0;
+                        metadataStartedAt = Stopwatch.GetTimestamp();
+                    }
                     catch (Exception ex) when (!IsFatalMetadataError(ex) && !initializationToken.IsCancellationRequested)
                     {
-                        if (attempt >= _options.MaxInitRetries)
+                        if (metadataFailureCount >= _options.MaxInitRetries)
                         {
-                            LogMetadataInitializationAbandoned(ex, attempt + 1);
+                            LogMetadataInitializationAbandoned(ex, metadataFailureCount + 1);
                             throw;
                         }
 
-                        var elapsed = Stopwatch.GetElapsedTime(startedAt);
+                        var elapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
                         var remainingMs = _options.InitTimeoutMs - elapsed.TotalMilliseconds;
                         if (remainingMs <= 0)
                         {
-                            LogMetadataInitializationAbandoned(ex, attempt + 1);
+                            LogMetadataInitializationAbandoned(ex, metadataFailureCount + 1);
                             throw new KafkaTimeoutException(
                                 TimeoutKind.Metadata,
                                 elapsed,
@@ -544,8 +580,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
                         var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                             _options.RetryBackoffMs,
                             _options.RetryBackoffMaxMs,
-                            attempt + 1);
-                        LogMetadataInitializationFailed(ex, attempt + 1, backoffMs);
+                            ++metadataFailureCount);
+                        LogMetadataInitializationFailed(ex, metadataFailureCount, backoffMs);
                         await Task.Delay((int)Math.Min(backoffMs, remainingMs), initializationToken).ConfigureAwait(false);
                     }
                 }
@@ -863,6 +899,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
     {
         Exception? lastException = null;
         var retryRequestedRebootstrap = false;
+        List<string>? unresolvedBootstrapServers = null;
+        var sawNonDnsFailure = false;
 
         if (_options.MetadataRecoveryStrategy == MetadataRecoveryStrategy.Rebootstrap
             && TryConsumeMetadataRebootstrapRequest())
@@ -973,7 +1011,22 @@ public sealed partial class MetadataManager : IAsyncDisposable
             {
                 LogMetadataRefreshFailed(ex, host, port);
                 lastException = ex;
+                if (!_hasSuccessfulRefresh && IsDnsResolutionFailure(ex))
+                {
+                    (unresolvedBootstrapServers ??= []).Add($"{host}:{port}");
+                }
+                else
+                {
+                    sawNonDnsFailure = true;
+                }
             }
+        }
+
+        if (!_hasSuccessfulRefresh
+            && unresolvedBootstrapServers is not null
+            && !sawNonDnsFailure)
+        {
+            throw new BootstrapResolutionPendingException(unresolvedBootstrapServers, lastException!);
         }
 
         // All known endpoints failed - try rebootstrap if configured
@@ -991,6 +1044,45 @@ public sealed partial class MetadataManager : IAsyncDisposable
             RequestMetadataRebootstrap();
 
         throw new InvalidOperationException("Failed to refresh metadata from any broker", lastException);
+    }
+
+    private long GetOrStartBootstrapResolutionTimer()
+    {
+        var startedAt = Volatile.Read(ref _bootstrapResolutionStartedAt);
+        if (startedAt != 0)
+            return startedAt;
+
+        var now = Stopwatch.GetTimestamp();
+        var existing = Interlocked.CompareExchange(ref _bootstrapResolutionStartedAt, now, 0);
+        return existing == 0 ? now : existing;
+    }
+
+    private static bool IsDnsResolutionFailure(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is DnsResolutionException)
+                return true;
+
+            if (current is AggregateException aggregateException)
+            {
+                foreach (var innerException in aggregateException.InnerExceptions)
+                {
+                    if (IsDnsResolutionFailure(innerException))
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class BootstrapResolutionPendingException(
+        IReadOnlyList<string> unresolvedBootstrapServers,
+        Exception innerException)
+        : Exception("No bootstrap server DNS name could be resolved.", innerException)
+    {
+        public IReadOnlyList<string> UnresolvedBootstrapServers { get; } = unresolvedBootstrapServers;
     }
 
     /// <summary>
@@ -1492,6 +1584,12 @@ public sealed partial class MetadataManager : IAsyncDisposable
     [LoggerMessage(Level = LogLevel.Warning, Message = "Metadata initialization failed after {AttemptCount} attempts")]
     private partial void LogMetadataInitializationAbandoned(Exception ex, int attemptCount);
 
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Bootstrap DNS resolution attempt {Attempt} failed; retrying in {BackoffMs}ms")]
+    private partial void LogBootstrapResolutionRetry(Exception ex, int attempt, long backoffMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unable to resolve any bootstrap server after {ElapsedMs}ms")]
+    private partial void LogBootstrapResolutionExpired(double elapsedMs);
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Refreshed metadata: {BrokerCount} brokers, {TopicCount} topics")]
     private partial void LogMetadataRefreshed(int brokerCount, int topicCount);
 
@@ -1591,6 +1689,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
 /// </summary>
 public sealed class MetadataOptions
 {
+    /// <summary>
+    /// Maximum time in milliseconds spent retrying initial bootstrap DNS resolution.
+    /// This KIP-909 budget is independent of metadata initialization and request timeouts.
+    /// Default is 120000 (2 minutes).
+    /// </summary>
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
+
     /// <summary>
     /// Interval for background metadata refresh.
     /// Metadata is never considered stale - it refreshes periodically and swaps in silently.

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -513,6 +513,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposalCts.Token);
             var initializationToken = linkedCts.Token;
             var metadataStartedAt = Stopwatch.GetTimestamp();
+            var bootstrapStartedAt = GetOrStartBootstrapResolutionTimer();
+            var bootstrapResolutionCompleted = false;
             var metadataFailureCount = 0;
             var bootstrapFailureCount = 0;
 
@@ -525,37 +527,39 @@ public sealed partial class MetadataManager : IAsyncDisposable
                         metadataFailureCount + bootstrapFailureCount + 1);
                     try
                     {
-                        await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
+                        if (bootstrapResolutionCompleted)
+                        {
+                            await RefreshMetadataAsync(initializationToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs
+                                - Stopwatch.GetElapsedTime(bootstrapStartedAt).TotalMilliseconds;
+                            var metadataRemainingMs = _options.InitTimeoutMs
+                                - Stopwatch.GetElapsedTime(metadataStartedAt).TotalMilliseconds;
+                            await RefreshMetadataWithinBootstrapDeadlineAsync(
+                                    Math.Max(0, Math.Min(bootstrapRemainingMs, metadataRemainingMs)),
+                                    initializationToken)
+                                .ConfigureAwait(false);
+                        }
                         break;
                     }
                     catch (BootstrapResolutionPendingException ex) when (!initializationToken.IsCancellationRequested)
                     {
-                        var bootstrapStartedAt = GetOrStartBootstrapResolutionTimer();
                         var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
                         var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
                         var metadataElapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
                         var metadataRemainingMs = _options.InitTimeoutMs - metadataElapsed.TotalMilliseconds;
                         var remainingMs = Math.Min(bootstrapRemainingMs, metadataRemainingMs);
-                        if (remainingMs <= 0 && metadataRemainingMs <= bootstrapRemainingMs)
-                        {
-                            LogMetadataInitializationAbandoned(ex, metadataFailureCount + bootstrapFailureCount + 1);
-                            throw new KafkaTimeoutException(
-                                TimeoutKind.Metadata,
-                                metadataElapsed,
-                                TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
-                                $"Failed to fetch initial metadata within {_options.InitTimeoutMs}ms. " +
-                                "Ensure the Kafka cluster is reachable and the bootstrap servers are correct.",
-                                ex);
-                        }
-
                         if (remainingMs <= 0)
-                        {
-                            LogBootstrapResolutionExpired(bootstrapElapsed.TotalMilliseconds);
-                            throw new BootstrapResolutionException(
+                            throw CreateBootstrapDeadlineException(
                                 ex.UnresolvedBootstrapServers,
-                                TimeSpan.FromMilliseconds(_options.BootstrapResolveTimeoutMs),
-                                ex.InnerException ?? ex);
-                        }
+                                ex,
+                                bootstrapElapsed,
+                                bootstrapRemainingMs,
+                                metadataElapsed,
+                                metadataRemainingMs,
+                                metadataFailureCount + bootstrapFailureCount + 1);
 
                         var backoffMs = ExponentialRetryBackoff.CalculateDelayMilliseconds(
                             _options.RetryBackoffMs,
@@ -571,8 +575,29 @@ public sealed partial class MetadataManager : IAsyncDisposable
                         // overall initialization deadline (for example max.block.ms) still applies.
                         metadataFailureCount = 0;
                     }
+                    catch (OperationCanceledException ex) when (
+                        !initializationToken.IsCancellationRequested
+                        && !bootstrapResolutionCompleted
+                        && IsDnsResolutionFailure(ex))
+                    {
+                        var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
+                        var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
+                        var metadataElapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
+                        var metadataRemainingMs = _options.InitTimeoutMs - metadataElapsed.TotalMilliseconds;
+                        throw CreateBootstrapDeadlineException(
+                            _originalBootstrapHostnames,
+                            ex,
+                            bootstrapElapsed,
+                            bootstrapRemainingMs,
+                            metadataElapsed,
+                            metadataRemainingMs,
+                            metadataFailureCount + bootstrapFailureCount + 1);
+                    }
                     catch (Exception ex) when (!IsFatalMetadataError(ex) && !initializationToken.IsCancellationRequested)
                     {
+                        // Any non-DNS failure proves resolution completed. Stop applying the
+                        // bootstrap DNS deadline to connection, authentication, and metadata work.
+                        bootstrapResolutionCompleted = true;
                         if (metadataFailureCount >= _options.MaxInitRetries)
                         {
                             LogMetadataInitializationAbandoned(ex, metadataFailureCount + 1);
@@ -1071,6 +1096,57 @@ public sealed partial class MetadataManager : IAsyncDisposable
         var now = Stopwatch.GetTimestamp();
         var existing = Interlocked.CompareExchange(ref _bootstrapResolutionStartedAt, now, 0);
         return existing == 0 ? now : existing;
+    }
+
+    private async ValueTask RefreshMetadataWithinBootstrapDeadlineAsync(
+        double remainingMs,
+        CancellationToken cancellationToken)
+    {
+        using var deadlineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadlineCts.CancelAfter(TimeSpan.FromMilliseconds(remainingMs));
+        try
+        {
+            await RefreshMetadataAsync(deadlineCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (
+            !cancellationToken.IsCancellationRequested
+            && !IsDnsResolutionFailure(ex))
+        {
+            // The DNS lookup completed and the shared deadline expired in a later connection
+            // phase. Translate this into a normal retriable initialization failure so future
+            // attempts use only the metadata initialization deadline.
+            throw new TimeoutException("Bootstrap connection attempt exceeded the DNS deadline after resolution.", ex);
+        }
+    }
+
+    private Exception CreateBootstrapDeadlineException(
+        IReadOnlyList<string> unresolvedBootstrapServers,
+        Exception innerException,
+        TimeSpan bootstrapElapsed,
+        double bootstrapRemainingMs,
+        TimeSpan metadataElapsed,
+        double metadataRemainingMs,
+        int attemptCount)
+    {
+        if (metadataRemainingMs <= bootstrapRemainingMs)
+        {
+            LogMetadataInitializationAbandoned(innerException, attemptCount);
+            return new KafkaTimeoutException(
+                TimeoutKind.Metadata,
+                metadataElapsed,
+                TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
+                $"Failed to fetch initial metadata within {_options.InitTimeoutMs}ms. " +
+                "Ensure the Kafka cluster is reachable and the bootstrap servers are correct.",
+                innerException);
+        }
+
+        LogBootstrapResolutionExpired(bootstrapElapsed.TotalMilliseconds);
+        return new BootstrapResolutionException(
+            unresolvedBootstrapServers,
+            TimeSpan.FromMilliseconds(_options.BootstrapResolveTimeoutMs),
+            innerException is BootstrapResolutionPendingException { InnerException: not null } pending
+                ? pending.InnerException!
+                : innerException);
     }
 
     private static bool IsDnsResolutionFailure(Exception exception)

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -514,6 +514,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
             var bootstrapStartedAt = Stopwatch.GetTimestamp();
             var metadataStartedAt = 0L;
             var bootstrapResolutionCompleted = false;
+            BootstrapResolutionPendingException? lastBootstrapResolutionFailure = null;
             var metadataFailureCount = 0;
             var bootstrapFailureCount = 0;
 
@@ -528,7 +529,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     {
                         if (bootstrapResolutionCompleted)
                         {
-                            await RefreshMetadataForInitializationAsync(initializationToken).ConfigureAwait(false);
+                            await RefreshMetadataAfterBootstrapResolutionAsync(initializationToken)
+                                .ConfigureAwait(false);
                         }
                         else
                         {
@@ -536,6 +538,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                                 - Stopwatch.GetElapsedTime(bootstrapStartedAt).TotalMilliseconds;
                             await RefreshMetadataWithinBootstrapDeadlineAsync(
                                     Math.Max(0, bootstrapRemainingMs),
+                                    lastBootstrapResolutionFailure,
                                     initializationToken)
                                 .ConfigureAwait(false);
                         }
@@ -543,6 +546,7 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     }
                     catch (BootstrapResolutionPendingException ex) when (!initializationToken.IsCancellationRequested)
                     {
+                        lastBootstrapResolutionFailure = ex;
                         var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
                         var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
                         if (bootstrapRemainingMs <= 0)
@@ -885,20 +889,27 @@ public sealed partial class MetadataManager : IAsyncDisposable
         RefreshMetadataAsyncCore(
             topics,
             forceRefresh,
-            allowBootstrapResolutionPending: false,
+            BootstrapResolutionFailureMode.PublicException,
             cancellationToken);
 
     private ValueTask RefreshMetadataForInitializationAsync(CancellationToken cancellationToken) =>
         RefreshMetadataAsyncCore(
             topics: null,
             forceRefresh: false,
-            allowBootstrapResolutionPending: true,
+            BootstrapResolutionFailureMode.Pending,
+            cancellationToken);
+
+    private ValueTask RefreshMetadataAfterBootstrapResolutionAsync(CancellationToken cancellationToken) =>
+        RefreshMetadataAsyncCore(
+            topics: null,
+            forceRefresh: false,
+            BootstrapResolutionFailureMode.MetadataFailure,
             cancellationToken);
 
     private async ValueTask RefreshMetadataAsyncCore(
         IEnumerable<string>? topics,
         bool forceRefresh,
-        bool allowBootstrapResolutionPending,
+        BootstrapResolutionFailureMode bootstrapResolutionFailureMode,
         CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -923,9 +934,15 @@ public sealed partial class MetadataManager : IAsyncDisposable
             {
                 await RefreshMetadataInternalAsync(topics, cancellationToken).ConfigureAwait(false);
             }
-            catch (BootstrapResolutionPendingException ex) when (!allowBootstrapResolutionPending)
+            catch (BootstrapResolutionPendingException ex) when (
+                bootstrapResolutionFailureMode != BootstrapResolutionFailureMode.Pending)
             {
-                throw CreateBootstrapResolutionException(ex.UnresolvedBootstrapServers, ex);
+                if (bootstrapResolutionFailureMode == BootstrapResolutionFailureMode.PublicException)
+                    throw CreateBootstrapResolutionException(ex.UnresolvedBootstrapServers, ex);
+
+                throw new InvalidOperationException(
+                    "Failed to refresh metadata from any broker",
+                    ex.InnerException ?? ex);
             }
         }
         finally
@@ -1104,10 +1121,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     private async ValueTask RefreshMetadataWithinBootstrapDeadlineAsync(
         double remainingMs,
+        BootstrapResolutionPendingException? previousDnsFailure,
         CancellationToken cancellationToken)
     {
         using var deadlineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        deadlineCts.CancelAfter(TimeSpan.FromMilliseconds(remainingMs));
+        // A zero budget still gets one bounded probe so an immediate DNS failure retains
+        // its endpoint details instead of racing a pre-cancelled refresh lock.
+        deadlineCts.CancelAfter(TimeSpan.FromMilliseconds(Math.Max(1, remainingMs)));
         try
         {
             await RefreshMetadataForInitializationAsync(deadlineCts.Token).ConfigureAwait(false);
@@ -1116,6 +1136,9 @@ public sealed partial class MetadataManager : IAsyncDisposable
             !cancellationToken.IsCancellationRequested
             && !IsDnsResolutionFailure(ex))
         {
+            if (previousDnsFailure is not null)
+                throw previousDnsFailure;
+
             // The DNS lookup completed and the shared deadline expired in a later connection
             // phase. Translate this into a normal retriable initialization failure so future
             // attempts use only the metadata initialization deadline.
@@ -1170,6 +1193,13 @@ public sealed partial class MetadataManager : IAsyncDisposable
         : Exception("No bootstrap server DNS name could be resolved.", innerException)
     {
         public IReadOnlyList<string> UnresolvedBootstrapServers { get; } = unresolvedBootstrapServers;
+    }
+
+    private enum BootstrapResolutionFailureMode
+    {
+        Pending,
+        PublicException,
+        MetadataFailure
     }
 
     /// <summary>

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -531,11 +531,26 @@ public sealed partial class MetadataManager : IAsyncDisposable
                     catch (BootstrapResolutionPendingException ex) when (!initializationToken.IsCancellationRequested)
                     {
                         var bootstrapStartedAt = GetOrStartBootstrapResolutionTimer();
-                        var elapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
-                        var remainingMs = _options.BootstrapResolveTimeoutMs - elapsed.TotalMilliseconds;
+                        var bootstrapElapsed = Stopwatch.GetElapsedTime(bootstrapStartedAt);
+                        var bootstrapRemainingMs = _options.BootstrapResolveTimeoutMs - bootstrapElapsed.TotalMilliseconds;
+                        var metadataElapsed = Stopwatch.GetElapsedTime(metadataStartedAt);
+                        var metadataRemainingMs = _options.InitTimeoutMs - metadataElapsed.TotalMilliseconds;
+                        var remainingMs = Math.Min(bootstrapRemainingMs, metadataRemainingMs);
+                        if (remainingMs <= 0 && metadataRemainingMs <= bootstrapRemainingMs)
+                        {
+                            LogMetadataInitializationAbandoned(ex, metadataFailureCount + bootstrapFailureCount + 1);
+                            throw new KafkaTimeoutException(
+                                TimeoutKind.Metadata,
+                                metadataElapsed,
+                                TimeSpan.FromMilliseconds(_options.InitTimeoutMs),
+                                $"Failed to fetch initial metadata within {_options.InitTimeoutMs}ms. " +
+                                "Ensure the Kafka cluster is reachable and the bootstrap servers are correct.",
+                                ex);
+                        }
+
                         if (remainingMs <= 0)
                         {
-                            LogBootstrapResolutionExpired(elapsed.TotalMilliseconds);
+                            LogBootstrapResolutionExpired(bootstrapElapsed.TotalMilliseconds);
                             throw new BootstrapResolutionException(
                                 ex.UnresolvedBootstrapServers,
                                 TimeSpan.FromMilliseconds(_options.BootstrapResolveTimeoutMs),
@@ -547,13 +562,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
                             _options.RetryBackoffMaxMs,
                             ++bootstrapFailureCount);
                         LogBootstrapResolutionRetry(ex, bootstrapFailureCount, backoffMs);
-                        await Task.Delay((int)Math.Min(backoffMs, remainingMs), initializationToken)
+                        await Task.Delay(
+                                (int)Math.Min(backoffMs, remainingMs),
+                                initializationToken)
                             .ConfigureAwait(false);
 
-                        // DNS resolution has its own KIP-909 budget. Once it recovers, connection,
-                        // authentication, and metadata failures receive their full normal budget.
+                        // DNS failures do not consume the normal retry count, but the caller's
+                        // overall initialization deadline (for example max.block.ms) still applies.
                         metadataFailureCount = 0;
-                        metadataStartedAt = Stopwatch.GetTimestamp();
                     }
                     catch (Exception ex) when (!IsFatalMetadataError(ex) && !initializationToken.IsCancellationRequested)
                     {

--- a/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
+++ b/src/Dekaf/Networking/ClientDnsEndpointResolver.cs
@@ -82,6 +82,14 @@ internal sealed class ClientDnsEndpointResolver
 
 internal readonly record struct ClientDnsEndpoint(IPAddress Address, int Port, string TargetHost);
 
+internal sealed class DnsResolutionException(string host, int port, Exception? innerException = null)
+    : Exception($"DNS resolution failed for host '{host}:{port}'.", innerException)
+{
+    public string Host { get; } = host;
+
+    public int Port { get; } = port;
+}
+
 internal interface IDnsLookup
 {
     ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -381,7 +381,17 @@ public sealed partial class KafkaConnection :
 
         using var connectTimeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         connectTimeoutCts.CancelAfter(_options.ConnectionTimeout);
-        var (socket, targetHost) = await ConnectSocketAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+        (Socket socket, string targetHost) socketResult;
+        try
+        {
+            socketResult = await ConnectSocketAsync(connectTimeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (DnsResolutionException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException("DNS resolution was cancelled.", ex, cancellationToken);
+        }
+
+        var (socket, targetHost) = socketResult;
         _socket = socket;
         _resolvedTargetHost = targetHost;
 
@@ -485,12 +495,23 @@ public sealed partial class KafkaConnection :
 
     private async ValueTask<(Socket Socket, string TargetHost)> ConnectSocketAsync(CancellationToken cancellationToken)
     {
-        var endpoints = await _options.DnsResolver
-            .ResolveAsync(_host, _port, _options.ClientDnsLookup, cancellationToken)
-            .ConfigureAwait(false);
+        IReadOnlyList<ClientDnsEndpoint> endpoints;
+        try
+        {
+            endpoints = await _options.DnsResolver
+                .ResolveAsync(_host, _port, _options.ClientDnsLookup, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DnsResolutionException(_host, _port, ex);
+        }
 
         if (endpoints.Count == 0)
-            throw new SocketException((int)SocketError.HostNotFound);
+            throw new DnsResolutionException(
+                _host,
+                _port,
+                new SocketException((int)SocketError.HostNotFound));
 
         Exception? lastException = null;
         foreach (var endpoint in endpoints)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -3524,8 +3524,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     private static bool IsRetriablePartitionEnrollmentException(Exception exception) =>
-        exception is IOException or System.Net.Sockets.SocketException or TimeoutException
-        || exception is KafkaException { IsRetriable: true };
+        RetryHelper.IsRetriableRequestFailure(exception);
 
     private Action<Exception?>[] ResetPartitionEnrollmentState()
     {

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -302,6 +302,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             MetadataClusterCheckEnabled = options.MetadataClusterCheckEnabled,
             RetryBackoffMs = options.RetryBackoffMs,
             RetryBackoffMaxMs = options.RetryBackoffMaxMs,
+            BootstrapResolveTimeoutMs = options.BootstrapResolveTimeoutMs,
             InitTimeoutMs = options.MaxBlockMs
         };
         var metadataManager = new MetadataManager(

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -621,6 +621,12 @@ public sealed class ProducerOptions
     /// </summary>
     public ClientDnsLookup ClientDnsLookup { get; init; } = ClientDnsLookup.UseAllDnsIps;
 
+    /// <summary>
+    /// Maximum time in milliseconds spent retrying initial bootstrap DNS resolution.
+    /// Equivalent to Kafka's <c>bootstrap.resolve.timeout.ms</c>. Default is 120000.
+    /// </summary>
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
+
     internal ClientDnsEndpointResolver DnsResolver { get; init; } = ClientDnsEndpointResolver.Default;
 
     /// <summary>

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -1,4 +1,5 @@
 using Dekaf.Metadata;
+using Dekaf.Networking;
 
 namespace Dekaf.Retry;
 
@@ -95,8 +96,28 @@ internal static class RetryHelper
     }
 
     internal static bool IsRetriableRequestFailure(Exception exception)
-        => exception is IOException or System.Net.Sockets.SocketException or TimeoutException
-           || exception is KafkaException { IsRetriable: true };
+    {
+        if (exception is KafkaException kafkaException)
+            return kafkaException.IsRetriable;
+
+        if (exception is IOException
+            or System.Net.Sockets.SocketException
+            or TimeoutException
+            or DnsResolutionException)
+            return true;
+
+        if (exception is AggregateException aggregateException)
+        {
+            foreach (var innerException in aggregateException.InnerExceptions)
+            {
+                if (IsRetriableRequestFailure(innerException))
+                    return true;
+            }
+        }
+
+        return exception.InnerException is not null
+            && IsRetriableRequestFailure(exception.InnerException);
+    }
 
     private static async ValueTask RefreshMetadataForRetryAsync(
         MetadataManager metadataManager,

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -108,7 +108,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 MetadataClusterCheckEnabled = options.MetadataClusterCheckEnabled,
                 RetryBackoffMs = options.RetryBackoffMs,
-                RetryBackoffMaxMs = options.RetryBackoffMaxMs
+                RetryBackoffMaxMs = options.RetryBackoffMaxMs,
+                BootstrapResolveTimeoutMs = options.BootstrapResolveTimeoutMs
             },
             logger: loggerFactory?.CreateLogger<MetadataManager>());
 

--- a/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
+++ b/src/Dekaf/ShareConsumer/ShareConsumerOptions.cs
@@ -226,6 +226,12 @@ public sealed class ShareConsumerOptions
     public bool MetadataClusterCheckEnabled { get; init; } = true;
 
     /// <summary>
+    /// Maximum time in milliseconds spent retrying initial bootstrap DNS resolution.
+    /// Equivalent to Kafka's <c>bootstrap.resolve.timeout.ms</c>. Default is 120000.
+    /// </summary>
+    public int BootstrapResolveTimeoutMs { get; init; } = 120000;
+
+    /// <summary>
     /// Custom retry policy for transient errors.
     /// </summary>
     public IRetryPolicy? RetryPolicy { get; init; }

--- a/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTimeoutTests.cs
@@ -63,30 +63,30 @@ public sealed class ProducerTimeoutTests(KafkaTestContainer kafka) : KafkaIntegr
     }
 
     [Test]
-    public async Task MaxBlock_ExceededWaitingForMetadata_ErrorPropagated()
+    public async Task BootstrapResolveTimeout_ExceededWaitingForMetadata_ErrorPropagated()
     {
         // Arrange & Act - Resolve the invalid bootstrap server deterministically so metadata lookup will fail.
-        // BuildAsync() eagerly initializes, retrying metadata until MaxBlock expires
-        // (Java max.block.ms parity), then surfaces a timeout rather than hanging.
+        // KIP-909 gives bootstrap DNS resolution an independent deadline, then surfaces
+        // the dedicated resolution exception rather than hanging.
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
-        var exception = await Assert.ThrowsAsync<KafkaTimeoutException>(async () =>
+        var exception = await Assert.ThrowsAsync<BootstrapResolutionException>(async () =>
         {
             await using var producer = await Kafka.CreateProducer<string, string>()
                 .WithBootstrapServers("invalid-host-that-does-not-exist:9092")
                 .WithDnsResolver(new ClientDnsEndpointResolver(new FailingDnsLookup()))
-                .WithClientId("test-maxblock-exceeded")
-                .WithMaxBlock(TimeSpan.FromSeconds(2))
+                .WithClientId("test-bootstrap-resolve-timeout")
+                .WithBootstrapResolveTimeout(TimeSpan.FromSeconds(2))
                 .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
                 .BuildAsync();
         });
 
         sw.Stop();
 
-        // The timeout should identify the metadata phase and carry the underlying
-        // failure. The injected resolver avoids depending on the host DNS timeout.
-        // The key invariant is that the error does NOT hang indefinitely.
-        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
+        // The injected resolver avoids depending on the host DNS timeout.
+        await Assert.That(exception!.Timeout).IsEqualTo(TimeSpan.FromSeconds(2));
+        await Assert.That(exception.UnresolvedBootstrapServers)
+            .IsEquivalentTo(["invalid-host-that-does-not-exist:9092"]);
         await Assert.That(exception.InnerException).IsNotNull();
         await Assert.That(sw.Elapsed.TotalSeconds).IsGreaterThanOrEqualTo(2);
         await Assert.That(sw.Elapsed.TotalSeconds).IsLessThan(30);

--- a/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ConnectionBuilderOptionsTests.cs
@@ -196,6 +196,55 @@ public sealed class ConnectionBuilderOptionsTests
     }
 
     [Test]
+    public async Task Builders_WithBootstrapResolveTimeout_PreserveCommonSetting()
+    {
+        var timeout = TimeSpan.FromSeconds(7);
+
+        await using var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithBootstrapResolveTimeout(timeout)
+            .Build();
+        await using var consumer = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("consumer-group")
+            .WithBootstrapResolveTimeout(timeout)
+            .Build();
+        await using var shareConsumer = Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithGroupId("share-group")
+            .WithBootstrapResolveTimeout(timeout)
+            .Build();
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers("localhost:9092")
+            .WithBootstrapResolveTimeout(timeout)
+            .Build();
+        await using var client = Kafka.Connect("localhost:9092", builder => builder
+            .WithBootstrapResolveTimeout(timeout));
+        await using var clientProducer = client.CreateProducer<string, string>().Build();
+
+        await AssertBootstrapResolveTimeout(GetPrivateOptions<ProducerOptions>(producer), 7000);
+        await AssertBootstrapResolveTimeout(GetPrivateOptions<ConsumerOptions>(consumer), 7000);
+        await AssertBootstrapResolveTimeout(GetPrivateOptions<Dekaf.ShareConsumer.ShareConsumerOptions>(shareConsumer), 7000);
+        await AssertBootstrapResolveTimeout(GetPrivateOptions<AdminClientOptions>(admin), 7000);
+        await AssertBootstrapResolveTimeout(GetPrivateOptions<ProducerOptions>(clientProducer), 7000);
+    }
+
+    [Test]
+    public async Task ClientOptions_BootstrapResolveTimeout_DefaultsTo120000()
+    {
+        await AssertBootstrapResolveTimeout(new ProducerOptions { BootstrapServers = ["localhost:9092"] }, 120000);
+        await AssertBootstrapResolveTimeout(new ConsumerOptions { BootstrapServers = ["localhost:9092"] }, 120000);
+        await AssertBootstrapResolveTimeout(
+            new Dekaf.ShareConsumer.ShareConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                GroupId = "share-group"
+            },
+            120000);
+        await AssertBootstrapResolveTimeout(new AdminClientOptions { BootstrapServers = ["localhost:9092"] }, 120000);
+    }
+
+    [Test]
     public async Task BuilderConnectionOptions_CanDisableTcpKeepAlive()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -223,6 +272,8 @@ public sealed class ConnectionBuilderOptionsTests
             .Throws<ArgumentOutOfRangeException>();
         await Assert.That(() => builder.WithRemoteCertificateValidationCallback(null!))
             .Throws<ArgumentNullException>();
+        await Assert.That(() => builder.WithBootstrapResolveTimeout(TimeSpan.FromMilliseconds(-1)))
+            .Throws<ArgumentOutOfRangeException>();
     }
 
     private static async Task AssertConnectionOptions(
@@ -267,5 +318,11 @@ public sealed class ConnectionBuilderOptionsTests
         var maximum = (int)optionsType.GetProperty("RetryBackoffMaxMs")!.GetValue(options)!;
         await Assert.That(initial).IsEqualTo(123);
         await Assert.That(maximum).IsEqualTo(456);
+    }
+
+    private static async Task AssertBootstrapResolveTimeout(object options, int expected)
+    {
+        var value = (int)options.GetType().GetProperty("BootstrapResolveTimeoutMs")!.GetValue(options)!;
+        await Assert.That(value).IsEqualTo(expected);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -258,6 +258,40 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task TypedClientOptions_PreserveBootstrapResolveTimeout()
+    {
+        var services = new ServiceCollection();
+        services.AddDekaf(builder =>
+        {
+            builder.AddProducer<string, string>(new ProducerOptions
+            {
+                BootstrapServers = ["broker1:9092"],
+                BootstrapResolveTimeoutMs = 11000
+            });
+            builder.AddConsumer<string, string>(new ConsumerOptions
+            {
+                BootstrapServers = ["broker1:9092"],
+                GroupId = "group",
+                BootstrapResolveTimeoutMs = 12000
+            });
+            builder.AddAdminClient(new AdminClientOptions
+            {
+                BootstrapServers = ["broker1:9092"],
+                BootstrapResolveTimeoutMs = 13000
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+
+        await Assert.That(GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>())
+            .BootstrapResolveTimeoutMs).IsEqualTo(11000);
+        await Assert.That(GetConsumerOptions(provider.GetRequiredService<IKafkaConsumer<string, string>>())
+            .BootstrapResolveTimeoutMs).IsEqualTo(12000);
+        await Assert.That(GetAdminOptions(provider.GetRequiredService<IAdminClient>())
+            .BootstrapResolveTimeoutMs).IsEqualTo(13000);
+    }
+
+    [Test]
     public async Task AddProducer_WithTypedOptionsAndIdempotenceDisabled_UsesNonIdempotentMaxInFlightDefault()
     {
         var services = new ServiceCollection();
@@ -690,7 +724,8 @@ public class DependencyInjectionTests
             ["Kafka:Producers:Orders:MetadataRecoveryStrategy"] = "None",
             ["Kafka:Producers:Orders:MetadataClusterCheckEnabled"] = "false",
             ["Kafka:Producers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "60000",
-            ["Kafka:Producers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly"
+            ["Kafka:Producers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly",
+            ["Kafka:Producers:Orders:BootstrapResolveTimeoutMs"] = "11000"
         });
 
         services.AddDekaf(builder =>
@@ -745,6 +780,7 @@ public class DependencyInjectionTests
         await Assert.That(options.MetadataClusterCheckEnabled).IsFalse();
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(60000);
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
+        await Assert.That(options.BootstrapResolveTimeoutMs).IsEqualTo(11000);
     }
 
     [Test]
@@ -926,6 +962,7 @@ public class DependencyInjectionTests
             ["Kafka:Consumers:Orders:MetadataClusterCheckEnabled"] = "false",
             ["Kafka:Consumers:Orders:MetadataRecoveryRebootstrapTriggerMs"] = "90000",
             ["Kafka:Consumers:Orders:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly",
+            ["Kafka:Consumers:Orders:BootstrapResolveTimeoutMs"] = "12000",
             ["Kafka:Consumers:Orders:PrefetchPipelineDepth"] = "4",
             ["Kafka:Consumers:Orders:ConnectionsPerBroker"] = "2",
             ["Kafka:Consumers:Orders:EnableAdaptiveConnections"] = "false",
@@ -989,6 +1026,7 @@ public class DependencyInjectionTests
         await Assert.That(options.MetadataClusterCheckEnabled).IsFalse();
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(90000);
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
+        await Assert.That(options.BootstrapResolveTimeoutMs).IsEqualTo(12000);
         await Assert.That(options.PrefetchPipelineDepth).IsEqualTo(4);
         await Assert.That(options.ConnectionsPerBroker).IsEqualTo(2);
         await Assert.That(options.EnableAdaptiveConnections).IsFalse();
@@ -1110,7 +1148,8 @@ public class DependencyInjectionTests
             ["Kafka:Admin:MetadataRecoveryStrategy"] = "None",
             ["Kafka:Admin:MetadataClusterCheckEnabled"] = "false",
             ["Kafka:Admin:MetadataRecoveryRebootstrapTriggerMs"] = "120000",
-            ["Kafka:Admin:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly"
+            ["Kafka:Admin:ClientDnsLookup"] = "ResolveCanonicalBootstrapServersOnly",
+            ["Kafka:Admin:BootstrapResolveTimeoutMs"] = "13000"
         });
 
         services.AddDekaf(builder =>
@@ -1137,6 +1176,7 @@ public class DependencyInjectionTests
         await Assert.That(options.MetadataClusterCheckEnabled).IsFalse();
         await Assert.That(options.MetadataRecoveryRebootstrapTriggerMs).IsEqualTo(120000);
         await Assert.That(options.ClientDnsLookup).IsEqualTo(ClientDnsLookup.ResolveCanonicalBootstrapServersOnly);
+        await Assert.That(options.BootstrapResolveTimeoutMs).IsEqualTo(13000);
     }
 
     #endregion

--- a/tests/Dekaf.Tests.Unit/Metadata/BootstrapResolutionClientTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/BootstrapResolutionClientTests.cs
@@ -1,0 +1,166 @@
+using System.Net.Sockets;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Internal;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Metadata;
+
+public sealed class BootstrapResolutionClientTests
+{
+    [Test]
+    public async Task ProducerInitializeAsync_TransientDnsFailure_Recovers()
+    {
+        var infrastructure = CreateRecoveryInfrastructure();
+        await using var pool = infrastructure.Pool;
+        await using var metadataManager = infrastructure.MetadataManager;
+        await using var producer = new KafkaProducer<string, string>(
+            new ProducerOptions
+            {
+                BootstrapServers = ["recovering-host:9092"],
+                EnableIdempotence = false
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager,
+            DekafMemoryBudget.Global);
+
+        await producer.InitializeAsync();
+
+        await Assert.That(infrastructure.GetAttempts()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerInitializeAsync_TransientDnsFailure_Recovers()
+    {
+        var infrastructure = CreateRecoveryInfrastructure();
+        await using var pool = infrastructure.Pool;
+        await using var metadataManager = infrastructure.MetadataManager;
+        await using var consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["recovering-host:9092"],
+                GroupId = "group"
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager,
+            DekafMemoryBudget.Global);
+
+        await consumer.InitializeAsync();
+
+        await Assert.That(infrastructure.GetAttempts()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ShareConsumerInitializeAsync_TransientDnsFailure_Recovers()
+    {
+        var infrastructure = CreateRecoveryInfrastructure();
+        await using var pool = infrastructure.Pool;
+        await using var metadataManager = infrastructure.MetadataManager;
+        await using var consumer = new KafkaShareConsumer<string, string>(
+            new ShareConsumerOptions
+            {
+                BootstrapServers = ["recovering-host:9092"],
+                GroupId = "group"
+            },
+            Serializers.String,
+            Serializers.String,
+            pool,
+            metadataManager);
+
+        await consumer.InitializeAsync();
+
+        await Assert.That(infrastructure.GetAttempts()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task AdminProgress_TransientDnsFailure_Recovers()
+    {
+        var infrastructure = CreateRecoveryInfrastructure();
+        await using var pool = infrastructure.Pool;
+        await using var metadataManager = infrastructure.MetadataManager;
+        await using var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["recovering-host:9092"] },
+            pool,
+            metadataManager);
+
+        _ = await admin.ListTopicsAsync();
+
+        await Assert.That(infrastructure.GetAttempts()).IsEqualTo(2);
+    }
+
+    private static RecoveryInfrastructure CreateRecoveryInfrastructure()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.IsConnected.Returns(true);
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new MetadataResponse
+            {
+                Brokers = [new BrokerMetadata { NodeId = 1, Host = "recovering-host", Port = 9092 }],
+                Topics = []
+            }));
+
+        var attempts = 0;
+        var pool = new ConnectionPool(
+            clientId: null,
+            new ConnectionOptions
+            {
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            connectionsPerBroker: 1,
+            connectionFactory: (_, host, port, _, _) => Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<IKafkaConnection>(new DnsResolutionException(
+                    host,
+                    port,
+                    new SocketException((int)SocketError.HostNotFound)))
+                : ValueTask.FromResult(connection));
+        var metadataManager = new MetadataManager(
+            pool,
+            ["recovering-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 1,
+                MaxInitRetries = 0,
+                BootstrapResolveTimeoutMs = 1000,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+
+        return new RecoveryInfrastructure(pool, metadataManager, () => Volatile.Read(ref attempts));
+    }
+
+    private sealed record RecoveryInfrastructure(
+        ConnectionPool Pool,
+        MetadataManager MetadataManager,
+        Func<int> GetAttempts);
+}

--- a/tests/Dekaf.Tests.Unit/Metadata/BootstrapResolutionClientTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/BootstrapResolutionClientTests.cs
@@ -149,7 +149,7 @@ public sealed class BootstrapResolutionClientTests
             new MetadataOptions
             {
                 EnableBackgroundRefresh = false,
-                InitTimeoutMs = 1,
+                InitTimeoutMs = 1000,
                 MaxInitRetries = 0,
                 BootstrapResolveTimeoutMs = 1000,
                 RetryBackoffMs = 0,

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -558,11 +558,15 @@ public class MetadataManagerTests
     }
 
     [Test]
-    public async Task InitializeAsync_ShorterMetadataDeadlineDuringBootstrapDns_ThrowsMetadataTimeout()
+    public async Task InitializeAsync_MetadataDeadlineDoesNotCapBootstrapDnsRecovery()
     {
         var pool = Substitute.For<IConnectionPool>();
+        var connection = CreateSuccessfulMetadataConnection("recovering-host", 9092);
+        var attempts = 0;
         pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
-            .Returns(_ => ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092)));
+            .Returns(_ => Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092))
+                : ValueTask.FromResult(connection));
 
         await using var manager = new MetadataManager(
             pool,
@@ -576,12 +580,10 @@ public class MetadataManagerTests
                 RetryBackoffMaxMs = 0
             });
 
-        var exception = await Assert.That(() => manager.InitializeAsync().AsTask())
-            .Throws<KafkaTimeoutException>();
+        await manager.InitializeAsync();
 
-        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
-        await Assert.That(exception.InnerException).IsNotNull();
-        await Assert.That(exception.InnerException!.InnerException).IsTypeOf<DnsResolutionException>();
+        await Assert.That(attempts).IsEqualTo(2);
+        await Assert.That(manager.Metadata.LastRefreshed).IsNotEqualTo(default(DateTimeOffset));
     }
 
     [Test]
@@ -642,6 +644,37 @@ public class MetadataManagerTests
         await Assert.That(exception!.Timeout).IsEqualTo(TimeSpan.FromMilliseconds(20));
         await Assert.That(exception.UnresolvedBootstrapServers).IsEquivalentTo(["slow-host:9092"]);
         await Assert.That(Stopwatch.GetElapsedTime(startedAt)).IsLessThan(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task InitializeAsync_AfterBootstrapDeadlineFailure_GetsFreshDeadline()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = CreateSuccessfulMetadataConnection("recovering-host", 9092);
+        var resolve = 0;
+        pool.GetConnectionAsync("recovering-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(call => Volatile.Read(ref resolve) != 0
+                ? YieldSuccessfulConnectionAsync(connection, call.Arg<CancellationToken>())
+                : ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("recovering-host", 9092)));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["recovering-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 100,
+                RetryBackoffMs = 100,
+                RetryBackoffMaxMs = 100
+            });
+
+        await Assert.That(() => manager.InitializeAsync().AsTask())
+            .Throws<BootstrapResolutionException>();
+
+        Volatile.Write(ref resolve, 1);
+        await manager.InitializeAsync();
+
+        await Assert.That(manager.Metadata.LastRefreshed).IsNotEqualTo(default(DateTimeOffset));
     }
 
     [Test]
@@ -1008,6 +1041,30 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task RefreshMetadataAsync_BootstrapDnsFailure_ThrowsPublicException()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092)));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 1000
+            });
+
+        var exception = await Assert.That(() => manager.RefreshMetadataAsync().AsTask())
+            .Throws<BootstrapResolutionException>();
+
+        await Assert.That(exception!.UnresolvedBootstrapServers)
+            .IsEquivalentTo(["missing-host:9092"]);
+        await Assert.That(exception.InnerException).IsTypeOf<DnsResolutionException>();
+    }
+
+    [Test]
     public async Task BackgroundRefreshLoop_ObjectDisposedConnection_DoesNotResetInitialized()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -1116,6 +1173,15 @@ public class MetadataManagerTests
         {
             throw new DnsResolutionException(host, port, ex);
         }
+    }
+
+    private static async ValueTask<IKafkaConnection> YieldSuccessfulConnectionAsync(
+        IKafkaConnection connection,
+        CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+        cancellationToken.ThrowIfCancellationRequested();
+        return connection;
     }
 
     private static IKafkaConnection CreateSuccessfulMetadataConnection(string host, int port)

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -612,6 +612,39 @@ public class MetadataManagerTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task InitializeAsync_FirstBootstrapDnsAttempt_RespectsDedicatedDeadline(
+        CancellationToken cancellationToken)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("slow-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(call => WaitForDnsCancellationAsync(
+                "slow-host",
+                9092,
+                call.Arg<CancellationToken>()));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["slow-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 1000,
+                BootstrapResolveTimeoutMs = 20,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+        var startedAt = Stopwatch.GetTimestamp();
+
+        var exception = await Assert.That(() => manager.InitializeAsync(cancellationToken).AsTask())
+            .Throws<BootstrapResolutionException>();
+
+        await Assert.That(exception!.Timeout).IsEqualTo(TimeSpan.FromMilliseconds(20));
+        await Assert.That(exception.UnresolvedBootstrapServers).IsEquivalentTo(["slow-host:9092"]);
+        await Assert.That(Stopwatch.GetElapsedTime(startedAt)).IsLessThan(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
     public async Task InitializeAsync_OneResolvableBootstrapHost_Succeeds()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -1068,6 +1101,22 @@ public class MetadataManagerTests
 
     private static DnsResolutionException CreateDnsFailure(string host, int port) =>
         new(host, port, new SocketException((int)SocketError.HostNotFound));
+
+    private static async ValueTask<IKafkaConnection> WaitForDnsCancellationAsync(
+        string host,
+        int port,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The DNS deadline did not cancel the lookup.");
+        }
+        catch (OperationCanceledException ex)
+        {
+            throw new DnsResolutionException(host, port, ex);
+        }
+    }
 
     private static IKafkaConnection CreateSuccessfulMetadataConnection(string host, int port)
     {

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -678,6 +678,34 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task InitializeAsync_AfterConnectionPhase_DnsFailureUsesMetadataRetryPolicy()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var attempts = 0;
+        pool.GetConnectionAsync("intermittent-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(call => Interlocked.Increment(ref attempts) == 1
+                ? WaitForCancellationAsync(call.Arg<CancellationToken>())
+                : ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("intermittent-host", 9092)));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["intermittent-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 1000,
+                MaxInitRetries = 1,
+                BootstrapResolveTimeoutMs = 10,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+
+        await Assert.That(() => manager.InitializeAsync().AsTask())
+            .Throws<InvalidOperationException>();
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task InitializeAsync_OneResolvableBootstrapHost_Succeeds()
     {
         var pool = Substitute.For<IConnectionPool>();
@@ -1182,6 +1210,13 @@ public class MetadataManagerTests
         await Task.Yield();
         cancellationToken.ThrowIfCancellationRequested();
         return connection;
+    }
+
+    private static async ValueTask<IKafkaConnection> WaitForCancellationAsync(
+        CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("The bootstrap deadline did not cancel the connection attempt.");
     }
 
     private static IKafkaConnection CreateSuccessfulMetadataConnection(string host, int port)

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -544,7 +544,7 @@ public class MetadataManagerTests
             new MetadataOptions
             {
                 EnableBackgroundRefresh = false,
-                InitTimeoutMs = 1,
+                InitTimeoutMs = 1000,
                 MaxInitRetries = 0,
                 BootstrapResolveTimeoutMs = 1000,
                 RetryBackoffMs = 0,
@@ -555,6 +555,33 @@ public class MetadataManagerTests
 
         await Assert.That(attempts).IsEqualTo(3);
         await Assert.That(manager.Metadata.LastRefreshed).IsNotEqualTo(default(DateTimeOffset));
+    }
+
+    [Test]
+    public async Task InitializeAsync_ShorterMetadataDeadlineDuringBootstrapDns_ThrowsMetadataTimeout()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092)));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 0,
+                BootstrapResolveTimeoutMs = 1000,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+
+        var exception = await Assert.That(() => manager.InitializeAsync().AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Metadata);
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(exception.InnerException!.InnerException).IsTypeOf<DnsResolutionException>();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Metadata/MetadataManagerTests.cs
@@ -528,6 +528,149 @@ public class MetadataManagerTests
     }
 
     [Test]
+    public async Task InitializeAsync_TransientBootstrapDnsFailure_RecoversWithinDedicatedDeadline()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = CreateSuccessfulMetadataConnection("recovering-host", 9092);
+        var attempts = 0;
+        pool.GetConnectionAsync("recovering-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => Interlocked.Increment(ref attempts) <= 2
+                ? ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("recovering-host", 9092))
+                : ValueTask.FromResult<IKafkaConnection>(connection));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["recovering-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                InitTimeoutMs = 1,
+                MaxInitRetries = 0,
+                BootstrapResolveTimeoutMs = 1000,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+
+        await manager.InitializeAsync();
+
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(manager.Metadata.LastRefreshed).IsNotEqualTo(default(DateTimeOffset));
+    }
+
+    [Test]
+    public async Task InitializeAsync_BootstrapDnsDeadlineExpires_ThrowsDedicatedException()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092)));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 0,
+                RetryBackoffMs = 0,
+                RetryBackoffMaxMs = 0
+            });
+
+        var exception = await Assert.That(() => manager.InitializeAsync().AsTask())
+            .Throws<BootstrapResolutionException>();
+
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.Timeout).IsEqualTo(TimeSpan.Zero);
+        await Assert.That(exception.UnresolvedBootstrapServers).IsEquivalentTo(["missing-host:9092"]);
+        await Assert.That(exception.InnerException).IsTypeOf<DnsResolutionException>();
+    }
+
+    [Test]
+    public async Task InitializeAsync_OneResolvableBootstrapHost_Succeeds()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var connection = CreateSuccessfulMetadataConnection("available-host", 9093);
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092)));
+        pool.GetConnectionAsync("available-host", 9093, Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<IKafkaConnection>(connection));
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092", "available-host:9093"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 0
+            });
+
+        await manager.InitializeAsync();
+
+        await Assert.That(manager.Metadata.LastRefreshed).IsNotEqualTo(default(DateTimeOffset));
+    }
+
+    [Test]
+    public async Task InitializeAsync_BootstrapDnsRetry_CancellationStopsPromptly()
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var attempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                attempted.TrySetResult();
+                return ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092));
+            });
+
+        await using var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 120000,
+                RetryBackoffMs = 1000,
+                RetryBackoffMaxMs = 1000
+            });
+        using var cts = new CancellationTokenSource();
+        var initialization = manager.InitializeAsync(cts.Token).AsTask();
+        await attempted.Task;
+
+        cts.Cancel();
+
+        await Assert.That(initialization).Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task InitializeAsync_BootstrapDnsRetry_DisposalStopsPromptly(CancellationToken cancellationToken)
+    {
+        var pool = Substitute.For<IConnectionPool>();
+        var attempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        pool.GetConnectionAsync("missing-host", 9092, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                attempted.TrySetResult();
+                return ValueTask.FromException<IKafkaConnection>(CreateDnsFailure("missing-host", 9092));
+            });
+
+        var manager = new MetadataManager(
+            pool,
+            ["missing-host:9092"],
+            new MetadataOptions
+            {
+                EnableBackgroundRefresh = false,
+                BootstrapResolveTimeoutMs = 120000,
+                RetryBackoffMs = 1000,
+                RetryBackoffMaxMs = 1000
+            });
+        var initialization = manager.InitializeAsync(CancellationToken.None).AsTask();
+        await attempted.Task.WaitAsync(cancellationToken);
+
+        await manager.DisposeAsync().AsTask().WaitAsync(cancellationToken);
+
+        await Assert.That(initialization).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
     public async Task InitializeAsync_SixthBootstrapFailure_LogsWarning()
     {
         var pool = CreateFailingConnectionPool();
@@ -894,6 +1037,35 @@ public class MetadataManagerTests
         pool.GetConnectionAsync("localhost", 9092, Arg.Any<CancellationToken>())
             .Returns(_ => ValueTask.FromException<IKafkaConnection>(new SocketException()));
         return pool;
+    }
+
+    private static DnsResolutionException CreateDnsFailure(string host, int port) =>
+        new(host, port, new SocketException((int)SocketError.HostNotFound));
+
+    private static IKafkaConnection CreateSuccessfulMetadataConnection(string host, int port)
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                Arg.Any<ApiVersionsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys =
+                [
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
+            }));
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse((1, host, port))));
+        return connection;
     }
 
     private static bool IsFatalMetadataError(MetadataManager metadataManager, Exception exception)

--- a/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ClientDnsLookupTests.cs
@@ -96,6 +96,58 @@ public sealed class ClientDnsLookupTests
         await Assert.That(endpoints[0].Address).IsEqualTo(IPAddress.Loopback);
     }
 
+    [Test]
+    public async Task KafkaConnection_ConnectAsync_DnsFailure_PreservesResolutionContext()
+    {
+        await using var connection = new KafkaConnection(
+            "missing.example",
+            9092,
+            options: new ConnectionOptions
+            {
+                DnsResolver = new ClientDnsEndpointResolver(new ThrowingDnsLookup())
+            });
+
+        var exception = await Assert.That(() => connection.ConnectAsync().AsTask())
+            .Throws<DnsResolutionException>();
+
+        await Assert.That(exception!.Host).IsEqualTo("missing.example");
+        await Assert.That(exception.Port).IsEqualTo(9092);
+        await Assert.That(exception.InnerException).IsTypeOf<SocketException>();
+    }
+
+    [Test]
+    public async Task KafkaConnection_ConnectAsync_SlowDnsConnectionDeadline_IsResolutionFailure()
+    {
+        await using var connection = new KafkaConnection(
+            "slow.example",
+            9092,
+            options: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromMilliseconds(10),
+                DnsResolver = new ClientDnsEndpointResolver(new BlockingDnsLookup())
+            });
+
+        await Assert.That(() => connection.ConnectAsync().AsTask())
+            .Throws<DnsResolutionException>();
+    }
+
+    [Test]
+    public async Task KafkaConnection_ConnectAsync_CallerCancelsDns_PreservesCancellation()
+    {
+        await using var connection = new KafkaConnection(
+            "slow.example",
+            9092,
+            options: new ConnectionOptions
+            {
+                ConnectionTimeout = TimeSpan.FromSeconds(5),
+                DnsResolver = new ClientDnsEndpointResolver(new BlockingDnsLookup())
+            });
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(10));
+
+        await Assert.That(() => connection.ConnectAsync(cts.Token).AsTask())
+            .Throws<OperationCanceledException>();
+    }
+
     private static async Task<Socket> AcceptAndCompleteHandshakeAsync(TcpListener listener)
     {
         var socket = await listener.AcceptSocketAsync();
@@ -159,6 +211,30 @@ public sealed class ClientDnsLookupTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return ValueTask.FromResult(_hostEntry);
+        }
+    }
+
+    private sealed class ThrowingDnsLookup : IDnsLookup
+    {
+        public ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken) =>
+            ValueTask.FromException<IPAddress[]>(new SocketException((int)SocketError.HostNotFound));
+
+        public ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken) =>
+            ValueTask.FromException<IPHostEntry>(new SocketException((int)SocketError.HostNotFound));
+    }
+
+    private sealed class BlockingDnsLookup : IDnsLookup
+    {
+        public async ValueTask<IPAddress[]> GetHostAddressesAsync(string host, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return [];
+        }
+
+        public async ValueTask<IPHostEntry> GetHostEntryAsync(string host, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new IPHostEntry();
         }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using Dekaf.Errors;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -70,6 +71,43 @@ public sealed class RetryHelperTests
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task DnsResolutionFailure_RetriesOriginalOperation()
+    {
+        await using var metadataManager = CreateUnavailableMetadataManager();
+        var attempts = 0;
+
+        var result = await RetryHelper.WithRetryAsync(
+            () => Interlocked.Increment(ref attempts) == 1
+                ? ValueTask.FromException<int>(new DnsResolutionException(
+                    "broker",
+                    9092,
+                    new SocketException((int)SocketError.HostNotFound)))
+                : ValueTask.FromResult(42),
+            metadataManager,
+            CancellationToken.None,
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0,
+            maxRetries: 1);
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task BootstrapResolutionDeadline_RemainsNonRetriable()
+    {
+        var exception = new BootstrapResolutionException(
+            ["broker:9092"],
+            TimeSpan.FromSeconds(1),
+            new DnsResolutionException(
+                "broker",
+                9092,
+                new SocketException((int)SocketError.HostNotFound)));
+
+        await Assert.That(RetryHelper.IsRetriableRequestFailure(exception)).IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add KIP-909 `bootstrap.resolve.timeout.ms` equivalents across producer, consumer, share consumer, Admin, root client, and DI configuration
- retry initial bootstrap-only DNS failures under an independent bounded deadline, with cancellation/disposal and multi-host handling
- surface non-retriable `BootstrapResolutionException` with unresolved endpoint context
- preserve rebootstrap and `ClientDnsLookup` behavior; document the new option

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- focused DNS/metadata/client/builder/DI tests: 173/173 on net10.0 and 173/173 on net8.0
- full unit suite: 5954/5954 on net10.0 and 5827/5827 on net8.0
- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release`
- `git diff --check`

## Performance
Connection/bootstrap control paths only; no per-message serialization, produce, consume, batch, or receive-loop changes. No hot-path benchmark required.

Closes #2240