### PR TITLE
Add rich record deserialization failures

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Serialization;
 using Dekaf.Telemetry;
 
@@ -711,20 +712,41 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
     private ConsumeResult<TKey, TValue> ToConsumeResult(TopicPartition topicPartition, InMemoryRecord record)
     {
-        return new ConsumeResult<TKey, TValue>(
-            topic: topicPartition.Topic,
-            partition: topicPartition.Partition,
-            offset: record.Offset,
-            keyData: record.Key,
-            isKeyNull: record.IsKeyNull,
-            valueData: record.Value,
-            isValueNull: record.IsValueNull,
-            headers: record.Headers,
-            timestampMs: record.TimestampMs,
-            timestampType: TimestampType.CreateTime,
-            leaderEpoch: null,
-            keyDeserializer: _keyDeserializer,
-            valueDeserializer: _valueDeserializer);
+        try
+        {
+            return new ConsumeResult<TKey, TValue>(
+                topic: topicPartition.Topic,
+                partition: topicPartition.Partition,
+                offset: record.Offset,
+                keyData: record.Key,
+                isKeyNull: record.IsKeyNull,
+                valueData: record.Value,
+                isValueNull: record.IsValueNull,
+                headers: record.Headers,
+                timestampMs: record.TimestampMs,
+                timestampType: TimestampType.CreateTime,
+                leaderEpoch: null,
+                keyDeserializer: _keyDeserializer,
+                valueDeserializer: _valueDeserializer);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw ConsumeResult<TKey, TValue>.CreateDeserializationException(
+                ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
+                topicPartition.Topic,
+                topicPartition.Partition,
+                record.Offset,
+                record.TimestampMs,
+                TimestampType.CreateTime,
+                record.Key,
+                record.IsKeyNull,
+                record.Value,
+                record.IsValueNull,
+                record.Headers,
+                pooledHeaders: null,
+                pooledHeaderCount: 0,
+                ex);
+        }
     }
 
     private void ReplaceAssignment(IEnumerable<TopicPartition> partitions)

--- a/src/Dekaf/Consumer/ConsumeBatch.cs
+++ b/src/Dekaf/Consumer/ConsumeBatch.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
+using Dekaf.Errors;
 using Dekaf.Serialization;
 
 namespace Dekaf.Consumer
@@ -168,6 +169,33 @@ namespace Dekaf.Consumer
             return new Enumerator(this);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void ThrowAfterDeserializationFailure(PendingFetchData pending, long offset, Exception exception)
+        {
+            if (exception is not OperationCanceledException)
+            {
+                ref readonly var record = ref pending.CurrentRecord;
+                exception = ConsumeResult<TKey, TValue>.CreateDeserializationException(
+                    ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
+                    pending.Topic,
+                    pending.PartitionIndex,
+                    offset,
+                    pending.CurrentBaseTimestamp + record.TimestampDelta,
+                    pending.CurrentTimestampType,
+                    record.Key,
+                    record.IsKeyNull,
+                    record.Value,
+                    record.IsValueNull,
+                    headers: null,
+                    record.Headers,
+                    record.HeaderCount,
+                    exception);
+            }
+
+            _rewindAfterDeliveryFailure?.Invoke(pending, offset);
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+
         IEnumerator<ConsumeResult<TKey, TValue>> IEnumerable<ConsumeResult<TKey, TValue>>.GetEnumerator()
         {
             return GetEnumerator();
@@ -266,11 +294,11 @@ namespace Dekaf.Consumer
                         keyDeserializer: _batch._keyDeserializer,
                         valueDeserializer: _batch._valueDeserializer);
                 }
-                catch
+                catch (Exception ex)
                 {
                     _canContinue = false;
-                    _batch._rewindAfterDeliveryFailure?.Invoke(pending, offset);
-                    throw;
+                    _batch.ThrowAfterDeserializationFailure(pending, offset, ex);
+                    return false;
                 }
 
                 if (!_batch._iterationGuard.IsCurrent(pending.TopicPartition, ref _observedVersion))

--- a/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
+++ b/src/Dekaf/Consumer/DeadLetter/DeadLetterHeaders.cs
@@ -1,3 +1,4 @@
+using Dekaf.Errors;
 using Dekaf.Serialization;
 
 namespace Dekaf.Consumer.DeadLetter;
