### PR TITLE
fix: align tracing and metrics with current OTel messaging semconv

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -41,12 +41,12 @@ metrics.AddMeter(DekafDiagnostics.MeterName);           // "Dekaf"
 
 ## Tracing
 
-Dekaf emits spans following the [OpenTelemetry messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/kafka/):
+Dekaf emits spans following the [OpenTelemetry messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/kafka/). Span names use the spec's `{operation name} {destination}` format:
 
 | Span | Kind | When |
 |------|------|------|
-| `{topic} publish` | `Producer` | Each `ProduceAsync` / `Send` |
-| `{topic} receive` | `Consumer` | Each consumed message |
+| `send {topic}` | `Producer` | Each `ProduceAsync` / `Send` |
+| `poll {topic}` | `Consumer` | Each consumed message |
 
 ### Trace Context Propagation
 
@@ -56,47 +56,48 @@ Producer spans inject W3C `traceparent` (and `tracestate`) headers into the outg
 
 Both spans set `messaging.system = kafka` plus:
 
-| Attribute | Publish | Receive |
-|-----------|---------|---------|
+| Attribute | Send | Poll |
+|-----------|------|------|
 | `messaging.destination.name` (topic) | ✓ | ✓ |
-| `messaging.operation.type` | `publish` | `receive` |
+| `messaging.operation.name` | `send` | `poll` |
+| `messaging.operation.type` | `send` | `receive` |
 | `messaging.client.id` | ✓ | ✓ |
 | `messaging.kafka.message.key` | ✓ (string-convertible keys) | |
-| `messaging.destination.partition.id` | | ✓ |
-| `messaging.kafka.message.offset` | | ✓ |
-| `messaging.message.body.size` | | ✓ |
+| `messaging.destination.partition.id` | ✓ (on delivery) | ✓ |
+| `messaging.kafka.offset` | ✓ (on delivery) | ✓ |
+| `messaging.message.body.size` | ✓ (on delivery) | ✓ |
+| `messaging.kafka.message.tombstone` | ✓ (null-value messages) | ✓ (tombstone records) |
 | `messaging.consumer.group.name` | | ✓ |
 
-Failures set the span status to `Error` and record an `exception` event with `exception.type`, `exception.message`, and `exception.stacktrace`.
+`messaging.message.body.size` is the value payload only — the key is not part of the message body; tombstones report `0`.
+
+Failures set the span status to `Error`, set `error.type` to the exception's fully-qualified type name, and record an `exception` event with `exception.type`, `exception.message`, and `exception.stacktrace`. Successful spans leave the status unset, per the OTel span-status guidance.
 
 ## Metrics
 
 ### Standard Messaging Metrics
 
-These follow the OTel messaging semantic conventions:
+These are the spec-defined instruments from the [OTel messaging metrics conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/):
 
 | Instrument | Type | Unit | Description |
 |------------|------|------|-------------|
 | `messaging.client.sent.messages` | Counter | `{message}` | Messages published |
-| `messaging.client.sent.bytes` | Counter | `By` | Bytes published |
-| `messaging.client.sent.errors` | Counter | `{error}` | Produce errors |
-| `messaging.client.sent.retries` | Counter | `{retry}` | Produce retries |
-| `messaging.client.operation.duration` | Histogram | `s` | Produce/consume operation duration |
+| `messaging.client.operation.duration` | Histogram | `s` | Produce operation duration (successes and failures) |
 | `messaging.client.consumed.messages` | Counter | `{message}` | Messages received |
-| `messaging.client.consumed.bytes` | Counter | `By` | Bytes received |
-| `messaging.consumer.lag` | ObservableGauge | `{message}` | High watermark minus consumed position, per partition |
-| `messaging.consumer.rebalance.duration` | Histogram | `s` | Consumer group rebalance duration |
-| `messaging.consumer.fetch.duration` | Histogram | `s` | Fetch request round-trip time |
-| `messaging.consumer.batch.parse.errors` | Counter | `{error}` | Record batches that failed protocol parsing |
+
+All three carry the spec-required `messaging.system = kafka` and `messaging.operation.name` (`send`/`poll`) tags plus `messaging.destination.name`. Failed produce operations record `messaging.client.operation.duration` with an additional `error.type` tag, per the spec's error model.
 
 ### Dekaf Internal Metrics
 
-Dekaf-specific instruments under the `dekaf.*` prefix expose internal controller state — useful for diagnosing backpressure, buffer exhaustion, and adaptive-connection behavior:
+Dekaf-specific instruments live under the `dekaf.*` prefix — the `messaging.*` namespace is reserved for spec-defined instruments. These cover throughput detail beyond the spec metrics plus internal controller state, useful for diagnosing backpressure, buffer exhaustion, and adaptive-connection behavior. Per-broker instruments carry a `dekaf.broker.id` tag.
 
 **Producer:**
 
 | Instrument | Description |
 |------------|-------------|
+| `dekaf.producer.sent.bytes` | Bytes published (key + value) |
+| `dekaf.producer.send.errors` | Produce errors (includes fire-and-forget delivery failures) |
+| `dekaf.producer.send.retries` | Produce retries |
 | `dekaf.producer.buffer.used_bytes` / `limit_bytes` | `BufferMemory` reservation vs configured limit |
 | `dekaf.producer.buffer.pressure_events` | Times `ProduceAsync` entered the buffer-full slow path |
 | `dekaf.producer.broker.budget_bytes` / `unacked_bytes` | Per-broker unacked-byte admission budget and standing charge |
@@ -113,6 +114,11 @@ Dekaf-specific instruments under the `dekaf.*` prefix expose internal controller
 
 | Instrument | Description |
 |------------|-------------|
