### PR TITLE
Recover live consumer groups after coordinator failover

### DIFF
--- a/src/Dekaf/Admin/AdminClient.cs
+++ b/src/Dekaf/Admin/AdminClient.cs
@@ -4813,41 +4813,70 @@ public sealed class AdminClient : IAdminClient
             throw new InvalidOperationException("No brokers available");
         }
 
-        using var connectionLease = await _connectionPool.LeaseConnectionAsync(brokers[0].NodeId, cancellationToken).ConfigureAwait(false);
-
-        var connection = connectionLease.Connection;
-
         var request = new FindCoordinatorRequest
         {
             Key = groupId,
             KeyType = CoordinatorType.Group
         };
+        Exception? lastFailure = null;
 
-        var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-            connection,
-            Protocol.ApiKey.FindCoordinator,
-            FindCoordinatorRequest.LowestSupportedVersion,
-            FindCoordinatorRequest.HighestSupportedVersion);
-
-        var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-            request,
-            apiVersion,
-            cancellationToken).ConfigureAwait(false);
-
-        if (response.Coordinators.Count == 0)
+        foreach (var broker in brokers)
         {
-            throw new Errors.GroupException(Protocol.ErrorCode.CoordinatorNotAvailable,
-                "FindCoordinator returned an empty Coordinators array");
+            try
+            {
+                using var connectionLease = await _connectionPool.LeaseConnectionAsync(
+                    broker.NodeId,
+                    cancellationToken).ConfigureAwait(false);
+                var connection = connectionLease.Connection;
+                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    Protocol.ApiKey.FindCoordinator,
+                    FindCoordinatorRequest.LowestSupportedVersion,
+                    FindCoordinatorRequest.HighestSupportedVersion);
+                var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                    request,
+                    apiVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (response.Coordinators.Count == 0)
+                {
+                    lastFailure = new Errors.GroupException(
+                        Protocol.ErrorCode.CoordinatorNotAvailable,
+                        "FindCoordinator returned an empty Coordinators array");
+                    continue;
+                }
+
+                var coordinator = response.Coordinators[0];
+                if (coordinator.ErrorCode is Protocol.ErrorCode.CoordinatorNotAvailable
+                    or Protocol.ErrorCode.CoordinatorLoadInProgress)
+                {
+                    lastFailure = new Errors.GroupException(
+                        coordinator.ErrorCode,
+                        $"FindCoordinator failed: {coordinator.ErrorCode}");
+                    continue;
+                }
+
+                if (coordinator.ErrorCode != Protocol.ErrorCode.None)
+                {
+                    throw new Errors.GroupException(
+                        coordinator.ErrorCode,
+                        $"FindCoordinator failed: {coordinator.ErrorCode}");
+                }
+
+                _connectionPool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
+                return coordinator.NodeId;
+            }
+            catch (Exception exception) when (
+                RetryHelper.IsRetriableRequestFailure(exception)
+                && !cancellationToken.IsCancellationRequested)
+            {
+                lastFailure = exception;
+            }
         }
 
