### PR TITLE
fix(consumer): recover recreated topics

### DIFF
--- a/src/Dekaf/Consumer/FetchSessionHandler.cs
+++ b/src/Dekaf/Consumer/FetchSessionHandler.cs
@@ -14,6 +14,9 @@ internal sealed class FetchSessionHandler
     private int _nextEpoch;
     private Dictionary<TopicPartition, CachedPartitionData> _sessionPartitions = [];
     private Dictionary<TopicPartition, CachedPartitionData> _lastDesiredPartitions = [];
+    private ClusterMetadataSnapshot? _sessionMetadataSnapshot;
+    private ClusterMetadataSnapshot? _responseMetadataSnapshot;
+    private ClusterMetadataSnapshot? _lastBuildMetadataSnapshot;
     private bool _lastBuildWasFull;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -24,7 +27,19 @@ internal sealed class FetchSessionHandler
     public bool HasActiveSession => _sessionId != 0;
 
     public FetchSessionBuildResult Build(IReadOnlyList<FetchRequestTopic> desiredTopics, ClusterMetadata? clusterMetadata)
+        => BuildCore(desiredTopics, clusterMetadata?.CaptureSnapshot());
+
+    public FetchSessionBuildResult BuildFromSnapshot(
+        IReadOnlyList<FetchRequestTopic> desiredTopics,
+        ClusterMetadataSnapshot metadataSnapshot)
+        => BuildCore(desiredTopics, metadataSnapshot);
+
+    private FetchSessionBuildResult BuildCore(
+        IReadOnlyList<FetchRequestTopic> desiredTopics,
+        ClusterMetadataSnapshot? metadataSnapshot)
     {
+        _responseMetadataSnapshot = _sessionMetadataSnapshot;
+        _lastBuildMetadataSnapshot = metadataSnapshot;
         var desiredPartitions = FlattenDesiredPartitions(desiredTopics);
         _lastDesiredPartitions = desiredPartitions;
 
@@ -45,7 +60,7 @@ internal sealed class FetchSessionHandler
         var changed = new List<(string Topic, Guid TopicId, FetchRequestPartition Partition)>();
         foreach (var topic in desiredTopics)
         {
-            var topicName = ResolveTopicName(topic, clusterMetadata);
+            var topicName = ResolveTopicName(topic, metadataSnapshot);
             foreach (var partition in topic.Partitions)
             {
                 var tp = new TopicPartition(topicName, partition.Partition);
@@ -55,7 +70,7 @@ internal sealed class FetchSessionHandler
             }
         }
 
-        var forgotten = BuildForgottenTopicsData(desiredPartitions, clusterMetadata);
+        var forgotten = BuildForgottenTopicsData(desiredPartitions, metadataSnapshot);
         _lastBuildWasFull = false;
 
         return new FetchSessionBuildResult(
@@ -80,6 +95,8 @@ internal sealed class FetchSessionHandler
         if (_lastBuildWasFull || _sessionId != 0)
             _sessionPartitions = new Dictionary<TopicPartition, CachedPartitionData>(_lastDesiredPartitions);
 
+        _sessionMetadataSnapshot = _lastBuildMetadataSnapshot;
+
         _nextEpoch = _sessionId == 0 ? InitialSessionEpoch : NextEpoch(_nextEpoch);
         return true;
     }
@@ -101,6 +118,9 @@ internal sealed class FetchSessionHandler
         _nextEpoch = InitialSessionEpoch;
         _sessionPartitions.Clear();
         _lastDesiredPartitions.Clear();
+        _sessionMetadataSnapshot = null;
+        _responseMetadataSnapshot = null;
+        _lastBuildMetadataSnapshot = null;
         _lastBuildWasFull = false;
     }
 
@@ -135,7 +155,7 @@ internal sealed class FetchSessionHandler
 
     private List<ForgottenTopic> BuildForgottenTopicsData(
         Dictionary<TopicPartition, CachedPartitionData> desiredPartitions,
-        ClusterMetadata? clusterMetadata)
+        ClusterMetadataSnapshot? metadataSnapshot)
     {
         Dictionary<string, List<int>>? forgottenPartitions = null;
         foreach (var tp in _sessionPartitions.Keys)
@@ -161,7 +181,10 @@ internal sealed class FetchSessionHandler
             result.Add(new ForgottenTopic
             {
                 Topic = kvp.Key,
-                TopicId = clusterMetadata?.GetTopic(kvp.Key)?.TopicId ?? Guid.Empty,
+                TopicId = metadataSnapshot is not null
+                    && metadataSnapshot.Topics.TryGetValue(kvp.Key, out var topicInfo)
+                        ? topicInfo.TopicId
+                        : Guid.Empty,
                 Partitions = [.. kvp.Value]
             });
         }
@@ -213,14 +236,32 @@ internal sealed class FetchSessionHandler
         return result;
     }
 
-    private static string ResolveTopicName(FetchRequestTopic topic, ClusterMetadata? clusterMetadata)
+    public bool TryResolveResponseTopicName(Guid topicId, out string topic)
+    {
+        if (_responseMetadataSnapshot is not null
+            && _responseMetadataSnapshot.TopicsById.TryGetValue(topicId, out var topicInfo))
+        {
+            topic = topicInfo.Name;
+            return true;
+        }
+
+        topic = string.Empty;
+        return false;
+    }
+
+    private static string ResolveTopicName(
+        FetchRequestTopic topic,
+        ClusterMetadataSnapshot? metadataSnapshot)
     {
         if (!string.IsNullOrEmpty(topic.Topic))
             return topic.Topic!;
 
         return topic.TopicId == Guid.Empty
             ? string.Empty
-            : clusterMetadata?.GetTopic(topic.TopicId)?.Name ?? string.Empty;
+            : metadataSnapshot is not null
+                && metadataSnapshot.TopicsById.TryGetValue(topic.TopicId, out var topicInfo)
+                    ? topicInfo.Name
+                    : string.Empty;
     }
 
     private static int NextEpoch(int current)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1085,6 +1085,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private readonly ConcurrentDictionary<TopicPartition, PreferredReadReplicaState> _preferredReadReplicas = new();
     private readonly object _leaderRefreshTasksLock = new();
     private readonly ConcurrentDictionary<string, Task> _pendingLeaderRefreshTasks = new();
+    // Topic identity checks run once per immutable metadata snapshot, never per message.
+    // The semaphore serializes the consume and prefetch loops when a new snapshot arrives.
+    private readonly SemaphoreSlim _topicIdentityLock = new(1, 1);
+    private readonly Dictionary<string, Guid> _observedTopicIds = [];
+    private ClusterMetadataSnapshot? _observedTopicIdentitySnapshot;
     private int _assignmentEnsureVersion;
     private int _lastManualAssignmentEnsureVersion = -1;
     private int _lastCoordinatorAssignmentVersion = -1;
@@ -3291,6 +3296,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     topic,
                                     partitionResponse,
                                     response.NodeEndpoints).ConfigureAwait(false);
+                            }
+                            else if (IsTopicIdentityRefreshError(partitionResponse.ErrorCode))
+                            {
+                                await HandleTopicIdentityRefreshAsync(
+                                    topic,
+                                    topicResponse.TopicId,
+                                    tp,
+                                    fetchSessionHandler,
+                                    cancellationToken).ConfigureAwait(false);
                             }
                             else
                             {
@@ -6651,6 +6665,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         Interlocked.Increment(ref _assignmentEnsureVersion);
         Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
+        Volatile.Write(ref _observedTopicIdentitySnapshot, null);
     }
 
     /// <summary>
@@ -6791,6 +6806,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private async ValueTask<Dictionary<int, List<TopicPartition>>> GroupPartitionsByBrokerAsync(CancellationToken cancellationToken)
     {
+        await HandleTopicIdentityChangesAsync(cancellationToken).ConfigureAwait(false);
+
         // Check cache and capture version to detect concurrent invalidation
         int capturedVersion;
         TopicPartition[] assignmentArray;
@@ -6897,6 +6914,115 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             return result;
+        }
+    }
+
+    private async ValueTask HandleTopicIdentityChangesAsync(
+        CancellationToken cancellationToken,
+        string? rejectedTopic = null,
+        Guid rejectedTopicId = default)
+    {
+        var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+        if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
+            return;
+
+        await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+            _topicIdentityLock,
+            nameof(KafkaConsumer<TKey, TValue>),
+            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+            if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
+                return;
+
+            if (rejectedTopic is { Length: > 0 } &&
+                rejectedTopicId != Guid.Empty &&
+                !_observedTopicIds.ContainsKey(rejectedTopic))
+            {
+                _observedTopicIds[rejectedTopic] = rejectedTopicId;
+            }
+
+            Dictionary<string, (Guid Previous, Guid Current)>? changedTopics = null;
+            var assignment = _assignmentSnapshot;
+            foreach (var partition in assignment)
+            {
+                if (!metadataSnapshot.Topics.TryGetValue(partition.Topic, out var topicInfo) ||
+                    topicInfo.TopicId == Guid.Empty)
+                {
+                    continue;
+                }
+
+                if (_observedTopicIds.TryGetValue(partition.Topic, out var previousTopicId) &&
+                    previousTopicId != Guid.Empty &&
+                    previousTopicId != topicInfo.TopicId)
+                {
+                    changedTopics ??= [];
+                    changedTopics[partition.Topic] = (previousTopicId, topicInfo.TopicId);
+                }
+                else
+                {
+                    _observedTopicIds[partition.Topic] = topicInfo.TopicId;
+                }
+            }
+
+            if (changedTopics is not null)
+            {
+                _coordinator?.RequestRejoin();
+
+                var recreatedPartitions = new HashSet<TopicPartition>();
+                foreach (var partition in assignment)
+                {
+                    if (changedTopics.ContainsKey(partition.Topic))
+                        recreatedPartitions.Add(partition);
+                }
+
+                ClearFetchBufferForPartitions(recreatedPartitions);
+                InvalidatePartitionCache();
+                InvalidateFetchRequestCache();
+                var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
+
+                foreach (var partition in recreatedPartitions)
+                {
+                    ClearStoredOffset(partition);
+                    _pendingRebalanceSeeks.TryRemove(partition, out _);
+                    _committed.TryRemove(partition, out _);
+                    _highWatermarks.TryRemove(partition, out _);
+                    _watermarks.TryRemove(partition, out _);
+                    _eofEmitted.TryRemove(partition, out _);
+
+                    var topicInfo = metadataSnapshot.Topics[partition.Topic];
+                    if ((uint)partition.Partition >= (uint)topicInfo.PartitionCount)
+                    {
+                        _positions.TryRemove(partition, out _);
+                        _fetchPositions.TryRemove(partition, out _);
+                        ClearLastConsumedLeaderEpoch(partition);
+                        continue;
+                    }
+
+                    await ResetOffsetOutOfRangeAsync(
+                        partition,
+                        fetchBufferEpoch,
+                        cancellationToken).ConfigureAwait(false);
+                    var identities = changedTopics[partition.Topic];
+                    var fetchPosition = _fetchPositions.GetValueOrDefault(partition, long.MinValue);
+                    LogTopicIdentityReset(
+                        partition.Topic,
+                        partition.Partition,
+                        identities.Previous,
+                        identities.Current,
+                        fetchPosition);
+                }
+
+                foreach (var (topic, identities) in changedTopics)
+                    _observedTopicIds[topic] = identities.Current;
+            }
+
+            Volatile.Write(ref _observedTopicIdentitySnapshot, metadataSnapshot);
+        }
+        finally
+        {
+            SemaphoreHelper.ReleaseSafely(_topicIdentityLock);
         }
     }
 
