### PR TITLE
fix(networking): coordinate broker retirement

### DIFF
--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -1032,8 +1032,8 @@ public sealed partial class MetadataManager : IAsyncDisposable
 
     /// <summary>
     /// Shared rebootstrap execution: re-resolves bootstrap DNS and attempts metadata fetch from new endpoints.
-    /// Intentionally does not re-check the response for <see cref="ErrorCode.RebootstrapRequired"/>
-    /// to prevent infinite recursion when the new broker also signals rebootstrap.
+    /// Re-checks newly resolved endpoints for <see cref="ErrorCode.RebootstrapRequired"/> and
+    /// advances to the next endpoint without recursively triggering another rebootstrap.
     /// </summary>
     private async ValueTask<bool> ExecuteRebootstrapAsync(IEnumerable<string>? topics, CancellationToken cancellationToken)
     {
@@ -1090,7 +1090,6 @@ public sealed partial class MetadataManager : IAsyncDisposable
                 }
 
                 ResetFinalizedFeaturesForRebootstrap();
-                BeginMetadataRebootstrap();
 
                 UpdateVersionlessCapabilities(
                     connection,

--- a/src/Dekaf/Networking/ConnectionPool.cs
+++ b/src/Dekaf/Networking/ConnectionPool.cs
@@ -75,6 +75,7 @@ public sealed partial class ConnectionPool :
     // Multi-connection support: connection groups and round-robin index
     private readonly ConcurrentDictionary<int, IKafkaConnection[]> _connectionGroupsById = new();
     private readonly ConcurrentDictionary<(int BrokerId, int Index), SemaphoreSlim> _connectionReplacementLocks = new();
+    private readonly ConcurrentDictionary<Task, byte> _retiredConnectionDisposalTasks = new();
     private readonly Lock _connectionGroupRetentionLock = new();
     private readonly Dictionary<(int BrokerId, int Index), int> _connectionGroupRetainers = [];
 
@@ -805,21 +806,9 @@ public sealed partial class ConnectionPool :
                 _scaleLock.Release();
             }
 
-            // Dispose old connection outside the lock to avoid blocking scale operations.
-            // Fire-and-forget with exception observation to prevent UnobservedTaskException.
+            // Drain the old connection outside the lock and track it for coordinated disposal.
             if (oldConnection is not null)
