### PR TITLE
fix(producer): preserve pin on local ID miss

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4087,8 +4087,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         {
             // Send failed (connection error, timeout, etc.) — retry batches instead of permanently failing.
             // Aligned with Java Kafka's Sender: transient failures cause reenqueue for retry.
-            _pinnedConnections[connectionIndex] = null; // Invalidate only the broken connection
-            LogResponseFailed(ex, _brokerId);
+            if (ex is not LocalTopicIdMissException)
+            {
+                _pinnedConnections[connectionIndex] = null; // Invalidate only the broken connection
+                LogResponseFailed(ex, _brokerId);
+            }
 
             for (var i = 0; i < count; i++)
             {
@@ -4192,6 +4195,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         batch.RetryNotBefore = _getTimestamp() + (long)(delayMs * StopwatchTicksPerMillisecond);
         return delayMs;
     }
+
+    private sealed class LocalTopicIdMissException(string message)
+        : KafkaException(Protocol.ErrorCode.UnknownTopicId, message);
 
     /// <summary>
     /// Pre-allocated scratch space for building ProduceRequest without per-send allocations.
@@ -4334,8 +4340,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         // exception-path ClearReferences() releases those batch references.
                         _lastTopicCount = Math.Max(_lastTopicCount, topicIdx);
                         _lastPartitionCount = Math.Max(_lastPartitionCount, partIdx);
-                        throw new KafkaException(
-                            ErrorCode.UnknownTopicId,
+                        throw new LocalTopicIdMissException(
                             $"Produce v{apiVersion} requires a current topic ID for '{topicName}'.");
                     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1140,6 +1140,58 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
 
     [Test]
     [Timeout(120_000)]
+    public async Task SendLoop_ProduceV13_LocalTopicIdMissPreservesPinnedConnection(
+        CancellationToken cancellationToken)
+    {
+        const string topic = "local-topic-id-miss";
+        var topicId = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+        var response = new TaskCompletionSource<ProduceResponse>();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (pool, connection) = CreateMockConnection(
+            new Queue<TaskCompletionSource<ProduceResponse>>([response]),
+            () => sent.TrySetResult());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+        var options = CreateOptions(retryBackoffMs: 0, retryBackoffMaxMs: 0);
+        var accumulator = new RecordAccumulator(options);
+        await using var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(CreateLeaderMetadataResponse(topic, 1, 1, topicId: Guid.Empty));
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledged = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) => acknowledged.TrySetResult(error),
+            metadataManager,
+            produceApiVersion: 13);
+        var batch = CreateTestBatch(valueTaskSourcePool, topic, partition: 0);
+
+        try
+        {
+            sender.Enqueue(batch);
+            await WaitUntilAsync(() => batch.DiagTrace.Contains('Z'), cancellationToken);
+
+            await Assert.That(GetPinnedConnection(sender, 0)).IsSameReferenceAs(connection);
+
+            metadataManager.Metadata.Update(CreateLeaderMetadataResponse(topic, 1, 2, topicId: topicId));
+            await sent.Task.WaitAsync(cancellationToken);
+            response.SetResult(CreateTopicIdResponse(topicId, 0, ErrorCode.None, baseOffset: 42));
+
+            await Assert.That(await acknowledged.Task.WaitAsync(cancellationToken)).IsNull();
+            await Assert.That(GetPinnedConnection(sender, 0)).IsSameReferenceAs(connection);
+            await Assert.That(connection.SendPipelinedAfterWriteCalls).IsEqualTo(1);
+        }
+        finally
+        {
+            response.TrySetResult(CreateTopicIdResponse(topicId, 0, ErrorCode.None));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
     public async Task SendLoop_ProduceV12_FallsBackToTopicNames(
         CancellationToken cancellationToken)
     {
@@ -4077,6 +4129,11 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         (int)typeof(BrokerSender).GetField(
             "_totalPendingResponseCount",
             BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!;
+
+    private static IKafkaConnection? GetPinnedConnection(BrokerSender sender, int connectionIndex) =>
+        ((IKafkaConnection?[])typeof(BrokerSender).GetField(
+            "_pinnedConnections",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!)[connectionIndex];
 
     private static int GetDeferredPendingResponseCleanupCount(BrokerSender sender) =>
         (int)typeof(BrokerSender).GetField(

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchIncarnationTests.cs
@@ -270,7 +270,7 @@ public sealed class ReadyBatchIncarnationTests
             thrown = exception;
         }
 
-        await Assert.That(thrown?.InnerException).IsTypeOf<KafkaException>();
+        await Assert.That(thrown?.InnerException is KafkaException).IsTrue();
         await Assert.That(((KafkaException)thrown!.InnerException!).ErrorCode)
             .IsEqualTo(ErrorCode.UnknownTopicId);
         await Assert.That(recordBatches[0][0]).IsSameReferenceAs(knownTopicBatch.RecordBatch);


### PR DESCRIPTION
## Summary
- tag the pre-send Produce v13 topic-ID cache miss with an internal exception type
- preserve the healthy pinned connection and avoid transport-failure logging for that local miss
- prove retry uses the same connection, sends only after metadata supplies the topic ID, and acknowledges once

Follow-up to the blocking current-head review on merged #2313 / #2231.

## Performance
The successful coalesced-send path gains no assignment, branch, allocation, or virtual dispatch. The only changed runtime behavior is the already-exceptional local topic-ID-miss path; it allocates the same single `KafkaException` object via a sealed internal subtype.

Attempted exact base `Dekaf_ProduceBatch` `[MemoryDiagnoser]` run on `11810b81`, but all four baseline cases produced no measurements: the Docker Kafka broker advertised the host-mapped port back inside the container, so topic creation and initial metadata timed out. The failed baseline was not repeated unchanged, and no candidate comparison is claimed.

## Validation
- Release unit build: 0 warnings/errors
- `BrokerSenderSendLoopTests` + `ReadyBatchIncarnationTests`: 81/81 net10.0; 81/81 net8.0
- full units: 5,940/5,940 net10.0
- full net8.0: 5,812 passed, 1 unrelated existing timing failure in `ConsumerProtocol_SteadyHeartbeat_CrossesMaxPollWhileAcquiringConnection_DoesNotSend`; investigation found its final `DidNotReceive` includes steady-heartbeat calls recorded before the measured phase
- Release integration build: 0 warnings/errors