@@ -7143,6 +7269,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 topic,
                                 partitionResponse,
                                 response.NodeEndpoints).ConfigureAwait(false);
+                        }
+                        else if (IsTopicIdentityRefreshError(partitionResponse.ErrorCode))
+                        {
+                            await HandleTopicIdentityRefreshAsync(
+                                topic,
+                                topicResponse.TopicId,
+                                tp,
+                                fetchSessionHandler,
+                                cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -7442,6 +7577,35 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private static bool IsLeaderEpochRefreshError(ErrorCode errorCode) =>
         errorCode is ErrorCode.NotLeaderOrFollower or ErrorCode.FencedLeaderEpoch or ErrorCode.UnknownLeaderEpoch;
+
+    private static bool IsTopicIdentityRefreshError(ErrorCode errorCode) =>
+        errorCode is ErrorCode.UnknownTopicId or ErrorCode.UnknownTopicOrPartition;
+
+    private async ValueTask HandleTopicIdentityRefreshAsync(
+        string topic,
+        Guid rejectedTopicId,
+        TopicPartition partition,
+        FetchSessionHandler? fetchSessionHandler,
+        CancellationToken cancellationToken)
+    {
+        fetchSessionHandler?.HandleError();
+        ClearPreferredReadReplica(partition);
+
+        if (string.IsNullOrEmpty(topic) && rejectedTopicId != Guid.Empty)
+            topic = _metadataManager.Metadata.GetTopic(rejectedTopicId)?.Name ?? string.Empty;
+
+        if (string.IsNullOrEmpty(topic))
+            return;
+
+        await _metadataManager.RefreshMetadataAsync(
+            [topic],
+            forceRefresh: true,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        InvalidatePartitionCache();
+        await HandleTopicIdentityChangesAsync(cancellationToken, topic, rejectedTopicId)
+            .ConfigureAwait(false);
+    }
 
     private ValueTask HandleLeaderEpochRefreshAsync(
         string topic,
@@ -8720,6 +8884,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         _assignmentLock.Dispose();
         _initLock.Dispose();
+        _topicIdentityLock.Dispose();
         _prefetchMemoryAvailable.Dispose();
 
         if (_coordinator is not null)
@@ -8866,6 +9031,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "TopicId {TopicId} not found in local metadata, falling back to topic name from response")]
     private partial void LogUnknownTopicId(Guid topicId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Topic identity changed for {Topic}-{Partition} from {PreviousTopicId} to {CurrentTopicId}; reset fetch position to {FetchPosition}")]
+    private partial void LogTopicIdentityReset(
+        string topic,
+        int partition,
+        Guid previousTopicId,
+        Guid currentTopicId,
+        long fetchPosition);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ListOffsets error for {Topic}-{Partition}: {Error}")]
     private partial void LogListOffsetsError(string topic, int partition, ErrorCode error);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1089,7 +1089,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // The semaphore serializes the consume and prefetch loops when a new snapshot arrives.
     private readonly SemaphoreSlim _topicIdentityLock = new(1, 1);
     private readonly Dictionary<string, Guid> _observedTopicIds = [];
-    private ClusterMetadataSnapshot? _observedTopicIdentitySnapshot;
+    // A metadata snapshot means observation is current. An assignment snapshot is an invalidation token.
+    private object? _observedTopicIdentityMarker;
     private int _assignmentEnsureVersion;
     private int _lastManualAssignmentEnsureVersion = -1;
     private int _lastCoordinatorAssignmentVersion = -1;
@@ -3171,13 +3172,16 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             var fetchMaxBytes = CurrentFetchMaxBytes;
             // Build fetch request — pass index range to avoid GetRange allocation
-            var topicData = BuildFetchRequestTopicsForConnection(
+            var topicData = BuildFetchRequestTopicsForConnectionWithSnapshot(
                 partitions,
                 partitionStartIndex,
                 partitionCount,
                 brokerId,
-                connectionIndex);
-            FetchSessionBuildResult? fetchSessionBuild = fetchSessionHandler?.Build(topicData, _metadataManager.Metadata);
+                connectionIndex,
+                out var requestMetadataSnapshot);
+            FetchSessionBuildResult? fetchSessionBuild = fetchSessionHandler?.BuildFromSnapshot(
+                topicData,
+                requestMetadataSnapshot);
 
             var request = FetchRequest.Rent();
             request.MaxWaitMs = _options.FetchMaxWaitMs;
@@ -3239,13 +3243,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             var pendingItems = _prefetchPendingItemsByBroker.GetOrAdd((brokerId, connectionIndex), static _ => []);
             pendingItems.Clear();
             var queuedDivergingEpochReset = false;
+            Dictionary<string, Guid>? topicIdentityRefreshes = null;
 
             // Write to prefetch channel
             try
             {
                 foreach (var topicResponse in response.Responses)
                 {
-                    var topic = ResolveTopicName(topicResponse);
+                    var topic = ResolveTopicName(
+                        topicResponse,
+                        requestMetadataSnapshot,
+                        fetchSessionHandler);
+                    if (string.IsNullOrEmpty(topic))
+                        continue;
+
                     var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
 
                     foreach (var partitionResponse in topicResponse.Partitions)
@@ -3299,12 +3310,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             }
                             else if (IsTopicIdentityRefreshError(partitionResponse.ErrorCode))
                             {
-                                await HandleTopicIdentityRefreshAsync(
+                                QueueTopicIdentityRefresh(
+                                    ref topicIdentityRefreshes,
                                     topic,
                                     topicResponse.TopicId,
-                                    tp,
-                                    fetchSessionHandler,
-                                    cancellationToken).ConfigureAwait(false);
+                                    tp);
                             }
                             else
                             {
@@ -3346,6 +3356,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             }
                         }
                     }
+                }
+
+                if (topicIdentityRefreshes is not null)
+                {
+                    await HandleTopicIdentityRefreshesAsync(
+                        topicIdentityRefreshes,
+                        fetchSessionHandler,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
             catch
@@ -6665,7 +6683,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
         Interlocked.Increment(ref _assignmentEnsureVersion);
         Volatile.Write(ref _lastCoordinatorAssignmentVersion, -1);
-        Volatile.Write(ref _observedTopicIdentitySnapshot, null);
+        Volatile.Write(ref _observedTopicIdentityMarker, assignmentSnapshot);
     }
 
     /// <summary>
@@ -6923,18 +6941,29 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         Guid rejectedTopicId = default)
     {
         var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
-        if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
+        if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentityMarker)))
             return ValueTask.CompletedTask;
 
         return HandleTopicIdentityChangesSlowAsync(
             rejectedTopic,
             rejectedTopicId,
-            cancellationToken);
+            rejectedTopics: null,
+            cancellationToken: cancellationToken);
     }
+
+    private ValueTask HandleRejectedTopicIdentityChangesAsync(
+        Dictionary<string, Guid> rejectedTopics,
+        CancellationToken cancellationToken) =>
+        HandleTopicIdentityChangesSlowAsync(
+            rejectedTopic: null,
+            rejectedTopicId: default,
+            rejectedTopics: rejectedTopics,
+            cancellationToken: cancellationToken);
 
     private async ValueTask HandleTopicIdentityChangesSlowAsync(
         string? rejectedTopic,
         Guid rejectedTopicId,
+        Dictionary<string, Guid>? rejectedTopics,
         CancellationToken cancellationToken)
     {
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(
@@ -6944,7 +6973,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         try
         {
             var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
-            if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
+            var observedTopicIdentityMarker = Volatile.Read(ref _observedTopicIdentityMarker);
+            if (rejectedTopics is null
+                && rejectedTopic is not { Length: > 0 }
+                && ReferenceEquals(metadataSnapshot, observedTopicIdentityMarker))
                 return;
 
             if (rejectedTopic is { Length: > 0 } &&
@@ -6952,6 +6984,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 !_observedTopicIds.ContainsKey(rejectedTopic))
             {
                 _observedTopicIds[rejectedTopic] = rejectedTopicId;
+            }
+
+            if (rejectedTopics is not null)
+            {
+                foreach (var (topic, topicId) in rejectedTopics)
+                {
+                    if (topicId != Guid.Empty && !_observedTopicIds.ContainsKey(topic))
+                        _observedTopicIds[topic] = topicId;
+                }
             }
 
             Dictionary<string, (Guid Previous, Guid Current)>? changedTopics = null;
@@ -7059,7 +7100,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     _observedTopicIds[topic] = identities.Current;
             }
 
-            Volatile.Write(ref _observedTopicIdentitySnapshot, metadataSnapshot);
+            // Publish only if no assignment snapshot replaced the marker while resets awaited.
+            Interlocked.CompareExchange(
+                ref _observedTopicIdentityMarker,
+                metadataSnapshot,
+                observedTopicIdentityMarker);
         }
         finally
         {
@@ -7229,13 +7274,18 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         await ResolveSpecialOffsetsAsync(partitions, 0, partitions.Count, cancellationToken).ConfigureAwait(false);
 
         // Build fetch request - use imperative code to avoid LINQ allocations
-        var topicData = BuildFetchRequestTopics(partitions, 0, partitions.Count, brokerId);
+        var topicData = BuildFetchRequestTopicsWithSnapshot(
+            partitions,
+            0,
+            partitions.Count,
+            brokerId,
+            out var requestMetadataSnapshot);
         FetchSessionHandler? fetchSessionHandler = null;
         FetchSessionBuildResult? fetchSessionBuild = null;
         if (ShouldUseFetchSessions && apiVersion >= 7)
         {
             fetchSessionHandler = _fetchSessions.GetOrAdd((brokerId, 0), static _ => new FetchSessionHandler());
-            fetchSessionBuild = fetchSessionHandler.Build(topicData, _metadataManager.Metadata);
+            fetchSessionBuild = fetchSessionHandler.BuildFromSnapshot(topicData, requestMetadataSnapshot);
         }
 
         var request = FetchRequest.Rent();
@@ -7293,13 +7343,20 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Collect pending fetch data items - we need to assign memory owner to the last one
         List<PendingFetchData>? pendingItems = null;
         var queuedDivergingEpochReset = false;
+        Dictionary<string, Guid>? topicIdentityRefreshes = null;
 
         // Queue pending fetch data for lazy iteration - don't parse records yet!
         try
         {
             foreach (var topicResponse in response.Responses)
             {
-                var topic = ResolveTopicName(topicResponse);
+                var topic = ResolveTopicName(
+                    topicResponse,
+                    requestMetadataSnapshot,
+                    fetchSessionHandler);
+                if (string.IsNullOrEmpty(topic))
+                    continue;
+
                 var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
 
                 foreach (var partitionResponse in topicResponse.Partitions)
@@ -7354,12 +7411,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
                         else if (IsTopicIdentityRefreshError(partitionResponse.ErrorCode))
                         {
-                            await HandleTopicIdentityRefreshAsync(
+                            QueueTopicIdentityRefresh(
+                                ref topicIdentityRefreshes,
                                 topic,
                                 topicResponse.TopicId,
-                                tp,
-                                fetchSessionHandler,
-                                cancellationToken).ConfigureAwait(false);
+                                tp);
                         }
                         else
                         {
@@ -7406,6 +7462,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         }
                     }
                 }
+            }
+
+            if (topicIdentityRefreshes is not null)
+            {
+                await HandleTopicIdentityRefreshesAsync(
+                    topicIdentityRefreshes,
+                    fetchSessionHandler,
+                    cancellationToken).ConfigureAwait(false);
             }
         }
         catch
