### PR TITLE
fix(networking): drain requests before pooled reset

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -130,6 +130,7 @@ public sealed partial class KafkaConnection :
     private readonly CancellationTokenSource _pendingRequestSlotCts = new();
     private readonly TaskCompletionSource _pendingRequestSlotOperationsDrained =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource? _pendingRequestsDrained;
     private int _pendingRequestSlotOperationCount;
     private int _pendingRequestSlotsClosed;
     private int _pendingRequestCount;
@@ -1010,6 +1011,7 @@ public sealed partial class KafkaConnection :
         => PooledPipelinedResponse<TRequest, TResponse>.ApproximatePoolCount;
 
     internal static Action? PipelinedResponseBeforePublishTestHook;
+    internal static Action? PendingRequestDrainStartedTestHook;
 
     private sealed class PooledPipelinedResponse<TRequest, TResponse> :
         IPipelinedResponseSource<TResponse>
@@ -2369,24 +2371,6 @@ public sealed partial class KafkaConnection :
         }
     }
 
-    private void ReleasePendingRequestSlots(int count)
-    {
-        if (count <= 0 || !TryEnterPendingRequestSlotOperation())
-            return;
-
-        try
-        {
-            _pendingRequestSlots.Release(count);
-        }
-        catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0 || Volatile.Read(ref _pendingRequestSlotsClosed) != 0)
-        {
-        }
-        finally
-        {
-            ExitPendingRequestSlotOperation();
-        }
-    }
-
     private void MarkDisposed()
     {
         Volatile.Write(ref _disposed, 1);
@@ -2474,6 +2458,9 @@ public sealed partial class KafkaConnection :
             var remaining = Interlocked.Decrement(ref _pendingRequestCount);
             Debug.Assert(remaining >= 0);
 
+            if (remaining == 0 && Volatile.Read(ref _disposed) != 0)
+                Volatile.Read(ref _pendingRequestsDrained)?.TrySetResult();
+
             RefreshReceiveTimeout();
 
             ReleasePendingRequestSlot();
@@ -2483,6 +2470,22 @@ public sealed partial class KafkaConnection :
     }
 
     private int GetPendingRequestCount() => Volatile.Read(ref _pendingRequestCount);
+
+    private Task WaitForPendingRequestsDrainedAsync()
+    {
+        if (GetPendingRequestCount() == 0)
+            return Task.CompletedTask;
+
+        var drained = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Volatile.Write(ref _pendingRequestsDrained, drained);
+
+        // Close the race where the final owner removed its request before the
+        // completion source was published.
+        if (GetPendingRequestCount() == 0)
+            drained.TrySetResult();
+
+        return drained.Task;
+    }
 
     private bool HasPendingRequests() => Volatile.Read(ref _pendingRequestCount) != 0;
 
@@ -2676,32 +2679,6 @@ public sealed partial class KafkaConnection :
                     slot.Request.TrySetException(slot.Version, ex);
             }
         }
-    }
-
-    private void ReturnAllPendingRequestsToPool()
-    {
-        var releasedSlots = 0;
-        foreach (var shard in _pendingRequestShards)
-        {
-            lock (shard.Gate)
-            {
-                foreach (var slot in shard.Requests.Values)
-                {
-                    _pendingRequestPool.Return(slot.Request);
-                    releasedSlots++;
-                }
-
-                shard.Requests.Clear();
-            }
-        }
-
-        if (releasedSlots != 0)
-        {
-            var remaining = Interlocked.Add(ref _pendingRequestCount, -releasedSlots);
-            Debug.Assert(remaining >= 0);
-        }
-
-        ReleasePendingRequestSlots(releasedSlots);
     }
 
 #if NETSTANDARD2_0
@@ -3944,11 +3921,14 @@ public sealed partial class KafkaConnection :
         _loadedClientCertificate?.Dispose();
 
         FailAllPendingRequests(new ObjectDisposedException(nameof(KafkaConnection)));
+        var pendingRequestsDrained = WaitForPendingRequestsDrainedAsync();
 
