### PR TITLE
test: BrokerSender leak gates + Debug CI leg for counter asserts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
   # build job computed.
   publish:
     name: Publish NuGet
-    needs: [build, unit-net8, aot-smoke, aot-integration-publish, release-matrix, release-matrix-aot, code-quality]
+    needs: [build, unit-net8, leak-gates-debug, aot-smoke, aot-integration-publish, release-matrix, release-matrix-aot, code-quality]
     if: github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,66 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # The produce-path leak gates carry ProducerDebugCounters balance assertions
+  # (rent/return parity, zero duplicate pool returns, completion-source
+  # conservation) that are [Conditional("DEBUG")] — compiled out of the Release
+  # binaries every other job runs. This leg builds the unit test project in
+  # Debug so those invariants actually execute. Free runner; builds only the
+  # test project (ProjectReference pulls Dekaf in Debug).
+  leak-gates-debug:
+    name: Leak Gates (Debug counters)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props', '**/Directory.Build.targets') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Build unit tests (Debug)
+        run: dotnet build tests/Dekaf.Tests.Unit --configuration Debug
+
+      - name: Run leak gates with debug counters
+        run: >-
+          ./tests/Dekaf.Tests.Unit/bin/Debug/net10.0/Dekaf.Tests.Unit
+          --hangdump --hangdump-timeout 10m
+          --treenode-filter
+          "/*/*/(ProducerMemoryLeakGateTests|ProducerLeakUnderLoadTests|ProducerLeakEdgeCaseTests|ProducerBatchLifecycleHammerTests|BrokerSenderLeakGateTests)/*"
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-results-leak-gates-debug
+          path: |
+            **/TestResults/**
+            **/test-results/**
+          retention-days: 7
+
+      - name: Upload HangDump artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: hangdump-artifacts-leak-gates-debug
+          path: |
+            **/*.dmp
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Integration categories run via the shared group definitions in
   # integration-groups.yml against the prebuilt binaries (no rebuild).
   # PRs run net10.0 only; pushes to main add net8.0. NuGet publish dispatches
@@ -562,7 +622,7 @@ jobs:
   # release-only jobs skip on PR/push runs).
   ci-passed:
     name: CI Passed