+| `dekaf.consumer.consumed.bytes` | Bytes received (key + value) |
+| `dekaf.consumer.lag` | High watermark minus consumed position, per partition (ObservableGauge) |
+| `dekaf.consumer.rebalance.duration` | Consumer group rebalance duration (Histogram, `s`) |
+| `dekaf.consumer.fetch.duration` | Fetch request round-trip time per broker (Histogram, `s`) |
+| `dekaf.consumer.batch.parse.errors` | Record batches that failed protocol parsing |
 | `dekaf.consumer.fetch_buffer.used_bytes` / `free_bytes` | Fetch response memory reserved vs available |
 | `dekaf.consumer.fetch_buffer.depleted_percent` / `depleted_duration` | Time spent waiting for fetch response memory |
 

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -291,7 +291,7 @@ internal sealed class PendingFetchData : IDisposable
     [MethodImpl(MethodImplOptions.NoInlining)]
     private string CreateActivityName()
     {
-        var activityName = string.Concat(Topic, " receive");
+        var activityName = Diagnostics.DekafDiagnostics.PollSpanName(Topic);
         _activityName = activityName;
         return activityName;
     }
@@ -2118,7 +2118,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     record.HeaderCount,
                                     pending,
                                     pending.HeaderGeneration);
-                                activity = StartConsumeActivity(pending, headers, offset, messageBytes);
+                                activity = StartConsumeActivity(pending, headers, offset,
+                                    record.Value.Length, record.IsValueNull);
                                 if (activity is not null)
                                     previousActivity = activity;
                             }
@@ -3257,7 +3258,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     if (string.IsNullOrEmpty(topic))
                         continue;
 
-                    var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
+                    var activityName = _activityNameCache.GetOrAdd(topic, static t => Diagnostics.DekafDiagnostics.PollSpanName(t));
 
                     foreach (var partitionResponse in topicResponse.Partitions)
                     {
@@ -4335,7 +4336,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 pooledHeaderCount,
                                 pending,
                                 pending.HeaderGeneration);
-                            activity = StartConsumeActivity(pending, headers, offset, messageBytes);
+                            activity = StartConsumeActivity(pending, headers, offset,
+                                valueData.Length, isValueNull);
                         }
 
                         // User deserialization begins in this constructor. Its exceptions
@@ -4489,7 +4491,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 pooledHeaderCount,
                                 pending,
                                 pending.HeaderGeneration);
-                            activity = StartConsumeActivity(pending, headers, offset, messageBytes);
+                            activity = StartConsumeActivity(pending, headers, offset,
+                                valueData.Length, isValueNull);
                         }
 
                         // User deserialization begins in this await. Its exceptions must
@@ -4991,8 +4994,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
         if (!_metricTagsCache.TryGetValue(fetch.Topic, out var metricTags))
         {
-            metricTags = new System.Diagnostics.TagList
-                { { Diagnostics.DekafDiagnostics.MessagingDestinationName, fetch.Topic } };
+            metricTags = Diagnostics.DekafDiagnostics.ClientMetricTags(
+                Diagnostics.DekafDiagnostics.OperationNamePoll, fetch.Topic);
             _metricTagsCache[fetch.Topic] = metricTags;
         }
         Diagnostics.DekafMetrics.MessagesReceived.Add(messageCount, metricTags);
@@ -5012,7 +5015,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private TagList GetFetchDurationMetricTags(int brokerId) =>
         _fetchDurationMetricTagsCache.GetOrAdd(
             brokerId,
-            static id => new TagList { { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, id } });
+            static id => new TagList { { Diagnostics.DekafDiagnostics.DekafBrokerId, id } });
 
     public void Seek(TopicPartitionOffset offset)
     {
@@ -7357,7 +7360,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 if (string.IsNullOrEmpty(topic))
                     continue;
 
-                var activityName = _activityNameCache.GetOrAdd(topic, static t => $"{t} receive");
+                var activityName = _activityNameCache.GetOrAdd(topic, static t => Diagnostics.DekafDiagnostics.PollSpanName(t));
 
                 foreach (var partitionResponse in topicResponse.Partitions)
                 {
@@ -7538,7 +7541,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         PendingFetchData pending,
         IReadOnlyList<Header>? headers,
         long offset,
-        int messageBytes)
+        int valueLength,
+        bool isTombstone)
     {
         // Use span links (not parent-child) per OTel messaging semantic conventions:
         // the consumer span gets its own trace root, linked to the producer span.
@@ -7573,10 +7577,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         {
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingSystem, Diagnostics.DekafDiagnostics.MessagingSystemValue);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationName, pending.Topic);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationType, "receive");
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationName, Diagnostics.DekafDiagnostics.OperationNamePoll);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationType, Diagnostics.DekafDiagnostics.OperationTypeReceive);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationPartitionId, pending.PartitionIndex);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageOffset, offset);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, messageBytes);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaOffset, offset);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, isTombstone ? 0 : valueLength);
+            if (isTombstone)
+                activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaTombstone, Diagnostics.DekafDiagnostics.BoxedTrue);
             if (_options.ClientId is not null)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingClientId, _options.ClientId);
             if (_options.GroupId is not null)

--- a/src/Dekaf/Diagnostics/DekafDiagnostics.cs
+++ b/src/Dekaf/Diagnostics/DekafDiagnostics.cs
@@ -27,21 +27,60 @@ public static class DekafDiagnostics
     // OTel semantic convention attribute names — messaging
     internal const string MessagingSystem = "messaging.system";
     internal const string MessagingDestinationName = "messaging.destination.name";
+    internal const string MessagingOperationName = "messaging.operation.name";
     internal const string MessagingOperationType = "messaging.operation.type";
-    internal const string MessagingMessageOffset = "messaging.kafka.message.offset";
+    internal const string MessagingKafkaOffset = "messaging.kafka.offset";
     internal const string MessagingDestinationPartitionId = "messaging.destination.partition.id";
     internal const string MessagingConsumerGroupName = "messaging.consumer.group.name";
     internal const string MessagingMessageKey = "messaging.kafka.message.key";
