### PR TITLE
Test consumer offset retention expiry

### DIFF
--- a/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
+++ b/src/Dekaf/Consumer/AutoOffsetResetStrategy.cs
@@ -24,15 +24,22 @@ internal static class AutoOffsetResetStrategy
             AutoOffsetReset.ByDuration => GetByDurationTimestamp(duration, now),
             AutoOffsetReset.None => throw new KafkaException(
                 ErrorCode.OffsetOutOfRange,
-                GetOffsetResetNoneMessage(partition)),
+                GetOffsetResetNoneMessage(partition, options.GroupId)),
             _ => throw new InvalidOperationException($"Unknown AutoOffsetReset value: {policy}")
         };
     }
 
-    private static string GetOffsetResetNoneMessage(TopicPartition? partition) =>
-        partition is { } tp
-            ? $"No committed offset for {tp.Topic}-{tp.Partition} and auto.offset.reset is 'none'"
-            : "No committed offset and auto.offset.reset is 'none'";
+    private static string GetOffsetResetNoneMessage(TopicPartition? partition, string? groupId) =>
+        (partition, groupId) switch
+        {
+            ({ } tp, { Length: > 0 } group) =>
+                $"No committed offset for group '{group}', partition {tp.Topic}-{tp.Partition} and auto.offset.reset is 'none'",
+            ({ } tp, _) =>
+                $"No committed offset for {tp.Topic}-{tp.Partition} and auto.offset.reset is 'none'",
+            (_, { Length: > 0 } group) =>
+                $"No committed offset for group '{group}' and auto.offset.reset is 'none'",
+            _ => "No committed offset and auto.offset.reset is 'none'"
+        };
 
     public static long GetByDurationTimestamp(TimeSpan? duration, DateTimeOffset now)
     {

--- a/tests/Dekaf.Tests.Integration/ConsumerOffsetRetentionIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerOffsetRetentionIntegrationTests.cs
@@ -1,0 +1,234 @@
+using System.Diagnostics;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[ClassDataSource<OffsetRetentionKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class ConsumerOffsetRetentionIntegrationTests(OffsetRetentionKafkaContainer kafka)
+{
+    private static readonly TimeSpan OffsetExpiryTimeout = TimeSpan.FromSeconds(100);
+    private static readonly TimeSpan ActiveRetentionObservation = TimeSpan.FromSeconds(70);
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task ConsumerGroup_OffsetsExpiredWhileEmpty_EarliestReset_ReprocessesFromStart(
+        CancellationToken cancellationToken)
+    {
+        var scenario = await CreateExpiredOffsetScenarioAsync(cancellationToken).ConfigureAwait(false);
+        await ProduceRangeAsync(scenario.Topic, start: 5, count: 2, cancellationToken).ConfigureAwait(false);
+
+        await using var consumer = await CreateConsumerAsync(
+            scenario.Topic,
+            scenario.GroupId,
+            AutoOffsetReset.Earliest,
+            cancellationToken).ConfigureAwait(false);
+
+        var records = await ConsumeCountAsync(consumer, count: 7, cancellationToken).ConfigureAwait(false);
+
+        await Assert.That(records.Select(static record => record.Offset)).IsEquivalentTo([0L, 1L, 2L, 3L, 4L, 5L, 6L]);
+    }
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task ConsumerGroup_OffsetsExpiredWhileEmpty_LatestReset_SkipsToEnd(
+        CancellationToken cancellationToken)
+    {
+        var scenario = await CreateExpiredOffsetScenarioAsync(cancellationToken).ConfigureAwait(false);
+        await ProduceRangeAsync(scenario.Topic, start: 5, count: 2, cancellationToken).ConfigureAwait(false);
+
+        await using var consumer = await CreateConsumerAsync(
+            scenario.Topic,
+            scenario.GroupId,
+            AutoOffsetReset.Latest,
+            cancellationToken).ConfigureAwait(false);
+        var partition = new TopicPartition(scenario.Topic, 0);
+        var consumeTask = consumer.ConsumeOneAsync(TimeSpan.FromSeconds(60), cancellationToken).AsTask();
+
+        await WaitForPositionAsync(consumer, partition, expected: 7, cancellationToken).ConfigureAwait(false);
+        await ProduceRangeAsync(scenario.Topic, start: 7, count: 1, cancellationToken).ConfigureAwait(false);
+
+        var record = await consumeTask.ConfigureAwait(false);
+        await Assert.That(record).IsNotNull();
+        await Assert.That(record!.Value.Offset).IsEqualTo(7);
+    }
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task ConsumerGroup_OffsetsExpired_AutoOffsetResetNone_ThrowsClearException(
+        CancellationToken cancellationToken)
+    {
+        var scenario = await CreateExpiredOffsetScenarioAsync(cancellationToken).ConfigureAwait(false);
+        await using var consumer = await CreateConsumerAsync(
+            scenario.Topic,
+            scenario.GroupId,
+            AutoOffsetReset.None,
+            cancellationToken).ConfigureAwait(false);
+
+        var exception = await Assert.That(async () =>
+                await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false))
+            .Throws<KafkaException>();
+
+        await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.OffsetOutOfRange);
+        await Assert.That(exception.Message).Contains(scenario.GroupId);
+        await Assert.That(exception.Message).Contains($"{scenario.Topic}-0");
+    }
+
+    [Test]
+    [Timeout(180_000)]
+    public async Task ConsumerGroup_ActiveGroup_OffsetsNotExpired(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"active-retention-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+        await ProduceRangeAsync(topic, start: 0, count: 5, cancellationToken).ConfigureAwait(false);
+
+        await using var consumer = await CreateConsumerAsync(
+            topic,
+            groupId,
+            AutoOffsetReset.Earliest,
+            cancellationToken).ConfigureAwait(false);
+        _ = await ConsumeCountAsync(consumer, count: 3, cancellationToken).ConfigureAwait(false);
+        await consumer.CommitAsync([
+            new TopicPartitionOffset(partition.Topic, partition.Partition, 3)
+        ], cancellationToken).ConfigureAwait(false);
+
+        await using var admin = kafka.CreateAdminClient();
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < ActiveRetentionObservation)
+        {
+            var offsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken).ConfigureAwait(false);
+            await Assert.That(offsets.GetValueOrDefault(partition, -1)).IsEqualTo(3);
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<ExpiredOffsetScenario> CreateExpiredOffsetScenarioAsync(CancellationToken cancellationToken)
+    {
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var groupId = $"expired-retention-{Guid.NewGuid():N}";
+        var partition = new TopicPartition(topic, 0);
+        await ProduceRangeAsync(topic, start: 0, count: 5, cancellationToken).ConfigureAwait(false);
+
+        await using (var consumer = await CreateConsumerAsync(
+            topic,
+            groupId,
+            AutoOffsetReset.Earliest,
+            cancellationToken).ConfigureAwait(false))
+        {
+            _ = await ConsumeCountAsync(consumer, count: 3, cancellationToken).ConfigureAwait(false);
+            await consumer.CommitAsync([
+                new TopicPartitionOffset(partition.Topic, partition.Partition, 3)
+            ], cancellationToken).ConfigureAwait(false);
+        }
+
+        await using var admin = kafka.CreateAdminClient();
+        await WaitForOffsetAsync(admin, groupId, partition, shouldExist: true, TimeSpan.FromSeconds(15), cancellationToken)
+            .ConfigureAwait(false);
+        await WaitForOffsetAsync(admin, groupId, partition, shouldExist: false, OffsetExpiryTimeout, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ExpiredOffsetScenario(topic, groupId);
+    }
+
+    private async Task ProduceRangeAsync(string topic, int start, int count, CancellationToken cancellationToken)
+    {
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"offset-retention-producer-{Guid.NewGuid():N}")
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+
+        for (var value = start; value < start + count; value++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = 0,
+                Key = value.ToString(),
+                Value = value.ToString()
+            }, cancellationToken).ConfigureAwait(false);
+        }
+
+        await producer.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateConsumerAsync(
+        string topic,
+        string groupId,
+        AutoOffsetReset reset,
+        CancellationToken cancellationToken)
+    {
+        var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId($"offset-retention-consumer-{Guid.NewGuid():N}")
+            .WithGroupId(groupId)
+            .WithAutoOffsetReset(reset)
+            .WithOffsetCommitMode(OffsetCommitMode.Manual)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken).ConfigureAwait(false);
+        consumer.Subscribe(topic);
+        return consumer;
+    }
+
+    private static async Task<List<ConsumeResult<string, string>>> ConsumeCountAsync(
+        IKafkaConsumer<string, string> consumer,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        var records = new List<ConsumeResult<string, string>>(count);
+        while (records.Count < count)
+        {
+            var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            if (record is null)
+                throw new TimeoutException($"Consumed {records.Count} of {count} expected records.");
+            records.Add(record.Value);
+        }
+
+        return records;
+    }
+
+    private static async Task WaitForOffsetAsync(
+        IAdminClient admin,
+        string groupId,
+        TopicPartition partition,
+        bool shouldExist,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < timeout)
+        {
+            var offsets = await admin.ListConsumerGroupOffsetsAsync(groupId, cancellationToken).ConfigureAwait(false);
+            if (offsets.ContainsKey(partition) == shouldExist)
+                return;
+            await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Offset for group '{groupId}', partition {partition} did not become {(shouldExist ? "present" : "absent")}.");
+    }
+
+    private static async Task WaitForPositionAsync(
+        IKafkaConsumer<string, string> consumer,
+        TopicPartition partition,
+        long expected,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(30))
+        {
+            if (consumer.GetPosition(partition) == expected)
+                return;
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Consumer position for {partition} did not reach {expected}.");
+    }
+
+    private sealed record ExpiredOffsetScenario(string Topic, string GroupId);
+}