-            {
-                _ = RetiredConnectionDisposer.DrainAndDisposeAsync(oldConnection, CancellationToken.None).AsTask().ContinueWith(
-                    static (t, state) =>
-                    {
-                        var (logger, id, idx) = ((ILogger, int, int))state!;
-                        LogOldConnectionDisposalFailed(logger, id, idx, t.Exception!);
-                    },
-                    (_logger, brokerId, index),
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-            }
+                RetireConnection(oldConnection);
 
             // If the index is now out of bounds (shrink happened concurrently),
             // dispose the orphaned connection to avoid leaking TCP handles.
@@ -1529,8 +1518,8 @@ public sealed partial class ConnectionPool :
     {
         foreach (var connection in group)
         {
-            if (connection is not null)
-                return ConnectionMatchesBroker(connection, brokerInfo);
+            if (connection is not null && ConnectionMatchesBroker(connection, brokerInfo))
+                return true;
         }
 
         return false;
@@ -1539,7 +1528,14 @@ public sealed partial class ConnectionPool :
     private void RetireConnection(IKafkaConnection connection)
     {
         BeginConnectionRetirement(connection);
-        _ = DrainRetiredConnectionAsync(connection);
+        var drainTask = DrainRetiredConnectionAsync(connection);
+        _retiredConnectionDisposalTasks.TryAdd(drainTask, 0);
+        _ = drainTask.ContinueWith(
+            static (task, state) => ((ConnectionPool)state!).ObserveRetiredConnectionDisposal(task),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task DrainRetiredConnectionAsync(IKafkaConnection connection)
@@ -1547,13 +1543,30 @@ public sealed partial class ConnectionPool :
         try
         {
             await RetiredConnectionDisposer
-                .DrainAndDisposeAsync(connection, CancellationToken.None)
+                .DrainAndDisposeAsync(connection, _disposeCts.Token)
                 .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_disposeCts.IsCancellationRequested)
+        {
+            try
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
+            }
         }
         catch (Exception ex)
         {
             LogIdleConnectionDisposalFailed(ex, connection.BrokerId, connection.Host, connection.Port);
         }
+    }
+
+    private void ObserveRetiredConnectionDisposal(Task task)
+    {
+        _retiredConnectionDisposalTasks.TryRemove(task, out _);
+        _ = task.Exception;
     }
 
     private static void BeginConnectionRetirement(IKafkaConnection connection)
@@ -1736,6 +1749,10 @@ public sealed partial class ConnectionPool :
 
         await CloseAllAsync().ConfigureAwait(false);
 
+        var retiredConnectionDisposals = _retiredConnectionDisposalTasks.Keys.ToArray();
+        if (retiredConnectionDisposals.Length > 0)
+            await Task.WhenAll(retiredConnectionDisposals).ConfigureAwait(false);
+
         _sharedOAuthBearerTokenProvider?.Dispose();
         _disposeCts.Dispose();
         _disposeLock.Dispose();
@@ -1788,9 +1805,6 @@ public sealed partial class ConnectionPool :
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Shrunk connection group from {OldCount} to {NewCount} connections for broker {BrokerId}")]
     private partial void LogShrunkConnectionGroup(int oldCount, int newCount, int brokerId);
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to dispose replaced connection for broker {BrokerId} index {Index}")]
-    private static partial void LogOldConnectionDisposalFailed(ILogger logger, int brokerId, int index, Exception ex);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Waiting {DelayMs}ms before reconnecting to broker {BrokerId} at {Host}:{Port} after {FailureCount} failed attempt(s)")]
     private partial void LogReconnectBackoffDelay(double delayMs, int brokerId, string host, int port, int failureCount);

--- a/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
@@ -1,4 +1,5 @@
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -13,6 +14,12 @@ namespace Dekaf.Tests.Integration;
 [Category("Admin")]
 public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    private static (string Host, int Port) ParseBootstrapEndpoint(string bootstrapServers)
+    {
+        var separator = bootstrapServers.LastIndexOf(':');
+        return (bootstrapServers[..separator], int.Parse(bootstrapServers[(separator + 1)..]));
+    }
+
     private static async Task<ApiVersionsResponse> SendApiVersionsAsync(IKafkaConnection connection)
     {
         var request = new ApiVersionsRequest
@@ -103,6 +110,76 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         {
             await pool.DisposeAsync();
         }
+    }
+
+    [Test]
+    [SupportsKafka(440)]
+    public async Task Connection_MetadataClusterCheck_RejectsMisrouteAndRecovers()
+    {
+        await using var admin = KafkaContainer.CreateAdminClient();
+        var cluster = await admin.DescribeClusterAsync();
+        var clusterId = cluster.ClusterId
+            ?? throw new InvalidOperationException("Broker did not return a cluster ID.");
+        var broker = cluster.Nodes[0];
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
+
+        await using var pool = new ConnectionPool(
+            "metadata-cluster-check-test",
+            new ConnectionOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            loggerFactory: null);
+        var identityPool = (IMetadataClusterIdentityPool)pool;
+        identityPool.ConfigureMetadataClusterCheck(enabled: true);
+        identityPool.UpdateMetadataClusterId("unexpected-cluster-id");
+        pool.RegisterBroker(broker.NodeId, host, port);
+
+        Func<Task> connectToMisroutedBroker = () =>
+            pool.GetConnectionAsync(broker.NodeId).AsTask();
+        var exception = await Assert.That(connectToMisroutedBroker)
+            .Throws<KafkaException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.RebootstrapRequired);
+        await Assert.That(identityPool.TryConsumeMetadataRebootstrapRequest()).IsTrue();
+
+        identityPool.UpdateMetadataClusterId(clusterId);
+        var connection = await pool.GetConnectionAsync(broker.NodeId);
+
+        await Assert.That(connection.IsConnected).IsTrue();
+    }
+
+    [Test]
+    public async Task Connection_BrokerEndpointChange_ReplacesLiveConnection()
+    {
+        await using var admin = KafkaContainer.CreateAdminClient();
+        var cluster = await admin.DescribeClusterAsync();
+        var broker = cluster.Nodes[0];
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
+        var replacementHost = host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            ? "127.0.0.1"
+            : "localhost";
+
+        await using var pool = new ConnectionPool(
+            "endpoint-change-test",
+            new ConnectionOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                ReconnectBackoff = TimeSpan.Zero,
+                ReconnectBackoffMax = TimeSpan.Zero
+            },
+            loggerFactory: null);
+        pool.RegisterBroker(broker.NodeId, host, port);
+        var staleConnection = await pool.GetConnectionAsync(broker.NodeId);
+
+        pool.RegisterBroker(broker.NodeId, replacementHost, port);
+        var replacement = await pool.GetConnectionAsync(broker.NodeId);
+
+        await Assert.That(replacement).IsNotSameReferenceAs(staleConnection);
+        await Assert.That(replacement.Host).IsEqualTo(replacementHost);
+        await Assert.That(replacement.IsConnected).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -206,6 +206,79 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
+    [NotInParallel]
+    [Timeout(5_000)]
+    public async Task RegisterBroker_EndpointChange_RetiresMixedConnectionGroup(
+        CancellationToken cancellationToken)
+    {
+        var endpointUpdated = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRegistration = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 2,
+            connectionFactory: (brokerId, host, port, _, _) =>
+                ValueTask.FromResult(CreateConnectedConnection(brokerId, host, port)),
+            brokerEndpointUpdated: () =>
+            {
+                endpointUpdated.TrySetResult();
+                releaseRegistration.Task.GetAwaiter().GetResult();
+            });
+
+        pool.RegisterBroker(1, "host-a", 9092);
+        var oldFirst = await pool.GetConnectionByIndexAsync(1, 0, cancellationToken);
+        var oldSecond = await pool.GetConnectionByIndexAsync(1, 1, cancellationToken);
+        oldFirst.IsConnected.Returns(false);
+
+        var registration = Task.Run(
+            () => pool.RegisterBroker(1, "host-b", 9093),
+            cancellationToken);
+        IKafkaConnection replacement;
+        try
+        {
+            await endpointUpdated.Task.WaitAsync(cancellationToken);
+            replacement = await pool.GetConnectionByIndexAsync(1, 0, cancellationToken);
+        }
+        finally
+        {
+            releaseRegistration.TrySetResult();
+        }
+
+        await registration.WaitAsync(cancellationToken);
+        var fresh = await pool.GetConnectionByIndexAsync(1, 0, cancellationToken);
+        await pool.DisposeAsync();
+
+        await Assert.That(replacement.Host).IsEqualTo("host-b");
+        await Assert.That(fresh).IsNotSameReferenceAs(replacement);
+        await oldSecond.Received(1).DisposeAsync();
+        await replacement.Received(1).DisposeAsync();
+    }
+
+    [Test]
+    public async Task DisposeAsync_ForceDisposesTrackedRetiredConnection()
+    {
+        var retired = new TestIdleConnection(1, "host-a", 9092);
+        var pool = new ConnectionPool(
+            clientId: "test-client",
+            connectionOptions: new ConnectionOptions(),
+            connectionsPerBroker: 1,
+            connectionFactory: (_, host, port, _, _) =>
+                ValueTask.FromResult<IKafkaConnection>(host == "host-a"
+                    ? retired
+                    : new TestIdleConnection(1, host, port)));
+
+        pool.RegisterBroker(1, "host-a", 9092);
+        _ = await pool.GetConnectionAsync(1);
+        await Assert.That(KafkaConnectionLease.TryAcquire(retired, out var lease)).IsTrue();
+        pool.RegisterBroker(1, "host-b", 9093);
+
+        await pool.DisposeAsync();
+
+        await Assert.That(retired.DisposeCount).IsEqualTo(1);
+        lease.Dispose();
+    }
+
+    [Test]
     public async Task RegisterBroker_MultipleBrokers_AllRegistered()
     {
         await using var pool = new ConnectionPool("test-client");


### PR DESCRIPTION
Follow-up to #2316. Its final automated review arrived while the original PR was merging, so these fixes were not included in the merge commit.

## Changes
- retire a multi-connection broker group when any slot still targets the stale endpoint
- track retired connection drains and coordinate/force disposal during pool shutdown
- keep the trusted metadata cluster identity continuously armed during successful rebootstrap
- correct stale rebootstrap documentation
- add deterministic mixed-group and stuck-lease unit coverage
- add current real-broker endpoint-replacement integration coverage
- add Kafka 4.4-gated KIP-1242 identity rejection/recovery coverage

## Validation
- unit build: clean, 0 warnings/errors
- targeted retirement tests: 3/3 on net10.0 and 3/3 on net8.0
- integration build: clean, 0 warnings/errors
- Kafka 4.3.1 endpoint replacement: 1/1 passed
- Kafka 4.4 identity test is version-gated; `apache/kafka:4.4.0` is not yet published
- `/simplify`: complete

No hot-path behavior changed; benchmark not applicable.