### PR TITLE
fix: surface unsupported LZ4 frame features as InvalidDataException

### DIFF
--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -56,6 +56,7 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
             throw new InvalidDataException("Invalid LZ4 payload.", exception);
         }
         catch (NotImplementedException exception)
+            when (!trackedDestination.DestinationThrewNotImplementedException)
         {
             // K4os throws NotImplementedException for valid-but-unsupported frame
             // features (e.g. the DictID flag); surface those as corrupt-payload
@@ -93,10 +94,13 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
 
         internal bool DestinationThrewInvalidOperationException { get; private set; }
 
+        internal bool DestinationThrewNotImplementedException { get; private set; }
+
         internal void Initialize(IBufferWriter<byte> destination)
         {
             _destination = destination;
             DestinationThrewInvalidOperationException = false;
+            DestinationThrewNotImplementedException = false;
         }
 
         internal void Release() => _destination = null;
@@ -112,6 +116,11 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
                 DestinationThrewInvalidOperationException = true;
                 throw;
             }
+            catch (NotImplementedException)
+            {
+                DestinationThrewNotImplementedException = true;
+                throw;
+            }
         }
 
         public Memory<byte> GetMemory(int sizeHint = 0)
@@ -125,6 +134,11 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
                 DestinationThrewInvalidOperationException = true;
                 throw;
             }
+            catch (NotImplementedException)
+            {
+                DestinationThrewNotImplementedException = true;
+                throw;
+            }
         }
 
         public Span<byte> GetSpan(int sizeHint = 0)
@@ -136,6 +150,11 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
             catch (InvalidOperationException)
             {
                 DestinationThrewInvalidOperationException = true;
+                throw;
+            }
+            catch (NotImplementedException)
+            {
+                DestinationThrewNotImplementedException = true;
                 throw;
             }
         }

--- a/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
+++ b/src/Dekaf.Compression.Lz4/Lz4CompressionCodec.cs
@@ -55,6 +55,13 @@ public sealed class Lz4CompressionCodec : ICompressionCodec
         {
             throw new InvalidDataException("Invalid LZ4 payload.", exception);
         }
+        catch (NotImplementedException exception)
+        {
+            // K4os throws NotImplementedException for valid-but-unsupported frame
+            // features (e.g. the DictID flag); surface those as corrupt-payload
+            // errors so hostile data cannot escape the codec with an unexpected type.
+            throw new InvalidDataException("LZ4 frame uses an unsupported feature.", exception);
+        }
         finally
         {
             trackedDestination.Release();

--- a/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
@@ -113,6 +113,25 @@ public class Lz4CompressionCodecTests
     }
 
     [Test]
+    public async Task Lz4CompressionCodec_Decompress_DictionaryFrame_ThrowsInvalidDataException()
+    {
+        var codec = new Lz4CompressionCodec();
+        // Crash input from scheduled protocol-fuzz run 30059467365: the frame FLG
+        // requests a predefined dictionary, which K4os rejects with
+        // NotImplementedException rather than a data error.
+        byte[] dictionaryFrame =
+        [
+            0x04, 0x22, 0x4D, 0x18, 0xC1, 0x60, 0x40, 0x82, 0x1C, 0x00, 0x00,
+            0x80, 0x72, 0x65, 0x63, 0x6F, 0x72, 0x64, 0x2D, 0x62, 0x61, 0x2E
+        ];
+
+        await Assert.That(() => codec.Decompress(
+                new ReadOnlySequence<byte>(dictionaryFrame),
+                new ArrayBufferWriter<byte>()))
+            .ThrowsExactly<InvalidDataException>();
+    }
+
+    [Test]
     public async Task Lz4CompressionCodec_Decompress_DestinationFailure_IsPreserved()
     {
         var codec = new Lz4CompressionCodec();

--- a/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/Lz4CompressionCodecTests.cs
@@ -144,6 +144,21 @@ public class Lz4CompressionCodecTests
             .ThrowsExactly<InvalidOperationException>();
     }
 
+    [Test]
+    public async Task Lz4CompressionCodec_Decompress_DestinationNotImplemented_IsPreserved()
+    {
+        var codec = new Lz4CompressionCodec();
+        var compressedBuffer = new ArrayBufferWriter<byte>();
+        codec.Compress(new ReadOnlySequence<byte>("test"u8.ToArray()), compressedBuffer);
+
+        // A NotImplementedException thrown by the caller-provided destination must not be
+        // misreported as an unsupported LZ4 frame feature.
+        await Assert.That(() => codec.Decompress(
+                new ReadOnlySequence<byte>(compressedBuffer.WrittenMemory),
+                new NotImplementedBufferWriter()))
+            .ThrowsExactly<NotImplementedException>();
+    }
+
     #endregion
 
     #region Compression Level Tests
@@ -284,6 +299,15 @@ public class Lz4CompressionCodecTests
         public Memory<byte> GetMemory(int sizeHint = 0) => throw new InvalidOperationException();
 
         public Span<byte> GetSpan(int sizeHint = 0) => throw new InvalidOperationException();
+    }
+
+    private sealed class NotImplementedBufferWriter : IBufferWriter<byte>
+    {
+        public void Advance(int count) => throw new NotImplementedException();
+
+        public Memory<byte> GetMemory(int sizeHint = 0) => throw new NotImplementedException();
+
+        public Span<byte> GetSpan(int sizeHint = 0) => throw new NotImplementedException();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Scheduled Protocol Fuzzing run [30059467365](https://github.com/thomhurst/Dekaf/actions/runs/30059467365) crashed the `record-batch` target with:
```
System.NotImplementedException: Feature 'Predefined dictionaries feature is not implemented' is not implemented
```

**Root cause:** an LZ4 frame whose FLG byte sets the DictID flag makes K4os throw `NotImplementedException` from the frame decoder. `Lz4CompressionCodec.Decompress` only translated `InvalidOperationException` into `InvalidDataException`, so this escaped the codec raw. A hostile or corrupt compressed record batch could surface an unexpected `NotImplementedException` from the consumer fetch/parse path instead of the corrupt-data error contract the receive pipeline (and the fuzz harness) expect.

## Fix
Catch `NotImplementedException` in `Decompress` and wrap it as `InvalidDataException("LZ4 frame uses an unsupported feature.")`, matching how truncated and malformed frames already fail. Cold error path only — no hot-path or allocation impact. (Zstd/Gzip/Snappy/Brotli codecs were checked: Zstd uses the status-code API and already maps invalid data to `InvalidDataException`; only LZ4 had this leak.)

## Verification
- New regression test `Lz4CompressionCodec_Decompress_DictionaryFrame_ThrowsInvalidDataException` embeds the exact retained crash frame; it threw `NotImplementedException` before the fix and passes after.
- The retained crash input replays cleanly through `RecordBatchFuzzTarget.Run` — no exception escapes.
- LZ4 codec suite 14/14 and `RecordBatchFuzzCorpusTests` 16/16 pass locally.