@@ -7663,29 +7727,31 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private static bool IsTopicIdentityRefreshError(ErrorCode errorCode) =>
         errorCode is ErrorCode.UnknownTopicId or ErrorCode.UnknownTopicOrPartition;
 
-    private async ValueTask HandleTopicIdentityRefreshAsync(
+    private void QueueTopicIdentityRefresh(
+        ref Dictionary<string, Guid>? topicIdentityRefreshes,
         string topic,
         Guid rejectedTopicId,
-        TopicPartition partition,
+        TopicPartition partition)
+    {
+        ClearPreferredReadReplica(partition);
+        topicIdentityRefreshes ??= new Dictionary<string, Guid>(StringComparer.Ordinal);
+        topicIdentityRefreshes.TryAdd(topic, rejectedTopicId);
+    }
+
+    private async ValueTask HandleTopicIdentityRefreshesAsync(
+        Dictionary<string, Guid> rejectedTopics,
         FetchSessionHandler? fetchSessionHandler,
         CancellationToken cancellationToken)
     {
         fetchSessionHandler?.HandleError();
-        ClearPreferredReadReplica(partition);
-
-        if (string.IsNullOrEmpty(topic) && rejectedTopicId != Guid.Empty)
-            topic = _metadataManager.Metadata.GetTopic(rejectedTopicId)?.Name ?? string.Empty;
-
-        if (string.IsNullOrEmpty(topic))
-            return;
 
         await _metadataManager.RefreshMetadataAsync(
-            [topic],
+            rejectedTopics.Keys,
             forceRefresh: true,
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         InvalidatePartitionCache();
-        await HandleTopicIdentityChangesAsync(cancellationToken, topic, rejectedTopicId)
+        await HandleRejectedTopicIdentityChangesAsync(rejectedTopics, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -7886,8 +7952,58 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         List<TopicPartition> partitions, int startIndex, int count, int brokerId)
         => BuildFetchRequestTopicsForConnection(partitions, startIndex, count, brokerId, connectionIndex: 0);
 
+    private List<FetchRequestTopic> BuildFetchRequestTopicsWithSnapshot(
+        List<TopicPartition> partitions,
+        int startIndex,
+        int count,
+        int brokerId,
+        out ClusterMetadataSnapshot metadataSnapshot)
+        => BuildFetchRequestTopicsForConnectionWithSnapshot(
+            partitions,
+            startIndex,
+            count,
+            brokerId,
+            connectionIndex: 0,
+            out metadataSnapshot);
+
     private List<FetchRequestTopic> BuildFetchRequestTopicsForConnection(
         List<TopicPartition> partitions, int startIndex, int count, int brokerId, int connectionIndex)
+    {
+        var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+        return BuildFetchRequestTopicsForConnectionCore(
+            partitions,
+            startIndex,
+            count,
+            brokerId,
+            connectionIndex,
+            metadataSnapshot);
+    }
+
+    private List<FetchRequestTopic> BuildFetchRequestTopicsForConnectionWithSnapshot(
+        List<TopicPartition> partitions,
+        int startIndex,
+        int count,
+        int brokerId,
+        int connectionIndex,
+        out ClusterMetadataSnapshot metadataSnapshot)
+    {
+        metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+        return BuildFetchRequestTopicsForConnectionCore(
+            partitions,
+            startIndex,
+            count,
+            brokerId,
+            connectionIndex,
+            metadataSnapshot);
+    }
+
+    private List<FetchRequestTopic> BuildFetchRequestTopicsForConnectionCore(
+        List<TopicPartition> partitions,
+        int startIndex,
+        int count,
+        int brokerId,
+        int connectionIndex,
+        ClusterMetadataSnapshot metadataSnapshot)
     {
         if (count == 0)
             return ConsumerFetchPools.RentFetchRequestTopicList(0);
@@ -7921,8 +8037,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     cachedEntry.TopicPartitions,
                     _fetchPositions,
                     _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-                    _metadataManager.Metadata,
-                    _lastConsumedLeaderEpochs)
+                    metadataSnapshot: metadataSnapshot,
+                    lastConsumedLeaderEpochs: _lastConsumedLeaderEpochs)
                 : BuildRotatedFetchResult(
                     cachedEntry.TopicPartitions,
                     _fetchPositions,
@@ -7930,8 +8046,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     cachedRotationStart.TopicIndex,
                     cachedRotationStart.PartitionIndex,
                     _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-                    _metadataManager.Metadata,
-                    _lastConsumedLeaderEpochs);
+                    metadataSnapshot: metadataSnapshot,
+                    lastConsumedLeaderEpochs: _lastConsumedLeaderEpochs);
         }
 
         // Cache miss: build fresh structure with TopicPartition stored alongside.
@@ -7976,8 +8092,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 topicPartitions,
                 _fetchPositions,
                 _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-                _metadataManager.Metadata,
-                _lastConsumedLeaderEpochs)
+                metadataSnapshot: metadataSnapshot,
+                lastConsumedLeaderEpochs: _lastConsumedLeaderEpochs)
             : BuildRotatedFetchResult(
                 topicPartitions,
                 _fetchPositions,
@@ -7985,8 +8101,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 newRotationStart.TopicIndex,
                 newRotationStart.PartitionIndex,
                 _adaptiveFetchSizer?.CurrentPartitionFetchBytes,
-                _metadataManager.Metadata,
-                _lastConsumedLeaderEpochs);
+                metadataSnapshot: metadataSnapshot,
+                lastConsumedLeaderEpochs: _lastConsumedLeaderEpochs);
 
         // Update cache if this range is new or the cached partition range is stale.
         lock (_fetchCacheLock)
@@ -8039,17 +8155,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// cannot observe each other's offset values.
     /// Allocation is per fetch cycle (per-batch), not per-message.
     /// </summary>
-    private string ResolveTopicName(FetchResponseTopic topicResponse)
+    private string ResolveTopicName(
+        FetchResponseTopic topicResponse,
+        ClusterMetadataSnapshot requestMetadataSnapshot,
+        FetchSessionHandler? fetchSessionHandler)
     {
         if (topicResponse.TopicId != Guid.Empty)
         {
-            var resolved = _metadataManager.Metadata.GetTopic(topicResponse.TopicId)?.Name;
-            if (resolved is not null)
+            if (requestMetadataSnapshot.TopicsById.TryGetValue(topicResponse.TopicId, out var requestTopic))
             {
-                return resolved;
+                return requestTopic.Name;
             }
 
-            // TopicId present but not in local metadata — fall back to topic name from response
+            if (fetchSessionHandler?.TryResolveResponseTopicName(topicResponse.TopicId, out var sessionTopic) == true)
+            {
+                return sessionTopic;
+            }
+
             LogUnknownTopicId(topicResponse.TopicId);
             return topicResponse.Topic ?? string.Empty;
         }
@@ -8062,8 +8184,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
         int? adaptivePartitionMaxBytes = null,
         ClusterMetadata? clusterMetadata = null,
-        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null)
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null,
+        ClusterMetadataSnapshot? metadataSnapshot = null)
     {
+        metadataSnapshot ??= clusterMetadata?.CaptureSnapshot();
         var result = ConsumerFetchPools.RentFetchRequestTopicList(templateDict.Count);
 
         foreach (var kvp in templateDict)
@@ -8076,7 +8200,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (!fetchPositions.TryGetValue(tp, out var fetchOffset))
                     continue;
 
-                var currentLeaderEpoch = clusterMetadata?.GetPartitionInfo(tp.Topic, tp.Partition)?.LeaderEpoch ?? -1;
+                var currentLeaderEpoch = GetLeaderEpoch(metadataSnapshot, tp);
                 partitionList.Add(new FetchRequestPartition
                 {
                     Partition = template.Partition,
@@ -8097,7 +8221,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             result.Add(new FetchRequestTopic
             {
                 Topic = kvp.Key,
-                TopicId = clusterMetadata?.GetTopic(kvp.Key)?.TopicId ?? Guid.Empty,
+                TopicId = GetTopicId(metadataSnapshot, kvp.Key),
                 Partitions = partitionList
             });
         }
@@ -8113,8 +8237,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         int partitionRotation,
         int? adaptivePartitionMaxBytes = null,
         ClusterMetadata? clusterMetadata = null,
-        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null)
+        ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs = null,
+        ClusterMetadataSnapshot? metadataSnapshot = null)
     {
+        metadataSnapshot ??= clusterMetadata?.CaptureSnapshot();
         var result = ConsumerFetchPools.RentFetchRequestTopicList(templateDict.Count);
         var topicCount = topicOrder.Count;
         var topicStart = (int)((uint)topicRotation % (uint)topicCount);
@@ -8127,7 +8253,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 templateDict[topic],
                 fetchPositions,
                 adaptivePartitionMaxBytes,
-                clusterMetadata,
+                metadataSnapshot,
                 lastConsumedLeaderEpochs,
                 partitionRotation);
         }