-        var coordinator = response.Coordinators[0];
-        if (coordinator.ErrorCode != Protocol.ErrorCode.None)
-        {
-            throw new Errors.GroupException(coordinator.ErrorCode, $"FindCoordinator failed: {coordinator.ErrorCode}");
-        }
-
-        _connectionPool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
-        return coordinator.NodeId;
+        throw lastFailure ?? new Errors.GroupException(
+            Protocol.ErrorCode.CoordinatorNotAvailable,
+            $"FindCoordinator failed for group '{groupId}'");
     }
 
     private async ValueTask<int> FindTransactionCoordinatorAsync(string transactionalId, CancellationToken cancellationToken)

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -645,10 +645,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 return;
             }
             catch (Exception ex) when (
-                attempt < maxRetries - 1 &&
                 RetryHelper.IsRetriableRequestFailure(ex) &&
                 !cancellationToken.IsCancellationRequested)
             {
+                if (attempt == maxRetries - 1)
+                {
+                    throw new Errors.GroupException(
+                        ErrorCode.CoordinatorNotAvailable,
+                        $"FindCoordinator failed after {maxRetries} retries: {ex.Message}",
+                        ex)
+                    {
+                        GroupId = _options.GroupId
+                    };
+                }
+
                 var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -579,67 +579,80 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
         for (var attempt = 0; attempt < maxRetries; attempt++)
         {
-            // Cycle through brokers on retries to avoid wasting all attempts on one slow broker.
-            var broker = brokers[attempt % brokers.Count];
-            using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
-                broker.NodeId,
-                _getCoordinationConnectionIndex(),
-                cancellationToken)
-                .ConfigureAwait(false);
-            var connection = connectionLease.Connection;
-
-            // Use negotiated API version
-            var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
-                connection,
-                ApiKey.FindCoordinator,
-                FindCoordinatorRequest.LowestSupportedVersion,
-                FindCoordinatorRequest.HighestSupportedVersion);
-
-            var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-                request,
-                findCoordinatorVersion,
-                cancellationToken).ConfigureAwait(false);
-
-            if (response.Coordinators.Count == 0)
+            try
             {
-                throw new Errors.GroupException(ErrorCode.CoordinatorNotAvailable,
-                    "FindCoordinator returned an empty Coordinators array")
-                { GroupId = _options.GroupId };
+                // Cycle through brokers on retries to avoid wasting all attempts on one
+                // unavailable broker.
+                var broker = brokers[attempt % brokers.Count];
+                using var connectionLease = await _connectionPool.LeaseConnectionByIndexAsync(
+                    broker.NodeId,
+                    _getCoordinationConnectionIndex(),
+                    cancellationToken)
+                    .ConfigureAwait(false);
+                var connection = connectionLease.Connection;
+
+                // Use negotiated API version
+                var findCoordinatorVersion = _metadataManager.GetNegotiatedApiVersion(
+                    connection,
+                    ApiKey.FindCoordinator,
+                    FindCoordinatorRequest.LowestSupportedVersion,
+                    FindCoordinatorRequest.HighestSupportedVersion);
+
+                var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                    request,
+                    findCoordinatorVersion,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (response.Coordinators.Count == 0)
+                {
+                    throw new Errors.GroupException(ErrorCode.CoordinatorNotAvailable,
+                        "FindCoordinator returned an empty Coordinators array")
+                    { GroupId = _options.GroupId };
+                }
+
+                var coordinator = response.Coordinators[0];
+                var errorCode = coordinator.ErrorCode;
+                var nodeId = coordinator.NodeId;
+                var host = coordinator.Host;
+                var port = coordinator.Port;
+
+                // Retry on transient coordinator errors
+                if (errorCode == ErrorCode.CoordinatorNotAvailable ||
+                    errorCode == ErrorCode.CoordinatorLoadInProgress)
+                {
+                    if (attempt == maxRetries - 1)
+                        break;
+
+                    var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
+                    LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
+
+                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (errorCode != ErrorCode.None)
+                {
+                    throw new Errors.GroupException(errorCode, $"FindCoordinator failed: {errorCode}")
+                    {
+                        GroupId = _options.GroupId
+                    };
+                }
+
+                _coordinatorId = nodeId;
+                _connectionPool.RegisterBroker(nodeId, host, port);
+
+                LogFoundCoordinator(_coordinatorId, _options.GroupId!);
+                return;
             }
-
-            var coordinator = response.Coordinators[0];
-            var errorCode = coordinator.ErrorCode;
-            var nodeId = coordinator.NodeId;
-            var host = coordinator.Host;
-            var port = coordinator.Port;
-
-            // Retry on transient coordinator errors
-            if (errorCode == ErrorCode.CoordinatorNotAvailable ||
-                errorCode == ErrorCode.CoordinatorLoadInProgress)
+            catch (Exception ex) when (
+                attempt < maxRetries - 1 &&
+                RetryHelper.IsRetriableRequestFailure(ex) &&
+                !cancellationToken.IsCancellationRequested)
             {
-                if (attempt == maxRetries - 1)
-                    break;
-
                 var retryDelayMs = CalculateRequestRetryBackoff(attempt + 1);
                 LogCoordinatorNotAvailableRetry(attempt + 1, maxRetries, retryDelayMs);
-
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                continue;
             }
-
-            if (errorCode != ErrorCode.None)
-            {
-                throw new Errors.GroupException(errorCode, $"FindCoordinator failed: {errorCode}")
-                {
-                    GroupId = _options.GroupId
-                };
-            }
-
-            _coordinatorId = nodeId;
-            _connectionPool.RegisterBroker(nodeId, host, port);
-
-            LogFoundCoordinator(_coordinatorId, _options.GroupId!);
-            return;
         }
 
         throw new Errors.GroupException(ErrorCode.CoordinatorNotAvailable,
@@ -1980,7 +1993,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     break;
                 }
 
-                // Non-group error — continue heartbeating
+                // Transport and connection failures may mean the cached coordinator broker
+                // disappeared. Force FindCoordinator on the next foreground group operation.
+                MarkCoordinatorUnknown();
+                break;
             }
         }
     }

--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -434,6 +434,11 @@ public sealed class GroupException : KafkaException
     {
     }
 
