### PR TITLE
test(integration): cover live broker scale-out

### DIFF
--- a/tests/Dekaf.Tests.Integration/BrokerScaleOutIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/BrokerScaleOutIntegrationTests.cs
@@ -1,0 +1,222 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Admin")]
+[Category("Consumer")]
+[Category("Producer")]
+[Category("Resilience")]
+[NotInParallel("BrokerScaleOutKafkaContainer")]
+[ClassDataSource<BrokerScaleOutKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class BrokerScaleOutIntegrationTests(BrokerScaleOutKafkaContainer kafka)
+{
+    private static readonly int[] InitialReplicas = [1, 2];
+    private static readonly int[] ScaleOutReplicas = [3, 2];
+
+    [Test]
+    [Timeout(240_000)]
+    public async Task Clients_DiscoverAndRouteThroughBrokerAddedMidRun(
+        CancellationToken cancellationToken)
+    {
+        const int messagesBeforeScaleOut = 20;
+        const int messagesAfterScaleOut = 20;
+        var topic = $"broker-scale-out-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+
+        await using var admin = Kafka.CreateAdminClient()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithMetadataMaxAge(TimeSpan.FromMilliseconds(250))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .Build();
+        await admin.CreateTopicsAsync(
+        [
+            new NewTopic
+            {
+                Name = topic,
+                NumPartitions = -1,
+                ReplicationFactor = -1,
+                ReplicaAssignments = new Dictionary<int, IReadOnlyList<int>>
+                {
+                    [0] = InitialReplicas
+                },
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = "1"
+                }
+            }
+        ], cancellationToken: cancellationToken).ConfigureAwait(false);
+        await WaitForAssignmentAsync(
+            admin,
+            topic,
+            InitialReplicas,
+            expectedLeader: 1,
+            cancellationToken).ConfigureAwait(false);
+
+        var initialCluster = await admin.DescribeClusterAsync(cancellationToken).ConfigureAwait(false);
+        await Assert.That(initialCluster.Nodes.Select(static node => node.NodeId))
+            .IsEquivalentTo(InitialReplicas);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"scale-out-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithIdempotence(true)
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(45))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"scale-out-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+        consumer.Assign(partition);
+
+        await ProduceRangeAsync(
+            producer,
+            topic,
+            start: 0,
+            count: messagesBeforeScaleOut,
+            cancellationToken).ConfigureAwait(false);
+        await ConsumeRangeAsync(
+            consumer,
+            topic,
+            start: 0,
+            count: messagesBeforeScaleOut,
+            cancellationToken).ConfigureAwait(false);
+
+        await kafka.StartBrokerAsync(nodeId: 3, cancellationToken).ConfigureAwait(false);
+        await WaitUntilAsync(
+            async token =>
+            {
+                var cluster = await admin.DescribeClusterAsync(token).ConfigureAwait(false);
+                return cluster.Nodes.Any(static node => node.NodeId == 3);
+            },
+            "The running admin client did not discover broker 3.",
+            cancellationToken).ConfigureAwait(false);
+
+        await admin.AlterPartitionReassignmentsAsync(
+            new Dictionary<TopicPartition, Optional<NewPartitionReassignment>>
+            {
+                [partition] = NewPartitionReassignment.ToReplicas(ScaleOutReplicas)
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        await WaitForAssignmentAsync(
+            admin,
+            topic,
+            ScaleOutReplicas,
+            expectedLeader: 3,
+            cancellationToken).ConfigureAwait(false);
+
+        await ProduceRangeAsync(
+            producer,
+            topic,
+            start: messagesBeforeScaleOut,
+            count: messagesAfterScaleOut,
+            cancellationToken).ConfigureAwait(false);
+        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        await ConsumeRangeAsync(
+            consumer,
+            topic,
+            start: messagesBeforeScaleOut,
+            count: messagesAfterScaleOut,
+            cancellationToken).ConfigureAwait(false);
+
+        var duplicate = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+            .ConfigureAwait(false);
+        await Assert.That(duplicate).IsNull();
+    }
+
+    private static async Task ProduceRangeAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        int start,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        for (var sequence = start; sequence < start + count; sequence++)
+        {
+            var value = sequence.ToString();
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = value,
+                Value = value
+            }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ConsumeRangeAsync(
+        IKafkaConsumer<string, string> consumer,
+        string topic,
+        int start,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        for (var sequence = start; sequence < start + count; sequence++)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(15), cancellationToken)
+                .ConfigureAwait(false);
+            if (result is null)
+                throw new InvalidOperationException($"Timed out waiting for {topic}-0@{sequence}.");
+
+            var record = result.Value;
+            var expected = sequence.ToString();
+            if (record.Topic != topic || record.Partition != 0 || record.Offset != sequence ||
+                record.Key != expected || record.Value != expected)
+            {
+                throw new InvalidOperationException(
+                    $"Expected {topic}-0@{sequence} value '{expected}', got " +
+                    $"{record.Topic}-{record.Partition}@{record.Offset} value '{record.Value}'.");
+            }
+        }
+    }
+
+    private static Task WaitForAssignmentAsync(
+        IAdminClient admin,
+        string topic,
+        IReadOnlyList<int> expectedReplicas,
+        int expectedLeader,
+        CancellationToken cancellationToken) =>
+        WaitUntilAsync(
+            async token =>
+            {
+                var active = await admin.ListPartitionReassignmentsAsync(
+                    [new TopicPartition(topic, 0)],
+                    cancellationToken: token).ConfigureAwait(false);
+                if (active.Count != 0)
+                    return false;
+
+                var descriptions = await admin.DescribeTopicsAsync([topic], token).ConfigureAwait(false);
+                var partition = descriptions[topic].Partitions.Single();
+                return partition.LeaderId == expectedLeader &&
+                       partition.ReplicaNodes.SequenceEqual(expectedReplicas) &&
+                       expectedReplicas.All(partition.IsrNodes.Contains);
+            },
+            $"Topic '{topic}' did not reach assignment [{string.Join(",", expectedReplicas)}] " +
+            $"with leader {expectedLeader}.",
+            cancellationToken);
+
+    private static async Task WaitUntilAsync(
+        Func<CancellationToken, Task<bool>> predicate,
+        string timeoutMessage,
+        CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(90));
+
+        try
+        {
+            while (!await predicate(timeout.Token).ConfigureAwait(false))
+                await Task.Delay(TimeSpan.FromMilliseconds(200), timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(timeoutMessage);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/BrokerScaleOutKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/BrokerScaleOutKafkaContainer.cs
@@ -1,0 +1,11 @@
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Rack-aware cluster that forms with brokers 1 and 2 while broker 3 remains unstarted.
+/// </summary>
+public sealed class BrokerScaleOutKafkaContainer : RackAwareKafkaContainer
+{
+    private static readonly int[] InitialBrokerNodeIds = [1, 2];
+
+    protected override IReadOnlyList<int> InitiallyStartedBrokerIds => InitialBrokerNodeIds;
+}

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetry.cs
@@ -46,7 +46,11 @@ internal static class ContainerStartupRetry
         Contains(exception, static candidate =>
             candidate is DockerApiException &&
             (candidate.Message.Contains("port is already allocated", StringComparison.OrdinalIgnoreCase) ||
-             candidate.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase)));
+             candidate.Message.Contains("address already in use", StringComparison.OrdinalIgnoreCase) ||
+             candidate.Message.Contains("ports are not available", StringComparison.OrdinalIgnoreCase) ||
+             candidate.Message.Contains(
+                 "Only one usage of each socket address",
+                 StringComparison.OrdinalIgnoreCase)));
 
     internal static bool IsKafkaStartupScriptBusy(Exception exception) =>
         Contains(exception, static candidate =>

--- a/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
+++ b/tests/Dekaf.Tests.Integration/ContainerStartupRetryTests.cs
@@ -10,6 +10,7 @@ public sealed class ContainerStartupRetryTests
     [Test]
     [Arguments("Bind for 0.0.0.0:32769 failed: port is already allocated")]
     [Arguments("failed to bind host port 0.0.0.0:58162/tcp: address already in use")]
+    [Arguments("ports are not available: listen tcp 0.0.0.0:51600: bind: Only one usage of each socket address is normally permitted")]
     public async Task RunAsync_PortBindingCollision_UsesFreshAttempt(string message)
     {
         var attempts = 0;

--- a/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/RackAwareKafkaContainer.cs
@@ -8,8 +8,9 @@ using TUnit.Core.Interfaces;
 
 namespace Dekaf.Tests.Integration;
 
-public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
+public class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
+    private static readonly int[] AllBrokerNodeIds = [1, 2, 3];
     private static readonly string Image = $"apache/kafka:{KafkaContainerDefault.ImageTag}";
     private const int InternalBrokerPort = 9092;
     private const int ControllerPort = 9093;
@@ -19,6 +20,8 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
     private int[] _hostPorts = [];
     private IContainer[] _brokers = [];
     private INetwork? _network;
+
+    protected virtual IReadOnlyList<int> InitiallyStartedBrokerIds => AllBrokerNodeIds;
 
     public string BootstrapServers => string.Join(",", _hostPorts.Select(port => $"127.0.0.1:{port}"));
 
@@ -45,13 +48,16 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         _brokers[1] = CreateBroker(nodeId: 2, rack: "rack-a", externalPort: _hostPorts[1]);
         _brokers[2] = CreateBroker(nodeId: 3, rack: "rack-a", externalPort: _hostPorts[2]);
 
-        await Task.WhenAll(_brokers.Select(broker => broker.StartAsync())).ConfigureAwait(false);
-        await WaitForClusterAsync().ConfigureAwait(false);
+        var initiallyStartedBrokerIds = InitiallyStartedBrokerIds;
+        await Task.WhenAll(initiallyStartedBrokerIds.Select(nodeId => GetBroker(nodeId).StartAsync()))
+            .ConfigureAwait(false);
+        await WaitForClusterAsync(initiallyStartedBrokerIds.Count).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
         await DisposeClusterAttemptAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
     }
 
     private async ValueTask DisposeClusterAttemptAsync()
@@ -193,7 +199,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
     {
         await StartBrokerWithoutClusterWaitAsync(nodeId, cancellationToken).ConfigureAwait(false);
 
-        await WaitForClusterAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForClusterAsync(expectedBrokerCount: 3, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task StartBrokerWithoutClusterWaitAsync(
@@ -211,7 +217,7 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
     {
         await Task.WhenAll(nodeIds.Select(nodeId =>
             StartBrokerWithoutClusterWaitAsync(nodeId, cancellationToken))).ConfigureAwait(false);
-        await WaitForClusterAsync(cancellationToken).ConfigureAwait(false);
+        await WaitForClusterAsync(expectedBrokerCount: 3, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<int> WaitForPartitionLeaderChangeAsync(
@@ -294,7 +300,9 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
         };
     }
 
-    private async Task WaitForClusterAsync(CancellationToken cancellationToken = default)
+    private async Task WaitForClusterAsync(
+        int expectedBrokerCount,
+        CancellationToken cancellationToken = default)
     {
         _ = await PollUntilAsync(
             async token =>
@@ -303,10 +311,10 @@ public sealed class RackAwareKafkaContainer : IAsyncInitializer, IAsyncDisposabl
                 var cluster = await admin.DescribeClusterAsync(token).ConfigureAwait(false);
                 return cluster.Nodes.Count;
             },
-            isComplete: nodeCount => nodeCount == 3,
+            isComplete: nodeCount => nodeCount == expectedBrokerCount,
             maxAttempts: 90,
             delay: TimeSpan.FromSeconds(1),
-            timeoutMessage: "Rack-aware Kafka cluster was not ready after 90s.",
+            timeoutMessage: $"Rack-aware Kafka cluster did not report {expectedBrokerCount} brokers after 90s.",
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary
- add a true scale-out Kafka fixture that forms a two-broker KRaft cluster while broker 3 has never started
- verify a running admin client discovers broker 3 after its first registration
- move partition leadership to broker 3 and verify the same producer and consumer route there without skipped or duplicate records
- recognize Docker Desktop''s Windows port-collision wording so container startup retries with fresh resources

Closes #2250

## Prerequisites
- Native GitHub `blockedBy` gate had zero open prerequisites immediately before claim
- prerequisite #2228 landed via merged PR #2275; merge commit `8aa9816d` is on `origin/main`

## Validation
- `dotnet build Dekaf.sln --configuration Release --no-restore` (0 warnings, 0 errors)
- scale-out integration: net10 1/1, net8 1/1
- Windows port-collision retry units: 3/3
- existing three-broker rack-aware integration: 1/1

No benchmark: test infrastructure and integration coverage only; no product hot path changed.