### PR TITLE
Test TLS certificate rotation and expiry

### DIFF
--- a/src/Dekaf/Errors/KafkaException.cs
+++ b/src/Dekaf/Errors/KafkaException.cs
@@ -561,6 +561,8 @@ public sealed class BrokerVersionException : KafkaException
 /// </summary>
 public sealed class AuthenticationException : KafkaException
 {
+    internal bool IsTlsHandshakeFailure { get; }
+
     public AuthenticationException() : base()
     {
     }
@@ -576,6 +578,15 @@ public sealed class AuthenticationException : KafkaException
     public AuthenticationException(ErrorCode errorCode, string message) : base(errorCode, message)
     {
     }
+
+    private AuthenticationException(string message, Exception innerException, bool isTlsHandshakeFailure)
+        : base(message, innerException)
+    {
+        IsTlsHandshakeFailure = isTlsHandshakeFailure;
+    }
+
+    internal static AuthenticationException FromTlsHandshake(string message, Exception innerException)
+        => new(message, innerException, isTlsHandshakeFailure: true);
 }
 
 /// <summary>

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -171,6 +171,7 @@ public sealed partial class KafkaConnection :
     // Certificates loaded from files that we own and must dispose
     private X509Certificate2Collection? _loadedCaCertificates;
     private X509Certificate2? _loadedClientCertificate;
+    private string? _tlsCertificateValidationFailure;
 
     public int BrokerId { get; private set; } = -1;
     public string Host => _host;
@@ -404,6 +405,7 @@ public sealed partial class KafkaConnection :
 
         if (_options.UseTls || _options.TlsConfig is not null)
         {
+            _tlsCertificateValidationFailure = null;
 #if NETSTANDARD2_0
             var sslStream = new SslStream(
                 networkStream,
@@ -436,9 +438,11 @@ public sealed partial class KafkaConnection :
                 // Wrap as a Dekaf AuthenticationException (a KafkaException) so callers can catch it
                 // and metadata refresh treats it as fatal instead of masking it behind a generic
                 // "failed to refresh metadata" error.
-                throw new AuthenticationException(
-                    $"TLS handshake failed: {authenticationException.Message}",
-                    authenticationException);
+                var validationFailure = _tlsCertificateValidationFailure;
+                var message = string.IsNullOrWhiteSpace(validationFailure)
+                    ? $"TLS handshake failed: {authenticationException.Message}"
+                    : $"TLS handshake failed: {authenticationException.Message} Certificate validation: {validationFailure}";
+                throw new AuthenticationException(message, authenticationException);
             }
             networkStream = sslStream;
             _isTls = true;
@@ -2786,11 +2790,16 @@ public sealed partial class KafkaConnection :
             // Custom CA certificate validation
             var caCertificates = LoadCaCertificatesWithOwnership(tlsConfig!);
             return (_, certificate, chain, sslPolicyErrors) =>
-                ValidateServerCertificate(
+            {
+                var isValid = ValidateServerCertificate(
                     certificate,
                     chain,
                     ApplyServerCertificateHostNamePolicy(sslPolicyErrors, validateServerCertificateHostName),
-                    caCertificates);
+                    caCertificates,
+                    out var failureDetail);
+                _tlsCertificateValidationFailure = failureDetail;
+                return isValid;
+            };
         }
 
         if (!validateServerCertificateHostName)
@@ -3110,10 +3119,15 @@ public sealed partial class KafkaConnection :
         X509Certificate? certificate,
         X509Chain? chain,
         SslPolicyErrors sslPolicyErrors,