@@ -8141,7 +8267,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         List<(FetchRequestPartition Partition, TopicPartition TopicPartition)> cachedPartitions,
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
         int? adaptivePartitionMaxBytes,
-        ClusterMetadata? clusterMetadata,
+        ClusterMetadataSnapshot? metadataSnapshot,
         ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs,
         int partitionRotation)
     {
@@ -8155,7 +8281,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 cachedPartitions[partitionIndex],
                 fetchPositions,
                 adaptivePartitionMaxBytes,
-                clusterMetadata,
+                metadataSnapshot,
                 lastConsumedLeaderEpochs);
 
         for (var partitionIndex = 0; partitionIndex < partitionStart; partitionIndex++)
@@ -8164,7 +8290,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 cachedPartitions[partitionIndex],
                 fetchPositions,
                 adaptivePartitionMaxBytes,
-                clusterMetadata,
+                metadataSnapshot,
                 lastConsumedLeaderEpochs);
 
         if (partitionList.Count == 0)
@@ -8176,7 +8302,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         result.Add(new FetchRequestTopic
         {
             Topic = topic,
-            TopicId = clusterMetadata?.GetTopic(topic)?.TopicId ?? Guid.Empty,
+            TopicId = GetTopicId(metadataSnapshot, topic),
             Partitions = partitionList
         });
     }
@@ -8187,14 +8313,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         (FetchRequestPartition Partition, TopicPartition TopicPartition) cachedPartition,
         ConcurrentDictionary<TopicPartition, long> fetchPositions,
         int? adaptivePartitionMaxBytes,
