### PR TITLE
Bound broker response array allocations

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -808,6 +808,26 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a legacy array whose elements have a known minimum encoded size, bounding
+    /// hostile counts before the array allocation.
+    /// </summary>
+    public T[] ReadArray<T>(ReadFunc<T> readItem, int minElementSize, int maxCount)
+    {
+        var length = ReadInt32();
+        if (length <= 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Reads a nullable array with 4-byte length prefix (legacy format).
     /// </summary>
     public T[]? ReadNullableArray<T>(ReadFunc<T> readItem)

--- a/src/Dekaf/Protocol/Messages/AddPartitionsToTxnResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AddPartitionsToTxnResponse.cs
@@ -8,6 +8,11 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AddPartitionsToTxnResponse : IKafkaResponse
 {
+    // A response echoes one client request. One million entries is deliberately
+    // conservative while still bounding hostile frame-valid object allocation.
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AddPartitionsToTxn;
     public static short LowestSupportedVersion => 3;
     public static short HighestSupportedVersion => 4;
@@ -81,7 +86,7 @@ public sealed class AddPartitionsToTxnResponse : IKafkaResponse
             static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnTopicResult.Read(ref r, v),
             version,
             minElementSize: 3,
-            maxCount: int.MaxValue);
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -109,7 +114,7 @@ public sealed class AddPartitionsToTxnTopicResult
             static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnPartitionResult.Read(ref r, v),
             version,
             minElementSize: 7,
-            maxCount: int.MaxValue);
+            maxCount: AddPartitionsToTxnResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/AddPartitionsToTxnResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AddPartitionsToTxnResponse.cs
@@ -77,7 +77,11 @@ public sealed class AddPartitionsToTxnResponse : IKafkaResponse
 
     private static IKafkaResponse ReadV0ToV3(ref KafkaProtocolReader reader, short version, int throttleTimeMs)
     {
-        var results = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnTopicResult.Read(ref r, v), version);
+        var results = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnTopicResult.Read(ref r, v),
+            version,
+            minElementSize: 3,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 
@@ -101,7 +105,11 @@ public sealed class AddPartitionsToTxnTopicResult
     {
         var name = reader.ReadCompactNonNullableString();
 
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnPartitionResult.Read(ref r, v), version);
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => AddPartitionsToTxnPartitionResult.Read(ref r, v),
+            version,
+            minElementSize: 7,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ApiVersionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ApiVersionsResponse.cs
@@ -43,8 +43,14 @@ public sealed class ApiVersionsResponse : IKafkaResponse
         var flexible = wireVersion >= 3;
 
         var apiKeys = flexible
-            ? reader.ReadCompactArray(static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: true))
-            : reader.ReadArray(static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: false));
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: true),
+                minElementSize: 7,
+                maxCount: int.MaxValue)
+            : reader.ReadArray(
+                static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: false),
+                minElementSize: 6,
+                maxCount: int.MaxValue);
 
         var throttleTimeMs = wireVersion >= 1 ? reader.ReadInt32() : 0;
 
@@ -64,14 +70,18 @@ public sealed class ApiVersionsResponse : IKafkaResponse
                 {
                     case 0:
                         supportedFeatures = reader.ReadCompactArray(
-                            static (ref KafkaProtocolReader r) => ReadSupportedFeature(ref r));
+                            static (ref KafkaProtocolReader r) => ReadSupportedFeature(ref r),
+                            minElementSize: 6,
+                            maxCount: int.MaxValue);
                         break;
                     case 1:
                         finalizedFeaturesEpoch = reader.ReadInt64();
                         break;
                     case 2:
                         finalizedFeatures = reader.ReadCompactArray(
-                            static (ref KafkaProtocolReader r) => ReadFinalizedFeature(ref r));
+                            static (ref KafkaProtocolReader r) => ReadFinalizedFeature(ref r),
+                            minElementSize: 6,
+                            maxCount: int.MaxValue);
                         break;
                     case 3:
                         zkMigrationReady = reader.ReadUInt8() != 0;