-        X509Certificate2Collection trustedCaCertificates)
+        X509Certificate2Collection trustedCaCertificates,
+        out string? failureDetail)
     {
+        failureDetail = null;
         if (certificate is null)
+        {
+            failureDetail = "the broker did not provide a certificate";
             return false;
+        }
 
         // If there are no policy errors, the certificate is valid
         if (sslPolicyErrors == SslPolicyErrors.None)
@@ -3148,7 +3162,19 @@ public sealed partial class KafkaConnection :
 
                 if (customChain.Build(cert2))
                 {
-                    return IsChainRootedInTrustedCa(customChain, trustedCaCertificates);
+                    if (IsChainRootedInTrustedCa(customChain, trustedCaCertificates))
+                    {
+                        return true;
+                    }
+
+                    failureDetail = "the certificate chain does not terminate at a configured CA";
+                }
+                else
+                {
+                    failureDetail = string.Join(
+                        "; ",
+                        customChain.ChainStatus.Select(status =>
+                            $"{status.Status}: {status.StatusInformation.Trim()}"));
                 }
             }
             finally
@@ -3157,6 +3183,7 @@ public sealed partial class KafkaConnection :
             }
         }
 
+        failureDetail ??= sslPolicyErrors.ToString();
         return false;
     }
 

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -442,7 +442,7 @@ public sealed partial class KafkaConnection :
                 var message = string.IsNullOrWhiteSpace(validationFailure)
                     ? $"TLS handshake failed: {authenticationException.Message}"
                     : $"TLS handshake failed: {authenticationException.Message} Certificate validation: {validationFailure}";
-                throw new AuthenticationException(message, authenticationException);
+                throw AuthenticationException.FromTlsHandshake(message, authenticationException);
             }
             networkStream = sslStream;
             _isTls = true;

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4059,7 +4059,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
         }
-        catch (AuthenticationException ex) when (IsFatalAuthenticationFailure(ex))
+        catch (AuthenticationException ex) when (IsFatalAuthenticationFailure(ex, _options))
         {
             // TLS validation cannot succeed without a configuration/trust change, and a
             // broker-rejected static PLAIN/SCRAM credential cannot repair itself. Surface both
@@ -4161,17 +4161,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
         }
     }
 
-    private bool IsFatalAuthenticationFailure(AuthenticationException exception)
+    internal static bool IsFatalAuthenticationFailure(
+        AuthenticationException exception,
+        ProducerOptions options)
     {
         if (exception.ErrorCode == ErrorCode.SaslAuthenticationFailed)
         {
-            return !_options.UsesDynamicSaslCredentials
-                && _options.SaslMechanism is SaslMechanism.Plain
+            return !options.UsesDynamicSaslCredentials
+                && options.SaslMechanism is SaslMechanism.Plain
                     or SaslMechanism.ScramSha256
                     or SaslMechanism.ScramSha512;
         }
 
-        return _options.UseTls || _options.TlsConfig is not null;
+        return exception.IsTlsHandshakeFailure;
     }
 
     private void PrepareDeferredNetworkRetry(ReadyBatch batch, HashSet<string> metadataRefreshTopics)

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4059,15 +4059,11 @@ internal sealed partial class BrokerSender : IAsyncDisposable
             if (!pendingResponseAdded)
                 ArrayPool<ReadyBatch>.Shared.Return(batches, clearArray: true);
         }
-        catch (AuthenticationException ex) when (
-            ex.ErrorCode == ErrorCode.SaslAuthenticationFailed
-            && !_options.UsesDynamicSaslCredentials
-            && _options.SaslMechanism is SaslMechanism.Plain
-                or SaslMechanism.ScramSha256
-                or SaslMechanism.ScramSha512)
+        catch (AuthenticationException ex) when (IsFatalAuthenticationFailure(ex))
         {
-            // A broker-rejected static PLAIN/SCRAM credential is fatal. Dynamic credential
-            // providers and other authentication-adjacent failures follow the normal retry path.
+            // TLS validation cannot succeed without a configuration/trust change, and a
+            // broker-rejected static PLAIN/SCRAM credential cannot repair itself. Surface both
+            // immediately instead of hiding the actionable error behind delivery timeout.
             _pinnedConnections[connectionIndex] = null;
             LogResponseFailed(ex, _brokerId);
             for (var i = 0; i < count; i++)
@@ -4163,6 +4159,19 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 ArrayPool<int>.Shared.Return(generations);
             }
         }