-    needs: [changes, build, unit-net8, integration, aot-smoke, aot-integration-publish, aot-integration-smoke, release-matrix, release-matrix-aot, publish, code-quality]
+    needs: [changes, build, unit-net8, leak-gates-debug, integration, aot-smoke, aot-integration-publish, aot-integration-smoke, release-matrix, release-matrix-aot, publish, code-quality]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderLeakGateTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderLeakGateTests.cs
@@ -1,0 +1,328 @@
+using System.Buffers;
+using Dekaf.Errors;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+using NSubstitute;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Leak gates for <see cref="BrokerSender"/>'s cleanup paths — the layer below the
+/// accumulator-level gates (<c>ProducerMemoryLeakGateTests</c> and friends), and the layer
+/// where the #2187 double-return and #1578 send-loop-death leaks lived. Batches flow through
+/// the real send loop against scripted produce responses
+/// (<see cref="ScriptedProduceResponseFixture"/>), with real BufferMemory reservations
+/// (<c>markMemoryReleased: false</c>) so the sender's own refund path is what returns them.
+/// </summary>
+/// <remarks>
+/// Exactly-once refunds are asserted with a canary reservation: the accumulator holds a
+/// canary of reserved bytes for the whole test, and after every delivery the buffered total
+/// must land exactly back on the canary. A missed refund leaves it above; a double refund
+/// pulls it below — visible even if the accounting clamps at zero. The accumulator's
+/// pipeline counters (<c>InFlightBatchCount</c>) are deliberately not asserted here:
+/// manually built batches never enter the accumulator pipeline, so the sender's
+/// <c>OnBatchExitsPipeline</c> legitimately drives that counter negative in this harness.
+/// </remarks>
+public sealed class BrokerSenderLeakGateTests : ScriptedProduceResponseFixture
+{
+    private const string Topic = "leak-sender";
+    private const int BatchDataSize = 100;
+    private const int CanaryBytes = 1_000;
+
+    /// <summary>
+    /// Repeated send → ack cycles through the real send loop, each batch carrying a live
+    /// BufferMemory reservation that only the sender can refund. By design the sender
+    /// releases at TCP-send time (post-write, pre-response), with the error-path cleanup
+    /// releasing for batches that never reached the wire and an idempotency guard making
+    /// the overlap safe — the gate asserts the composed result: exactly one refund per
+    /// batch, from whichever site fires. Any cycle that misses (or doubles) the refund
+    /// moves <c>BufferedBytes</c> off the canary and fails immediately.
+    /// </summary>
+    [Test]
+    [Timeout(60_000)]
+    public async Task RepeatedSendAckCycles_SenderRefundsExactlyOnce(
+        CancellationToken cancellationToken)
+    {
+        const int Cycles = 50;
+
+        var responses = new Queue<TaskCompletionSource<ProduceResponse>>();
+        for (var i = 0; i < Cycles; i++)
+        {
+            var response = new TaskCompletionSource<ProduceResponse>();
+            response.SetResult(CreateSuccessResponse(Topic, partition: 0, baseOffset: i));
+            responses.Enqueue(response);
+        }
+
+        var (pool, _) = CreateScriptedConnection(responses);
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            await accumulator.ReserveMemoryAsync(CanaryBytes, cancellationToken);
+
+            for (var cycle = 0; cycle < Cycles; cycle++)
+            {
+                await accumulator.ReserveMemoryAsync(BatchDataSize, cancellationToken);
+                var (batch, delivery) = CreateReservedBatchWithDelivery(valueTaskSourcePool);
+
+                sender.Enqueue(batch);
+                var metadata = await delivery.WaitAsync(cancellationToken);
+
+                await Assert.That(metadata.Offset).IsEqualTo(cycle);
+                await Assert.That(accumulator.BufferedBytes).IsEqualTo((long)CanaryBytes);
+            }
+
+            accumulator.ReleaseMemory(CanaryBytes);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo(0L);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// A faulted response task (connection failure mid-request) forces the sender through
+    /// its retry path; the retry succeeds. The reservation must be refunded exactly once
+    /// across the failure + retry — the #2187 double-return family raced exactly this
+    /// hand-off between the failure cleanup and the retry's success cleanup.
+    /// </summary>
+    [Test]
+    [Timeout(60_000)]
+    public async Task ConnectionFailureThenRetrySuccess_RefundsExactlyOnce(
+        CancellationToken cancellationToken)
+    {
+        var faulted = new TaskCompletionSource<ProduceResponse>();
+        faulted.SetException(new IOException("simulated connection failure"));
+        var success = new TaskCompletionSource<ProduceResponse>();
+        success.SetResult(CreateSuccessResponse(Topic, partition: 0, baseOffset: 42));
+
+        var (pool, _) = CreateScriptedConnection(
+            new Queue<TaskCompletionSource<ProduceResponse>>([faulted, success]));
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            await accumulator.ReserveMemoryAsync(CanaryBytes, cancellationToken);
+            await accumulator.ReserveMemoryAsync(BatchDataSize, cancellationToken);
+            var (batch, delivery) = CreateReservedBatchWithDelivery(valueTaskSourcePool);
+
+            sender.Enqueue(batch);
+            var metadata = await delivery.WaitAsync(cancellationToken);
+
+            await Assert.That(metadata.Offset).IsEqualTo(42);
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo((long)CanaryBytes);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// A terminal (non-retriable) broker error must fail the batch's completion source and
+    /// refund the reservation exactly once through the sender's failure cleanup path.
+    /// </summary>
+    [Test]
+    [Timeout(60_000)]
+    public async Task TerminalBrokerError_FailsDelivery_RefundsExactlyOnce(
+        CancellationToken cancellationToken)
+    {
+        var errorResponse = new TaskCompletionSource<ProduceResponse>();
+        errorResponse.SetResult(CreateErrorResponse(Topic, partition: 0, ErrorCode.MessageTooLarge));
+
+        var (pool, _) = CreateScriptedConnection(
+            new Queue<TaskCompletionSource<ProduceResponse>>([errorResponse]));
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            await accumulator.ReserveMemoryAsync(CanaryBytes, cancellationToken);
+            await accumulator.ReserveMemoryAsync(BatchDataSize, cancellationToken);
+            var (batch, delivery) = CreateReservedBatchWithDelivery(valueTaskSourcePool);
+
+            sender.Enqueue(batch);
+
+            Exception? observed = null;
+            try
+            {
+                _ = await delivery.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                observed = exception;
+            }
+
+            await Assert.That(observed).IsNotNull();
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo((long)CanaryBytes);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Disposing the sender while a request is in flight (response parked, never completed)
+    /// must terminate the batch's completion source and refund the reservation — a stranded
+    /// source or a lost refund here is exactly the shutdown-path leak class.
+    /// </summary>
+    [Test]
+    [Timeout(60_000)]
+    public async Task DisposeWithParkedInFlightRequest_TerminatesDelivery_RefundsExactlyOnce(
+        CancellationToken cancellationToken)
+    {
+        var parked = new TaskCompletionSource<ProduceResponse>();
+        var sent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var (pool, _) = CreateScriptedConnection(
+            new Queue<TaskCompletionSource<ProduceResponse>>([parked]),
+            onSend: () => sent.TrySetResult());
+        cancellationToken = GuardUnscriptedSends(cancellationToken);
+
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            await accumulator.ReserveMemoryAsync(CanaryBytes, cancellationToken);
+            await accumulator.ReserveMemoryAsync(BatchDataSize, cancellationToken);
+            var (batch, delivery) = CreateReservedBatchWithDelivery(valueTaskSourcePool);
+
+            sender.Enqueue(batch);
+            await sent.Task.WaitAsync(cancellationToken);
+
+            await sender.DisposeAsync();
+
+            // The source must reach a terminal state — success or failure — never strand.
+            try
+            {
+                _ = await delivery.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                // Terminal failure from shutdown is the expected outcome.
+            }
+
+            await Assert.That(accumulator.BufferedBytes).IsEqualTo((long)CanaryBytes);
+        }
+        finally
+        {
+            parked.TrySetResult(CreateSuccessResponse(Topic, partition: 0, baseOffset: 0));
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    private static ProducerOptions CreateOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        MaxInFlightRequestsPerConnection = 1,
+        ConnectionsPerBroker = 1,
+        EnableIdempotence = true,
+        Acks = Acks.All,
+        DeliveryTimeoutMs = 30_000,
+        RetryBackoffMs = 0,
+        RetryBackoffMaxMs = 0,
+        RequestTimeoutMs = 30_000,
+        LingerMs = 0,
+    };
+
+    /// <summary>
+    /// One-record batch carrying a live reservation (<c>markMemoryReleased: false</c>) whose
+    /// single completion source is exposed as the delivery task. The caller must have
+    /// reserved <see cref="BatchDataSize"/> bytes on the accumulator first.
+    /// </summary>
+    private static (ReadyBatch Batch, Task<RecordMetadata> Delivery) CreateReservedBatchWithDelivery(
+        ValueTaskSourcePool<RecordMetadata> pool)
+    {
+        var source = pool.Rent();
+        var delivery = source.Task.AsTask();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
+        sources[0] = source;
+
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(Topic, 0),
+            new Dekaf.Protocol.Records.RecordBatch { Records = Array.Empty<Dekaf.Protocol.Records.Record>() },
+            sources,
+            completionSourcesCount: 1,
+            recordCount: 1,
+            dataSize: BatchDataSize);
+        batch.MarkPreSerialized();
+        return (batch, delivery);
+    }
+
+    private (IConnectionPool Pool, TestKafkaConnection Connection) CreateScriptedConnection(
+        Queue<TaskCompletionSource<ProduceResponse>> responses,
+        Action? onSend = null)
+    {
+        var connection = new TestKafkaConnection();
+        var scripted = RegisterScript(responses, onSend);
+        connection.SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(scripted.Dequeue());
+
+        var pool = Substitute.For<IConnectionPool>();
+        pool.GetConnectionAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        pool.GetConnectionByIndexAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(connection);
+        return (pool, connection);
+    }
+
+    private static ProduceResponse CreateErrorResponse(string topic, int partition, ErrorCode errorCode) =>
+        new()
+        {
+            TopicCount = 1,
+            Responses =
+            [
+                new ProduceResponseTopicData
+                {
+                    Name = topic,
+                    PartitionCount = 1,
+                    PartitionResponses =
+                    [
+                        new ProduceResponsePartitionData
+                        {
+                            Index = partition,
+                            ErrorCode = errorCode,
+                            BaseOffset = -1
+                        }
+                    ]
+                }
+            ]
+        };
+}


### PR DESCRIPTION
## Summary

The two follow-ups from #2372.

### 1. `BrokerSenderLeakGateTests` — leak gates one layer down

The accumulator-level gates in #2372 stop at the accumulator boundary; this adds the sender layer, where the #2187 double-return and #1578 send-loop-death leaks actually lived. Batches flow through the **real send loop** against scripted produce responses (`ScriptedProduceResponseFixture`, with its unscripted-send guard), carrying **live BufferMemory reservations** (`markMemoryReleased: false`) so the sender's own refund machinery is what must return them.

**Canary invariant:** the accumulator holds a standing canary reservation for the whole test; after every delivery `BufferedBytes` must land exactly back on the canary. A missed refund leaves it above, a double refund pulls it below — visible even though the accounting clamps at zero. (`InFlightBatchCount` is deliberately not asserted: manually built batches never enter the accumulator pipeline, so the sender legitimately drives that counter negative in this harness.)

Scenarios:
- 50 repeated send → ack cycles (refund exactly once per cycle)
- connection failure (faulted response task) → retry → success (exactly one refund across the failure/retry hand-off — the #2187 race shape)
- terminal broker error (`MessageTooLarge`) → delivery fails, refund exactly once
- dispose with a parked in-flight request → completion source reaches a terminal state (never strands), refund exactly once

**Sensitivity, mutation-verified against `src/`:** disabling only the error-path release (`CleanupBatchResources`) correctly does *not* trip the gates — the sender releases at TCP-send time by design (post-write, pre-response), with the error-path release covering batches that never reached the wire and an idempotency guard making the overlap safe. Disabling **both** release sites trips all four tests in <200ms. `src/` is untouched in this PR.

### 2. `leak-gates-debug` CI job

Free `ubuntu-latest` leg that builds the unit test project in **Debug** and runs the leak-gate classes plus `ProducerBatchLifecycleHammerTests`. This activates the `[Conditional("DEBUG")]` `ProducerDebugCounters` balance asserts (rent/return parity, zero duplicate pool returns, completion-source conservation) that compile out of every Release leg — closing the gap flagged in #2372 where the pool-imbalance leak class was Release-invisible in CI. Wired into the `ci-passed` required check; treated as skipped on docs-only PRs like every other job.

## Validation

- 13 consecutive full-filter runs locally (10 Release + 3 Debug, 14 tests each): zero failures.
- The exact CI filter passes in Debug locally in ~3s (hammer test included — its Debug-only asserts verified locally before wiring into CI).
- Mutation evidence above; all mutations reverted, `git diff src/` empty.

No paid runners added — the new job is standard `ubuntu-latest`.