--- a/tests/Dekaf.Tests.Integration/OffsetRetentionKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/OffsetRetentionKafkaContainer.cs
@@ -1,0 +1,12 @@
+using Testcontainers.Kafka;
+
+namespace Dekaf.Tests.Integration;
+
+public sealed class OffsetRetentionKafkaContainer : KafkaContainerDefault
+{
+    protected override KafkaBuilder ConfigureBuilder(KafkaBuilder builder) =>
+        base.ConfigureBuilder(builder)
+            .WithEnvironment("KAFKA_OFFSETS_RETENTION_MINUTES", "1")
+            .WithEnvironment("KAFKA_OFFSETS_RETENTION_CHECK_INTERVAL_MS", "1000")
+            .WithEnvironment("KAFKA_LOG_RETENTION_MS", "600000");
+}

--- a/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/AutoOffsetResetStrategyTests.cs
@@ -36,11 +36,12 @@ public class AutoOffsetResetStrategyTests
     }
 
     [Test]
-    public async Task GetListOffsetsTimestamp_NoneIncludesPartitionInExceptionMessage()
+    public async Task GetListOffsetsTimestamp_NoneIncludesGroupAndPartitionInExceptionMessage()
     {
         var options = new ConsumerOptions
         {
             BootstrapServers = ["localhost:9092"],
+            GroupId = "orders-group",
             AutoOffsetReset = AutoOffsetReset.None
         };
 
@@ -49,7 +50,8 @@ public class AutoOffsetResetStrategyTests
                 DateTimeOffset.Parse("2026-07-02T12:00:00Z"),
                 new TopicPartition("orders", 5)))
             .Throws<KafkaException>()
-            .WithMessageContaining("orders-5");
+            .WithMessageContaining("orders-group")
+            .And.WithMessageContaining("orders-5");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add a dedicated Kafka fixture with one-minute consumer-offset retention
- verify expired groups honor `earliest`, `latest`, and `none` reset policies
- verify active consumer groups retain committed offsets
- include group and partition context in the `AutoOffsetReset.None` exception

Closes #2259

## Validation
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release` (0 warnings)
- `dotnet build tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj --configuration Release --no-restore` (0 warnings)
- focused unit tests: net10 11/11; net8 11/11
- full unit tests before rebase: net10 6205/6205; net8 6078/6078
- offset-retention integration tests before rebase: net10 4/4; net8 4/4
- offset-retention integration tests after rebase onto `70325397`: net10 4/4

## Performance
No hot-path behavior changes. The only library change adds context while constructing the cold-path `AutoOffsetReset.None` exception; benchmarks are not applicable.