+    }
+
+    private bool IsFatalAuthenticationFailure(AuthenticationException exception)
+    {
+        if (exception.ErrorCode == ErrorCode.SaslAuthenticationFailed)
+        {
+            return !_options.UsesDynamicSaslCredentials
+                && _options.SaslMechanism is SaslMechanism.Plain
+                    or SaslMechanism.ScramSha256
+                    or SaslMechanism.ScramSha512;
+        }
+
+        return _options.UseTls || _options.TlsConfig is not null;
     }
 
     private void PrepareDeferredNetworkRetry(ReadyBatch batch, HashSet<string> metadataRefreshTopics)

--- a/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TestCertificateGenerator.cs
@@ -139,7 +139,9 @@ internal sealed class TestCertificateGenerator : IDisposable
         X509Certificate2 caCert,
         string subjectName,
         bool isServer,
-        out string privateKeyPem)
+        out string privateKeyPem,
+        DateTimeOffset? notBefore = null,
+        DateTimeOffset? notAfter = null)
     {
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest(
@@ -200,8 +202,8 @@ internal sealed class TestCertificateGenerator : IDisposable
 
         using var cert = request.Create(
             caCert,
-            DateTimeOffset.UtcNow.AddMinutes(-5),
-            DateTimeOffset.UtcNow.AddYears(2),
+            notBefore ?? DateTimeOffset.UtcNow.AddMinutes(-5),
+            notAfter ?? DateTimeOffset.UtcNow.AddYears(2),
             serialNumber);
 
         // Combine signed certificate with private key
@@ -214,6 +216,20 @@ internal sealed class TestCertificateGenerator : IDisposable
             StorePassword,
             X509KeyStorageFlags.Exportable);
     }
