### PR TITLE
Fix flaky producer saturation tests

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderMuteOrderingTests.cs
@@ -1515,29 +1515,28 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
     [Timeout(30_000)]
     public async Task MultiplePartitionsMuted_IndependentlyBlocked_OtherPartitionsProceed(CancellationToken ct)
     {
-        // Send 1: A(p0) + B(p1) + C(p2) → p0 error, p1 error, p2 success
-        // Retries may share one request or use one request per partition.
-        var tcs1 = new TaskCompletionSource<ProduceResponse>();
         var sendCount = 0;
-        var firstSend = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var partitionAttempts = new int[3];
         var connection = new TestKafkaConnection { CaptureProduceRequests = true };
         connection.SendProducePipelinedAfterWrite = () =>
         {
-            if (Interlocked.Increment(ref sendCount) == 1)
-            {
-                firstSend.TrySetResult();
-                return new ValueTask<Task<ProduceResponse>>(tcs1.Task);
-            }
+            Interlocked.Increment(ref sendCount);
 
-            string requestInfo;
+            IReadOnlyList<(string Name, Guid TopicId, int Partition)> requestedTopics;
             lock (connection.CapturedProduceRequests)
-                requestInfo = connection.CapturedProduceRequests[^1].Info;
+                requestedTopics = connection.CapturedProduceRequests[^1].Topics;
 
-            var partitions = new List<(int partition, ErrorCode errorCode, long baseOffset)>(2);
-            if (requestInfo.Contains("test-topic-0(", StringComparison.Ordinal))
-                partitions.Add((0, ErrorCode.None, 100));
-            if (requestInfo.Contains("test-topic-1(", StringComparison.Ordinal))
-                partitions.Add((1, ErrorCode.None, 200));
+            var partitions = new List<(int partition, ErrorCode errorCode, long baseOffset)>(
+                requestedTopics.Count);
+            foreach (var requestedTopic in requestedTopics)
+            {
+                var partition = requestedTopic.Partition;
+                var attempt = Interlocked.Increment(ref partitionAttempts[partition]);
+                var errorCode = partition < 2 && attempt == 1
+                    ? ErrorCode.NotLeaderOrFollower
+                    : ErrorCode.None;
+                partitions.Add((partition, errorCode, (partition + 1) * 100L));
+            }
 
             return new ValueTask<Task<ProduceResponse>>(Task.FromResult(
                 CreateMultiPartitionResponse("test-topic", partitions.ToArray())));
@@ -1578,23 +1577,15 @@ public sealed class BrokerSenderMuteOrderingTests : ScriptedProduceResponseFixtu
             sender.Enqueue(batchC);
             connectionAvailable.SetResult(connection);
 
-            await firstSend.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
-
-            // p0 and p1 fail, p2 succeeds
-            tcs1.SetResult(CreateMultiPartitionResponse("test-topic",
-                (0, ErrorCode.NotLeaderOrFollower, -1),
-                (1, ErrorCode.NotLeaderOrFollower, -1),
-                (2, ErrorCode.None, 300)));
-
             await allAcknowledged.Task.WaitAsync(TimeSpan.FromSeconds(30), ct);
 
-            // p2 acknowledged first (succeeded in send 1)
-            await Assert.That(ackPartitions[0]).IsEqualTo((2, 300L));
-            // p0 and p1 acknowledged after retry (order between them is implementation detail)
-            var retryAcks = ackPartitions.Skip(1).OrderBy(a => a.partition).ToList();
-            await Assert.That(retryAcks[0]).IsEqualTo((0, 100L));
-            await Assert.That(retryAcks[1]).IsEqualTo((1, 200L));
-            await Assert.That(Volatile.Read(ref sendCount)).IsBetween(2, 3);
+            await Assert.That(ackPartitions).IsEquivalentTo([
+                (0, 100L),
+                (1, 200L),
+                (2, 300L),
+            ]);
+            await Assert.That(partitionAttempts).IsEquivalentTo([2, 2, 1]);
+            await Assert.That(Volatile.Read(ref sendCount)).IsBetween(2, 5);
         }
         finally
         {

--- a/tests/Dekaf.Tests.Unit/Producer/LeakGateHarness.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LeakGateHarness.cs
@@ -119,7 +119,8 @@ internal static class LeakGateHarness
         int partitionCount,
         int valueSize,
         string topic,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TaskCompletionSource? reservationWaitObserved = null)
     {
         var completionTasks = new List<Task<RecordMetadata>>();
         var acceptedTotal = 0;
@@ -136,29 +137,35 @@ internal static class LeakGateHarness
 
             try
             {
-                bool accepted;
+                ValueTask<bool> appendTask;
+                Task<RecordMetadata>? completionTask = null;
                 if ((i & 1) == 0)
                 {
                     var completion = completionPool.Rent();
-                    var completionTask = completion.Task.AsTask();
-                    accepted = await accumulator.AppendAsync(
+                    completionTask = completion.Task.AsTask();
+                    appendTask = accumulator.AppendAsync(
                         topic, partition, timestamp, PooledMemory.Null, value,
                         headers: null, headerCount: 0, completion, callback: null, cancellationToken);
-                    if (accepted)
-                        completionTasks.Add(completionTask);
                 }
                 else
                 {
-                    accepted = await accumulator.AppendAsync(
+                    appendTask = accumulator.AppendAsync(
                         topic, partition, timestamp, PooledMemory.Null, value,
                         headers: null, headerCount: 0, completionSource: null,
                         callback, cancellationToken);
-                    if (accepted)
-                        acceptedFireAndForget++;
                 }
 
+                if (!appendTask.IsCompleted)
+                    reservationWaitObserved?.TrySetResult();
+
+                var accepted = await appendTask;
                 if (!accepted)
                     break;
+
+                if (completionTask is not null)
+                    completionTasks.Add(completionTask);
+                else
+                    acceptedFireAndForget++;
 
                 acceptedTotal++;
                 Interlocked.Increment(ref counters.AcceptedTotal);

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
@@ -59,15 +59,27 @@ public sealed class ProducerLeakEdgeCaseTests
             var drainerGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             using var victimCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            Task<AppenderResult> StartAppender(int appenderId, CancellationToken token) =>
+            Task<AppenderResult> StartAppender(
+                int appenderId,
+                CancellationToken token,
+                TaskCompletionSource? reservationWaitObserved = null) =>
                 Task.Run(
                     () => LeakGateHarness.RunAppenderAsync(
                         accumulator, completionPool, counters, appenderId, MessagesPerAppender,
-                        PartitionCount, ValueSize, Topic, token),
+                        PartitionCount, ValueSize, Topic, token, reservationWaitObserved),
                     cancellationToken);
 
             var survivorTasks = new[] { StartAppender(0, cancellationToken), StartAppender(1, cancellationToken) };
-            var victimTasks = new[] { StartAppender(2, victimCts.Token), StartAppender(3, victimCts.Token) };
+            var victimWaitSignals = new[]
+            {
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+            };
+            var victimTasks = new[]
+            {
+                StartAppender(2, victimCts.Token, victimWaitSignals[0]),
+                StartAppender(3, victimCts.Token, victimWaitSignals[1]),
+            };
 
             var drainerTask = Task.Run(async () =>
             {
@@ -76,10 +88,10 @@ public sealed class ProducerLeakEdgeCaseTests
                     accumulator, counters, failEveryNthBatch: 0, DrainWaitMode.WakeupSignal, cancellationToken);
             }, cancellationToken);
 
-            // Hold the drainer shut until an appender is provably blocked in the slow-path
-            // reservation wait, then cancel the victims while they are blocked.
-            await LeakGateHarness.WaitForSaturationAsync(
-                accumulator, [.. survivorTasks, .. victimTasks], cancellationToken);
+            // Hold the drainer shut until both victims are provably blocked in the slow-path
+            // reservation wait, then cancel them while they are blocked.
+            await Task.WhenAll(victimWaitSignals.Select(static signal => signal.Task))
+                .WaitAsync(cancellationToken);
             await victimCts.CancelAsync();
             drainerGate.SetResult();
 


### PR DESCRIPTION
## Summary
- wait until each cancellation victim actually enters the reservation slow path before cancellation
- generate mute-ordering responses from the partitions present in each captured request
- assert per-partition retry counts without assuming batching or acknowledgement order

## Validation
- before fix: saturation test failed on iteration 11/50 (`WasCancelled` false)
- after fix: saturation test 100/100
- after fix: mute-ordering test 100/100
- `Dekaf.Tests.Unit` net10.0: 6371/6371
- `Dekaf.Tests.Unit` net8.0: 6244/6244
- Release build: 0 warnings, 0 errors
- scoped whitespace format: clean

Closes #2377
Closes #2290