@@ -40,6 +41,48 @@ public static class DeadLetterHeaders
     {
         // Hoisted: each Headers access on the readonly struct constructs a new lazy wrapper.
         var originalHeaders = result.Headers;
+        return Build(
+            originalHeaders,
+            result.Topic,
+            result.Partition,
+            result.Offset,
+            exception,
+            failureCount,
+            includeException);
+    }
+
+    /// <summary>
+    /// Builds DLQ headers directly from a failed deserialization record.
+    /// </summary>
+    /// <param name="exception">The record deserialization failure.</param>
+    /// <param name="failureCount">The number of processing failures.</param>
+    /// <param name="includeException">Whether to include exception details in headers.</param>
+    /// <returns>A Headers collection with original headers preserved and DLQ metadata appended.</returns>
+    public static Headers Build(
+        RecordDeserializationException exception,
+        int failureCount,
+        bool includeException)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return Build(
+            exception.Headers,
+            exception.TopicPartition.Topic,
+            exception.TopicPartition.Partition,
+            exception.Offset,
+            exception,
+            failureCount,
+            includeException);
+    }
+
+    private static Headers Build(
+        IReadOnlyList<Header> originalHeaders,
+        string topic,
+        int partition,
+        long offset,
+        Exception exception,
+        int failureCount,
+        bool includeException)
+    {
         var dlqHeaderCount = includeException ? 7 : 5;
         var headers = new Headers(originalHeaders.Count + dlqHeaderCount);
 
@@ -50,9 +93,9 @@ public static class DeadLetterHeaders
         }
 
         // Source metadata
-        var sourceTopic = RetryTopicHeaders.GetSourceTopic(originalHeaders) ?? result.Topic;
-        var sourcePartition = RetryTopicHeaders.GetSourcePartition(originalHeaders) ?? result.Partition;
-        var sourceOffset = RetryTopicHeaders.GetSourceOffset(originalHeaders) ?? result.Offset;
+        var sourceTopic = RetryTopicHeaders.GetSourceTopic(originalHeaders) ?? topic;
+        var sourcePartition = RetryTopicHeaders.GetSourcePartition(originalHeaders) ?? partition;
+        var sourceOffset = RetryTopicHeaders.GetSourceOffset(originalHeaders) ?? offset;
         headers.Add(SourceTopicKey, sourceTopic);
         headers.Add(SourcePartitionKey, DeadLetterHeaderFormatting.FormatInt(sourcePartition));
         headers.Add(SourceOffsetKey, DeadLetterHeaderFormatting.FormatLong(sourceOffset));

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -583,6 +583,54 @@ public readonly struct ConsumeResult<TKey, TValue>
         }
     }
 
+    internal static DeserializationExceptionOrigin LastDeserializationOrigin
+        => t_serializationContext.Component == SerializationComponent.Key
+            ? DeserializationExceptionOrigin.Key
+            : DeserializationExceptionOrigin.Value;
+
+    internal static RecordDeserializationException CreateDeserializationException(
+        DeserializationExceptionOrigin origin,
+        string topic,
+        int partition,
+        long offset,
+        long timestampMs,
+        TimestampType timestampType,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        IReadOnlyList<Header>? headers,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        Exception innerException)
+    {
+        var topicPartition = new TopicPartition(topic, partition);
+        return headers is not null
+            ? new RecordDeserializationException(
+                origin,
+                topicPartition,
+                offset,
+                timestampMs,
+                timestampType,
+                isKeyNull ? (ReadOnlyMemory<byte>?)null : keyData,
+                isValueNull ? (ReadOnlyMemory<byte>?)null : valueData,
+                headers,
+                innerException)
+            : new RecordDeserializationException(
+                origin,
+                topicPartition,
+                offset,
+                timestampMs,
+                timestampType,
+                keyData,
+                isKeyNull,
+                valueData,
+                isValueNull,
+                pooledHeaders,
+                pooledHeaderCount,
+                innerException);
+    }
+
     /// <summary>
     /// Creates a partition EOF result (no message data).
     /// This is primarily used internally by the consumer when EnablePartitionEof is true.

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -2067,6 +2067,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         // the try block (CS1626), so we build the result first then yield below.
                         var readingProtocolData = true;
                         var offset = -1L;