+
+    /// <summary>
+    /// Generates another TLS server certificate signed by this generator's CA.
+    /// </summary>
+    public X509Certificate2 GenerateServerCertificate(
+        DateTimeOffset? notBefore = null,
+        DateTimeOffset? notAfter = null)
+        => GenerateSignedCertificate(
+            CaCertificate,
+            "CN=kafka-broker, O=Dekaf Test, C=US",
+            isServer: true,
+            out _,
+            notBefore,
+            notAfter);
 
     private void ExportCertificates()
     {

--- a/tests/Dekaf.Tests.Integration/Security/TlsCertificateRotationTests.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsCertificateRotationTests.cs
@@ -1,0 +1,210 @@
+using System.Diagnostics;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Security;
+
+namespace Dekaf.Tests.Integration.Security;
+
+public sealed class TlsCertificateRotationKafkaContainer : TlsKafkaContainer;
+
+[Category("Tls")]
+[NotInParallel("TlsCertificateRotationKafkaContainer")]
+[ClassDataSource<TlsCertificateRotationKafkaContainer>(Shared = SharedType.PerTestSession)]
+public sealed class TlsCertificateRotationTests(TlsCertificateRotationKafkaContainer kafka)
+{
+    [Test]
+    public async Task BrokerCertificateRotation_EnforcesAndRefreshesTrustWithoutMessageLoss()
+    {
+        using var baselineCertificate = kafka.CertificateGenerator.GenerateServerCertificate();
+        await kafka.RestartWithServerCertificateAsync(baselineCertificate).ConfigureAwait(false);
+
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var staticTlsConfig = CreateTlsConfig(kafka.CaCertificate);
+
+        await using var staticTrustProducer = await CreateProducerBuilder("tls-static-trust", staticTlsConfig)
+            .BuildAsync().ConfigureAwait(false);
+        await ProduceAsync(staticTrustProducer, topic, "before-rotation").ConfigureAwait(false);
+
+        using var sameCaCertificate = kafka.CertificateGenerator.GenerateServerCertificate();
+        await kafka.RestartWithServerCertificateAsync(sameCaCertificate).ConfigureAwait(false);
+        await ProduceAsync(staticTrustProducer, topic, "after-same-ca-rotation").ConfigureAwait(false);
+
+        var reloadableTrust = new ReloadableCertificateTrust(kafka.CaCertificate);
+        await using var reloadableTrustProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("tls-reloadable-trust")
+            .UseTls(new TlsConfig { TargetHost = "localhost" })
+            .WithRemoteCertificateValidationCallback(reloadableTrust.Validate)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        await ProduceAsync(reloadableTrustProducer, topic, "before-ca-rotation").ConfigureAwait(false);
+
+        using var rotatedAuthority = new TestCertificateGenerator();
+        using var newCaCertificate = rotatedAuthority.GenerateServerCertificate();
+        await kafka.RestartWithServerCertificateAsync(newCaCertificate).ConfigureAwait(false);
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = await Assert.ThrowsAsync<AuthenticationException>(async () =>
+            await ProduceAsync(staticTrustProducer, topic, "untrusted-ca").ConfigureAwait(false));
+
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.Message).Contains("TLS handshake failed");
+        await Assert.That(exception.Message).Contains("Certificate validation:");
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(15));
+
+        reloadableTrust.TrustedRoot = rotatedAuthority.CaCertificate;
+        await ProduceAsync(reloadableTrustProducer, topic, "after-trust-refresh").ConfigureAwait(false);
+
+        var values = await ConsumeValuesAsync(
+            topic,
+            reloadableTrust,
+            expectedCount: 4).ConfigureAwait(false);
+
+        await Assert.That(values).IsEquivalentTo([
+            "before-rotation",
+            "after-same-ca-rotation",
+            "before-ca-rotation",
+            "after-trust-refresh"
+        ]);
+        await Assert.That(values).Count().IsEqualTo(values.Distinct().Count());
+    }
+
+    [Test]
+    public async Task ExpiredBrokerCertificate_ExistingConnectionSurvivesButReconnectFailsCleanly()
+    {
+        using var baselineCertificate = kafka.CertificateGenerator.GenerateServerCertificate();
+        await kafka.RestartWithServerCertificateAsync(baselineCertificate).ConfigureAwait(false);
+
+        var topic = await kafka.CreateTestTopicAsync().ConfigureAwait(false);
+        var notAfter = DateTimeOffset.UtcNow.AddSeconds(45);
+        using var expiringCertificate = kafka.CertificateGenerator.GenerateServerCertificate(
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            notAfter);
+        await kafka.RestartWithServerCertificateAsync(expiringCertificate).ConfigureAwait(false);
+
+        await using var producer = await CreateProducerBuilder(
+                "tls-expiring-certificate",
+                CreateTlsConfig(kafka.CaCertificate))
+            .BuildAsync().ConfigureAwait(false);
+        await ProduceAsync(producer, topic, "before-expiry").ConfigureAwait(false);
+
+        var expiryDelay = expiringCertificate.NotAfter.ToUniversalTime() - DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        if (expiryDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(expiryDelay).ConfigureAwait(false);
+        }
+
+        await ProduceAsync(producer, topic, "existing-connection-after-expiry").ConfigureAwait(false);
+        await ((KafkaProducer<string, string>)producer).CloseConnectionsForTestingAsync().ConfigureAwait(false);
+
+        var stopwatch = Stopwatch.StartNew();
+        var exception = await Assert.ThrowsAsync<AuthenticationException>(async () =>
+            await ProduceAsync(producer, topic, "reconnect-after-expiry").ConfigureAwait(false));
+
+        await Assert.That(exception!.IsRetriable).IsFalse();
+        await Assert.That(exception.Message).Contains("TLS handshake failed");
+        await Assert.That(exception.Message).Contains("NotTimeValid");
+        await Assert.That(exception.InnerException).IsNotNull();
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(15));
+    }
+
+    private ProducerBuilder<string, string> CreateProducerBuilder(string clientId, TlsConfig tlsConfig)
+        => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId(clientId)
+            .UseTls(tlsConfig)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithRequestTimeout(TimeSpan.FromSeconds(5))
+            .WithDeliveryTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory());
+
+    private async Task<List<string>> ConsumeValuesAsync(
+        string topic,
+        ReloadableCertificateTrust trust,
+        int expectedCount)
+    {
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(kafka.BootstrapServers)
+            .WithClientId("tls-rotation-consumer")
+            .WithGroupId($"tls-rotation-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(AutoOffsetReset.Earliest)
+            .UseTls(new TlsConfig { TargetHost = "localhost" })
+            .WithRemoteCertificateValidationCallback(trust.Validate)
+            .WithConnectionTimeout(TimeSpan.FromSeconds(5))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync().ConfigureAwait(false);
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var values = new List<string>(expectedCount);
+        while (values.Count < expectedCount)
+        {
+            var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token).ConfigureAwait(false);
+            await Assert.That(result).IsNotNull();
+            values.Add(result!.Value.Value);
+        }
+
+        return values;
+    }
+
+    private static TlsConfig CreateTlsConfig(X509Certificate2 caCertificate) => new()
+    {
+        CaCertificateObject = caCertificate,
+        ValidateServerCertificate = true,
+        TargetHost = "localhost"
+    };
+
+    private static async Task ProduceAsync(
+        IKafkaProducer<string, string> producer,
+        string topic,
+        string value)
+    {
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = topic,
+            Key = value,
+            Value = value
+        }, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private sealed class ReloadableCertificateTrust(X509Certificate2 trustedRoot)
+    {
+        public X509Certificate2 TrustedRoot { get; set; } = trustedRoot;
+
+        public bool Validate(
+            object sender,
+            X509Certificate? certificate,
+            X509Chain? chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (certificate is null ||
+                (sslPolicyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
+            {
+                return false;
+            }
+
+            using var serverCertificate = LoadCertificate(certificate.Export(X509ContentType.Cert));
+            using var validationChain = new X509Chain();
+            validationChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+            validationChain.ChainPolicy.CustomTrustStore.Add(TrustedRoot);
+            validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            return validationChain.Build(serverCertificate);
+        }
+
+        private static X509Certificate2 LoadCertificate(byte[] rawData)
+        {
+#if NET10_0_OR_GREATER
+            return X509CertificateLoader.LoadCertificate(rawData);
+#else
+            return new X509Certificate2(rawData);
+#endif
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -20,6 +20,8 @@ namespace Dekaf.Tests.Integration.Security;
 /// </summary>
 public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
 {
+    private const ushort KafkaContainerPort = 9092;
+    private const string ServerKeystoreContainerPath = "/etc/kafka/secrets/server.p12";
     private KafkaContainer? _container;
     private TestCertificateGenerator? _certGenerator;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _createdTopics = new();
@@ -66,13 +68,13 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         _certGenerator = new TestCertificateGenerator();
 
         Console.WriteLine("[TlsKafkaContainer] Starting TLS-enabled Kafka container...");
+        var stableHostPort = GetFreeTcpPort();
 
         // Container paths for certificate files
         const string containerCertDir = "/etc/kafka/secrets";
         const string caCertContainerPath = $"{containerCertDir}/ca-cert.pem";
         const string serverCertContainerPath = $"{containerCertDir}/server-cert.pem";
         const string serverKeyContainerPath = $"{containerCertDir}/server-key.pem";
-        const string serverKeystoreContainerPath = $"{containerCertDir}/server.p12";
         const string truststoreContainerPath = $"{containerCertDir}/truststore.p12";
         const string clientCertContainerPath = $"{containerCertDir}/client-cert.pem";
         const string clientKeyContainerPath = $"{containerCertDir}/client-key.pem";
@@ -91,7 +93,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
             .WithEnvironment("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "PLAINTEXT:SSL,BROKER:PLAINTEXT,CONTROLLER:PLAINTEXT")
             // SSL configuration using PKCS12 keystore (Kafka supports PKCS12 natively)
             .WithEnvironment("KAFKA_SSL_KEYSTORE_TYPE", "PKCS12")
-            .WithEnvironment("KAFKA_SSL_KEYSTORE_LOCATION", serverKeystoreContainerPath)
+            .WithEnvironment("KAFKA_SSL_KEYSTORE_LOCATION", ServerKeystoreContainerPath)
             .WithEnvironment("KAFKA_SSL_KEYSTORE_PASSWORD", TestCertificateGenerator.StorePassword)
             .WithEnvironment("KAFKA_SSL_KEY_PASSWORD", TestCertificateGenerator.StorePassword)
             // Use a PEM truststore (the CA cert) rather than PKCS12: a .NET-exported cert-only
@@ -109,10 +111,13 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
             .WithResourceMapping(File.ReadAllBytes(_certGenerator.CaCertPemPath), caCertContainerPath)
             .WithResourceMapping(File.ReadAllBytes(serverCertPemPath), serverCertContainerPath)
             .WithResourceMapping(File.ReadAllBytes(serverKeyPemPath), serverKeyContainerPath)
-            .WithResourceMapping(File.ReadAllBytes(_certGenerator.ServerKeystorePath), serverKeystoreContainerPath)
+            .WithResourceMapping(File.ReadAllBytes(_certGenerator.ServerKeystorePath), ServerKeystoreContainerPath)
             .WithResourceMapping(File.ReadAllBytes(_certGenerator.ServerTruststorePath), truststoreContainerPath)
             .WithResourceMapping(File.ReadAllBytes(_certGenerator.ClientCertPemPath), clientCertContainerPath)
             .WithResourceMapping(File.ReadAllBytes(_certGenerator.ClientKeyPemPath), clientKeyContainerPath)
+            // Docker may assign a different ephemeral host port after stop/start. A fixed host
+            // binding keeps existing clients' advertised endpoint valid across certificate rotation.
+            .WithPortBinding(stableHostPort, KafkaContainerPort)
             .Build();
 
         await _container.StartAsync();
@@ -125,6 +130,36 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         await WaitForKafkaSslAsync();
     }
 
+    /// <summary>
+    /// Restarts the same broker after replacing its TLS server keystore.
+    /// Broker data and the mapped endpoint are retained across the restart.
+    /// </summary>
+    public async Task RestartWithServerCertificateAsync(X509Certificate2 serverCertificate)
+    {
+        var container = _container ?? throw new InvalidOperationException("Container not initialized");
+        if (!serverCertificate.HasPrivateKey)
+        {
+            throw new ArgumentException("The server certificate must contain its private key.", nameof(serverCertificate));
+        }
+
+        await container.StopAsync();
+        await container.CopyAsync(
+            serverCertificate.Export(X509ContentType.Pfx, TestCertificateGenerator.StorePassword),
+            ServerKeystoreContainerPath);
+        await container.StartAsync();
+        try
+        {
+            await WaitForKafkaSslAsync(maxAttempts: 10);
+        }
+        catch
+        {
+            var (stdout, stderr) = await container.GetLogsAsync();
+            Console.WriteLine($"[TlsKafkaContainer] Kafka stdout after failed restart:{Environment.NewLine}{stdout}");
+            Console.WriteLine($"[TlsKafkaContainer] Kafka stderr after failed restart:{Environment.NewLine}{stderr}");
+            throw;
+        }
+    }
+
     private static string ExtractHostPort(string address)
     {
         if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
@@ -132,6 +167,20 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
             return $"{uri.Host}:{uri.Port}";
         }
         return address.TrimEnd('/');
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     /// <summary>
@@ -146,10 +195,9 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
             TargetHost = "localhost"
         };
 
-    private async Task WaitForKafkaSslAsync()
+    private async Task WaitForKafkaSslAsync(int maxAttempts = 30)
     {
         Console.WriteLine("[TlsKafkaContainer] Waiting for Kafka SSL listener to be ready...");
-        const int maxAttempts = 30;
 
         var colonIndex = BootstrapServers.LastIndexOf(':');
         var host = BootstrapServers[..colonIndex];

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -81,8 +81,9 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     public async Task SendLoop_TlsAuthenticationFailure_FailsBatchWithoutRetry(
         CancellationToken cancellationToken)
     {
-        var authenticationFailure = new AuthenticationException(
-            "TLS handshake failed: certificate chain validation failed");
+        var authenticationFailure = AuthenticationException.FromTlsHandshake(
+            "TLS handshake failed: certificate chain validation failed",
+            new System.Security.Authentication.AuthenticationException("certificate rejected"));
         var pool = Substitute.For<IConnectionPool>();
         pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns<ValueTask<IKafkaConnection>>(_ =>
@@ -118,6 +119,19 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             await accumulator.DisposeAsync();
             await valueTaskSourcePool.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task AuthenticationFailure_FromSaslOverTls_RemainsRetriable()
+    {
+        var authenticationFailure = new AuthenticationException("OAuth token has expired");
+        var options = CreateOptions(
+            saslMechanism: SaslMechanism.OAuthBearer,
+            useTls: true);
+
+        var isFatal = BrokerSender.IsFatalAuthenticationFailure(authenticationFailure, options);
+
+        await Assert.That(isFatal).IsFalse();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -77,6 +77,50 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Timeout(30_000)]
+    public async Task SendLoop_TlsAuthenticationFailure_FailsBatchWithoutRetry(
+        CancellationToken cancellationToken)
+    {
+        var authenticationFailure = new AuthenticationException(
+            "TLS handshake failed: certificate chain validation failed");
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                ValueTask.FromException<IKafkaConnection>(authenticationFailure));
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<ValueTask<IKafkaConnection>>(_ =>
+                ValueTask.FromException<IKafkaConnection>(authenticationFailure));
+
+        var options = CreateOptions(
+            deliveryTimeoutMs: 20_000,
+            requestTimeoutMs: 5_000,
+            useTls: true);
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var acknowledgement = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sender = CreateSender(
+            pool,
+            options,
+            accumulator,
+            (_, _, _, _, error) => acknowledgement.TrySetResult(error));
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, "test-topic", partition: 0));
+
+            var observed = await acknowledgement.Task.WaitAsync(cancellationToken);
+            await Assert.That(observed).IsSameReferenceAs(authenticationFailure);
+            await pool.Received(1).GetConnectionAsync(1, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     public async Task DeliveryLatencyOrigin_SealWithinLinger_UsesSealNotCreation()
     {
         // Sealing within the configured linger: the origin stays the seal, so opted-in
@@ -857,7 +901,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         long? unackedByteBudgetCapOverride = null, long? scaleCooldownMsOverride = null,
         string? transactionalId = null, int lingerMs = 0,
         bool enableDeliveryDiagnostics = false,
-        SaslMechanism saslMechanism = SaslMechanism.None) => new()
+        SaslMechanism saslMechanism = SaslMechanism.None,
+        bool useTls = false) => new()
         {
             BootstrapServers = ["localhost:9092"],
             MaxInFlightRequestsPerConnection = maxInFlight,
@@ -875,7 +920,8 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
             UnackedByteBudgetCapOverride = unackedByteBudgetCapOverride,
             ScaleCooldownMsOverride = scaleCooldownMsOverride,
             TransactionalId = transactionalId,
-            SaslMechanism = saslMechanism
+            SaslMechanism = saslMechanism,
+            UseTls = useTls
         };
 
     private sealed class ThrowingCompressionCodec : ICompressionCodec


### PR DESCRIPTION
## Summary
- add deterministic broker certificate replacement/restart infrastructure with a stable advertised endpoint
- cover same-CA leaf rotation, new-CA rejection, reloadable trust recovery, and post-expiry reconnect behavior
- surface TLS authentication failures immediately from producer sends with actionable chain status instead of delivery timeout

## Validation
- Release solution build (0 warnings/errors)
- full unit suites: net10 6206/6206, net8 6079/6079
- TLS rotation integrations: net10 2/2, net8 2/2
- existing TLS producer smoke: net10 1/1, net8 1/1
- post-rebase Release build, focused auth units both TFMs, TLS rotation net10 2/2

Closes #2260