### PR TITLE
feat(consumer): support KIP-1092 close options

### DIFF
--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -387,8 +387,22 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             _storedOffsets[new TopicPartition(offset.Topic, offset.Partition)] = offset.Offset;
     }
 
-    public ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>
+        CloseAsync(new ConsumerCloseOptions(), cancellationToken);
+
+    public ValueTask CloseAsync(
+        ConsumerCloseOptions options,
+        CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!Enum.IsDefined(options.GroupMembershipOperation))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.GroupMembershipOperation,
+                "The group membership operation is invalid.");
+        }
+
         cancellationToken.ThrowIfCancellationRequested();
 
         if (_disposed)
@@ -402,7 +416,8 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
                 CommitStoredOffsets();
 
-            UnregisterConsumerGroupMemberUnderLock();
+            if (options.GroupMembershipOperation != ConsumerGroupMembershipOperation.RemainInGroup)
+                UnregisterConsumerGroupMemberUnderLock();
             _disposed = true;
         }
 

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -416,8 +416,9 @@ public sealed class InMemoryConsumer<TKey, TValue> :
             if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
                 CommitStoredOffsets();
 
-            if (options.GroupMembershipOperation != ConsumerGroupMembershipOperation.RemainInGroup)
-                UnregisterConsumerGroupMemberUnderLock();
+            // The in-memory cluster has no broker session timer. Always unregister on close so
+            // RemainInGroup cannot create an immortal member that permanently owns partitions.
+            UnregisterConsumerGroupMemberUnderLock();
             _disposed = true;
         }
 

--- a/src/Dekaf/Consumer/ConsumerCloseOptions.cs
+++ b/src/Dekaf/Consumer/ConsumerCloseOptions.cs
@@ -1,0 +1,37 @@
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Specifies how closing a consumer affects its consumer-group membership.
+/// </summary>
+public enum ConsumerGroupMembershipOperation
+{
+    /// <summary>
+    /// Uses Kafka's default close behavior: dynamic members leave the group, while static
+    /// members retain their membership so they can rejoin without a rebalance.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Permanently leaves the consumer group. For a static member, this releases its static
+    /// membership and triggers a rebalance instead of keeping its assignment warm.
+    /// </summary>
+    LeaveGroup,
+
+    /// <summary>
+    /// Closes without sending a terminal group heartbeat. The broker retains the member until
+    /// its session expires.
+    /// </summary>
+    RemainInGroup
+}
+
+/// <summary>
+/// Options controlling consumer shutdown behavior.
+/// </summary>
+public sealed class ConsumerCloseOptions
+{
+    /// <summary>
+    /// Gets how closing affects consumer-group membership.
+    /// </summary>
+    public ConsumerGroupMembershipOperation GroupMembershipOperation { get; init; } =
+        ConsumerGroupMembershipOperation.Default;
+}

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -2026,7 +2026,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             _state = CoordinatorState.Unjoined;
 
             LogMaxPollIntervalExceeded(_options.MaxPollIntervalMs);
-            await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
+            await SendConsumerProtocolLeaveRequestAsync(
+                ConsumerGroupMembershipOperation.Default,
+                cancellationToken).ConfigureAwait(false);
             return (true, lost);
         }
         finally
@@ -2071,12 +2073,15 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     }
 
     /// <summary>
-    /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic members,
-    /// or -2 for static members so the broker keeps the assignment warm.
+    /// KIP-848 leave: sends ConsumerGroupHeartbeat with MemberEpoch=-1 for dynamic or permanently
+    /// departing static members, or -2 for default static-member close so the broker keeps the
+    /// assignment warm.
     /// </summary>
-    private async ValueTask LeaveGroupConsumerProtocolAsync(CancellationToken cancellationToken)
+    private async ValueTask LeaveGroupConsumerProtocolAsync(
+        ConsumerGroupMembershipOperation operation,
+        CancellationToken cancellationToken)
     {
-        await SendConsumerProtocolLeaveRequestAsync(cancellationToken).ConfigureAwait(false);
+        await SendConsumerProtocolLeaveRequestAsync(operation, cancellationToken).ConfigureAwait(false);
 
         await StopHeartbeatAsyncCore(cancellationToken).ConfigureAwait(false);
 
@@ -2091,7 +2096,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         }
     }
 