--- a/src/Dekaf/Protocol/Messages/ApiVersionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ApiVersionsResponse.cs
@@ -6,6 +6,11 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ApiVersionsResponse : IKafkaResponse
 {
+    // Kafka API keys occupy an Int16 domain. Feature counts are cluster-level and
+    // capped far above any practical broker response to bound frame-valid amplification.
+    internal const int MaxApiKeyCount = 65_536;
+    internal const int MaxFeatureCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.ApiVersions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 5;
@@ -46,11 +51,11 @@ public sealed class ApiVersionsResponse : IKafkaResponse
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: true),
                 minElementSize: 7,
-                maxCount: int.MaxValue)
+                maxCount: MaxApiKeyCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r) => ReadApiVersion(ref r, flexible: false),
                 minElementSize: 6,
-                maxCount: int.MaxValue);
+                maxCount: MaxApiKeyCount);
 
         var throttleTimeMs = wireVersion >= 1 ? reader.ReadInt32() : 0;
 
@@ -72,7 +77,7 @@ public sealed class ApiVersionsResponse : IKafkaResponse
                         supportedFeatures = reader.ReadCompactArray(
                             static (ref KafkaProtocolReader r) => ReadSupportedFeature(ref r),
                             minElementSize: 6,
-                            maxCount: int.MaxValue);
+                            maxCount: MaxFeatureCount);
                         break;
                     case 1:
                         finalizedFeaturesEpoch = reader.ReadInt64();
@@ -81,7 +86,7 @@ public sealed class ApiVersionsResponse : IKafkaResponse
                         finalizedFeatures = reader.ReadCompactArray(
                             static (ref KafkaProtocolReader r) => ReadFinalizedFeature(ref r),
                             minElementSize: 6,
-                            maxCount: int.MaxValue);
+                            maxCount: MaxFeatureCount);
                         break;
                     case 3:
                         zkMigrationReady = reader.ReadUInt8() != 0;

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
@@ -61,6 +61,7 @@ public sealed class DescribeShareGroupOffsetsRequestGroup
         IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? topics = null;
         if (topicsLength >= 0)
         {
+            reader.ValidateReadableLength(topicsLength, minElementSize: 3, maxCount: int.MaxValue);
             var topicsList = new DescribeShareGroupOffsetsRequestTopic[topicsLength];
             for (int i = 0; i < topicsLength; i++)
             {
@@ -110,7 +111,9 @@ public sealed class DescribeShareGroupOffsetsRequestTopic
         var topicName = reader.ReadCompactNonNullableString();
 
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsRequest.cs
@@ -6,6 +6,11 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeShareGroupOffsetsRequest : IKafkaRequest<DescribeShareGroupOffsetsResponse>
 {
+    // Defensive read-only path used by tests today. Keep finite caps in case request
+    // decoding becomes broker-controlled in the future.
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeShareGroupOffsets;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -61,7 +66,10 @@ public sealed class DescribeShareGroupOffsetsRequestGroup
         IReadOnlyList<DescribeShareGroupOffsetsRequestTopic>? topics = null;
         if (topicsLength >= 0)
         {
-            reader.ValidateReadableLength(topicsLength, minElementSize: 3, maxCount: int.MaxValue);
+            reader.ValidateReadableLength(
+                topicsLength,
+                minElementSize: 3,
+                maxCount: DescribeShareGroupOffsetsRequest.MaxTopicCount);
             var topicsList = new DescribeShareGroupOffsetsRequestTopic[topicsLength];
             for (int i = 0; i < topicsLength; i++)
             {
@@ -113,7 +121,7 @@ public sealed class DescribeShareGroupOffsetsRequestTopic
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
-            maxCount: int.MaxValue);
+            maxCount: DescribeShareGroupOffsetsRequest.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/MetadataResponse.cs
+++ b/src/Dekaf/Protocol/Messages/MetadataResponse.cs
@@ -27,13 +27,21 @@ public sealed class MetadataResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
 
-        var brokers = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => BrokerMetadata.Read(ref r, v), version);
+        var brokers = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => BrokerMetadata.Read(ref r, v),
+            version,
+            minElementSize: 11,
+            maxCount: int.MaxValue);
 
         var clusterId = reader.ReadCompactString();
 
         var controllerId = reader.ReadInt32();
 
-        var topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => TopicMetadata.Read(ref r, v), version);
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => TopicMetadata.Read(ref r, v),
+            version,
+            minElementSize: version >= 10 ? 26 : 10,
+            maxCount: int.MaxValue);
 
         var clusterAuthorizedOperations = int.MinValue;
         if (version <= 10)
