### PR TITLE
feat(share-consumer): implement KIP-1222 renewal

### DIFF
--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -83,6 +83,7 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     }
 
     public string? MemberId => _memberId;
+    public int? AcquisitionLockTimeoutMs => null;
 
 #if !NET10_0_OR_GREATER
     IReadOnlyCollection<string> IKafkaShareConsumer<TKey, TValue>.Subscription => Subscription;

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -545,6 +545,10 @@ public sealed class BrokerVersionException : KafkaException
     public BrokerVersionException(string message, Exception innerException) : base(message, innerException)
     {
     }
+
+    public BrokerVersionException(ErrorCode errorCode, string message) : base(errorCode, message)
+    {
+    }
 }
 
 /// <summary>

--- a/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/IKafkaShareConsumer.cs
@@ -38,6 +38,12 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     string? MemberId { get; }
 
     /// <summary>
+    /// Gets the acquisition lock timeout reported by the latest applicable ShareFetch or
+    /// renewal ShareAcknowledge response, or <see langword="null"/> before one is available.
+    /// </summary>
+    int? AcquisitionLockTimeoutMs { get; }
+
+    /// <summary>
     /// Subscribes to topics. Share groups do not support manual partition assignment.
     /// </summary>
     IKafkaShareConsumer<TKey, TValue> Subscribe(params string[] topics);
@@ -61,7 +67,8 @@ public interface IKafkaShareConsumer<TKey, TValue> : IInitializableKafkaClient, 
     IAsyncEnumerable<ShareConsumeResult<TKey, TValue>> PollAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Sets the acknowledgement type for a specific record.
+    /// Sets the acknowledgement type for a specific record. Renewal is supported only in
+    /// explicit acknowledgement mode and requires ShareFetch/ShareAcknowledge v2.
     /// In implicit acknowledgement mode, records default to <see cref="AcknowledgeType.Accept"/>.
     /// <para>
     /// <b>Warning:</b> In implicit mode, call this before the next <see cref="PollAsync"/> or

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -388,11 +388,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 }
             }
 
-            if (recordCount < _options.MaxPollRecords && _renewedRecords is { Count: > 0 })
+            var bufferedRecordCount = fetchedRecords?.Count ?? 0;
+            if (recordCount + bufferedRecordCount < _options.MaxPollRecords
+                && _renewedRecords is { Count: > 0 })
             {
                 var renewedRecords = GetActiveRenewedRecords(
                     assignment,
-                    _options.MaxPollRecords - recordCount);
+                    _options.MaxPollRecords - recordCount - bufferedRecordCount);
                 foreach (var renewedRecord in renewedRecords)
                 {
                     Interlocked.Increment(ref _renewedRecordReplayCount);

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -51,6 +51,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     private int _disposed;
     private readonly bool _ownsInfrastructure;
     private volatile Task? _pendingReleaseTask;
+    private Dictionary<RenewedRecordKey, RenewedRecordState>? _renewedRecords;
+    private int _acquisitionLockTimeoutMs = -1;
+    private long _renewalRequestCount;
+    private long _renewedRecordReplayCount;
 
     internal KafkaShareConsumer(
         ShareConsumerOptions options,
@@ -158,6 +162,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     public StringSet Subscription => _subscriptionSnapshot;
     public TopicPartitionSet Assignment => _assignmentSnapshot;
     public string? MemberId => _coordinator.MemberId;
+    public int? AcquisitionLockTimeoutMs
+    {
+        get
+        {
+            var timeoutMs = Volatile.Read(ref _acquisitionLockTimeoutMs);
+            return timeoutMs >= 0 ? timeoutMs : null;
+        }
+    }
+
+    internal long RenewalRequestCount => Interlocked.Read(ref _renewalRequestCount);
+    internal long RenewedRecordReplayCount => Interlocked.Read(ref _renewedRecordReplayCount);
 
     public async ValueTask InitializeAsync(CancellationToken cancellationToken = default)
     {
@@ -198,6 +213,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
         _subscriptionSnapshot = new HashSet<string>();
         _sessionManager.ResetAll();
+        ClearRenewedRecords();
         return this;
     }
 
@@ -218,6 +234,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             _assignmentSnapshot = _coordinator.Assignment;
 
             var assignment = _assignmentSnapshot;
+            RemoveRenewedRecordsOutsideAssignment(assignment);
             if (assignment.Count == 0)
             {
                 // No partitions assigned (e.g. rebalance removed them while state is Stable).
@@ -236,7 +253,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             // Send fetch requests to all brokers concurrently. Session epochs are per-broker
             // and independent, so parallelism is safe. This avoids waiting for each broker's
             // MaxWaitMs sequentially when partitions span multiple brokers.
-            var fetchTasks = new List<Task<(int BrokerId, ShareFetchResponse? Response)>>(
+            var fetchTasks = new List<Task<ShareFetchBrokerResult>>(
                 partitionsByBroker.Count);
 
             foreach (var (brokerId, partitions) in partitionsByBroker)
@@ -244,20 +261,35 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 fetchTasks.Add(SendShareFetchForPartitionsAsync(brokerId, partitions, pendingAcks, cancellationToken));
             }
 
-            await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+            try
+            {
+                await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (pendingAcks is not null)
+                    _ackTracker.RequeueAcks(pendingAcks);
+                throw;
+            }
 
             // Process responses sequentially — yielding records and tracking acks
             var recordCount = 0;
+            List<ShareConsumeResult<TKey, TValue>>? fetchedRecords = _renewedRecords is null
+                ? null
+                : new List<ShareConsumeResult<TKey, TValue>>(_options.MaxPollRecords);
 
             foreach (var fetchTask in fetchTasks)
             {
-                if (recordCount >= _options.MaxPollRecords)
+                if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
                     break;
 
-                var (brokerId, response) = fetchTask.Result;
+                var (brokerId, version, response, sentAcks) = fetchTask.Result;
 
                 if (response is null)
+                {
+                    RequeueAcknowledgements(sentAcks);
                     continue;
+                }
 
                 // Handle top-level errors
                 if (response.ErrorCode != ErrorCode.None)
@@ -267,39 +299,31 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
+                        ClearRenewedRecords();
                         // Note: _ackTracker may still hold pending acks from the now-invalid session.
                         // On next CommitAsync those acks will be sent with epoch 0 (new session).
                         // The broker will reject them if the old record locks have expired, which is
                         // safe — CommitAsync will re-queue the failed acks for retry.
                     }
+                    RequeueAcknowledgements(sentAcks);
                     continue;
                 }
 
-                // Check whether any partition in this response has acquired records.
-                // We must advance the session epoch BEFORE yielding so that even if
+                // Advance the session epoch BEFORE yielding so that even if
                 // the caller breaks from the async enumerable (disposing the iterator),
                 // the epoch is already correct for a subsequent ShareAcknowledge/CommitAsync.
-                // Without this, the session epoch stays at 0 while the broker expects 1,
-                // causing InvalidShareSessionEpoch on the next request.
-                var hasAcquiredRecords = false;
-                for (var ti = 0; ti < response.Responses.Count && !hasAcquiredRecords; ti++)
-                {
-                    var respPartitions = response.Responses[ti].Partitions;
-                    for (var pi = 0; pi < respPartitions.Count; pi++)
-                    {
-                        var p = respPartitions[pi];
-                        if (p.ErrorCode == ErrorCode.None && !p.RecordBytes.IsEmpty &&
-                            p.AcquiredRecords.Count > 0)
-                        {
-                            hasAcquiredRecords = true;
-                            break;
-                        }
-                    }
-                }
+                _sessionManager.IncrementEpoch(brokerId);
+                if (version >= 1)
+                    Volatile.Write(ref _acquisitionLockTimeoutMs, response.AcquisitionLockTimeoutMs);
 
-                if (hasAcquiredRecords)
+                if (TryGetAcknowledgementError(response, out var acknowledgementError))
                 {
-                    _sessionManager.IncrementEpoch(brokerId);
+                    RequeueAcknowledgements(sentAcks);
+                    LogInlineAcknowledgeFailed(brokerId, acknowledgementError);
+                }
+                else
+                {
+                    ApplySuccessfulAcknowledgements(sentAcks);
                 }
 
                 // Process partition responses
@@ -324,13 +348,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         // Parse all records from this partition eagerly (KafkaProtocolReader is a
                         // ref struct and cannot be preserved across yield boundaries)
                         var parsed = ParsePartitionRecords(
-                            topicInfo, partition, _options.MaxPollRecords - recordCount);
+                            topicInfo,
+                            partition,
+                            _options.MaxPollRecords - (fetchedRecords?.Count ?? recordCount));
 
                         var tp = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
 
                         foreach (var result in parsed)
                         {
-                            if (recordCount >= _options.MaxPollRecords)
+                            if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
                                 break;
 
                             // Track only records actually yielded to the consumer so implicit
@@ -340,10 +366,43 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                                 _ackTracker.TrackDeliveredRecords(tp, result.Offset, result.Offset);
                             }
 
+                            RemoveRenewedRecord(result.Topic, result.Partition, result.Offset);
+
+                            if (fetchedRecords is not null)
+                            {
+                                fetchedRecords.Add(result);
+                                continue;
+                            }
+
                             recordCount++;
                             yield return result;
                         }
                     }
+                }
+            }
+
+            if (recordCount < _options.MaxPollRecords && _renewedRecords is { Count: > 0 })
+            {
+                var renewedRecords = GetActiveRenewedRecords(
+                    assignment,
+                    _options.MaxPollRecords - recordCount);
+                foreach (var renewedRecord in renewedRecords)
+                {
+                    Interlocked.Increment(ref _renewedRecordReplayCount);
+                    recordCount++;
+                    yield return renewedRecord;
+                }
+            }
+
+            if (fetchedRecords is not null)
+            {
+                foreach (var fetchedRecord in fetchedRecords)
+                {
+                    if (recordCount >= _options.MaxPollRecords)
+                        break;
+
+                    recordCount++;
+                    yield return fetchedRecord;
                 }
             }
 
@@ -356,6 +415,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     {
         ThrowIfDisposed();
 
+        if (type == AcknowledgeType.Renew
+            && _options.AcknowledgementMode != ShareAcknowledgementMode.Explicit)
+        {
+            throw new InvalidOperationException(
+                "Renew acknowledgements require explicit acknowledgement mode.");
+        }
+
         record.AcknowledgeType = type;
         var tp = new TopicPartition(record.Topic, record.Partition);
         _ackTracker.Acknowledge(
@@ -363,6 +429,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             record.Offset,
             type,
             requireTracked: _options.AcknowledgementMode == ShareAcknowledgementMode.Implicit);
+
+        TrackRenewalDisposition(record, type);
     }
 
     public async ValueTask CommitAsync(CancellationToken cancellationToken = default)
@@ -404,7 +472,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         foreach (var (acks, error) in results)
         {
             if (error is null)
+            {
+                ApplySuccessfulAcknowledgements(acks);
                 continue;
+            }
 
             firstError ??= error;
             _ackTracker.RequeueAcks(acks);
@@ -412,6 +483,9 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
         if (firstError is not null)
         {
+            if (firstError is BrokerVersionException)
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstError).Throw();
+
             throw new KafkaException(
                 $"CommitAsync partially failed — failed partitions have been re-queued for retry",
                 firstError);
@@ -424,6 +498,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             return;
 
         LogClosingShareConsumer();
+        ClearRenewedRecords();
 
         // Step 1: Flush all pending acks as Accept via ShareAcknowledge
         if (_ackTracker.HasPending)
@@ -458,8 +533,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        ClearRenewedRecords();
+
         // Ensure close is called
-        if (Interlocked.Exchange(ref _closed, 1) == 0)
+        if (Volatile.Read(ref _closed) == 0)
         {
             try
             {
@@ -559,12 +636,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         });
     }
 