-    private async ValueTask SendConsumerProtocolLeaveRequestAsync(CancellationToken cancellationToken)
+    private async ValueTask SendConsumerProtocolLeaveRequestAsync(
+        ConsumerGroupMembershipOperation operation,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -2104,7 +2111,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             {
                 GroupId = _options.GroupId!,
                 MemberId = _memberId!,
-                MemberEpoch = _options.GroupInstanceId is null ? -1 : -2,
+                MemberEpoch = operation == ConsumerGroupMembershipOperation.LeaveGroup ||
+                              _options.GroupInstanceId is null
+                    ? -1
+                    : -2,
                 InstanceId = _options.GroupInstanceId,
             };
 
@@ -2138,7 +2148,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     public async ValueTask LeaveGroupAsync(CancellationToken cancellationToken = default)
     {
+        await LeaveGroupAsync(ConsumerGroupMembershipOperation.Default, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async ValueTask LeaveGroupAsync(
+        ConsumerGroupMembershipOperation operation,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Enum.IsDefined(operation))
+            throw new ArgumentOutOfRangeException(nameof(operation), operation, "The group membership operation is invalid.");
+
         if (Volatile.Read(ref _disposed) != 0)
+            return;
+
+        if (operation == ConsumerGroupMembershipOperation.RemainInGroup)
             return;
 
         // Only leave if we're part of a group
@@ -2149,7 +2172,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         if (_coordinatorId < 0)
             return;
 
-        await LeaveGroupConsumerProtocolAsync(cancellationToken).ConfigureAwait(false);
+        await LeaveGroupConsumerProtocolAsync(operation, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -193,6 +193,21 @@ public interface IKafkaConsumer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
     /// </exception>
     ValueTask CloseAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gracefully closes the consumer using the specified group-membership behavior.
+    /// </summary>
+    /// <param name="options">Close options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous close operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <see cref="ConsumerCloseOptions.GroupMembershipOperation"/> is invalid.
+    /// </exception>
+    /// <exception cref="KafkaTimeoutException">
+    /// The operation exceeds <see cref="ConsumerOptions.DefaultApiTimeoutMs"/>.
+    /// </exception>
+    ValueTask CloseAsync(ConsumerCloseOptions options, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -8218,8 +8218,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     }
 
     /// <inheritdoc />
-    public async ValueTask CloseAsync(CancellationToken cancellationToken = default)
+    public ValueTask CloseAsync(CancellationToken cancellationToken = default) =>
+        CloseAsync(new ConsumerCloseOptions(), cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask CloseAsync(
+        ConsumerCloseOptions options,
+        CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!Enum.IsDefined(options.GroupMembershipOperation))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.GroupMembershipOperation,
+                "The group membership operation is invalid.");
+        }
+
         // Idempotent - return early if already closed/disposed
         if (Interlocked.Exchange(ref _closed, 1) != 0 || Volatile.Read(ref _consumerDisposed) != 0)
             return;
@@ -8227,7 +8242,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         using var apiTimeout = new ApiTimeoutScope(_options.DefaultApiTimeoutMs, cancellationToken);
         try
         {
-            await CloseAsyncCore(apiTimeout.Token).ConfigureAwait(false);
+            await CloseAsyncCore(options, apiTimeout.Token).ConfigureAwait(false);
             apiTimeout.Token.ThrowIfCancellationRequested();
         }
         catch (OperationCanceledException ex) when (apiTimeout.DefaultTimeoutExpired)
@@ -8240,7 +8255,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// Core teardown logic shared by <see cref="CloseAsync"/> and <see cref="DisposeAsync"/>.
     /// Callers must ensure this is invoked at most once via an atomic CAS on <c>_closed</c>.
     /// </summary>
-    private async ValueTask CloseAsyncCore(CancellationToken cancellationToken)
+    private async ValueTask CloseAsyncCore(
+        ConsumerCloseOptions options,
+        CancellationToken cancellationToken)
     {
         LogClosingConsumer();
 
@@ -8345,11 +8362,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Step 7: Send LeaveGroup request to coordinator
-        if (_coordinator is not null)
+        if (_coordinator is not null &&
+            options.GroupMembershipOperation != ConsumerGroupMembershipOperation.RemainInGroup)
         {
             try
             {
-                await _coordinator.LeaveGroupAsync(cancellationToken).ConfigureAwait(false);
+                await _coordinator.LeaveGroupAsync(
+                    options.GroupMembershipOperation,
+                    cancellationToken).ConfigureAwait(false);
                 LogLeftConsumerGroup();
             }
             catch (Exception ex)
@@ -8594,7 +8614,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 using var cts = new CancellationTokenSource(
                     Math.Min(_options.DefaultApiTimeoutMs, 30_000));
-                await CloseAsyncCore(cts.Token).ConfigureAwait(false);
+                await CloseAsyncCore(new ConsumerCloseOptions(), cts.Token).ConfigureAwait(false);
             }
             catch
             {

--- a/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
+++ b/tests/Dekaf.Tests.Integration/StaticMembershipTests.cs
@@ -273,6 +273,138 @@ public sealed class StaticMembershipTests(KafkaTestContainer kafka) : KafkaInteg
     }
 
     [Test]
+    public async Task StaticMember_PermanentLeave_RebalancesToDynamicMember()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2);
+        var groupId = $"static-permanent-leave-{Guid.NewGuid():N}";
+        var instanceId = $"static-instance-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var staticConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("static-consumer")
+            .WithGroupId(groupId)
+            .WithGroupInstanceId(instanceId)
+            .WithSessionTimeout(TimeSpan.FromSeconds(30))
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        try
+        {
+            staticConsumer.Subscribe(topic);
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "before-close",
+                Value = "before-close",
+                Partition = 0
+            }, CancellationToken.None);
+
+            using var joinCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var initial = await staticConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), joinCts.Token);
+            await Assert.That(initial).IsNotNull();
+
+            await staticConsumer.CloseAsync(new ConsumerCloseOptions
+            {
+                GroupMembershipOperation = ConsumerGroupMembershipOperation.LeaveGroup
+            });
+
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "after-close",
+                Value = "after-close",
+                Partition = 1
+            }, CancellationToken.None);
+
+            await using var dynamicConsumer = await Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId("dynamic-consumer")
+                .WithGroupId(groupId)
+                .WithSessionTimeout(TimeSpan.FromSeconds(10))
+                .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                .WithOffsetCommitMode(OffsetCommitMode.Manual)
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+            dynamicConsumer.Subscribe(topic);
+            using var consumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var result = await dynamicConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), consumeCts.Token);
+
+            await Assert.That(result).IsNotNull();
+            await Assert.That(dynamicConsumer.Assignment.ToArray()).IsNotEmpty();
+        }
+        finally
+        {
+            await staticConsumer.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task DynamicMember_RemainInGroup_DoesNotTriggerImmediateRebalance()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var groupId = $"dynamic-remain-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var firstConsumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("dynamic-consumer-1")
+            .WithGroupId(groupId)
+            .WithSessionTimeout(TimeSpan.FromSeconds(30))
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        try
+        {
+            firstConsumer.Subscribe(topic);
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Key = "before-close",
+                Value = "before-close"
+            }, CancellationToken.None);
+
+            using var joinCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var initial = await firstConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), joinCts.Token);
+            await Assert.That(initial).IsNotNull();
+
+            await firstConsumer.CloseAsync(new ConsumerCloseOptions
+            {
+                GroupMembershipOperation = ConsumerGroupMembershipOperation.RemainInGroup
+            });
+
+            await using var secondConsumer = await Kafka.CreateConsumer<string, string>()
+                .WithBootstrapServers(KafkaContainer.BootstrapServers)
+                .WithClientId("dynamic-consumer-2")
+                .WithGroupId(groupId)
+                .WithSessionTimeout(TimeSpan.FromSeconds(10))
+                .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+                .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+            secondConsumer.Subscribe(topic);
+            using var consumeCts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+            var result = await secondConsumer.ConsumeOneAsync(TimeSpan.FromSeconds(5), consumeCts.Token);
+
+            await Assert.That(result).IsNull();
+            await Assert.That(secondConsumer.Assignment.ToArray()).IsEmpty();
+        }
+        finally
+        {
+            await firstConsumer.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task StaticMember_DuplicateInstanceId_FencingBehavior()
     {
         // Tests that a second consumer with the same GroupInstanceId can take over

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCloseTests.cs
@@ -8,6 +8,41 @@ namespace Dekaf.Tests.Unit.Consumer;
 /// </summary>
 public class ConsumerCloseTests
 {
+    [Test]
+    public async Task ConsumerCloseOptions_DefaultsToKafkaMembershipBehavior()
+    {
+        var options = new ConsumerCloseOptions();
+
+        await Assert.That(options.GroupMembershipOperation)
+            .IsEqualTo(ConsumerGroupMembershipOperation.Default);
+    }
+
+    [Test]
+    public async Task KafkaConsumer_CloseAsync_RejectsInvalidMembershipOperation()
+    {
+        var options = new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "test-consumer"
+        };
+
+        await using var consumer = new KafkaConsumer<string, string>(
+            options,
+            Serializers.String,
+            Serializers.String);
+
+        var closeOptions = new ConsumerCloseOptions
+        {
+            GroupMembershipOperation = (ConsumerGroupMembershipOperation)int.MaxValue
+        };
+
+        await Assert.That(async () => await consumer.CloseAsync(closeOptions))
+            .Throws<ArgumentOutOfRangeException>();
+
+        // Invalid options are rejected before the consumer transitions to closed.
+        await consumer.CloseAsync();
+    }
+
     #region Consumer CloseAsync Idempotency Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3190,6 +3190,51 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_StaticMemberPermanentLeave_SendsMemberEpochNegativeOne()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions(groupInstanceId: "static-instance-1");
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+        SetupConsumerGroupHeartbeat();
+
+        await coordinator.LeaveGroupAsync(
+            ConsumerGroupMembershipOperation.LeaveGroup,
+            CancellationToken.None);
+
+        await _connection.Received().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Is<ConsumerGroupHeartbeatRequest>(r =>
+                r != null && r.MemberEpoch == -1 && r.InstanceId == "static-instance-1"),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ConsumerProtocol_RemainInGroup_SendsNoTerminalHeartbeat()
+    {
+        SetupSuccessfulConsumerProtocolJoin();
+        var options = CreateConsumerProtocolOptions();
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        _connection.ClearReceivedCalls();
+
+        await coordinator.LeaveGroupAsync(
+            ConsumerGroupMembershipOperation.RemainInGroup,
+            CancellationToken.None);
+
+        await _connection.DidNotReceive().SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+            Arg.Any<ConsumerGroupHeartbeatRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_EmptyStaticMemberLeaveGroup_SendsMemberEpochNegativeTwo()
     {
         SetupSuccessfulConsumerProtocolJoin();

--- a/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PartitionedConsumerRuntimeTests.cs
@@ -1398,6 +1398,11 @@ public sealed class PartitionedConsumerRuntimeTests
         public ValueTask CloseAsync(CancellationToken cancellationToken = default)
             => ValueTask.CompletedTask;
 
+        public ValueTask CloseAsync(
+            ConsumerCloseOptions options,
+            CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
         public ValueTask DisposeAsync()
             => ValueTask.CompletedTask;
 

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryKafkaClusterTests.cs
@@ -661,6 +661,45 @@ public sealed class InMemoryKafkaClusterTests
     }
 
     [Test]
+    public async Task ConsumerClose_RemainInGroup_DoesNotCreateImmortalInMemoryMember()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        cluster.CreateTopic("close-remain");
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var firstConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "close-remain-group",
+                MemberId = "a-first",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        firstConsumer.Subscribe("close-remain");
+        await Assert.That(firstConsumer.Assignment).Count().IsEqualTo(1);
+
+        await firstConsumer.CloseAsync(new ConsumerCloseOptions
+        {
+            GroupMembershipOperation = ConsumerGroupMembershipOperation.RemainInGroup
+        });
+
+        await producer.ProduceAsync("close-remain", "key", "value");
+        await using var secondConsumer = new InMemoryConsumer<string, string>(
+            cluster,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "close-remain-group",
+                MemberId = "b-second",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+        secondConsumer.Subscribe("close-remain");
+
+        var result = await secondConsumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(50));
+
+        await Assert.That(secondConsumer.Assignment).Count().IsEqualTo(1);
+        await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
     public async Task Consumer_AssignFailureDoesNotLeavePartialState()
     {
         var cluster = new InMemoryKafkaCluster();


### PR DESCRIPTION
## Summary
- add KIP-1092-style `ConsumerCloseOptions` with `Default`, `LeaveGroup`, and `RemainInGroup` membership operations
- preserve existing dynamic `-1` and temporary static `-2` close behavior while allowing permanent static leave via `-1`
- support silent shutdown without a terminal group heartbeat in real and in-memory consumers
- add unit and Kafka integration coverage for default, remain, and permanent-leave behavior

Closes #827

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- net10 unit suite: 6,209 passed
- net8 unit suite: 6,082 passed
- focused post-rebase unit tests: 73 passed
- close-membership integration matrix: 3/3 net10 and 3/3 net8
- post-rebase close-membership integrations: 3/3 net10

No benchmark: close is a cold shutdown path; no per-message hot path changed.