+                        var runningInterceptor = false;
                         try
                         {
                             if (!pending.MoveNext())
@@ -2152,7 +2153,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             // Uses hoisted hasInterceptors to skip method call when no interceptors
                             if (hasInterceptors)
                             {
+                                runningInterceptor = true;
                                 nextResult = ApplyOnConsumeInterceptors(nextResult);
+                                runningInterceptor = false;
 
                                 // An interceptor can run long enough for background prefetch to
                                 // publish a divergence reset. Do not mark that stale record consumed.
@@ -2186,9 +2189,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                             break;
                         }
-                        catch (Exception) when (!readingProtocolData)
+                        catch (Exception ex) when (!readingProtocolData)
                         {
-                            RewindAfterDeliveryFailure(pending, offset);
+                            ThrowAfterDeliveryFailure(
+                                pending, offset, runningInterceptor, hasAsyncDeserializers, ex);
                             throw;
                         }
 
@@ -4260,6 +4264,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 {
                     var readingProtocolData = true;
                     var offset = -1L;
+                    var runningInterceptor = false;
                     try
                     {
                         if (!pending.MoveNext())
@@ -4317,7 +4322,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (hasInterceptors)
                         {
+                            runningInterceptor = true;
                             result = ApplyOnConsumeInterceptors(result);
+                            runningInterceptor = false;
 
                             if (HasPendingFetchClear(pending.TopicPartition))
                                 break;
@@ -4343,9 +4350,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         LogRecordParsingError(ex, pending.Topic, pending.PartitionIndex);
                         break;
                     }
-                    catch (Exception) when (!readingProtocolData)
+                    catch (Exception ex) when (!readingProtocolData)
                     {
-                        RewindAfterDeliveryFailure(pending, offset);
+                        ThrowAfterDeliveryFailure(
+                            pending, offset, runningInterceptor, hasAsyncDeserializers: false, ex);
                         throw;
                     }
                 }
@@ -4527,6 +4535,38 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// semantics mirror the eager ConsumeResult constructor: null keys skip the deserializer,
     /// null values invoke it with empty data and <c>IsNull = true</c>.
     /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ThrowAfterDeliveryFailure(
+        PendingFetchData pending,
+        long offset,
+        bool runningInterceptor,
+        bool hasAsyncDeserializers,
+        Exception exception)
+    {
+        if (!runningInterceptor && !hasAsyncDeserializers && exception is not OperationCanceledException)
+        {
+            ref readonly var record = ref pending.CurrentRecord;
+            exception = ConsumeResult<TKey, TValue>.CreateDeserializationException(
+                ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
+                pending.Topic,
+                pending.PartitionIndex,
+                offset,
+                pending.CurrentBaseTimestamp + record.TimestampDelta,
+                pending.CurrentTimestampType,
+                record.Key,
+                record.IsKeyNull,
+                record.Value,
+                record.IsValueNull,
+                headers: null,
+                record.Headers,
+                record.HeaderCount,
+                exception);
+        }
+
+        RewindAfterDeliveryFailure(pending, offset);
+        ExceptionDispatchInfo.Capture(exception).Throw();
+    }
+
     private async ValueTask<ConsumeResult<TKey, TValue>> CreateResultWithAsyncDeserializationAsync(
         PendingFetchData pending,
         long offset,
@@ -4553,9 +4593,28 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 Component = SerializationComponent.Key,
                 IsNull = false
             };
-            key = _asyncKeyDeserializer is not null
-                ? await _asyncKeyDeserializer.DeserializeAsync(keyData, keyContext, cancellationToken).ConfigureAwait(false)
-                : _keyDeserializer.Deserialize(keyData, keyContext);
+            try
+            {
+                key = _asyncKeyDeserializer is not null
+                    ? await _asyncKeyDeserializer.DeserializeAsync(keyData, keyContext, cancellationToken).ConfigureAwait(false)
+                    : _keyDeserializer.Deserialize(keyData, keyContext);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw new RecordDeserializationException(
+                    DeserializationExceptionOrigin.Key,
+                    new TopicPartition(topic, partition),
+                    offset,
+                    timestampMs,
+                    timestampType,
+                    keyData,
+                    isKeyNull,
+                    valueData,
+                    isValueNull,
+                    pooledHeaders,
+                    pooledHeaderCount,
+                    ex);
+            }
         }
 
         var valueContext = new SerializationContext
@@ -4565,9 +4624,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             IsNull = isValueNull
         };
         var valueBytes = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
