### PR TITLE
test(consumer): isolate heartbeat phase

### DIFF
--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -496,6 +496,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
         await coordinator.StopHeartbeatAsync();
+        // Isolate the explicit heartbeat below from calls completed before the background loop stopped.
+        _connection.ClearReceivedCalls();
 
         var connectionRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var connectionAvailable = new TaskCompletionSource<IKafkaConnection>(


### PR DESCRIPTION
## Summary
- clear substitute call history after the background heartbeat loop is stopped
- make the max-poll acquisition test assert only calls from its explicit measured heartbeat
- remove scheduling dependence without delays or retries

Closes #2322.

## Validation
- Release unit build: 0 warnings/errors
- exact test: 20/20 consecutive net8.0; 1/1 net10.0
- full units: 5,942/5,942 net10.0; 5,815/5,815 net8.0

Test-only change; no runtime or allocation impact.