-    private async Task<(int BrokerId, ShareFetchResponse? Response)> SendShareFetchForPartitionsAsync(
+    private async Task<ShareFetchBrokerResult> SendShareFetchForPartitionsAsync(
         int brokerId,
         List<TopicPartition> partitions,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>>? pendingAcks,
         CancellationToken cancellationToken)
     {
+        var brokerAcks = SelectAcknowledgements(pendingAcks, partitions);
+        var isRenewAck = ContainsRenewAcknowledgement(brokerAcks);
+
         for (var attempt = 0; ; attempt++)
         {
             try
@@ -577,19 +657,21 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     ApiKey.ShareFetch,
                     ShareFetchRequest.LowestSupportedVersion,
                     ShareFetchRequest.HighestSupportedVersion);
-                var maxRecords = version >= 1 ? _options.MaxPollRecords : 0;
+                EnsureRenewalSupported(ApiKey.ShareFetch, version, isRenewAck);
+                var maxRecords = !isRenewAck && version >= 1 ? _options.MaxPollRecords : 0;
                 var request = new ShareFetchRequest
                 {
                     GroupId = _options.GroupId,
                     MemberId = _coordinator.MemberId!,
                     ShareSessionEpoch = _sessionManager.GetSessionEpoch(brokerId),
-                    MaxWaitMs = _options.FetchMaxWaitMs,
-                    MinBytes = _options.FetchMinBytes,
-                    MaxBytes = _options.FetchMaxBytes,
+                    MaxWaitMs = isRenewAck ? 0 : _options.FetchMaxWaitMs,
+                    MinBytes = isRenewAck ? 0 : _options.FetchMinBytes,
+                    MaxBytes = isRenewAck ? 0 : _options.FetchMaxBytes,
                     MaxRecords = maxRecords,
-                    BatchSize = maxRecords,
+                    BatchSize = isRenewAck ? 0 : maxRecords,
                     ShareAcquireMode = (sbyte)_options.ShareAcquireMode,
-                    Topics = BuildShareFetchTopics(partitions, pendingAcks, version)
+                    IsRenewAck = isRenewAck,
+                    Topics = BuildShareFetchTopics(partitions, brokerAcks, version)
                 };
                 var response = (ShareFetchResponse)await connection
                     .SendAsync<ShareFetchRequest, ShareFetchResponse>(request, version, cancellationToken)
@@ -601,7 +683,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     continue;
                 }
 
-                return (brokerId, response);
+                return new ShareFetchBrokerResult(brokerId, version, response, brokerAcks);
             }
             catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)
             {
@@ -613,7 +695,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 LogFetchFailed(brokerId, ex);
                 _sessionManager.ResetSession(brokerId);
-                return (brokerId, null);
+                ClearRenewedRecords();
+                return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks);
             }
         }
     }
@@ -681,15 +764,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         CancellationToken cancellationToken)
     {
         var topics = BuildShareAcknowledgeTopics(topicAcks);
-        var sessionEpoch = _sessionManager.GetSessionEpoch(brokerId);
-
-        var request = new ShareAcknowledgeRequest
-        {
-            GroupId = _options.GroupId,
-            MemberId = _coordinator.MemberId!,
-            ShareSessionEpoch = sessionEpoch,
-            Topics = topics
-        };
+        var isRenewAck = ContainsRenewAcknowledgement(topicAcks);
 
         for (var attempt = 0; ; attempt++)
         {
@@ -703,7 +778,16 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     ApiKey.ShareAcknowledge,
                     ShareAcknowledgeRequest.LowestSupportedVersion,
                     ShareAcknowledgeRequest.HighestSupportedVersion);
+                EnsureRenewalSupported(ApiKey.ShareAcknowledge, shareAckVersion, isRenewAck);
 
+                var request = new ShareAcknowledgeRequest
+                {
+                    GroupId = _options.GroupId,
+                    MemberId = _coordinator.MemberId!,
+                    ShareSessionEpoch = _sessionManager.GetSessionEpoch(brokerId),
+                    IsRenewAck = isRenewAck,
+                    Topics = topics
+                };
                 var response = (ShareAcknowledgeResponse)await connection
                     .SendAsync<ShareAcknowledgeRequest, ShareAcknowledgeResponse>(
                         request, shareAckVersion, cancellationToken)
@@ -711,9 +795,28 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 if (response.ErrorCode != ErrorCode.None)
                 {
+                    if (response.ErrorCode is ErrorCode.ShareSessionNotFound
+                        or ErrorCode.InvalidShareSessionEpoch)
+                    {
+                        _sessionManager.ResetSession(brokerId);
+                        ClearRenewedRecords();
+                    }
+                    else
+                    {
+                        _sessionManager.IncrementEpoch(brokerId);
+                    }
+
                     throw KafkaException.FromErrorCode(response.ErrorCode,
                         $"ShareAcknowledge failed for broker {brokerId}: {response.ErrorCode} - {response.ErrorMessage}");
                 }
+
+                _sessionManager.IncrementEpoch(brokerId);
+
+                if (isRenewAck)
+                    Volatile.Write(ref _acquisitionLockTimeoutMs, response.AcquisitionLockTimeoutMs);
+
+                if (TryGetAcknowledgementError(response, out var acknowledgementError))
+                    throw acknowledgementError;
 
                 return;
             }