-        var value = _asyncValueDeserializer is not null
-            ? await _asyncValueDeserializer.DeserializeAsync(valueBytes, valueContext, cancellationToken).ConfigureAwait(false)
-            : _valueDeserializer.Deserialize(valueBytes, valueContext);
+        TValue value;
+        try
+        {
+            value = _asyncValueDeserializer is not null
+                ? await _asyncValueDeserializer.DeserializeAsync(valueBytes, valueContext, cancellationToken).ConfigureAwait(false)
+                : _valueDeserializer.Deserialize(valueBytes, valueContext);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new RecordDeserializationException(
+                DeserializationExceptionOrigin.Value,
+                new TopicPartition(topic, partition),
+                offset,
+                timestampMs,
+                timestampType,
+                keyData,
+                isKeyNull,
+                valueData,
+                isValueNull,
+                pooledHeaders,
+                pooledHeaderCount,
+                ex);
+        }
 
         return new ConsumeResult<TKey, TValue>(
             topic,

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -604,7 +604,7 @@ public sealed class AuthorizationException : KafkaException
 /// <summary>
 /// Exception thrown when serialization or deserialization fails.
 /// </summary>
-public sealed class SerializationException : KafkaException
+public class SerializationException : KafkaException
 {
     public SerializationException() : base()
     {
@@ -641,4 +641,176 @@ public sealed class SerializationException : KafkaException
     /// The component (key or value) that failed to serialize.
     /// </summary>
     public SerializationComponent Component { get; init; }
+}
+
+/// <summary>
+/// Identifies which record component failed deserialization.
+/// </summary>
+public enum DeserializationExceptionOrigin
+{
+    /// <summary>The record key failed deserialization.</summary>
+    Key,
+
+    /// <summary>The record value failed deserialization.</summary>
+    Value
+}
+
+/// <summary>
+/// Exception thrown when a consumed record key or value cannot be deserialized.
+/// Carries an owned snapshot of the failed record so callers can inspect, retry, skip,
+/// or publish it after the consumer releases its pooled fetch buffer.
+/// </summary>
+/// <remarks>
+/// <see cref="KeyData"/>, <see cref="ValueData"/>, and header values are copied only on
+/// deserialization failure. A <see langword="null"/> key or value remains <see langword="null"/>;
+/// an empty non-null key or value is represented by an empty array. The returned arrays are
+/// owned by this exception and remain valid for its lifetime.
+/// </remarks>
+public sealed class RecordDeserializationException : SerializationException
+{
+    /// <summary>
+    /// Creates a record deserialization exception and takes owned snapshots of the supplied data.
+    /// </summary>
+    public RecordDeserializationException(
+        DeserializationExceptionOrigin origin,
+        TopicPartition topicPartition,
+        long offset,
+        long timestampMs,
+        Consumer.TimestampType timestampType,
+        ReadOnlyMemory<byte>? keyData,
+        ReadOnlyMemory<byte>? valueData,
+        IReadOnlyList<Header>? headers,
+        Exception innerException)
+        : base(
+            CreateMessage(origin, topicPartition, offset),
+            innerException,
+            topicPartition.Topic,
+            ToSerializationComponent(origin))
+    {
+        Origin = origin;
+        TopicPartition = topicPartition;
+        Offset = offset;
+        TimestampMs = timestampMs;
+        TimestampType = timestampType;
+        KeyData = CopyData(keyData);
+        ValueData = CopyData(valueData);
+        Headers = CopyHeaders(headers);
+    }
+
+    internal RecordDeserializationException(
+        DeserializationExceptionOrigin origin,
+        TopicPartition topicPartition,
+        long offset,
+        long timestampMs,
+        Consumer.TimestampType timestampType,
+        ReadOnlyMemory<byte> keyData,
+        bool isKeyNull,
+        ReadOnlyMemory<byte> valueData,
+        bool isValueNull,
+        Header[]? headers,
+        int headerCount,
+        Exception innerException)
+        : base(
+            CreateMessage(origin, topicPartition, offset),
+            innerException,
+            topicPartition.Topic,
+            ToSerializationComponent(origin))
+    {
+        Origin = origin;
+        TopicPartition = topicPartition;
+        Offset = offset;
+        TimestampMs = timestampMs;
+        TimestampType = timestampType;
+        KeyData = isKeyNull ? null : keyData.ToArray();
+        ValueData = isValueNull ? null : valueData.ToArray();
+        Headers = CopyHeaders(headers, headerCount);
+    }
+
+    /// <summary>The record component whose deserializer failed.</summary>
+    public DeserializationExceptionOrigin Origin { get; }
+
+    /// <summary>The topic and partition containing the failed record.</summary>
+    public TopicPartition TopicPartition { get; }
+
+    /// <summary>The failed record offset.</summary>
+    public long Offset { get; }
+
+    /// <summary>The failed record timestamp as raw Unix milliseconds.</summary>
+    public long TimestampMs { get; }
+
+    /// <summary>The failed record timestamp.</summary>
+    public DateTimeOffset Timestamp => DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs);
+
+    /// <summary>The failed record timestamp type.</summary>
+    public Consumer.TimestampType TimestampType { get; }
+
+    /// <summary>
+    /// Owned raw key bytes, or <see langword="null"/> when the Kafka record key was null.
+    /// </summary>
+    public byte[]? KeyData { get; }
+
+    /// <summary>
+    /// Owned raw value bytes, or <see langword="null"/> when the Kafka record value was null.
+    /// </summary>
+    public byte[]? ValueData { get; }
+
+    /// <summary>
+    /// Owned record headers in wire order. Duplicate keys and null values are preserved.
+    /// </summary>
+    public IReadOnlyList<Header> Headers { get; }
+
+    private static string CreateMessage(
+        DeserializationExceptionOrigin origin,
+        TopicPartition topicPartition,
+        long offset)
+        => $"Failed to deserialize record {GetOriginName(origin)} for " +
+           $"{topicPartition.Topic}-{topicPartition.Partition} at offset {offset}";
+
+    private static string GetOriginName(DeserializationExceptionOrigin origin) => origin switch
+    {
+        DeserializationExceptionOrigin.Key => "key",
+        DeserializationExceptionOrigin.Value => "value",
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, null)
+    };
+
+    private static SerializationComponent ToSerializationComponent(
+        DeserializationExceptionOrigin origin) => origin switch
+    {
+        DeserializationExceptionOrigin.Key => SerializationComponent.Key,
+        DeserializationExceptionOrigin.Value => SerializationComponent.Value,
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, null)
+    };
+
+    private static byte[]? CopyData(ReadOnlyMemory<byte>? data)
+        => data?.ToArray();
+
+    private static IReadOnlyList<Header> CopyHeaders(IReadOnlyList<Header>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return Array.Empty<Header>();
+
+        var copy = new Header[headers.Count];
+        for (var i = 0; i < headers.Count; i++)
+            copy[i] = CopyHeader(headers[i]);
+
+        return new ReadOnlyCollection<Header>(copy);
+    }
+
+    private static IReadOnlyList<Header> CopyHeaders(Header[]? headers, int headerCount)
+    {
+        if (headers is null || headerCount == 0)
+            return Array.Empty<Header>();
+
+        var copy = new Header[headerCount];
+        for (var i = 0; i < headerCount; i++)
+            copy[i] = CopyHeader(headers[i]);
+
+        return new ReadOnlyCollection<Header>(copy);
+    }
+
+    private static Header CopyHeader(Header header)
+        => new(
+            header.Key,
+            header.IsValueNull ? ReadOnlyMemory<byte>.Empty : header.Value.ToArray(),
+            header.IsValueNull);
 }

