### PR TITLE
fix(consumer): discard stale rebalance fetches

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4932,7 +4932,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     internal void StageRebalanceSeek(TopicPartitionOffset offset)
     {
         var partition = new TopicPartition(offset.Topic, offset.Partition);
-        _assignmentLock.Wait();
+        SemaphoreHelper.AcquireOrThrowDisposed(
+            _assignmentLock,
+            nameof(KafkaConsumer<TKey, TValue>));
         try
         {
             _pendingRebalanceSeeks[partition] = offset;
@@ -5195,6 +5197,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 // Coordinator revocation supersedes any correction from the old assignment.
                 // Keep the revocation marker so the consume loop still drains stale buffers.
+                _pendingRebalanceSeeks.TryRemove(partition, out _);
                 _pendingDivergingEpochResets.TryRemove(partition, out _);
                 _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
             }
@@ -6261,13 +6264,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         if (!_pendingRebalanceSeeks.TryRemove(partition, out var offset))
             return;
 
-        if (offset.LeaderEpoch >= 0)
-            SetLastConsumedLeaderEpoch(partition, offset.LeaderEpoch);
-        else
-            ClearLastConsumedLeaderEpoch(partition);
-        SetPosition(partition, offset.Offset, dirty: true);
-        _fetchPositions[partition] = offset.Offset;
-        _eofEmitted.TryRemove(partition, out _);
+        // Keep invalidation, buffer drain, and position replacement atomic with prefetch publication.
+        // The immediate path can run after this partition has already prefetched records.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            ClearFetchBufferForPartitions([partition]);
+
+            if (offset.LeaderEpoch >= 0)
+                SetLastConsumedLeaderEpoch(partition, offset.LeaderEpoch);
+            else
+                ClearLastConsumedLeaderEpoch(partition);
+            SetPosition(partition, offset.Offset, dirty: true);
+            _fetchPositions[partition] = offset.Offset;
+            _eofEmitted.TryRemove(partition, out _);
+        }
     }
 
     private async ValueTask<long> GetResetOffsetAsync(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -179,6 +179,47 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task StageRebalanceSeek_SyncedAssignment_DiscardsStalePendingFetch()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        SetupFindCoordinator(connection);
+        SetupConsumerGroupHeartbeat(connection, CreateAssignment(0));
+        SetupOffsetFetch(connection);
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        consumer.Subscribe("test-topic");
+        await consumer.EnsureAssignmentAsync(CancellationToken.None);
+
+        var partition = new TopicPartition("test-topic", 0);
+        GetPendingFetches(consumer).Enqueue(
+            CreateFetch(partition: 0, baseOffset: 10, value: "stale"));
+
+        consumer.StageRebalanceSeek(new TopicPartitionOffset(partition.Topic, partition.Partition, 42));
+
+        await Assert.That(GetPendingFetches(consumer)).IsEmpty();
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(42L);
+        await Assert.That(consumer.GetPosition(partition)).IsEqualTo(42L);
+    }
+
+    [Test]
+    public async Task StageRebalanceSeek_RevokedBeforeSync_DiscardsPendingSeek()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        var partition = new TopicPartition("test-topic", 0);
+
+        consumer.StageRebalanceSeek(new TopicPartitionOffset(partition.Topic, partition.Partition, 42));
+        QueueCoordinatorRevokedPartitionsForFetchClear(consumer, [partition]);
+
+        await Assert.That(consumer.GetRebalancePosition(partition)).IsNull();
+    }
+
+    [Test]
     public async Task EnsureAssignmentAsync_ChangedCoordinatorAssignment_RequiresAssignmentLock()
     {
         var connectionPool = Substitute.For<IConnectionPool>();


### PR DESCRIPTION
## Summary
- atomically invalidate and drain prefetched records before applying an immediate rebalance-callback seek
- discard staged seeks when a partition is revoked before local assignment synchronization
- use the standard disposed-semaphore diagnostic path
- add regressions for the synced-assignment stale-fetch race and revoke-before-sync cleanup

Follow-up to the blocking review on #2343.

## Validation
- Release unit build: 0 warnings, 0 errors
- net10 unit suite: 6151 passed
- net8 unit suite: 6024 passed
- focused regressions: 2 passed on each TFM

## Performance
Cold rebalance/error-recovery path only; no per-message successful consume path changes. No benchmark run.