### PR TITLE
fix: resolve release-gate matrix failures on 4.0.2/4.1.2 brokers and KIP-848 commit race

### DIFF
--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -863,7 +863,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         LogCommitOffsetsStarted(_options.GroupId!);
         // Lock is intentionally held across retries to protect the shared _commitTopicGroups dictionary,
         // which is reused across calls to avoid allocations. With up to 3 retries x ~600ms each,
-        // the lock can be held for up to ~1.8 seconds. Concurrent callers will block for the full retry duration.
+        // the lock can be held for up to ~1.8 seconds — longer when a StaleMemberEpoch retry waits
+        // up to one heartbeat interval for the refreshed epoch. Concurrent callers block for the
+        // full retry duration.
         await _commitLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -969,8 +971,22 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     {
                         if (partition.ErrorCode != ErrorCode.None)
                         {
+                            var staleMemberEpoch = partition.ErrorCode == ErrorCode.StaleMemberEpoch;
+                            if (staleMemberEpoch)
+                            {
+                                // KIP-848: the coordinator bumped the member epoch (e.g. a
+                                // reassignment) after this request was built. The member is
+                                // still in the group; wait for the background heartbeat to
+                                // deliver the refreshed epoch, then retry the commit with it —
+                                // matching the Java client's commit semantics.
+                                await WaitForMemberEpochRefreshAsync(
+                                    request.GenerationIdOrMemberEpoch,
+                                    cancellationToken).ConfigureAwait(false);
+                            }
+
                             throw new Errors.GroupException(partition.ErrorCode,
-                                $"OffsetCommit failed for {topicName}-{partition.PartitionIndex}: {partition.ErrorCode}")
+                                $"OffsetCommit failed for {topicName}-{partition.PartitionIndex}: {partition.ErrorCode}",
+                                isRetriable: staleMemberEpoch || partition.ErrorCode.IsRetriable())
                             {
                                 GroupId = _options.GroupId
                             };
@@ -978,11 +994,29 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                     }
                 }
             }, _metadataManager, cancellationToken, _options.RetryBackoffMs, _options.RetryBackoffMaxMs,