-        ClusterMetadata? clusterMetadata,
+        ClusterMetadataSnapshot? metadataSnapshot,
         ConcurrentDictionary<TopicPartition, int>? lastConsumedLeaderEpochs)
     {
         var (template, tp) = cachedPartition;
         if (!fetchPositions.TryGetValue(tp, out var fetchOffset))
             return;
 
-        var currentLeaderEpoch = clusterMetadata?.GetPartitionInfo(tp.Topic, tp.Partition)?.LeaderEpoch ?? -1;
+        var currentLeaderEpoch = GetLeaderEpoch(metadataSnapshot, tp);
         partitionList.Add(new FetchRequestPartition
         {
             Partition = template.Partition,
@@ -8204,6 +8330,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             LogStartOffset = template.LogStartOffset,
             PartitionMaxBytes = adaptivePartitionMaxBytes ?? template.PartitionMaxBytes
         });
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Guid GetTopicId(ClusterMetadataSnapshot? metadataSnapshot, string topic) =>
+        metadataSnapshot is not null && metadataSnapshot.Topics.TryGetValue(topic, out var topicInfo)
+            ? topicInfo.TopicId
+            : Guid.Empty;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetLeaderEpoch(ClusterMetadataSnapshot? metadataSnapshot, TopicPartition partition)
+    {
+        if (metadataSnapshot is null
+            || !metadataSnapshot.PartitionsByTopicIndex.TryGetValue(partition.Topic, out var partitions)
+            || (uint)partition.Partition >= (uint)partitions.Length)
+        {
+            return -1;
+        }
+
+        return partitions[partition.Partition]?.LeaderEpoch ?? -1;
     }
 
     internal static List<ForgottenTopic> BuildForgottenTopicsData(

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -915,7 +915,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // #2211). The _paused/_pausedSnapshot pair follows the same split.
     private readonly ConcurrentDictionary<string, byte> _subscription = new();
     private readonly HashSet<TopicPartition> _assignment = [];
-    private volatile TopicPartitionSet _assignmentSnapshot = new HashSet<TopicPartition>();
+    private volatile HashSet<TopicPartition> _assignmentSnapshot = [];
     private readonly ConcurrentDictionary<TopicPartition, byte> _paused = new();
     private volatile StringSet _subscriptionSnapshot = new HashSet<string>();
     private volatile TopicPartitionSet _pausedSnapshot = new HashSet<TopicPartition>();
@@ -6917,22 +6917,33 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
     }
 
-    private async ValueTask HandleTopicIdentityChangesAsync(
+    private ValueTask HandleTopicIdentityChangesAsync(
         CancellationToken cancellationToken,
         string? rejectedTopic = null,
         Guid rejectedTopicId = default)
     {
         var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
         if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
-            return;
+            return ValueTask.CompletedTask;
 
+        return HandleTopicIdentityChangesSlowAsync(
+            rejectedTopic,
+            rejectedTopicId,
+            cancellationToken);
+    }
+
+    private async ValueTask HandleTopicIdentityChangesSlowAsync(
+        string? rejectedTopic,
+        Guid rejectedTopicId,
+        CancellationToken cancellationToken)
+    {
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(
             _topicIdentityLock,
             nameof(KafkaConsumer<TKey, TValue>),
             cancellationToken).ConfigureAwait(false);
         try
         {
-            metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
+            var metadataSnapshot = _metadataManager.Metadata.CaptureSnapshot();
             if (ReferenceEquals(metadataSnapshot, Volatile.Read(ref _observedTopicIdentitySnapshot)))
                 return;
 
@@ -6944,9 +6955,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             }
 
             Dictionary<string, (Guid Previous, Guid Current)>? changedTopics = null;
+            var assignedTopics = new HashSet<string>(StringComparer.Ordinal);
             var assignment = _assignmentSnapshot;
             foreach (var partition in assignment)
             {
+                assignedTopics.Add(partition.Topic);
+
                 if (!metadataSnapshot.Topics.TryGetValue(partition.Topic, out var topicInfo) ||
                     topicInfo.TopicId == Guid.Empty)
                 {
@@ -6965,6 +6979,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     _observedTopicIds[partition.Topic] = topicInfo.TopicId;
                 }
             }
+            PruneObservedTopicIds(assignedTopics);
 
             if (changedTopics is not null)
             {
@@ -6981,37 +6996,63 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 InvalidatePartitionCache();
                 InvalidateFetchRequestCache();
                 var fetchBufferEpoch = Volatile.Read(ref _fetchBufferEpoch);
+                Task[]? resetTasks = null;
+                var resetTaskCount = 0;
 
-                foreach (var partition in recreatedPartitions)
+                try
                 {
-                    ClearStoredOffset(partition);
-                    _pendingRebalanceSeeks.TryRemove(partition, out _);
-                    _committed.TryRemove(partition, out _);
-                    _highWatermarks.TryRemove(partition, out _);
-                    _watermarks.TryRemove(partition, out _);
-                    _eofEmitted.TryRemove(partition, out _);
-
-                    var topicInfo = metadataSnapshot.Topics[partition.Topic];
-                    if ((uint)partition.Partition >= (uint)topicInfo.PartitionCount)
+                    foreach (var partition in recreatedPartitions)
                     {
-                        _positions.TryRemove(partition, out _);
-                        _fetchPositions.TryRemove(partition, out _);
-                        ClearLastConsumedLeaderEpoch(partition);
-                        continue;
+                        ClearStoredOffset(partition);
+                        _pendingRebalanceSeeks.TryRemove(partition, out _);
+                        _committed.TryRemove(partition, out _);
+                        _highWatermarks.TryRemove(partition, out _);
+                        _watermarks.TryRemove(partition, out _);
+                        _eofEmitted.TryRemove(partition, out _);
+
+                        var topicInfo = metadataSnapshot.Topics[partition.Topic];
+                        if ((uint)partition.Partition >= (uint)topicInfo.PartitionCount)
+                        {
+                            _positions.TryRemove(partition, out _);
+                            _fetchPositions.TryRemove(partition, out _);
+                            ClearLastConsumedLeaderEpoch(partition);
+                            continue;
+                        }
+
+                        var identities = changedTopics[partition.Topic];
+                        var reset = ResetOffsetOutOfRangeAsync(
+                            partition,
+                            fetchBufferEpoch,
+                            cancellationToken);
+                        if (reset.IsCompletedSuccessfully)
+                        {
+                            reset.GetAwaiter().GetResult();
+                            LogTopicIdentityReset(partition, identities);
+                            continue;
+                        }
+
+                        resetTasks ??= ArrayPool<Task>.Shared.Rent(recreatedPartitions.Count);
+                        resetTasks[resetTaskCount++] = CompleteTopicIdentityResetAsync(
+                            reset,
+                            partition,
+                            identities);
                     }
 
-                    await ResetOffsetOutOfRangeAsync(
-                        partition,
-                        fetchBufferEpoch,
-                        cancellationToken).ConfigureAwait(false);
-                    var identities = changedTopics[partition.Topic];
-                    var fetchPosition = _fetchPositions.GetValueOrDefault(partition, long.MinValue);
-                    LogTopicIdentityReset(
-                        partition.Topic,
-                        partition.Partition,
-                        identities.Previous,
-                        identities.Current,
-                        fetchPosition);
+#if NETSTANDARD2_0
+                    if (resetTaskCount > 0)
+                        await Task.WhenAll(resetTasks!.Take(resetTaskCount)).ConfigureAwait(false);
+#else
+                    if (resetTaskCount > 0)
+                    {
+                        await Task.WhenAll(
+                            new ReadOnlySpan<Task>(resetTasks!, 0, resetTaskCount)).ConfigureAwait(false);
+                    }
+#endif
+                }
+                finally
+                {
+                    if (resetTasks is not null)
+                        ArrayPool<Task>.Shared.Return(resetTasks, clearArray: true);
                 }
 
                 foreach (var (topic, identities) in changedTopics)
@@ -7024,6 +7065,47 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             SemaphoreHelper.ReleaseSafely(_topicIdentityLock);
         }
+    }
+
+    private void PruneObservedTopicIds(HashSet<string> assignedTopics)
+    {
+        List<string>? removedTopics = null;
+        foreach (var topic in _observedTopicIds.Keys)
+        {
+            if (assignedTopics.Contains(topic))
+                continue;
+
+            removedTopics ??= [];
+            removedTopics.Add(topic);
+        }
+
+        if (removedTopics is null)
+            return;
+
+        foreach (var topic in removedTopics)
+            _observedTopicIds.Remove(topic);
+    }
+
+    private async Task CompleteTopicIdentityResetAsync(
+        ValueTask reset,
+        TopicPartition partition,
+        (Guid Previous, Guid Current) identities)
+    {
+        await reset.ConfigureAwait(false);
+        LogTopicIdentityReset(partition, identities);
+    }
+
+    private void LogTopicIdentityReset(
+        TopicPartition partition,
+        (Guid Previous, Guid Current) identities)
+    {
+        var fetchPosition = _fetchPositions.GetValueOrDefault(partition, long.MinValue);
+        LogTopicIdentityReset(
+            partition.Topic,
+            partition.Partition,
+            identities.Previous,
+            identities.Current,
+            fetchPosition);
     }
 
     private bool IsPartitionBrokerCacheValid(PartitionBrokerCacheEntry cached, long now)

--- a/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
+++ b/tests/Dekaf.Tests.Integration/CustomSerializerErrorTests.cs
@@ -251,6 +251,9 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
 
         await Assert.That(caughtException).IsNotNull();
         var failedRecord = caughtException!;
+        // Stop background prefetch from repeatedly refilling the failed offset while the
+        // dead-letter write completes. Seek drains any in-flight fetch before Resume.
+        consumer.Pause(tp);
         await Assert.That(failedRecord.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
         await Assert.That(failedRecord.TopicPartition).IsEqualTo(tp);
         await Assert.That(failedRecord.Offset).IsEqualTo(0L);
@@ -284,6 +287,7 @@ public class CustomSerializerErrorTests(KafkaTestContainer kafka) : KafkaIntegra
 
         // Seek past the bad message to offset 1 (the normal message)
         consumer.Seek(new TopicPartitionOffset(topic, 0, 1));
+        consumer.Resume(tp);
 
         // Second consume attempt - should succeed for the normal message
         using var cts2 = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
@@ -1,0 +1,469 @@
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Resilience")]
+public sealed class TopicRecreationIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    private static readonly TimeSpan MetadataMaxAge = TimeSpan.FromSeconds(1);
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task Producer_TopicRecreated_RefreshesTopicIdAndContinues(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var producer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+
+        await ProduceAsync(producer, topic, partition: 0, "old", cancellationToken).ConfigureAwait(false);
+        var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+        var newTopicId = await RecreateTopicAsync(
+            admin,
+            topic,
+            oldTopicId,
+            partitions: 1,
+            cancellationToken).ConfigureAwait(false);
+
+        await ProduceAsync(producer, topic, partition: 0, "new-0", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(producer, topic, partition: 0, "new-1", cancellationToken).ConfigureAwait(false);
+
+        await using var verifier = await CreateAssignedConsumerAsync(topic, cancellationToken)
+            .ConfigureAwait(false);
+        var records = await ConsumeCountAsync(verifier, count: 2, cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(newTopicId).IsNotEqualTo(oldTopicId);
+        await Assert.That(records.Select(static record => record.Value)).IsEquivalentTo(["new-0", "new-1"]);
+        await Assert.That(records.Select(static record => record.Offset)).IsEquivalentTo([0L, 1L]);
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task Consumer_TopicRecreated_AppliesEarliestOffsetReset(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"topic-recreate-earliest-{Guid.NewGuid():N}";
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var initialProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await using var consumer = await CreateGroupConsumerAsync(topic, groupId, cancellationToken)
+            .ConfigureAwait(false);
+
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-0", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-1", cancellationToken).ConfigureAwait(false);
+        var oldRecords = await ConsumeCountAsync(consumer, count: 2, cancellationToken).ConfigureAwait(false);
+        await consumer.CommitAsync([
+            new TopicPartitionOffset(topic, partition: 0, offset: 2, leaderEpoch: -1)
+        ], cancellationToken).ConfigureAwait(false);
+
+        var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+        _ = await RecreateTopicAsync(admin, topic, oldTopicId, partitions: 1, cancellationToken)
+            .ConfigureAwait(false);
+        await using var newProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-0", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-1", cancellationToken).ConfigureAwait(false);
+
+        var firstRecreatedRecord = await ConsumeMatchingAsync(
+            consumer,
+            static record => record.Value.StartsWith("new-", StringComparison.Ordinal),
+            cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(oldRecords.Select(static record => record.Value)).IsEquivalentTo(["old-0", "old-1"]);
+        await Assert.That(firstRecreatedRecord.Value).IsEqualTo("new-0");
+        await Assert.That(firstRecreatedRecord.Offset).IsEqualTo(0);
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task Consumer_TopicRecreated_AppliesLatestOffsetReset(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"topic-recreate-latest-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var initialProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await using var consumer = await CreateGroupConsumerAsync(
+            topic,
+            groupId,
+            AutoOffsetReset.Latest,
+            cancellationToken).ConfigureAwait(false);
+
+        await WaitForPositionWithoutRecordsAsync(consumer, partition, expectedPosition: 0, cancellationToken)
+            .ConfigureAwait(false);
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-0", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-1", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-2", cancellationToken).ConfigureAwait(false);
+        _ = await ConsumeCountAsync(consumer, count: 3, cancellationToken).ConfigureAwait(false);
+        await consumer.CommitAsync([
+            new TopicPartitionOffset(topic, partition: 0, offset: 3, leaderEpoch: -1)
+        ], cancellationToken).ConfigureAwait(false);
+
+        var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+        _ = await RecreateTopicAsync(admin, topic, oldTopicId, partitions: 1, cancellationToken)
+            .ConfigureAwait(false);
+        await using var newProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-before-reset-0", cancellationToken)
+            .ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-before-reset-1", cancellationToken)
+            .ConfigureAwait(false);
+
+        await WaitForPositionWithoutRecordsAsync(consumer, partition, expectedPosition: 2, cancellationToken)
+            .ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-after-reset", cancellationToken)
+            .ConfigureAwait(false);
+
+        var firstRecordAfterReset = await ConsumeMatchingAsync(
+            consumer,
+            static record => record.Value.StartsWith("new-", StringComparison.Ordinal),
+            cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(firstRecordAfterReset.Value).IsEqualTo("new-after-reset");
+        await Assert.That(firstRecordAfterReset.Offset).IsEqualTo(2);
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task Consumer_TopicRecreatedWithFewerPartitions_DropsVanishedPartition(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 2).ConfigureAwait(false);
+        var groupId = $"topic-recreate-shrink-{Guid.NewGuid():N}";
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var initialProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await using var consumer = await CreateGroupConsumerAsync(topic, groupId, cancellationToken)
+            .ConfigureAwait(false);
+
+        await ProduceAsync(initialProducer, topic, partition: 0, "old-p0", cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(initialProducer, topic, partition: 1, "old-p1", cancellationToken).ConfigureAwait(false);
+        _ = await ConsumeCountAsync(consumer, count: 2, cancellationToken).ConfigureAwait(false);
+
+        var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+        _ = await RecreateTopicAsync(admin, topic, oldTopicId, partitions: 1, cancellationToken)
+            .ConfigureAwait(false);
+        await using var newProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+        await ProduceAsync(newProducer, topic, partition: 0, "new-p0", cancellationToken).ConfigureAwait(false);
+
+        var recreatedRecord = await ConsumeMatchingAsync(
+            consumer,
+            static record => record.Value == "new-p0",
+            cancellationToken).ConfigureAwait(false);
+        await WaitForAssignmentAsync(
+            consumer,
+            assignment => assignment.Count == 1 && assignment.Contains(new TopicPartition(topic, 0)),
+            cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(recreatedRecord.Partition).IsEqualTo(0);
+        await Assert.That(recreatedRecord.Offset).IsEqualTo(0);
+        await Assert.That(consumer.Assignment).DoesNotContain(new TopicPartition(topic, 1));
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task Commit_AgainstRecreatedTopic_DoesNotResurrectStaleOffsets(
+        CancellationToken cancellationToken)
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"topic-recreate-commit-{Guid.NewGuid():N}";
+        await using var admin = KafkaContainer.CreateAdminClient();
+        await using var initialProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+
+        await using (var consumer = await CreateGroupConsumerAsync(topic, groupId, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            await ProduceAsync(initialProducer, topic, partition: 0, "old-0", cancellationToken)
+                .ConfigureAwait(false);
+            await ProduceAsync(initialProducer, topic, partition: 0, "old-1", cancellationToken)
+                .ConfigureAwait(false);
+            _ = await ConsumeCountAsync(consumer, count: 2, cancellationToken).ConfigureAwait(false);
+            await consumer.CommitAsync([
+                new TopicPartitionOffset(topic, partition: 0, offset: 2, leaderEpoch: -1)
+            ], cancellationToken).ConfigureAwait(false);
+
+            var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+            _ = await RecreateTopicAsync(admin, topic, oldTopicId, partitions: 1, cancellationToken)
+                .ConfigureAwait(false);
+            await using var newProducer = await CreateProducerAsync(cancellationToken).ConfigureAwait(false);
+            await ProduceAsync(newProducer, topic, partition: 0, "new-0", cancellationToken)
+                .ConfigureAwait(false);
+
+            var recreatedRecord = await ConsumeMatchingAsync(
+                consumer,
+                static record => record.Value == "new-0",
+                cancellationToken).ConfigureAwait(false);
+            await consumer.CommitAsync([
+                new TopicPartitionOffset(
+                    topic,
+                    partition: 0,
+                    offset: recreatedRecord.Offset + 1,
+                    leaderEpoch: recreatedRecord.LeaderEpoch ?? -1)
+            ], cancellationToken).ConfigureAwait(false);
+            await ProduceAsync(newProducer, topic, partition: 0, "new-1", cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await using var restartedConsumer = await CreateGroupConsumerAsync(topic, groupId, cancellationToken)
+            .ConfigureAwait(false);
+        var resumedRecord = await ConsumeMatchingAsync(
+            restartedConsumer,
+            static record => record.Value.StartsWith("new-", StringComparison.Ordinal),
+            cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(resumedRecord.Value).IsEqualTo("new-1");
+        await Assert.That(resumedRecord.Offset).IsEqualTo(1);
+    }
+
+    private async Task<IKafkaProducer<string, string>> CreateProducerAsync(
+        CancellationToken cancellationToken) =>
+        await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithMetadataMaxAge(MetadataMaxAge)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    private async Task<IKafkaConsumer<string, string>> CreateGroupConsumerAsync(
+        string topic,
+        string groupId,
+        CancellationToken cancellationToken) =>
+        await CreateGroupConsumerAsync(topic, groupId, AutoOffsetReset.Earliest, cancellationToken)
+            .ConfigureAwait(false);
+
+    private async Task<IKafkaConsumer<string, string>> CreateGroupConsumerAsync(
+        string topic,
+        string groupId,
+        AutoOffsetReset autoOffsetReset,
+        CancellationToken cancellationToken)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(autoOffsetReset)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithAutoOffsetStore(false)
+            .WithMetadataMaxAge(MetadataMaxAge)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.Subscribe(topic);
+        return consumer;
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateAssignedConsumerAsync(
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken)
+            .ConfigureAwait(false);
+        consumer.IncrementalAssign([
+            new TopicPartitionOffset(topic, partition: 0, offset: 0, leaderEpoch: -1)
+        ]);
+        return consumer;
+    }
+
+    private static async Task ProduceAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        int partition,
+        string value,
+        CancellationToken cancellationToken)
+    {
+        _ = await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Partition = partition,
+            Key = value,
+            Value = value
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<ConsumeResult<string, string>>> ConsumeCountAsync(
+        IKafkaConsumer<string, string> consumer,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        var records = new List<ConsumeResult<string, string>>(count);
+        while (records.Count < count)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+                .ConfigureAwait(false);
+            if (record is not null)
+                records.Add(record.Value);
+        }
+
+        return records;
+    }
+
+    private static async Task<ConsumeResult<string, string>> ConsumeMatchingAsync(
+        IKafkaConsumer<string, string> consumer,
+        Func<ConsumeResult<string, string>, bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(2), cancellationToken)
+                .ConfigureAwait(false);
+            if (record is not null && predicate(record.Value))
+                return record.Value;
+        }
+    }
+
+    private static async Task WaitForAssignmentAsync(
+        IKafkaConsumer<string, string> consumer,
+        Func<IReadOnlySet<TopicPartition>, bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        while (!predicate(consumer.Assignment))
+        {
+            _ = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(500), cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WaitForPositionWithoutRecordsAsync(
+        IKafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long expectedPosition,
+        CancellationToken cancellationToken)
+    {
+        while (consumer.GetPosition(partition) != expectedPosition)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromMilliseconds(500), cancellationToken)
+                .ConfigureAwait(false);
+            if (record is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Expected latest offset reset to skip {record.Value.TopicPartitionOffset}.");
+            }
+        }
+    }
+
+    private static async Task<Guid> RecreateTopicAsync(
+        IAdminClient admin,
+        string topic,
+        Guid oldTopicId,
+        int partitions,
+        CancellationToken cancellationToken)
+    {
+        await admin.DeleteTopicsAsync([topic], cancellationToken: cancellationToken).ConfigureAwait(false);
+        await WaitForTopicDeletionAsync(admin, topic, cancellationToken).ConfigureAwait(false);
+        await CreateTopicAfterDeletionAsync(admin, topic, oldTopicId, partitions, cancellationToken)
+            .ConfigureAwait(false);
+
+        return await WaitForTopicIdAsync(
+            admin,
+            topic,
+            topicId => topicId != Guid.Empty && topicId != oldTopicId,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task CreateTopicAfterDeletionAsync(
+        IAdminClient admin,
+        string topic,
+        Guid oldTopicId,
+        int partitions,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                await admin.CreateTopicsAsync([new NewTopic
+                {
+                    Name = topic,
+                    NumPartitions = partitions,
+                    ReplicationFactor = 1
+                }], cancellationToken: cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (KafkaException exception) when (exception.ErrorCode == ErrorCode.TopicAlreadyExists)
+            {
+                var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken)
+                    .ConfigureAwait(false);
+                if (descriptions.TryGetValue(topic, out var description) &&
+                    description.ErrorCode == ErrorCode.None &&
+                    description.TopicId != Guid.Empty &&
+                    description.TopicId != oldTopicId &&
+                    description.Partitions.Count == partitions)
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task<Guid> GetTopicIdAsync(
+        IAdminClient admin,
+        string topic,
+        CancellationToken cancellationToken) =>
+        await WaitForTopicIdAsync(
+            admin,
+            topic,
+            static topicId => topicId != Guid.Empty,
+            cancellationToken).ConfigureAwait(false);
+
+    private static async Task<Guid> WaitForTopicIdAsync(
+        IAdminClient admin,
+        string topic,
+        Func<Guid, bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken)
+                    .ConfigureAwait(false);
+                if (descriptions.TryGetValue(topic, out var description) &&
+                    description.ErrorCode == ErrorCode.None &&
+                    predicate(description.TopicId))
+                {
+                    return description.TopicId;
+                }
+            }
+            catch (KafkaException exception) when (
+                exception.ErrorCode is ErrorCode.UnknownTopicOrPartition or ErrorCode.UnknownTopicId)
+            {
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task WaitForTopicDeletionAsync(
+        IAdminClient admin,
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                var descriptions = await admin.DescribeTopicsAsync([topic], cancellationToken)
+                    .ConfigureAwait(false);
+                if (!descriptions.TryGetValue(topic, out var description) ||
+                    description.ErrorCode is ErrorCode.UnknownTopicOrPartition or ErrorCode.UnknownTopicId)
+                {
+                    return;
+                }
+            }
+            catch (KafkaException exception) when (
+                exception.ErrorCode is ErrorCode.UnknownTopicOrPartition or ErrorCode.UnknownTopicId)
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
@@ -318,7 +318,7 @@ public sealed class TopicRecreationIntegrationTests(KafkaTestContainer kafka) : 
 
     private static async Task WaitForAssignmentAsync(
         IKafkaConsumer<string, string> consumer,
-        Func<IReadOnlySet<TopicPartition>, bool> predicate,
+        Func<IReadOnlyCollection<TopicPartition>, bool> predicate,
         CancellationToken cancellationToken)
     {
         while (!predicate(consumer.Assignment))

--- a/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/TopicRecreationIntegrationTests.cs
@@ -6,6 +6,7 @@ using Dekaf.Protocol;
 
 namespace Dekaf.Tests.Integration;
 
+[NotInParallel]
 [Category("Resilience")]
 public sealed class TopicRecreationIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
@@ -103,6 +104,7 @@ public sealed class TopicRecreationIntegrationTests(KafkaTestContainer kafka) : 
             new TopicPartitionOffset(topic, partition: 0, offset: 3, leaderEpoch: -1)
         ], cancellationToken).ConfigureAwait(false);
 
+        consumer.Pause(partition);
         var oldTopicId = await GetTopicIdAsync(admin, topic, cancellationToken).ConfigureAwait(false);
         _ = await RecreateTopicAsync(admin, topic, oldTopicId, partitions: 1, cancellationToken)
             .ConfigureAwait(false);
@@ -111,6 +113,7 @@ public sealed class TopicRecreationIntegrationTests(KafkaTestContainer kafka) : 
             .ConfigureAwait(false);
         await ProduceAsync(newProducer, topic, partition: 0, "new-before-reset-1", cancellationToken)
             .ConfigureAwait(false);
+        consumer.Resume(partition);
 
         await WaitForPositionWithoutRecordsAsync(consumer, partition, expectedPosition: 2, cancellationToken)
             .ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1260,6 +1260,160 @@ public sealed class ConsumerAssignmentFastPathTests
         await Assert.That(GetPrefetchedBytes(consumer)).IsEqualTo(0L);
     }
 
+    [Test]
+    public async Task TopicIdentityChange_ResetsPartitionsConcurrently()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset("test-topic", 0, 10),
+            new TopicPartitionOffset("test-topic", 1, 20)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var firstRequestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRequest = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCount = 0;
+        var firstPartition = -1;
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var partition = call.ArgAt<ListOffsetsRequest>(0).Topics[0].Partitions[0].PartitionIndex;
+                if (Interlocked.Increment(ref requestCount) != 1)
+                    return ValueTask.FromResult(CreateListOffsetsResponse(partition, 100 + partition));
+
+                firstPartition = partition;
+                firstRequestStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseFirstRequest.Task);
+            });
+
+        var recreatedTopicId = Guid.NewGuid();
+        metadataManager.Metadata.Update(CreateMetadataResponse(recreatedTopicId, partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+
+        await firstRequestStarted.Task;
+        try
+        {
+            await Assert.That(Volatile.Read(ref requestCount)).IsEqualTo(2);
+        }
+        finally
+        {
+            releaseFirstRequest.TrySetResult(CreateListOffsetsResponse(firstPartition, 100 + firstPartition));
+            await recovery;
+        }
+
+        await Assert.That(GetFetchPositions(consumer)[new TopicPartition("test-topic", 0)]).IsEqualTo(100L);
+        await Assert.That(GetFetchPositions(consumer)[new TopicPartition("test-topic", 1)]).IsEqualTo(101L);
+        await Assert.That(GetObservedTopicIds(consumer)["test-topic"]).IsEqualTo(recreatedTopicId);
+    }
+
+    [Test]
+    public async Task TopicIdentityChange_DropsVanishedPartition()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var partition = call.ArgAt<ListOffsetsRequest>(0).Topics[0].Partitions[0].PartitionIndex;
+                return ValueTask.FromResult(CreateListOffsetsResponse(partition, 100));
+            });
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var retained = new TopicPartition("test-topic", 0);
+        var vanished = new TopicPartition("test-topic", 1);
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(retained.Topic, retained.Partition, 10),
+            new TopicPartitionOffset(vanished.Topic, vanished.Partition, 20)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var recreatedTopicId = Guid.NewGuid();
+        metadataManager.Metadata.Update(CreateMetadataResponse(recreatedTopicId, partitionCount: 1));
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        await Assert.That(GetFetchPositions(consumer)[retained]).IsEqualTo(100L);
+        await Assert.That(GetFetchPositions(consumer).ContainsKey(vanished)).IsFalse();
+        await Assert.That(GetObservedTopicIds(consumer)["test-topic"]).IsEqualTo(recreatedTopicId);
+    }
+
+    [Test]
+    public async Task TopicIdentityRefresh_SeedsRejectedTopicIdBeforeReset()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateListOffsetsResponse(0, 100)));
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 20)]);
+
+        var rejectedTopicId = Guid.NewGuid();
+        await InvokeHandleTopicIdentityChangesAsync(consumer, "test-topic", rejectedTopicId);
+
+        await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(100L);
+        await Assert.That(GetObservedTopicIds(consumer)["test-topic"]).IsEqualTo(TestTopicId);
+    }
+
+    [Test]
+    public async Task TopicIdentityObservation_UnassignedTopic_IsPruned()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        var partition = new TopicPartition("test-topic", 0);
+        consumer.IncrementalAssign([new TopicPartitionOffset(partition.Topic, partition.Partition, 0)]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+        await Assert.That(GetObservedTopicIds(consumer)).ContainsKey(partition.Topic);
+
+        consumer.IncrementalUnassign([partition]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        await Assert.That(GetObservedTopicIds(consumer)).DoesNotContainKey(partition.Topic);
+    }
+
     private static KafkaConsumer<string, string> CreateConsumer()
     {
         return new KafkaConsumer<string, string>(
@@ -1305,7 +1459,9 @@ public sealed class ConsumerAssignmentFastPathTests
         OffsetCommitMode offsetCommitMode = OffsetCommitMode.Manual,
         int requestTimeoutMs = 30_000,
         int defaultApiTimeoutMs = 60_000,
-        AutoOffsetReset? autoOffsetResetNewPartitions = null)
+        AutoOffsetReset? autoOffsetResetNewPartitions = null,
+        AutoOffsetReset autoOffsetReset = AutoOffsetReset.Latest,
+        TimeSpan? autoOffsetResetDuration = null)
     {
         return new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -1317,7 +1473,9 @@ public sealed class ConsumerAssignmentFastPathTests
                 MaxPollIntervalMs = maxPollIntervalMs,
                 RequestTimeoutMs = requestTimeoutMs,
                 DefaultApiTimeoutMs = defaultApiTimeoutMs,
-                AutoOffsetResetNewPartitions = autoOffsetResetNewPartitions
+                AutoOffsetResetNewPartitions = autoOffsetResetNewPartitions,
+                AutoOffsetReset = autoOffsetReset,
+                AutoOffsetResetDuration = autoOffsetResetDuration
             },
             Serializers.String,
             Serializers.String,
@@ -1331,44 +1489,37 @@ public sealed class ConsumerAssignmentFastPathTests
         metadataManager.SetApiVersion(ApiKey.ConsumerGroupHeartbeat, 0, 0);
         metadataManager.SetApiVersion(ApiKey.FindCoordinator, 4, 5);
         metadataManager.SetApiVersion(ApiKey.OffsetFetch, OffsetFetchRequest.LowestSupportedVersion, 9);
-        metadataManager.Metadata.Update(new MetadataResponse
-        {
-            Brokers =
-            [
-                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
-            ],
-            Topics =
-            [
-                new TopicMetadata
-                {
-                    Name = "test-topic",
-                    TopicId = TestTopicId,
-                    ErrorCode = ErrorCode.None,
-                    Partitions =
-                    [
-                        new PartitionMetadata
-                        {
-                            PartitionIndex = 0,
-                            LeaderId = 0,
-                            ErrorCode = ErrorCode.None,
-                            ReplicaNodes = [0],
-                            IsrNodes = [0]
-                        },
-                        new PartitionMetadata
-                        {
-                            PartitionIndex = 1,
-                            LeaderId = 0,
-                            ErrorCode = ErrorCode.None,
-                            ReplicaNodes = [0],
-                            IsrNodes = [0]
-                        }
-                    ]
-                }
-            ]
-        });
+        metadataManager.Metadata.Update(CreateMetadataResponse(TestTopicId, partitionCount: 2));
 
         return metadataManager;
     }