@@ -922,6 +1025,224 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         return topics;
     }
 
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SelectAcknowledgements(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? pendingAcks,
+        List<TopicPartition> partitions)
+    {
+        if (pendingAcks is null)
+            return null;
+
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? selected = null;
+        foreach (var partition in partitions)
+        {
+            if (!pendingAcks.TryGetValue(partition, out var batches))
+                continue;
+
+            selected ??= [];
+            selected[partition] = batches;
+        }
+
+        return selected;
+    }
+
+    private static bool ContainsRenewAcknowledgement(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
+    {
+        if (acknowledgements is null)
+            return false;
+
+        foreach (var batches in acknowledgements.Values)
+        {
+            foreach (var batch in batches)
+            {
+                for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                {
+                    if (batch.AcknowledgeTypes[i] == (byte)AcknowledgeType.Renew)
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void EnsureRenewalSupported(ApiKey apiKey, short version, bool isRenewAck)
+    {
+        if (!isRenewAck || version >= 2)
+            return;
+
+        throw new BrokerVersionException(
+            ErrorCode.UnsupportedVersion,
+            $"Broker does not support {apiKey} v2 required for Renew acknowledgements.");
+    }
+
+    private void RequeueAcknowledgements(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
+    {
+        if (acknowledgements is not null && acknowledgements.Count > 0)
+            _ackTracker.RequeueAcks(acknowledgements);
+    }
+
+    private static bool TryGetAcknowledgementError(
+        ShareFetchResponse response,
+        out KafkaException error)
+    {
+        foreach (var topic in response.Responses)
+        {
+            foreach (var partition in topic.Partitions)
+            {
+                if (partition.AcknowledgeErrorCode == ErrorCode.None)
+                    continue;
+
+                error = KafkaException.FromErrorCode(
+                    partition.AcknowledgeErrorCode,
+                    $"Inline ShareFetch acknowledgement failed for partition " +
+                    $"{partition.PartitionIndex}: {partition.AcknowledgeErrorMessage}");
+                return true;
+            }
+        }
+
+        error = null!;
+        return false;
+    }
+
+    private static bool TryGetAcknowledgementError(
+        ShareAcknowledgeResponse response,
+        out KafkaException error)
+    {
+        foreach (var topic in response.Responses)
+        {
+            foreach (var partition in topic.Partitions)
+            {
+                if (partition.ErrorCode == ErrorCode.None)
+                    continue;
+
+                error = KafkaException.FromErrorCode(
+                    partition.ErrorCode,
+                    $"ShareAcknowledge failed for partition {partition.PartitionIndex}: " +
+                    partition.ErrorMessage);
+                return true;
+            }
+        }
+
+        error = null!;
+        return false;
+    }
+
+    private void TrackRenewalDisposition(
+        ShareConsumeResult<TKey, TValue> record,
+        AcknowledgeType type)
+    {
+        if (type != AcknowledgeType.Renew)
+            return;
+
+        var key = new RenewedRecordKey(record.Topic, record.Partition, record.Offset);
+        _renewedRecords ??= [];
+        if (_renewedRecords.TryGetValue(key, out var state))
+            state.Record = record;
+        else
+            _renewedRecords[key] = new RenewedRecordState(record);
+
+        Interlocked.Increment(ref _renewalRequestCount);
+        LogRenewalRequested(record.Topic, record.Partition, record.Offset);
+    }
+
+    private void ApplySuccessfulAcknowledgements(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
+    {
+        if (_renewedRecords is null || acknowledgements is null)
+            return;
+
+        foreach (var (topicPartition, batches) in acknowledgements)
+        {
+            foreach (var batch in batches)
+            {
+                for (var i = 0; i < batch.AcknowledgeTypes.Length; i++)
+                {
+                    var key = new RenewedRecordKey(
+                        topicPartition.Topic,
+                        topicPartition.Partition,
+                        batch.FirstOffset + i);
+                    var type = (AcknowledgeType)batch.AcknowledgeTypes[i];
+                    if (type == AcknowledgeType.Renew)
+                    {
+                        if (_renewedRecords.TryGetValue(key, out var state))
+                            state.Active = true;
+                    }
+                    else
+                    {
+                        _renewedRecords.Remove(key);
+                    }
+                }
+            }
+        }
+
+        if (_renewedRecords.Count == 0)
+            _renewedRecords = null;
+    }
+
+    private List<ShareConsumeResult<TKey, TValue>> GetActiveRenewedRecords(
+        TopicPartitionSet assignment,
+        int maxRecords)
+    {
+        if (_renewedRecords is null || maxRecords <= 0)
+            return [];
+
+        var records = new List<ShareConsumeResult<TKey, TValue>>(
+            Math.Min(_renewedRecords.Count, maxRecords));
+        foreach (var (key, state) in _renewedRecords)
+        {
+            if (!state.Active
+                || !assignment.Contains(new TopicPartition(key.Topic, key.Partition)))
+            {
+                continue;
+            }
+
+            records.Add(state.Record);
+            if (records.Count == maxRecords)
+                break;
+        }
+
+        return records;
+    }
+
+    private void RemoveRenewedRecord(string topic, int partition, long offset)
+    {
+        if (_renewedRecords is null)
+            return;
+
+        _renewedRecords.Remove(new RenewedRecordKey(topic, partition, offset));
+        if (_renewedRecords.Count == 0)
+            _renewedRecords = null;
+    }
+
+    private void RemoveRenewedRecordsOutsideAssignment(TopicPartitionSet assignment)
+    {
+        if (_renewedRecords is null)
+            return;
+
+        List<RenewedRecordKey>? removed = null;
+        foreach (var key in _renewedRecords.Keys)
+        {
+            if (assignment.Contains(new TopicPartition(key.Topic, key.Partition)))
+                continue;
+
+            removed ??= [];
+            removed.Add(key);
+        }
+
+        if (removed is null)
+            return;
+
+        foreach (var key in removed)
+            _renewedRecords.Remove(key);
+
+        if (_renewedRecords.Count == 0)
+            _renewedRecords = null;
+    }
+
+    private void ClearRenewedRecords() => _renewedRecords = null;
+
     /// <summary>
     /// Groups acknowledgement data by leader broker.
     /// </summary>
@@ -1027,6 +1348,20 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         return -1;
     }
 
+    private readonly record struct RenewedRecordKey(string Topic, int Partition, long Offset);
+
+    private sealed class RenewedRecordState(ShareConsumeResult<TKey, TValue> record)
+    {
+        internal ShareConsumeResult<TKey, TValue> Record { get; set; } = record;
+        internal bool Active { get; set; }
+    }
+
+    private readonly record struct ShareFetchBrokerResult(
+        int BrokerId,
+        short Version,
+        ShareFetchResponse? Response,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SentAcknowledgements);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfNotInitialized()
     {
@@ -1061,6 +1396,12 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ShareAcknowledge request failed for broker {BrokerId}")]
     private partial void LogAcknowledgeRequestFailed(int brokerId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Inline ShareFetch acknowledgement failed for broker {BrokerId}")]
+    private partial void LogInlineAcknowledgeFailed(int brokerId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Requested acquisition lock renewal for {Topic}-{Partition} at offset {Offset}")]
+    private partial void LogRenewalRequested(string topic, int partition, long offset);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Closing share consumer")]
     private partial void LogClosingShareConsumer();

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -272,7 +272,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 throw;
             }
 
-            // Process responses sequentially — yielding records and tracking acks
+            // Process every response before yielding. Session epochs and inline
+            // acknowledgements must advance even when an earlier broker fills the poll budget.
             var recordCount = 0;
             List<ShareConsumeResult<TKey, TValue>>? fetchedRecords = _renewedRecords is null
                 ? null
@@ -280,9 +281,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
             foreach (var fetchTask in fetchTasks)
             {
-                if ((fetchedRecords?.Count ?? recordCount) >= _options.MaxPollRecords)
-                    break;
-
                 var (brokerId, version, response, sentAcks) = fetchTask.Result;
 
                 if (response is null)
@@ -299,11 +297,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearRenewedRecordsForBroker(brokerId);
                         // Note: _ackTracker may still hold pending acks from the now-invalid session.
                         // On next CommitAsync those acks will be sent with epoch 0 (new session).
-                        // The broker will reject them if the old record locks have expired, which is
-                        // safe — CommitAsync will re-queue the failed acks for retry.
+                        // Keep renewal state so a re-queued Renew can activate the record after the
+                        // new session accepts it.
                     }
                     RequeueAcknowledgements(sentAcks);
                     continue;
@@ -332,6 +329,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 {
                     ApplySuccessfulAcknowledgements(sentAcks);
                 }
+            }
+
+            // Parse records only after all broker bookkeeping is complete. This second broker scan
+            // is per poll, not per message, and avoids buffering records when no renewal is active.
+            foreach (var fetchTask in fetchTasks)
+            {
+                var (_, _, response, _) = fetchTask.Result;
+                if (response is null || response.ErrorCode != ErrorCode.None)
+                    continue;
 
                 // Process partition responses
                 foreach (var topicResponse in response.Responses)
@@ -447,6 +453,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         ThrowIfDisposed();
         ThrowIfNotInitialized();
 
+        await CommitCoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask CommitCoreAsync(CancellationToken cancellationToken)
+    {
         if (!_ackTracker.HasPending)
             return;
 
@@ -508,7 +519,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         {
             try
             {
-                await CommitAsync(cancellationToken).ConfigureAwait(false);
+                await CommitCoreAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -700,7 +711,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 LogFetchFailed(brokerId, ex);
                 _sessionManager.ResetSession(brokerId);
-                ClearRenewedRecordsForBroker(brokerId);
                 return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks);
             }
         }
@@ -808,7 +818,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         or ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearRenewedRecordsForBroker(brokerId);
                     }
                     else
                     {
@@ -1397,32 +1406,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     }
 
     private void ClearRenewedRecords() => _renewedRecords = null;
-
-    private void ClearRenewedRecordsForBroker(int brokerId)
-    {
-        if (_renewedRecords is null)
-            return;
-
-        List<RenewedRecordKey>? removed = null;
-        foreach (var key in _renewedRecords.Keys)
-        {
-            var leader = _metadataManager.Metadata.GetPartitionLeader(key.Topic, key.Partition);
-            if (leader?.NodeId != brokerId)
-                continue;
-
-            removed ??= [];
-            removed.Add(key);
-        }
-
-        if (removed is null)
-            return;
-
-        foreach (var key in removed)
-            _renewedRecords.Remove(key);
-
-        if (_renewedRecords.Count == 0)
-            _renewedRecords = null;
-    }
 
     /// <summary>
     /// Groups acknowledgement data by leader broker.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -299,7 +299,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearRenewedRecords();
+                        ClearRenewedRecordsForBroker(brokerId);
                         // Note: _ackTracker may still hold pending acks from the now-invalid session.
                         // On next CommitAsync those acks will be sent with epoch 0 (new session).
                         // The broker will reject them if the old record locks have expired, which is
@@ -316,10 +316,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 if (version >= 1)
                     Volatile.Write(ref _acquisitionLockTimeoutMs, response.AcquisitionLockTimeoutMs);
 
-                if (TryGetAcknowledgementError(response, out var acknowledgementError))
+                var acknowledgementFailures = GetAcknowledgementFailures(response, sentAcks);
+                if (acknowledgementFailures is not null)
                 {
-                    RequeueAcknowledgements(sentAcks);
-                    LogInlineAcknowledgeFailed(brokerId, acknowledgementError);
+                    SplitAcknowledgements(
+                        sentAcks,
+                        acknowledgementFailures,
+                        out var successfulAcknowledgements,
+                        out var failedAcknowledgements);
+                    ApplySuccessfulAcknowledgements(successfulAcknowledgements);
+                    RequeueAcknowledgements(failedAcknowledgements);
+                    LogInlineAcknowledgeFailed(brokerId, acknowledgementFailures.FirstError);
                 }
                 else
                 {
@@ -453,32 +460,26 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         {
             try
             {
-                await SendAcknowledgeAsync(
+                return await SendAcknowledgeAsync(
                         kvp.Key,
                         kvp.Value,
                         retryRetriableFailures: true,
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
-                return (Acks: kvp.Value, Error: (Exception?)null);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                return (Acks: kvp.Value, Error: ex);
+                return new AcknowledgeBrokerResult(null, kvp.Value, ex);
             }
         })).ConfigureAwait(false);
 
         // Re-queue failed partitions so they can be retried on the next commit
         Exception? firstError = null;
-        foreach (var (acks, error) in results)
+        foreach (var result in results)
         {
-            if (error is null)
-            {
-                ApplySuccessfulAcknowledgements(acks);
-                continue;
-            }
-
-            firstError ??= error;
-            _ackTracker.RequeueAcks(acks);
+            ApplySuccessfulAcknowledgements(result.SuccessfulAcknowledgements);
+            RequeueAcknowledgements(result.FailedAcknowledgements);
+            firstError ??= result.Error;
         }
 
         if (firstError is not null)
@@ -621,12 +622,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 try
                 {
-                    await SendAcknowledgeAsync(
+                    var result = await SendAcknowledgeAsync(
                             brokerId,
                             acks,
                             retryRetriableFailures: false,
                             cancellationToken: CancellationToken.None)
                         .ConfigureAwait(false);
+                    if (result.Error is not null)
+                        LogAcknowledgeRequestFailed(brokerId, result.Error);
                 }
                 catch (Exception ex)
                 {
@@ -695,7 +698,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 LogFetchFailed(brokerId, ex);
                 _sessionManager.ResetSession(brokerId);
-                ClearRenewedRecords();
+                ClearRenewedRecordsForBroker(brokerId);
                 return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks);
             }
         }
@@ -757,19 +760,23 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         }
     }
 
-    private async Task SendAcknowledgeAsync(
+    private async Task<AcknowledgeBrokerResult> SendAcknowledgeAsync(
         int brokerId,
         Dictionary<TopicPartition, List<AcknowledgementBatchData>> topicAcks,
         bool retryRetriableFailures,
         CancellationToken cancellationToken)
     {
-        var topics = BuildShareAcknowledgeTopics(topicAcks);
-        var isRenewAck = ContainsRenewAcknowledgement(topicAcks);
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? successfulAcknowledgements = null;
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? failedAcknowledgements = null;
+        Exception? firstError = null;
+        var pendingAcknowledgements = topicAcks;
 
         for (var attempt = 0; ; attempt++)
         {
             try
             {
+                var topics = BuildShareAcknowledgeTopics(pendingAcknowledgements);
+                var isRenewAck = ContainsRenewAcknowledgement(pendingAcknowledgements);
                 using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokerId, cancellationToken)
                     .ConfigureAwait(false);
                 var connection = connectionLease.Connection;
@@ -799,7 +806,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         or ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearRenewedRecords();
+                        ClearRenewedRecordsForBroker(brokerId);
                     }
                     else
                     {
@@ -815,16 +822,76 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 if (isRenewAck)
                     Volatile.Write(ref _acquisitionLockTimeoutMs, response.AcquisitionLockTimeoutMs);
 
-                if (TryGetAcknowledgementError(response, out var acknowledgementError))
-                    throw acknowledgementError;
+                var acknowledgementFailures = GetAcknowledgementFailures(
+                    response,
+                    pendingAcknowledgements);
+                if (acknowledgementFailures is null)
+                {
+                    MergeAcknowledgements(ref successfulAcknowledgements, pendingAcknowledgements);
+                    return new AcknowledgeBrokerResult(
+                        successfulAcknowledgements,
+                        failedAcknowledgements,
+                        firstError);
+                }
 
-                return;
+                SplitAcknowledgements(
+                    pendingAcknowledgements,
+                    acknowledgementFailures,
+                    out var successfulThisAttempt,
+                    out var failedThisAttempt);
+                MergeAcknowledgements(ref successfulAcknowledgements, successfulThisAttempt);
+
+                SplitRetriableAcknowledgements(
+                    failedThisAttempt!,
+                    acknowledgementFailures,
+                    retryRetriableFailures,
+                    out var retriableAcknowledgements,
+                    out var terminalAcknowledgements);
+                if (terminalAcknowledgements is not null)
+                {
+                    MergeAcknowledgements(ref failedAcknowledgements, terminalAcknowledgements);
+                    firstError ??= acknowledgementFailures.GetFirstError(terminalAcknowledgements.Keys);
+                }
+
+                if (retriableAcknowledgements is not null && attempt < RetryHelper.MaxRetries)
+                {
+                    pendingAcknowledgements = retriableAcknowledgements;
+                    await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (retriableAcknowledgements is not null)
+                {
+                    MergeAcknowledgements(ref failedAcknowledgements, retriableAcknowledgements);
+                    firstError ??= acknowledgementFailures.GetFirstError(retriableAcknowledgements.Keys);
+                }
+
+                return new AcknowledgeBrokerResult(
+                    successfulAcknowledgements,
+                    failedAcknowledgements,
+                    firstError);
+            }
+            catch (BrokerVersionException)
+            {
+                throw;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex) when (retryRetriableFailures
                                        && attempt < RetryHelper.MaxRetries
                                        && RetryHelper.IsRetriableRequestFailure(ex))
             {
                 await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                MergeAcknowledgements(ref failedAcknowledgements, pendingAcknowledgements);
+                return new AcknowledgeBrokerResult(
+                    successfulAcknowledgements,
+                    failedAcknowledgements,
+                    firstError ?? ex);
             }
         }
     }
@@ -1083,10 +1150,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             _ackTracker.RequeueAcks(acknowledgements);
     }
 
-    private static bool TryGetAcknowledgementError(
+    private AcknowledgementFailures? GetAcknowledgementFailures(
         ShareFetchResponse response,
-        out KafkaException error)
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements)
     {
+        if (acknowledgements is null || acknowledgements.Count == 0)
+            return null;
+
+        Dictionary<TopicPartition, KafkaException>? errors = null;
         foreach (var topic in response.Responses)
         {
             foreach (var partition in topic.Partitions)
@@ -1094,22 +1165,31 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 if (partition.AcknowledgeErrorCode == ErrorCode.None)
                     continue;
 
-                error = KafkaException.FromErrorCode(
+                var error = KafkaException.FromErrorCode(
                     partition.AcknowledgeErrorCode,
                     $"Inline ShareFetch acknowledgement failed for partition " +
                     $"{partition.PartitionIndex}: {partition.AcknowledgeErrorMessage}");
-                return true;
+                var topicInfo = _metadataManager.Metadata.GetTopic(topic.TopicId);
+                if (topicInfo is null)
+                    return AcknowledgementFailures.ForAll(acknowledgements.Keys, error);
+
+                var topicPartition = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+                if (!acknowledgements.ContainsKey(topicPartition))
+                    continue;
+
+                errors ??= [];
+                errors[topicPartition] = error;
             }
         }
 
-        error = null!;
-        return false;
+        return errors is null ? null : new AcknowledgementFailures(errors);
     }
 
-    private static bool TryGetAcknowledgementError(
+    private AcknowledgementFailures? GetAcknowledgementFailures(
         ShareAcknowledgeResponse response,
-        out KafkaException error)
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements)
     {
+        Dictionary<TopicPartition, KafkaException>? errors = null;
         foreach (var topic in response.Responses)
         {
             foreach (var partition in topic.Partitions)
@@ -1117,16 +1197,89 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 if (partition.ErrorCode == ErrorCode.None)
                     continue;
 
-                error = KafkaException.FromErrorCode(
+                var error = KafkaException.FromErrorCode(
                     partition.ErrorCode,
                     $"ShareAcknowledge failed for partition {partition.PartitionIndex}: " +
                     partition.ErrorMessage);
-                return true;
+                var topicInfo = _metadataManager.Metadata.GetTopic(topic.TopicId);
+                if (topicInfo is null)
+                    return AcknowledgementFailures.ForAll(acknowledgements.Keys, error);
+
+                var topicPartition = new TopicPartition(topicInfo.Name, partition.PartitionIndex);
+                if (!acknowledgements.ContainsKey(topicPartition))
+                    continue;
+
+                errors ??= [];
+                errors[topicPartition] = error;
             }
         }
 
-        error = null!;
-        return false;
+        return errors is null ? null : new AcknowledgementFailures(errors);
+    }
+
+    private static void SplitAcknowledgements(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? acknowledgements,
+        AcknowledgementFailures failures,
+        out Dictionary<TopicPartition, List<AcknowledgementBatchData>>? successful,
+        out Dictionary<TopicPartition, List<AcknowledgementBatchData>>? failed)
+    {
+        successful = null;
+        failed = null;
+        if (acknowledgements is null)
+            return;
+
+        foreach (var (topicPartition, batches) in acknowledgements)
+        {
+            if (failures.Errors.ContainsKey(topicPartition))
+            {
+                failed ??= [];
+                failed[topicPartition] = batches;
+            }
+            else
+            {
+                successful ??= [];
+                successful[topicPartition] = batches;
+            }
+        }
+    }
+
+    private static void SplitRetriableAcknowledgements(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements,
+        AcknowledgementFailures failures,
+        bool retryRetriableFailures,
+        out Dictionary<TopicPartition, List<AcknowledgementBatchData>>? retriable,
+        out Dictionary<TopicPartition, List<AcknowledgementBatchData>>? terminal)
+    {
+        retriable = null;
+        terminal = null;
+        foreach (var (topicPartition, batches) in acknowledgements)
+        {
+            var canRetry = retryRetriableFailures
+                           && failures.Errors[topicPartition].ErrorCode is { } errorCode
+                           && errorCode.IsRetriable();
+            if (canRetry)
+            {
+                retriable ??= [];
+                retriable[topicPartition] = batches;
+            }
+            else
+            {
+                terminal ??= [];
+                terminal[topicPartition] = batches;
+            }
+        }
+    }
+
+    private static void MergeAcknowledgements(
+        ref Dictionary<TopicPartition, List<AcknowledgementBatchData>>? target,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? source)
+    {
+        if (source is null)
+            return;
+
+        target ??= [];
+        foreach (var (topicPartition, batches) in source)
+            target[topicPartition] = batches;
     }
 
     private void TrackRenewalDisposition(
@@ -1243,6 +1396,32 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
     private void ClearRenewedRecords() => _renewedRecords = null;
 
+    private void ClearRenewedRecordsForBroker(int brokerId)
+    {
+        if (_renewedRecords is null)
+            return;
+
+        List<RenewedRecordKey>? removed = null;
+        foreach (var key in _renewedRecords.Keys)
+        {
+            var leader = _metadataManager.Metadata.GetPartitionLeader(key.Topic, key.Partition);
+            if (leader?.NodeId != brokerId)
+                continue;
+
+            removed ??= [];
+            removed.Add(key);
+        }
+
+        if (removed is null)
+            return;
+
+        foreach (var key in removed)
+            _renewedRecords.Remove(key);
+
+        if (_renewedRecords.Count == 0)
+            _renewedRecords = null;
+    }
+
     /// <summary>
     /// Groups acknowledgement data by leader broker.
     /// </summary>
@@ -1355,6 +1534,40 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         internal ShareConsumeResult<TKey, TValue> Record { get; set; } = record;
         internal bool Active { get; set; }
     }
+
+    private sealed class AcknowledgementFailures(
+        Dictionary<TopicPartition, KafkaException> errors)
+    {
+        internal Dictionary<TopicPartition, KafkaException> Errors { get; } = errors;
+        internal KafkaException FirstError => Errors.Values.First();
+
+        internal KafkaException GetFirstError(IEnumerable<TopicPartition> topicPartitions)
+        {
+            foreach (var topicPartition in topicPartitions)
+            {
+                if (Errors.TryGetValue(topicPartition, out var error))
+                    return error;
+            }
+
+            return FirstError;
+        }
+
+        internal static AcknowledgementFailures ForAll(
+            IEnumerable<TopicPartition> topicPartitions,
+            KafkaException error)
+        {
+            var errors = new Dictionary<TopicPartition, KafkaException>();
+            foreach (var topicPartition in topicPartitions)
+                errors[topicPartition] = error;
+
+            return new AcknowledgementFailures(errors);
+        }
+    }
+
+    private readonly record struct AcknowledgeBrokerResult(
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SuccessfulAcknowledgements,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? FailedAcknowledgements,
+        Exception? Error);
 
     private readonly record struct ShareFetchBrokerResult(
         int BrokerId,

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -266,7 +266,17 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     cancellationToken));
             }
 
-            await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+            try
+            {
+                await Task.WhenAll(fetchTasks).ConfigureAwait(false);
+            }
+            catch
+            {
+                // A broker task should normally return its failure in ShareFetchBrokerResult.
+                // Preserve every drained acknowledgement if an unexpected fault escapes.
+                RequeueAcknowledgements(pendingAcks);
+                throw;
+            }
 
             // Process every response before yielding. Session epochs and inline
             // acknowledgements must advance even when an earlier broker fills the poll budget.
@@ -301,11 +311,11 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearActiveRenewedRecordsForBroker(brokerId);
                         // Note: _ackTracker may still hold pending acks from the now-invalid session.
                         // On next CommitAsync those acks will be sent with epoch 0 (new session).
-                        // Keep renewal state so a re-queued Renew can activate the record after the
-                        // new session accepts it.
+                        // Renewal records represent partition locks, not fetch-session membership.
+                        // Keep active records available for replay and pending Renew records ready
+                        // for activation after the new session accepts them.
                     }
                     RequeueAcknowledgements(sentAcks);
                     continue;
@@ -721,7 +731,18 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 if (attempt < RetryHelper.MaxRetries && response.ErrorCode.IsRetriable())
                 {
-                    await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+                    var retryError = await PrepareShareFetchRetryAsync(attempt, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (retryError is not null)
+                    {
+                        return new ShareFetchBrokerResult(
+                            brokerId,
+                            version,
+                            null,
+                            brokerAcks,
+                            retryError);
+                    }
+
                     continue;
                 }
 
@@ -735,15 +756,40 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             {
                 if (attempt < RetryHelper.MaxRetries && RetryHelper.IsRetriableRequestFailure(ex))
                 {
-                    await PrepareRequestRetryAsync(attempt, cancellationToken).ConfigureAwait(false);
+                    var retryError = await PrepareShareFetchRetryAsync(attempt, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (retryError is not null)
+                    {
+                        return new ShareFetchBrokerResult(
+                            brokerId,
+                            0,
+                            null,
+                            brokerAcks,
+                            retryError);
+                    }
+
                     continue;
                 }
 
                 LogFetchFailed(brokerId, ex);
                 _sessionManager.ResetSession(brokerId);
-                ClearActiveRenewedRecordsForBroker(brokerId);
                 return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks, null);
             }
+        }
+    }
+
+    private async ValueTask<Exception?> PrepareShareFetchRetryAsync(
+        int zeroBasedAttempt,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await PrepareRequestRetryAsync(zeroBasedAttempt, cancellationToken).ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
         }
     }
 