-                onRetry: FindCoordinatorAsync).ConfigureAwait(false);
+                onRetry: FindCoordinatorAsync,
+                shouldRefreshMetadata: ShouldRefreshMetadataForGroupRetry).ConfigureAwait(false);
         }
         finally
         {
             _commitLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Waits for the background heartbeat loop to advance the member epoch past the value a
+    /// failed OffsetCommit was sent with. Bounded by one heartbeat interval plus slack: if the
+    /// epoch has not refreshed by then (e.g. the member was reset), the retry proceeds anyway
+    /// and surfaces the coordinator's verdict.
+    /// </summary>
+    private async ValueTask WaitForMemberEpochRefreshAsync(int staleEpoch, CancellationToken cancellationToken)
+    {
+        var maxWait = TimeSpan.FromMilliseconds(_heartbeatIntervalMs + 1_000);
+        var startedAt = Stopwatch.GetTimestamp();
+        while (_generationId == staleEpoch && Stopwatch.GetElapsedTime(startedAt) < maxWait)
+        {
+            ThrowIfMaxPollIntervalExpired();
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -1194,7 +1228,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
                 _options.RetryBackoffMs,
                 _options.RetryBackoffMaxMs,
                 onRetry: RecoverOffsetFetchAsync,
-                shouldRefreshMetadata: ShouldRefreshMetadataForOffsetFetchRetry).ConfigureAwait(false);
+                shouldRefreshMetadata: ShouldRefreshMetadataForGroupRetry).ConfigureAwait(false);
             }
             finally
             {
@@ -1227,7 +1261,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
         await FindCoordinatorAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private static bool ShouldRefreshMetadataForOffsetFetchRetry(KafkaException exception) =>
+    // Membership errors are recovered by the group protocol (epoch refresh or rejoin),
+    // so a cluster metadata refresh buys nothing for their retries.
+    private static bool ShouldRefreshMetadataForGroupRetry(KafkaException exception) =>
         exception.ErrorCode is not ErrorCode.StaleMemberEpoch and not ErrorCode.UnknownMemberId;
 
     private bool HandleOffsetFetchMembershipError(ErrorCode errorCode)

--- a/src/Dekaf/Retry/RetryHelper.cs
+++ b/src/Dekaf/Retry/RetryHelper.cs
@@ -18,6 +18,9 @@ internal static class RetryHelper
     /// callback (e.g. to re-discover a coordinator), and retries after KIP-580 backoff.
     /// </summary>
     /// <param name="maxRetries">Maximum number of retries. Defaults to <see cref="MaxRetries"/> (3).</param>
+    /// <param name="shouldRefreshMetadata">
+    /// Optional predicate that suppresses metadata refresh for errors recovered by other means.
+    /// </param>
     internal static async ValueTask WithRetryAsync(
         Func<ValueTask> operation,
         MetadataManager metadataManager,
@@ -25,7 +28,8 @@ internal static class RetryHelper
         int retryBackoffMs = 100,
         int retryBackoffMaxMs = 1000,
         Func<CancellationToken, ValueTask>? onRetry = null,
-        int maxRetries = MaxRetries)
+        int maxRetries = MaxRetries,
+        Func<KafkaException, bool>? shouldRefreshMetadata = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -36,7 +40,11 @@ internal static class RetryHelper
             }
             catch (Exception ex) when (IsRetriableRequestFailure(ex) && attempt < maxRetries)
             {
-                await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
+                if (ex is not KafkaException kafkaException ||
+                    shouldRefreshMetadata?.Invoke(kafkaException) != false)
+                {
+                    await RefreshMetadataForRetryAsync(metadataManager, cancellationToken).ConfigureAwait(false);
+                }
 
                 if (onRetry is not null)
                     await onRetry(cancellationToken).ConfigureAwait(false);

--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -668,7 +668,6 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
     [Test]
     [Arguments(OffsetSpec.EarliestLocal, 0L)]
     [Arguments(OffsetSpec.LatestTiered, -1L)]
-    [Arguments(OffsetSpec.EarliestPendingUpload, -1L)]
     public async Task ListOffsetsAsync_StoragePosition_ReturnsExpectedOffsetWithoutTiering(
         OffsetSpec spec,
         long expectedOffset)
@@ -688,6 +687,14 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
 
         await Assert.That(offsets[topicPartition].Offset).IsEqualTo(expectedOffset);
     }
+
+    // EarliestPendingUpload requires ListOffsets v11, which brokers only expose from Kafka 4.2.
+    [Test]
+    [SupportsKafka(420)]
+    public Task ListOffsetsAsync_EarliestPendingUpload_ReturnsExpectedOffsetWithoutTiering() =>
+        ListOffsetsAsync_StoragePosition_ReturnsExpectedOffsetWithoutTiering(
+            OffsetSpec.EarliestPendingUpload,
+            expectedOffset: -1L);
 
     #endregion
 

--- a/tests/Dekaf.Tests.Integration/AdminControlPlaneVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminControlPlaneVersionTests.cs
@@ -7,7 +7,10 @@ namespace Dekaf.Tests.Integration;
 [Category("Admin")]
 public sealed class AdminControlPlaneVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    // ListConfigResources v1 (typed resource filtering) only exists from Kafka 4.1;
+    // 4.0 brokers expose ListClientMetricsResources (API key 74) at v0 only.
     [Test]
+    [SupportsKafka(410)]
     public async Task ListConfigResourcesAsync_V1Broker_ReturnsTypedBrokerResources()
     {
         await using var admin = KafkaContainer.CreateAdminClient();

--- a/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
@@ -538,7 +538,7 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var result = consumer.Consume(TimeSpan.FromMilliseconds(200));
+                    var result = ConsumeClassicTolerant(consumer, TimeSpan.FromMilliseconds(200));
                     if (result is null)
                         continue;
 
@@ -559,6 +559,24 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
             cancellationToken,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);
