### PR TITLE
fix(stress): retry Toxiproxy control calls

### DIFF
--- a/tools/Dekaf.StressTests.Tests/FaultInjection/ToxiproxyControlPlaneTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/ToxiproxyControlPlaneTests.cs
@@ -1,0 +1,96 @@
+using System.Net.Http;
+using Dekaf.StressTests.FaultInjection;
+using Newtonsoft.Json;
+
+namespace Dekaf.StressTests.Tests.FaultInjection;
+
+public class ToxiproxyControlPlaneTests
+{
+    [Test]
+    public async Task ExecuteAsync_RetriesJsonReaderExceptionUntilSuccess()
+    {
+        var attempts = 0;
+
+        await FaultInjectionKafkaEnvironment.ExecuteToxiproxyControlPlaneAsync(
+            "reset proxies",
+            () =>
+            {
+                attempts++;
+                if (attempts < 3)
+                {
+                    throw new JsonReaderException("invalid response");
+                }
+
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            retryDelay: TimeSpan.Zero);
+
+        await Assert.That(attempts).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_RetriesHttpRequestExceptionUntilSuccess()
+    {
+        var attempts = 0;
+
+        await FaultInjectionKafkaEnvironment.ExecuteToxiproxyControlPlaneAsync(
+            "add toxic",
+            () =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    throw new HttpRequestException("control API unavailable");
+                }
+
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            retryDelay: TimeSpan.Zero);
+
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ExhaustedRetriesThrowsInfrastructureError()
+    {
+        var attempts = 0;
+
+        var exception = await Assert.ThrowsAsync<ToxiproxyControlPlaneException>(() =>
+            FaultInjectionKafkaEnvironment.ExecuteToxiproxyControlPlaneAsync(
+                "reset proxies",
+                () =>
+                {
+                    attempts++;
+                    throw new JsonReaderException("invalid response");
+                },
+                CancellationToken.None,
+                retryDelay: TimeSpan.Zero));
+
+        await Assert.That(attempts).IsEqualTo(3);
+        await Assert.That(exception!.Message).Contains("harness infrastructure");
+        await Assert.That(exception.Message).Contains("reset proxies");
+        await Assert.That(exception.InnerException).IsTypeOf<JsonReaderException>();
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DoesNotRetryNonTransientFailure()
+    {
+        var attempts = 0;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            FaultInjectionKafkaEnvironment.ExecuteToxiproxyControlPlaneAsync(
+                "reset proxies",
+                () =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("bad test setup");
+                },
+                CancellationToken.None,
+                retryDelay: TimeSpan.Zero));
+
+        await Assert.That(attempts).IsEqualTo(1);
+        await Assert.That(exception!.Message).IsEqualTo("bad test setup");
+    }
+}

--- a/tools/Dekaf.StressTests.Tests/FaultInjection/ToxiproxyControlPlaneTests.cs
+++ b/tools/Dekaf.StressTests.Tests/FaultInjection/ToxiproxyControlPlaneTests.cs
@@ -1,6 +1,10 @@
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using Dekaf.StressTests.FaultInjection;
 using Newtonsoft.Json;
+using Toxiproxy.Net;
+using Toxiproxy.Net.Toxics;
 
 namespace Dekaf.StressTests.Tests.FaultInjection;
 
@@ -92,5 +96,111 @@ public class ToxiproxyControlPlaneTests
 
         await Assert.That(attempts).IsEqualTo(1);
         await Assert.That(exception!.Message).IsEqualTo("bad test setup");
+    }
+
+    [Test]
+    public async Task ExecuteToxicAddAsync_AmbiguousRealAdd_TreatsConflictAsSuccess()
+    {
+        var handler = new QueueHttpMessageHandler(
+            JsonResponse(
+                HttpStatusCode.OK,
+                """{"name":"broker-1","listen":"0.0.0.0:19092","upstream":"broker-1:9092","enabled":true}"""),
+            JsonResponse(HttpStatusCode.OK, "<html>"),
+            JsonResponse(HttpStatusCode.OK, "<html>"),
+            JsonResponse(HttpStatusCode.OK, """
+                [{"name":"latency-upstream","type":"latency","stream":"upstream","toxicity":1,"attributes":{"latency":300,"jitter":0}}]
+                """));
+        var proxy = await CreateProxyAsync(handler);
+        var toxic = CreateLatencyToxic();
+
+        await FaultInjectionKafkaEnvironment.ExecuteToxiproxyToxicAddAsync(
+            proxy,
+            toxic,
+            CancellationToken.None,
+            retryDelay: TimeSpan.Zero);
+
+        await Assert.That(handler.RequestCount).IsEqualTo(4);
+        await Assert.That(handler.ToxicAddRequestCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ExecuteToxicAddAsync_FirstAttemptConflict_IsPreserved()
+    {
+        var handler = new QueueHttpMessageHandler(
+            JsonResponse(
+                HttpStatusCode.OK,
+                """{"name":"broker-1","listen":"0.0.0.0:19092","upstream":"broker-1:9092","enabled":true}"""),
+            JsonResponse(
+                HttpStatusCode.Conflict,
+                """{"error":"toxic already exists","status":409}"""));
+        var proxy = await CreateProxyAsync(handler);
+        var toxic = CreateLatencyToxic();
+
+        var exception = await Assert.ThrowsAsync<ToxiProxiException>(() =>
+            FaultInjectionKafkaEnvironment.ExecuteToxiproxyToxicAddAsync(
+                proxy,
+                toxic,
+                CancellationToken.None,
+                retryDelay: TimeSpan.Zero));
+
+        await Assert.That(handler.RequestCount).IsEqualTo(2);
+        await Assert.That(exception!.Message).IsEqualTo("duplicated entity");
+    }
+
+    private static Task<Proxy> CreateProxyAsync(QueueHttpMessageHandler handler)
+    {
+        var client = new Client(new StubHttpClientFactory(handler));
+        return client.AddAsync(new Proxy
+        {
+            Name = "broker-1",
+            Listen = "0.0.0.0:19092",
+            Upstream = "broker-1:9092",
+            Enabled = true
+        });
+    }
+
+    private static LatencyToxic CreateLatencyToxic() =>
+        new()
+        {
+            Name = "latency-upstream",
+            Stream = ToxicDirection.UpStream,
+            Toxicity = 1,
+            Attributes = { Latency = 300 }
+        };
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string content) =>
+        new(statusCode)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        };
+
+    private sealed class StubHttpClientFactory(QueueHttpMessageHandler handler) : IHttpClientFactory
+    {
+        public Uri BaseUrl { get; } = new("http://toxiproxy.test");
+
+        public HttpClient Create() => new(handler, disposeHandler: false)
+        {
+            BaseAddress = BaseUrl
+        };
+    }
+
+    private sealed class QueueHttpMessageHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+        private readonly List<(HttpMethod Method, string Path)> _requests = [];
+
+        internal int RequestCount => _requests.Count;
+
+        internal int ToxicAddRequestCount => _requests.Count(static request =>
+            request.Method == HttpMethod.Post
+            && request.Path.EndsWith("/toxics", StringComparison.Ordinal));
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _requests.Add((request.Method, request.RequestUri!.AbsolutePath));
+            return Task.FromResult(_responses.Dequeue());
+        }
     }
 }

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -440,9 +440,9 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
         foreach (var proxy in _proxies)
         {
             var toxic = toxicFactory();
-            await ExecuteToxiproxyControlPlaneAsync(
-                $"add toxic '{toxic.Name}' to proxy '{proxy.Name}'",
-                () => proxy.AddAsync(toxic).WaitAsync(cancellationToken),
+            await ExecuteToxiproxyToxicAddAsync(
+                proxy,
+                toxic,
                 cancellationToken).ConfigureAwait(false);
         }
     }