@@ -849,7 +895,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         or ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
-                        ClearActiveRenewedRecordsForBroker(brokerId);
                     }
                     else
                     {
@@ -1441,35 +1486,6 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     }
 
     private void ClearRenewedRecords() => _renewedRecords = null;
-
-    private void ClearActiveRenewedRecordsForBroker(int brokerId)
-    {
-        if (_renewedRecords is null)
-            return;
-
-        List<RenewedRecordKey>? removed = null;
-        foreach (var (key, state) in _renewedRecords)
-        {
-            if (!state.Active)
-                continue;
-
-            var leader = _metadataManager.Metadata.GetPartitionLeader(key.Topic, key.Partition);
-            if (leader?.NodeId != brokerId)
-                continue;
-
-            removed ??= [];
-            removed.Add(key);
-        }
-
-        if (removed is null)
-            return;
-
-        foreach (var key in removed)
-            _renewedRecords.Remove(key);
-
-        if (_renewedRecords.Count == 0)
-            _renewedRecords = null;
-    }
 
     /// <summary>
     /// Groups acknowledgement data by leader broker.

--- a/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
+++ b/src/Dekaf/ShareConsumer/KafkaShareConsumer.cs
@@ -258,19 +258,15 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
             foreach (var (brokerId, partitions) in partitionsByBroker)
             {
-                fetchTasks.Add(SendShareFetchForPartitionsAsync(brokerId, partitions, pendingAcks, cancellationToken));
+                var brokerAcks = SelectAcknowledgements(pendingAcks, partitions);
+                fetchTasks.Add(SendShareFetchForBrokerAsync(
+                    brokerId,
+                    partitions,
+                    brokerAcks,
+                    cancellationToken));
             }
 
-            try
-            {
-                await Task.WhenAll(fetchTasks).ConfigureAwait(false);
-            }
-            catch
-            {
-                if (pendingAcks is not null)
-                    _ackTracker.RequeueAcks(pendingAcks);
-                throw;
-            }
+            await Task.WhenAll(fetchTasks).ConfigureAwait(false);
 
             // Process every response before yielding. Session epochs and inline
             // acknowledgements must advance even when an earlier broker fills the poll budget.
@@ -278,10 +274,18 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
             List<ShareConsumeResult<TKey, TValue>>? fetchedRecords = _renewedRecords is null
                 ? null
                 : new List<ShareConsumeResult<TKey, TValue>>(_options.MaxPollRecords);
+            Exception? firstFetchError = null;
 
             foreach (var fetchTask in fetchTasks)
             {
-                var (brokerId, version, response, sentAcks) = fetchTask.Result;
+                var (brokerId, version, response, sentAcks, error) = fetchTask.Result;
+
+                if (error is not null)
+                {
+                    RequeueAcknowledgements(sentAcks);
+                    firstFetchError ??= error;
+                    continue;
+                }
 
                 if (response is null)
                 {
@@ -297,6 +301,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         response.ErrorCode == ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
+                        ClearActiveRenewedRecordsForBroker(brokerId);
                         // Note: _ackTracker may still hold pending acks from the now-invalid session.
                         // On next CommitAsync those acks will be sent with epoch 0 (new session).
                         // Keep renewal state so a re-queued Renew can activate the record after the
@@ -331,11 +336,14 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                 }
             }
 
+            if (firstFetchError is not null)
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstFetchError).Throw();
+
             // Parse records only after all broker bookkeeping is complete. This second broker scan
             // is per poll, not per message, and avoids buffering records when no renewal is active.
             foreach (var fetchTask in fetchTasks)
             {
-                var (_, _, response, _) = fetchTask.Result;
+                var (_, _, response, _, _) = fetchTask.Result;
                 if (response is null || response.ErrorCode != ErrorCode.None)
                     continue;
 
@@ -659,6 +667,24 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         CancellationToken cancellationToken)
     {
         var brokerAcks = SelectAcknowledgements(pendingAcks, partitions);
+        var result = await SendShareFetchForBrokerAsync(
+                brokerId,
+                partitions,
+                brokerAcks,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (result.Error is not null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(result.Error).Throw();
+
+        return result;
+    }
+
+    private async Task<ShareFetchBrokerResult> SendShareFetchForBrokerAsync(
+        int brokerId,
+        List<TopicPartition> partitions,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? brokerAcks,
+        CancellationToken cancellationToken)
+    {
         var isRenewAck = ContainsRenewAcknowledgement(brokerAcks);
 
         for (var attempt = 0; ; attempt++)
@@ -699,9 +725,13 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                     continue;
                 }
 
-                return new ShareFetchBrokerResult(brokerId, version, response, brokerAcks);
+                return new ShareFetchBrokerResult(brokerId, version, response, brokerAcks, null);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException and not BrokerVersionException)
+            catch (Exception ex) when (ex is OperationCanceledException or BrokerVersionException)
+            {
+                return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks, ex);
+            }
+            catch (Exception ex)
             {
                 if (attempt < RetryHelper.MaxRetries && RetryHelper.IsRetriableRequestFailure(ex))
                 {
@@ -711,7 +741,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
 
                 LogFetchFailed(brokerId, ex);
                 _sessionManager.ResetSession(brokerId);
-                return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks);
+                ClearActiveRenewedRecordsForBroker(brokerId);
+                return new ShareFetchBrokerResult(brokerId, 0, null, brokerAcks, null);
             }
         }
     }