--- a/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
+++ b/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
@@ -1,5 +1,8 @@
 using System.Buffers;
+using System.Text;
 using Dekaf.Consumer;
+using Dekaf.Consumer.DeadLetter;
+using Dekaf.Errors;
 using Dekaf.Producer;
 using Dekaf.Serialization;
 
@@ -182,8 +185,7 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
             {
                 // Should not reach here - exception expected before yield
             }
-        }).Throws<InvalidOperationException>()
-          .WithMessage("Deserializer intentionally threw for test");
+        }).Throws<RecordDeserializationException>();
     }
 
     [Test]
@@ -191,6 +193,8 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
     {
         // Arrange - produce two messages: one that triggers the error and one normal
         var topic = await KafkaContainer.CreateTestTopicAsync();
+        var deadLetterTopic = await KafkaContainer.CreateTestTopicAsync();
+        var failedTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(1_700_000_000_123L);
 
         await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(KafkaContainer.BootstrapServers)
@@ -203,7 +207,11 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
         {
             Topic = topic,
             Key = "key-bad",
-            Value = ThrowingValueDeserializer.TriggerValue
+            Value = ThrowingValueDeserializer.TriggerValue,
+            Timestamp = failedTimestamp,
+            Headers = new Headers()
+                .Add("trace-id", "abc123")
+                .Add("nullable", (byte[]?)null)
         }, CancellationToken.None);
 
         // Message 2: normal message
@@ -227,7 +235,7 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
 
         // First consume attempt - should throw on the bad message
         using var cts1 = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        var caughtException = false;
+        RecordDeserializationException? caughtException = null;
 
         try
         {
@@ -236,12 +244,43 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
                 // Should throw before yielding
             }
         }
-        catch (InvalidOperationException)
+        catch (RecordDeserializationException exception)
         {
-            caughtException = true;
+            caughtException = exception;
         }
 