@@ -116,7 +124,11 @@ public sealed class TopicMetadata
 
         var isInternal = reader.ReadBoolean();
 
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => PartitionMetadata.Read(ref r, v), version);
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => PartitionMetadata.Read(ref r, v),
+            version,
+            minElementSize: 18,
+            maxCount: int.MaxValue);
 
         var topicAuthorizedOperations = reader.ReadInt32();
 
@@ -154,9 +166,18 @@ public sealed class PartitionMetadata
         var leaderId = reader.ReadInt32();
         var leaderEpoch = reader.ReadInt32();
 
-        var replicaNodes = reader.ReadCompactArray((ref KafkaProtocolReader r) => r.ReadInt32());
-        var isrNodes = reader.ReadCompactArray((ref KafkaProtocolReader r) => r.ReadInt32());
-        var offlineReplicas = reader.ReadCompactArray((ref KafkaProtocolReader r) => r.ReadInt32());
+        var replicaNodes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: int.MaxValue);
+        var isrNodes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: int.MaxValue);
+        var offlineReplicas = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/MetadataResponse.cs
+++ b/src/Dekaf/Protocol/Messages/MetadataResponse.cs
@@ -6,6 +6,13 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class MetadataResponse : IKafkaResponse
 {
+    // Absolute parse caps bound frame-valid object amplification while remaining far
+    // above practical Kafka cluster, topic, partition, and replication-factor limits.
+    internal const int MaxBrokerCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxReplicaCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.Metadata;
     public static short LowestSupportedVersion => 9;
     public static short HighestSupportedVersion => 13;
@@ -31,7 +38,7 @@ public sealed class MetadataResponse : IKafkaResponse
             static (ref KafkaProtocolReader r, short v) => BrokerMetadata.Read(ref r, v),
             version,
             minElementSize: 11,
-            maxCount: int.MaxValue);
+            maxCount: MaxBrokerCount);
 
         var clusterId = reader.ReadCompactString();
 
@@ -41,7 +48,7 @@ public sealed class MetadataResponse : IKafkaResponse
             static (ref KafkaProtocolReader r, short v) => TopicMetadata.Read(ref r, v),
             version,
             minElementSize: version >= 10 ? 26 : 10,
-            maxCount: int.MaxValue);
+            maxCount: MaxTopicCount);
 
         var clusterAuthorizedOperations = int.MinValue;
         if (version <= 10)
@@ -128,7 +135,7 @@ public sealed class TopicMetadata
             static (ref KafkaProtocolReader r, short v) => PartitionMetadata.Read(ref r, v),
             version,
             minElementSize: 18,
-            maxCount: int.MaxValue);
+            maxCount: MetadataResponse.MaxPartitionCount);
 
         var topicAuthorizedOperations = reader.ReadInt32();
 
@@ -169,15 +176,15 @@ public sealed class PartitionMetadata
         var replicaNodes = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
-            maxCount: int.MaxValue);
+            maxCount: MetadataResponse.MaxReplicaCount);
         var isrNodes = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
-            maxCount: int.MaxValue);
+            maxCount: MetadataResponse.MaxReplicaCount);
         var offlineReplicas = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
