### PR TITLE
test: add deterministic produce-path memory leak gates

### DIFF
--- a/tests/Dekaf.Tests.Unit/Concurrency/ProducerLeakUnderLoadTests.cs
+++ b/tests/Dekaf.Tests.Unit/Concurrency/ProducerLeakUnderLoadTests.cs
@@ -1,0 +1,325 @@
+using Dekaf.Producer;
+using Dekaf.Tests.Unit.Producer;
+
+namespace Dekaf.Tests.Unit.Concurrency;
+
+/// <summary>
+/// Leak gates for the produce path under concurrency and load — the conditions where the
+/// historical leaks actually happened (BufferMemory refund leaks #1516/#2199, pool
+/// double-returns #2187, stranded pipeline tracking). Complements
+/// <c>ProducerMemoryLeakGateTests</c> (sequential drift) and
+/// <c>ProducerBatchLifecycleHammerTests</c> (single-batch cleanup-owner races) by racing
+/// many appenders against concurrent drainers, a flush storm, linger expiry, and injected
+/// batch failures — then asserting every accounting invariant lands exactly on zero.
+/// The <c>#if DEBUG</c> counter-balance blocks compile only against Debug builds
+/// (<c>ProducerDebugCounters</c> is stripped from Release); the accounting and heap
+/// assertions run in every configuration.
+/// </summary>
+[NotInParallel]
+public sealed class ProducerLeakUnderLoadTests
+{
+    private const string Topic = "leak-load";
+    private const int PartitionCount = 8;
+    private const int ValueSize = 1024;
+    private const int Appenders = 4;
+    private const int MessagesPerAppender = 2_000;
+    private const int Drainers = 2;
+    private const int FailEveryNthBatch = 5;
+
+    /// <summary>
+    /// Sustained load with every producer-side race surface active at once: 4 concurrent
+    /// appenders (awaited + fire-and-forget), 2 concurrent drainers completing batches with
+    /// every 5th batch failed, a flush-storm task racing seals against appends, and a linger
+    /// expiry loop forcing partial-batch seals mid-append. Two waves: the first warms pools
+    /// and the thread pool, the second is measured for retained-heap growth after full GC.
+    /// After each wave the accounting must return exactly to zero — under load, any missed
+    /// or doubled refund on the success, failure, or flush path shows up here.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task ConcurrentAppendDrainFlushRaces_AccountingReturnsToZero_AndHeapDoesNotGrow(
+        CancellationToken cancellationToken)
+    {
+        const long MaxRetainedGrowthBytes = 8 * 1024 * 1024;
+
+        var accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "leak-load",
+            BufferMemory = 16UL * 1024 * 1024,
+            BatchSize = 16384,
+            LingerMs = 1_000,
+            MaxBlockMs = 60_000,
+        });
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        ProducerDebugCounters.Reset();
+
+        var totalDrainedBatches = 0;
+        var totalFailedBatches = 0;
+        var totalAwaited = 0;
+        try
+        {
+            async Task RunAssertedWaveAsync()
+            {
+                var (counters, appenders) = await RunLoadWaveAsync(accumulator, completionPool, cancellationToken);
+                await AssertWaveFullyRetiredAsync(accumulator, counters, appenders);
+                totalDrainedBatches += counters.DrainedBatches;
+                totalFailedBatches += counters.FailedBatches;
+                totalAwaited += appenders.Sum(static r => r.CompletionTasks.Count);
+            }
+
+            await RunAssertedWaveAsync();
+            var baseline = LeakGateHarness.GetStableHeapBytes();
+            await RunAssertedWaveAsync();
+            var retainedGrowth = LeakGateHarness.GetStableHeapBytes() - baseline;
+
+            await Assert.That(retainedGrowth).IsLessThan(MaxRetainedGrowthBytes);
+
+#if DEBUG
+            var counters = ProducerDebugCounters.GetSnapshot();
+            await Assert.That(counters.MessagesAppended).IsEqualTo(2 * Appenders * MessagesPerAppender);
+            await Assert.That(counters.CompletionSourcesStoredInBatch).IsEqualTo(totalAwaited);
+            await Assert.That(counters.CompletionSourcesCompleted + counters.CompletionSourcesFailed)
+                .IsEqualTo(totalAwaited);
+            await Assert.That(counters.ReadyBatchesRented).IsEqualTo(totalDrainedBatches);
+            await Assert.That(counters.ReadyBatchesReturned).IsEqualTo(totalDrainedBatches);
+            await Assert.That(counters.ReadyBatchDuplicateReturns).IsEqualTo(0);
+            await Assert.That(counters.BatchesSentSuccessfully)
+                .IsEqualTo(totalDrainedBatches - totalFailedBatches);
+            await Assert.That(counters.BatchesFailed).IsEqualTo(totalFailedBatches);
+#endif
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+            ProducerDebugCounters.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Backpressure saturation: 4 MB of traffic pushed through a 128 KB buffer while the
+    /// drainer is gated shut until an appender is provably blocked in the slow-path memory
+    /// reservation wait. The drainer then races the blocked appenders' admission path, with
+    /// every 7th batch failed so the failure-path refund races the pending-append drain.
+    /// This is the exact territory of the #2199 refund-leak family: a refund that is lost
+    /// (or doubled) under saturation either strands the blocked appenders or corrupts
+    /// <c>BufferedBytes</c> — both caught by the end-state asserts.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task BackpressureSaturation_RefundsUnderPressure_AccountingReturnsToZero(
+        CancellationToken cancellationToken)
+    {
+        const int SaturationMessagesPerAppender = 1_024;
+        const int SaturationFailEveryNthBatch = 7;
+
+        var accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "leak-saturation",
+            BufferMemory = 128 * 1024,
+            BatchSize = 16384,
+            LingerMs = 1_000,
+            MaxBlockMs = 60_000,
+        });
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        ProducerDebugCounters.Reset();
+
+        try
+        {
+            var counters = new LeakGateCounters();
+            var drainerGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var appenderTasks = StartAppenders(
+                accumulator, completionPool, counters, SaturationMessagesPerAppender, cancellationToken);
+
+            // Hold the drainer shut until an appender is provably blocked so the slow-path
+            // reservation wait (and its refund-driven wakeup) is guaranteed to be
+            // exercised, not skipped on a fast machine.
+            var drainerTask = Task.Run(async () =>
+            {
+                await drainerGate.Task.WaitAsync(cancellationToken);
+                await LeakGateHarness.DrainUntilStoppedAsync(
+                    accumulator, counters, SaturationFailEveryNthBatch, DrainWaitMode.WakeupSignal, cancellationToken);
+            }, cancellationToken);
+
+            await LeakGateHarness.WaitForSaturationAsync(accumulator, appenderTasks, cancellationToken);
+            drainerGate.SetResult();
+
+            var appenderResults = await Task.WhenAll(appenderTasks).WaitAsync(cancellationToken);
+            await accumulator.FlushAsync(cancellationToken);
+            counters.RequestStop();
+            await drainerTask.WaitAsync(cancellationToken);
+
+            await AwaitCompletionsAsync(appenderResults, cancellationToken);
+
+            // Saturation must actually have happened for this test to mean anything.
+            await Assert.That(accumulator.BufferPressureEvents).IsGreaterThan(0L);
+
+            var totalMessages = Appenders * SaturationMessagesPerAppender;
+            await Assert.That(counters.DrainedRecords).IsEqualTo(totalMessages);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+
+#if DEBUG
+            var snapshot = ProducerDebugCounters.GetSnapshot();
+            var awaited = appenderResults.Sum(static r => r.CompletionTasks.Count);
+            await Assert.That(snapshot.CompletionSourcesStoredInBatch).IsEqualTo(awaited);
+            await Assert.That(snapshot.CompletionSourcesCompleted + snapshot.CompletionSourcesFailed)
+                .IsEqualTo(awaited);
+            await Assert.That(snapshot.ReadyBatchesRented).IsEqualTo(counters.DrainedBatches);
+            await Assert.That(snapshot.ReadyBatchesReturned).IsEqualTo(counters.DrainedBatches);
+            await Assert.That(snapshot.ReadyBatchDuplicateReturns).IsEqualTo(0);
+#endif
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+            ProducerDebugCounters.Reset();
+        }
+    }
+
+    /// <summary>
+    /// One full loaded wave: concurrent appenders, concurrent drainers with failure
+    /// injection, a flush storm, and a linger-expiry loop — then quiesce and retire
+    /// every outstanding completion.
+    /// </summary>
+    private static async Task<(LeakGateCounters Counters, AppenderResult[] Appenders)> RunLoadWaveAsync(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> completionPool,
+        CancellationToken cancellationToken)
+    {
+        var counters = new LeakGateCounters();
+        using var stormCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var appenderTasks = StartAppenders(
+            accumulator, completionPool, counters, MessagesPerAppender, cancellationToken);
+
+        // Only the first drainer may await the wakeup signal (single-waiter contract —
+        // see DrainWaitMode); the rest poll.
+        var drainerTasks = new Task[Drainers];
+        for (var i = 0; i < Drainers; i++)
+        {
+            var waitMode = i == 0 ? DrainWaitMode.WakeupSignal : DrainWaitMode.Poll;
+            drainerTasks[i] = Task.Run(
+                () => LeakGateHarness.DrainUntilStoppedAsync(
+                    accumulator, counters, FailEveryNthBatch, waitMode, cancellationToken),
+                cancellationToken);
+        }
+
+        // Flush storm: races seal-and-claim against in-progress appends.
+        var flushStormTask = Task.Run(async () =>
+        {
+            while (!stormCts.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    await accumulator.FlushAsync(stormCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                await Task.Yield();
+            }
+        }, CancellationToken.None);
+
+        // Linger expiry loop: forces partial-batch seals mid-append, racing the appenders.
+        var lingerTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!stormCts.Token.IsCancellationRequested)
+                {
+                    await accumulator.ExpireLingerAsync(stormCts.Token);
+                    await Task.Delay(1, stormCts.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }, CancellationToken.None);
+
+        var appenderResults = await Task.WhenAll(appenderTasks).WaitAsync(cancellationToken);
+
+        await stormCts.CancelAsync();
+        await flushStormTask.WaitAsync(cancellationToken);
+        await lingerTask.WaitAsync(cancellationToken);
+
+        // Final flush completes only when every batch has exited the pipeline, so the
+        // stop flag cannot strand an undrained batch.
+        await accumulator.FlushAsync(cancellationToken);
+        counters.RequestStop();
+        await Task.WhenAll(drainerTasks).WaitAsync(cancellationToken);
+
+        await AwaitCompletionsAsync(appenderResults, cancellationToken);
+
+        return (counters, appenderResults);
+    }
+
+    private static Task<AppenderResult>[] StartAppenders(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> completionPool,
+        LeakGateCounters counters,
+        int messagesPerAppender,
+        CancellationToken cancellationToken)
+    {
+        var tasks = new Task<AppenderResult>[Appenders];
+        for (var i = 0; i < Appenders; i++)
+        {
+            var appenderId = i;
+            tasks[i] = Task.Run(
+                () => LeakGateHarness.RunAppenderAsync(
+                    accumulator, completionPool, counters, appenderId, messagesPerAppender,
+                    PartitionCount, ValueSize, Topic, cancellationToken),
+                cancellationToken);
+        }
+
+        return tasks;
+    }
+
+    private static async Task AwaitCompletionsAsync(
+        AppenderResult[] appenderResults,
+        CancellationToken cancellationToken)
+    {
+        foreach (var result in appenderResults)
+        {
+            foreach (var task in result.CompletionTasks)
+            {
+                try
+                {
+                    _ = await task.WaitAsync(cancellationToken);
+                }
+                catch (ExpectedInjectedFailureException)
+                {
+                    // Injected failure winner; awaiting proves the source terminated.
+                }
+            }
+        }
+    }
+
+    private static async Task AssertWaveFullyRetiredAsync(
+        RecordAccumulator accumulator,
+        LeakGateCounters counters,
+        AppenderResult[] appenderResults)
+    {
+        foreach (var result in appenderResults)
+        {
+            await Assert.That(result.WasCancelled).IsFalse();
+            await Assert.That(result.AcceptedTotal).IsEqualTo(MessagesPerAppender);
+        }
+
+        var fireAndForget = appenderResults.Sum(static r => r.AcceptedFireAndForget);
+        await Assert.That(counters.DrainedRecords).IsEqualTo(Appenders * MessagesPerAppender);
+        await Assert.That(Volatile.Read(ref counters.CallbackInvocations)).IsEqualTo(fireAndForget);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+        await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+        await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/LeakGateHarness.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LeakGateHarness.cs
@@ -1,0 +1,262 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Shared simulated-sender harness for the produce-path leak gates
+/// (<c>ProducerMemoryLeakGateTests</c>, <c>ProducerLeakUnderLoadTests</c>,
+/// <c>ProducerLeakEdgeCaseTests</c>). Centralizes the two pieces of
+/// production-mirroring knowledge the gates' validity depends on: the batch
+/// retirement sequence (<see cref="RetireBatch"/>) and the wakeup-signal
+/// contract (<see cref="DrainWaitMode"/>).
+/// </summary>
+internal static class LeakGateHarness
+{
+    /// <summary>
+    /// Retires one drained batch exactly the way <c>BrokerSender</c>'s cleanup path does:
+    /// CompleteSend/Fail → ReleaseBatchMemory → OnBatchExitsPipeline → ReturnReadyBatch.
+    /// The leak gates' validity depends on this mirror staying faithful to the production
+    /// sequence — if the sender's retirement contract changes, change it here, once.
+    /// </summary>
+    public static void RetireBatch(
+        RecordAccumulator accumulator,
+        ReadyBatch batch,
+        long offset,
+        Exception? failWith = null)
+    {
+        if (failWith is not null)
+            batch.Fail(failWith);
+        else
+            batch.CompleteSend(offset, DateTimeOffset.UtcNow);
+
+        accumulator.ReleaseBatchMemory(batch);
+        accumulator.OnBatchExitsPipeline(batch);
+        accumulator.ReturnReadyBatch(batch);
+    }
+
+    /// <summary>
+    /// Drains one batch if available and retires it, failing every
+    /// <paramref name="failEveryNthBatch"/>th batch with <see cref="ExpectedInjectedFailureException"/>
+    /// (0 = never fail). Returns false when nothing was drainable.
+    /// </summary>
+    public static bool TryDrainAndRetireOne(
+        RecordAccumulator accumulator,
+        LeakGateCounters counters,
+        int failEveryNthBatch)
+    {
+        if (!accumulator.TryDrainBatch(out var batch))
+            return false;
+
+        var sequence = Interlocked.Increment(ref counters.DrainSequence);
+        var recordCount = batch!.RecordBatch.Records.Count;
+
+        Exception? failWith = null;
+        if (failEveryNthBatch > 0 && sequence % failEveryNthBatch == 0)
+        {
+            failWith = new ExpectedInjectedFailureException();
+            Interlocked.Increment(ref counters.FailedBatchCount);
+        }
+
+        RetireBatch(accumulator, batch, sequence, failWith);
+
+        Interlocked.Increment(ref counters.DrainedBatchCount);
+        Interlocked.Add(ref counters.DrainedRecordCount, recordCount);
+        return true;
+    }
+
+    /// <summary>
+    /// Simulated sender loop: drains and retires batches until
+    /// <see cref="LeakGateCounters.RequestStop"/> is called and the pipeline is empty.
+    /// Tolerates the accumulator being disposed underneath it.
+    /// </summary>
+    public static async Task DrainUntilStoppedAsync(
+        RecordAccumulator accumulator,
+        LeakGateCounters counters,
+        int failEveryNthBatch,
+        DrainWaitMode waitMode,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            bool drained;
+            try
+            {
+                drained = TryDrainAndRetireOne(accumulator, counters, failEveryNthBatch);
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+
+            if (drained)
+                continue;
+            if (counters.StopRequested)
+                break;
+
+            if (waitMode == DrainWaitMode.WakeupSignal)
+                await accumulator.WaitForWakeupAsync(5);
+            else
+                await Task.Delay(1, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Appends until <paramref name="messageCount"/> messages are accepted, the token is
+    /// cancelled, or the accumulator rejects the append (disposal). Even-indexed messages
+    /// are awaited via a rented completion source; odd-indexed messages are fire-and-forget
+    /// with a callback that increments <see cref="LeakGateCounters.CallbackInvocations"/>.
+    /// A completion task is recorded only after the append is accepted, so an append that
+    /// throws leaves nothing to await.
+    /// </summary>
+    public static async Task<AppenderResult> RunAppenderAsync(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> completionPool,
+        LeakGateCounters counters,
+        int appenderId,
+        int messageCount,
+        int partitionCount,
+        int valueSize,
+        string topic,
+        CancellationToken cancellationToken)
+    {
+        var completionTasks = new List<Task<RecordMetadata>>();
+        var acceptedTotal = 0;
+        var acceptedFireAndForget = 0;
+        var wasCancelled = false;
+        Action<RecordMetadata, Exception?> callback =
+            (_, _) => Interlocked.Increment(ref counters.CallbackInvocations);
+
+        for (var i = 0; i < messageCount; i++)
+        {
+            var value = RentPooled(valueSize, appenderId * 31 + i);
+            var partition = (appenderId + i * 7) % partitionCount;
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+            try
+            {
+                bool accepted;
+                if ((i & 1) == 0)
+                {
+                    var completion = completionPool.Rent();
+                    var completionTask = completion.Task.AsTask();
+                    accepted = await accumulator.AppendAsync(
+                        topic, partition, timestamp, PooledMemory.Null, value,
+                        headers: null, headerCount: 0, completion, callback: null, cancellationToken);
+                    if (accepted)
+                        completionTasks.Add(completionTask);
+                }
+                else
+                {
+                    accepted = await accumulator.AppendAsync(
+                        topic, partition, timestamp, PooledMemory.Null, value,
+                        headers: null, headerCount: 0, completionSource: null,
+                        callback, cancellationToken);
+                    if (accepted)
+                        acceptedFireAndForget++;
+                }
+
+                if (!accepted)
+                    break;
+
+                acceptedTotal++;
+                Interlocked.Increment(ref counters.AcceptedTotal);
+            }
+            catch (OperationCanceledException)
+            {
+                wasCancelled = true;
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+        }
+
+        return new AppenderResult(acceptedTotal, acceptedFireAndForget, wasCancelled, completionTasks);
+    }
+
+    /// <summary>
+    /// Waits until at least one appender is provably in the slow-path memory reservation
+    /// wait (the mechanism gated saturation tests need), escaping if every appender
+    /// finishes without pressure so a mis-sized scenario fails on its assertions instead
+    /// of burning the test timeout.
+    /// </summary>
+    public static Task WaitForSaturationAsync(
+        RecordAccumulator accumulator,
+        IReadOnlyList<Task> appenderTasks,
+        CancellationToken cancellationToken)
+    {
+        return TestWait.UntilAsync(
+            () => accumulator.BufferPressureEvents > 0 || appenderTasks.All(static t => t.IsCompleted),
+            cancellationToken,
+            TimeSpan.FromMilliseconds(1));
+    }
+
+    /// <summary>
+    /// Managed-heap size after a full stabilization pass. <c>GC.GetTotalMemory(true)</c>
+    /// alone collects but does not wait for pending finalizers, so objects queued for
+    /// finalization by earlier tests in the same process can drift a raw before/after
+    /// delta; the collect → wait → collect dance removes that noise.
+    /// </summary>
+    public static long GetStableHeapBytes()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        return GC.GetTotalMemory(forceFullCollection: true);
+    }
+
+    /// <summary>Rents a pooled payload of <paramref name="size"/> bytes filled from the seed.</summary>
+    public static PooledMemory RentPooled(int size, int seed)
+    {
+        var buffer = ProducerDataPool.BytePool.Rent(size);
+        buffer.AsSpan(0, size).Fill((byte)seed);
+        return new PooledMemory(buffer, size);
+    }
+}
+
+/// <summary>
+/// How the drain loop idles when the pipeline is momentarily empty.
+/// <see cref="RecordAccumulator.WaitForWakeupAsync"/> is backed by a single-waiter pooled
+/// ValueTask source that is torn down by disposal, so <see cref="WakeupSignal"/> is valid
+/// only for the sole signal-awaiting drainer on an accumulator that outlives the loop
+/// (production sender loops exit via their own cancellation before disposal, so they never
+/// violate this). Any additional concurrent drainer, and any drainer that may outlive the
+/// accumulator, must use <see cref="Poll"/>.
+/// </summary>
+internal enum DrainWaitMode
+{
+    WakeupSignal,
+    Poll,
+}
+
+/// <summary>Shared mutable counters for one leak-gate scenario run.</summary>
+internal sealed class LeakGateCounters
+{
+    public int AcceptedTotal;
+    public int CallbackInvocations;
+    public int DrainSequence;
+    public int DrainedBatchCount;
+    public int DrainedRecordCount;
+    public int FailedBatchCount;
+    private int _stopRequested;
+
+    public int DrainedBatches => Volatile.Read(ref DrainedBatchCount);
+    public int DrainedRecords => Volatile.Read(ref DrainedRecordCount);
+    public int FailedBatches => Volatile.Read(ref FailedBatchCount);
+    public bool StopRequested => Volatile.Read(ref _stopRequested) != 0;
+
+    public void RequestStop() => Volatile.Write(ref _stopRequested, 1);
+}
+
+/// <summary>Per-appender outcome from <see cref="LeakGateHarness.RunAppenderAsync"/>.</summary>
+internal sealed record AppenderResult(
+    int AcceptedTotal,
+    int AcceptedFireAndForget,
+    bool WasCancelled,
+    List<Task<RecordMetadata>> CompletionTasks);
+
+/// <summary>Marker exception for intentionally failed batches in leak-gate scenarios.</summary>
+internal sealed class ExpectedInjectedFailureException : Exception;

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
@@ -1,0 +1,517 @@
+using Dekaf.Producer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Edge-case leak gates for the produce path, covering the corners the sequential drift gate
+/// (<c>ProducerMemoryLeakGateTests</c>) and the load/race gates (<c>ProducerLeakUnderLoadTests</c>)
+/// do not reach:
+/// <list type="bullet">
+/// <item><description>Appender cancellation mid-reservation-wait under saturation — a cancelled
+/// waiter that leaves a reservation, a pending-append entry, or a phantom appended record behind
+/// is caught by the drained-vs-accepted reconciliation.</description></item>
+/// <item><description>Disposal racing active appenders and an active drainer — every accepted
+/// message must terminate exactly once and all reserved memory must be refunded by the orphan
+/// sweep, with no stranded completion.</description></item>
+/// <item><description>Extreme payload shapes (null/empty/1-byte/batch-filling/oversized values,
+/// pooled keys, pooled header arrays) — exercises arena rotation boundaries and the oversized
+/// single-record batch path, with occupancy asserts proving the oversized path was taken.
+/// Key/header pooled-array hygiene is exercised here but is observable only through the
+/// accounting and heap gates, not asserted per-array.</description></item>
+/// <item><description>User callbacks that throw, on both the success and the failure delivery
+/// path — a throwing callback must not skip sibling callbacks or the batch refund.</description></item>
+/// <item><description>Cancelled flushes — repeated abandoned flush waits must not accumulate
+/// claim state or strand sealed batches.</description></item>
+/// </list>
+/// </summary>
+[NotInParallel]
+public sealed class ProducerLeakEdgeCaseTests
+{
+    private const string Topic = "leak-edge";
+    private const int PartitionCount = 4;
+    private const int ValueSize = 1024;
+    private const int KeySize = 16;
+
+    private static readonly byte[] TraceIdHeaderValue = "0123456789abcdef"u8.ToArray();
+
+    /// <summary>
+    /// Saturates a 128 KB buffer with the drainer gated shut so appenders block in the
+    /// slow-path reservation wait, then cancels half of them mid-wait. The cancellation
+    /// contract under test: a cancelled append must either complete fully (accepted, delivered)
+    /// or leave no trace at all — no reservation, no pending-append entry, no phantom record.
+    /// Drained records reconciled against per-appender accepted counts detect both a leaked
+    /// reservation (BufferedBytes residue) and a phantom append (drained &gt; accepted).
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task CancelledAppendersUnderSaturation_NoPhantomRecordsOrResidue(
+        CancellationToken cancellationToken)
+    {
+        const int MessagesPerAppender = 768;
+
+        var accumulator = new RecordAccumulator(CreateOptions("leak-edge-cancel", bufferMemory: 128 * 1024));
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var counters = new LeakGateCounters();
+            var drainerGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var victimCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            Task<AppenderResult> StartAppender(int appenderId, CancellationToken token) =>
+                Task.Run(
+                    () => LeakGateHarness.RunAppenderAsync(
+                        accumulator, completionPool, counters, appenderId, MessagesPerAppender,
+                        PartitionCount, ValueSize, Topic, token),
+                    cancellationToken);
+
+            var survivorTasks = new[] { StartAppender(0, cancellationToken), StartAppender(1, cancellationToken) };
+            var victimTasks = new[] { StartAppender(2, victimCts.Token), StartAppender(3, victimCts.Token) };
+
+            var drainerTask = Task.Run(async () =>
+            {
+                await drainerGate.Task.WaitAsync(cancellationToken);
+                await LeakGateHarness.DrainUntilStoppedAsync(
+                    accumulator, counters, failEveryNthBatch: 0, DrainWaitMode.WakeupSignal, cancellationToken);
+            }, cancellationToken);
+
+            // Hold the drainer shut until an appender is provably blocked in the slow-path
+            // reservation wait, then cancel the victims while they are blocked.
+            await LeakGateHarness.WaitForSaturationAsync(
+                accumulator, [.. survivorTasks, .. victimTasks], cancellationToken);
+            await victimCts.CancelAsync();
+            drainerGate.SetResult();
+
+            var survivorResults = await Task.WhenAll(survivorTasks).WaitAsync(cancellationToken);
+            var victimResults = await Task.WhenAll(victimTasks).WaitAsync(cancellationToken);
+
+            await accumulator.FlushAsync(cancellationToken);
+            counters.RequestStop();
+            await drainerTask.WaitAsync(cancellationToken);
+
+            // The victims must actually have been interrupted mid-run for the test to
+            // exercise cancellation inside the reservation wait.
+            await Assert.That(accumulator.BufferPressureEvents).IsGreaterThan(0L);
+            foreach (var victim in victimResults)
+            {
+                await Assert.That(victim.WasCancelled).IsTrue();
+                await Assert.That(victim.AcceptedTotal).IsLessThan(MessagesPerAppender);
+            }
+
+            var allResults = survivorResults.Concat(victimResults).ToArray();
+            var acceptedTotal = allResults.Sum(static r => r.AcceptedTotal);
+            var acceptedFireAndForget = allResults.Sum(static r => r.AcceptedFireAndForget);
+
+            // Exactly the accepted messages must flow through the pipeline — no more, no less.
+            await Assert.That(counters.DrainedRecords).IsEqualTo(acceptedTotal);
+            await Assert.That(Volatile.Read(ref counters.CallbackInvocations)).IsEqualTo(acceptedFireAndForget);
+
+            // Cancellation after acceptance stops the caller's wait, never the delivery:
+            // every accepted awaited message must complete successfully.
+            foreach (var result in allResults)
+            {
+                foreach (var task in result.CompletionTasks)
+                    _ = await task.WaitAsync(cancellationToken);
+            }
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Disposes the accumulator while appenders and a drainer are running at full speed.
+    /// Appenders run open-ended until disposal rejects them, so the dispose orphan sweep is
+    /// guaranteed to race live appends, live drains, and in-flight batches. Invariants: every
+    /// accepted message terminates exactly once (fire-and-forget callbacks invoked exactly
+    /// once, every awaited completion reaches a terminal state), and the sweep refunds all
+    /// reserved memory — <c>BufferedBytes</c> lands on exactly zero after quiesce.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task DisposeDuringActiveLoad_AcceptedMessagesTerminateExactlyOnce_NoResidue(
+        CancellationToken cancellationToken)
+    {
+        const int Appenders = 4;
+        const int DisposeAfterAcceptedMessages = 20_000;
+
+        var accumulator = new RecordAccumulator(CreateOptions("leak-edge-dispose", bufferMemory: 16UL * 1024 * 1024));
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var counters = new LeakGateCounters();
+
+            var appenderTasks = new Task<AppenderResult>[Appenders];
+            for (var i = 0; i < Appenders; i++)
+            {
+                var appenderId = i;
+                appenderTasks[i] = Task.Run(
+                    () => LeakGateHarness.RunAppenderAsync(
+                        accumulator, completionPool, counters, appenderId, messageCount: int.MaxValue,
+                        PartitionCount, ValueSize, Topic, cancellationToken),
+                    cancellationToken);
+            }
+
+            // Poll mode: this drainer outlives the accumulator, and a drainer caught inside
+            // the wakeup signal when the accumulator is disposed strands forever.
+            var drainerTask = Task.Run(
+                () => LeakGateHarness.DrainUntilStoppedAsync(
+                    accumulator, counters, failEveryNthBatch: 0, DrainWaitMode.Poll, cancellationToken),
+                cancellationToken);
+
+            while (Volatile.Read(ref counters.AcceptedTotal) < DisposeAfterAcceptedMessages)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+
+            // Dispose races live appenders and the live drainer. The drainer keeps running
+            // through disposal so the pipeline can quiesce, then is stopped afterwards.
+            await accumulator.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+
+            var appenderResults = await Task.WhenAll(appenderTasks).WaitAsync(cancellationToken);
+            counters.RequestStop();
+            await drainerTask.WaitAsync(cancellationToken);
+
+            var acceptedTotal = appenderResults.Sum(static r => r.AcceptedTotal);
+            var acceptedFireAndForget = appenderResults.Sum(static r => r.AcceptedFireAndForget);
+            await Assert.That(acceptedTotal).IsGreaterThanOrEqualTo(DisposeAfterAcceptedMessages);
+
+            // Every accepted awaited message must reach a terminal state — delivered by the
+            // drainer or failed by the dispose sweep — never stranded.
+            foreach (var result in appenderResults)
+            {
+                foreach (var task in result.CompletionTasks)
+                {
+                    try
+                    {
+                        _ = await task.WaitAsync(cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch
+                    {
+                        // Terminal failure from the dispose sweep is a valid outcome;
+                        // awaiting proves the source terminated.
+                    }
+                }
+            }
+
+            await Assert.That(Volatile.Read(ref counters.CallbackInvocations)).IsEqualTo(acceptedFireAndForget);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Repeated waves of pathological payload shapes: null values, empty values, single bytes,
+    /// near-batch-filling values, oversized values (3× BatchSize, forcing the dedicated
+    /// single-record batch path), pooled non-null keys, and pooled header arrays. These are
+    /// the arena-boundary and ownership-transfer paths where the original BufferMemory bypass
+    /// (#1516 family) lived. Accounting must return exactly to zero after every wave, and the
+    /// drained batch count must prove the oversized messages each occupied their own batch.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task ExtremePayloadShapes_MixedSizesKeysAndHeaders_AccountingReturnsToZero(
+        CancellationToken cancellationToken)
+    {
+        const int Cycles = 20;
+        const int MessagesPerCycle = 120;
+        const int BatchSize = 16384;
+        const int OversizedPerCycle = MessagesPerCycle / 6;
+
+        var accumulator = new RecordAccumulator(CreateOptions("leak-edge-shapes", bufferMemory: 32UL * 1024 * 1024));
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            for (var cycle = 0; cycle < Cycles; cycle++)
+            {
+                var completionTasks = new List<Task<RecordMetadata>>();
+                var callbackInvocations = 0;
+                var expectedCallbacks = 0;
+                Action<RecordMetadata, Exception?> callback =
+                    (_, _) => Interlocked.Increment(ref callbackInvocations);
+
+                for (var i = 0; i < MessagesPerCycle; i++)
+                {
+                    var value = (i % 6) switch
+                    {
+                        0 => PooledMemory.Null,
+                        1 => new PooledMemory(ProducerDataPool.BytePool.Rent(1), 0),
+                        2 => LeakGateHarness.RentPooled(1, i),
+                        3 => LeakGateHarness.RentPooled(4 * 1024, i),
+                        4 => LeakGateHarness.RentPooled(BatchSize - 1024, i),
+                        _ => LeakGateHarness.RentPooled(3 * BatchSize, i),
+                    };
+                    var key = (i % 2) == 0 ? LeakGateHarness.RentPooled(KeySize, i * 17) : PooledMemory.Null;
+
+                    Header[]? headers = null;
+                    var headerCount = 0;
+                    if (i % 3 == 0)
+                    {
+                        headers = ProducerContainerPools.Headers.Rent(2);
+                        headers[0] = new Header("trace-id", TraceIdHeaderValue);
+                        headers[1] = new Header("origin", (byte[]?)null);
+                        headerCount = 2;
+                    }
+
+                    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    bool accepted;
+                    if (i % 4 == 1)
+                    {
+                        var completion = completionPool.Rent();
+                        completionTasks.Add(completion.Task.AsTask());
+                        accepted = await accumulator.AppendAsync(
+                            Topic, i % PartitionCount, timestamp, key, value,
+                            headers, headerCount, completion, callback: null, cancellationToken);
+                    }
+                    else
+                    {
+                        expectedCallbacks++;
+                        accepted = await accumulator.AppendAsync(
+                            Topic, i % PartitionCount, timestamp, key, value,
+                            headers, headerCount, completionSource: null, callback, cancellationToken);
+                    }
+
+                    if (!accepted)
+                        throw new InvalidOperationException($"Cycle {cycle} message {i} rejected.");
+                }
+
+                var counters = await DrainCycleAsync(accumulator, MessagesPerCycle, failEveryNthBatch: 0, cancellationToken);
+                foreach (var task in completionTasks)
+                    _ = await task.WaitAsync(cancellationToken);
+
+                await Assert.That(counters.DrainedRecords).IsEqualTo(MessagesPerCycle);
+                // Each 3×BatchSize value cannot share a batch, so the wave must produce at
+                // least one batch per oversized message — proof the oversized path ran.
+                await Assert.That(counters.DrainedBatches).IsGreaterThanOrEqualTo(OversizedPerCycle);
+                await Assert.That(Volatile.Read(ref callbackInvocations)).IsEqualTo(expectedCallbacks);
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+                await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+                await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+                await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+            }
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Fire-and-forget callbacks that throw, delivered on both the success path and the
+    /// failure path (every 4th batch is failed). A throwing user callback must not skip
+    /// sibling callbacks in the same batch, must not skip the batch refund, and must not
+    /// kill the simulated sender — every callback still fires exactly once and accounting
+    /// returns to zero.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task ThrowingUserCallbacks_DoNotSkipSiblingCallbacksOrRefunds(
+        CancellationToken cancellationToken)
+    {
+        const int Cycles = 10;
+        const int MessagesPerCycle = 128;
+        const int FailEveryNthBatch = 4;
+
+        var accumulator = new RecordAccumulator(CreateOptions("leak-edge-callbacks", bufferMemory: 16UL * 1024 * 1024));
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            for (var cycle = 0; cycle < Cycles; cycle++)
+            {
+                var completionTasks = new List<Task<RecordMetadata>>();
+                var callbackInvocations = 0;
+                var expectedCallbacks = 0;
+                Action<RecordMetadata, Exception?> countingCallback =
+                    (_, _) => Interlocked.Increment(ref callbackInvocations);
+                Action<RecordMetadata, Exception?> throwingCallback = (_, _) =>
+                {
+                    Interlocked.Increment(ref callbackInvocations);
+                    throw new InvalidOperationException("Expected leak-edge callback failure");
+                };
+
+                for (var i = 0; i < MessagesPerCycle; i++)
+                {
+                    var value = LeakGateHarness.RentPooled(ValueSize, i);
+                    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    bool accepted;
+                    if ((i & 1) == 0)
+                    {
+                        var completion = completionPool.Rent();
+                        completionTasks.Add(completion.Task.AsTask());
+                        accepted = await accumulator.AppendAsync(
+                            Topic, i % PartitionCount, timestamp, PooledMemory.Null, value,
+                            headers: null, headerCount: 0, completion, callback: null, cancellationToken);
+                    }
+                    else
+                    {
+                        expectedCallbacks++;
+                        accepted = await accumulator.AppendAsync(
+                            Topic, i % PartitionCount, timestamp, PooledMemory.Null, value,
+                            headers: null, headerCount: 0, completionSource: null,
+                            i % 3 == 0 ? throwingCallback : countingCallback,
+                            cancellationToken);
+                    }
+
+                    if (!accepted)
+                        throw new InvalidOperationException($"Cycle {cycle} message {i} rejected.");
+                }
+
+                var counters = await DrainCycleAsync(accumulator, MessagesPerCycle, FailEveryNthBatch, cancellationToken);
+                foreach (var task in completionTasks)
+                {
+                    try
+                    {
+                        _ = await task.WaitAsync(cancellationToken);
+                    }
+                    catch (ExpectedInjectedFailureException)
+                    {
+                        // Awaited message landed in an intentionally failed batch.
+                    }
+                }
+
+                await Assert.That(Volatile.Read(ref callbackInvocations)).IsEqualTo(expectedCallbacks);
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+                await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+                await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+            }
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Repeatedly abandons flush waits — alternating between a flush cancelled mid-wait and a
+    /// flush called with an already-cancelled token — then drains cleanly. Cancelled flush
+    /// waiters must not accumulate claim state, strand sealed batches, or distort accounting
+    /// across cycles.
+    /// </summary>
+    [Test]
+    [Timeout(120_000)]
+    public async Task CancelledFlushes_RepeatedCycles_NoResidualClaimsOrStrandedBatches(
+        CancellationToken cancellationToken)
+    {
+        const int Cycles = 20;
+        const int MessagesPerCycle = 64;
+
+        var accumulator = new RecordAccumulator(CreateOptions("leak-edge-flush", bufferMemory: 16UL * 1024 * 1024));
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            for (var cycle = 0; cycle < Cycles; cycle++)
+            {
+                var completionTasks = new List<Task<RecordMetadata>>();
+                for (var i = 0; i < MessagesPerCycle; i++)
+                {
+                    var value = LeakGateHarness.RentPooled(ValueSize, i);
+                    var completion = completionPool.Rent();
+                    completionTasks.Add(completion.Task.AsTask());
+                    var accepted = await accumulator.AppendAsync(
+                        Topic, i % PartitionCount, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        PooledMemory.Null, value, headers: null, headerCount: 0,
+                        completion, callback: null, cancellationToken);
+                    if (!accepted)
+                        throw new InvalidOperationException($"Cycle {cycle} message {i} rejected.");
+                }
+
+                // Abandon a flush: nothing drains yet, so the wait is guaranteed pending
+                // when the cancellation lands (even cycles) or already cancelled (odd cycles).
+                using var flushCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                try
+                {
+                    if ((cycle & 1) == 0)
+                    {
+                        var abandonedFlush = accumulator.FlushAsync(flushCts.Token).AsTask();
+                        await flushCts.CancelAsync();
+                        await abandonedFlush;
+                    }
+                    else
+                    {
+                        // A pre-cancelled token makes FlushAsync throw synchronously at entry,
+                        // so the call itself must be inside the try.
+                        await flushCts.CancelAsync();
+                        await accumulator.FlushAsync(flushCts.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+
+                // A clean flush + drain must fully retire the wave despite the abandoned wait.
+                var counters = await DrainCycleAsync(accumulator, MessagesPerCycle, failEveryNthBatch: 0, cancellationToken);
+                foreach (var task in completionTasks)
+                    _ = await task.WaitAsync(cancellationToken);
+
+                await Assert.That(counters.DrainedRecords).IsEqualTo(MessagesPerCycle);
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+                await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+                await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+            }
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    private static ProducerOptions CreateOptions(string clientId, ulong bufferMemory) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = clientId,
+        BufferMemory = bufferMemory,
+        BatchSize = 16384,
+        LingerMs = 1_000,
+        MaxBlockMs = 60_000,
+    };
+
+    /// <summary>
+    /// Flushes, then drains inline as the sole simulated sender until every appended record
+    /// has been retired.
+    /// </summary>
+    private static async Task<LeakGateCounters> DrainCycleAsync(
+        RecordAccumulator accumulator,
+        int expectedRecords,
+        int failEveryNthBatch,
+        CancellationToken cancellationToken)
+    {
+        var counters = new LeakGateCounters();
+        var flushTask = accumulator.FlushAsync(cancellationToken).AsTask();
+
+        while (counters.DrainedRecords < expectedRecords)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!LeakGateHarness.TryDrainAndRetireOne(accumulator, counters, failEveryNthBatch))
+                await accumulator.WaitForWakeupAsync(5);
+        }
+
+        await flushTask.WaitAsync(cancellationToken);
+        return counters;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerMemoryLeakGateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerMemoryLeakGateTests.cs
@@ -1,0 +1,197 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Deterministic leak gates for the produce path. Each test runs repeated
+/// produce → flush → drain → complete waves through a <see cref="RecordAccumulator"/>
+/// with a simulated sender and asserts that every resource-accounting invariant
+/// returns exactly to zero after every wave.
+/// </summary>
+/// <remarks>
+/// Leak classes this gate catches, and how:
+/// <list type="bullet">
+/// <item><description>BufferMemory refund leaks (the #1516/#2199 family): a missed or
+/// double-counted <c>ReleaseBatchMemory</c> leaves <c>BufferedBytes</c> non-zero after the
+/// wave completes — caught on the first leaking cycle, not after gigabytes of drift.</description></item>
+/// <item><description>Pipeline tracking leaks: <c>InFlightBatchCount</c> or the pending-append
+/// queue not draining to zero means batches or admissions are stranded.</description></item>
+/// <item><description>Pool imbalance (the #2187 family): rent/return counters must match
+/// exactly with zero duplicate returns in this race-free harness. Note these counter
+/// assertions are Debug-only — <c>ProducerDebugCounters</c> is compiled out of Release
+/// builds, so this class of check runs on Debug executions, not in Release CI.</description></item>
+/// <item><description>Rooted-object leaks (completed batches or completion sources retained
+/// anywhere): steady-state managed-heap growth across cycles, measured after full GC, must
+/// stay near zero. Historical leaks in this class measured tens of MB at this message volume
+/// (e.g. ~2 KB/message string caching would show as ~100 MB here).</description></item>
+/// </list>
+/// Unlike the integration-level <c>BufferMemoryStressTests</c> (15 s wall clock, 2 GB
+/// threshold, requires Docker), these run broker-free in seconds and fail on first drift.
+/// </remarks>
+[NotInParallel]
+public sealed class ProducerMemoryLeakGateTests
+{
+    private const string Topic = "leak-gate";
+    private const int PartitionCount = 4;
+    private const int MessagesPerCycle = 512;
+    private const int AwaitedPerCycle = MessagesPerCycle / 2;
+    private const int ValueSize = 1024;
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task RepeatedProduceDrainCycles_AccountingReturnsToZero_EveryCycle(
+        CancellationToken cancellationToken)
+    {
+        const int CycleCount = 50;
+
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+        ProducerDebugCounters.Reset();
+
+        var totalBatches = 0;
+        try
+        {
+            for (var cycle = 0; cycle < CycleCount; cycle++)
+            {
+                var result = await RunProduceDrainCycleAsync(accumulator, completionPool, cancellationToken);
+                totalBatches += result.DrainedBatches;
+
+                // Every wave must retire completely: any residue here is a leak that
+                // compounds per wave in a long-running producer.
+                await Assert.That(result.DrainedRecords).IsEqualTo(MessagesPerCycle);
+                await Assert.That(result.CallbackInvocations).IsEqualTo(MessagesPerCycle - AwaitedPerCycle);
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+                await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(0L);
+                await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+                await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+            }
+
+#if DEBUG
+            var counters = ProducerDebugCounters.GetSnapshot();
+            const int TotalMessages = CycleCount * MessagesPerCycle;
+            const int AwaitedMessages = CycleCount * AwaitedPerCycle;
+            await Assert.That(counters.MessagesAppended).IsEqualTo(TotalMessages);
+            await Assert.That(counters.CompletionSourcesStoredInBatch).IsEqualTo(AwaitedMessages);
+            await Assert.That(counters.CompletionSourcesCompleted).IsEqualTo(AwaitedMessages);
+            await Assert.That(counters.CompletionSourcesFailed).IsEqualTo(0);
+            await Assert.That(counters.ReadyBatchesRented).IsEqualTo(totalBatches);
+            await Assert.That(counters.ReadyBatchesReturned).IsEqualTo(totalBatches);
+            await Assert.That(counters.ReadyBatchDuplicateReturns).IsEqualTo(0);
+            await Assert.That(counters.BatchesSentSuccessfully).IsEqualTo(totalBatches);
+            await Assert.That(counters.BatchesFailed).IsEqualTo(0);
+#endif
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+            ProducerDebugCounters.Reset();
+        }
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task RepeatedProduceDrainCycles_ManagedHeapDoesNotGrow(
+        CancellationToken cancellationToken)
+    {
+        const int WarmupCycles = 8;
+        const int MeasuredCycles = 100;
+
+        // Pool population, channel segments, and arena growth all happen during warmup;
+        // the measured region below is pure steady-state reuse and must retain ~nothing.
+        // A real rooted-object leak at this volume (51,200 messages, ~50 MB of payload)
+        // measures tens of MB; the 8 MB bound leaves generous headroom for GC bookkeeping
+        // while staying an order of magnitude below any historical produce-path leak.
+        const long MaxRetainedGrowthBytes = 8 * 1024 * 1024;
+
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var completionPool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            for (var cycle = 0; cycle < WarmupCycles; cycle++)
+                await RunProduceDrainCycleAsync(accumulator, completionPool, cancellationToken);
+
+            var baseline = LeakGateHarness.GetStableHeapBytes();
+
+            for (var cycle = 0; cycle < MeasuredCycles; cycle++)
+                await RunProduceDrainCycleAsync(accumulator, completionPool, cancellationToken);
+
+            var retainedGrowth = LeakGateHarness.GetStableHeapBytes() - baseline;
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+            await Assert.That(retainedGrowth).IsLessThan(MaxRetainedGrowthBytes);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await completionPool.DisposeAsync();
+        }
+    }
+
+    private static ProducerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "leak-gate",
+        BufferMemory = 16UL * 1024 * 1024,
+        BatchSize = 16384,
+        LingerMs = 1_000,
+    };
+
+    /// <summary>
+    /// One full produce wave: append (half awaited, half fire-and-forget with callbacks),
+    /// flush, then drain inline as the simulated sender via
+    /// <see cref="LeakGateHarness.TryDrainAndRetireOne"/>.
+    /// </summary>
+    private static async Task<LeakGateCounters> RunProduceDrainCycleAsync(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> completionPool,
+        CancellationToken cancellationToken)
+    {
+        var counters = new LeakGateCounters();
+        var completionTasks = new List<Task<RecordMetadata>>(AwaitedPerCycle);
+        Action<RecordMetadata, Exception?> callback =
+            (_, _) => Interlocked.Increment(ref counters.CallbackInvocations);
+
+        for (var i = 0; i < MessagesPerCycle; i++)
+        {
+            var value = LeakGateHarness.RentPooled(ValueSize, i);
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            bool accepted;
+            if ((i & 1) == 0)
+            {
+                var completion = completionPool.Rent();
+                completionTasks.Add(completion.Task.AsTask());
+                accepted = await accumulator.AppendAsync(
+                    Topic, i % PartitionCount, timestamp, PooledMemory.Null, value,
+                    headers: null, headerCount: 0, completion, callback: null, cancellationToken);
+            }
+            else
+            {
+                accepted = await accumulator.AppendAsync(
+                    Topic, i % PartitionCount, timestamp, PooledMemory.Null, value,
+                    headers: null, headerCount: 0, completionSource: null, callback, cancellationToken);
+            }
+
+            if (!accepted)
+                throw new InvalidOperationException($"Append {i} rejected — accumulator disposed?");
+        }
+
+        // Flush seals every current batch; drain inline as the simulated sender.
+        var flushTask = accumulator.FlushAsync(cancellationToken).AsTask();
+
+        while (counters.DrainedRecords < MessagesPerCycle)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!LeakGateHarness.TryDrainAndRetireOne(accumulator, counters, failEveryNthBatch: 0))
+                await accumulator.WaitForWakeupAsync(10);
+        }
+
+        await flushTask.WaitAsync(cancellationToken);
+
+        foreach (var task in completionTasks)
+            _ = await task.WaitAsync(cancellationToken);
+
+        return counters;
+    }
+}


### PR DESCRIPTION
## Summary

Nine broker-free unit-level leak gates (~1s total runtime, no Docker) that catch produce-path leak classes **on the first leaking wave**, instead of surfacing as multi-GB drift in the 15s Docker integration test or in paid stress lanes.

| File | Gates |
|---|---|
| `ProducerMemoryLeakGateTests` | Sequential 50-wave accounting drift gate (every wave must land `BufferedBytes`/`InFlightBatchCount`/`UnsealedBatchCount`/pending-appends exactly on 0) + 100-wave retained-heap gate (<8MB after stabilized full GC) |
| `ProducerLeakUnderLoadTests` | 4 appenders x 2 drainers x flush storm x linger expiry with every-5th-batch failure injection; backpressure saturation test that gates the drainer until an appender provably blocks in the slow-path reservation wait (`BufferPressureEvents > 0`), racing refunds against the pending-append drain with every-7th-batch failures |
| `ProducerLeakEdgeCaseTests` | Cancellation mid-reservation-wait under saturation (drained-vs-accepted reconciliation detects both leaked reservations and phantom appends); dispose racing active open-ended appenders + drainer (exactly-once termination, orphan-sweep refund to 0); extreme payload shapes (null/empty/1B/batch-filling/3xBatchSize values, pooled keys, pooled `Header[]`) with oversized-batch occupancy asserts; throwing user callbacks on both success and failure delivery paths; cancelled-flush cycles (mid-wait + pre-cancelled variants) |
| `LeakGateHarness` | Shared simulated sender. Centralizes the two pieces of production-mirroring knowledge the gates depend on: the batch retirement sequence (`CompleteSend`/`Fail` -> `ReleaseBatchMemory` -> `OnBatchExitsPipeline` -> `ReturnReadyBatch`, documented once at `RetireBatch`) and the single-waiter wakeup-signal contract (`DrainWaitMode`) |

Leak classes covered map to real history: BufferMemory refund leaks (#1516/#2199 family), pool double-returns (#2187 family), stranded pipeline tracking, rooted-object retention.

## Sensitivity (mutation-verified)

- Skipping the `ReleaseBatchMemory` refund in the shared retire helper fails the drift gate at **cycle 1 in <100ms** (`BufferedBytes` assert).
- A failure-path-only refund skip (only every 5th batch leaks, under full concurrency) is caught in **<400ms** on wave 1.

## Stability evidence

- 25/25 clean runs after final hardening (20 Release + 5 Debug), on top of 57 prior clean runs including 15 under 6-core CPU contention.
- One unreproduced single-test failure occurred in an early post-refactor run before failure-detail capture was in place (1 in ~83 runs; identity unknown). Elimination pointed at GC finalizer-timing noise in the heap deltas, so both heap gates now measure via `GetStableHeapBytes()` (collect -> `WaitForPendingFinalizers` -> collect). If a leak-gate failure ever appears in CI, the assertion output self-identifies the invariant and values - please treat it as signal, not a re-run candidate.

## Caveats / follow-ups

- The `ProducerDebugCounters` balance asserts (`ReadyBatchesRented == Returned`, zero duplicate returns, completion-source conservation) compile only against Debug builds; Release CI runs all accounting and heap assertions but not these. A free ubuntu-latest Debug leg running just the `[NotInParallel]` leak-gate classes would light them up - happy to add in a follow-up if wanted.
- Next highest-value layer not covered here: BrokerSender-level accounting gates (scale-down/mute/timeout refund paths, #2187/#1578 territory) via the fake-connection harness from `BrokerSenderSendLoopTests`.

Tests-only change; no `src/` modifications, so no benchmark evidence required.