+    internal const string MessagingKafkaTombstone = "messaging.kafka.message.tombstone";
     internal const string MessagingClientId = "messaging.client.id";
+
+    /// <summary>Payload (value) size only — the key is not part of the message body.</summary>
     internal const string MessagingMessageBodySize = "messaging.message.body.size";
-    internal const string MessagingKafkaBrokerId = "messaging.kafka.broker.id";
+    internal const string ErrorType = "error.type";
+
+    // Dekaf-specific attribute — Kafka's numeric broker id has no OTel equivalent
+    // (the registry models brokers as server.address/server.port), so it lives in
+    // the dekaf.* namespace and is only attached to dekaf.* metrics.
+    internal const string DekafBrokerId = "dekaf.broker.id";
 
     internal const string MessagingSystemValue = "kafka";
+
+    // messaging.operation.type well-known values / messaging.operation.name values
+    internal const string OperationTypeSend = "send";
+    internal const string OperationTypeReceive = "receive";
+    internal const string OperationNameSend = "send";
+    internal const string OperationNamePoll = "poll";
 
     // OTel semantic convention attribute names — exceptions
     internal const string ExceptionType = "exception.type";
     internal const string ExceptionMessage = "exception.message";
     internal const string ExceptionStacktrace = "exception.stacktrace";
+
+    /// <summary>Cached box for boolean tags — SetTag(string, object) would box a fresh bool per call.</summary>
+    internal static readonly object BoxedTrue = true;
+
+    /// <summary>
+    /// Span name per messaging semconv: "{operation name} {destination}". Derived from the
+    /// same constants as the messaging.operation.name tag so the two cannot desynchronize.
+    /// Callers cache the result per topic.
+    /// </summary>
+    internal static string SendSpanName(string topic) => string.Concat(OperationNameSend, " ", topic);
+
+    /// <inheritdoc cref="SendSpanName"/>
+    internal static string PollSpanName(string topic) => string.Concat(OperationNamePoll, " ", topic);
+
+    /// <summary>
+    /// Tag set for messaging.client.* instruments: the spec-required messaging.system and
+    /// messaging.operation.name plus the destination. Callers cache the result per topic.
+    /// </summary>
+    internal static System.Diagnostics.TagList ClientMetricTags(string operationName, string topic) => new()
+    {
+        { MessagingSystem, MessagingSystemValue },
+        { MessagingOperationName, operationName },
+        { MessagingDestinationName, topic }
+    };
 
     /// <summary>
     /// Records an exception on an activity following OTel exception semantic conventions.
@@ -49,11 +88,13 @@ public static class DekafDiagnostics
     /// </summary>
     internal static void RecordException(Activity activity, Exception ex)
     {
+        var exceptionType = ex.GetType().FullName;
         activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity.SetTag(ErrorType, exceptionType);
         activity.AddEvent(new ActivityEvent("exception",
             tags: new ActivityTagsCollection
             {
-                { ExceptionType, ex.GetType().FullName },
+                { ExceptionType, exceptionType },
                 { ExceptionMessage, ex.Message },
                 { ExceptionStacktrace, ex.ToString() }
             }));

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -10,7 +10,8 @@ namespace Dekaf.Diagnostics;
 /// </summary>
 internal static class DekafMetrics
 {
-    // OTel semantic convention metrics
+    // OTel semantic convention metrics (messaging.* namespace is reserved for the
+    // spec-defined instruments; everything Dekaf-specific lives under dekaf.*)
     internal static readonly Counter<long> MessagesSent =
         DekafDiagnostics.Meter.CreateCounter<long>(
             "messaging.client.sent.messages",
@@ -19,7 +20,7 @@ internal static class DekafMetrics
 
     internal static readonly Counter<long> BytesSent =
         DekafDiagnostics.Meter.CreateCounter<long>(
-            "messaging.client.sent.bytes",
+            "dekaf.producer.sent.bytes",
             unit: "By",
             description: "Total bytes published to Kafka.");
 
@@ -31,13 +32,13 @@ internal static class DekafMetrics
 
     internal static readonly Counter<long> ProduceErrors =
         DekafDiagnostics.Meter.CreateCounter<long>(
-            "messaging.client.sent.errors",
+            "dekaf.producer.send.errors",
             unit: "{error}",
             description: "Number of produce errors.");
 
     internal static readonly Counter<long> Retries =
         DekafDiagnostics.Meter.CreateCounter<long>(
-            "messaging.client.sent.retries",
+            "dekaf.producer.send.retries",
             unit: "{retry}",
             description: "Number of produce retries.");
 
@@ -80,25 +81,25 @@ internal static class DekafMetrics
 
     internal static readonly Counter<long> BytesReceived =
         DekafDiagnostics.Meter.CreateCounter<long>(
-            "messaging.client.consumed.bytes",
+            "dekaf.consumer.consumed.bytes",
             unit: "By",
             description: "Total bytes received from Kafka.");
 
     internal static readonly Histogram<double> RebalanceDuration =
         DekafDiagnostics.Meter.CreateHistogram<double>(
-            "messaging.consumer.rebalance.duration",
+            "dekaf.consumer.rebalance.duration",
             unit: "s",
             description: "Duration of consumer group rebalances.");
 
     internal static readonly Histogram<double> FetchDuration =
         DekafDiagnostics.Meter.CreateHistogram<double>(
-            "messaging.consumer.fetch.duration",
+            "dekaf.consumer.fetch.duration",
             unit: "s",
             description: "Round-trip time of fetch requests to Kafka brokers.");
 
     internal static readonly Counter<long> BatchParseErrors =
         DekafDiagnostics.Meter.CreateCounter<long>(
-            "messaging.consumer.batch.parse.errors",
+            "dekaf.consumer.batch.parse.errors",
             unit: "{error}",
             description: "Number of record batches that failed protocol parsing.");
 
@@ -111,7 +112,7 @@ internal static class DekafMetrics
 
     internal static readonly ObservableGauge<long> ConsumerLagGauge =
         DekafDiagnostics.Meter.CreateObservableGauge(
-            "messaging.consumer.lag",
+            "dekaf.consumer.lag",
             observeValues: ObserveAllConsumerLag,
             unit: "{message}",
             description: "Difference between high watermark and consumed position per partition.");

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -5339,7 +5339,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     private TagList BrokerIdTags() => new()
     {
-        { Diagnostics.DekafDiagnostics.MessagingKafkaBrokerId, _brokerId }
+        { Diagnostics.DekafDiagnostics.DekafBrokerId, _brokerId }
     };
 
     public async ValueTask DisposeAsync()

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -955,9 +955,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
             return metadata;
         }
-        catch
+        catch (Exception ex)
         {
-            Diagnostics.DekafMetrics.ProduceErrors.Add(1, GetMetricTags(topic));
+            EmitProduceErrorMetrics(topic, startTimestamp, ex);
             throw;
         }
     }
@@ -979,11 +979,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             var metadata = await completion.Task.ConfigureAwait(false);
 
-            // Success: record metrics and set activity tags
+            // Success: record metrics and set activity tags. Span status stays unset —
+            // OTel says instrumentation should not set Ok on successful spans.
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationPartitionId, metadata.Partition);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageOffset, metadata.Offset);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, metadata.KeySize + metadata.ValueSize);
-            activity.SetStatus(ActivityStatusCode.Ok);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaOffset, metadata.Offset);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, metadata.ValueSize);
 
             EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
 