-            maxCount: int.MaxValue);
+            maxCount: MetadataResponse.MaxReplicaCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/OffsetFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetFetchResponse.cs
@@ -39,12 +39,20 @@ public sealed class OffsetFetchResponse : IKafkaResponse
 
         if (version < 8)
         {
-            topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v), version);
+            topics = reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v),
+                version,
+                minElementSize: 3,
+                maxCount: int.MaxValue);
             errorCode = (ErrorCode)reader.ReadInt16();
         }
         else
         {
-            groups = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseGroup.Read(ref r, v), version);
+            groups = reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseGroup.Read(ref r, v),
+                version,
+                minElementSize: 5,
+                maxCount: int.MaxValue);
         }
 
         reader.SkipTaggedFields();
@@ -74,7 +82,11 @@ public sealed class OffsetFetchResponseTopic
             ? string.Empty
             : reader.ReadCompactNonNullableString();
         var topicId = version >= OffsetFetchRequest.TopicIdVersion ? reader.ReadUuid() : Guid.Empty;
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetFetchResponsePartition.Read(ref r, v), version);
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => OffsetFetchResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 20,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 
@@ -132,7 +144,11 @@ public sealed class OffsetFetchResponseGroup
     {
         var groupId = reader.ReadCompactNonNullableString();
 
-        var topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v), version);
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: version >= OffsetFetchRequest.TopicIdVersion ? 18 : 3,
+            maxCount: int.MaxValue);
 
         var errorCode = (ErrorCode)reader.ReadInt16();
 

--- a/src/Dekaf/Protocol/Messages/OffsetFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetFetchResponse.cs
@@ -5,6 +5,12 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class OffsetFetchResponse : IKafkaResponse
 {
+    // Group results are cluster-level; topic and partition caps allow extreme requests
+    // while preventing one frame from driving effectively unbounded object allocation.
+    internal const int MaxGroupCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.OffsetFetch;
     public static short LowestSupportedVersion => 6;
     public static short HighestSupportedVersion => OffsetFetchRequest.TopicIdVersion;
@@ -43,7 +49,7 @@ public sealed class OffsetFetchResponse : IKafkaResponse
                 static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v),
                 version,
                 minElementSize: 3,
-                maxCount: int.MaxValue);
+                maxCount: MaxTopicCount);
             errorCode = (ErrorCode)reader.ReadInt16();
         }
         else
@@ -52,7 +58,7 @@ public sealed class OffsetFetchResponse : IKafkaResponse
                 static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseGroup.Read(ref r, v),
                 version,
                 minElementSize: 5,
-                maxCount: int.MaxValue);
+                maxCount: MaxGroupCount);
         }
 
         reader.SkipTaggedFields();
@@ -86,7 +92,7 @@ public sealed class OffsetFetchResponseTopic
             static (ref KafkaProtocolReader r, short v) => OffsetFetchResponsePartition.Read(ref r, v),
             version,
             minElementSize: 20,
-            maxCount: int.MaxValue);
+            maxCount: OffsetFetchResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 
@@ -148,7 +154,7 @@ public sealed class OffsetFetchResponseGroup
             static (ref KafkaProtocolReader r, short v) => OffsetFetchResponseTopic.Read(ref r, v),
             version,
             minElementSize: version >= OffsetFetchRequest.TopicIdVersion ? 18 : 3,
-            maxCount: int.MaxValue);
+            maxCount: OffsetFetchResponse.MaxTopicCount);
 
         var errorCode = (ErrorCode)reader.ReadInt16();
 

--- a/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
@@ -55,10 +55,14 @@ public sealed class ShareFetchResponse : IKafkaResponse
 
         var responses = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => ShareFetchResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 18,
+            maxCount: int.MaxValue);
 
         var nodeEndpoints = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareFetchNodeEndpoint.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareFetchNodeEndpoint.Read(ref r),
