### PR TITLE
fix(producer): probe wave before deadline

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1508,14 +1508,14 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         _options.TransactionalId is not null))
                 {
                     waveCoalesceArmed = false;
-                    _onWaveCoalesceStarted?.Invoke();
                     var coalescedCountBeforeSpin = coalescedCount;
                     var started = Stopwatch.GetTimestamp();
                     var hardDeadline = started + waveCoalesceMaxTicks;
                     var quietDeadline = Math.Min(started + waveCoalesceQuietTicks, hardDeadline);
-                    while (coalescedCount < maxCoalesce
-                           && coalescedPartitions.Count < _knownPartitions.Count
-                           && Stopwatch.GetTimestamp() < quietDeadline)
+                    _onWaveCoalesceStarted?.Invoke();
+                    // Probe once before consulting the deadline. A queued sibling must not be
+                    // split into a later request solely because this thread was preempted here.
+                    do
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         if (!eventReader.TryRead(out var evt))
@@ -1552,6 +1552,9 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                             break;
                         }
                     }
+                    while (coalescedCount < maxCoalesce
+                           && coalescedPartitions.Count < _knownPartitions.Count
+                           && Stopwatch.GetTimestamp() < quietDeadline);
 
                     waveCoalesceGate.OnSpinCompleted(
                         coalescedCount > coalescedCountBeforeSpin,

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -467,6 +467,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var accumulator = new RecordAccumulator(options);
         var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
         var injectSibling = 0;
+        var expireWaveDeadline = 0;
         var idleWaitCount = 0;
         BrokerSender? sender = null;
         sender = CreateSender(
@@ -477,7 +478,16 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             onWaveCoalesceStarted: () =>
             {
                 if (Volatile.Read(ref injectSibling) != 0)
+                {
                     sender!.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 1));
+                    if (Volatile.Read(ref expireWaveDeadline) != 0)
+                    {
+                        // Expire both zero-linger deadlines after the sibling is queued.
+                        var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency / 1_000;
+                        while (Stopwatch.GetTimestamp() < deadline)
+                            Thread.SpinWait(32);
+                    }
+                }
             },
             onIdleWaitStarted: () => Interlocked.Increment(ref idleWaitCount));
 
@@ -501,6 +511,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
                 cancellationToken);
 
             Volatile.Write(ref injectSibling, 1);
+            Volatile.Write(ref expireWaveDeadline, 1);
             expectedIdleWaitCount = Volatile.Read(ref idleWaitCount) + 1;
             sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", 0));
             await WaitUntilAsync(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/WaveCoalesceProbeBenchmarks.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class WaveCoalesceProbeBenchmarks
+{
+    private readonly long _expiredDeadline = 0;
+    private readonly Channel<int> _channel = Channel.CreateUnbounded<int>();
+
+    [GlobalSetup]
+    public void Setup() => _channel.Writer.TryWrite(1);
+
+    [Benchmark(Baseline = true)]
+    public bool DeadlineFirst()
+    {
+        if (Stopwatch.GetTimestamp() >= _expiredDeadline)
+            return false;
+
+        return _channel.Reader.TryRead(out _);
+    }
+
+    [Benchmark]
+    public bool ProbeFirst()
+    {
+        if (!_channel.Reader.TryRead(out var item))
+            return false;
+
+        return _channel.Writer.TryWrite(item);
+    }
+}


### PR DESCRIPTION
Closes #2327.

A wave now performs one non-blocking channel probe before checking its quiet deadline. This prevents a queued sibling from being split solely because the sender was preempted after arming the zero-linger deadline. The existing quiet/hard deadline condition is unchanged for every subsequent iteration.

## Validation
- unit build: clean, 0 warnings/errors
- exact deterministic regression: 1/1 net10.0, 1/1 net8.0
- `BrokerSenderSendLoopTests`: 71/71 net10.0, 71/71 net8.0
- benchmark build: clean, 0 warnings/errors
- `/simplify`: complete; final implementation uses `do/while`, adding no boolean/helper to later probes

## MemoryDiagnoser / performance

Same-run exact comparator, .NET 10.0.10, i7-12700K:

| Path | Mean | Allocated |
|---|---:|---:|
| Deadline-first expired skip (old) | 13.24 ns | 0 B |
| Probe-first queued read/write (new) | 22.52 ns | 0 B |

Cost: +9.28 ns once per armed request wave. Subsequent iterations retain the prior deadline condition exactly. No per-message allocation, no changed quiet/hard bounds, and no blocking operation.