### PR TITLE
test(protocol): cover capability generations

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -65,6 +65,35 @@ Register `ISerializer<T>` and `IDeserializer<T>` in DI when your application use
 
 Use Testcontainers or another real broker for protocol compatibility and integration coverage.
 
+## Protocol capability regression tests
+
+Physical-connection API negotiation has deterministic coverage for heterogeneous brokers,
+reconnect generations, `ApiVersions` fallback, finalized-feature epochs, concurrent replacement,
+and handshake disposal. Run the focused cross-platform suite with:
+
+```bash
+dotnet run --project tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj \
+  --framework net10.0 -- \
+  --treenode-filter "/*/*/(KafkaConnectionCapabilitiesTests|KafkaConnectionCapabilityHandshakeTests)/*"
+```
+
+Run the capability creation and lookup benchmarks with:
+
+```bash
+dotnet run --configuration Release \
+  --project tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj -- \
+  --filter "*ApiVersionNegotiationBenchmarks*"
+```
+
+The ready-connection send path performs an O(1), allocation-free packed-array lookup and no
+network call. Mandatory negotiation adds one `ApiVersions` request/response round trip when a
+physical connection is created. A broker that rejects v4 adds one v3 fallback round trip. Snapshot
+creation happens once per physical connection generation and is measured separately from lookup.
+
+The release integration matrix retains Kafka 4.0.2 as the compatibility floor and Kafka 4.3.1 as
+the current release, with intermediate 4.1.2 and 4.2.1 coverage. NativeAOT release gates cover the
+4.0.2 floor and 4.3.1 current release.
+
 ## NativeAOT smoke validation
 
 CI runs a `NativeAOT Smoke` pull-request job for the supported `linux-x64`

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilitiesTests.cs
@@ -210,6 +210,90 @@ public class KafkaConnectionCapabilitiesTests
 
         await Assert.That(olderVersion).IsEqualTo((short)14);
         await Assert.That(newerVersion).IsEqualTo((short)16);