+            minElementSize: 11,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 
@@ -94,7 +98,9 @@ public sealed class ShareFetchResponseTopic
         var topicId = reader.ReadUuid();
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => ShareFetchResponsePartition.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 22,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 
@@ -179,7 +185,9 @@ public sealed class ShareFetchResponsePartition
         }
 
         var acquiredRecords = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareFetchAcquiredRecords.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareFetchAcquiredRecords.Read(ref r),
+            minElementSize: 19,
+            maxCount: int.MaxValue);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareFetchResponse.cs
@@ -7,6 +7,13 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ShareFetchResponse : IKafkaResponse
 {
+    // Share-fetch entries echo one request/session. These deliberately generous caps
+    // bound hostile object amplification without constraining practical workloads.
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxAcquiredRecordRangeCount = 1_000_000;
+    internal const int MaxNodeEndpointCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.ShareFetch;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 2;
@@ -57,12 +64,12 @@ public sealed class ShareFetchResponse : IKafkaResponse
             static (ref KafkaProtocolReader r, short v) => ShareFetchResponseTopic.Read(ref r, v),
             version,
             minElementSize: 18,
-            maxCount: int.MaxValue);
+            maxCount: MaxTopicCount);
 
         var nodeEndpoints = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => ShareFetchNodeEndpoint.Read(ref r),
             minElementSize: 11,
-            maxCount: int.MaxValue);
+            maxCount: MaxNodeEndpointCount);
 
         reader.SkipTaggedFields();
 
@@ -100,7 +107,7 @@ public sealed class ShareFetchResponseTopic
             static (ref KafkaProtocolReader r, short v) => ShareFetchResponsePartition.Read(ref r, v),
             version,
             minElementSize: 22,
-            maxCount: int.MaxValue);
+            maxCount: ShareFetchResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 
@@ -187,7 +194,7 @@ public sealed class ShareFetchResponsePartition
         var acquiredRecords = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => ShareFetchAcquiredRecords.Read(ref r),
             minElementSize: 19,
-            maxCount: int.MaxValue);
+            maxCount: ShareFetchResponse.MaxAcquiredRecordRangeCount);
 
         reader.SkipTaggedFields();
 

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
@@ -62,6 +62,19 @@ public sealed class ResponseArrayBoundsTests
     }
 
     [Test]