-        await Assert.That(caughtException).IsTrue();
+        await Assert.That(caughtException).IsNotNull();
+        var failedRecord = caughtException!;
+        await Assert.That(failedRecord.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
+        await Assert.That(failedRecord.TopicPartition).IsEqualTo(tp);
+        await Assert.That(failedRecord.Offset).IsEqualTo(0L);
+        await Assert.That(failedRecord.Timestamp).IsEqualTo(failedTimestamp);
+        await Assert.That(failedRecord.KeyData).IsEquivalentTo("key-bad"u8.ToArray());
+        await Assert.That(failedRecord.ValueData)
+            .IsEquivalentTo(Encoding.UTF8.GetBytes(ThrowingValueDeserializer.TriggerValue));
+        await Assert.That(failedRecord.Headers[0].Key).IsEqualTo("trace-id");
+        await Assert.That(failedRecord.Headers[1].IsValueNull).IsTrue();
+        await Assert.That(failedRecord.InnerException).IsTypeOf<InvalidOperationException>();
+
+        await using (var deadLetterProducer = await Kafka.CreateProducer<byte[]?, byte[]?>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-deser-dlq")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync())
+        {
+            var deadLetterMetadata = await deadLetterProducer.ProduceAsync(
+                new ProducerMessage<byte[]?, byte[]?>
+                {
+                    Topic = deadLetterTopic,
+                    Key = failedRecord.KeyData,
+                    Value = failedRecord.ValueData,
+                    Timestamp = failedRecord.Timestamp,
+                    Headers = DeadLetterHeaders.Build(failedRecord, 1, includeException: true)
+                },
+                CancellationToken.None);
+
+            await Assert.That(deadLetterMetadata.Offset).IsEqualTo(0L);
+        }
 
         // Seek past the bad message to offset 1 (the normal message)
         consumer.Seek(new TopicPartitionOffset(topic, 0, 1));

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
+using Dekaf.Errors;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Dekaf.Tests.Unit.Producer;
@@ -487,20 +488,98 @@ public sealed class ConsumeOneFastPathTests
     }
 
     [Test]
-    public async Task ConsumeOneAsync_DeserializerInvalidDataException_Propagates()
+    public async Task ConsumeOneAsync_DeserializerInvalidDataException_ProvidesRecordContext()
+    {
+        var record = CreateRecord(
+            0,
+            "key",
+            "value",
+            [
+                new Header("trace-id", Encoding.UTF8.GetBytes("abc")),
+                new Header("nullable", (byte[]?)null)
+            ]);
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(0, record)
+        ]);
+        await using var consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            valueDeserializer: new InvalidDataThrowingDeserializer());
+
+        var exception = (await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
+            .Throws<RecordDeserializationException>())!;
+
+        await Assert.That(exception.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
+        await Assert.That(exception.TopicPartition).IsEqualTo(new TopicPartition(Topic, Partition));
+        await Assert.That(exception.Offset).IsEqualTo(0L);
+        await Assert.That(exception.KeyData).IsEquivalentTo(Encoding.UTF8.GetBytes("key"));
+        await Assert.That(exception.ValueData).IsEquivalentTo(Encoding.UTF8.GetBytes("value"));
+        await Assert.That(exception.TimestampMs).IsEqualTo(1_700_000_000_000L);
+        await Assert.That(exception.Headers[0].Key).IsEqualTo("trace-id");
+        await Assert.That(Encoding.UTF8.GetString(exception.Headers[0].Value.Span)).IsEqualTo("abc");
+        await Assert.That(exception.Headers[1].IsValueNull).IsTrue();
+        await Assert.That(exception.InnerException).IsTypeOf<InvalidDataException>();
+        await Assert.That(exception.InnerException!.Message).Contains("user deserializer");
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_KeyDeserializerFailure_ReportsKeyOrigin()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(7, CreateRecord(1, "bad-key", "value"))
+        ]);
+        await using var consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            keyDeserializer: new InvalidDataThrowingDeserializer());
+
+        var exception = (await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
+            .Throws<RecordDeserializationException>())!;
+
+        await Assert.That(exception.Origin).IsEqualTo(DeserializationExceptionOrigin.Key);
+        await Assert.That(exception.Component).IsEqualTo(SerializationComponent.Key);
+        await Assert.That(exception.Offset).IsEqualTo(8L);
+        await Assert.That(exception.KeyData).IsEquivalentTo(Encoding.UTF8.GetBytes("bad-key"));
+        await Assert.That(exception.ValueData).IsEquivalentTo(Encoding.UTF8.GetBytes("value"));
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_AsyncDeserializerFailure_ProvidesRecordContext()
+    {
+        var fetch = PendingFetchData.Create(Topic, Partition,
+        [
+            CreateBatch(10, CreateRecord(2, "key", "value"))
+        ]);
+        await using var consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            asyncValueDeserializer: new InvalidDataThrowingAsyncDeserializer());
+
+        var exception = (await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
+            .Throws<RecordDeserializationException>())!;
+
+        await Assert.That(exception.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
+        await Assert.That(exception.Offset).IsEqualTo(12L);
+        await Assert.That(exception.ValueData).IsEquivalentTo(Encoding.UTF8.GetBytes("value"));
+        await Assert.That(exception.InnerException).IsTypeOf<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_AsyncDeserializerCancellation_IsNotWrapped()
     {
         var fetch = PendingFetchData.Create(Topic, Partition,
         [
             CreateBatch(0, CreateRecord(0, "key", "value"))
         ]);
-        await using var consumer = CreateInitializedConsumerWithValueDeserializer(
-            new InvalidDataThrowingDeserializer(),
-            fetch);
+        await using var consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            asyncValueDeserializer: new CancellationThrowingAsyncDeserializer());
 
         await Assert.That(async () =>
-            await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
-            .Throws<InvalidDataException>()
-            .WithMessageContaining("user deserializer");
+                await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), CancellationToken.None))
+            .Throws<OperationCanceledException>();
     }
 
     private static KafkaConsumer<string, string> CreateInitializedConsumer(params PendingFetchData[] fetches)
@@ -578,9 +657,11 @@ public sealed class ConsumeOneFastPathTests
         return consumer;
     }
 
-    private static KafkaConsumer<string, string> CreateInitializedConsumerWithValueDeserializer(
-        IDeserializer<string> valueDeserializer,
-        PendingFetchData fetch)
+    private static KafkaConsumer<string, string> CreateInitializedConsumerWithDeserializers(
+        PendingFetchData fetch,
+        IDeserializer<string>? keyDeserializer = null,
+        IDeserializer<string>? valueDeserializer = null,
+        IAsyncDeserializer<string>? asyncValueDeserializer = null)
     {
         var consumer = new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -590,8 +671,9 @@ public sealed class ConsumeOneFastPathTests
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200
             },
-            Serializers.String,
-            valueDeserializer);
+            keyDeserializer ?? Serializers.String,
+            valueDeserializer ?? Serializers.String,
+            asyncValueDeserializer: asyncValueDeserializer);
 
         SetInitialized(consumer);
         AssignTestPartition(consumer);
@@ -642,6 +724,24 @@ public sealed class ConsumeOneFastPathTests
     {
         public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
             throw new InvalidDataException("user deserializer failed");
+    }
+
+    private sealed class InvalidDataThrowingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        public ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromException<string>(new InvalidDataException("async user deserializer failed"));
+    }
+
+    private sealed class CancellationThrowingAsyncDeserializer : IAsyncDeserializer<string>
+    {
+        public ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromException<string>(new OperationCanceledException(cancellationToken));
     }
 
     private static void AssignTestPartition(KafkaConsumer<string, string> consumer)