+
+    private static MetadataResponse CreateMetadataResponse(Guid topicId, int partitionCount) => new()
+    {
+        Brokers =
+        [
+            new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 }
+        ],
+        Topics =
+        [
+            new TopicMetadata
+            {
+                Name = "test-topic",
+                TopicId = topicId,
+                ErrorCode = ErrorCode.None,
+                Partitions = Enumerable.Range(0, partitionCount)
+                    .Select(static partition => new PartitionMetadata
+                    {
+                        PartitionIndex = partition,
+                        LeaderId = 0,
+                        ErrorCode = ErrorCode.None,
+                        ReplicaNodes = [0],
+                        IsrNodes = [0]
+                    })
+                    .ToArray()
+            }
+        ]
+    };
 
     private static void SetupConnectionPool(IConnectionPool connectionPool, IKafkaConnection connection)
     {
@@ -1936,6 +2087,36 @@ public sealed class ConsumerAssignmentFastPathTests
             ?? throw new InvalidOperationException("_fetchPositions field not found.");
 
         return (ConcurrentDictionary<TopicPartition, long>)field.GetValue(consumer)!;
+    }
+
+    private static Dictionary<string, Guid> GetObservedTopicIds(
+        KafkaConsumer<string, string> consumer)
+    {
+        var field = typeof(KafkaConsumer<string, string>).GetField(
+            "_observedTopicIds",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_observedTopicIds field not found.");
+
+        return (Dictionary<string, Guid>)field.GetValue(consumer)!;
+    }
+
+    private static async ValueTask InvokeHandleTopicIdentityChangesAsync(
+        KafkaConsumer<string, string> consumer,
+        string? rejectedTopic = null,
+        Guid rejectedTopicId = default)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "HandleTopicIdentityChangesAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("HandleTopicIdentityChangesAsync method not found.");
+
+        var result = method.Invoke(
+            consumer,
+            [CancellationToken.None, rejectedTopic, rejectedTopicId]);
+        if (result is not ValueTask valueTask)
+            throw new InvalidOperationException("HandleTopicIdentityChangesAsync returned unexpected type.");
+
+        await valueTask.ConfigureAwait(false);
     }
 
     private static int GetLastConsumedLeaderEpoch(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerAssignmentFastPathTests.cs
@@ -1324,6 +1324,70 @@ public sealed class ConsumerAssignmentFastPathTests
     }
 
     [Test]