+        await Assert.That(((CapabilityConnection)olderConnection).SendCount).IsEqualTo(0);
+        await Assert.That(((CapabilityConnection)newerConnection).SendCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task HeterogeneousBrokers_ConcurrentSendsUseTargetConnectionVersions()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["bootstrap:9092"]);
+        metadata.SetApiVersion(ApiKey.Metadata, 9, 13);
+
+        var releaseSends = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var older = new GenerationConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 11)),
+            releaseSends.Task);
+        var newer = new GenerationConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Metadata, 9, 13)),
+            releaseSends.Task);
+
+        var olderSend = SendMetadataAsync(metadata, older);
+        var newerSend = SendMetadataAsync(metadata, newer);
+        await Task.WhenAll(older.SendStarted, newer.SendStarted);
+
+        releaseSends.SetResult();
+        await Task.WhenAll(olderSend, newerSend);
+
+        await Assert.That(older.ObservedApiVersion).IsEqualTo((short)11);
+        await Assert.That(newer.ObservedApiVersion).IsEqualTo((short)13);
+    }
+
+    [Test]
+    public async Task ExactConnectionVersionSelection_IsAllocationFreeAndDoesNotSend()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["bootstrap:9092"]);
+        metadata.SetApiVersion(ApiKey.Produce, 3, 13);
+        var connection = new CapabilityConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Produce, 3, 7)));
+
+        _ = metadata.GetNegotiatedApiVersion(connection, ApiKey.Produce, 3, 13);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var versionSum = 0;
+        for (var i = 0; i < 10_000; i++)
+        {
+            versionSum += metadata.GetNegotiatedApiVersion(
+                connection,
+                ApiKey.Produce,
+                3,
+                13);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        GC.KeepAlive(versionSum);
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(connection.SendCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DisjointTargetRange_FailsBeforeRequestWrite()
+    {
+        await using var metadata = new MetadataManager(
+            Substitute.For<IConnectionPool>(),
+            ["bootstrap:9092"]);
+        var connection = new CapabilityConnection(
+            CreateCapabilities(new ApiVersion(ApiKey.Produce, 0, 2)));
+
+        Func<Task> send = async () =>
+        {
+            var version = metadata.GetNegotiatedApiVersion(
+                connection,
+                ApiKey.Produce,
+                3,
+                13);
+            _ = await connection.SendAsync<ProduceRequest, ProduceResponse>(
+                new ProduceRequest(),
+                version,
+                CancellationToken.None);
+        };
+
+        await Assert.That(send).Throws<BrokerVersionException>();
+        await Assert.That(connection.SendCount).IsEqualTo(0);
     }
 
     [Test]
@@ -356,6 +440,21 @@ public class KafkaConnectionCapabilitiesTests
     private static KafkaConnectionCapabilities CreateCapabilities(params ApiVersion[] versions)
         => KafkaConnectionCapabilities.Create(CreateResponse(versions));
 
+    private static async Task SendMetadataAsync(
+        MetadataManager metadata,
+        GenerationConnection connection)
+    {
+        var version = metadata.GetNegotiatedApiVersion(
+            connection,
+            ApiKey.Metadata,
+            9,
+            13);
+        _ = await connection.SendAsync<MetadataRequest, MetadataResponse>(
+            MetadataRequest.ForAllTopics(),
+            version,
+            CancellationToken.None);
+    }
+
     private static KafkaConnectionCapabilities CreateFeatureCapabilities(
         long epoch,
         params FinalizedFeature[] features)
@@ -387,6 +486,7 @@ public class KafkaConnectionCapabilitiesTests
         public bool IsConnected => true;
         public KafkaConnectionCapabilities Capabilities { get; } = capabilities;
         public short ObservedApiVersion { get; private set; } = -1;
+        public int SendCount { get; private set; }
 
         public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
@@ -397,6 +497,7 @@ public class KafkaConnectionCapabilitiesTests
             where TRequest : IKafkaRequest<TResponse>
             where TResponse : IKafkaResponse
         {
+            SendCount++;
             if (request is not MetadataRequest)
                 throw new NotSupportedException();
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -65,6 +65,58 @@ public class KafkaConnectionCapabilityHandshakeTests
     }
 
     [Test]
+    [Timeout(15_000)]
+    public async Task DisposeDuringCapabilityHandshake_NeverPublishesReadyConnection(
+        CancellationToken cancellationToken)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var requestReceived = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var serverTask = Task.Run(async () =>
+        {
+            using var socket = await listener.AcceptSocketAsync(cancellationToken);
+            await using var stream = new NetworkStream(socket, ownsSocket: false);
+            _ = await ReadFrameAsync(stream, cancellationToken);
+            requestReceived.SetResult();
+
+            var buffer = new byte[1];
+            try
+            {
+                var bytesRead = await stream.ReadAsync(buffer, cancellationToken);
+                await Assert.That(bytesRead).IsEqualTo(0);
+            }
+            catch (IOException)
+            {
+                // Windows commonly reports the intentional client-side abort as a reset.
+            }
+        }, cancellationToken);
+
+        var connection = new KafkaConnection(1, "127.0.0.1", port);
+        var connectTask = connection.ConnectAsync(cancellationToken).AsTask();
+        await requestReceived.Task.WaitAsync(cancellationToken);
+
+        await connection.DisposeAsync();
+        Exception? connectException = null;
+        try
+        {
+            await connectTask;
+        }
+        catch (Exception exception)
+        {
+            connectException = exception;
+        }
+
+        await serverTask;
+        await Assert.That(connectException).IsNotNull();
+        await Assert.That(connection.IsConnected).IsFalse();
+        await Assert.That(() => ((IKafkaCapabilityProvider)connection).Capabilities)
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
     [Timeout(5_000)]
     public async Task ConnectAsync_WhenV4IsUnsupported_RetriesV3OnSameConnection(
         CancellationToken cancellationToken)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ApiVersionNegotiationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ApiVersionNegotiationBenchmarks.cs
@@ -1,7 +1,10 @@
+using System.Collections.Concurrent;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dekaf.Metadata;
+using Dekaf.Networking;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -10,6 +13,11 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class ApiVersionNegotiationBenchmarks
 {
     private MetadataManager _metadataManager = null!;
+    private ApiVersionsResponse _response = null!;
+    private KafkaConnectionCapabilities _capabilities = null!;
+    private IKafkaConnection _connection = null!;
+    private ConcurrentDictionary<ApiKey, short> _concurrentCache = null!;
+    private int _volatileProducerVersion;
 
     [GlobalSetup]
     public void Setup()
@@ -17,15 +25,99 @@ public class ApiVersionNegotiationBenchmarks
         _metadataManager = new MetadataManager(
             connectionPool: null!,
             bootstrapServers: ["localhost:9092"]);
-        _metadataManager.SetApiVersion(ApiKey.Fetch, 0, 18);
+        _metadataManager.SetApiVersion(ApiKey.Produce, 3, 13);
+        _response = new ApiVersionsResponse
+        {
+            ErrorCode = ErrorCode.None,
+            ApiKeys =
+            [
+                new ApiVersion(ApiKey.ApiVersions, 0, 4),
+                new ApiVersion(ApiKey.Metadata, 9, 13),
+                new ApiVersion(ApiKey.Produce, 3, 13),
+                new ApiVersion(ApiKey.Fetch, 12, 18)
+            ],
+            SupportedFeatures = [new SupportedFeature("kraft.version", 0, 1)],
+            FinalizedFeaturesEpoch = 42,
+            FinalizedFeatures = [new FinalizedFeature("transaction.version", 2, 0)]
+        };
+        _capabilities = KafkaConnectionCapabilities.Create(_response);
+        _connection = new CapabilityConnection(_capabilities);
+        _concurrentCache = new ConcurrentDictionary<ApiKey, short>();
+        _concurrentCache[ApiKey.Produce] = 13;
+        _volatileProducerVersion = 13;
 
-        _ = _metadataManager.GetNegotiatedApiVersion(ApiKey.Fetch, 4, 17);
+        _ = _metadataManager.GetNegotiatedApiVersion(_connection, ApiKey.Produce, 3, 13);
     }
 
     [GlobalCleanup]
     public async Task Cleanup() => await _metadataManager.DisposeAsync().ConfigureAwait(false);
 
-    [Benchmark]
-    public short GetNegotiatedApiVersion() =>
-        _metadataManager.GetNegotiatedApiVersion(ApiKey.Fetch, 4, 17);
+    [Benchmark(Description = "Connection setup: capability snapshot")]
+    public int CreateCapabilitySnapshot() =>
+        KafkaConnectionCapabilities.Create(_response).ApiRangeCount;
+
+    [Benchmark(Description = "O(1) packed-array lookup/intersection")]
+    public short ConnectionSnapshotLookup() =>
+        _capabilities.NegotiateVersion(ApiKey.Produce, 3, 13);
+
+    [Benchmark(Description = "Producer send: exact connection selection")]
+    public short ProducerConnectionSelection() =>
+        _metadataManager.GetNegotiatedApiVersion(_connection, ApiKey.Produce, 3, 13);
+
+    [Benchmark(Description = "Legacy producer volatile cache")]
+    public int VolatileProducerCache() => Volatile.Read(ref _volatileProducerVersion);
+
+    [Benchmark(Description = "ConcurrentDictionary cache")]
+    public short ConcurrentDictionaryCache() => _concurrentCache[ApiKey.Produce];
+
+    private sealed class CapabilityConnection(KafkaConnectionCapabilities capabilities) :
+        IKafkaConnection,
+        IKafkaCapabilityProvider
+    {
+        public int BrokerId => 1;
+        public string Host => "benchmark";
+        public int Port => 9092;
+        public bool IsConnected => true;
+        public KafkaConnectionCapabilities Capabilities { get; } = capabilities;
+
+        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask SendFireAndForgetWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public Task<TResponse> SendPipelinedWithCallerTimeoutAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse => throw new NotSupportedException();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 }


### PR DESCRIPTION
Closes #2237

## Summary
- add deterministic heterogeneous-broker, concurrent-send, disjoint-range, allocation, and handshake-disposal regressions
- benchmark capability snapshot creation, packed-array lookup, exact producer selection, volatile cache, and ConcurrentDictionary baseline
- document focused protocol tests, handshake latency, allocation/network gates, and Kafka compatibility matrix

## Validation
- `dotnet build Dekaf.slnx -c Release --no-restore` (0 warnings, 0 errors)
- full unit suite net10.0: 5985 passed
- full unit suite net8.0: 5858 passed
- focused protocol suite: 27 passed on net10.0 and net8.0
- disposal-during-handshake regression: 10 consecutive passes
- `ApiVersionNegotiationBenchmarks` completed; packed lookup and producer selection allocate 0 B