### PR TITLE
Bind Confluent ProducerConfig JSON

### DIFF
--- a/src/Dekaf.Extensions.DependencyInjection/ConfluentConfigurationBinding.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ConfluentConfigurationBinding.cs
@@ -111,15 +111,18 @@ internal static class ConfluentConfigurationBinding
             builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
         if (TryGet(configuration, "MessageMaxBytes", out int maxRequestSize))
             builder.WithMaxRequestSize(maxRequestSize);
-        if (TryGet(configuration, "EnableIdempotence", out bool enableIdempotence))
-            builder.WithIdempotence(enableIdempotence);
-        if (TryGet(configuration, "TransactionalId", out string transactionalId))
+        var hasTransactionalId = TryGet(configuration, "TransactionalId", out string transactionalId);
+        builder.WithIdempotence(
+            TryGet(configuration, "EnableIdempotence", out bool enableIdempotence)
+                ? enableIdempotence
+                : hasTransactionalId);
+        if (hasTransactionalId)
             builder.WithTransactionalId(transactionalId);
         if (TryGet(configuration, "TransactionTimeoutMs", out int transactionTimeoutMs))
             builder.WithTransactionTimeout(TimeSpan.FromMilliseconds(transactionTimeoutMs));
         if (TryGetEnum(configuration, "CompressionType", out ConfluentCompressionType compressionType))
             builder.UseCompression(MapCompressionType(compressionType));
-        if (TryGet(configuration, "CompressionLevel", out int compressionLevel))
+        if (TryGet(configuration, "CompressionLevel", out int compressionLevel) && compressionLevel != -1)
             builder.WithCompressionLevel(compressionLevel);
         if (TryGetEnum(configuration, "Partitioner", out ConfluentPartitioner partitioner))
             builder.WithPartitioner(MapPartitioner(partitioner));
@@ -488,6 +491,8 @@ internal static class ConfluentConfigurationBinding
             ConfluentPartitioner.ConsistentRandom => PartitionerType.ConsistentRandom,
             ConfluentPartitioner.Murmur2 => PartitionerType.Murmur2,
             ConfluentPartitioner.Murmur2Random => PartitionerType.Murmur2Random,
+            ConfluentPartitioner.Fnv1a => PartitionerType.Fnv1A,
+            ConfluentPartitioner.Fnv1aRandom => PartitionerType.Fnv1ARandom,
             _ => throw new UnreachableException()
         };
 
@@ -517,6 +522,8 @@ internal static class ConfluentConfigurationBinding
         Consistent,
         ConsistentRandom,
         Murmur2,
-        Murmur2Random
+        Murmur2Random,
+        Fnv1a,
+        Fnv1aRandom
     }
 }