@@ -475,21 +475,34 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
         string operation,
         Func<Task> action,
         CancellationToken cancellationToken,
-        TimeSpan? retryDelay = null)
+        TimeSpan? retryDelay = null,
+        Func<Task<bool>>? isAppliedAfterTransientFailure = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(operation);
         ArgumentNullException.ThrowIfNull(action);
 
         var delay = retryDelay ?? ToxiproxyControlPlaneRetryDelay;
+        var verifyApplicationBeforeRetry = false;
         for (var attempt = 1; attempt <= ToxiproxyControlPlaneMaxAttempts; attempt++)
         {
             try
             {
+                if (verifyApplicationBeforeRetry)
+                {
+                    if (await isAppliedAfterTransientFailure!().ConfigureAwait(false))
+                    {
+                        return;
+                    }
+
+                    verifyApplicationBeforeRetry = false;
+                }
+
                 await action().ConfigureAwait(false);
                 return;
             }
             catch (Exception exception) when (IsTransientToxiproxyControlPlaneFailure(exception))
             {
+                verifyApplicationBeforeRetry = isAppliedAfterTransientFailure is not null;
                 if (attempt == ToxiproxyControlPlaneMaxAttempts)
                 {
                     throw new ToxiproxyControlPlaneException(
@@ -503,6 +516,38 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
         }
+    }
+
+    internal static Task ExecuteToxiproxyToxicAddAsync<T>(
+        Proxy proxy,
+        T toxic,
+        CancellationToken cancellationToken,
+        TimeSpan? retryDelay = null)
+        where T : ToxicBase =>
+        ExecuteToxiproxyControlPlaneAsync(
+            $"add toxic '{toxic.Name}' to proxy '{proxy.Name}'",
+            () => proxy.AddAsync(toxic).WaitAsync(cancellationToken),
+            cancellationToken,
+            retryDelay,
+            () => IsToxicAppliedAsync(proxy, toxic.Name, cancellationToken));
+
+    private static async Task<bool> IsToxicAppliedAsync(
+        Proxy proxy,
+        string toxicName,
+        CancellationToken cancellationToken)
+    {
+        var toxics = await proxy.GetAllToxicsAsync()
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(false);
+        foreach (var toxic in toxics)
+        {
+            if (string.Equals(toxic.Name, toxicName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsTransientToxiproxyControlPlaneFailure(Exception exception) =>

--- a/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/FaultInjectionKafkaEnvironment.cs
@@ -6,6 +6,7 @@ using Docker.DotNet.Models;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
+using Newtonsoft.Json;
 using Testcontainers.Toxiproxy;
 using Toxiproxy.Net;
 using Toxiproxy.Net.Toxics;
@@ -22,6 +23,8 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
     private const ushort ExternalBrokerPort = 29092;
     private const string ToxiproxyImage = "ghcr.io/shopify/toxiproxy:2.12.0";
     private const string ClusterId = "MkU3OEVBNTcwNTJENDM2Qg";
+    private const int ToxiproxyControlPlaneMaxAttempts = 3;
+    private static readonly TimeSpan ToxiproxyControlPlaneRetryDelay = TimeSpan.FromMilliseconds(250);
 
     private readonly INetwork _network;
     private readonly ToxiproxyContainer _toxiproxyContainer;
@@ -436,7 +439,11 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
     {
         foreach (var proxy in _proxies)
         {
-            await proxy.AddAsync(toxicFactory()).WaitAsync(cancellationToken).ConfigureAwait(false);
+            var toxic = toxicFactory();
+            await ExecuteToxiproxyControlPlaneAsync(
+                $"add toxic '{toxic.Name}' to proxy '{proxy.Name}'",
+                () => proxy.AddAsync(toxic).WaitAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -445,18 +452,61 @@ internal sealed class FaultInjectionKafkaEnvironment : IAsyncDisposable
         foreach (var proxy in _proxies)
         {
             proxy.Enabled = enabled;
-            await proxy.UpdateAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+            await ExecuteToxiproxyControlPlaneAsync(
+                $"set proxy '{proxy.Name}' enabled={enabled}",
+                () => proxy.UpdateAsync().WaitAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
         }
     }
 
     private async Task ResetProxiesAsync()
     {
-        await _toxiproxyClient.ResetAsync().ConfigureAwait(false);
+        await ExecuteToxiproxyControlPlaneAsync(
+            "reset proxies",
+            _toxiproxyClient.ResetAsync,
+            CancellationToken.None).ConfigureAwait(false);
         foreach (var proxy in _proxies)
         {
             proxy.Enabled = true;
         }
     }
+
+    internal static async Task ExecuteToxiproxyControlPlaneAsync(
+        string operation,
+        Func<Task> action,
+        CancellationToken cancellationToken,
+        TimeSpan? retryDelay = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(operation);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var delay = retryDelay ?? ToxiproxyControlPlaneRetryDelay;
+        for (var attempt = 1; attempt <= ToxiproxyControlPlaneMaxAttempts; attempt++)
+        {
+            try
+            {
+                await action().ConfigureAwait(false);
+                return;
+            }
+            catch (Exception exception) when (IsTransientToxiproxyControlPlaneFailure(exception))
+            {
+                if (attempt == ToxiproxyControlPlaneMaxAttempts)
+                {
+                    throw new ToxiproxyControlPlaneException(
+                        operation,
+                        ToxiproxyControlPlaneMaxAttempts,
+                        exception);
+                }
+
+                Console.Error.WriteLine(
+                    $"Toxiproxy control-plane operation '{operation}' failed on attempt {attempt}; retrying.");
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static bool IsTransientToxiproxyControlPlaneFailure(Exception exception) =>
+        exception is JsonReaderException or HttpRequestException;
 
     private async Task RestoreBrokerAsync(IContainer broker, string topic)
     {

--- a/tools/Dekaf.StressTests/FaultInjection/ToxiproxyControlPlaneException.cs
+++ b/tools/Dekaf.StressTests/FaultInjection/ToxiproxyControlPlaneException.cs
@@ -1,0 +1,9 @@
+namespace Dekaf.StressTests.FaultInjection;
+
+internal sealed class ToxiproxyControlPlaneException(
+    string operation,
+    int attemptCount,
+    Exception innerException)
+    : Exception(
+        $"Toxiproxy control-plane operation '{operation}' failed after {attemptCount} attempts due to a harness infrastructure error.",
+        innerException);


### PR DESCRIPTION
## Summary
- retry transient `JsonReaderException` and `HttpRequestException` failures from Toxiproxy toxic add, proxy update, and reset calls
- verify toxic installation after ambiguous add failures before issuing another POST; transient verification failures retry verification
- cap retries at three with cancellation-aware backoff
- surface exhausted retries as a typed harness infrastructure failure
- preserve first-attempt conflicts and cover the real ToxiproxyNetCore `Proxy.AddAsync` HTTP path

## Test plan
- [x] `dotnet build tools/Dekaf.StressTests.Tests/Dekaf.StressTests.Tests.csproj --configuration Release`
- [x] focused `ToxiproxyControlPlaneTests` (6/6)
- [x] full `Dekaf.StressTests.Tests` (39/39)
- [x] `dotnet build --configuration Release` (0 warnings/errors)
- [x] scoped `dotnet format --verify-no-changes` for all changed files
- [ ] repo-wide `dotnet format --verify-no-changes --no-restore` (fails on pre-existing unrelated whitespace; no changed file reported)

Closes #2396