### PR TITLE
ci(renovate): pin EF Core 8 update train

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,13 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "EF 8.x train pinned for the net8.0 TFM (Directory.Packages.props conditioned entry); 9+/10+ do not support net8.0",
+      "matchPackageNames": [
+        "/^Microsoft\\.EntityFrameworkCore\\./"
+      ],
+      "matchCurrentVersion": "/^8\\./",
+      "allowedVersions": "<9"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- constrain EF Core dependency instances already on 8.x to updates below 9
- preserve normal 10.x updates for non-net8.0 conditioned entries
- retire invalid Renovate PRs #2379 and #2380

## Test plan
- [x] `ConvertFrom-Json` parses `renovate.json`
- [x] `renovate-config-validator renovate.json`
- [x] `git diff --check`

Closes #2397