+
+    private static ConfluentKafka.ConsumeResult<string, string>? ConsumeClassicTolerant(
+        ConfluentKafka.IConsumer<string, string> consumer,
+        TimeSpan timeout)
+    {
+        try
+        {
+            return consumer.Consume(timeout);
+        }
+        catch (ConfluentKafka.ConsumeException exception)
+            when (IsUnknownTopicError(exception.Error.Code))
+        {
+            // Metadata for the freshly created topic has not reached every broker yet.
+            // librdkafka surfaces this as an error event but keeps refreshing metadata,
+            // so treat it like an empty poll instead of a fatal consume failure.
+            return null;
+        }
+    }
 
     private static bool CommitClassicWithRetry(
         ConfluentKafka.IConsumer<string, string> consumer,
@@ -606,6 +624,11 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
         }
     }
 
+    private static bool IsUnknownTopicError(ConfluentKafka.ErrorCode errorCode) =>
+        errorCode.ToString() is
+            "UnknownTopicOrPart" or
+            "Local_UnknownTopic";
+
     private static bool IsTransientCoordinatorError(ConfluentKafka.ErrorCode errorCode) =>
         errorCode.ToString() is
             "CoordinatorLoadInProgress" or
@@ -637,7 +660,7 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
             () =>
             {
                 while (!cancellationToken.IsCancellationRequested)
-                    _ = consumer.Consume(TimeSpan.FromMilliseconds(200));
+                    _ = ConsumeClassicTolerant(consumer, TimeSpan.FromMilliseconds(200));
             },
             cancellationToken,
             TaskCreationOptions.LongRunning,

--- a/tests/Dekaf.Tests.Integration/DynamicConfigurationIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/DynamicConfigurationIntegrationTests.cs
@@ -62,6 +62,10 @@ public sealed class DynamicConfigurationIntegrationTests(RackAwareKafkaContainer
             LowMaxMessageBytes.ToString(),
             cancellationToken).ConfigureAwait(false);
 
+        // Latent race, mirror of the raised-limit test: if the lowered limit has not reached the
+        // partition leader yet, this oversized produce would be accepted and the Throws assertion
+        // would flake. Not yet observed in CI; the raised-limit direction uses
+        // ProduceUntilAcceptedAsync for the same reason.
         var oversizedTask = producer.ProduceAsync(topic, null, largeMessage, cancellationToken).AsTask();
         var validTask = producer.ProduceAsync(topic, null, smallMessage, cancellationToken).AsTask();
         var exception = await Assert.That(async () => await oversizedTask.ConfigureAwait(false))
@@ -100,7 +104,10 @@ public sealed class DynamicConfigurationIntegrationTests(RackAwareKafkaContainer
             HighMaxMessageBytes.ToString(),
             cancellationToken).ConfigureAwait(false);
 
-        var accepted = await producer.ProduceAsync(topic, null, largeMessage, cancellationToken)
+        // DescribeConfigs reflects the raised limit before the partition leader applies it to
+        // produce validation, so the first large produce can still be rejected. Rejected records
+        // are never appended, which keeps the accepted record's expected offset at 0.
+        var accepted = await ProduceUntilAcceptedAsync(producer, topic, largeMessage, cancellationToken)
             .ConfigureAwait(false);
 
         await Assert.That(exception!.ErrorCode).IsEqualTo(ErrorCode.MessageTooLarge);