@@ -836,7 +936,7 @@ public sealed class ConsumeOneFastPathTests
         };
     }
 
-    private static Record CreateRecord(int offsetDelta, string key, string value)
+    private static Record CreateRecord(int offsetDelta, string key, string value, Header[]? headers = null)
     {
         return new Record
         {
@@ -846,8 +946,8 @@ public sealed class ConsumeOneFastPathTests
             IsKeyNull = false,
             Value = Encoding.UTF8.GetBytes(value),
             IsValueNull = false,
-            Headers = null,
-            HeaderCount = 0
+            Headers = headers,
+            HeaderCount = headers?.Length ?? 0
         };
     }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterHeadersTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/DeadLetter/DeadLetterHeadersTests.cs
@@ -1,5 +1,6 @@
 using Dekaf.Consumer;
 using Dekaf.Consumer.DeadLetter;
+using Dekaf.Errors;
 using Dekaf.Serialization;
 
 namespace Dekaf.Tests.Unit.Consumer.DeadLetter;
@@ -108,6 +109,30 @@ public class DeadLetterHeadersTests
         await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceTopicKey)).IsEqualTo("orders");
         await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourcePartitionKey)).IsEqualTo("3");
         await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceOffsetKey)).IsEqualTo("99");
+    }
+
+    [Test]
+    public async Task BuildHeaders_FromDeserializationException_PreservesFailedRecordContext()
+    {
+        var exception = new RecordDeserializationException(
+            DeserializationExceptionOrigin.Value,
+            new TopicPartition("orders", 3),
+            99,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            TimestampType.CreateTime,
+            keyData: null,
+            valueData: new byte[] { 1, 2, 3 },
+            headers: [new Header("trace-id", "abc123"u8.ToArray())],
+            new InvalidDataException("bad value"));
+
+        var headers = DeadLetterHeaders.Build(exception, 2, includeException: true);
+
+        await Assert.That(headers.GetFirstAsString("trace-id")).IsEqualTo("abc123");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceTopicKey)).IsEqualTo("orders");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourcePartitionKey)).IsEqualTo("3");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.SourceOffsetKey)).IsEqualTo("99");
+        await Assert.That(headers.GetFirstAsString(DeadLetterHeaders.ErrorTypeKey))
+            .IsEqualTo(nameof(RecordDeserializationException));
     }
 
     private static ConsumeResult<string, string> CreateTestConsumeResult(

--- a/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/OffsetStoreTimingTests.cs
@@ -97,7 +97,7 @@ public sealed class OffsetStoreTimingTests
         await Assert.That(TryConsumeOneFromPendingFetches(consumer, out var first)).IsTrue();
         await Assert.That(first.Offset).IsEqualTo(20L);
         await Assert.That(() => TryConsumeOneFromPendingFetches(consumer, out _))
-            .Throws<InvalidOperationException>();
+            .Throws<RecordDeserializationException>();
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
         await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
@@ -133,7 +133,7 @@ public sealed class OffsetStoreTimingTests
         {
             await foreach (var result in consumer.ConsumeAsync(CancellationToken.None))
                 await Assert.That(result.Offset).IsEqualTo(20L);
-        }).Throws<InvalidOperationException>();
+        }).Throws<RecordDeserializationException>();
 
         await Assert.That(GetDirtyStoredOffsets(consumer)[tp]).IsEqualTo(21L);
         await Assert.That(GetPositions(consumer)[tp]).IsEqualTo(21L);
@@ -533,7 +533,7 @@ public sealed class OffsetStoreTimingTests
             {
                 records.MoveNext();
             }
-            catch (InvalidOperationException)
+            catch (RecordDeserializationException)
             {
                 threw = true;
             }
@@ -1010,7 +1010,7 @@ public sealed class OffsetStoreTimingTests
         consumer.Assign(partition);
 
         await Assert.That(async () => await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1)))
-            .Throws<InvalidOperationException>();
+            .Throws<RecordDeserializationException>();
         var replay = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
 
         await Assert.That(replay!.Value.Offset).IsEqualTo(0L);