--- a/src/Dekaf.Extensions.DependencyInjection/ConfluentConfigurationBinding.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ConfluentConfigurationBinding.cs
@@ -1,0 +1,522 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+using Dekaf.Security;
+using Dekaf.Security.Sasl;
+using Microsoft.Extensions.Configuration;
+
+namespace Dekaf.Extensions.DependencyInjection;
+
+[RequiresDynamicCode(DekafConfigurationBinding.RequiresDynamicCodeMessage)]
+[RequiresUnreferencedCode(DekafConfigurationBinding.RequiresUnreferencedCodeMessage)]
+internal static class ConfluentConfigurationBinding
+{
+    private static readonly HashSet<string> s_clientProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "BootstrapServers",
+        "ClientDnsLookup",
+        "ClientId",
+        "ClientRack",
+        "ConnectionsMaxIdleMs",
+        "EnableSslCertificateVerification",
+        "MaxInFlight",
+        "MessageMaxBytes",
+        "MetadataMaxAgeMs",
+        "MetadataRecoveryRebootstrapTriggerMs",
+        "MetadataRecoveryStrategy",
+        "ReconnectBackoffMaxMs",
+        "ReconnectBackoffMs",
+        "RetryBackoffMaxMs",
+        "RetryBackoffMs",
+        "SaslKerberosKeytab",
+        "SaslKerberosPrincipal",
+        "SaslKerberosServiceName",
+        "SaslMechanism",
+        "SaslOauthbearerClientId",
+        "SaslOauthbearerClientSecret",
+        "SaslOauthbearerGrantType",
+        "SaslOauthbearerMethod",
+        "SaslOauthbearerScope",
+        "SaslOauthbearerTokenEndpointUrl",
+        "SaslPassword",
+        "SaslUsername",
+        "SecurityProtocol",
+        "SocketConnectionSetupTimeoutMs",
+        "SocketKeepaliveEnable",
+        "SocketNagleDisable",
+        "SocketReceiveBufferBytes",
+        "SocketSendBufferBytes",
+        "SslCaLocation",
+        "SslCertificateLocation",
+        "SslEndpointIdentificationAlgorithm",
+        "SslKeyLocation",
+        "SslKeyPassword",
+        "SslKeystoreLocation",
+        "SslKeystorePassword"
+    };
+
+    private static readonly HashSet<string> s_producerProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Acks",
+        "BatchSize",
+        "CompressionLevel",
+        "CompressionType",
+        "EnableIdempotence",
+        "LingerMs",
+        "MessageSendMaxRetries",
+        "MessageTimeoutMs",
+        "Partitioner",
+        "QueueBufferingMaxKbytes",
+        "RequestTimeoutMs",
+        "TransactionTimeoutMs",
+        "TransactionalId"
+    };
+
+    public static void ApplyProducer<TKey, TValue>(
+        IConfiguration configuration,
+        ProducerBuilder<TKey, TValue> builder)
+    {
+        ValidateProducerProperties(configuration);
+
+        if (TryGetEnum(configuration, "Acks", out Acks acks))
+            builder.WithAcks(acks);
+        if (TryGetWholeMilliseconds(configuration, "LingerMs", out var linger))
+            builder.WithLinger(linger);
+        if (TryGet(configuration, "BatchSize", out int batchSize))
+            builder.WithBatchSize(batchSize);
+        if (TryGet(configuration, "QueueBufferingMaxKbytes", out int bufferMemoryKbytes))
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(bufferMemoryKbytes);
+            builder.WithBufferMemory(checked((ulong)bufferMemoryKbytes * 1024));
+        }
+        if (TryGet(configuration, "MaxInFlight", out int maxInFlight))
+            builder.WithMaxInFlightRequestsPerConnection(maxInFlight);
+        if (TryGet(configuration, "MessageSendMaxRetries", out int retries))
+            builder.WithRetries(retries);
+        if (TryGet(configuration, "MessageTimeoutMs", out int deliveryTimeoutMs))
+        {
+            if (deliveryTimeoutMs == 0)
+            {
+                throw new NotSupportedException(
+                    "Confluent property 'MessageTimeoutMs' value '0' means infinite delivery time, " +
+                    "which Dekaf cannot represent exactly.");
+            }
+
+            builder.WithDeliveryTimeout(TimeSpan.FromMilliseconds(deliveryTimeoutMs));
+        }
+        if (TryGet(configuration, "RequestTimeoutMs", out int requestTimeoutMs))
+            builder.WithRequestTimeout(TimeSpan.FromMilliseconds(requestTimeoutMs));
+        if (TryGet(configuration, "MessageMaxBytes", out int maxRequestSize))
+            builder.WithMaxRequestSize(maxRequestSize);
+        if (TryGet(configuration, "EnableIdempotence", out bool enableIdempotence))
+            builder.WithIdempotence(enableIdempotence);
+        if (TryGet(configuration, "TransactionalId", out string transactionalId))
+            builder.WithTransactionalId(transactionalId);
+        if (TryGet(configuration, "TransactionTimeoutMs", out int transactionTimeoutMs))
+            builder.WithTransactionTimeout(TimeSpan.FromMilliseconds(transactionTimeoutMs));
+        if (TryGetEnum(configuration, "CompressionType", out ConfluentCompressionType compressionType))
+            builder.UseCompression(MapCompressionType(compressionType));
+        if (TryGet(configuration, "CompressionLevel", out int compressionLevel))
+            builder.WithCompressionLevel(compressionLevel);
+        if (TryGetEnum(configuration, "Partitioner", out ConfluentPartitioner partitioner))
+            builder.WithPartitioner(MapPartitioner(partitioner));
+
+        ApplySharedClient(configuration, builder);
+        ApplySecurity(configuration, builder);
+    }
+
+    private static void ApplySharedClient<TKey, TValue>(
+        IConfiguration configuration,
+        ProducerBuilder<TKey, TValue> builder)
+    {
+        if (TryGet(configuration, "BootstrapServers", out string bootstrapServers))
+            builder.WithBootstrapServers(bootstrapServers);
+        if (TryGet(configuration, "ClientId", out string clientId))
+            builder.WithClientId(clientId);
+        if (TryGet(configuration, "ClientRack", out string clientRack))
+            builder.WithClientRack(clientRack);
+        if (TryGetEnum(configuration, "ClientDnsLookup", out ClientDnsLookup clientDnsLookup))
+            builder.WithClientDnsLookup(clientDnsLookup);
+        if (TryGet(configuration, "ConnectionsMaxIdleMs", out int connectionsMaxIdleMs))
+        {
+            builder.WithConnectionsMaxIdle(connectionsMaxIdleMs == 0
+                ? Timeout.InfiniteTimeSpan
+                : TimeSpan.FromMilliseconds(connectionsMaxIdleMs));
+        }
+        if (TryGet(configuration, "MetadataMaxAgeMs", out int metadataMaxAgeMs))
+            builder.WithMetadataMaxAge(TimeSpan.FromMilliseconds(metadataMaxAgeMs));
+        if (TryGetEnum(
+                configuration,
+                "MetadataRecoveryStrategy",
+                out MetadataRecoveryStrategy metadataRecoveryStrategy))
+        {
+            builder.WithMetadataRecoveryStrategy(metadataRecoveryStrategy);
+        }
+        if (TryGet(
+                configuration,
+                "MetadataRecoveryRebootstrapTriggerMs",
+                out int metadataRecoveryRebootstrapTriggerMs))
+        {
+            builder.WithMetadataRecoveryRebootstrapTrigger(
+                TimeSpan.FromMilliseconds(metadataRecoveryRebootstrapTriggerMs));
+        }
+        if (TryGet(configuration, "RetryBackoffMs", out int retryBackoffMs))
+            builder.WithRetryBackoff(TimeSpan.FromMilliseconds(retryBackoffMs));
+        if (TryGet(configuration, "RetryBackoffMaxMs", out int retryBackoffMaxMs))
+            builder.WithRetryBackoffMax(TimeSpan.FromMilliseconds(retryBackoffMaxMs));
+        if (TryGet(configuration, "ReconnectBackoffMs", out int reconnectBackoffMs))
+            builder.WithReconnectBackoff(TimeSpan.FromMilliseconds(reconnectBackoffMs));
+        if (TryGet(configuration, "ReconnectBackoffMaxMs", out int reconnectBackoffMaxMs))
+            builder.WithReconnectBackoffMax(TimeSpan.FromMilliseconds(reconnectBackoffMaxMs));
+        if (TryGet(configuration, "SocketConnectionSetupTimeoutMs", out int connectionTimeoutMs))
+            builder.WithConnectionTimeout(TimeSpan.FromMilliseconds(connectionTimeoutMs));
+        if (TryGet(configuration, "SocketKeepaliveEnable", out bool enableTcpKeepAlive))
+            builder.WithTcpKeepAlive(enableTcpKeepAlive);
+        if (TryGet(configuration, "SocketNagleDisable", out bool disableNagle) && !disableNagle)
+        {
+            throw new NotSupportedException(
+                "Confluent property 'SocketNagleDisable' value 'false' cannot be represented exactly; " +
+                "Dekaf always disables Nagle's algorithm.");
+        }
+        if (TryGet(configuration, "SocketSendBufferBytes", out int socketSendBufferBytes))
+            builder.WithSocketSendBufferBytes(socketSendBufferBytes);
+        if (TryGet(configuration, "SocketReceiveBufferBytes", out int socketReceiveBufferBytes))
+            builder.WithSocketReceiveBufferBytes(socketReceiveBufferBytes);
+    }
+
+    private static void ApplySecurity<TKey, TValue>(
+        IConfiguration configuration,
+        ProducerBuilder<TKey, TValue> builder)
+    {
+        var protocol = GetSecurityProtocol(configuration);
+        var tlsEnabled = protocol is ConfluentSecurityProtocol.Ssl or ConfluentSecurityProtocol.SaslSsl;
+        var saslEnabled = protocol is ConfluentSecurityProtocol.SaslPlaintext or ConfluentSecurityProtocol.SaslSsl;
+
+        var hasTlsSettings = HasAny(
+            configuration,
+            "EnableSslCertificateVerification",
+            "SslCaLocation",
+            "SslCertificateLocation",
+            "SslEndpointIdentificationAlgorithm",
+            "SslKeyLocation",
+            "SslKeyPassword",
+            "SslKeystoreLocation",
+            "SslKeystorePassword");
+        if (hasTlsSettings && !tlsEnabled)
+        {
+            throw new InvalidOperationException(
+                "Confluent TLS properties require SecurityProtocol to be Ssl or SaslSsl.");
+        }
+
+        if (tlsEnabled)
+            builder.UseTls(CreateTlsConfig(configuration));
+
+        var hasSaslSettings = HasAny(
+            configuration,
+            "SaslKerberosKeytab",
+            "SaslKerberosPrincipal",
+            "SaslKerberosServiceName",
+            "SaslMechanism",
+            "SaslOauthbearerClientId",
+            "SaslOauthbearerClientSecret",
+            "SaslOauthbearerGrantType",
+            "SaslOauthbearerMethod",
+            "SaslOauthbearerScope",
+            "SaslOauthbearerTokenEndpointUrl",
+            "SaslPassword",
+            "SaslUsername");
+        if (hasSaslSettings && !saslEnabled)
+        {
+            throw new InvalidOperationException(
+                "Confluent SASL properties require SecurityProtocol to be SaslPlaintext or SaslSsl.");
+        }
+
+        if (!saslEnabled)
+            return;
+
+        var mechanism = TryGetSaslMechanism(configuration, out var configuredMechanism)
+            ? configuredMechanism
+            : SaslMechanism.Gssapi;
+        TryGet(configuration, "SaslUsername", out string? username);
+        TryGet(configuration, "SaslPassword", out string? password);
+
+        GssapiConfig? gssapi = null;
+        OAuthBearerConfig? oauth = null;
+        switch (mechanism)
+        {
+            case SaslMechanism.Plain or SaslMechanism.ScramSha256 or SaslMechanism.ScramSha512:
+                if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+                {
+                    throw new InvalidOperationException(
+                        $"SaslUsername and SaslPassword are required for {mechanism}.");
+                }
+                break;
+            case SaslMechanism.Gssapi:
+                gssapi = new GssapiConfig
+                {
+                    ServiceName = Get(configuration, "SaslKerberosServiceName") ?? "kafka",
+                    Principal = Get(configuration, "SaslKerberosPrincipal"),
+                    KeytabPath = Get(configuration, "SaslKerberosKeytab")
+                };
+                break;
+            case SaslMechanism.OAuthBearer:
+                oauth = CreateOAuthConfig(configuration);
+                break;
+            default:
+                throw UnsupportedValue("SaslMechanism", mechanism.ToString());
+        }
+
+        builder.WithSaslOptions(mechanism, username, password, gssapi, oauth, awsMskIamConfig: null);
+    }
+
+    private static TlsConfig CreateTlsConfig(IConfiguration configuration)
+    {
+        var certificateLocation = Get(configuration, "SslCertificateLocation");
+        var keyLocation = Get(configuration, "SslKeyLocation");
+        var keystoreLocation = Get(configuration, "SslKeystoreLocation");
+        if (certificateLocation is not null && keystoreLocation is not null)
+        {
+            throw new InvalidOperationException(
+                "SslCertificateLocation and SslKeystoreLocation cannot both be configured.");
+        }
+
+        return new TlsConfig
+        {
+            CaCertificatePath = Get(configuration, "SslCaLocation"),
+            ClientCertificatePath = certificateLocation ?? keystoreLocation,
+            ClientKeyPath = keyLocation,
+            ClientKeyPassword = Get(configuration, "SslKeyPassword")
+                ?? Get(configuration, "SslKeystorePassword"),
+            ValidateServerCertificate = !TryGet(
+                configuration,
+                "EnableSslCertificateVerification",
+                out bool validateCertificate) || validateCertificate,
+            ValidateServerCertificateHostName = GetEndpointIdentification(configuration)
+        };
+    }
+
+    private static OAuthBearerConfig CreateOAuthConfig(IConfiguration configuration)
+    {
+        var method = Get(configuration, "SaslOauthbearerMethod") ?? "Default";
+        if (!method.Equals("Oidc", StringComparison.OrdinalIgnoreCase))
+            throw UnsupportedValue("SaslOauthbearerMethod", method);
+
+        var grantType = Get(configuration, "SaslOauthbearerGrantType");
+        if (grantType is not null &&
+            !grantType.Equals("client_credentials", StringComparison.OrdinalIgnoreCase) &&
+            !grantType.Equals("ClientCredentials", StringComparison.OrdinalIgnoreCase))
+        {
+            throw UnsupportedValue("SaslOauthbearerGrantType", grantType);
+        }
+
+        return new OAuthBearerConfig
+        {
+            TokenEndpointUrl = GetRequired(configuration, "SaslOauthbearerTokenEndpointUrl"),
+            ClientId = GetRequired(configuration, "SaslOauthbearerClientId"),
+            ClientSecret = Get(configuration, "SaslOauthbearerClientSecret"),
+            Scope = Get(configuration, "SaslOauthbearerScope")
+        };
+    }
+
+    private static ConfluentSecurityProtocol GetSecurityProtocol(IConfiguration configuration)
+    {
+        var raw = Get(configuration, "SecurityProtocol");
+        if (raw is null)
+            return ConfluentSecurityProtocol.Plaintext;
+        return Enum.TryParse<ConfluentSecurityProtocol>(NormalizeEnumValue(raw), ignoreCase: true, out var protocol) &&
+               Enum.IsDefined(protocol)
+            ? protocol
+            : throw UnsupportedValue("SecurityProtocol", raw);
+    }
+
+    private static bool TryGetSaslMechanism(
+        IConfiguration configuration,
+        out SaslMechanism mechanism)
+    {
+        var raw = Get(configuration, "SaslMechanism");
+        if (raw is null)
+        {
+            mechanism = default;
+            return false;
+        }
+
+        if (Enum.TryParse<SaslMechanism>(NormalizeEnumValue(raw), ignoreCase: true, out mechanism) &&
+            Enum.IsDefined(mechanism))
+            return true;
+        throw UnsupportedValue("SaslMechanism", raw);
+    }
+
+    private static bool GetEndpointIdentification(IConfiguration configuration)
+    {
+        var raw = Get(configuration, "SslEndpointIdentificationAlgorithm");
+        if (raw is null || raw.Equals("Https", StringComparison.OrdinalIgnoreCase))
+            return true;
+        if (raw.Equals("None", StringComparison.OrdinalIgnoreCase))
+            return false;
+        throw UnsupportedValue("SslEndpointIdentificationAlgorithm", raw);
+    }
+
+    private static bool TryGetWholeMilliseconds(
+        IConfiguration configuration,
+        string key,
+        out TimeSpan value)
+    {
+        if (!TryGet(configuration, key, out double milliseconds))
+        {
+            value = default;
+            return false;
+        }
+
+        if (milliseconds != Math.Truncate(milliseconds))
+        {
+            throw new NotSupportedException(
+                $"Confluent property '{key}' value '{milliseconds}' cannot be represented exactly by Dekaf; " +
+                "use a whole number of milliseconds.");
+        }
+
+        value = TimeSpan.FromMilliseconds(milliseconds);
+        return true;
+    }
+
+    private static bool TryGetEnum<TEnum>(
+        IConfiguration configuration,
+        string key,
+        out TEnum value)
+        where TEnum : struct, Enum
+    {
+        var raw = Get(configuration, key);
+        if (raw is null)
+        {
+            value = default;
+            return false;
+        }
+
+        if (Enum.TryParse<TEnum>(NormalizeEnumValue(raw), ignoreCase: true, out value) &&
+            Enum.IsDefined(value))
+        {
+            return true;
+        }
+
+        throw UnsupportedValue(key, raw);
+    }
+
+    private static string NormalizeEnumValue(string value) =>
+        value.Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal);
+
+    private static void ValidateProducerProperties(IConfiguration configuration)
+    {
+        foreach (var child in configuration.GetChildren())
+        {
+            if (!s_clientProperties.Contains(child.Key) && !s_producerProperties.Contains(child.Key))
+            {
+                throw new NotSupportedException(
+                    $"Confluent ProducerConfig property '{child.Key}' has no exact Dekaf equivalent. " +
+                    "Remove it or configure the corresponding Dekaf builder API explicitly.");
+            }
+        }
+    }
+
+    private static bool HasAny(IConfiguration configuration, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (configuration.GetSection(key).Exists())
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGet<T>(IConfiguration configuration, string key, out T value)
+    {
+        var section = configuration.GetSection(key);
+        if (!section.Exists())
+        {
+            value = default!;
+            return false;
+        }
+
+        var bound = section.Get<T>();
+        if (bound is null)
+        {
+            throw new InvalidOperationException(
+                $"Confluent property '{key}' could not be bound to {typeof(T).Name}.");
+        }
+
+        value = bound;
+        return true;
+    }
+
+    private static string? Get(IConfiguration configuration, string key)
+    {
+        var section = configuration.GetSection(key);
+        if (!section.Exists())
+            return null;
+
+        return section.Value ?? throw new InvalidOperationException(
+            $"Confluent property '{key}' must be a scalar value.");
+    }
+
+    private static string GetRequired(IConfiguration configuration, string key)
+    {
+        var value = Get(configuration, key);
+        return !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new InvalidOperationException($"{key} is required for Confluent OAUTHBEARER configuration.");
+    }
+
+    private static CompressionType MapCompressionType(ConfluentCompressionType compressionType) =>
+        compressionType switch
+        {
+            ConfluentCompressionType.None => CompressionType.None,
+            ConfluentCompressionType.Gzip => CompressionType.Gzip,
+            ConfluentCompressionType.Snappy => CompressionType.Snappy,
+            ConfluentCompressionType.Lz4 => CompressionType.Lz4,
+            ConfluentCompressionType.Zstd => CompressionType.Zstd,
+            _ => throw new UnreachableException()
+        };
+
+    private static PartitionerType MapPartitioner(ConfluentPartitioner partitioner) =>
+        partitioner switch
+        {
+            ConfluentPartitioner.Random => PartitionerType.Random,
+            ConfluentPartitioner.Consistent => PartitionerType.Consistent,
+            ConfluentPartitioner.ConsistentRandom => PartitionerType.ConsistentRandom,
+            ConfluentPartitioner.Murmur2 => PartitionerType.Murmur2,
+            ConfluentPartitioner.Murmur2Random => PartitionerType.Murmur2Random,
+            _ => throw new UnreachableException()
+        };
+
+    private static NotSupportedException UnsupportedValue(string key, string value) =>
+        new($"Confluent property '{key}' value '{value}' has no exact Dekaf equivalent.");
+
+    private enum ConfluentSecurityProtocol
+    {
+        Plaintext,
+        Ssl,
+        SaslPlaintext,
+        SaslSsl
+    }
+
+    private enum ConfluentCompressionType
+    {
+        None,
+        Gzip,
+        Snappy,
+        Lz4,
+        Zstd
+    }
+
+    private enum ConfluentPartitioner
+    {
+        Random,
+        Consistent,
+        ConsistentRandom,
+        Murmur2,
+        Murmur2Random
+    }
+}

