### PR TITLE
test(retry): make cancellation deterministic

### DIFF
--- a/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
+++ b/tests/Dekaf.Tests.Unit/Retry/RetryHelperTests.cs
@@ -76,7 +76,7 @@ public sealed class RetryHelperTests
     public async Task CancellationDuringBackoff_StopsRetrying()
     {
         await using var metadataManager = CreateUnavailableMetadataManager();
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
+        using var cancellation = new CancellationTokenSource();
         var attempts = 0;
 
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
@@ -90,6 +90,11 @@ public sealed class RetryHelperTests
                 cancellation.Token,
                 retryBackoffMs: 1000,
                 retryBackoffMaxMs: 1000,
+                onRetry: _ =>
+                {
+                    cancellation.Cancel();
+                    return ValueTask.CompletedTask;
+                },
                 maxRetries: 3));
 
         await Assert.That(attempts).IsEqualTo(1);


### PR DESCRIPTION
## Summary
- replace wall-clock cancellation in the RetryHelper backoff test
- cancel deterministically from the onRetry boundary after metadata refresh and before Task.Delay
- preserve the assertion that cancellation prevents a second operation attempt

## Validation
- unit build: 0 warnings/errors
- target test: 1/1 net10.0, 1/1 net8.0
- full unit: 5981/5981 net10.0, 5854/5854 net8.0
- /simplify complete

Closes #2326