+    internal GroupException(ErrorCode errorCode, string message, Exception innerException)
+        : base(errorCode, message, innerException)
+    {
+    }
+
     internal GroupException(ErrorCode errorCode, string message, bool isRetriable)
         : base(errorCode, message, isRetriable)
     {

--- a/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
@@ -1,0 +1,813 @@
+using System.Collections.Concurrent;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+using ConfluentKafka = Confluent.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[Category("Resilience")]
+[NotInParallel("RackAwareKafkaContainer")]
+[ClassDataSource<RackAwareKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaContainer kafka)
+{
+    private const int PartitionCount = 6;
+    private const int MessagesPerPartition = 20;
+    private const int MessageCount = PartitionCount * MessagesPerPartition;
+    private static readonly TimeSpan SessionTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan CoordinatorRecoveryObservationPeriod = TimeSpan.FromSeconds(18);
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task CoordinatorFailover_CommitsResumeWithoutLossOrDuplicates(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"coordinator-failover-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var records = new ConcurrentDictionary<(int Partition, long Offset), int>();
+
+        await using var first = await CreateConsumerAsync(groupId, listener: null, cancellationToken)
+            .ConfigureAwait(false);
+        await using var second = await CreateConsumerAsync(groupId, listener: null, cancellationToken)
+            .ConfigureAwait(false);
+        first.Subscribe(topic);
+        second.Subscribe(topic);
+        var consumeTasks = new[]
+        {
+            ConsumeAndCommitAsync(first, records, scenarioCancellation.Token),
+            ConsumeAndCommitAsync(second, records, scenarioCancellation.Token)
+        };
+
+        try
+        {
+            await ProduceRangeAsync(topic, startPerPartition: 0, countPerPartition: 5, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForProgressOrFailureAsync(
+                    records,
+                    expectedCount: PartitionCount * 5,
+                    consumeTasks,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            await ProduceRangeAsync(topic, startPerPartition: 5, countPerPartition: 15, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForProgressOrFailureAsync(records, MessageCount, consumeTasks, cancellationToken)
+                .ConfigureAwait(false);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(consumeTasks).ConfigureAwait(false);
+            AssertCompleteSequences(records);
+            await AssertCommittedOffsetsAsync(topic, groupId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(consumeTasks).ConfigureAwait(false);
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task CoordinatorFailover_HeartbeatsRediscoverAndConverge(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"coordinator-heartbeat-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var firstListener = new AssignmentListener();
+        var secondListener = new AssignmentListener();
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await using var first = await CreateConsumerAsync(groupId, firstListener, cancellationToken)
+            .ConfigureAwait(false);
+        await using var second = await CreateConsumerAsync(groupId, secondListener, cancellationToken)
+            .ConfigureAwait(false);
+        first.Subscribe(topic);
+        second.Subscribe(topic);
+        var pollTasks = new[]
+        {
+            PollAsync(first, scenarioCancellation.Token),
+            PollAsync(second, scenarioCancellation.Token)
+        };
+
+        try
+        {
+            await WaitForStableAssignmentAsync(firstListener, secondListener, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+            var revocationsBefore = firstListener.RevocationCount + secondListener.RevocationCount;
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await AssertMembersSurviveCoordinatorMoveAsync(groupId, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForStableAssignmentAsync(firstListener, secondListener, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+
+            var revocationsAfter = firstListener.RevocationCount + secondListener.RevocationCount;
+            AssertNoRebalanceStorm(revocationsBefore, revocationsAfter);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(pollTasks).ConfigureAwait(false);
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task CoordinatorFailover_DuringMemberJoin_Converges(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"coordinator-join-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var firstListener = new AssignmentListener();
+        var secondListener = new AssignmentListener();
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        await using var first = await CreateConsumerAsync(groupId, firstListener, cancellationToken)
+            .ConfigureAwait(false);
+        first.Subscribe(topic);
+        var firstPoll = PollAsync(first, scenarioCancellation.Token);
+        Task? secondPoll = null;
+        IKafkaConsumer<string, string>? second = null;
+
+        try
+        {
+            await WaitForAssignmentCountAsync(firstListener, PartitionCount, [firstPoll], cancellationToken)
+                .ConfigureAwait(false);
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+
+            second = await CreateConsumerAsync(groupId, secondListener, cancellationToken)
+                .ConfigureAwait(false);
+            second.Subscribe(topic);
+            secondPoll = PollAsync(second, scenarioCancellation.Token);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForStableAssignmentAsync(
+                    firstListener,
+                    secondListener,
+                    [firstPoll, secondPoll],
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var overlap = firstListener.Assignment.Intersect(secondListener.Assignment).ToArray();
+            await Assert.That(overlap).IsEmpty();
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(secondPoll is null ? [firstPoll] : [firstPoll, secondPoll])
+                .ConfigureAwait(false);
+            if (second is not null)
+                await second.DisposeAsync().ConfigureAwait(false);
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
+    public async Task ClassicCoordinatorFailover_CommitsResumeWithoutLossOrDuplicates(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"classic-coordinator-failover-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var records = new ConcurrentDictionary<(int Partition, long Offset), int>();
+        using var first = CreateClassicConsumer(groupId);
+        using var second = CreateClassicConsumer(groupId);
+        first.Subscribe(topic);
+        second.Subscribe(topic);
+        var consumeTasks = new[]
+        {
+            ConsumeAndCommitClassicAsync(first, records, scenarioCancellation.Token),
+            ConsumeAndCommitClassicAsync(second, records, scenarioCancellation.Token)
+        };
+
+        try
+        {
+            await ProduceRangeAsync(topic, startPerPartition: 0, countPerPartition: 5, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForProgressOrFailureAsync(
+                    records,
+                    expectedCount: PartitionCount * 5,
+                    consumeTasks,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            await ProduceRangeAsync(topic, startPerPartition: 5, countPerPartition: 15, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForProgressOrFailureAsync(records, MessageCount, consumeTasks, cancellationToken)
+                .ConfigureAwait(false);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(consumeTasks).ConfigureAwait(false);
+            AssertCompleteSequences(records);
+            await AssertCommittedOffsetsAsync(topic, groupId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(consumeTasks).ConfigureAwait(false);
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
+    public async Task ClassicCoordinatorFailover_HeartbeatsRediscoverAndConverge(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"classic-coordinator-heartbeat-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var firstListener = new AssignmentListener();
+        var secondListener = new AssignmentListener();
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var first = CreateClassicConsumer(groupId, firstListener);
+        using var second = CreateClassicConsumer(groupId, secondListener);
+        first.Subscribe(topic);
+        second.Subscribe(topic);
+        var pollTasks = new[]
+        {
+            PollClassicAsync(first, scenarioCancellation.Token),
+            PollClassicAsync(second, scenarioCancellation.Token)
+        };
+
+        try
+        {
+            await WaitForStableAssignmentAsync(firstListener, secondListener, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+            var revocationsBefore = firstListener.RevocationCount + secondListener.RevocationCount;
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await AssertMembersSurviveCoordinatorMoveAsync(groupId, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForStableAssignmentAsync(firstListener, secondListener, pollTasks, cancellationToken)
+                .ConfigureAwait(false);
+
+            var revocationsAfter = firstListener.RevocationCount + secondListener.RevocationCount;
+            AssertNoRebalanceStorm(revocationsBefore, revocationsAfter);
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(pollTasks).ConfigureAwait(false);
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    [Test]
+    [Timeout(240_000)]
+    [SkipWhenNativeAot("Confluent.Kafka native delegate binding requires runtime reflection.")]
+    public async Task ClassicCoordinatorFailover_DuringMemberJoin_Converges(
+        CancellationToken cancellationToken)
+    {
+        var groupId = $"classic-coordinator-join-{Guid.NewGuid():N}";
+        var (topic, expectedCoordinatorId) = await CreateScenarioAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var firstListener = new AssignmentListener();
+        var secondListener = new AssignmentListener();
+        int? stoppedBrokerId = null;
+        using var scenarioCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var first = CreateClassicConsumer(groupId, firstListener);
+        first.Subscribe(topic);
+        var firstPoll = PollClassicAsync(first, scenarioCancellation.Token);
+        Task? secondPoll = null;
+        ConfluentKafka.IConsumer<string, string>? second = null;
+
+        try
+        {
+            await WaitForAssignmentCountAsync(firstListener, PartitionCount, [firstPoll], cancellationToken)
+                .ConfigureAwait(false);
+            stoppedBrokerId = await kafka.GetGroupCoordinatorIdAsync(groupId, cancellationToken)
+                .ConfigureAwait(false);
+            AssertExpectedCoordinator(stoppedBrokerId.Value, expectedCoordinatorId);
+            await kafka.StopBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+
+            second = CreateClassicConsumer(groupId, secondListener);
+            second.Subscribe(topic);
+            secondPoll = PollClassicAsync(second, scenarioCancellation.Token);
+            _ = await kafka.WaitForGroupCoordinatorChangeAsync(
+                    groupId,
+                    stoppedBrokerId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await WaitForStableAssignmentAsync(
+                    firstListener,
+                    secondListener,
+                    [firstPoll, secondPoll],
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            var overlap = firstListener.Assignment.Intersect(secondListener.Assignment).ToArray();
+            await Assert.That(overlap).IsEmpty();
+
+            await kafka.StartBrokerAsync(stoppedBrokerId.Value, cancellationToken).ConfigureAwait(false);
+            stoppedBrokerId = null;
+        }
+        finally
+        {
+            scenarioCancellation.Cancel();
+            await ObserveCancellationAsync(secondPoll is null ? [firstPoll] : [firstPoll, secondPoll])
+                .ConfigureAwait(false);
+            second?.Dispose();
+            if (stoppedBrokerId is { } brokerId)
+                await kafka.StartBrokerAsync(brokerId, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<(string Topic, int CoordinatorId)> CreateScenarioAsync(
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        var coordinatorId = await kafka.FindGroupCoordinatorIdAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var topic = await kafka.CreateDistributedReplicatedTopicAsync(
+                PartitionCount,
+                excludedLeaderId: coordinatorId)
+            .ConfigureAwait(false);
+        return (topic, coordinatorId);
+    }
+
+    private static void AssertExpectedCoordinator(int actualCoordinatorId, int expectedCoordinatorId)
+    {
+        if (actualCoordinatorId != expectedCoordinatorId)
+        {
+            throw new InvalidOperationException(
+                $"FindCoordinator changed before failover: expected broker {expectedCoordinatorId}, " +
+                $"actual broker {actualCoordinatorId}.");
+        }
+    }
+
+    private static void AssertNoRebalanceStorm(int revocationsBefore, int revocationsAfter)
+    {
+        var failoverRevocations = revocationsAfter - revocationsBefore;
+        if (failoverRevocations > 2)
+        {
+            throw new InvalidOperationException(
+                $"Coordinator failover caused a rebalance storm: {failoverRevocations} revocations.");
+        }
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateConsumerAsync(
+        string groupId,
+        IRebalanceListener? listener,
+        CancellationToken cancellationToken)
+    {
+        var builder = Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithClientId($"coordinator-failover-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithSessionTimeout(SessionTimeout)
+            .WithHeartbeatInterval(TimeSpan.FromSeconds(1))
+            .WithDefaultApiTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory());
+        if (listener is not null)
+            builder.WithRebalanceListener(listener);
+
+        return await builder.BuildAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private ConfluentKafka.IConsumer<string, string> CreateClassicConsumer(
+        string groupId,
+        AssignmentListener? listener = null)
+    {
+        var builder = new ConfluentKafka.ConsumerBuilder<string, string>(new ConfluentKafka.ConsumerConfig
+        {
+            BootstrapServers = kafka.BootstrapServers,
+            GroupId = groupId,
+            ClientId = $"classic-coordinator-failover-{Guid.NewGuid():N}",
+            GroupProtocol = ConfluentKafka.GroupProtocol.Classic,
+            PartitionAssignmentStrategy = ConfluentKafka.PartitionAssignmentStrategy.Range,
+            AutoOffsetReset = ConfluentKafka.AutoOffsetReset.Earliest,
+            EnableAutoCommit = false,
+            EnableAutoOffsetStore = false,
+            SessionTimeoutMs = (int)SessionTimeout.TotalMilliseconds,
+            HeartbeatIntervalMs = 1_000
+        });
+        if (listener is not null)
+        {
+            builder
+                .SetPartitionsAssignedHandler((_, partitions) => listener.Assign(
+                    partitions.Select(static partition =>
+                        new TopicPartition(partition.Topic, partition.Partition.Value))))
+                .SetPartitionsRevokedHandler((_, partitions) => listener.Revoke(
+                    partitions.Select(static partition =>
+                        new TopicPartition(partition.Topic, partition.Partition.Value))))
+                .SetPartitionsLostHandler((_, partitions) => listener.Lose(
+                    partitions.Select(static partition =>
+                        new TopicPartition(partition.Topic, partition.Partition.Value))));
+        }
+
+        return builder.Build();
+    }
+
+    private async Task ProduceRangeAsync(
+        string topic,
+        int startPerPartition,
+        int countPerPartition,
+        CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithAcks(Acks.All)
+            .WithIdempotence(true)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(60))
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            for (var offset = startPerPartition; offset < startPerPartition + countPerPartition; offset++)
+            {
+                await producer.ProduceAsync(new ProducerMessage<string, string>
+                {
+                    Topic = topic,
+                    Partition = partition,
+                    Key = $"{partition}:{offset}",
+                    Value = offset.ToString()
+                }, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task ConsumeAndCommitAsync(
+        IKafkaConsumer<string, string> consumer,
+        ConcurrentDictionary<(int Partition, long Offset), int> records,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+                .ConfigureAwait(false);
+            if (result is not { } record)
+                continue;
+
+            records.AddOrUpdate((record.Partition, record.Offset), 1, static (_, count) => count + 1);
+            await consumer.CommitAsync([
+                new TopicPartitionOffset(record.Topic, record.Partition, record.Offset + 1)
+            ], cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static Task ConsumeAndCommitClassicAsync(
+        ConfluentKafka.IConsumer<string, string> consumer,
+        ConcurrentDictionary<(int Partition, long Offset), int> records,
+        CancellationToken cancellationToken) =>
+        Task.Factory.StartNew(
+            () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var result = consumer.Consume(TimeSpan.FromMilliseconds(200));
+                    if (result is null)
+                        continue;
+
+                    if (!CommitClassicWithRetry(
+                            consumer,
+                            result.TopicPartitionOffset,
+                            cancellationToken))
+                    {
+                        continue;
+                    }
+
+                    records.AddOrUpdate(
+                        (result.Partition.Value, result.Offset.Value),
+                        1,
+                        static (_, count) => count + 1);
+                }
+            },
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+    private static bool CommitClassicWithRetry(
+        ConfluentKafka.IConsumer<string, string> consumer,
+        ConfluentKafka.TopicPartitionOffset consumed,
+        CancellationToken cancellationToken)
+    {
+        var committed = new ConfluentKafka.TopicPartitionOffset(
+            consumed.TopicPartition,
+            consumed.Offset + 1);
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                consumer.Commit([committed]);
+                return true;
+            }
+            catch (ConfluentKafka.TopicPartitionOffsetException exception)
+                when (exception.Results.All(static result =>
+                    IsTransientCoordinatorError(result.Error.Code)))
+            {
+                Thread.Sleep(50);
+            }
+            catch (ConfluentKafka.KafkaException exception)
+                when (IsTransientCoordinatorError(exception.Error.Code))
+            {
+                Thread.Sleep(50);
+            }
+            catch (ConfluentKafka.KafkaException exception)
+                when (IsRejoinError(exception.Error.Code))
+            {
+                try
+                {
+                    consumer.Seek(consumed);
+                }
+                catch (Exception seekException) when (
+                    seekException is ConfluentKafka.KafkaException or InvalidOperationException)
+                {
+                    // An eager rebalance already revoked the partition. Its next owner resumes
+                    // from the last successful commit, so this record will be delivered again.
+                }
+
+                return false;
+            }
+        }
+    }
+
+    private static bool IsTransientCoordinatorError(ConfluentKafka.ErrorCode errorCode) =>
+        errorCode.ToString() is
+            "CoordinatorLoadInProgress" or
+            "CoordinatorNotAvailable" or
+            "NotCoordinator" or
+            "Local_AllBrokersDown" or
+            "Local_Transport" or
+            "Local_TimedOut" or
+            "Local_WaitCoord";
+
+    private static bool IsRejoinError(ConfluentKafka.ErrorCode errorCode) =>
+        errorCode.ToString() is
+            "IllegalGeneration" or
+            "UnknownMemberId" or
+            "RebalanceInProgress";
+
+    private static async Task PollAsync(
+        IKafkaConsumer<string, string> consumer,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+            _ = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Task PollClassicAsync(
+        ConfluentKafka.IConsumer<string, string> consumer,
+        CancellationToken cancellationToken) =>
+        Task.Factory.StartNew(
+            () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                    _ = consumer.Consume(TimeSpan.FromMilliseconds(200));
+            },
+            cancellationToken,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+    private static async Task WaitForProgressOrFailureAsync(
+        ConcurrentDictionary<(int Partition, long Offset), int> records,
+        int expectedCount,
+        IReadOnlyList<Task> consumeTasks,
+        CancellationToken cancellationToken)
+    {
+        while (records.Count < expectedCount)
+        {
+            var failed = consumeTasks.FirstOrDefault(static task => task.IsFaulted);
+            if (failed is not null)
+                await failed.ConfigureAwait(false);
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WaitForStableAssignmentAsync(
+        AssignmentListener first,
+        AssignmentListener second,
+        IReadOnlyList<Task> pollTasks,
+        CancellationToken cancellationToken)
+    {
+        while (first.Assignment.Count + second.Assignment.Count != PartitionCount
+               || first.Assignment.Overlaps(second.Assignment))
+        {
+            var failed = pollTasks.FirstOrDefault(static task => task.IsFaulted);
+            if (failed is not null)
+                await failed.ConfigureAwait(false);
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task AssertMembersSurviveCoordinatorMoveAsync(
+        string groupId,
+        IReadOnlyList<Task> pollTasks,
+        CancellationToken cancellationToken)
+    {
+        await Task.Delay(CoordinatorRecoveryObservationPeriod, cancellationToken).ConfigureAwait(false);
+        var failed = pollTasks.FirstOrDefault(static task => task.IsFaulted);
+        if (failed is not null)
+            await failed.ConfigureAwait(false);
+
+        await using var admin = kafka.CreateAdminClient();
+        var groups = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken)
+            .ConfigureAwait(false);
+        if (!groups.TryGetValue(groupId, out var group) || group.Members.Count != 2)
+        {
+            throw new InvalidOperationException(
+                $"Expected both group members to survive coordinator failover; actual count " +
+                $"{(groups.TryGetValue(groupId, out group) ? group.Members.Count : 0)}.");
+        }
+    }
+
+    private static async Task WaitForAssignmentCountAsync(
+        AssignmentListener listener,
+        int expectedCount,
+        IReadOnlyList<Task> pollTasks,
+        CancellationToken cancellationToken)
+    {
+        while (listener.Assignment.Count != expectedCount)
+        {
+            var failed = pollTasks.FirstOrDefault(static task => task.IsFaulted);
+            if (failed is not null)
+                await failed.ConfigureAwait(false);
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ObserveCancellationAsync(IEnumerable<Task> tasks)
+    {
+        foreach (var task in tasks)
+        {
+            try { await task.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    private static void AssertCompleteSequences(
+        IReadOnlyDictionary<(int Partition, long Offset), int> records)
+    {
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            for (var offset = 0; offset < MessagesPerPartition; offset++)
+            {
+                if (!records.TryGetValue((partition, offset), out var count) || count != 1)
+                {
+                    throw new InvalidOperationException(
+                        $"Expected {partition}:{offset} exactly once; actual count {count}.");
+                }
+            }
+        }
+    }
+
+    private async Task AssertCommittedOffsetsAsync(
+        string topic,
+        string groupId,
+        CancellationToken cancellationToken)
+    {
+        await using var admin = kafka.CreateAdminClient();
+        var committed = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken)
+            .ConfigureAwait(false);
+        for (var partition = 0; partition < PartitionCount; partition++)
+        {
+            var topicPartition = new TopicPartition(topic, partition);
+            if (!committed.TryGetValue(topicPartition, out var offset) || offset != MessagesPerPartition)
+            {
+                throw new InvalidOperationException(
+                    $"Committed offset for {topicPartition} expected {MessagesPerPartition}, actual " +
+                    $"{(committed.TryGetValue(topicPartition, out offset) ? offset : -1)}.");
+            }
+        }
+    }
+
+    private sealed class AssignmentListener : IRebalanceListener
+    {
+        private readonly ConcurrentDictionary<TopicPartition, byte> _assignment = new();
+        private int _revocationCount;
+
+        public HashSet<TopicPartition> Assignment => _assignment.Keys.ToHashSet();
+        public int RevocationCount => Volatile.Read(ref _revocationCount);
+
+        public void Assign(IEnumerable<TopicPartition> partitions)
+        {
+            foreach (var partition in partitions)
+                _assignment[partition] = 0;
+        }
+
+        public void Revoke(IEnumerable<TopicPartition> partitions)
+        {
+            Interlocked.Increment(ref _revocationCount);
+            Remove(partitions);
+        }
+
+        public void Lose(IEnumerable<TopicPartition> partitions) => Remove(partitions);
+
+        public ValueTask OnPartitionsAssignedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Assign(partitions);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsRevokedAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Revoke(partitions);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnPartitionsLostAsync(
+            IEnumerable<TopicPartition> partitions,
+            CancellationToken cancellationToken)
+        {
+            Lose(partitions);
+            return ValueTask.CompletedTask;
+        }
+
+        private void Remove(IEnumerable<TopicPartition> partitions)
+        {
+            foreach (var partition in partitions)
+                _assignment.TryRemove(partition, out _);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Sockets;
 using Dekaf.Admin;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
@@ -149,6 +152,127 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         await WaitForTopicAssignmentAsync(admin, topic, [1, 2, 3]).ConfigureAwait(false);
         return topic;
     }
+
+    public async Task<string> CreateDistributedReplicatedTopicAsync(
+        int partitionCount = 6,
+        int minInSyncReplicas = 2,
+        int? excludedLeaderId = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+        if (excludedLeaderId is < 1 or > 3)
+            throw new ArgumentOutOfRangeException(nameof(excludedLeaderId));
+
+        var topic = $"distributed-{Guid.NewGuid():N}";
+        var eligibleLeaders = Enumerable.Range(1, 3)
+            .Where(nodeId => nodeId != excludedLeaderId)
+            .ToArray();
+        var assignments = Enumerable.Range(0, partitionCount)
+            .ToDictionary(
+                static partition => partition,
+                partition =>
+                {
+                    var leader = eligibleLeaders[partition % eligibleLeaders.Length];
+                    return (IReadOnlyList<int>)[leader, .. Enumerable.Range(1, 3).Where(id => id != leader)];
+                });
+        await using var admin = CreateAdminClient();
+
+        await admin.CreateTopicsAsync([
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = -1,
+                ReplicationFactor = -1,
+                ReplicaAssignments = assignments,
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = minInSyncReplicas.ToString()
+                }
+            }
+        ]).ConfigureAwait(false);
+
+        await WaitForTopicAssignmentAsync(admin, topic, assignments).ConfigureAwait(false);
+        return topic;
+    }
+
+    public async Task<int> FindGroupCoordinatorIdAsync(
+        string groupId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var pool = new ConnectionPool(
+            $"coordinator-probe-{Guid.NewGuid():N}",
+            new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(5) },
+            loggerFactory: null);
+        Exception? lastFailure = null;
+
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            foreach (var port in _hostPorts)
+            {
+                try
+                {
+                    var connection = await pool.GetConnectionAsync(
+                        "127.0.0.1",
+                        port,
+                        cancellationToken).ConfigureAwait(false);
+                    var response = await connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                        new FindCoordinatorRequest
+                        {
+                            Key = groupId,
+                            KeyType = CoordinatorType.Group
+                        },
+                        FindCoordinatorRequest.HighestSupportedVersion,
+                        cancellationToken).ConfigureAwait(false);
+                    var coordinator = response.Coordinators.SingleOrDefault();
+                    if (coordinator is not null && coordinator.ErrorCode == ErrorCode.None)
+                        return coordinator.NodeId;
+
+                    lastFailure = new InvalidOperationException(
+                        $"FindCoordinator failed for group '{groupId}': " +
+                        $"{coordinator?.ErrorCode.ToString() ?? "empty response"}.");
+                }
+                catch (Exception exception) when (
+                    exception is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    lastFailure = exception;
+                }
+            }
+
+            await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"No broker resolved a coordinator for group '{groupId}'.",
+            lastFailure);
+    }
+
+    public async Task<int> GetGroupCoordinatorIdAsync(
+        string groupId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var admin = CreateAdminClient();
+        var groups = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken)
+            .ConfigureAwait(false);
+        if (!groups.TryGetValue(groupId, out var group) || group.CoordinatorId is not { } coordinatorId)
+        {
+            throw new InvalidOperationException(
+                $"DescribeConsumerGroups did not return a coordinator for group '{groupId}'.");
+        }
+
+        return coordinatorId;
+    }
+
+    public Task<int> WaitForGroupCoordinatorChangeAsync(
+        string groupId,
+        int previousCoordinatorId,
+        CancellationToken cancellationToken = default) =>
+        PollUntilAsync(
+            token => GetGroupCoordinatorIdAsync(groupId, token),
+            coordinatorId => coordinatorId >= 0 && coordinatorId != previousCoordinatorId,
+            maxAttempts: 90,
+            delay: TimeSpan.FromMilliseconds(500),
+            timeoutMessage:
+                $"Group '{groupId}' did not move from coordinator {previousCoordinatorId}.",
+            cancellationToken: cancellationToken);
 
     public async Task<string> CreateUncleanElectionTopicAsync()
     {
@@ -316,6 +440,30 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         CancellationToken cancellationToken = default)
     {
         await WaitForTopicAssignmentAsync(admin, topic, [1, 2], cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task WaitForTopicAssignmentAsync(
+        IAdminClient admin,
+        string topic,
+        IReadOnlyDictionary<int, IReadOnlyList<int>> expectedAssignments,
+        CancellationToken cancellationToken = default)
+    {
+        _ = await PollUntilAsync(
+            async token =>
+            {
+                var descriptions = await admin.DescribeTopicsAsync([topic], token).ConfigureAwait(false);
+                return descriptions[topic].Partitions;
+            },
+            partitions => partitions.Count == expectedAssignments.Count
+                && partitions.All(partition =>
+                    expectedAssignments.TryGetValue(partition.PartitionIndex, out var expectedReplicas)
+                    && expectedReplicas.Contains(partition.LeaderId)
+                    && partition.ReplicaNodes.SequenceEqual(expectedReplicas)
+                    && expectedReplicas.All(partition.IsrNodes.Contains)),
+            maxAttempts: 60,
+            delay: TimeSpan.FromMilliseconds(500),
+            timeoutMessage: $"Topic '{topic}' did not get expected distributed assignment.",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task WaitForTopicAssignmentAsync(

--- a/tests/Dekaf.Tests.Unit/Admin/AdminClientConsumerGroupDescribeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Admin/AdminClientConsumerGroupDescribeTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using Dekaf.Admin;
 using Dekaf.Metadata;
 using Dekaf.Networking;
@@ -9,6 +10,83 @@ namespace Dekaf.Tests.Unit.Admin;
 
 public sealed class AdminClientConsumerGroupDescribeTests
 {
+    [Test]
+    public async Task DescribeConsumerGroupsAsync_FindCoordinatorTransportFailureTriesNextBroker()
+    {
+        var connection = Substitute.For<IKafkaConnection>();
+        connection.BrokerId.Returns(2);
+        connection.Host.Returns("broker-2");
+        connection.Port.Returns(9092);
+        connection.IsConnected.Returns(true);
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Is(1), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(
+                new SocketException((int)SocketError.ConnectionRefused)));
+        pool.GetConnectionAsync(Arg.Is(2), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(connection));
+        connection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "consumer-group",
+                        NodeId = 2,
+                        Host = "broker-2",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+        connection.SendAsync<ConsumerGroupDescribeRequest, ConsumerGroupDescribeResponse>(
+                Arg.Any<ConsumerGroupDescribeRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ConsumerGroupDescribeResponse
+            {
+                Groups =
+                [
+                    new ConsumerGroupDescribeGroup
+                    {
+                        ErrorCode = ErrorCode.None,
+                        GroupId = "consumer-group",
+                        GroupState = "Stable",
+                        GroupEpoch = 1,
+                        AssignmentEpoch = 1,
+                        AssignorName = "uniform",
+                        Members = []
+                    }
+                ]
+            }));
+        var metadataManager = new MetadataManager(pool, ["broker-1:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 },
+                new BrokerMetadata { NodeId = 2, Host = "broker-2", Port = 9092 }
+            ],
+            ClusterId = "test-cluster",
+            ControllerId = 2,
+            Topics = []
+        });
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.SetApiVersion(ApiKey.ConsumerGroupDescribe, 0, 1);
+        await using var admin = new AdminClient(
+            new AdminClientOptions { BootstrapServers = ["broker-1:9092"] },
+            pool,
+            metadataManager);
+
+        var descriptions = await admin.DescribeConsumerGroupsAsync(["consumer-group"]);
+
+        await Assert.That(descriptions["consumer-group"].CoordinatorId).IsEqualTo(2);
+        await pool.Received().GetConnectionAsync(Arg.Is(2), Arg.Any<CancellationToken>());
+    }
+
     [Test]
     public async Task DescribeConsumerGroupsAsync_FallsBackPerGroupWhenApi69ReportsClassicGroup()
     {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -112,6 +112,8 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         int heartbeatIntervalMs = 3000,
         int rebalanceTimeoutMs = 30000,
         int maxPollIntervalMs = 300000,
+        int retryBackoffMs = 100,
+        int retryBackoffMaxMs = 1000,
         IConsumerAwareRebalanceListener? consumerAwareRebalanceListener = null) => new()
         {
             BootstrapServers = ["localhost:9092"],
@@ -123,7 +125,9 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             ConsumerAwareRebalanceListener = consumerAwareRebalanceListener,
             HeartbeatIntervalMs = heartbeatIntervalMs,
             RebalanceTimeoutMs = rebalanceTimeoutMs,
-            MaxPollIntervalMs = maxPollIntervalMs
+            MaxPollIntervalMs = maxPollIntervalMs,
+            RetryBackoffMs = retryBackoffMs,
+            RetryBackoffMaxMs = retryBackoffMaxMs
         };
 
     private void SetupFindCoordinator()
@@ -211,6 +215,17 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
             BindingFlags.NonPublic | BindingFlags.Instance);
 
         return (Task)method!.Invoke(coordinator, [cancellationToken])!;
+    }
+
+    private static ValueTask InvokeFindCoordinatorAsync(
+        ConsumerCoordinator coordinator,
+        CancellationToken cancellationToken)
+    {
+        var method = typeof(ConsumerCoordinator).GetMethod(
+            "FindCoordinatorAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return (ValueTask)method!.Invoke(coordinator, [cancellationToken])!;
     }
 
     private static ConsumerGroupHeartbeatAssignment CreateAssignment(
@@ -3539,6 +3554,42 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
         await Assert.That(GetPrivateField<int>(coordinator, "_coordinatorId")).IsEqualTo(1);
         await connectionPool.Received().GetConnectionByIndexAsync(
             Arg.Is(1),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_FindCoordinator_TransportFailureExhaustionThrowsGroupException()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        connectionPool.GetConnectionByIndexAsync(
+                Arg.Any<int>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(
+                new SocketException((int)SocketError.ConnectionRefused)));
+
+        await using var metadataManager = new MetadataManager(connectionPool, ["broker-0:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "broker-0", Port = 9092 },
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 }
+            ],
+            Topics = []
+        });
+        var options = CreateConsumerProtocolOptions(retryBackoffMs: 1, retryBackoffMaxMs: 1);
+        await using var coordinator = new ConsumerCoordinator(options, connectionPool, metadataManager);
+
+        var exception = await Assert.That(async () =>
+                await InvokeFindCoordinatorAsync(coordinator, CancellationToken.None))
+            .Throws<GroupException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.CoordinatorNotAvailable);
+        await Assert.That(exception.InnerException).IsTypeOf<SocketException>();
+        await connectionPool.Received(5).GetConnectionByIndexAsync(
+            Arg.Any<int>(),
             Arg.Any<int>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net.Sockets;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -3443,6 +3444,106 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_TransportFailureDuringHeartbeat_InvalidatesCoordinator()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+        await coordinator.StopHeartbeatAsync();
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<ConsumerGroupHeartbeatResponse>(
+                new IOException("coordinator connection closed")));
+        SetPrivateField(coordinator, "_heartbeatIntervalMs", 1);
+
+        await InvokeConsumerProtocolHeartbeatLoopAsync(coordinator, CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Unjoined);
+        await Assert.That(GetPrivateField<int>(coordinator, "_coordinatorId")).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_FindCoordinator_TransportFailureTriesNextBroker()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var availableConnection = Substitute.For<IKafkaConnection>();
+        connectionPool.GetConnectionByIndexAsync(
+                Arg.Is(0),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromException<IKafkaConnection>(
+                new SocketException((int)SocketError.ConnectionRefused)));
+        connectionPool.GetConnectionByIndexAsync(
+                Arg.Is(1),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(availableConnection));
+        availableConnection.SendAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                Arg.Any<FindCoordinatorRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = "test-group",
+                        NodeId = 1,
+                        Host = "broker-1",
+                        Port = 9092,
+                        ErrorCode = ErrorCode.None
+                    }
+                ]
+            }));
+        availableConnection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+            {
+                ErrorCode = ErrorCode.None,
+                MemberId = "member-1",
+                MemberEpoch = 1,
+                HeartbeatIntervalMs = 60_000
+            }));
+
+        await using var metadataManager = new MetadataManager(connectionPool, ["broker-0:9092"]);
+        metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 0);
+        metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "broker-0", Port = 9092 },
+                new BrokerMetadata { NodeId = 1, Host = "broker-1", Port = 9092 }
+            ],
+            Topics = []
+        });
+        await using var coordinator = new ConsumerCoordinator(
+            CreateConsumerProtocolOptions(heartbeatIntervalMs: 60_000),
+            connectionPool,
+            metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(
+            new HashSet<string> { "test-topic" },
+            CancellationToken.None);
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(GetPrivateField<int>(coordinator, "_coordinatorId")).IsEqualTo(1);
+        await connectionPool.Received().GetConnectionByIndexAsync(
+            Arg.Is(1),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     [Arguments(ErrorCode.GroupAuthorizationFailed)]
     [Arguments(ErrorCode.InvalidGroupId)]
     public async Task ConsumerProtocol_FatalGroupErrorDuringHeartbeat_PropagatesOnNextEnsureActiveGroup(
@@ -4125,6 +4226,15 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     #endregion
+
+    private static T GetPrivateField<T>(ConsumerCoordinator coordinator, string fieldName)
+    {
+        var field = typeof(ConsumerCoordinator).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        return (T)field.GetValue(coordinator)!;
+    }
 
     private static void SetPrivateField<T>(ConsumerCoordinator coordinator, string fieldName, T value)
     {


### PR DESCRIPTION
## Summary

- invalidate stale KIP-848 coordinators after heartbeat transport failures
- retry consumer and admin `FindCoordinator` requests across known brokers
- add deterministic three-broker failover coverage for commits, heartbeats, and member joins under KIP-848 and classic protocols
- keep data-partition leaders off the coordinator broker so the scenarios isolate group coordination

## Validation

- `dotnet build Dekaf.sln --no-restore` (0 warnings, 0 errors)
- .NET 10 unit suite: 6124/6124 passed
- .NET 8 unit suite: 5997/5997 passed
- coordinator failover integration matrix, .NET 10: 6/6 passed
- coordinator failover integration matrix, .NET 8: 6/6 passed

Closes #2249