@@ -818,6 +849,7 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
                         or ErrorCode.InvalidShareSessionEpoch)
                     {
                         _sessionManager.ResetSession(brokerId);
+                        ClearActiveRenewedRecordsForBroker(brokerId);
                     }
                     else
                     {
@@ -1303,7 +1335,10 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         var key = new RenewedRecordKey(record.Topic, record.Partition, record.Offset);
         _renewedRecords ??= [];
         if (_renewedRecords.TryGetValue(key, out var state))
+        {
             state.Record = record;
+            state.Active = false;
+        }
         else
             _renewedRecords[key] = new RenewedRecordState(record);
 
@@ -1406,6 +1441,35 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
     }
 
     private void ClearRenewedRecords() => _renewedRecords = null;
+
+    private void ClearActiveRenewedRecordsForBroker(int brokerId)
+    {
+        if (_renewedRecords is null)
+            return;
+
+        List<RenewedRecordKey>? removed = null;
+        foreach (var (key, state) in _renewedRecords)
+        {
+            if (!state.Active)
+                continue;
+
+            var leader = _metadataManager.Metadata.GetPartitionLeader(key.Topic, key.Partition);
+            if (leader?.NodeId != brokerId)
+                continue;
+
+            removed ??= [];
+            removed.Add(key);
+        }
+
+        if (removed is null)
+            return;
+
+        foreach (var key in removed)
+            _renewedRecords.Remove(key);
+
+        if (_renewedRecords.Count == 0)
+            _renewedRecords = null;
+    }
 
     /// <summary>
     /// Groups acknowledgement data by leader broker.
@@ -1558,7 +1622,8 @@ internal sealed partial class KafkaShareConsumer<TKey, TValue> : IKafkaShareCons
         int BrokerId,
         short Version,
         ShareFetchResponse? Response,
-        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SentAcknowledgements);
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>>? SentAcknowledgements,
+        Exception? Error);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfNotInitialized()

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -209,6 +209,43 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     }
 
     [Test]
+    public async Task ShareConsumer_Renewal_RetainsRecordAcrossPolls()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var groupId = $"share-group-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+        await using var consumer = await Kafka.CreateShareConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAcknowledgementMode(ShareAcknowledgementMode.Explicit)
+            .WithMaxPollRecords(1)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Subscribe(topic);
+        await ShareConsumerTestHelper.PrimeShareConsumerAsync(consumer);
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 1);
+        var first = await ConsumeOneAsync(consumer);
+
+        consumer.Acknowledge(first, AcknowledgeType.Renew);
+        await consumer.CommitAsync();
+        await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 1);
+        var renewed = await ConsumeOneAsync(consumer);
+
+        await Assert.That(consumer.AcquisitionLockTimeoutMs).IsNotNull();
+        await Assert.That(consumer.AcquisitionLockTimeoutMs!.Value).IsGreaterThan(0);
+        await Assert.That(renewed.Offset).IsEqualTo(first.Offset);
+        await Assert.That(renewed.Value).IsEqualTo(first.Value);
+
+        consumer.Acknowledge(renewed, AcknowledgeType.Accept);
+        await consumer.CommitAsync();
+    }
+
+    [Test]
     public async Task ShareConsumer_Builder_ConfiguresCorrectly()
     {
         var groupId = $"share-group-{Guid.NewGuid():N}";

--- a/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ShareConsumerTests.cs
@@ -234,13 +234,16 @@ public class ShareConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest
         consumer.Acknowledge(first, AcknowledgeType.Renew);
         await consumer.CommitAsync();
         await ShareConsumerTestHelper.ProduceAsync(producer, topic, count: 1);
+        var fetched = await ConsumeOneAsync(consumer);
         var renewed = await ConsumeOneAsync(consumer);
 
         await Assert.That(consumer.AcquisitionLockTimeoutMs).IsNotNull();
         await Assert.That(consumer.AcquisitionLockTimeoutMs!.Value).IsGreaterThan(0);
+        await Assert.That(fetched.Offset).IsEqualTo(first.Offset + 1);
         await Assert.That(renewed.Offset).IsEqualTo(first.Offset);
         await Assert.That(renewed.Value).IsEqualTo(first.Value);
 
+        consumer.Acknowledge(fetched, AcknowledgeType.Accept);
         consumer.Acknowledge(renewed, AcknowledgeType.Accept);
         await consumer.CommitAsync();
     }

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -160,48 +160,9 @@ public sealed class ShareConsumerRenewalTests
     [Test]
     public async Task Poll_FetchedRecord_ReservesBudgetBeforeRenewalReplay()
     {
-        var buffer = new ArrayBufferWriter<byte>();
-        using (var batch = new RecordBatch
-        {
-            BaseOffset = 100,
-            Records = [new Record { IsKeyNull = true, Value = "new-value"u8.ToArray() }]
-        })
-        {
-            batch.Write(buffer);
-        }
-
         var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
         {
-            ShareFetchResponse = new ShareFetchResponse
-            {
-                ErrorCode = ErrorCode.None,
-                Responses =
-                [
-                    new ShareFetchResponseTopic
-                    {
-                        TopicId = TopicId,
-                        Partitions =
-                        [
-                            new ShareFetchResponsePartition
-                            {
-                                PartitionIndex = 0,
-                                CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
-                                RecordBytes = buffer.WrittenMemory,
-                                AcquiredRecords =
-                                [
-                                    new ShareFetchAcquiredRecords
-                                    {
-                                        FirstOffset = 100,
-                                        LastOffset = 100,
-                                        DeliveryCount = 1
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
-                NodeEndpoints = []
-            }
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 100)
         };
         await using var fixture = CreateFixture(connection, maxPollRecords: 1);
         PrepareForPoll(fixture.Consumer);
@@ -217,6 +178,41 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(poll.Current.Offset).IsEqualTo(100);
         var assignment = new HashSet<TopicPartition> { new("topic", 0) };
         await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).HasSingleItem();
+    }
+
+    [Test]
+    public async Task Poll_MaxPollRecords_ProcessesEveryBrokerResponse()
+    {
+        var firstConnection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = CreateFetchResponse(partition: 0, offset: 100)
+        };
+        var secondConnection = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(
+            firstConnection,
+            maxPollRecords: 1,
+            secondConnection: secondConnection);
+        PrepareForPoll(
+            fixture.Consumer,
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsTrue();
+        await Assert.That(poll.Current.Offset).IsEqualTo(100);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(1);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 2)).IsEqualTo(1);
     }
 
     [Test]
@@ -392,7 +388,7 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
-    public async Task Poll_SessionLoss_ClearsRenewedRecords()
+    public async Task Poll_SessionLoss_PreservesRenewalForRetry()
     {
         using var cancellation = new CancellationTokenSource();
         var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
@@ -411,73 +407,16 @@ public sealed class ShareConsumerRenewalTests
         fixture.Consumer.Subscribe("topic");
         var record = CreateRecord();
         fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
-        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
-        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
 
         await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
         var moved = await poll.MoveNextAsync();
 
         await Assert.That(moved).IsFalse();
-        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
-    }
-
-    [Test]
-    public async Task BrokerSessionLoss_ClearsOnlyBrokerRenewedRecords()
-    {
-        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
-        await using var fixture = CreateFixture(connection);
-        fixture.MetadataManager.Metadata.Update(new MetadataResponse
-        {
-            Brokers =
-            [
-                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 },
-                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9092 }
-            ],
-            Topics =
-            [
-                new TopicMetadata
-                {
-                    ErrorCode = ErrorCode.None,
-                    Name = "topic",
-                    TopicId = TopicId,
-                    Partitions =
-                    [
-                        new PartitionMetadata
-                        {
-                            ErrorCode = ErrorCode.None,
-                            PartitionIndex = 0,
-                            LeaderId = 1,
-                            ReplicaNodes = [1],
-                            IsrNodes = [1]
-                        },
-                        new PartitionMetadata
-                        {
-                            ErrorCode = ErrorCode.None,
-                            PartitionIndex = 1,
-                            LeaderId = 2,
-                            ReplicaNodes = [2],
-                            IsrNodes = [2]
-                        }
-                    ]
-                }
-            ]
-        });
-        var first = CreateRecord(partition: 0, offset: 40);
-        var second = CreateRecord(partition: 1, offset: 41);
-        fixture.Consumer.Acknowledge(first, AcknowledgeType.Renew);
-        fixture.Consumer.Acknowledge(second, AcknowledgeType.Renew);
-        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgementsForBothPartitions());
-
-        InvokePrivate(fixture.Consumer, "ClearRenewedRecordsForBroker", 1);
-
-        var assignment = new HashSet<TopicPartition>
-        {
-            new("topic", 0),
-            new("topic", 1)
-        };
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsTrue();
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
         var active = GetActiveRenewedRecords(fixture.Consumer, assignment);
         await Assert.That(active).HasSingleItem();
-        await Assert.That(active[0].Partition).IsEqualTo(1);
+        await Assert.That(ReferenceEquals(active[0], record)).IsTrue();
     }
 
     [Test]
@@ -538,10 +477,32 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
     }
 
+    [Test]
+    public async Task Dispose_FlushesPendingAcknowledgements()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            ShareAcknowledgeResponse = new ShareAcknowledgeResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Accept);
+
+        await fixture.Consumer.DisposeAsync();
+
+        await Assert.That(connection.ShareAcknowledgeRequest).IsNotNull();
+    }
+
     private static Fixture CreateFixture(
         CapturingConnection connection,
         ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit,
-        int maxPollRecords = 500)
+        int maxPollRecords = 500,
+        CapturingConnection? secondConnection = null)
     {
         var options = new ShareConsumerOptions
         {
@@ -552,10 +513,18 @@ public sealed class ShareConsumerRenewalTests
         };
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        if (secondConnection is not null)
+            pool.GetConnectionAsync(2, Arg.Any<CancellationToken>()).Returns(secondConnection);
         var metadataManager = new MetadataManager(pool, options.BootstrapServers);
         metadataManager.Metadata.Update(new MetadataResponse
         {
-            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Brokers = secondConnection is null
+                ? [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }]
+                :
+                [
+                    new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 },
+                    new BrokerMetadata { NodeId = 2, Host = "localhost", Port = 9093 }
+                ],
             Topics =
             [
                 new TopicMetadata
@@ -577,9 +546,9 @@ public sealed class ShareConsumerRenewalTests
                         {
                             ErrorCode = ErrorCode.None,
                             PartitionIndex = 1,
-                            LeaderId = 1,
-                            ReplicaNodes = [1],
-                            IsrNodes = [1]
+                            LeaderId = secondConnection is null ? 1 : 2,
+                            ReplicaNodes = [secondConnection is null ? 1 : 2],
+                            IsrNodes = [secondConnection is null ? 1 : 2]
                         }
                     ]
                 }
@@ -593,6 +562,48 @@ public sealed class ShareConsumerRenewalTests
             metadataManager);
         SetMemberId(consumer, "member-1");
         return new Fixture(consumer, metadataManager);