@@ -215,6 +222,29 @@ public sealed class DynamicConfigurationIntegrationTests(RackAwareKafkaContainer
             .WithLinger(TimeSpan.FromMilliseconds(100))
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .BuildAsync(cancellationToken).ConfigureAwait(false);
+
+    private static async Task<RecordMetadata> ProduceUntilAcceptedAsync(
+        IKafkaProducer<byte[], byte[]> producer,
+        string topic,
+        byte[] message,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            try
+            {
+                return await producer.ProduceAsync(topic, null, message, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (ProduceException exception)
+                when (exception.ErrorCode == ErrorCode.MessageTooLarge
+                    && stopwatch.Elapsed < TimeSpan.FromSeconds(15))
+            {
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
 
     private static async Task SetTopicConfigAsync(
         IAdminClient admin,

--- a/tests/Dekaf.Tests.Integration/ProducerMinInSyncReplicasIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerMinInSyncReplicasIntegrationTests.cs
@@ -141,7 +141,11 @@ public sealed class ProducerMinInSyncReplicasIntegrationTests(RackAwareKafkaCont
             var duringOutage = await ProduceAsync(producer, topic, 1, cancellationToken).ConfigureAwait(false);
 
             await Assert.That(initial.Offset).IsEqualTo(0);
-            await Assert.That(duringOutage.Offset).IsEqualTo(1);
+            // The producer is non-idempotent with a 2s request timeout: a slow leader during
+            // the ISR shrink can time out the first attempt after the broker already appended
+            // it, and the retry then lands at a later offset. Delivery (not an exact offset)
+            // is the acks=leader guarantee under test.
+            await Assert.That(duringOutage.Offset).IsGreaterThanOrEqualTo(1);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerCoordinatorKip848Tests.cs
@@ -1469,6 +1469,65 @@ public sealed class ConsumerCoordinatorKip848Tests : IAsyncDisposable
     }
 
     [Test]
+    public async Task CommitOffsetsAsync_StaleMemberEpoch_RetriesWithRefreshedEpoch()
+    {
+        SetupFindCoordinator();
+        // Long heartbeat interval keeps the background loop quiet so the epoch transition
+        // below is driven solely by the commit stub.
+        SetupConsumerGroupHeartbeat(memberEpoch: 7, heartbeatIntervalMs: 60_000);
+        _metadataManager.SetApiVersion(ApiKey.OffsetCommit, 9, 9);
+
+        var options = CreateConsumerProtocolOptions(retryBackoffMs: 0, retryBackoffMaxMs: 0);
+        await using var coordinator = new ConsumerCoordinator(options, _connectionPool, _metadataManager);
+
+        var capturedEpochs = new List<int>();
+        _connection.SendAsync<OffsetCommitRequest, OffsetCommitResponse>(
+                Arg.Any<OffsetCommitRequest>(),
+                Arg.Any<short>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var request = callInfo.Arg<OffsetCommitRequest>()!;
+                capturedEpochs.Add(request.GenerationIdOrMemberEpoch);
+                if (capturedEpochs.Count == 1)
+                {
+                    // The coordinator bumped the member epoch (reassignment) after this
+                    // request was built; the client learns the new epoch from a heartbeat
+                    // while the commit retry waits for the refresh.
+                    SetPrivateField(coordinator, "_generationId", 8);
+                    return ValueTask.FromResult(new OffsetCommitResponse
+                    {
+                        Topics =
+                        [
+                            new OffsetCommitResponseTopic
+                            {
+                                Name = "test-topic",
+                                Partitions =
+                                [
+                                    new OffsetCommitResponsePartition
+                                    {
+                                        PartitionIndex = 0,
+                                        ErrorCode = ErrorCode.StaleMemberEpoch
+                                    }
+                                ]
+                            }
+                        ]
+                    });
+                }
+
+                return ValueTask.FromResult(new OffsetCommitResponse { Topics = [] });
+            });
+
+        await coordinator.EnsureActiveGroupAsync(new HashSet<string> { "test-topic" }, CancellationToken.None);
+
+        await coordinator.CommitOffsetsAsync(
+            [new TopicPartitionOffset("test-topic", 0, 1)],
+            CancellationToken.None);
+
+        await Assert.That(capturedEpochs).IsEquivalentTo([7, 8]);
+    }
+
+    [Test]
     public async Task CommitOffsetsAsync_OverdueBeforeHeartbeatExpiry_RejectsCommit()
     {
         SetupFindCoordinator();


### PR DESCRIPTION
Unblocks the NuGet release: fixes all 13 failed jobs in release-gate run [29701433641](https://github.com/thomhurst/Dekaf/actions/runs/29701433641). PR CI only tests broker 4.3.1, so these old-broker gaps surfaced first at the release gate's full 4.0.2/4.1.2/4.2.1/4.3.1 sweep.

## Failure inventory → fixes

| Failure (jobs) | Root cause | Fix |
|---|---|---|
| `ListOffsetsAsync_StoragePosition(EarliestPendingUpload)` — all 4.0.2/4.1.2 messaging jobs | `EarliestPendingUpload` needs ListOffsets v11 (Kafka 4.2+); brokers negotiate v10 max | Split into own test gated `[SupportsKafka(420)]`, delegating to the parameterized method |
| `ListConfigResourcesAsync_V1Broker` — 4.0.2 messaging jobs | ListConfigResources v1 only exists from Kafka 4.1; 4.0 has API 74 at v0 only | `[SupportsKafka(410)]` |
| `Producer_MaxMessageBytesRaisedMidRun` — 4.0.2 produce/messaging | DescribeConfigs convergence leads the partition leader's produce validation; first large produce still rejected on slow 4.0.2 | Retry produce on `MessageTooLarge` with 15s deadline (rejected records never append, so expected offset 0 is preserved); latent mirror race in the lowered-limit test documented |
| `ClassicCoordinatorFailover_*` — 4.0.2 consume/faults | Confluent classic consumer surfaces transient `UnknownTopicOrPartition` right after topic creation (metadata propagation); poll loops treated it as fatal | `ConsumeClassicTolerant` treats it like an empty poll (named predicate, matching the file's existing tolerance helpers) |
| `Producer_AcksLeader_UnaffectedByIsrShrink` — net8.0 produce jobs | Non-idempotent producer + 2s request timeout during ISR shrink: broker appended the first attempt, client timed out and retried → duplicate at offset 2; exact-offset assert over-specified | Assert `Offset >= 1` — delivery is the acks=leader guarantee under test |
| `Consumer_PartitionReassignment` — net8.0/4.2.1 faults, `StaleMemberEpoch` on commit | **Client bug**: KIP-848 coordinator bumps member epoch on reassignment; Dekaf failed the commit immediately while Java retries with the refreshed epoch | `CommitOffsetsAsync` now waits (bounded by one heartbeat interval + slack) for the heartbeat-refreshed epoch and retries; membership errors also skip the pointless metadata refresh on retry (`shouldRefreshMetadata` threaded through the void `RetryHelper` overload, reusing the fetch path's predicate) |

## Performance note (Rule 1/8)

The only `src/` changes are on the OffsetCommit **error path** (executed only when a partition returns a non-None error) plus the retry helper's cold retry branch. No produce/consume/serialize hot-path code touched, no allocations added to success paths — no benchmark run required.

## Validation

- Unit: `ConsumerCoordinatorKip848Tests` 107/107 pass, incl. new `CommitOffsetsAsync_StaleMemberEpoch_RetriesWithRefreshedEpoch` (asserts first commit sends stale epoch 7, retry sends refreshed epoch 8).
- Integration vs **4.0.2** (the worst matrix column): both gated tests skip; `Producer_MaxMessageBytesRaisedMidRun`, all 3 `ClassicCoordinatorFailover_*`, `Producer_AcksLeader_UnaffectedByIsrShrink`, `Consumer_PartitionReassignment` all pass.
- Integration vs **4.2.1**: `Consumer_PartitionReassignment` + `Classic*` pass after the refactor.
- Integration vs **4.3.1** (default): admin/ListOffsets/dynamic-config subsets pass with both gated tests running (not skipped).

`/simplify` review (4 agents) applied: deduped commit-error throws, `shouldRefreshMetadata` on the void retry overload, named tolerance predicate, unit-test cleanup.