--- a/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dekaf.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -397,6 +397,55 @@ public sealed class DekafBuilder
     }
 
     /// <summary>
+    /// Adds a producer configured from an <see cref="IConfiguration"/> section shaped like
+    /// Confluent.Kafka <c>ProducerConfig</c>. Fluent configuration runs after translation.
+    /// </summary>
+    /// <remarks>
+    /// This adapter does not reference Confluent.Kafka. Settings without an exact Dekaf
+    /// equivalent are rejected instead of being silently ignored.
+    /// </remarks>
+    /// <param name="configuration">The Confluent <c>ProducerConfig</c> JSON section.</param>
+    /// <param name="configure">Optional additional producer configuration.</param>
+    [RequiresDynamicCode(ConfigurationBindingRequiresDynamicCode)]
+    [RequiresUnreferencedCode(ConfigurationBindingRequiresUnreferencedCode)]
+    public DekafBuilder AddProducerFromConfluentConfig<TKey, TValue>(
+        IConfiguration configuration,
+        Action<ProducerBuilder<TKey, TValue>>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddProducer<TKey, TValue>(producer =>
+        {
+            ConfluentConfigurationBinding.ApplyProducer(configuration, producer);
+            configure?.Invoke(producer);
+        });
+    }
+
+    /// <summary>
+    /// Adds a keyed producer configured from an <see cref="IConfiguration"/> section shaped
+    /// like Confluent.Kafka <c>ProducerConfig</c>. Fluent configuration runs after translation.
+    /// </summary>
+    /// <param name="serviceKey">Key used to resolve the producer through keyed DI.</param>
+    /// <param name="configuration">The Confluent <c>ProducerConfig</c> JSON section.</param>
+    /// <param name="configure">Optional additional producer configuration.</param>
+    [RequiresDynamicCode(ConfigurationBindingRequiresDynamicCode)]
+    [RequiresUnreferencedCode(ConfigurationBindingRequiresUnreferencedCode)]
+    public DekafBuilder AddProducerFromConfluentConfig<TKey, TValue>(
+        object serviceKey,
+        IConfiguration configuration,
+        Action<ProducerBuilder<TKey, TValue>>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceKey);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return AddProducer<TKey, TValue>(serviceKey, producer =>
+        {
+            ConfluentConfigurationBinding.ApplyProducer(configuration, producer);
+            configure?.Invoke(producer);
+        });
+    }
+
+    /// <summary>
     /// Adds a consumer to the service collection.
     /// </summary>
     /// <param name="configure">Configures the full consumer builder surface.</param>

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -157,6 +157,190 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducerFromConfluentConfig_TranslatesProducerAndSecurityOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Aspire:Confluent:Kafka:Producer:Config:BootstrapServers"] = "broker1:9092,broker2:9092",
+            ["Aspire:Confluent:Kafka:Producer:Config:ClientId"] = "aspire-producer",
+            ["Aspire:Confluent:Kafka:Producer:Config:Acks"] = "Leader",
+            ["Aspire:Confluent:Kafka:Producer:Config:EnableIdempotence"] = "false",
+            ["Aspire:Confluent:Kafka:Producer:Config:LingerMs"] = "17",
+            ["Aspire:Confluent:Kafka:Producer:Config:BatchSize"] = "65536",
+            ["Aspire:Confluent:Kafka:Producer:Config:QueueBufferingMaxKbytes"] = "2048",
+            ["Aspire:Confluent:Kafka:Producer:Config:MessageTimeoutMs"] = "45000",
+            ["Aspire:Confluent:Kafka:Producer:Config:MessageSendMaxRetries"] = "12",
+            ["Aspire:Confluent:Kafka:Producer:Config:MaxInFlight"] = "3",
+            ["Aspire:Confluent:Kafka:Producer:Config:CompressionType"] = "Zstd",
+            ["Aspire:Confluent:Kafka:Producer:Config:Partitioner"] = "Murmur2Random",
+            ["Aspire:Confluent:Kafka:Producer:Config:MetadataMaxAgeMs"] = "90000",
+            ["Aspire:Confluent:Kafka:Producer:Config:SocketConnectionSetupTimeoutMs"] = "7000",
+            ["Aspire:Confluent:Kafka:Producer:Config:SocketKeepaliveEnable"] = "true",
+            ["Aspire:Confluent:Kafka:Producer:Config:SocketNagleDisable"] = "true",
+            ["Aspire:Confluent:Kafka:Producer:Config:SocketSendBufferBytes"] = "32768",
+            ["Aspire:Confluent:Kafka:Producer:Config:SecurityProtocol"] = "SaslSsl",
+            ["Aspire:Confluent:Kafka:Producer:Config:SaslMechanism"] = "ScramSha512",
+            ["Aspire:Confluent:Kafka:Producer:Config:SaslUsername"] = "user",
+            ["Aspire:Confluent:Kafka:Producer:Config:SaslPassword"] = "password",
+            ["Aspire:Confluent:Kafka:Producer:Config:SslCaLocation"] = "ca.pem",
+            ["Aspire:Confluent:Kafka:Producer:Config:SslEndpointIdentificationAlgorithm"] = "None"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Aspire:Confluent:Kafka:Producer:Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+
+        await Assert.That(options.BootstrapServers).IsEquivalentTo(["broker1:9092", "broker2:9092"]);
+        await Assert.That(options.ClientId).IsEqualTo("aspire-producer");
+        await Assert.That(options.Acks).IsEqualTo(Acks.Leader);
+        await Assert.That(options.EnableIdempotence).IsFalse();
+        await Assert.That(options.LingerMs).IsEqualTo(17);
+        await Assert.That(options.BatchSize).IsEqualTo(65536);
+        await Assert.That(options.BufferMemory).IsEqualTo(2UL * 1024 * 1024);
+        await Assert.That(options.DeliveryTimeoutMs).IsEqualTo(45000);
+        await Assert.That(options.Retries).IsEqualTo(12);
+        await Assert.That(options.MaxInFlightRequestsPerConnection).IsEqualTo(3);
+        await Assert.That(options.CompressionType).IsEqualTo(CompressionType.Zstd);
+        await Assert.That(options.Partitioner).IsEqualTo(PartitionerType.Murmur2Random);
+        await Assert.That(options.ConnectionTimeout).IsEqualTo(TimeSpan.FromSeconds(7));
+        await Assert.That(options.EnableTcpKeepAlive).IsTrue();
+        await Assert.That(options.SocketSendBufferBytes).IsEqualTo(32768);
+        await Assert.That(options.UseTls).IsTrue();
+        await Assert.That(options.TlsConfig!.CaCertificatePath).IsEqualTo("ca.pem");
+        await Assert.That(options.TlsConfig.ValidateServerCertificateHostName).IsFalse();
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.ScramSha512);
+        await Assert.That(options.SaslUsername).IsEqualTo("user");
+        await Assert.That(options.SaslPassword).IsEqualTo("password");
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_FluentConfigurationWins()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:ClientId"] = "json-client"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config"),
+            producer => producer.WithClientId("fluent-client")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.ClientId).IsEqualTo("fluent-client");
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_KeyedRegistration_BindsOptions()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:ClientId"] = "keyed-client"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            "orders",
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var producer = provider.GetRequiredKeyedService<IKafkaProducer<string, string>>("orders");
+        await Assert.That(GetProducerOptions(producer).ClientId).IsEqualTo("keyed-client");
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_UnsupportedProperty_FailsFast()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:EnableBackgroundPoll"] = "false"
+        });
+
+        await Assert.That(() => services.AddDekaf(builder =>
+                builder.AddProducerFromConfluentConfig<string, string>(configuration.GetSection("Config"))))
+            .Throws<NotSupportedException>()
+            .WithMessageContaining("EnableBackgroundPoll");
+    }
+
+    [Test]
+    [Arguments("MessageTimeoutMs", "0")]
+    [Arguments("SocketNagleDisable", "false")]
+    [Arguments("CompressionType", "Brotli")]
+    [Arguments("Partitioner", "RoundRobin")]
+    public async Task AddProducerFromConfluentConfig_InexactValue_FailsFast(
+        string property,
+        string value)
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            [$"Config:{property}"] = value
+        });
+
+        await Assert.That(() => services.AddDekaf(builder =>
+                builder.AddProducerFromConfluentConfig<string, string>(configuration.GetSection("Config"))))
+            .Throws<NotSupportedException>()
+            .WithMessageContaining(property);
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_ZeroConnectionIdle_DisablesReaping()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:ConnectionsMaxIdleMs"] = "0"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.ConnectionsMaxIdleMs).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_TranslatesOidcSecurity()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:SecurityProtocol"] = "SaslSsl",
+            ["Config:SaslMechanism"] = "OAuthBearer",
+            ["Config:SaslOauthbearerMethod"] = "Oidc",
+            ["Config:SaslOauthbearerGrantType"] = "ClientCredentials",
+            ["Config:SaslOauthbearerTokenEndpointUrl"] = "https://identity.example/token",
+            ["Config:SaslOauthbearerClientId"] = "client-id",
+            ["Config:SaslOauthbearerClientSecret"] = "client-secret",
+            ["Config:SaslOauthbearerScope"] = "kafka"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.SaslMechanism).IsEqualTo(SaslMechanism.OAuthBearer);
+        await Assert.That(options.OAuthBearerConfig!.TokenEndpointUrl)
+            .IsEqualTo("https://identity.example/token");
+        await Assert.That(options.OAuthBearerConfig.ClientId).IsEqualTo("client-id");
+        await Assert.That(options.OAuthBearerConfig.ClientSecret).IsEqualTo("client-secret");
+        await Assert.That(options.OAuthBearerConfig.Scope).IsEqualTo("kafka");
+    }
+
+    [Test]
     public async Task AddProducer_WithTypedOptions_BindsOptions()
     {
         var services = new ServiceCollection();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -420,6 +420,70 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    [Arguments("SslCaLocation", "ca.pem", "TLS")]
+    [Arguments("SaslUsername", "user", "SASL")]
+    public async Task AddProducerFromConfluentConfig_SecuritySettingWithoutProtocol_FailsFast(
+        string property,
+        string value,
+        string expectedMessage)
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            [$"Config:{property}"] = value
+        });
+
+        await Assert.That(() => services.AddDekaf(builder =>
+                builder.AddProducerFromConfluentConfig<string, string>(
+                    configuration.GetSection("Config"))))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining(expectedMessage);
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_CertificateAndKeystore_FailsFast()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:SecurityProtocol"] = "Ssl",
+            ["Config:SslCertificateLocation"] = "client.pem",
+            ["Config:SslKeystoreLocation"] = "client.p12"
+        });
+
+        await Assert.That(() => services.AddDekaf(builder =>
+                builder.AddProducerFromConfluentConfig<string, string>(
+                    configuration.GetSection("Config"))))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("cannot both be configured");
+    }
+
+    [Test]
+    [Arguments("SaslUsername", "user")]
+    [Arguments("SaslPassword", "password")]
+    public async Task AddProducerFromConfluentConfig_IncompletePlainCredentials_FailsFast(
+        string property,
+        string value)
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:SecurityProtocol"] = "SaslPlaintext",
+            ["Config:SaslMechanism"] = "Plain",
+            [$"Config:{property}"] = value
+        });
+
+        await Assert.That(() => services.AddDekaf(builder =>
+                builder.AddProducerFromConfluentConfig<string, string>(
+                    configuration.GetSection("Config"))))
+            .Throws<InvalidOperationException>()
+            .WithMessageContaining("SaslUsername and SaslPassword");
+    }
+
+    [Test]
     public async Task AddProducer_WithTypedOptions_BindsOptions()
     {
         var services = new ServiceCollection();

--- a/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/DependencyInjectionTests.cs
@@ -255,6 +255,85 @@ public class DependencyInjectionTests
     }
 
     [Test]