-        // Sweep any remaining entries that had no awaiter (edge case: request registered
-        // but cancelled before AwaitAndParseResponseAsync was entered). These won't be
-        // cleaned up by a continuation since none was registered.
-        ReturnAllPendingRequestsToPool();
+        Volatile.Read(ref PendingRequestDrainStartedTestHook)?.Invoke();
+
+        // Each registered request has an owning send path that removes and returns its
+        // source after observing completion. Wait for those owners before disposing the
+        // slot semaphore; resetting sources here would invalidate delayed ValueTask awaiters.
+        await pendingRequestsDrained.ConfigureAwait(false);
 
         await pendingRequestSlotOperationsDrained.ConfigureAwait(false);
         _pendingRequestSlots.Dispose();

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -14,6 +14,58 @@ namespace Dekaf.Tests.Unit.Networking;
 public sealed class KafkaConnectionPipelinedTests
 {
     [Test]
+    [NotInParallel]
+    [Timeout(10_000)]
+    public async Task DisposeAsync_DelayedPendingAwait_DoesNotResetSourceEarly(
+        CancellationToken cancellationToken)
+    {
+        var drainStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDrain = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        KafkaConnection.PendingRequestDrainStartedTestHook = () =>
+        {
+            drainStarted.TrySetResult();
+            releaseDrain.Task.GetAwaiter().GetResult();
+        };
+
+        var connection = new KafkaConnection("localhost", 9092);
+        const int correlationId = 42;
+        await ReservePendingRequestSlotAsync(connection);
+        var request = new PooledPendingRequest();
+        request.Initialize(responseHeaderVersion: 0, CancellationToken.None, registerCancellation: false);
+        var pendingTask = request.AsValueTask();
+        AddPendingRequest(connection, correlationId, request);
+
+        try
+        {
+            var disposeTask = Task.Run(async () => await connection.DisposeAsync(), CancellationToken.None);
+            await drainStarted.Task.WaitAsync(cancellationToken);
+
+            var removed = false;
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                try
+                {
+                    await pendingTask.ConfigureAwait(false);
+                }
+                finally
+                {
+                    removed = TryRemovePendingRequest(connection, correlationId);
+                }
+            });
+
+            await Assert.That(removed).IsTrue();
+            releaseDrain.TrySetResult();
+            await disposeTask.WaitAsync(cancellationToken);
+        }
+        finally
+        {
+            releaseDrain.TrySetResult();
+            KafkaConnection.PendingRequestDrainStartedTestHook = null;
+            await connection.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task SendPipelinedAsync_DisposedConnection_ThrowsObjectDisposedException()
     {
         var connection = new KafkaConnection("localhost", 9092);
@@ -86,6 +138,9 @@ public sealed class KafkaConnectionPipelinedTests
         await waitingForSlot.WaitAsync(TimeSpan.FromSeconds(1));
         ReleasePendingRequestSlot(connection);
 
+        for (var correlationId = 2; correlationId <= capacity; correlationId++)
+            await Assert.That(TryRemovePendingRequest(connection, correlationId)).IsTrue();
+
         await connection.DisposeAsync();
     }
 
@@ -94,12 +149,14 @@ public sealed class KafkaConnectionPipelinedTests
     {
         var connection = new KafkaConnection("localhost", 9092);
         var capacity = PoolSizing.ForConnection(maxInFlightRequestsPerConnection: 5).PendingRequests;
+        var pendingTasks = new Task<PooledResponseBuffer>[capacity];
 
         for (var i = 0; i < capacity; i++)
         {
             await ReservePendingRequestSlotAsync(connection);
             var request = new PooledPendingRequest();
             request.Initialize(responseHeaderVersion: 0, CancellationToken.None, registerCancellation: false);
+            pendingTasks[i] = request.AsValueTask().AsTask();
             AddPendingRequest(connection, i + 1, request);
         }
 
@@ -111,13 +168,22 @@ public sealed class KafkaConnectionPipelinedTests
 
         await Assert.That(waiters.Any(static waiter => !waiter.IsCompleted)).IsTrue();
 
-        await connection.DisposeAsync();
+        var disposeTask = Task.Run(async () => await connection.DisposeAsync(), CancellationToken.None);
 
         foreach (var waiter in waiters)
         {
             await Assert.That(async () => await waiter.WaitAsync(TimeSpan.FromSeconds(1)))
                 .Throws<ObjectDisposedException>();
         }
+
+        for (var i = 0; i < pendingTasks.Length; i++)
+        {
+            await Assert.That(async () => await pendingTasks[i].WaitAsync(TimeSpan.FromSeconds(1)))
+                .Throws<ObjectDisposedException>();
+            await Assert.That(TryRemovePendingRequest(connection, i + 1)).IsTrue();
+        }
+
+        await disposeTask.WaitAsync(TimeSpan.FromSeconds(1));
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PipelinedResponseAllocationBenchmarks.cs
@@ -33,10 +33,11 @@ public class PipelinedResponseAllocationBenchmarks
         var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
         var acceptTask = _listener.AcceptTcpClientAsync();
         _connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
-        await _connection.ConnectAsync().ConfigureAwait(false);
+        var connectTask = _connection.ConnectAsync();
         _serverClient = await acceptTask.ConfigureAwait(false);
         _serverCancellation = new CancellationTokenSource();
         _serverTask = RunServerAsync(_serverClient.GetStream(), _serverCancellation.Token);
+        await connectTask.ConfigureAwait(false);
     }
 
     [Benchmark(Baseline = true)]


### PR DESCRIPTION
## Summary

- stop disposal from sweeping/resetting `PooledPendingRequest` sources before their owners observe terminal completion
- lazily create a disposal-only drain signal and wait for request owners before disposing slot synchronization
- add deterministic delayed-await regression coverage and update pending-table tests to model owner cleanup
- repair `PipelinedResponseAllocationBenchmarks` setup so capability negotiation has a running server

Closes #2341

Native GitHub `blocked_by` was checked before claim and immediately before push; no prerequisites exist.

## Validation

- deterministic regression before fix: `InvalidOperationException` from stale `ManualResetValueTaskSourceCore` token
- networking unit suite: 335/335
- sequential net10 full suite: 6122/6122
- sequential net8 full suite: 5995/5995
- concurrent net10 + net8 reproduction: 6122/6122 and 5995/5995
- Release builds net10/net8: clean
- `/simplify`: removed redundant assertion; kept lazy disposal-only signal and exact lifecycle behavior

## Performance

Exact baseline: `825fad6aa4ea169d03a6cfc98a57b13439bebf15` (immediately preceding product SHA). Same repaired benchmark harness applied to both runs.

| Benchmark | Baseline | Candidate | Allocated baseline → candidate |
|---|---:|---:|---:|
| PublicTaskAdapter | 41.47 us ± 9.547 | 59.15 us ± 51.57 | 943 B → 895 B |
| PooledProducerPath | 49.54 us ± 176.538 | 73.24 us ± 113.08 | 760 B → 760 B |

All before/after 99.9% confidence intervals overlap. Pooled request-path allocation is unchanged. The new `TaskCompletionSource` is allocated only during disposal with outstanding requests, never per request/message during steady state.