+    }
+
+    private static ShareFetchResponse CreateFetchResponse(int partition, long offset)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using var batch = new RecordBatch
+        {
+            BaseOffset = offset,
+            Records = [new Record { IsKeyNull = true, Value = "new-value"u8.ToArray() }]
+        };
+        batch.Write(buffer);
+
+        return new ShareFetchResponse
+        {
+            ErrorCode = ErrorCode.None,
+            Responses =
+            [
+                new ShareFetchResponseTopic
+                {
+                    TopicId = TopicId,
+                    Partitions =
+                    [
+                        new ShareFetchResponsePartition
+                        {
+                            PartitionIndex = partition,
+                            CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                            RecordBytes = buffer.WrittenMemory,
+                            AcquiredRecords =
+                            [
+                                new ShareFetchAcquiredRecords
+                                {
+                                    FirstOffset = offset,
+                                    LastOffset = offset,
+                                    DeliveryCount = 1
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            NodeEndpoints = []
+        };
     }
 
     private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> RenewalAcknowledgements()
@@ -811,11 +822,14 @@ public sealed class ShareConsumerRenewalTests
         }
     }
 
-    private sealed class CapturingConnection(ApiKey apiKey, short maximumVersion) :
+    private sealed class CapturingConnection(
+        ApiKey apiKey,
+        short maximumVersion,
+        int brokerId = 1) :
         IKafkaConnection,
         IKafkaCapabilityProvider
     {
-        public int BrokerId => 1;
+        public int BrokerId => brokerId;
         public string Host => "localhost";
         public int Port => 9092;
         public bool IsConnected => true;

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -201,6 +201,133 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
+    public async Task Poll_InlineAcknowledgementError_RequeuesOnlyFailedPartition()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses =
+                [
+                    new ShareFetchResponseTopic
+                    {
+                        TopicId = TopicId,
+                        Partitions =
+                        [
+                            new ShareFetchResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                AcknowledgeErrorCode = ErrorCode.None,
+                                CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                                AcquiredRecords = []
+                            },
+                            new ShareFetchResponsePartition
+                            {
+                                PartitionIndex = 1,
+                                AcknowledgeErrorCode = ErrorCode.InvalidRecordState,
+                                CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                                AcquiredRecords = []
+                            }
+                        ]
+                    }
+                ],
+                NodeEndpoints = []
+            },
+            OnSend = cancellation.Cancel
+        };
+        await using var fixture = CreateFixture(connection);
+        PrepareForPoll(
+            fixture.Consumer,
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Accept);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Renew);
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await poll.MoveNextAsync();
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending.Keys).IsEquivalentTo([new TopicPartition("topic", 1)]);
+    }
+
+    [Test]
+    public async Task Commit_PartitionError_RequeuesOnlyFailedPartition()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            ShareAcknowledgeResponse = new ShareAcknowledgeResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses =
+                [
+                    new ShareAcknowledgeResponseTopic
+                    {
+                        TopicId = TopicId,
+                        Partitions =
+                        [
+                            new ShareAcknowledgeResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                ErrorCode = ErrorCode.None,
+                                CurrentLeader = new ShareAcknowledgeLeaderIdAndEpoch()
+                            },
+                            new ShareAcknowledgeResponsePartition
+                            {
+                                PartitionIndex = 1,
+                                ErrorCode = ErrorCode.InvalidRecordState,
+                                CurrentLeader = new ShareAcknowledgeLeaderIdAndEpoch()
+                            }
+                        ]
+                    }
+                ],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Accept);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Renew);
+
+        await Assert.That(async () => await fixture.Consumer.CommitAsync())
+            .Throws<KafkaException>();
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending.Keys).IsEquivalentTo([new TopicPartition("topic", 1)]);
+    }
+
+    [Test]
+    public async Task Commit_RetriablePartitionError_RetriesOnlyFailedPartition()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            ShareAcknowledgeResponses = new Queue<ShareAcknowledgeResponse>(
+            [
+                CreateAcknowledgeResponse(
+                    (0, ErrorCode.None),
+                    (1, ErrorCode.NotLeaderOrFollower)),
+                CreateAcknowledgeResponse((1, ErrorCode.None))
+            ])
+        };
+        await using var fixture = CreateFixture(connection);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Accept);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Renew);
+
+        await fixture.Consumer.CommitAsync();
+
+        await Assert.That(connection.ShareAcknowledgeRequests).Count().IsEqualTo(2);
+        var retryPartitions = connection.ShareAcknowledgeRequests[1].Topics
+            .SelectMany(static topic => topic.Partitions)
+            .Select(static partition => partition.PartitionIndex)
+            .ToArray();
+        await Assert.That(retryPartitions).IsEquivalentTo([1]);
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsFalse();
+    }
+
+    [Test]
     public async Task Poll_SessionLoss_ClearsRenewedRecords()
     {
         using var cancellation = new CancellationTokenSource();
@@ -228,6 +355,65 @@ public sealed class ShareConsumerRenewalTests
 
         await Assert.That(moved).IsFalse();
         await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+    }
+
+    [Test]
+    public async Task BrokerSessionLoss_ClearsOnlyBrokerRenewedRecords()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection);
+        fixture.MetadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9092 }
+            ],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic",
+                    TopicId = TopicId,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        },
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 1,
+                            LeaderId = 2,
+                            ReplicaNodes = [2],
+                            IsrNodes = [2]
+                        }
+                    ]
+                }
+            ]
+        });
+        var first = CreateRecord(partition: 0, offset: 40);
+        var second = CreateRecord(partition: 1, offset: 41);
+        fixture.Consumer.Acknowledge(first, AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(second, AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgementsForBothPartitions());
+
+        InvokePrivate(fixture.Consumer, "ClearRenewedRecordsForBroker", 1);
+
+        var assignment = new HashSet<TopicPartition>
+        {
+            new("topic", 0),
+            new("topic", 1)
+        };
+        var active = GetActiveRenewedRecords(fixture.Consumer, assignment);
+        await Assert.That(active).HasSingleItem();
+        await Assert.That(active[0].Partition).IsEqualTo(1);
     }
 
     [Test]
@@ -367,6 +553,47 @@ public sealed class ShareConsumerRenewalTests
             ]
         };
 
+    private static ShareAcknowledgeResponse CreateAcknowledgeResponse(
+        params (int Partition, ErrorCode ErrorCode)[] partitions)
+        => new()
+        {
+            ErrorCode = ErrorCode.None,
+            Responses =
+            [
+                new ShareAcknowledgeResponseTopic
+                {
+                    TopicId = TopicId,
+                    Partitions = partitions.Select(static partition =>
+                        new ShareAcknowledgeResponsePartition
+                        {
+                            PartitionIndex = partition.Partition,
+                            ErrorCode = partition.ErrorCode,
+                            CurrentLeader = new ShareAcknowledgeLeaderIdAndEpoch()
+                        }).ToArray()
+                }
+            ],
+            NodeEndpoints = []
+        };
+
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> RenewalAcknowledgementsForBothPartitions()
+        => new()
+        {
+            [new TopicPartition("topic", 0)] =
+            [
+                new AcknowledgementBatchData(
+                    40,
+                    40,
+                    [(byte)AcknowledgeType.Renew])
+            ],
+            [new TopicPartition("topic", 1)] =
+            [
+                new AcknowledgementBatchData(
+                    41,
+                    41,
+                    [(byte)AcknowledgeType.Renew])
+            ]
+        };
+
     private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> MixedAcknowledgements()
         => new()
         {
@@ -386,11 +613,13 @@ public sealed class ShareConsumerRenewalTests
             ]
         };
 
-    private static ShareConsumeResult<string, string> CreateRecord() => new()
+    private static ShareConsumeResult<string, string> CreateRecord(
+        int partition = 0,
+        long offset = 42) => new()
     {
         Topic = "topic",
-        Partition = 0,
-        Offset = 42,
+        Partition = partition,
+        Offset = offset,
         Value = "value",
         DeliveryCount = 1
     };
@@ -443,6 +672,15 @@ public sealed class ShareConsumerRenewalTests
             .GetValue(tracker)!;
     }
 
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> FlushPendingAcknowledgements(
+        KafkaShareConsumer<string, string> consumer)
+    {
+        var tracker = (AcknowledgementTracker)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_ackTracker", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        return tracker.Flush();
+    }
+
     private static int GetSessionEpoch(
         KafkaShareConsumer<string, string> consumer,
         int brokerId)
@@ -473,7 +711,9 @@ public sealed class ShareConsumerRenewalTests
             .SetValue(coordinator, memberId);
     }
 
-    private static void PrepareForPoll(KafkaShareConsumer<string, string> consumer)
+    private static void PrepareForPoll(
+        KafkaShareConsumer<string, string> consumer,
+        params TopicPartition[] assignedPartitions)
     {
         typeof(KafkaShareConsumer<string, string>)
             .GetField("_initialized", BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -481,9 +721,11 @@ public sealed class ShareConsumerRenewalTests
         var coordinator = typeof(KafkaShareConsumer<string, string>)
             .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(consumer)!;
+        if (assignedPartitions.Length == 0)
+            assignedPartitions = [new TopicPartition("topic", 0)];
         typeof(ShareConsumerCoordinator)
             .GetField("_assignedPartitions", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(coordinator, new HashSet<TopicPartition> { new("topic", 0) });
+            .SetValue(coordinator, assignedPartitions.ToHashSet());
         typeof(ShareConsumerCoordinator)
             .GetField("_state", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(coordinator, CoordinatorState.Stable);
@@ -494,11 +736,12 @@ public sealed class ShareConsumerRenewalTests
         MetadataManager metadataManager) : IAsyncDisposable
     {
         internal KafkaShareConsumer<string, string> Consumer { get; } = consumer;
+        internal MetadataManager MetadataManager { get; } = metadataManager;
 
         public async ValueTask DisposeAsync()
         {
             await Consumer.DisposeAsync();
-            await metadataManager.DisposeAsync();
+            await MetadataManager.DisposeAsync();
         }
     }
 
@@ -514,7 +757,14 @@ public sealed class ShareConsumerRenewalTests
             KafkaConnectionCapabilities.Create(new ApiVersionsResponse
             {
                 ErrorCode = ErrorCode.None,
-                ApiKeys = [new ApiVersion(apiKey, 0, maximumVersion)]
+                ApiKeys =
+                [
+                    new ApiVersion(apiKey, 0, maximumVersion),
+                    new ApiVersion(
+                        ApiKey.Metadata,
+                        MetadataRequest.LowestSupportedVersion,
+                        MetadataRequest.HighestSupportedVersion)
+                ]
             });
         internal int SendCount { get; private set; }
         internal short LastApiVersion { get; private set; }
@@ -522,6 +772,8 @@ public sealed class ShareConsumerRenewalTests
         internal ShareAcknowledgeRequest? ShareAcknowledgeRequest { get; private set; }
         internal ShareFetchResponse? ShareFetchResponse { get; init; }
         internal ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
+        internal Queue<ShareAcknowledgeResponse>? ShareAcknowledgeResponses { get; init; }
+        internal List<ShareAcknowledgeRequest> ShareAcknowledgeRequests { get; } = [];
         internal Action? OnSend { get; init; }
 
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
@@ -545,12 +797,46 @@ public sealed class ShareConsumerRenewalTests
                     }),
                 ShareAcknowledgeRequest acknowledge => Capture(
                     acknowledge,
-                    ShareAcknowledgeResponse ?? new ShareAcknowledgeResponse
+                    ShareAcknowledgeResponses is { Count: > 0 }
+                        ? ShareAcknowledgeResponses.Dequeue()
+                        : ShareAcknowledgeResponse ?? new ShareAcknowledgeResponse
                     {
                         ErrorCode = ErrorCode.None,
                         Responses = [],
                         NodeEndpoints = []
                     }),
+                MetadataRequest => new MetadataResponse
+                {
+                    Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+                    Topics =
+                    [
+                        new TopicMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            Name = "topic",
+                            TopicId = TopicId,
+                            Partitions =
+                            [
+                                new PartitionMetadata
+                                {
+                                    ErrorCode = ErrorCode.None,
+                                    PartitionIndex = 0,
+                                    LeaderId = 1,
+                                    ReplicaNodes = [1],
+                                    IsrNodes = [1]
+                                },
+                                new PartitionMetadata
+                                {
+                                    ErrorCode = ErrorCode.None,
+                                    PartitionIndex = 1,
+                                    LeaderId = 1,
+                                    ReplicaNodes = [1],
+                                    IsrNodes = [1]
+                                }
+                            ]
+                        }
+                    ]
+                },
                 _ => throw new NotSupportedException(typeof(TRequest).Name)
             };
             OnSend?.Invoke();