--- a/tests/Dekaf.Tests.Unit/Consumer/RecordDeserializationExceptionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/RecordDeserializationExceptionTests.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class RecordDeserializationExceptionTests
+{
+    private const string Topic = "orders";
+    private const int Partition = 3;
+    private const long Offset = 42;
+    private const long TimestampMs = 1_700_000_000_123;
+
+    [Test]
+    public async Task Constructor_CopiesRecordDataAndPreservesMetadata()
+    {
+        var key = Encoding.UTF8.GetBytes("key");
+        var value = Encoding.UTF8.GetBytes("value");
+        var firstHeaderValue = Encoding.UTF8.GetBytes("first");
+        var headers = new Header[]
+        {
+            new("trace-id", firstHeaderValue),
+            new("trace-id", (byte[]?)null),
+            new("empty", Array.Empty<byte>())
+        };
+        var inner = new InvalidDataException("bad payload");
+
+        var exception = new RecordDeserializationException(
+            DeserializationExceptionOrigin.Value,
+            new TopicPartition(Topic, Partition),
+            Offset,
+            TimestampMs,
+            TimestampType.LogAppendTime,
+            key,
+            value,
+            headers,
+            inner);
+
+        key[0] = (byte)'X';
+        value[0] = (byte)'X';
+        firstHeaderValue[0] = (byte)'X';
+
+        await Assert.That(exception.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
+        await Assert.That(exception.TopicPartition).IsEqualTo(new TopicPartition(Topic, Partition));
+        await Assert.That(exception.Offset).IsEqualTo(Offset);
+        await Assert.That(exception.TimestampMs).IsEqualTo(TimestampMs);
+        await Assert.That(exception.Timestamp).IsEqualTo(DateTimeOffset.FromUnixTimeMilliseconds(TimestampMs));
+        await Assert.That(exception.TimestampType).IsEqualTo(TimestampType.LogAppendTime);
+        await Assert.That(exception.Topic).IsEqualTo(Topic);
+        await Assert.That(exception.Component).IsEqualTo(SerializationComponent.Value);
+        await Assert.That(exception.InnerException).IsSameReferenceAs(inner);
+        await Assert.That(Encoding.UTF8.GetString(exception.KeyData!)).IsEqualTo("key");
+        await Assert.That(Encoding.UTF8.GetString(exception.ValueData!)).IsEqualTo("value");
+        await Assert.That(exception.Headers.Select(static header => header.Key).ToArray())
+            .IsEquivalentTo(["trace-id", "trace-id", "empty"]);
+        await Assert.That(Encoding.UTF8.GetString(exception.Headers[0].Value.Span)).IsEqualTo("first");
+        await Assert.That(exception.Headers[1].IsValueNull).IsTrue();
+        await Assert.That(exception.Headers[2].IsValueNull).IsFalse();
+        await Assert.That(exception.Headers[2].Value.IsEmpty).IsTrue();
+    }
+
+    [Test]
+    public async Task Constructor_DistinguishesEmptyDataFromNullData()
+    {
+        var exception = new RecordDeserializationException(
+            DeserializationExceptionOrigin.Key,
+            new TopicPartition(Topic, Partition),
+            Offset,
+            TimestampMs,
+            TimestampType.CreateTime,
+            ReadOnlyMemory<byte>.Empty,
+            valueData: null,
+            headers: null,
+            new InvalidDataException());
+
+        await Assert.That(exception.KeyData).IsNotNull();
+        await Assert.That(exception.KeyData).IsEmpty();
+        await Assert.That(exception.ValueData).IsNull();
+    }
+
+    [Test]
+    public async Task ConsumeResult_CancellationFromDeserializer_IsNotWrapped()
+    {
+        await Assert.That(() => new ConsumeResult<string, string>(
+                Topic,
+                Partition,
+                Offset,
+                Encoding.UTF8.GetBytes("key"),
+                isKeyNull: false,
+                Encoding.UTF8.GetBytes("value"),
+                isValueNull: false,
+                headers: null,
+                TimestampMs,
+                TimestampType.CreateTime,
+                leaderEpoch: null,
+                keyDeserializer: Serializers.String,
+                valueDeserializer: new ThrowingDeserializer(new OperationCanceledException())))
+            .Throws<OperationCanceledException>();
+    }
+
+    private sealed class ThrowingDeserializer(Exception exception) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => throw exception;
+    }
+}


### PR DESCRIPTION
Closes #2246

## Summary

- add `RecordDeserializationException` with key/value origin, topic-partition, offset, timestamp/type, owned raw key/value bytes, owned headers, and original cause
- surface rich failures across single-record, async-enumeration, batch, async-deserializer, and in-memory consumer paths while preserving rewind/redelivery semantics
- add a DLQ header overload so failed records can be published after pooled fetch buffers are released
- leave cancellation, interceptor, and protocol failures unwrapped

Native GitHub `blockedBy` for #2246 was queried before work and again before publication; both returned no blockers.

## Validation

- `dotnet build --configuration Release --no-restore`: clean
- unit net10: 6064 passed
- unit net8: 5937 passed
- `CustomSerializerErrorTests` against Kafka 4.3.1: 4 passed, including owned-context DLQ publish + seek recovery

## Performance

`ConsumerHotPathBenchmarks.ConsumeBatch_RawBytes_Enumerate`, .NET 10, ShortRun, MemoryDiagnoser, same machine:

| SHA | Mean | Allocated |
| --- | ---: | ---: |
| `1889528d` baseline control 1 | 30.328 ns/message | 0 B |
| `1889528d` baseline control 2 | 28.942 ns/message | 0 B |
| `210b533b` candidate | 28.966 ns/message | 0 B |

Rich snapshots are created only after deserialization failure. Successful batch enumeration remains zero-allocation; failure handling is isolated in no-inline cold helpers.

Implements the consumer-side behavior described by [KIP-1036](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1036%3A%2BExtend%2BRecordDeserializationException%2Bexception).