@@ -992,7 +992,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         catch (Exception ex)
         {
             Diagnostics.DekafDiagnostics.RecordException(activity, ex);
-            Diagnostics.DekafMetrics.ProduceErrors.Add(1, GetMetricTags(topic));
+            EmitProduceErrorMetrics(topic, startTimestamp, ex);
 
             throw;
         }
@@ -1018,11 +1018,22 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
     }
 
+    /// <summary>
+    /// Error path only. Failed operations record duration with error.type per the
+    /// messaging semconv; the TagList is a stack struct, so no heap allocation.
+    /// </summary>
+    private void EmitProduceErrorMetrics(string topic, long startTimestamp, Exception ex)
+    {
+        var tagList = GetMetricTags(topic);
+        tagList.Add(Diagnostics.DekafDiagnostics.ErrorType, ex.GetType().FullName);
+        Diagnostics.DekafMetrics.ProduceErrors.Add(1, tagList);
+        Diagnostics.DekafMetrics.OperationDuration.Record(
+            Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
+    }
+
     private TagList GetMetricTags(string topic)
-        => _metricTagsCache.GetOrAdd(topic, static t => new TagList
-        {
-            { Diagnostics.DekafDiagnostics.MessagingDestinationName, t }
-        });
+        => _metricTagsCache.GetOrAdd(topic, static t => Diagnostics.DekafDiagnostics.ClientMetricTags(
+            Diagnostics.DekafDiagnostics.OperationNameSend, t));
 
     /// <summary>
     /// Attempts synchronous produce for awaited ProduceAsync when metadata is cached.
@@ -1557,13 +1568,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         {
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingSystem, Diagnostics.DekafDiagnostics.MessagingSystemValue);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationName, message.Topic);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationType, "publish");
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationName, Diagnostics.DekafDiagnostics.OperationNameSend);
+            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingOperationType, Diagnostics.DekafDiagnostics.OperationTypeSend);
             if (_options.ClientId is not null)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingClientId, _options.ClientId);
             if (message.Key is string stringKey)
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageKey, stringKey);
             else if (message.Key is not null and not byte[])
                 activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageKey, message.Key.ToString());
+            if (message.Value is null)
+                activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaTombstone, Diagnostics.DekafDiagnostics.BoxedTrue);
             message = message with { Headers = Diagnostics.TraceContextPropagator.InjectTraceContext(message.Headers, activity) };
         }
 
@@ -1571,7 +1585,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     private string GetPublishActivityName(string topic)
-        => _activityNameCache.GetOrAdd(topic, static t => $"{t} publish");
+        => _activityNameCache.GetOrAdd(topic, static t => Diagnostics.DekafDiagnostics.SendSpanName(t));
 
     /// <summary>
     /// Invokes OnAcknowledgement interceptors for all messages in a batch.

--- a/src/Dekaf/Producer/ProducerStateSource.cs
+++ b/src/Dekaf/Producer/ProducerStateSource.cs
@@ -59,5 +59,5 @@ internal sealed class ProducerStateSource
     }
 
     private static KeyValuePair<string, object?> BrokerTag(int brokerId)
-        => new(DekafDiagnostics.MessagingKafkaBrokerId, brokerId);
+        => new(DekafDiagnostics.DekafBrokerId, brokerId);
 }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -9492,7 +9492,7 @@ internal sealed class ReadyBatch
 
             // Records without a completion source (fire-and-forget and callback appends) have
             // no awaiter that will observe this failure, so count them here — otherwise
-            // messaging.client.sent.errors never reflects fire-and-forget delivery failures.
+            // dekaf.producer.send.errors never reflects fire-and-forget delivery failures.
             // ProduceAsync records are excluded: each awaiter increments the counter itself.
             var unobservedRecords = _recordCount - _completionSourcesCount;
             if (Diagnostics.DekafMetrics.ProduceErrors.Enabled && unobservedRecords > 0)