@@ -570,6 +856,7 @@ public sealed class ShareConsumerRenewalTests
             ShareAcknowledgeResponse response)
         {
             ShareAcknowledgeRequest = request;
+            ShareAcknowledgeRequests.Add(request);
             return response;
         }
 

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1,0 +1,613 @@
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.ShareConsumer;
+
+public sealed class ShareConsumerRenewalTests
+{
+    private static readonly Guid TopicId = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef");
+
+    [Test]
+    public async Task ShareFetch_Renewal_UsesV2AndZeroFetchLimits()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection);
+        var acknowledgements = MixedAcknowledgements();
+
+        await InvokeShareFetchAsync(
+            fixture.Consumer,
+            acknowledgements,
+            [new TopicPartition("topic", 0), new TopicPartition("topic", 1)]);
+
+        var request = connection.ShareFetchRequest!;
+        await Assert.That(connection.LastApiVersion).IsEqualTo((short)2);
+        await Assert.That(request.IsRenewAck).IsTrue();
+        await Assert.That(request.MaxWaitMs).IsEqualTo(0);
+        await Assert.That(request.MinBytes).IsEqualTo(0);
+        await Assert.That(request.MaxBytes).IsEqualTo(0);
+        await Assert.That(request.MaxRecords).IsEqualTo(0);
+        await Assert.That(request.BatchSize).IsEqualTo(0);
+        var acknowledgementTypes = request.Topics[0].Partitions
+            .SelectMany(static partition => partition.AcknowledgementBatches!)
+            .SelectMany(static batch => batch.AcknowledgeTypes)
+            .ToArray();
+        await Assert.That(acknowledgementTypes).Contains((byte)AcknowledgeType.Accept);
+        await Assert.That(acknowledgementTypes).Contains((byte)AcknowledgeType.Renew);
+        await Assert.That(acknowledgementTypes).Contains((byte)AcknowledgeType.Reject);
+    }
+
+    [Test]
+    public async Task ShareFetch_Renewal_OnV1Broker_FailsLocally()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 1);
+        await using var fixture = CreateFixture(connection);
+
+        var exception = await Assert.That(async () =>
+                await InvokeShareFetchAsync(fixture.Consumer, RenewalAcknowledgements()))
+            .Throws<BrokerVersionException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.UnsupportedVersion);
+        await Assert.That(connection.SendCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShareAcknowledge_Renewal_UsesV2AndPublishesLockTimeout()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 2)
+        {
+            ShareAcknowledgeResponse = new ShareAcknowledgeResponse
+            {
+                ErrorCode = ErrorCode.None,
+                AcquisitionLockTimeoutMs = 45_000,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+
+        await InvokeShareAcknowledgeAsync(fixture.Consumer, RenewalAcknowledgements());
+
+        await Assert.That(connection.LastApiVersion).IsEqualTo((short)2);
+        await Assert.That(connection.ShareAcknowledgeRequest!.IsRenewAck).IsTrue();
+        await Assert.That(fixture.Consumer.AcquisitionLockTimeoutMs).IsEqualTo(45_000);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 1)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareAcknowledge_Renewal_OnV1Broker_FailsLocally()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareAcknowledge, 1);
+        await using var fixture = CreateFixture(connection);
+
+        var exception = await Assert.That(async () =>
+                await InvokeShareAcknowledgeAsync(fixture.Consumer, RenewalAcknowledgements()))
+            .Throws<BrokerVersionException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.UnsupportedVersion);
+        await Assert.That(connection.SendCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Acknowledge_Renewal_InImplicitMode_IsRejected()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection, ShareAcknowledgementMode.Implicit);
+
+        await Assert.That(() => fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ShareFetch_RenewalFlag_IsScopedToBrokerPartitions()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection);
+        var acknowledgements = MixedAcknowledgements();
+
+        await InvokeShareFetchAsync(
+            fixture.Consumer,
+            acknowledgements,
+            [new TopicPartition("topic", 0)]);
+        await Assert.That(connection.ShareFetchRequest!.IsRenewAck).IsFalse();
+        await Assert.That(connection.ShareFetchRequest.MaxWaitMs).IsGreaterThan(0);
+
+        await InvokeShareFetchAsync(
+            fixture.Consumer,
+            acknowledgements,
+            [new TopicPartition("topic", 1)]);
+        await Assert.That(connection.ShareFetchRequest!.IsRenewAck).IsTrue();
+        await Assert.That(connection.ShareFetchRequest.MaxWaitMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Poll_RenewalSuccess_ReplaysRecordAndPublishesLockTimeout()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                AcquisitionLockTimeoutMs = 30_000,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection);
+        var record = CreateRecord();
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
+
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsTrue();
+        await Assert.That(ReferenceEquals(poll.Current, record)).IsTrue();
+        await Assert.That(fixture.Consumer.AcquisitionLockTimeoutMs).IsEqualTo(30_000);
+        await Assert.That(fixture.Consumer.RenewedRecordReplayCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Poll_InlineAcknowledgementError_RequeuesAndDoesNotReplayRenewal()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                AcquisitionLockTimeoutMs = 30_000,
+                Responses =
+                [
+                    new ShareFetchResponseTopic
+                    {
+                        TopicId = TopicId,
+                        Partitions =
+                        [
+                            new ShareFetchResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                AcknowledgeErrorCode = ErrorCode.InvalidRecordState,
+                                CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                                AcquiredRecords = []
+                            }
+                        ]
+                    }
+                ],
+                NodeEndpoints = []
+            },
+            OnSend = cancellation.Cancel
+        };
+        await using var fixture = CreateFixture(connection);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsFalse();
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+        await Assert.That(HasPendingAcknowledgements(fixture.Consumer)).IsTrue();
+    }
+
+    [Test]
+    public async Task Poll_SessionLoss_ClearsRenewedRecords()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.ShareSessionNotFound,
+                Responses = [],
+                NodeEndpoints = []
+            },
+            OnSend = cancellation.Cancel
+        };
+        await using var fixture = CreateFixture(connection);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        var record = CreateRecord();
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsFalse();
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+    }
+
+    [Test]
+    public async Task SuccessfulRenewal_ReplaysRecordUntilTerminalAcknowledgementSucceeds()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection);
+        var record = CreateRecord();
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+
+        var replayed = GetActiveRenewedRecords(fixture.Consumer, assignment);
+        await Assert.That(replayed).HasSingleItem();
+        await Assert.That(ReferenceEquals(replayed[0], record)).IsTrue();
+        await Assert.That(fixture.Consumer.RenewalRequestCount).IsEqualTo(1);
+
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Accept);
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).HasSingleItem();
+
+        ApplySuccessfulAcknowledgements(fixture.Consumer, TerminalAcknowledgements());
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+    }
+
+    [Test]
+    public async Task RenewedRecord_IsRemovedByRedeliveryOrAssignmentLoss()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        await using var fixture = CreateFixture(connection);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+        InvokePrivate(fixture.Consumer, "RemoveRenewedRecord", "topic", 0, 42L);
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+        InvokePrivate(
+            fixture.Consumer,
+            "RemoveRenewedRecordsOutsideAssignment",
+            new HashSet<TopicPartition>());
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+    }
+
+    [Test]
+    public async Task Dispose_ClearsRenewedRecords()
+    {
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2);
+        var fixture = CreateFixture(connection);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+
+        await fixture.DisposeAsync();
+
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+    }
+
+    private static Fixture CreateFixture(
+        CapturingConnection connection,
+        ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit)
+    {
+        var options = new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "share-group",
+            AcknowledgementMode = acknowledgementMode
+        };
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);
+        var metadataManager = new MetadataManager(pool, options.BootstrapServers);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = "topic",
+                    TopicId = TopicId,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 1,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        },
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 1,
+                            LeaderId = 1,
+                            ReplicaNodes = [1],
+                            IsrNodes = [1]
+                        }
+                    ]
+                }
+            ]
+        });
+        var consumer = new KafkaShareConsumer<string, string>(
+            options,
+            Substitute.For<IDeserializer<string>>(),
+            Substitute.For<IDeserializer<string>>(),
+            pool,
+            metadataManager);
+        SetMemberId(consumer, "member-1");
+        return new Fixture(consumer, metadataManager);
+    }
+
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> RenewalAcknowledgements()
+        => new()
+        {
+            [new TopicPartition("topic", 0)] =
+            [
+                new AcknowledgementBatchData(
+                    42,
+                    42,
+                    [(byte)AcknowledgeType.Renew])
+            ]
+        };
+
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> TerminalAcknowledgements()
+        => new()
+        {
+            [new TopicPartition("topic", 0)] =
+            [
+                new AcknowledgementBatchData(
+                    42,
+                    42,
+                    [(byte)AcknowledgeType.Accept])
+            ]
+        };
+
+    private static Dictionary<TopicPartition, List<AcknowledgementBatchData>> MixedAcknowledgements()
+        => new()
+        {
+            [new TopicPartition("topic", 0)] =
+            [
+                new AcknowledgementBatchData(
+                    40,
+                    40,
+                    [(byte)AcknowledgeType.Accept])
+            ],
+            [new TopicPartition("topic", 1)] =
+            [
+                new AcknowledgementBatchData(
+                    41,
+                    42,
+                    [(byte)AcknowledgeType.Renew, (byte)AcknowledgeType.Reject])
+            ]
+        };
+
+    private static ShareConsumeResult<string, string> CreateRecord() => new()
+    {
+        Topic = "topic",
+        Partition = 0,
+        Offset = 42,
+        Value = "value",
+        DeliveryCount = 1
+    };
+
+    private static Task InvokeShareFetchAsync(
+        KafkaShareConsumer<string, string> consumer,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements,
+        List<TopicPartition>? partitions = null)
+        => (Task)InvokePrivate(
+            consumer,
+            "SendShareFetchForPartitionsAsync",
+            1,
+            partitions ?? [new TopicPartition("topic", 0)],
+            acknowledgements,
+            CancellationToken.None)!;
+
+    private static Task InvokeShareAcknowledgeAsync(
+        KafkaShareConsumer<string, string> consumer,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements)
+        => (Task)InvokePrivate(
+            consumer,
+            "SendAcknowledgeAsync",
+            1,
+            acknowledgements,
+            false,
+            CancellationToken.None)!;
+
+    private static void ApplySuccessfulAcknowledgements(
+        KafkaShareConsumer<string, string> consumer,
+        Dictionary<TopicPartition, List<AcknowledgementBatchData>> acknowledgements)
+        => InvokePrivate(consumer, "ApplySuccessfulAcknowledgements", acknowledgements);
+
+    private static List<ShareConsumeResult<string, string>> GetActiveRenewedRecords(
+        KafkaShareConsumer<string, string> consumer,
+        IReadOnlySet<TopicPartition> assignment)
+        => (List<ShareConsumeResult<string, string>>)InvokePrivate(
+            consumer,
+            "GetActiveRenewedRecords",
+            assignment,
+            10)!;
+
+    private static bool HasPendingAcknowledgements(
+        KafkaShareConsumer<string, string> consumer)
+    {
+        var tracker = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_ackTracker", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        return (bool)tracker.GetType()
+            .GetProperty("HasPending", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(tracker)!;
+    }
+
+    private static int GetSessionEpoch(
+        KafkaShareConsumer<string, string> consumer,
+        int brokerId)
+    {
+        var sessionManager = (ShareSessionManager)typeof(KafkaShareConsumer<string, string>)
+            .GetField("_sessionManager", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        return sessionManager.GetSessionEpoch(brokerId);
+    }
+
+    private static object? InvokePrivate(
+        KafkaShareConsumer<string, string> consumer,
+        string methodName,
+        params object?[] arguments)
+        => typeof(KafkaShareConsumer<string, string>)
+            .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(consumer, arguments);
+
+    private static void SetMemberId(
+        KafkaShareConsumer<string, string> consumer,
+        string memberId)
+    {
+        var coordinator = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        typeof(ShareConsumerCoordinator)
+            .GetField("_memberId", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, memberId);
+    }
+
+    private static void PrepareForPoll(KafkaShareConsumer<string, string> consumer)
+    {
+        typeof(KafkaShareConsumer<string, string>)
+            .GetField("_initialized", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(consumer, true);
+        var coordinator = typeof(KafkaShareConsumer<string, string>)
+            .GetField("_coordinator", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer)!;
+        typeof(ShareConsumerCoordinator)
+            .GetField("_assignedPartitions", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, new HashSet<TopicPartition> { new("topic", 0) });
+        typeof(ShareConsumerCoordinator)
+            .GetField("_state", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(coordinator, CoordinatorState.Stable);
+    }
+
+    private sealed class Fixture(
+        KafkaShareConsumer<string, string> consumer,
+        MetadataManager metadataManager) : IAsyncDisposable
+    {
+        internal KafkaShareConsumer<string, string> Consumer { get; } = consumer;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Consumer.DisposeAsync();
+            await metadataManager.DisposeAsync();
+        }
+    }
+
+    private sealed class CapturingConnection(ApiKey apiKey, short maximumVersion) :
+        IKafkaConnection,
+        IKafkaCapabilityProvider
+    {
+        public int BrokerId => 1;
+        public string Host => "localhost";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public KafkaConnectionCapabilities Capabilities { get; } =
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = [new ApiVersion(apiKey, 0, maximumVersion)]
+            });
+        internal int SendCount { get; private set; }
+        internal short LastApiVersion { get; private set; }
+        internal ShareFetchRequest? ShareFetchRequest { get; private set; }
+        internal ShareAcknowledgeRequest? ShareAcknowledgeRequest { get; private set; }
+        internal ShareFetchResponse? ShareFetchResponse { get; init; }
+        internal ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
+        internal Action? OnSend { get; init; }
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            SendCount++;
+            LastApiVersion = apiVersion;
+            IKafkaResponse response = request switch
+            {
+                ShareFetchRequest fetch => Capture(
+                    fetch,
+                    ShareFetchResponse ?? new ShareFetchResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        Responses = [],
+                        NodeEndpoints = []
+                    }),
+                ShareAcknowledgeRequest acknowledge => Capture(
+                    acknowledge,
+                    ShareAcknowledgeResponse ?? new ShareAcknowledgeResponse
+                    {
+                        ErrorCode = ErrorCode.None,
+                        Responses = [],
+                        NodeEndpoints = []
+                    }),
+                _ => throw new NotSupportedException(typeof(TRequest).Name)
+            };
+            OnSend?.Invoke();
+            return new ValueTask<TResponse>((TResponse)response);
+        }
+
+        private ShareFetchResponse Capture(
+            ShareFetchRequest request,
+            ShareFetchResponse response)
+        {
+            ShareFetchRequest = request;
+            return response;
+        }
+
+        private ShareAcknowledgeResponse Capture(
+            ShareAcknowledgeRequest request,
+            ShareAcknowledgeResponse response)
+        {
+            ShareAcknowledgeRequest = request;
+            return response;
+        }
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+            => throw new NotSupportedException();
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -5,6 +6,7 @@ using Dekaf.Metadata;
 using Dekaf.Networking;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Dekaf.ShareConsumer;
 using NSubstitute;
