### PR TITLE
feat(consumer): add KIP-1306 rebalance context

### DIFF
--- a/docs/docs/configuration/consumer-options.md
+++ b/docs/docs/configuration/consumer-options.md
@@ -309,6 +309,10 @@ auto-commit, `LeaveGroup`, assignment cleanup, and resource disposal:
 .WithRebalanceListener(new MyRebalanceListener())
 ```
 
+The same method accepts `IConsumerAwareRebalanceListener`. Its callbacks receive an
+`IRebalanceConsumer` view with safe commit, seek, pause/resume, metadata, and offset
+operations. The view is invalidated as soon as the callback completes.
+
 The stop callback is best-effort and bounded to five seconds. If it observes
 shutdown cancellation, Dekaf still completes local cleanup before rethrowing the
 cancellation from `CloseAsync`.

--- a/docs/docs/consumer/consumer-groups.md
+++ b/docs/docs/consumer/consumer-groups.md
@@ -139,6 +139,54 @@ Callback semantics:
 
 Non-cancellation callback exceptions are logged and suppressed. `OperationCanceledException` follows the supplied cancellation token.
 
+Use `IConsumerAwareRebalanceListener` when a callback must operate on the consumer
+without capturing its unrestricted instance:
+
+```csharp
+public sealed class ConsumerAwareListener : IConsumerAwareRebalanceListener
+{
+    public ValueTask OnPartitionsAssignedAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        var assigned = partitions.ToArray();
+        consumer.SeekToBeginning(assigned);
+        consumer.Pause(assigned);
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask OnPartitionsRevokedAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct)
+    {
+        var completed = GetCompletedOffsets(partitions);
+        await consumer.CommitAsync(completed, ct);
+    }
+
+    public ValueTask OnPartitionsLostAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken ct) => ValueTask.CompletedTask;
+}
+
+var consumer = await Kafka.CreateConsumer<string, string>()
+    .WithBootstrapServers("localhost:9092")
+    .WithGroupId("my-group")
+    .WithRebalanceListener(new ConsumerAwareListener())
+    .BuildAsync();
+```
+
+`IRebalanceConsumer` exposes commit/store, position and seek, pause/resume,
+assignment, group metadata, and offset queries. It intentionally excludes consume,
+close/dispose, subscribe, and assignment mutation. The view is valid only while its
+callback is running; using a retained view afterward throws `InvalidOperationException`.
+
+Existing `IRebalanceListener` implementations and registrations require no changes.
+Migrate only listeners that need safe consumer operations by changing the implemented
+interface and adding the `IRebalanceConsumer` callback parameter.
+
 For low-level consumers, track completed offsets only after durable processing.
 On revoke or graceful stop, commit those completed offsets. On lost, remove local
 state without committing:

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -976,7 +976,9 @@ internal static class DekafOptionsBinding
             options.SaslCredentialProvider,
             builder.WithSaslOptions,
             builder.WithOAuthBearer);
-        if (options.RebalanceListener is not null)
+        if (options.ConsumerAwareRebalanceListener is not null)
+            builder.WithRebalanceListener(options.ConsumerAwareRebalanceListener);
+        else if (options.RebalanceListener is not null)
             builder.WithRebalanceListener(options.RebalanceListener);
         builder.WithPartitionEof(options.EnablePartitionEof);
         builder.WithSocketSendBufferBytes(options.SocketSendBufferBytes);

--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -1642,6 +1642,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
     private int _maxCachedStringValueBytes = DefaultMaxCachedStringValueBytes;
     private int _maxCachedStringValueEntries = DefaultMaxCachedStringValueEntries;
     private IRebalanceListener? _rebalanceListener;
+    private IConsumerAwareRebalanceListener? _consumerAwareRebalanceListener;
     private Microsoft.Extensions.Logging.ILoggerFactory? _loggerFactory;
     private bool _enablePartitionEof;
     private int _socketSendBufferBytes;
@@ -2470,6 +2471,17 @@ public sealed class ConsumerBuilder<TKey, TValue>
     public ConsumerBuilder<TKey, TValue> WithRebalanceListener(IRebalanceListener listener)
     {
         _rebalanceListener = listener;
+        _consumerAwareRebalanceListener = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures a rebalance listener with callback-scoped access to safe consumer operations.
+    /// </summary>
+    public ConsumerBuilder<TKey, TValue> WithRebalanceListener(IConsumerAwareRebalanceListener listener)
+    {
+        _consumerAwareRebalanceListener = listener;
+        _rebalanceListener = null;
         return this;
     }
 
@@ -3180,6 +3192,7 @@ public sealed class ConsumerBuilder<TKey, TValue>
             OAuthBearerTokenProvider = _oauthTokenProvider,
             AwsMskIamConfig = _awsMskIamConfig,
             RebalanceListener = _rebalanceListener,
+            ConsumerAwareRebalanceListener = _consumerAwareRebalanceListener,
             EnablePartitionEof = _enablePartitionEof,
             SocketSendBufferBytes = _socketSendBufferBytes,
             SocketReceiveBufferBytes = _socketReceiveBufferBytes,

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -28,6 +28,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     private readonly IConnectionPool _connectionPool;
     private readonly MetadataManager _metadataManager;
     private readonly IRebalanceListener? _rebalanceListener;
+    private readonly IConsumerAwareRebalanceListener? _consumerAwareRebalanceListener;
     // Retained for the public six-parameter constructor and direct coordinator callers.
     // KafkaConsumer uses the pre-publication hook below to invalidate buffered fetches.
     private readonly Action<IReadOnlyList<TopicPartition>>? _onPartitionsRevoked;
@@ -38,6 +39,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     // Assignment snapshots wait for this hook so KafkaConsumer cannot discard dirty revoked offsets first.
     private readonly Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>?
         _onPartitionsRevokedAsync;
+    private readonly Func<
+        IEnumerable<TopicPartition>,
+        IEnumerable<TopicPartition>,
+        IRebalanceConsumerScope>? _createRebalanceConsumerScope;
     private readonly ConcurrentQueue<TopicPartition> _revokedPartitionsSinceLastSync = new();
     private Task _pendingRevocationCommit = Task.CompletedTask;
     // Assignment publication and revocation history form one snapshot. Rebalance callbacks
@@ -123,15 +128,27 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         Func<int>? getConnectionCount,
         Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoked,
         Action<IReadOnlyList<TopicPartition>>? onPartitionsRevoking,
-        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? onPartitionsRevokedAsync = null)
+        Func<IReadOnlyList<TopicPartition>, CancellationToken, ValueTask>? onPartitionsRevokedAsync = null,
+        Func<IEnumerable<TopicPartition>, IEnumerable<TopicPartition>, IRebalanceConsumerScope>?
+            createRebalanceConsumerScope = null)
     {
         _options = options;
         _connectionPool = connectionPool;
         _metadataManager = metadataManager;
-        _rebalanceListener = options.RebalanceListener;
+        _consumerAwareRebalanceListener = options.ConsumerAwareRebalanceListener;
+        _rebalanceListener = _consumerAwareRebalanceListener is null
+            ? options.RebalanceListener
+            : null;
         _onPartitionsRevoked = onPartitionsRevoked;
         _onPartitionsRevoking = onPartitionsRevoking;
         _onPartitionsRevokedAsync = onPartitionsRevokedAsync;
+        _createRebalanceConsumerScope = createRebalanceConsumerScope;
+        if (_consumerAwareRebalanceListener is not null && _createRebalanceConsumerScope is null)
+        {
+            throw new ArgumentException(
+                "Consumer-aware rebalance listeners require a KafkaConsumer-owned coordinator.",
+                nameof(options));
+        }
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ConsumerCoordinator>.Instance;
         _getCoordinationConnectionIndex = getConnectionCount is not null
             ? () => GetCoordinationConnectionIndex(getConnectionCount())
@@ -716,9 +733,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         try
         {
             LogRebalanceListenerCall(callbackName, partitions.Count);
-            var callbackTask = callback(listener, partitions, cancellationToken);
-
-            await callbackTask.ConfigureAwait(false);
+            await callback(listener, partitions, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -726,10 +741,53 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
     }
 
+    private async ValueTask InvokeConsumerAwareRebalanceListenerAsync(
+        string callbackName,
+        IReadOnlyList<TopicPartition> partitions,
+        IConsumerAwareRebalanceListener listener,
+        Func<
+            IConsumerAwareRebalanceListener,
+            IRebalanceConsumer,
+            IEnumerable<TopicPartition>,
+            CancellationToken,
+            ValueTask> consumerAwareCallback,
+        IEnumerable<TopicPartition> newlyAssigned,
+        CancellationToken cancellationToken)
+    {
+        IRebalanceConsumerScope? consumerScope = null;
+        try
+        {
+            LogRebalanceListenerCall(callbackName, partitions.Count);
+            consumerScope = _createRebalanceConsumerScope!(
+                _assignedPartitions,
+                newlyAssigned);
+            await consumerAwareCallback(
+                listener,
+                consumerScope,
+                partitions,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogRebalanceListenerCallbackError(callbackName, ex);
+        }
+        finally
+        {
+            consumerScope?.Invalidate();
+        }
+    }
+
     private async ValueTask InvokeRebalanceListenersAsync(
         string callbackName,
         IReadOnlyList<TopicPartition> partitions,
         Func<IRebalanceListener, IEnumerable<TopicPartition>, CancellationToken, ValueTask> callback,
+        Func<
+            IConsumerAwareRebalanceListener,
+            IRebalanceConsumer,
+            IEnumerable<TopicPartition>,
+            CancellationToken,
+            ValueTask> consumerAwareCallback,
+        IEnumerable<TopicPartition> newlyAssigned,
         CancellationToken cancellationToken)
     {
         var configuredListener = _rebalanceListener;
@@ -740,6 +798,18 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 partitions,
                 configuredListener,
                 callback,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var consumerAwareListener = _consumerAwareRebalanceListener;
+        if (consumerAwareListener is not null)
+        {
+            await InvokeConsumerAwareRebalanceListenerAsync(
+                callbackName,
+                partitions,
+                consumerAwareListener,
+                consumerAwareCallback,
+                newlyAssigned,
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -1242,6 +1312,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "OnPartitionsRevoked",
                 revoked,
                 static (listener, partitions, token) => listener.OnPartitionsRevokedAsync(partitions, token),
+                static (listener, consumer, partitions, token) =>
+                    listener.OnPartitionsRevokedAsync(consumer, partitions, token),
+                [],
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -1250,6 +1323,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "OnPartitionsAssigned",
                 result.Assigned,
                 static (listener, partitions, token) => listener.OnPartitionsAssignedAsync(partitions, token),
+                static (listener, consumer, partitions, token) =>
+                    listener.OnPartitionsAssignedAsync(consumer, partitions, token),
+                result.Assigned,
                 cancellationToken).ConfigureAwait(false);
     }
 
@@ -1983,6 +2059,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 "OnPartitionsLost",
                 lost,
                 static (listener, partitions, token) => listener.OnPartitionsLostAsync(partitions, token),
+                static (listener, consumer, partitions, token) =>
+                    listener.OnPartitionsLostAsync(consumer, partitions, token),
+                [],
                 CancellationToken.None).ConfigureAwait(false);
         }
         finally

--- a/src/Dekaf/Consumer/ConsumerOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerOptions.cs
@@ -380,6 +380,12 @@ public sealed class ConsumerOptions
     public IRebalanceListener? RebalanceListener { get; init; }
 
     /// <summary>
+    /// Rebalance listener that receives a callback-scoped restricted consumer view.
+    /// </summary>
+    /// <remarks>Takes precedence over <see cref="RebalanceListener"/> when both are set.</remarks>
+    public IConsumerAwareRebalanceListener? ConsumerAwareRebalanceListener { get; init; }
+
+    /// <summary>
     /// Socket send buffer size in bytes. Set to 0 to use system default.
     /// </summary>
     public int SocketSendBufferBytes { get; init; }

--- a/src/Dekaf/Consumer/IRebalanceConsumer.cs
+++ b/src/Dekaf/Consumer/IRebalanceConsumer.cs
@@ -1,0 +1,119 @@
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
+
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Restricted consumer operations available during a rebalance callback.
+/// </summary>
+/// <remarks>
+/// A view is valid only for the duration of the callback that received it. Retaining and
+/// using the view after the callback completes throws <see cref="InvalidOperationException"/>.
+/// Consumption, lifecycle, subscription, and assignment mutation operations are deliberately
+/// absent so callbacks cannot recursively poll or change group membership.
+/// </remarks>
+public interface IRebalanceConsumer
+{
+    /// <summary>Gets the current subscription.</summary>
+    StringSet Subscription { get; }
+
+    /// <summary>Gets the current server-side topic regex subscription, if any.</summary>
+    string? SubscriptionPattern { get; }
+
+    /// <summary>Gets the assignment visible to this callback.</summary>
+    TopicPartitionSet Assignment { get; }
+
+    /// <summary>Gets the paused partitions.</summary>
+    TopicPartitionSet Paused { get; }
+
+    /// <summary>Gets the current group member ID.</summary>
+    string? MemberId { get; }
+
+    /// <summary>Gets current consumer group metadata, if the group has been joined.</summary>
+    ConsumerGroupMetadata? ConsumerGroupMetadata { get; }
+
+    /// <summary>Commits all currently stored offsets.</summary>
+    ValueTask CommitAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Commits the specified offsets.</summary>
+    ValueTask CommitAsync(
+        IEnumerable<TopicPartitionOffset> offsets,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Stores an offset for the automatic commit loop.</summary>
+    void StoreOffset(TopicPartitionOffset offset);
+
+    /// <summary>Gets the committed offset for a partition.</summary>
+    ValueTask<long?> GetCommittedOffsetAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the current position for a partition.</summary>
+    long? GetPosition(TopicPartition partition);
+
+    /// <summary>Seeks to a specific offset.</summary>
+    void Seek(TopicPartitionOffset offset);
+
+    /// <summary>Seeks partitions to their beginning.</summary>
+    void SeekToBeginning(params TopicPartition[] partitions);
+
+    /// <summary>Seeks partitions to their end.</summary>
+    void SeekToEnd(params TopicPartition[] partitions);
+
+    /// <summary>Pauses consumption from partitions.</summary>
+    void Pause(params TopicPartition[] partitions);
+
+    /// <summary>Resumes consumption from partitions.</summary>
+    void Resume(params TopicPartition[] partitions);
+
+    /// <summary>Looks up offsets by timestamp.</summary>
+    ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
+        IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Gets cached watermark offsets for a partition.</summary>
+    WatermarkOffsets? GetWatermarkOffsets(TopicPartition topicPartition);
+
+    /// <summary>Queries current watermark offsets for a partition.</summary>
+    ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
+        TopicPartition topicPartition,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Rebalance listener that receives a callback-scoped restricted consumer view.
+/// </summary>
+/// <remarks>
+/// Existing <see cref="IRebalanceListener"/> implementations remain supported through the
+/// same builder registration API.
+/// </remarks>
+public interface IConsumerAwareRebalanceListener
+{
+    /// <summary>Called when partitions are assigned after a rebalance completes.</summary>
+    ValueTask OnPartitionsAssignedAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken cancellationToken);
+
+    /// <summary>Called when partitions are revoked during a cooperative rebalance.</summary>
+    ValueTask OnPartitionsRevokedAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken cancellationToken);
+
+    /// <summary>Called when partitions are lost due to involuntary group removal.</summary>
+    ValueTask OnPartitionsLostAsync(
+        IRebalanceConsumer consumer,
+        IEnumerable<TopicPartition> partitions,
+        CancellationToken cancellationToken);
+}
+
+internal interface IRebalanceConsumerScope : IRebalanceConsumer
+{
+    void Invalidate();
+}

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -938,6 +938,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<TopicPartition, long> _dirtyStoredOffsets = new(); // Stored offsets changed since last successful commit
     private readonly ConcurrentDictionary<TopicPartition, int> _storedOffsetLeaderEpochs = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _fetchPositions = new(); // Fetch position (what to fetch next)
+    private readonly ConcurrentDictionary<TopicPartition, TopicPartitionOffset> _pendingRebalanceSeeks = new();
     // Last consumed record-batch leader epoch, sent as FetchRequest.LastFetchedEpoch.
     private readonly ConcurrentDictionary<TopicPartition, int> _lastConsumedLeaderEpochs = new();
     private readonly ConcurrentDictionary<TopicPartition, long> _committed = new();
@@ -1425,7 +1426,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     : null,
                 onPartitionsRevoked: null,
                 onPartitionsRevoking: QueueCoordinatorRevokedPartitionsForFetchClear,
-                onPartitionsRevokedAsync: CommitRevokedOffsetsAsync);
+                onPartitionsRevokedAsync: CommitRevokedOffsetsAsync,
+                createRebalanceConsumerScope: (assignment, newlyAssigned) =>
+                    new RebalanceConsumerScope<TKey, TValue>(
+                        this,
+                        assignment,
+                        newlyAssigned,
+                        StageRebalanceSeek,
+                        GetRebalancePosition));
         }
 
         _prefetchBuffer = new MpscFetchBuffer(CalculatePrefetchBufferCapacity(options));
@@ -4916,6 +4924,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return _positions.TryGetValue(partition, out var position) ? position : null;
     }
 
+    internal long? GetRebalancePosition(TopicPartition partition) =>
+        _pendingRebalanceSeeks.TryGetValue(partition, out var pending)
+            ? pending.Offset
+            : GetPosition(partition);
+
+    internal void StageRebalanceSeek(TopicPartitionOffset offset)
+    {
+        var partition = new TopicPartition(offset.Topic, offset.Partition);
+        _assignmentLock.Wait();
+        try
+        {
+            _pendingRebalanceSeeks[partition] = offset;
+            if (_coordinator is { } coordinator
+                && _assignmentSnapshot.Contains(partition)
+                && IsCoordinatorAssignmentSyncCurrent(coordinator, out _))
+            {
+                ApplyPendingRebalanceSeek(partition);
+            }
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_assignmentLock);
+        }
+    }
+
     private void EmitFetchMetrics(PendingFetchData fetch)
     {
         if (!fetch.TryConsumeMetricDelta(out var messageCount, out var bytesConsumed))
@@ -5010,6 +5043,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             _positions.TryRemove(partition, out _);
             ClearStoredOffset(partition);
             _fetchPositions.TryRemove(partition, out _);
+            _pendingRebalanceSeeks.TryRemove(partition, out _);
             _minimumFetchBufferEpochsByPartition.TryRemove(partition, out _);
             _lastConsumedLeaderEpochs.TryRemove(partition, out _);
             _committed.TryRemove(partition, out _);
@@ -6209,6 +6243,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     _fetchPositions[partition] = offset;
                 }
 
+                ApplyPendingRebalanceSeek(partition);
+
                 if (isNewlyExpanded)
                     (initializedNewPartitions ??= []).Add(partition);
             }
@@ -6218,6 +6254,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             if (initializedNewPartitions is not null)
                 coordinator.AcknowledgeInitializedPartitions(initializedNewPartitions, assignmentVersion);
         }
+    }
+
+    private void ApplyPendingRebalanceSeek(TopicPartition partition)
+    {
+        if (!_pendingRebalanceSeeks.TryRemove(partition, out var offset))
+            return;
+
+        if (offset.LeaderEpoch >= 0)
+            SetLastConsumedLeaderEpoch(partition, offset.LeaderEpoch);
+        else
+            ClearLastConsumedLeaderEpoch(partition);
+        SetPosition(partition, offset.Offset, dirty: true);
+        _fetchPositions[partition] = offset.Offset;
+        _eofEmitted.TryRemove(partition, out _);
     }
 
     private async ValueTask<long> GetResetOffsetAsync(

--- a/src/Dekaf/Consumer/RebalanceConsumerScope.cs
+++ b/src/Dekaf/Consumer/RebalanceConsumerScope.cs
@@ -1,0 +1,124 @@
+#if NETSTANDARD2_0
+using StringSet = System.Collections.Generic.IReadOnlyCollection<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlyCollection<Dekaf.TopicPartition>;
+#else
+using StringSet = System.Collections.Generic.IReadOnlySet<string>;
+using TopicPartitionSet = System.Collections.Generic.IReadOnlySet<Dekaf.TopicPartition>;
+#endif
+
+namespace Dekaf.Consumer;
+
+internal sealed class RebalanceConsumerScope<TKey, TValue> : IRebalanceConsumerScope
+{
+    private IKafkaConsumer<TKey, TValue>? _consumer;
+    private readonly TopicPartitionSet _assignment;
+    private readonly HashSet<TopicPartition> _newlyAssigned;
+    private readonly Action<TopicPartitionOffset> _stageSeek;
+    private readonly Func<TopicPartition, long?> _getPosition;
+
+    internal RebalanceConsumerScope(
+        IKafkaConsumer<TKey, TValue> consumer,
+        IEnumerable<TopicPartition> assignment,
+        IEnumerable<TopicPartition> newlyAssigned,
+        Action<TopicPartitionOffset>? stageSeek = null,
+        Func<TopicPartition, long?>? getPosition = null)
+    {
+        _consumer = consumer;
+        _assignment = assignment.ToHashSet();
+        _newlyAssigned = newlyAssigned.ToHashSet();
+        _stageSeek = stageSeek ?? consumer.Positions.Seek;
+        _getPosition = getPosition ?? consumer.Positions.GetPosition;
+    }
+
+    public StringSet Subscription => GetConsumer().Subscription;
+    public string? SubscriptionPattern => GetConsumer().SubscriptionPattern;
+    public TopicPartitionSet Assignment
+    {
+        get
+        {
+            _ = GetConsumer();
+            return _assignment;
+        }
+    }
+
+    public TopicPartitionSet Paused => GetConsumer().Paused;
+    public string? MemberId => GetConsumer().MemberId;
+    public ConsumerGroupMetadata? ConsumerGroupMetadata => GetConsumer().ConsumerGroupMetadata;
+
+    public ValueTask CommitAsync(CancellationToken cancellationToken = default) =>
+        GetConsumer().CommitAsync(cancellationToken);
+
+    public ValueTask CommitAsync(
+        IEnumerable<TopicPartitionOffset> offsets,
+        CancellationToken cancellationToken = default) =>
+        GetConsumer().CommitAsync(offsets, cancellationToken);
+
+    public void StoreOffset(TopicPartitionOffset offset) => GetConsumer().StoreOffset(offset);
+
+    public ValueTask<long?> GetCommittedOffsetAsync(
+        TopicPartition partition,
+        CancellationToken cancellationToken = default) =>
+        GetConsumer().Positions.GetCommittedOffsetAsync(partition, cancellationToken);
+
+    public long? GetPosition(TopicPartition partition) =>
+        GetPositionCore(partition);
+
+    public void Seek(TopicPartitionOffset offset)
+    {
+        var consumer = GetConsumer();
+        if (_newlyAssigned.Contains(new TopicPartition(offset.Topic, offset.Partition)))
+            _stageSeek(offset);
+        else
+            consumer.Positions.Seek(offset);
+    }
+
+    public void SeekToBeginning(params TopicPartition[] partitions) =>
+        SeekPartitions(partitions, offset: 0);
+
+    public void SeekToEnd(params TopicPartition[] partitions) =>
+        SeekPartitions(partitions, offset: -1);
+
+    public void Pause(params TopicPartition[] partitions) => GetConsumer().Pause(partitions);
+    public void Resume(params TopicPartition[] partitions) => GetConsumer().Resume(partitions);
+
+    public ValueTask<IReadOnlyDictionary<TopicPartition, long>> GetOffsetsForTimesAsync(
+        IEnumerable<TopicPartitionTimestamp> timestampsToSearch,
+        CancellationToken cancellationToken = default) =>
+        GetConsumer().Offsets.GetOffsetsForTimesAsync(timestampsToSearch, cancellationToken);
+
+    public WatermarkOffsets? GetWatermarkOffsets(TopicPartition topicPartition) =>
+        GetConsumer().Offsets.GetWatermarkOffsets(topicPartition);
+
+    public ValueTask<WatermarkOffsets> QueryWatermarkOffsetsAsync(
+        TopicPartition topicPartition,
+        CancellationToken cancellationToken = default) =>
+        GetConsumer().Offsets.QueryWatermarkOffsetsAsync(topicPartition, cancellationToken);
+
+    public void Invalidate() => Interlocked.Exchange(ref _consumer, null);
+
+    private IKafkaConsumer<TKey, TValue> GetConsumer() =>
+        Volatile.Read(ref _consumer) ?? throw new InvalidOperationException(
+            "The rebalance consumer view is no longer valid because its callback has completed.");
+
+    private long? GetPositionCore(TopicPartition partition)
+    {
+        _ = GetConsumer();
+        return _getPosition(partition);
+    }
+
+    private void SeekPartitions(IEnumerable<TopicPartition> partitions, long offset)
+    {
+        var consumer = GetConsumer();
+        foreach (var partition in partitions)
+        {
+            var topicPartitionOffset = new TopicPartitionOffset(
+                partition.Topic,
+                partition.Partition,
+                offset);
+            if (_newlyAssigned.Contains(partition))
+                _stageSeek(topicPartitionOffset);
+            else
+                consumer.Positions.Seek(topicPartitionOffset);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/ConsumerAwareRebalanceListenerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerAwareRebalanceListenerTests.cs
@@ -1,0 +1,192 @@
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("ConsumerGroup")]
+public sealed class ConsumerAwareRebalanceListenerTests(KafkaTestContainer kafka)
+    : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task RevokedCallback_CanCommitOwnedOffsets()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 4);
+        var groupId = $"consumer-aware-revoke-{Guid.NewGuid():N}";
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
+        for (var partition = 0; partition < 4; partition++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition,
+                Key = $"key-{partition}",
+                Value = $"value-{partition}"
+            });
+        }
+
+        var listener = new CommittingRebalanceListener();
+        await using var consumer1 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithRebalanceListener(listener)
+            .BuildAsync();
+        consumer1.Subscribe(topic);
+        var consumed = await ConsumeMessagesAsync(consumer1, count: 4);
+        await Assert.That(consumed).Count().IsEqualTo(4);
+
+        await using var consumer2 = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .BuildAsync();
+        consumer2.Subscribe(topic);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumer2Task = consumer2.ConsumeOneAsync(
+            TimeSpan.FromSeconds(30),
+            timeout.Token).AsTask();
+
+        var committed = await listener.Committed.Task.WaitAsync(timeout.Token);
+
+        await Assert.That(committed).IsNotEmpty();
+        foreach (var offset in committed)
+        {
+            var actual = await consumer1.Positions.GetCommittedOffsetAsync(
+                new TopicPartition(offset.Topic, offset.Partition),
+                timeout.Token);
+            await Assert.That(actual).IsEqualTo(offset.Offset);
+        }
+
+        await timeout.CancelAsync();
+        try { await consumer2Task; }
+        catch (OperationCanceledException) { }
+    }
+
+    [Test]
+    public async Task AssignedCallback_CanSeekPauseResumeAndQueryOffsets()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"consumer-aware-{Guid.NewGuid():N}";
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .BuildAsync();
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "first",
+            Value = "first"
+        });
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = "second",
+            Value = "second"
+        });
+
+        var listener = new SeekingRebalanceListener();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithRebalanceListener(listener)
+            .BuildAsync();
+        consumer.Subscribe(topic);
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), timeout.Token);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Value).IsEqualTo("second");
+        await Assert.That(listener.AssignmentContainedCallbackPartitions).IsTrue();
+        await Assert.That(listener.PauseResumeObserved).IsTrue();
+        await Assert.That(listener.WatermarksQueried).IsTrue();
+        var retained = listener.RetainedView;
+        await Assert.That(retained).IsNotNull();
+        var exception = Assert.Throws<InvalidOperationException>(() => _ = retained!.Assignment);
+        await Assert.That(exception.Message).Contains("callback has completed");
+    }
+
+    private sealed class SeekingRebalanceListener : IConsumerAwareRebalanceListener
+    {
+        public IRebalanceConsumer? RetainedView { get; private set; }
+        public bool AssignmentContainedCallbackPartitions { get; private set; }
+        public bool PauseResumeObserved { get; private set; }
+        public bool WatermarksQueried { get; private set; }
+
+        public async ValueTask OnPartitionsAssignedAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            var assigned = partitions.ToArray();
+            RetainedView = consumer;
+            AssignmentContainedCallbackPartitions = assigned.All(consumer.Assignment.Contains);
+            consumer.Pause(assigned);
+            PauseResumeObserved = assigned.All(consumer.Paused.Contains);
+            consumer.Resume(assigned);
+            var watermarks = await consumer.QueryWatermarkOffsetsAsync(
+                assigned[0],
+                cancellationToken).ConfigureAwait(false);
+            WatermarksQueried = watermarks.High >= 2;
+            consumer.Seek(new TopicPartitionOffset(
+                assigned[0].Topic,
+                assigned[0].Partition,
+                1));
+        }
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public ValueTask OnPartitionsLostAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+
+    private sealed class CommittingRebalanceListener : IConsumerAwareRebalanceListener
+    {
+        public TaskCompletionSource<TopicPartitionOffset[]> Committed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+        public async ValueTask OnPartitionsRevokedAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            var offsets = partitions
+                .Select(static partition => new TopicPartitionOffset(
+                    partition.Topic,
+                    partition.Partition,
+                    1))
+                .ToArray();
+            if (offsets.Length == 0)
+                return;
+
+            try
+            {
+                await consumer.CommitAsync(offsets, cancellationToken).ConfigureAwait(false);
+                Committed.TrySetResult(offsets);
+            }
+            catch (Exception exception)
+            {
+                Committed.TrySetException(exception);
+                throw;
+            }
+        }
+
+        public ValueTask OnPartitionsLostAsync(
+            IRebalanceConsumer consumer,
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -110,7 +110,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         string? clientRack = null,
         int heartbeatIntervalMs = 3000,
         int rebalanceTimeoutMs = 30000,
-        int maxPollIntervalMs = 300000) => new()
+        int maxPollIntervalMs = 300000,
+        IConsumerAwareRebalanceListener? consumerAwareRebalanceListener = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
             GroupId = groupId,
@@ -118,6 +119,7 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             GroupInstanceId = groupInstanceId,
             ClientRack = clientRack,
             RebalanceListener = rebalanceListener,
+            ConsumerAwareRebalanceListener = consumerAwareRebalanceListener,
             HeartbeatIntervalMs = heartbeatIntervalMs,
             RebalanceTimeoutMs = rebalanceTimeoutMs,
             MaxPollIntervalMs = maxPollIntervalMs
@@ -184,6 +186,19 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         var result = method!.Invoke(coordinator, [false, true, CancellationToken.None])!;
         var task = (Task)result.GetType().GetMethod("AsTask")!.Invoke(result, null)!;
         await task;
+    }
+
+    private static ValueTask InvokePartitionsLostAsync(
+        ConsumerCoordinator coordinator,
+        IReadOnlyList<TopicPartition> partitions)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "InvokePartitionsLostAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("InvokePartitionsLostAsync method not found.");
+
+        return (ValueTask)(method.Invoke(coordinator, [partitions])
+            ?? throw new InvalidOperationException("InvokePartitionsLostAsync returned null."));
     }
 
     private static Task InvokeConsumerProtocolHeartbeatLoopAsync(
@@ -2297,6 +2312,195 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
 
         await Assert.That(assignedPartitions).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_ConsumerAwareAssignment_UsesAndInvalidatesScopedView()
+    {
+        var assignment = CreateAssignment(TestTopicId, 0, 1);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var listener = Substitute.For<IConsumerAwareRebalanceListener>();
+        IRebalanceConsumer? capturedView = null;
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IRebalanceConsumer>(),
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedView = callInfo.Arg<IRebalanceConsumer>();
+                return ValueTask.CompletedTask;
+            });
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(Substitute.For<IConsumerPositions>());
+        RebalanceConsumerScope<byte[], byte[]>? scope = null;
+        TopicPartition[]? callbackAssignment = null;
+        TopicPartition[]? newlyAssigned = null;
+        var options = CreateConsumerProtocolOptions(
+            consumerAwareRebalanceListener: listener);
+        await using var coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            logger: null,
+            getConnectionCount: null,
+            onPartitionsRevoked: null,
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: null,
+            createRebalanceConsumerScope: (current, added) =>
+            {
+                callbackAssignment = current.ToArray();
+                newlyAssigned = added.ToArray();
+                return scope = new RebalanceConsumerScope<byte[], byte[]>(
+                    consumer,
+                    current,
+                    added);
+            });
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+
+        await Assert.That(capturedView).IsSameReferenceAs(scope);
+        await Assert.That(callbackAssignment).Count().IsEqualTo(2);
+        await Assert.That(newlyAssigned).Count().IsEqualTo(2);
+        Assert.Throws<InvalidOperationException>(() => _ = scope!.Assignment);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_ConsumerAwareFailure_StillInvalidatesScopedView()
+    {
+        var assignment = CreateAssignment(TestTopicId, 0);
+        SetupSuccessfulConsumerProtocolJoin(assignment: assignment);
+        var listener = Substitute.For<IConsumerAwareRebalanceListener>();
+        listener.OnPartitionsAssignedAsync(
+                Arg.Any<IRebalanceConsumer>(),
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException(new InvalidOperationException("callback failed")));
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(Substitute.For<IConsumerPositions>());
+        RebalanceConsumerScope<byte[], byte[]>? scope = null;
+        var options = CreateConsumerProtocolOptions(
+            consumerAwareRebalanceListener: listener);
+        await using var coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            logger: null,
+            getConnectionCount: null,
+            onPartitionsRevoked: null,
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: null,
+            createRebalanceConsumerScope: (current, added) =>
+                scope = new RebalanceConsumerScope<byte[], byte[]>(consumer, current, added));
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+
+        Assert.Throws<InvalidOperationException>(() => _ = scope!.Assignment);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_ConsumerAwareRevocation_ReceivesScopedView()
+    {
+        SetupFindCoordinator();
+        var heartbeatCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var count = Interlocked.Increment(ref heartbeatCount);
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = count,
+                    HeartbeatIntervalMs = 60_000,
+                    Assignment = count == 1
+                        ? CreateAssignment(TestTopicId, 0, 1)
+                        : CreateAssignment(TestTopicId, 1)
+                });
+            });
+        IRebalanceConsumer? revokedView = null;
+        TopicPartition[]? revokedPartitions = null;
+        var listener = Substitute.For<IConsumerAwareRebalanceListener>();
+        listener.OnPartitionsRevokedAsync(
+                Arg.Any<IRebalanceConsumer>(),
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                revokedView = callInfo.Arg<IRebalanceConsumer>();
+                revokedPartitions = callInfo.Arg<IEnumerable<TopicPartition>>()!.ToArray();
+                return ValueTask.CompletedTask;
+            });
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(Substitute.For<IConsumerPositions>());
+        var options = CreateConsumerProtocolOptions(
+            heartbeatIntervalMs: 60_000,
+            consumerAwareRebalanceListener: listener);
+        await using var coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            logger: null,
+            getConnectionCount: null,
+            onPartitionsRevoked: null,
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: null,
+            createRebalanceConsumerScope: (current, added) =>
+                new RebalanceConsumerScope<byte[], byte[]>(consumer, current, added));
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        await InvokeSteadyConsumerGroupHeartbeatAsync(coordinator);
+
+        await Assert.That(revokedPartitions).IsEquivalentTo(
+            [new TopicPartition("test-topic", 0)]);
+        Assert.Throws<InvalidOperationException>(() => _ = revokedView!.Assignment);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_ConsumerAwareLostCancellation_InvalidatesScopedView()
+    {
+        IRebalanceConsumer? lostView = null;
+        var listener = Substitute.For<IConsumerAwareRebalanceListener>();
+        listener.OnPartitionsLostAsync(
+                Arg.Any<IRebalanceConsumer>(),
+                Arg.Any<IEnumerable<TopicPartition>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                lostView = callInfo.Arg<IRebalanceConsumer>();
+                return ValueTask.FromException(new OperationCanceledException("cancelled"));
+            });
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(Substitute.For<IConsumerPositions>());
+        var options = CreateConsumerProtocolOptions(
+            consumerAwareRebalanceListener: listener);
+        await using var coordinator = new ConsumerCoordinator(
+            options,
+            _connectionPool,
+            _metadataManager,
+            logger: null,
+            getConnectionCount: null,
+            onPartitionsRevoked: null,
+            onPartitionsRevoking: null,
+            onPartitionsRevokedAsync: null,
+            createRebalanceConsumerScope: (current, added) =>
+                new RebalanceConsumerScope<byte[], byte[]>(consumer, current, added));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await InvokePartitionsLostAsync(
+                coordinator,
+                [new TopicPartition("test-topic", 0)]));
+
+        Assert.Throws<InvalidOperationException>(() => _ = lostView!.Assignment);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerOptionsDefaultsTests.cs
@@ -246,6 +246,13 @@ public class ConsumerOptionsDefaultsTests
     }
 
     [Test]
+    public async Task ConsumerAwareRebalanceListener_DefaultsTo_Null()
+    {
+        var options = CreateOptions();
+        await Assert.That(options.ConsumerAwareRebalanceListener).IsNull();
+    }
+
+    [Test]
     public async Task SocketSendBufferBytes_DefaultsTo_0()
     {
         var options = CreateOptions();

--- a/tests/Dekaf.Tests.Unit/Consumer/RebalanceConsumerScopeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/RebalanceConsumerScopeTests.cs
@@ -1,0 +1,63 @@
+using Dekaf.Consumer;
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class RebalanceConsumerScopeTests
+{
+    [Test]
+    public async Task PublicSurface_ExcludesUnsafeConsumerOperations()
+    {
+        var methodNames = typeof(IRebalanceConsumer).GetMethods()
+            .Select(static method => method.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        await Assert.That(methodNames.Contains("ConsumeAsync")).IsFalse();
+        await Assert.That(methodNames.Contains("ConsumeOneAsync")).IsFalse();
+        await Assert.That(methodNames.Contains("CloseAsync")).IsFalse();
+        await Assert.That(methodNames.Contains("DisposeAsync")).IsFalse();
+        await Assert.That(methodNames.Contains("Subscribe")).IsFalse();
+        await Assert.That(methodNames.Contains("Unsubscribe")).IsFalse();
+        await Assert.That(methodNames.Contains("Assign")).IsFalse();
+        await Assert.That(methodNames.Contains("Unassign")).IsFalse();
+        await Assert.That(methodNames.Contains("IncrementalAssign")).IsFalse();
+        await Assert.That(methodNames.Contains("IncrementalUnassign")).IsFalse();
+    }
+
+    [Test]
+    public async Task AssignedSeek_IsStagedAndVisibleDuringCallback()
+    {
+        var partition = new TopicPartition("topic", 1);
+        var positions = Substitute.For<IConsumerPositions>();
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(positions);
+        TopicPartitionOffset? staged = null;
+        var scope = new RebalanceConsumerScope<byte[], byte[]>(
+            consumer,
+            [partition],
+            [partition],
+            offset => staged = offset,
+            requested => requested == partition ? staged?.Offset : null);
+
+        scope.Seek(new TopicPartitionOffset("topic", 1, 42));
+
+        await Assert.That(staged?.Offset).IsEqualTo(42L);
+        await Assert.That(scope.GetPosition(partition)).IsEqualTo(42L);
+        positions.DidNotReceiveWithAnyArgs().Seek(default);
+    }
+
+    [Test]
+    public async Task Invalidate_RejectsRetainedViewOperations()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<byte[], byte[]>>();
+        consumer.Positions.Returns(Substitute.For<IConsumerPositions>());
+        var scope = new RebalanceConsumerScope<byte[], byte[]>(consumer, [], []);
+        scope.Invalidate();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await scope.CommitAsync());
+
+        await Assert.That(exception!.Message).Contains("callback has completed");
+        Assert.Throws<InvalidOperationException>(() => _ = scope.Assignment);
+    }
+}


### PR DESCRIPTION
## Summary\n- add IConsumerAwareRebalanceListener with callback-scoped IRebalanceConsumer safe operations\n- invalidate retained views on success, failure, and cancellation; exclude consume, lifecycle, subscription, and assignment mutation APIs\n- stage assigned-partition seeks across local assignment initialization and preserve legacy listener behavior\n- document migration and wire builder/options/dependency-injection configuration\n\n## Validation\n- solution build: 0 warnings, 0 errors\n- net10 unit: 6107/6107\n- net8 unit: 5980/5980\n- consumer coordinator focused: 100/100\n- real Kafka integration: 2/2 (assigned seek/pause/resume/query; revoked offset commit)\n\nCloses #2241