+    public async Task TopicIdentityChange_AssignmentMutationDuringReset_IsReobserved()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        await using var consumer = CreateGroupConsumer(
+            connectionPool,
+            metadataManager,
+            autoOffsetReset: AutoOffsetReset.ByDuration,
+            autoOffsetResetDuration: TimeSpan.FromMinutes(1));
+        var partitions = new[]
+        {
+            new TopicPartition("test-topic", 0),
+            new TopicPartition("test-topic", 1)
+        };
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(partitions[0].Topic, partitions[0].Partition, 10),
+            new TopicPartitionOffset(partitions[1].Topic, partitions[1].Partition, 20)
+        ]);
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseReset = new TaskCompletionSource<ListOffsetsResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var partition = call.ArgAt<ListOffsetsRequest>(0).Topics[0].Partitions[0].PartitionIndex;
+                if (partition != 0)
+                    return ValueTask.FromResult(CreateListOffsetsResponse(partition, 100 + partition));
+
+                resetStarted.TrySetResult();
+                return new ValueTask<ListOffsetsResponse>(releaseReset.Task);
+            });
+
+        metadataManager.Metadata.Update(CreateMetadataResponse(Guid.NewGuid(), partitionCount: 2));
+        var recovery = InvokeHandleTopicIdentityChangesAsync(consumer).AsTask();
+        await resetStarted.Task;
+
+        try
+        {
+            consumer.IncrementalUnassign(partitions);
+        }
+        finally
+        {
+            releaseReset.TrySetResult(CreateListOffsetsResponse(0, 100));
+            await recovery;
+        }
+
+        await InvokeHandleTopicIdentityChangesAsync(consumer);
+
+        await Assert.That(GetObservedTopicIds(consumer)).DoesNotContainKey("test-topic");
+    }
+
+    [Test]
     public async Task TopicIdentityChange_DropsVanishedPartition()
     {
         var connectionPool = Substitute.For<IConnectionPool>();
@@ -1395,6 +1459,96 @@ public sealed class ConsumerAssignmentFastPathTests
 
         await Assert.That(GetFetchPositions(consumer)[partition]).IsEqualTo(100L);
         await Assert.That(GetObservedTopicIds(consumer)["test-topic"]).IsEqualTo(TestTopicId);
+    }
+
+    [Test]
+    public async Task FetchV13_TopicIdentityErrors_UseRequestIdentityAndRefreshOnce()
+    {
+        var connectionPool = Substitute.For<IConnectionPool>();
+        var connection = Substitute.For<IKafkaConnection>();
+        SetupConnectionPool(connectionPool, connection);
+        await using var metadataManager = CreateMetadataManager(connectionPool);
+        metadataManager.SetApiVersion(ApiKey.Fetch, 13, 13);
+        metadataManager.SetApiVersion(
+            ApiKey.ListOffsets,
+            ListOffsetsRequest.LowestSupportedVersion,
+            ListOffsetsRequest.HighestSupportedVersion);
+        SetMetadataApiVersion(metadataManager);
+        var recreatedTopicId = Guid.NewGuid();
+        Guid requestedTopicId = default;
+
+        connection.SendAsync<FetchRequest, FetchResponse>(
+                Arg.Any<FetchRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                requestedTopicId = call.ArgAt<FetchRequest>(0).Topics[0].TopicId;
+                metadataManager.Metadata.Update(CreateMetadataResponse(recreatedTopicId, partitionCount: 2));
+                return ValueTask.FromResult(new FetchResponse
+                {
+                    Responses =
+                    [
+                        new FetchResponseTopic
+                        {
+                            TopicId = TestTopicId,
+                            Partitions =
+                            [
+                                new FetchResponsePartition
+                                {
+                                    PartitionIndex = 0,
+                                    ErrorCode = ErrorCode.UnknownTopicId
+                                },
+                                new FetchResponsePartition
+                                {
+                                    PartitionIndex = 1,
+                                    ErrorCode = ErrorCode.UnknownTopicId
+                                }
+                            ]
+                        }
+                    ]
+                });
+            });
+        connection.SendAsync<MetadataRequest, MetadataResponse>(
+                Arg.Any<MetadataRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(CreateMetadataResponse(recreatedTopicId, partitionCount: 2)));
+        connection.SendAsync<ListOffsetsRequest, ListOffsetsResponse>(
+                Arg.Any<ListOffsetsRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var partition = call.ArgAt<ListOffsetsRequest>(0).Topics[0].Partitions[0].PartitionIndex;
+                return ValueTask.FromResult(CreateListOffsetsResponse(partition, 100 + partition));
+            });
+
+        await using var consumer = CreateGroupConsumer(connectionPool, metadataManager);
+        var partitions = new List<TopicPartition>
+        {
+            new("test-topic", 0),
+            new("test-topic", 1)
+        };
+        consumer.IncrementalAssign(
+        [
+            new TopicPartitionOffset(partitions[0].Topic, partitions[0].Partition, 10),
+            new TopicPartitionOffset(partitions[1].Topic, partitions[1].Partition, 20)
+        ]);
+
+        var pending = await InvokeFetchFromBrokerAsync(
+            consumer,
+            brokerId: 0,
+            partitions,
+            GetFetchBufferEpoch(consumer));
+
+        await Assert.That(pending).IsNull();
+        await Assert.That(requestedTopicId).IsEqualTo(TestTopicId);
+        await Assert.That(GetObservedTopicIds(consumer)["test-topic"]).IsEqualTo(recreatedTopicId);
+        _ = connection.Received(1).SendAsync<MetadataRequest, MetadataResponse>(
+            Arg.Any<MetadataRequest>(),
+            Arg.Any<short>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -1492,6 +1646,15 @@ public sealed class ConsumerAssignmentFastPathTests
         metadataManager.Metadata.Update(CreateMetadataResponse(TestTopicId, partitionCount: 2));
 
         return metadataManager;
+    }
+
+    private static void SetMetadataApiVersion(MetadataManager metadataManager)
+    {
+        var field = typeof(MetadataManager).GetField(
+            "_metadataApiVersion",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_metadataApiVersion field not found.");
+        field.SetValue(metadataManager, MetadataRequest.HighestSupportedVersion);
     }
 
     private static MetadataResponse CreateMetadataResponse(Guid topicId, int partitionCount) => new()
@@ -2117,6 +2280,25 @@ public sealed class ConsumerAssignmentFastPathTests
             throw new InvalidOperationException("HandleTopicIdentityChangesAsync returned unexpected type.");
 
         await valueTask.ConfigureAwait(false);
+    }
+
+    private static async ValueTask<List<PendingFetchData>?> InvokeFetchFromBrokerAsync(
+        KafkaConsumer<string, string> consumer,
+        int brokerId,
+        List<TopicPartition> partitions,
+        int fetchBufferEpoch)
+    {
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "FetchFromBrokerAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("FetchFromBrokerAsync method not found.");
+        var result = method.Invoke(
+            consumer,
+            [brokerId, partitions, fetchBufferEpoch, CancellationToken.None]);
+        if (result is not ValueTask<List<PendingFetchData>?> valueTask)
+            throw new InvalidOperationException("FetchFromBrokerAsync returned unexpected type.");
+
+        return await valueTask.ConfigureAwait(false);
     }
 
     private static int GetLastConsumedLeaderEpoch(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -2990,7 +2990,9 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
                 return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
             });
 