+    public async Task MetadataResponse_Read_BrokerCountExceedingAbsoluteCap_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        var hostileCount = MetadataResponse.MaxBrokerCount + 1;
+        writer.WriteInt32(0); // throttle time
+        writer.WriteUnsignedVarInt(hostileCount + 1);
+        writer.WriteRawBytes(new byte[hostileCount * 11]);
+
+        await AssertMalformedMetadata(buffer);
+    }
+
+    [Test]
     public async Task MetadataResponse_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
     {
         var buffer = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
@@ -1,0 +1,376 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ResponseArrayBoundsTests
+{
+    private const int HostileElementCount = 40;
+    private const int HostilePayloadLength = 60;
+
+    [Test]
+    public async Task ApiVersionsResponse_Read_FlexibleApiKeyCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedApiVersions(buffer, version: 3);
+    }
+
+    [Test]
+    public async Task ApiVersionsResponse_Read_LegacyApiKeyCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        WriteHostileLegacyArray(ref writer);
+
+        await AssertMalformedApiVersions(buffer, version: 0);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(2)]
+    public async Task ApiVersionsResponse_Read_FeatureCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData(
+        int tag)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(1); // empty API keys
+        writer.WriteInt32(0);          // throttle time
+        writer.WriteUnsignedVarInt(1); // one tagged field
+        writer.WriteUnsignedVarInt(tag);
+        writer.WriteUnsignedVarInt(HostilePayloadLength + 1);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedApiVersions(buffer, version: 3);
+    }
+
+    [Test]
+    public async Task MetadataResponse_Read_BrokerCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0); // throttle time
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedMetadata(buffer);
+    }
+
+    [Test]
+    public async Task MetadataResponse_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);          // throttle time
+        writer.WriteUnsignedVarInt(1); // empty brokers
+        writer.WriteUnsignedVarInt(0); // null cluster ID
+        writer.WriteInt32(-1);         // controller ID
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedMetadata(buffer);
+    }
+
+    [Test]
+    public async Task TopicMetadata_Read_PartitionCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteUuid(Guid.Empty);
+        writer.WriteBoolean(false);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadTopicMetadata(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task PartitionMetadata_Read_NodeCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData(
+        int arrayIndex)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);  // partition index
+        writer.WriteInt32(-1); // leader ID
+        writer.WriteInt32(-1); // leader epoch
+        for (var i = 0; i < arrayIndex; i++)
+            writer.WriteUnsignedVarInt(1);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadPartitionMetadata(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    [Arguments(7)]
+    [Arguments(10)]
+    public async Task OffsetFetchResponse_Read_TopLevelCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0); // throttle time
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadOffsetFetchResponse(buffer, version))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task OffsetFetchResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadOffsetFetchTopic(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task OffsetFetchResponseGroup_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadOffsetFetchGroup(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task AddPartitionsToTxnResponse_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0); // throttle time
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadAddPartitionsToTxnResponse(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task AddPartitionsToTxnTopicResult_Read_PartitionCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadAddPartitionsToTxnTopic(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task ShareFetchResponse_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        WriteShareFetchResponsePreamble(ref writer);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedShareFetch(buffer);
+    }
+
+    [Test]
+    public async Task ShareFetchResponse_Read_NodeEndpointCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        WriteShareFetchResponsePreamble(ref writer);
+        writer.WriteUnsignedVarInt(1); // empty topic responses
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMalformedShareFetch(buffer);
+    }
+
+    [Test]
+    public async Task ShareFetchResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadShareFetchTopic(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task ShareFetchResponsePartition_Read_AcquiredRecordCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);                  // partition index
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(0);         // null error message
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(0);         // null acknowledgement error message
+        writer.WriteInt32(-1);                 // leader ID
+        writer.WriteInt32(-1);                 // leader epoch
+        writer.WriteUnsignedVarInt(0);         // leader tagged fields
+        writer.WriteUnsignedVarInt(0);         // null records
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadShareFetchPartition(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task DescribeShareGroupOffsetsRequestGroup_Read_TopicCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadDescribeShareGroupOffsetsGroup(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    [Test]
+    public async Task DescribeShareGroupOffsetsRequestTopic_Read_PartitionCountExceedingMinimumEncodedSize_ThrowsMalformedProtocolData()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await Assert.That(() => ReadDescribeShareGroupOffsetsTopic(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    private static void WriteHostileCompactArray(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUnsignedVarInt(HostileElementCount + 1);
+        writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static void WriteHostileLegacyArray(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(HostileElementCount);
+        writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static void WriteShareFetchResponsePreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(0); // null error message
+    }
+
+    private static async Task AssertMalformedApiVersions(ArrayBufferWriter<byte> buffer, short version)
+    {
+        await Assert.That(() => ReadApiVersions(buffer, version))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    private static async Task AssertMalformedMetadata(ArrayBufferWriter<byte> buffer)
+    {
+        await Assert.That(() => ReadMetadata(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    private static async Task AssertMalformedShareFetch(ArrayBufferWriter<byte> buffer)
+    {
+        await Assert.That(() => ReadShareFetchResponse(buffer))
+            .Throws<MalformedProtocolDataException>();
+    }
+
+    private static void ReadApiVersions(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ApiVersionsResponse.Read(ref reader, version);
+    }
+
+    private static void ReadMetadata(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = MetadataResponse.Read(ref reader, version: 13);
+    }
+
+    private static void ReadTopicMetadata(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = TopicMetadata.Read(ref reader, version: 13);
+    }
+
+    private static void ReadPartitionMetadata(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = PartitionMetadata.Read(ref reader, version: 13);
+    }
+
+    private static void ReadOffsetFetchResponse(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetFetchResponse.Read(ref reader, version);
+    }
+
+    private static void ReadOffsetFetchTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetFetchResponseTopic.Read(ref reader, version: 10);
+    }
+
+    private static void ReadOffsetFetchGroup(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetFetchResponseGroup.Read(ref reader, version: 10);
+    }
+
+    private static void ReadAddPartitionsToTxnResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = AddPartitionsToTxnResponse.Read(ref reader, version: 3);
+    }
+
+    private static void ReadAddPartitionsToTxnTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = AddPartitionsToTxnTopicResult.Read(ref reader, version: 3);
+    }
+
+    private static void ReadShareFetchResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ShareFetchResponse.Read(ref reader, version: 0);
+    }
+
+    private static void ReadShareFetchTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ShareFetchResponseTopic.Read(ref reader, version: 0);
+    }
+
+    private static void ReadShareFetchPartition(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ShareFetchResponsePartition.Read(ref reader, version: 0);
+    }
+
+    private static void ReadDescribeShareGroupOffsetsGroup(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeShareGroupOffsetsRequestGroup.Read(ref reader);
+    }
+
+    private static void ReadDescribeShareGroupOffsetsTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeShareGroupOffsetsRequestTopic.Read(ref reader);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
@@ -1,0 +1,39 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Protocol;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class ResponseArrayBoundsBenchmarks
+{
+    private ReadOnlyMemory<byte> _payload;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUnsignedVarInt(101);
+        for (var i = 0; i < 100; i++)
+            writer.WriteInt32(i);
+        _payload = buffer.WrittenMemory;
+    }
+
+    [Benchmark(Baseline = true)]
+    public int[] ReadCompactArray_Unbounded()
+    {
+        var reader = new KafkaProtocolReader(_payload);
+        return reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+    }
+
+    [Benchmark]
+    public int[] ReadCompactArray_MinimumSizeBound()
+    {
+        var reader = new KafkaProtocolReader(_payload);
+        return reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: int.MaxValue);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
@@ -34,6 +34,6 @@ public class ResponseArrayBoundsBenchmarks
         return reader.ReadCompactArray(
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
-            maxCount: int.MaxValue);
+            maxCount: 1_000_000);
     }
 }


### PR DESCRIPTION
## Summary
- validate Metadata, OffsetFetch, legacy AddPartitionsToTxn, and ShareFetch array counts against each element's minimum wire size before allocation
- add the request-side DescribeShareGroupOffsets guard from the issue
- include ApiVersions arrays identified in the #2386 follow-up review, with a minimum-size-aware legacy `ReadArray` overload
- add 22 hostile-count regression cases and a permanent MemoryDiagnoser benchmark

## Performance evidence

Commit: `8efed5783c9817a13f8098713bcda73b3850e9ab`

Local same-process comparator on Windows 11, i7-12700K, .NET 10.0.10, BenchmarkDotNet ShortRun (3 warmups, 3 measured iterations):

| Path | Mean | Allocated | Gen0 |
|---|---:|---:|---:|
| Existing unbounded compact-array read | 140.8 ns | 424 B | 0.0324 |
| Minimum-wire-size bounded read | 126.9 ns | 424 B | 0.0324 |

Delta: -9.9% mean time, 0 B allocation delta, identical Gen0. This is a within-run exact-payload comparator; no protected metric regressed. Allocations are the returned response array itself, unchanged by the guard. p50/p99/max client latency and stress stability are not applicable to this deterministic per-response parser microbenchmark; no producer/consumer per-message path changed, so no paid stress lane was dispatched.

## Validation
- focused hostile-count tests: 23/23
- unit tests net10.0: 6396/6396
- unit tests net8.0: 6269/6269
- response parser fuzz corpus: 7/7
- full Release build: 0 warnings, 0 errors
- scoped whitespace + analyzer format: clean

Closes #2389