--- a/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerStateGaugeIntegrationTests.cs
@@ -140,7 +140,7 @@ public sealed class ProducerStateGaugeIntegrationTests(KafkaTestContainer kafka)
         {
             if (tag.Key == DekafDiagnostics.MessagingClientId)
                 clientId = tag.Value as string;
-            else if (tag.Key == DekafDiagnostics.MessagingKafkaBrokerId)
+            else if (tag.Key == DekafDiagnostics.DekafBrokerId)
                 brokerId = tag.Value;
         }
 

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -359,7 +359,7 @@ public sealed class ConsumeOneFastPathTests
         {
             if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
                 (instrument.Name == "messaging.client.consumed.messages" ||
-                 instrument.Name == "messaging.client.consumed.bytes"))
+                 instrument.Name == "dekaf.consumer.consumed.bytes"))
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
@@ -371,7 +371,7 @@ public sealed class ConsumeOneFastPathTests
 
             if (instrument.Name == "messaging.client.consumed.messages")
                 messagesReceived.Add(measurement);
-            else if (instrument.Name == "messaging.client.consumed.bytes")
+            else if (instrument.Name == "dekaf.consumer.consumed.bytes")
                 bytesReceived.Add(measurement);
         });
         listener.Start();

--- a/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/KafkaConsumerFetchMetricsTests.cs
@@ -36,15 +36,15 @@ public sealed class KafkaConsumerFetchMetricsTests
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
             if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                instrument.Name == "messaging.consumer.fetch.duration")