+    public async Task AddProducerFromConfluentConfig_UsesConfluentIdempotenceDefault()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:Acks"] = "None"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.EnableIdempotence).IsFalse();
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_TransactionalIdEnablesIdempotenceByDefault()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:TransactionalId"] = "transactional-producer"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.EnableIdempotence).IsTrue();
+        await Assert.That(options.TransactionalId).IsEqualTo("transactional-producer");
+    }
+
+    [Test]
+    public async Task AddProducerFromConfluentConfig_DefaultCompressionLevelUsesCodecDefault()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:CompressionType"] = "Gzip",
+            ["Config:CompressionLevel"] = "-1"
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.CompressionType).IsEqualTo(CompressionType.Gzip);
+        await Assert.That(options.CompressionLevel).IsNull();
+    }
+
+    [Test]
+    [Arguments("fnv1a", PartitionerType.Fnv1A)]
+    [Arguments("fnv1a_random", PartitionerType.Fnv1ARandom)]
+    public async Task AddProducerFromConfluentConfig_TranslatesFnvPartitioners(
+        string configuredValue,
+        PartitionerType expected)
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Config:BootstrapServers"] = "broker1:9092",
+            ["Config:Partitioner"] = configuredValue
+        });
+
+        services.AddDekaf(builder => builder.AddProducerFromConfluentConfig<string, string>(
+            configuration.GetSection("Config")));
+
+        await using var provider = services.BuildServiceProvider();
+        var options = GetProducerOptions(provider.GetRequiredService<IKafkaProducer<string, string>>());
+        await Assert.That(options.Partitioner).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task AddProducerFromConfluentConfig_UnsupportedProperty_FailsFast()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- add explicit keyed and unkeyed ProducerConfig-shaped IConfiguration registration
- translate producer, shared client, TLS, SASL/SCRAM, GSSAPI, and OIDC settings without a Confluent.Kafka dependency
- reject unsupported properties and inexact values with property-specific compatibility errors

## Validation
- dotnet build tests/Dekaf.Tests.Unit --configuration Release (net8.0 + net10.0, 0 warnings)
- focused DependencyInjectionTests/AddProducerFromConfluentConfig*: 10/10 net10.0, 10/10 net8.0
- full unit suite before no-overlap rebase: 6245/6245 net10.0, 6118/6118 net8.0
- exact-base focused rerun after rebase: 10/10 both TFMs

Benchmarks not run: configuration binding executes only during DI registration and does not touch producer hot paths.

Closes #2357