### PR TITLE
test(networking): tolerate timeout close

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -472,11 +472,19 @@ public class KafkaConnectionCapabilityHandshakeTests
                 using var socket = listener.AcceptSocketAsync(cancellationToken)
                     .AsTask().GetAwaiter().GetResult();
                 using var stream = new NetworkStream(socket, ownsSocket: false);
-                var length = new byte[sizeof(int)];
-                stream.ReadExactly(length);
-                var frame = new byte[BinaryPrimitives.ReadInt32BigEndian(length)];
-                stream.ReadExactly(frame);
-                releaseServer.Wait(cancellationToken);
+                try
+                {
+                    var length = new byte[sizeof(int)];
+                    stream.ReadExactly(length);
+                    var frame = new byte[BinaryPrimitives.ReadInt32BigEndian(length)];
+                    stream.ReadExactly(frame);
+                    releaseServer.Wait(cancellationToken);
+                }
+                catch (IOException)
+                {
+                    // The expected client-side timeout may close the socket before the
+                    // mock server finishes reading the request (including end-of-stream).
+                }
             },
             cancellationToken,
             TaskCreationOptions.LongRunning,
@@ -487,7 +495,7 @@ public class KafkaConnectionCapabilityHandshakeTests
             1,
             "127.0.0.1",
             port,
-            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(500) });
+            options: new ConnectionOptions { RequestTimeout = TimeSpan.FromMilliseconds(50) });
 
         try
         {


### PR DESCRIPTION
Closes #2325.

The negotiation-timeout test again uses its intended 50ms deadline. Its mock server now tolerates the expected `IOException`/`EndOfStreamException` read failure when the timed-out client closes the socket, while the test still requires `KafkaException(RequestTimedOut)` and a disconnected client.

Validation:
- unit build: clean, 0 warnings/errors
- exact test: 5/5 net10.0 and 5/5 net8.0
- full handshake class: 14/14 net10.0 and 14/14 net8.0
- `/simplify`: complete

Test-only change; benchmark not applicable.