### PR TITLE
Prevent stale heartbeat from invalidating rejoin

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -1955,6 +1955,10 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             {
                 break;
             }
+            catch (Exception) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
             catch (Exception ex)
             {
                 LogHeartbeatFailed(ex);

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -3529,6 +3529,58 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task ConsumerProtocol_CancelledHeartbeatTransportFailure_DoesNotInvalidateRejoin()
+    {
+        SetupFindCoordinator();
+        var oldHeartbeatStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var oldHeartbeatCancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var oldHeartbeatResponse = new TaskCompletionSource<ConsumerGroupHeartbeatResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var heartbeatCount = 0;
+        _connection.SendAsync<ConsumerGroupHeartbeatRequest, ConsumerGroupHeartbeatResponse>(
+                Arg.Any<ConsumerGroupHeartbeatRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var call = Interlocked.Increment(ref heartbeatCount);
+                if (call == 2)
+                {
+                    var heartbeatToken = callInfo.ArgAt<CancellationToken>(2);
+                    heartbeatToken.Register(
+                        static state => ((TaskCompletionSource<bool>)state!).TrySetResult(true),
+                        oldHeartbeatCancelled);
+                    oldHeartbeatStarted.TrySetResult(true);
+                    return new ValueTask<ConsumerGroupHeartbeatResponse>(oldHeartbeatResponse.Task);
+                }
+
+                return ValueTask.FromResult(new ConsumerGroupHeartbeatResponse
+                {
+                    ErrorCode = ErrorCode.None,
+                    MemberId = "member-1",
+                    MemberEpoch = call == 1 ? 1 : 2,
+                    HeartbeatIntervalMs = call == 1 ? 1 : 60_000
+                });
+            });
+
+        var options = CreateConsumerProtocolOptions(heartbeatIntervalMs: 1);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+        var topics = new HashSet<string> { "test-topic" };
+
+        await coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None);
+        await oldHeartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        coordinator.RequestRejoin();
+        var rejoin = coordinator.EnsureActiveGroupAsync(topics, CancellationToken.None).AsTask();
+        await oldHeartbeatCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        oldHeartbeatResponse.TrySetException(new IOException("retired coordinator connection closed"));
+        await rejoin.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(coordinator.State).IsEqualTo(CoordinatorState.Stable);
+        await Assert.That(coordinator.GenerationId).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task ConsumerProtocol_FindCoordinator_TransportFailureTriesNextBroker()
     {
         var connectionPool = Substitute.For<IConnectionPool>();


### PR DESCRIPTION
## Summary
- ignore non-cancellation exceptions from a retired KIP-848 heartbeat loop once its token is cancelled
- prevent that stale loop from invalidating coordinator state established by a newer rejoin
- add a deterministic regression test that holds the old heartbeat across a successful rejoin, then faults it

## Why
The coordinator starts the replacement heartbeat before cancelling the previous loop. A transport request that does not promptly honor cancellation can fail after the new generation is stable. The old loop's general exception handler then called `MarkCoordinatorUnknown()`, clobbering the fresh state and allowing coordinator-failover consumption to stall.

This catch filter runs only on the exception path after cancellation. It adds no per-message work or allocation.

## Validation
- regression test before fix: failed deterministically (`Stable` expected, `Unjoined` actual)
- `ConsumerProtocol_CancelledHeartbeatTransportFailure_DoesNotInvalidateRejoin`: 1/1 passed after fix
- `ConsumerCoordinatorKip848Tests`: 106/106 passed
- Windows exact coordinator-failover integration: 1/1 passed (41s)
- Linux exact coordinator-failover integration: 1/1 passed (45s)
- Linux CI-shaped `Resilience`: 99/99 passed (7m20s)
- Release builds: 0 warnings, 0 errors

Closes #2249