-        var options = CreateConsumerProtocolOptions();
+        var options = CreateConsumerProtocolOptions(
+            retryBackoffMs: 0,
+            retryBackoffMaxMs: 0);
         await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
         await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
         SetCoordinatorLongField(

--- a/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/FetchSessionHandlerTests.cs
@@ -152,6 +152,28 @@ public sealed class FetchSessionHandlerTests
         await Assert.That(build.IsFull).IsTrue();
     }
 
+    [Test]
+    public async Task ResponseTopicName_UsesMetadataFromActiveSession()
+    {
+        var oldTopicId = Guid.NewGuid();
+        var newTopicId = Guid.NewGuid();
+        var metadata = Metadata("topic-a", oldTopicId);
+        var handler = new FetchSessionHandler();
+        var topics = Topics(("topic-a", 0, 100, 1024));
+
+        handler.BuildFromSnapshot(topics, metadata.CaptureSnapshot());
+        handler.HandleResponse(Response(sessionId: 42));
+
+        metadata.Update(CreateMetadataResponse("topic-a", newTopicId));
+        handler.BuildFromSnapshot(topics, metadata.CaptureSnapshot());
+        handler.HandleResponse(Response(sessionId: 42));
+
+        var resolved = handler.TryResolveResponseTopicName(oldTopicId, out var topic);
+
+        await Assert.That(resolved).IsTrue();
+        await Assert.That(topic).IsEqualTo("topic-a");
+    }
+
     private static FetchResponse Response(int sessionId, ErrorCode errorCode = ErrorCode.None) => new()
     {
         SessionId = sessionId,
@@ -230,7 +252,12 @@ public sealed class FetchSessionHandlerTests
     private static ClusterMetadata Metadata(string topic, Guid topicId)
     {
         var metadata = new ClusterMetadata();
-        metadata.Update(new MetadataResponse
+        metadata.Update(CreateMetadataResponse(topic, topicId));
+        return metadata;
+    }
+
+    private static MetadataResponse CreateMetadataResponse(string topic, Guid topicId) =>
+        new()
         {
             Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
             Topics =
@@ -243,7 +270,5 @@ public sealed class FetchSessionHandlerTests
                     Partitions = [new PartitionMetadata { ErrorCode = ErrorCode.None, PartitionIndex = 0, LeaderId = 1, ReplicaNodes = [1], IsrNodes = [1] }]
                 }
             ]
-        });
-        return metadata;
-    }
+        };
 }

--- a/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/ConnectionPoolTests.cs
@@ -1198,7 +1198,10 @@ public sealed class ConnectionPoolTests
     }
 
     [Test]
-    public async Task ConnectionSetupTimeout_CancelsStalledAttemptAtEffectiveDeadline()
+    [NotInParallel]
+    [Timeout(5_000)]
+    public async Task ConnectionSetupTimeout_CancelsStalledAttemptAtEffectiveDeadline(
+        CancellationToken cancellationToken)
     {
         await using var pool = new ConnectionPool(
             clientId: "test-client",
@@ -1217,7 +1220,7 @@ public sealed class ConnectionPoolTests
             },
             randomDouble: static () => 0.5);
 
-        Func<Task> connect = () => pool.GetConnectionAsync("broker-a", 9092).AsTask();
+        Func<Task> connect = () => pool.GetConnectionAsync("broker-a", 9092, cancellationToken).AsTask();
 
         await Assert.That(connect).Throws<KafkaException>()
             .WithMessageContaining("Connection setup timeout after 20ms");

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionCapabilityHandshakeTests.cs
@@ -455,6 +455,7 @@ public class KafkaConnectionCapabilityHandshakeTests
     }
 
     [Test]
+    [NotInParallel]
     [Timeout(5_000)]
     public async Task ConnectAsync_WhenNegotiationTimesOut_ThrowsKafkaException(
         CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -31,6 +31,7 @@ public sealed class AdaptiveScaleDownTests
 {
     private const string Topic = "test-topic";
     private const int PartitionCount = 8;
+    private const int IdleConnectionMaxIdleMs = 120_000;
 
     private static ProducerOptions CreateOptions(
         bool idempotent,
@@ -318,19 +319,22 @@ public sealed class AdaptiveScaleDownTests
         var connections = new ConnectionPoolTests.TestIdleConnection[connectionCount];
         var pool = new ConnectionPool(
             clientId: "test-client",
-            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = 1 },
+            connectionOptions: new ConnectionOptions { ConnectionsMaxIdleMs = IdleConnectionMaxIdleMs },
             connectionsPerBroker: connectionCount,
             connectionFactory: (brokerId, host, port, index, _) =>
             {
                 var connection = new ConnectionPoolTests.TestIdleConnection(brokerId, host, port)
                 {
-                    LastUsedTimestampMs = 0
+                    LastUsedTimestampMs = StaleIdleTimestamp()
                 };
                 connections[index] = connection;
                 return new ValueTask<IKafkaConnection>(connection);
             });
         return (pool, connections);
     }
+
+    private static long StaleIdleTimestamp()
+        => Environment.TickCount64 - IdleConnectionMaxIdleMs - 1;
 
     [Test]
     public async Task FloorWidth_ReapsNeverRoutedSlots_ButKeepsRoutedSlot()
@@ -412,7 +416,7 @@ public sealed class AdaptiveScaleDownTests
                 await Assert.That(metadataManager.GetPartitionsForNode(1)).IsEmpty();
                 await Assert.That(GetField<int>(sender, "_retainedConnectionIndexCount")).IsEqualTo(0);
                 foreach (var connection in connections)
-                    connection.LastUsedTimestampMs = 0;
+                    connection.LastUsedTimestampMs = StaleIdleTimestamp();
 
                 var reaped = await pool.ReapIdleConnectionsAsync();
 
@@ -503,8 +507,8 @@ public sealed class AdaptiveScaleDownTests
                 await pool.ScaleConnectionGroupAsync(1, 2);
                 senderType.GetMethod("ApplyScaleUp", BindingFlags.Instance | BindingFlags.NonPublic)!
                     .Invoke(sender, [2]);
-                connections[0].LastUsedTimestampMs = 0;
-                connections[1].LastUsedTimestampMs = 0;
+                connections[0].LastUsedTimestampMs = StaleIdleTimestamp();
+                connections[1].LastUsedTimestampMs = StaleIdleTimestamp();
 
                 var reaped = await pool.ReapIdleConnectionsAsync();
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicIdentityCheckBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicIdentityCheckBenchmarks.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Guards the steady-state topic identity check that runs once per broker fetch cycle.
+/// The metadata snapshot is unchanged during measurement, so the benchmark covers the
+/// normal O(1) path rather than the rare delete/recreate recovery path.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class TopicIdentityCheckBenchmarks
+{
+    private static readonly Func<CancellationToken, string?, Guid, ValueTask> s_control =
+        static (_, _, _) => ValueTask.CompletedTask;
+
+    private KafkaConsumer<string, string> _consumer = null!;
+    private Func<CancellationToken, string?, Guid, ValueTask> _identityCheck = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual
+            },
+            Serializers.String,
+            Serializers.String);
+
+        var method = typeof(KafkaConsumer<string, string>).GetMethod(
+            "HandleTopicIdentityChangesAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Topic identity check method was not found.");
+        _identityCheck = method.CreateDelegate<Func<CancellationToken, string?, Guid, ValueTask>>(_consumer);
+
+        _identityCheck(CancellationToken.None, null, Guid.Empty).GetAwaiter().GetResult();
+    }
+
+    [Benchmark(Baseline = true)]
+    public ValueTask DelegateControl() =>
+        s_control(CancellationToken.None, null, Guid.Empty);
+
+    [Benchmark]
+    public ValueTask UnchangedMetadataSnapshot() =>
+        _identityCheck(CancellationToken.None, null, Guid.Empty);
+
+    [GlobalCleanup]
+    public void Cleanup() =>
+        _consumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+}


### PR DESCRIPTION
## Summary

- detect same-name topic recreation by immutable metadata snapshot and `TopicId`
- clear stale fetch/commit/watermark state, apply configured `auto.offset.reset`, and request group rejoin
- refresh metadata on `UNKNOWN_TOPIC_ID` / `UNKNOWN_TOPIC_OR_PARTITION` fetch errors
- cover producer recovery, consumer earliest/latest reset, partition shrink, and commit safety

Fixes #2248

## Correctness

- `TopicRecreationIntegrationTests`: 5/5 passed serially after rebase
- `Dekaf.Tests.Unit` net10.0: 6205/6205
- `Dekaf.Tests.Unit` net8.0: 6078/6078
- integration build: 0 warnings, 0 errors

The tests poll `DescribeTopics` until deletion and a different non-empty `TopicId` are observed. No fixed synchronization delay is used.

## Performance

The normal fetch-cycle path performs one immutable snapshot reference comparison. Assignment scans and state clearing run only after a metadata snapshot change; no per-message path changed.

`TopicIdentityCheckBenchmarks` (`[MemoryDiagnoser]`, .NET 10):

| Case | Mean | Allocated |
|---|---:|---:|
| Delegate control (pre-change equivalent) | 1.557 ns | 0 B |
| Unchanged metadata snapshot | 14.731 ns | 0 B |

A Docker-backed `ConsumerPollBenchmarks.Dekaf_PollSingle` predecessor run was attempted at `98f58090`, but produced no measurements because the benchmark container advertised its host-mapped listener internally; topic creation and consumer initialization timed out. It was not rerun unchanged.