@@ -153,6 +155,68 @@ public sealed class ShareConsumerRenewalTests
         await Assert.That(ReferenceEquals(poll.Current, record)).IsTrue();
         await Assert.That(fixture.Consumer.AcquisitionLockTimeoutMs).IsEqualTo(30_000);
         await Assert.That(fixture.Consumer.RenewedRecordReplayCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Poll_FetchedRecord_ReservesBudgetBeforeRenewalReplay()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var batch = new RecordBatch
+        {
+            BaseOffset = 100,
+            Records = [new Record { IsKeyNull = true, Value = "new-value"u8.ToArray() }]
+        })
+        {
+            batch.Write(buffer);
+        }
+
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses =
+                [
+                    new ShareFetchResponseTopic
+                    {
+                        TopicId = TopicId,
+                        Partitions =
+                        [
+                            new ShareFetchResponsePartition
+                            {
+                                PartitionIndex = 0,
+                                CurrentLeader = new ShareFetchLeaderIdAndEpoch(),
+                                RecordBytes = buffer.WrittenMemory,
+                                AcquiredRecords =
+                                [
+                                    new ShareFetchAcquiredRecords
+                                    {
+                                        FirstOffset = 100,
+                                        LastOffset = 100,
+                                        DeliveryCount = 1
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(connection, maxPollRecords: 1);
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+        FlushPendingAcknowledgements(fixture.Consumer);
+
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsTrue();
+        await Assert.That(poll.Current.Offset).IsEqualTo(100);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).HasSingleItem();
     }
 
     [Test]
@@ -476,13 +540,15 @@ public sealed class ShareConsumerRenewalTests
 
     private static Fixture CreateFixture(
         CapturingConnection connection,
-        ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit)
+        ShareAcknowledgementMode acknowledgementMode = ShareAcknowledgementMode.Explicit,
+        int maxPollRecords = 500)
     {
         var options = new ShareConsumerOptions
         {
             BootstrapServers = ["localhost:9092"],
             GroupId = "share-group",
-            AcknowledgementMode = acknowledgementMode
+            AcknowledgementMode = acknowledgementMode,
+            MaxPollRecords = maxPollRecords
         };
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(1, Arg.Any<CancellationToken>()).Returns(connection);

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -216,6 +216,39 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
+    public async Task Poll_BrokerFailure_RequeuesOnlyFailedBrokerAcknowledgements()
+    {
+        var firstConnection = new CapturingConnection(ApiKey.ShareFetch, 1);
+        var secondConnection = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(
+            firstConnection,
+            secondConnection: secondConnection);
+        PrepareForPoll(
+            fixture.Consumer,
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Accept);
+
+        await using var poll = fixture.Consumer.PollAsync().GetAsyncEnumerator();
+        await Assert.That(async () => await poll.MoveNextAsync())
+            .Throws<BrokerVersionException>();
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending.Keys).IsEquivalentTo([new TopicPartition("topic", 0)]);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 2)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Poll_InlineAcknowledgementError_RequeuesAndDoesNotReplayRenewal()
     {
         using var cancellation = new CancellationTokenSource();
@@ -417,6 +450,34 @@ public sealed class ShareConsumerRenewalTests
         var active = GetActiveRenewedRecords(fixture.Consumer, assignment);
         await Assert.That(active).HasSingleItem();
         await Assert.That(ReferenceEquals(active[0], record)).IsTrue();
+    }
+
+    [Test]
+    public async Task Poll_SessionLoss_DropsActiveRenewal()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.ShareSessionNotFound,
+                Responses = [],
+                NodeEndpoints = []
+            },
+            OnSend = cancellation.Cancel
+        };
+        await using var fixture = CreateFixture(connection);
+        var assignment = new HashSet<TopicPartition> { new("topic", 0) };
+        PrepareForPoll(fixture.Consumer);
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        var moved = await poll.MoveNextAsync();
+
+        await Assert.That(moved).IsFalse();
+        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
+++ b/tests/Dekaf.Tests.Unit/ShareConsumer/ShareConsumerRenewalTests.cs
@@ -249,6 +249,89 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
+    public async Task Poll_CancelledRetry_RequeuesFailedBrokerAndProcessesSuccessfulBroker()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var firstConnection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchException = new KafkaException(
+                ErrorCode.RequestTimedOut,
+                "simulated timeout"),
+            OnSend = cancellation.Cancel
+        };
+        var secondConnection = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(
+            firstConnection,
+            secondConnection: secondConnection);
+        PrepareForPoll(
+            fixture.Consumer,
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 40), AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 41), AcknowledgeType.Accept);
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await Assert.That(async () => await poll.MoveNextAsync())
+            .Throws<OperationCanceledException>();
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending.Keys).IsEquivalentTo([new TopicPartition("topic", 0)]);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 2)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Poll_CancelledResponseRetry_RequeuesFailedBrokerAndProcessesSuccessfulBroker()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var firstConnection = new CapturingConnection(ApiKey.ShareFetch, 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.RequestTimedOut,
+                Responses = [],
+                NodeEndpoints = []
+            },
+            OnSend = cancellation.Cancel
+        };
+        var secondConnection = new CapturingConnection(ApiKey.ShareFetch, 2, brokerId: 2)
+        {
+            ShareFetchResponse = new ShareFetchResponse
+            {
+                ErrorCode = ErrorCode.None,
+                Responses = [],
+                NodeEndpoints = []
+            }
+        };
+        await using var fixture = CreateFixture(
+            firstConnection,
+            secondConnection: secondConnection);
+        PrepareForPoll(
+            fixture.Consumer,
+            new TopicPartition("topic", 0),
+            new TopicPartition("topic", 1));
+        fixture.Consumer.Subscribe("topic");
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 0, offset: 42), AcknowledgeType.Renew);
+        fixture.Consumer.Acknowledge(CreateRecord(partition: 1, offset: 43), AcknowledgeType.Accept);
+
+        await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
+        await Assert.That(async () => await poll.MoveNextAsync())
+            .Throws<OperationCanceledException>();
+
+        var pending = FlushPendingAcknowledgements(fixture.Consumer);
+        await Assert.That(pending.Keys).IsEquivalentTo([new TopicPartition("topic", 0)]);
+        await Assert.That(GetSessionEpoch(fixture.Consumer, 2)).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Poll_InlineAcknowledgementError_RequeuesAndDoesNotReplayRenewal()
     {
         using var cancellation = new CancellationTokenSource();
@@ -453,7 +536,7 @@ public sealed class ShareConsumerRenewalTests
     }
 
     [Test]
-    public async Task Poll_SessionLoss_DropsActiveRenewal()
+    public async Task Poll_SessionLoss_ReplaysActiveRenewal()
     {
         using var cancellation = new CancellationTokenSource();
         var connection = new CapturingConnection(ApiKey.ShareFetch, 2)
@@ -470,14 +553,18 @@ public sealed class ShareConsumerRenewalTests
         var assignment = new HashSet<TopicPartition> { new("topic", 0) };
         PrepareForPoll(fixture.Consumer);
         fixture.Consumer.Subscribe("topic");
-        fixture.Consumer.Acknowledge(CreateRecord(), AcknowledgeType.Renew);
+        var record = CreateRecord();
+        fixture.Consumer.Acknowledge(record, AcknowledgeType.Renew);
         ApplySuccessfulAcknowledgements(fixture.Consumer, RenewalAcknowledgements());
 
         await using var poll = fixture.Consumer.PollAsync(cancellation.Token).GetAsyncEnumerator();
         var moved = await poll.MoveNextAsync();
 
-        await Assert.That(moved).IsFalse();
-        await Assert.That(GetActiveRenewedRecords(fixture.Consumer, assignment)).IsEmpty();
+        await Assert.That(moved).IsTrue();
+        await Assert.That(ReferenceEquals(poll.Current, record)).IsTrue();
+        var active = GetActiveRenewedRecords(fixture.Consumer, assignment);
+        await Assert.That(active).HasSingleItem();
+        await Assert.That(ReferenceEquals(active[0], record)).IsTrue();
     }
 
     [Test]
@@ -915,6 +1002,7 @@ public sealed class ShareConsumerRenewalTests
         internal ShareAcknowledgeResponse? ShareAcknowledgeResponse { get; init; }
         internal Queue<ShareAcknowledgeResponse>? ShareAcknowledgeResponses { get; init; }
         internal List<ShareAcknowledgeRequest> ShareAcknowledgeRequests { get; } = [];
+        internal Exception? ShareFetchException { get; init; }
         internal Action? OnSend { get; init; }
 
         public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
@@ -981,6 +1069,9 @@ public sealed class ShareConsumerRenewalTests
                 _ => throw new NotSupportedException(typeof(TRequest).Name)
             };
             OnSend?.Invoke();
+            if (request is ShareFetchRequest && ShareFetchException is not null)
+                throw ShareFetchException;
+
             return new ValueTask<TResponse>((TResponse)response);
         }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ShareConsumerRenewalBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class ShareConsumerRenewalBenchmarks
+{
+    private readonly KafkaShareConsumer<string, string> _consumer = new(
+        new ShareConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            GroupId = "benchmark-share-group",
+            AcknowledgementMode = ShareAcknowledgementMode.Explicit
+        },
+        Serializers.String,
+        Serializers.String);
+
+    private readonly ShareConsumeResult<string, string> _record = new()
+    {
+        Topic = "benchmark-topic",
+        Partition = 0,
+        Offset = 42,
+        Value = "value",
+        DeliveryCount = 1
+    };
+
+    [GlobalSetup]
+    public void Setup() => _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+
+    [Benchmark]
+    public void AcknowledgeExistingRenewal()
+        => _consumer.Acknowledge(_record, AcknowledgeType.Renew);
+}


### PR DESCRIPTION
## Summary
- implement explicit-mode Renew acknowledgements over ShareFetch/ShareAcknowledge v2 with actual-connection capability gates
- expose acquisition lock timeout and retain renewed records across polls until terminal acknowledgement, redelivery, or broker-scoped lifecycle reset
- advance share-session epochs across ShareFetch and ShareAcknowledge; retry/requeue acknowledgements at partition granularity
- reserve poll capacity for broker-fetched records before replaying retained renewals
- fix DisposeAsync so CloseAsync flush/session shutdown runs instead of being skipped by the closed guard
- add renewal diagnostics and mixed-success acknowledgement regressions

## Tests
- solution build: 0 warnings/errors
- unit net10.0: 5959 passed
- unit net8.0: 5832 passed
- Kafka 4.3 integration: ShareConsumer_Renewal_RetainsRecordAcrossPolls passed

Closes #2242