### PR TITLE
test(hosting): synchronize retry-topic resume

### DIFF
--- a/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
+++ b/tests/Dekaf.Tests.Integration/HostedServiceTests.cs
@@ -122,29 +122,6 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync();
 
-        var dueAt = DateTimeOffset.UtcNow.AddSeconds(5);
-        var inputs = new[]
-        {
-            new RetryTopicInput("retry-p0-a", 0, 0, dueAt),
-            new RetryTopicInput("retry-p0-b", 0, 1, dueAt),
-            new RetryTopicInput("retry-p1-a", 1, 0, dueAt),
-            new RetryTopicInput("retry-p1-b", 1, 1, dueAt)
-        };
-
-        foreach (var input in inputs)
-        {
-            await producer.ProduceAsync(new ProducerMessage<string, string>
-            {
-                Topic = retryTopic,
-                Key = input.Value,
-                Value = input.Value,
-                Partition = input.Partition,
-                Headers = BuildRetryHeaders(sourceTopic, input.Partition, input.SourceOffset, retryDelay, input.DueAt)
-            }, CancellationToken.None);
-        }
-
-        await producer.FlushWithTimeoutAsync();
-
         var builder = Host.CreateApplicationBuilder();
         builder.Services.AddSingleton(receivedMessages);
         builder.Services.AddSingleton<TestTopicHolder>(new TestTopicHolder(sourceTopic));
@@ -159,14 +136,54 @@ public sealed class HostedServiceTests(KafkaTestContainer kafka) : KafkaIntegrat
         });
 
         var host = builder.Build();
+        var consumer = host.Services.GetRequiredService<IKafkaConsumer<string, string>>();
         using var cts = new CancellationTokenSource();
         var hostTask = host.RunAsync(cts.Token);
 
         try
         {
+            var retryPartitions = new[]
+            {
+                new TopicPartition(retryTopic, 0),
+                new TopicPartition(retryTopic, 1)
+            };
+            await WaitForConditionAsync(
+                () => retryPartitions.All(consumer.Assignment.Contains),
+                TimeSpan.FromSeconds(30));
+
+            // Derive the due time only after assignment. On constrained NativeAOT runners,
+            // producer and host startup can otherwise consume the entire delay before the
+            // retry records are fetched, so the test never exercises pause/resume at all.
+            var dueAt = DateTimeOffset.UtcNow.AddSeconds(10);
+            var inputs = new[]
+            {
+                new RetryTopicInput("retry-p0-a", 0, 0, dueAt),
+                new RetryTopicInput("retry-p0-b", 0, 1, dueAt),
+                new RetryTopicInput("retry-p1-a", 1, 0, dueAt),
+                new RetryTopicInput("retry-p1-b", 1, 1, dueAt)
+            };
+
+            foreach (var input in inputs)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = retryTopic,
+                    Key = input.Value,
+                    Value = input.Value,
+                    Partition = input.Partition,
+                    Headers = BuildRetryHeaders(sourceTopic, input.Partition, input.SourceOffset, retryDelay, input.DueAt)
+                }, CancellationToken.None);
+            }
+
+            await producer.FlushWithTimeoutAsync();
+
+            await WaitForConditionAsync(
+                () => retryPartitions.All(consumer.Paused.Contains),
+                TimeSpan.FromSeconds(5));
+
             await WaitForConditionAsync(
                 () => receivedMessages.Count >= inputs.Length,
-                TimeSpan.FromSeconds(45));
+                TimeSpan.FromSeconds(30));
 
             await Assert.That(receivedMessages.Select(m => m.Value))
                 .IsEquivalentTo(inputs.Select(i => i.Value));


### PR DESCRIPTION
Closes #2346.

## What changed

- start the hosted consumer and wait until both retry-topic partitions are assigned before producing records
- derive `DueAt` after assignment so constrained NativeAOT startup cannot consume the test's delay budget
- observe both partitions in `Paused` before waiting for processing, proving the test actually exercises pause/resume
- retain the at-or-after-`DueAt`, cross-partition, and all-record assertions

The failed run's artifact showed all four publishes succeeded and the group joined, but it contained zero consume spans. The old test produced before consumer assignment and never observed the pause precondition, leaving startup/scheduling timing uncontrolled.

Native GitHub `blocked_by` for #2346 was checked before claim, commit, and push; it was empty each time.

## Validation

- Release integration build: 0 warnings/errors
- focused retry-topic regression: 4 consecutive passes
- managed Kafka 4.3.1 Messaging category: 21/21
- Linux NativeAOT Kafka 4.3.1 Messaging category: 21/21

No benchmark: test-only synchronization change; `src/` unchanged.