+                instrument.Name == "dekaf.consumer.fetch.duration")
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }
         };
         listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
         {
-            if (instrument.Name == "messaging.consumer.fetch.duration" &&
-                GetTag(tags, DekafDiagnostics.MessagingKafkaBrokerId) is int metricBrokerId &&
+            if (instrument.Name == "dekaf.consumer.fetch.duration" &&
+                GetTag(tags, DekafDiagnostics.DekafBrokerId) is int metricBrokerId &&
                 metricBrokerId == expectedBrokerId)
             {
                 duration = measurement;

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -19,7 +19,7 @@ public class PendingFetchDataTests
     {
         // Arrange
         const string topic = "test-topic";
-        const string activityName = "test-topic receive";
+        const string activityName = "poll test-topic";
 
         using var pending = PendingFetchData.Create(
             topic,
@@ -58,7 +58,7 @@ public class PendingFetchDataTests
             batches: Array.Empty<RecordBatch>());
 
         // Assert - falls back to lazy activity name creation
-        await Assert.That(pending.ActivityName).IsEqualTo("my-topic receive");
+        await Assert.That(pending.ActivityName).IsEqualTo("poll my-topic");
         await Assert.That(ActivityNameField.GetValue(pending)).IsSameReferenceAs(pending.ActivityName);
     }
 
@@ -67,7 +67,7 @@ public class PendingFetchDataTests
     {
         // Arrange - pre-compute the activity name (simulating the cache)
         const string topic = "shared-topic";
-        var activityName = $"{topic} receive";
+        var activityName = $"poll {topic}";
 
         using var pending1 = PendingFetchData.Create(
             topic,

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafDiagnosticsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafDiagnosticsTests.cs
@@ -16,9 +16,9 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("test publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send test", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
-        await Assert.That(activity!.OperationName).IsEqualTo("test publish");
+        await Assert.That(activity!.OperationName).IsEqualTo("send test");
         await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Producer);
     }
 
@@ -32,17 +32,19 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("test-topic publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send test-topic", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
 
         activity!.SetTag(DekafDiagnostics.MessagingSystem, DekafDiagnostics.MessagingSystemValue);
         activity.SetTag(DekafDiagnostics.MessagingDestinationName, "test-topic");
-        activity.SetTag(DekafDiagnostics.MessagingOperationType, "publish");
+        activity.SetTag(DekafDiagnostics.MessagingOperationName, DekafDiagnostics.OperationNameSend);
+        activity.SetTag(DekafDiagnostics.MessagingOperationType, DekafDiagnostics.OperationTypeSend);
 
         var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
         await Assert.That(tags["messaging.system"]).IsEqualTo("kafka");
         await Assert.That(tags["messaging.destination.name"]).IsEqualTo("test-topic");
-        await Assert.That(tags["messaging.operation.type"]).IsEqualTo("publish");
+        await Assert.That(tags["messaging.operation.name"]).IsEqualTo("send");
+        await Assert.That(tags["messaging.operation.type"]).IsEqualTo("send");
     }
 
     [Test]
@@ -76,10 +78,10 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        // OTel semantic convention: "{topic} publish" for producer spans
-        using var activity = DekafDiagnostics.Source.StartActivity("orders publish", ActivityKind.Producer);
+        // OTel semantic convention: "{operation name} {destination}" for producer spans
+        using var activity = DekafDiagnostics.Source.StartActivity("send orders", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
-        await Assert.That(activity!.OperationName).IsEqualTo("orders publish");
+        await Assert.That(activity!.OperationName).IsEqualTo("send orders");
         await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Producer);
     }
 
@@ -93,10 +95,10 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        // OTel semantic convention: "{topic} receive" for consumer spans
-        using var activity = DekafDiagnostics.Source.StartActivity("orders receive", ActivityKind.Consumer);
+        // OTel semantic convention: "{operation name} {destination}" for consumer spans
+        using var activity = DekafDiagnostics.Source.StartActivity("poll orders", ActivityKind.Consumer);
         await Assert.That(activity).IsNotNull();
-        await Assert.That(activity!.OperationName).IsEqualTo("orders receive");
+        await Assert.That(activity!.OperationName).IsEqualTo("poll orders");
         await Assert.That(activity.Kind).IsEqualTo(ActivityKind.Consumer);
     }
 
@@ -110,27 +112,29 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("my-topic publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send my-topic", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
 
         // Simulate what the producer does (using string values for tag retrieval compatibility)
         activity!.SetTag(DekafDiagnostics.MessagingSystem, DekafDiagnostics.MessagingSystemValue);
         activity.SetTag(DekafDiagnostics.MessagingDestinationName, "my-topic");
-        activity.SetTag(DekafDiagnostics.MessagingOperationType, "publish");
+        activity.SetTag(DekafDiagnostics.MessagingOperationName, DekafDiagnostics.OperationNameSend);
+        activity.SetTag(DekafDiagnostics.MessagingOperationType, DekafDiagnostics.OperationTypeSend);
         activity.SetTag(DekafDiagnostics.MessagingClientId, "my-producer");
         activity.SetTag(DekafDiagnostics.MessagingMessageKey, "order-123");
         activity.SetTag(DekafDiagnostics.MessagingDestinationPartitionId, "2");
-        activity.SetTag(DekafDiagnostics.MessagingMessageOffset, "42");
+        activity.SetTag(DekafDiagnostics.MessagingKafkaOffset, "42");
         activity.SetTag(DekafDiagnostics.MessagingMessageBodySize, 1024);
 
         var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
         await Assert.That(tags["messaging.system"]).IsEqualTo("kafka");
         await Assert.That(tags["messaging.destination.name"]).IsEqualTo("my-topic");
-        await Assert.That(tags["messaging.operation.type"]).IsEqualTo("publish");
+        await Assert.That(tags["messaging.operation.name"]).IsEqualTo("send");
+        await Assert.That(tags["messaging.operation.type"]).IsEqualTo("send");
         await Assert.That(tags["messaging.client.id"]).IsEqualTo("my-producer");
         await Assert.That(tags["messaging.kafka.message.key"]).IsEqualTo("order-123");
         await Assert.That(tags["messaging.destination.partition.id"]).IsEqualTo("2");
-        await Assert.That(tags["messaging.kafka.message.offset"]).IsEqualTo("42");
+        await Assert.That(tags["messaging.kafka.offset"]).IsEqualTo("42");
         await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(1024);
     }
 
@@ -144,26 +148,28 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("my-topic receive", ActivityKind.Consumer);
+        using var activity = DekafDiagnostics.Source.StartActivity("poll my-topic", ActivityKind.Consumer);
         await Assert.That(activity).IsNotNull();
 
         // Simulate what the consumer does (using string values for tag retrieval compatibility)
         activity!.SetTag(DekafDiagnostics.MessagingSystem, DekafDiagnostics.MessagingSystemValue);
         activity.SetTag(DekafDiagnostics.MessagingDestinationName, "my-topic");
-        activity.SetTag(DekafDiagnostics.MessagingOperationType, "receive");
+        activity.SetTag(DekafDiagnostics.MessagingOperationName, DekafDiagnostics.OperationNamePoll);
+        activity.SetTag(DekafDiagnostics.MessagingOperationType, DekafDiagnostics.OperationTypeReceive);
         activity.SetTag(DekafDiagnostics.MessagingClientId, "my-consumer");
         activity.SetTag(DekafDiagnostics.MessagingDestinationPartitionId, "0");
-        activity.SetTag(DekafDiagnostics.MessagingMessageOffset, "100");
+        activity.SetTag(DekafDiagnostics.MessagingKafkaOffset, "100");
         activity.SetTag(DekafDiagnostics.MessagingMessageBodySize, 512);
         activity.SetTag(DekafDiagnostics.MessagingConsumerGroupName, "my-group");
 
         var tags = activity.Tags.ToDictionary(t => t.Key, t => t.Value);
         await Assert.That(tags["messaging.system"]).IsEqualTo("kafka");
         await Assert.That(tags["messaging.destination.name"]).IsEqualTo("my-topic");
+        await Assert.That(tags["messaging.operation.name"]).IsEqualTo("poll");
         await Assert.That(tags["messaging.operation.type"]).IsEqualTo("receive");
         await Assert.That(tags["messaging.client.id"]).IsEqualTo("my-consumer");
         await Assert.That(tags["messaging.destination.partition.id"]).IsEqualTo("0");
-        await Assert.That(tags["messaging.kafka.message.offset"]).IsEqualTo("100");
+        await Assert.That(tags["messaging.kafka.offset"]).IsEqualTo("100");
         await Assert.That(activity.GetTagItem("messaging.message.body.size")).IsEqualTo(512);
         await Assert.That(tags["messaging.consumer.group.name"]).IsEqualTo("my-group");
     }
@@ -184,7 +190,7 @@ public sealed class DekafDiagnosticsTests
         ActivitySpanId producerSpanId;
         Dekaf.Serialization.Headers headers;
         {
-            using var producerActivity = DekafDiagnostics.Source.StartActivity("orders publish", ActivityKind.Producer);
+            using var producerActivity = DekafDiagnostics.Source.StartActivity("send orders", ActivityKind.Producer);
             await Assert.That(producerActivity).IsNotNull();
             producerTraceId = producerActivity!.TraceId;
             producerSpanId = producerActivity.SpanId;
@@ -205,7 +211,7 @@ public sealed class DekafDiagnosticsTests
         // Consumer creates span with link (not parent-child) per OTel conventions
         var links = new[] { new ActivityLink(producerContext!.Value) };
         using var consumerActivity = DekafDiagnostics.Source.StartActivity(
-            "orders receive",
+            "poll orders",
             ActivityKind.Consumer,
             parentContext: default(ActivityContext),
             tags: null,
@@ -237,7 +243,7 @@ public sealed class DekafDiagnosticsTests
 
         // Consumer span without extracted producer context (no traceparent header)
         using var consumerActivity = DekafDiagnostics.Source.StartActivity(
-            "orders receive",
+            "poll orders",
             ActivityKind.Consumer,
             parentContext: default(ActivityContext),
             tags: null,
@@ -254,6 +260,14 @@ public sealed class DekafDiagnosticsTests
     }
 
     [Test]
+    public async Task MessagingKafkaOffset_ConstantHasCorrectValue()
+    {
+        // Current semconv name; "messaging.kafka.message.offset" is the deprecated form.
+        string value = DekafDiagnostics.MessagingKafkaOffset;
+        await Assert.That(value).IsEqualTo("messaging.kafka.offset");
+    }
+
+    [Test]
     public async Task ProducerSpan_WithByteArrayKey_DoesNotSetKeyAttribute()
     {
         using var listener = new ActivityListener
@@ -263,7 +277,7 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("my-topic publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send my-topic", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
 
         // Simulate the producer's key-handling logic with a byte[] key.
@@ -290,7 +304,7 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("my-topic publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send my-topic", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
 
         // Simulate the producer's key-handling logic with an int key.
@@ -308,7 +322,7 @@ public sealed class DekafDiagnosticsTests
     }
 
     [Test]
-    public async Task RecordException_SetsStatusAndAddsEvent()
+    public async Task RecordException_SetsStatusErrorTypeAndAddsEvent()
     {
         using var listener = new ActivityListener
         {
@@ -317,7 +331,7 @@ public sealed class DekafDiagnosticsTests
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = DekafDiagnostics.Source.StartActivity("test publish", ActivityKind.Producer);
+        using var activity = DekafDiagnostics.Source.StartActivity("send test", ActivityKind.Producer);
         await Assert.That(activity).IsNotNull();
 
         var exception = new InvalidOperationException("test error");
@@ -325,6 +339,10 @@ public sealed class DekafDiagnosticsTests
 
         await Assert.That(activity!.Status).IsEqualTo(ActivityStatusCode.Error);
         await Assert.That(activity.StatusDescription).IsEqualTo("test error");
+
+        // error.type is conditionally required on failed messaging spans
+        await Assert.That(activity.GetTagItem("error.type"))
+            .IsEqualTo(typeof(InvalidOperationException).FullName);
 
         var events = activity.Events.ToList();
         await Assert.That(events).Count().IsEqualTo(1);

--- a/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
+++ b/tests/Dekaf.Tests.Unit/Diagnostics/DekafMetricInstrumentTests.cs
@@ -36,20 +36,20 @@ public sealed class DekafMetricInstrumentTests
         DekafMetrics.FetchDuration.Record(0);
 
         await Assert.That(instrumentNames).Contains("messaging.client.sent.messages");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.sent.bytes");
         await Assert.That(instrumentNames).Contains("messaging.client.operation.duration");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.errors");
-        await Assert.That(instrumentNames).Contains("messaging.client.sent.retries");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.send.errors");
+        await Assert.That(instrumentNames).Contains("dekaf.producer.send.retries");
         await Assert.That(instrumentNames).Contains("dekaf.producer.batch.splits");
         await Assert.That(instrumentNames).Contains("dekaf.producer.inline_continuation.exceptions");
         await Assert.That(instrumentNames).Contains("dekaf.producer.completion_source.faults");
         await Assert.That(instrumentNames).Contains("dekaf.producer.pending_response.cleanup.deferred");
         await Assert.That(instrumentNames).Contains("dekaf.producer.pending_response.cleanup.recovered");
         await Assert.That(instrumentNames).Contains("messaging.client.consumed.messages");
-        await Assert.That(instrumentNames).Contains("messaging.client.consumed.bytes");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.rebalance.duration");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.fetch.duration");
-        await Assert.That(instrumentNames).Contains("messaging.consumer.lag");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.consumed.bytes");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.rebalance.duration");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch.duration");
+        await Assert.That(instrumentNames).Contains("dekaf.consumer.lag");
         await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.used_bytes");
         await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.free_bytes");
         await Assert.That(instrumentNames).Contains("dekaf.consumer.fetch_buffer.depleted_percent");

--- a/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Tests.Unit.Producer;
 /// Fire-and-forget records have no completion source, so a failed batch used to vanish
 /// without any signal: no exception, no callback, and no metric. These tests pin the fix —
 /// ReadyBatch.Fail must count records without completion sources on
-/// messaging.client.sent.errors so fire-and-forget delivery failures are observable.
+/// dekaf.producer.send.errors so fire-and-forget delivery failures are observable.
 /// </summary>
 public sealed class FireAndForgetDeliveryErrorMetricTests
 {

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
@@ -40,7 +40,7 @@ public sealed class KafkaProducerMetricsTests
                 messagesSent += measurement;
                 messagesTopic = metricTopic;
             }
-            else if (instrument.Name == "messaging.client.sent.bytes")
+            else if (instrument.Name == "dekaf.producer.sent.bytes")
             {
                 bytesSent += measurement;
                 bytesTopic = metricTopic;
@@ -152,6 +152,6 @@ public sealed class KafkaProducerMetricsTests
 
     private static bool IsProducerSuccessMetric(string name) =>
         name is "messaging.client.sent.messages"
-            or "messaging.client.sent.bytes"
+            or "dekaf.producer.sent.bytes"
             or "messaging.client.operation.duration";
 }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
@@ -15,7 +15,7 @@ namespace Dekaf.Tests.Unit.Producer;
 public class ProducerAsyncPreparerTests
 {
     private const string Topic = "prepare-topic";
-    private const string PublishActivityName = Topic + " publish";
+    private const string PublishActivityName = "send " + Topic;
 
     [Test]
     public async Task ActivityListener_IgnoresOtherDekafOperations()
@@ -24,7 +24,7 @@ public class ProducerAsyncPreparerTests
         using (listener)
         {
             using (var unrelated = DekafDiagnostics.Source.StartActivity(
-                       "other-topic publish", ActivityKind.Producer))
+                       "send other-topic", ActivityKind.Producer))
             {
                 await Assert.That(unrelated).IsNotNull();
             }

--- a/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/FetchResponseParseErrorTests.cs
@@ -35,7 +35,7 @@ public sealed class FetchResponseParseErrorTests
             InstrumentPublished = (instrument, meterListener) =>
             {
                 if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                    instrument.Name == "messaging.consumer.batch.parse.errors")
+                    instrument.Name == "dekaf.consumer.batch.parse.errors")
                 {
                     meterListener.EnableMeasurementEvents(instrument);
                 }

--- a/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
+++ b/tools/Dekaf.StressTests/Metrics/DekafDeliveryErrorListener.cs
@@ -5,7 +5,7 @@ namespace Dekaf.StressTests.Metrics;
 
 /// <summary>
 /// Counts Dekaf delivery failures into a <see cref="ThroughputTracker"/> by listening to
-/// the producer's <c>messaging.client.sent.errors</c> metric. Fire-and-forget appends have
+/// the producer's <c>dekaf.producer.send.errors</c> metric. Fire-and-forget appends have
 /// no awaiter or callback, so this metric is the only signal that an accepted message was
 /// never delivered — without it a produce run can lose messages with a zero error count.
 /// Cost: free on the FireAsync hot path (failures are counted once per failed batch), but

--- a/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
+++ b/tools/Dekaf.StressTests/Scenarios/StressTestHelpers.cs
@@ -410,7 +410,7 @@ internal static class StressTestHelpers
             catch (Exception ex)
             {
                 // Detail only: the failure count is already captured via the producer's
-                // messaging.client.sent.errors metric (DekafDeliveryErrorListener), and
+                // dekaf.producer.send.errors metric (DekafDeliveryErrorListener), and
                 // this message was accepted into MessageCount before delivery failed.
                 throughput.RecordDeliveryErrorDetail(ex, "SampleDeliveryLatency", messageIndex);
             }


### PR DESCRIPTION
## Summary

Audit against the [OTel messaging semantic conventions](https://opentelemetry.io/docs/specs/messaging/) (verified against the live Kafka + messaging-metrics pages) found several names that predate the semconv 1.25–1.27 rework, plus missing required attributes. This PR brings spans and metrics up to the current spec and moves Dekaf-specific instruments out of the reserved `messaging.*` namespace.

## Spans

| Change | Before | After |
|---|---|---|
| Span name format | `{topic} publish` / `{topic} receive` | `send {topic}` / `poll {topic}` (spec: `{operation name} {destination}`) |
| `messaging.operation.name` | absent (spec: **Required**) | `send` / `poll` |
| `messaging.operation.type` | `publish` (renamed in semconv 1.25) | `send` (consumer stays `receive`) |
| Offset attribute | `messaging.kafka.message.offset` (deprecated) | `messaging.kafka.offset` |
| `messaging.message.body.size` | key + value bytes | value payload only; tombstones report 0 |
| Tombstones | not marked | `messaging.kafka.message.tombstone = true` |
| Failed spans | exception event only | also sets `error.type` (conditionally required) |
| Successful spans | `Status = Ok` | status left unset per spec |

W3C `traceparent`/`tracestate` propagation and the consumer link-to-producer pattern were already conformant and are unchanged.

## Metrics

Spec-defined instruments keep their names and now carry the required `messaging.system` + `messaging.operation.name` tags (`messaging.client.sent.messages`, `messaging.client.consumed.messages`, `messaging.client.operation.duration`). Failed produces now record `messaging.client.operation.duration` with `error.type`, matching how the spec models errors.

Dekaf-specific instruments squatting on the reserved `messaging.*` namespace move to `dekaf.*`:

| Before | After |
|---|---|
| `messaging.client.sent.bytes` | `dekaf.producer.sent.bytes` |
| `messaging.client.sent.errors` | `dekaf.producer.send.errors` |
| `messaging.client.sent.retries` | `dekaf.producer.send.retries` |
| `messaging.client.consumed.bytes` | `dekaf.consumer.consumed.bytes` |
| `messaging.consumer.rebalance.duration` | `dekaf.consumer.rebalance.duration` |
| `messaging.consumer.fetch.duration` | `dekaf.consumer.fetch.duration` |
| `messaging.consumer.batch.parse.errors` | `dekaf.consumer.batch.parse.errors` |
| `messaging.consumer.lag` | `dekaf.consumer.lag` |
| `messaging.kafka.broker.id` tag (not in registry) | `dekaf.broker.id` |

`DekafDiagnostics` now owns the whole semconv shape — span-name helpers (`SendSpanName`/`PollSpanName`), operation-name constants, and the client-metric tag factory — so producer/consumer sites derive from one definition and cannot drift.

## Performance

No untraced hot-path change: every new expression sits behind the existing `HasListeners()` / `Instrument.Enabled` gates (verified call-site by call-site during review). Cached per-topic `TagList`s grow from 1 to 3 entries — still within TagList's 8-slot inline storage, so no allocation or copy-size change. The tombstone tag uses a cached boxed `true`. Error-path additions (`error.type` tag, duration-on-failure) are cold by definition.

## Breaking

Telemetry identifiers are breaking for dashboards/alerts pinned to the old names (span names, `messaging.kafka.message.offset`, and the eight renamed instruments above). All renames land in this single PR so consumers migrate once.

## Deferred

- `server.address`/`server.port` on spans (conditionally required "if available"): broker identity is not known at producer-span start and plumbing it into completion metadata touches hot structures; left out deliberately.
- Fire-and-forget batch-failure counter (`RecordAccumulator`) still emits destination-only tags — pre-existing shape, out of scope here.

## Testing

- Full unit suite: 6293/6293 pass (net10.0, Release).
- `/simplify` review (4 agents: reuse/simplification/efficiency/altitude) applied: centralized span-name + tag-set helpers, callee-owned tombstone body-size policy, cached bool box.