### PR TITLE
Bound classic group response arrays

### DIFF
--- a/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupDescribeResponse.cs
@@ -25,7 +25,10 @@ public sealed class ConsumerGroupDescribeResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
 
         var groups = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => ConsumerGroupDescribeGroup.Read(ref r, version));
+            static (ref KafkaProtocolReader r, short v) => ConsumerGroupDescribeGroup.Read(ref r, v),
+            version,
+            minElementSize: 20,
+            maxCount: ResponseArrayLimits.MaxGroupCount);
 
         reader.SkipTaggedFields();
 
@@ -81,7 +84,10 @@ public sealed class ConsumerGroupDescribeGroup
         var assignorName = reader.ReadCompactString() ?? string.Empty;
 
         var members = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => ConsumerGroupDescribeMember.Read(ref r, version));
+            static (ref KafkaProtocolReader r, short v) => ConsumerGroupDescribeMember.Read(ref r, v),
+            version,
+            minElementSize: version >= 1 ? 17 : 16,
+            maxCount: ResponseArrayLimits.MaxMemberCount);
 
         var authorizedOperations = reader.ReadInt32();
         reader.SkipTaggedFields();
@@ -153,7 +159,9 @@ public sealed class ConsumerGroupDescribeMember
         var clientHost = reader.ReadCompactString() ?? string.Empty;
 
         var subscribedTopicNames = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty,
+            minElementSize: 1,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         var subscribedTopicRegex = reader.ReadCompactString();
         var assignment = ConsumerGroupDescribeAssignment.Read(ref reader);
@@ -198,7 +206,9 @@ public sealed class ConsumerGroupDescribeAssignment
     public static ConsumerGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
     {
         var topicPartitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ConsumerGroupDescribeTopicPartitions.Read(ref r));
+            static (ref KafkaProtocolReader r) => ConsumerGroupDescribeTopicPartitions.Read(ref r),
+            minElementSize: 19,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -233,7 +243,9 @@ public sealed class ConsumerGroupDescribeTopicPartitions
         var topicId = reader.ReadUuid();
         var topicName = reader.ReadCompactString() ?? string.Empty;
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatRequest.cs
@@ -132,7 +132,9 @@ public sealed class ConsumerGroupHeartbeatTopicPartitions
     {
         var topicId = reader.ReadUuid();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         IReadOnlyList<int> newPartitions = [];
         var taggedFieldCount = reader.ReadUnsignedVarInt();
@@ -144,7 +146,9 @@ public sealed class ConsumerGroupHeartbeatTopicPartitions
             if (version >= 2 && tag == 0)
             {
                 newPartitions = reader.ReadCompactArray(
-                    static (ref KafkaProtocolReader r) => r.ReadInt32());
+                    static (ref KafkaProtocolReader r) => r.ReadInt32(),
+                    minElementSize: 4,
+                    maxCount: ResponseArrayLimits.MaxPartitionCount);
             }
             else
             {

--- a/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ConsumerGroupHeartbeatResponse.cs
@@ -108,7 +108,9 @@ public sealed class ConsumerGroupHeartbeatAssignment
         // PendingTopicPartitions is not present as a positional field in any version.
         var assignedTopicPartitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => ConsumerGroupHeartbeatTopicPartitions.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 18,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DeleteGroupsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteGroupsResponse.cs
@@ -27,7 +27,10 @@ public sealed class DeleteGroupsResponse : IKafkaResponse
 
         IReadOnlyList<DeleteGroupsResponseResult> results;
         results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteGroupsResponseResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DeleteGroupsResponseResult.Read(ref r, v),
+            version,
+            minElementSize: 4,
+            maxCount: ResponseArrayLimits.MaxGroupCount) ?? [];
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeGroupsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeGroupsResponse.cs
@@ -27,7 +27,9 @@ public sealed class DescribeGroupsResponse : IKafkaResponse
 
         var groups = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeGroupsResponseGroup.Read(ref r, v),
-            version);
+            version,
+            minElementSize: version >= 6 ? 13 : 12,
+            maxCount: ResponseArrayLimits.MaxGroupCount);
 
         reader.SkipTaggedFields();
 
@@ -99,7 +101,9 @@ public sealed class DescribeGroupsResponseGroup
 
         var members = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeGroupsResponseMember.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 7,
+            maxCount: ResponseArrayLimits.MaxMemberCount);
 
         var authorizedOperations = reader.ReadInt32();
 

--- a/src/Dekaf/Protocol/Messages/FindCoordinatorResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FindCoordinatorResponse.cs
@@ -23,7 +23,11 @@ public sealed class FindCoordinatorResponse : IKafkaResponse
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var throttleTimeMs = reader.ReadInt32();
-        var coordinators = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => Coordinator.Read(ref r, v), version);
+        var coordinators = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => Coordinator.Read(ref r, v),
+            version,
+            minElementSize: 14,
+            maxCount: ResponseArrayLimits.MaxCoordinatorCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/LeaveGroupResponse.cs
+++ b/src/Dekaf/Protocol/Messages/LeaveGroupResponse.cs
@@ -21,10 +21,14 @@ public sealed class LeaveGroupResponse : IKafkaResponse
         var members = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => LeaveGroupResponseMember.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 5,
+                maxCount: ResponseArrayLimits.MaxMemberCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => LeaveGroupResponseMember.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 6,
+                maxCount: ResponseArrayLimits.MaxMemberCount);
 
         if (flexible)
         {

--- a/src/Dekaf/Protocol/Messages/ListGroupsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ListGroupsResponse.cs
@@ -32,8 +32,17 @@ public sealed class ListGroupsResponse : IKafkaResponse
         var errorCode = (ErrorCode)reader.ReadInt16();
 
         IReadOnlyList<ListGroupsResponseGroup> groups;
+        var minGroupSize = version switch
+        {
+            >= 5 => 5,
+            >= 4 => 4,
+            _ => 3
+        };
         groups = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => ListGroupsResponseGroup.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => ListGroupsResponseGroup.Read(ref r, v),
+            version,
+            minElementSize: minGroupSize,
+            maxCount: ResponseArrayLimits.MaxGroupCount) ?? [];
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/OffsetCommitResponse.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetCommitResponse.cs
@@ -22,7 +22,11 @@ public sealed class OffsetCommitResponse : IKafkaResponse
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var throttleTimeMs = reader.ReadInt32();
-        var topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetCommitResponseTopic.Read(ref r, v), version);
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => OffsetCommitResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: version >= OffsetCommitRequest.TopicIdVersion ? 18 : 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -49,7 +53,11 @@ public sealed class OffsetCommitResponseTopic
             ? string.Empty
             : reader.ReadCompactNonNullableString();
         var topicId = version >= OffsetCommitRequest.TopicIdVersion ? reader.ReadUuid() : Guid.Empty;
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => OffsetCommitResponsePartition.Read(ref r, v), version);
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => OffsetCommitResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 7,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/OffsetDeleteResponse.cs
+++ b/src/Dekaf/Protocol/Messages/OffsetDeleteResponse.cs
@@ -32,7 +32,10 @@ public sealed class OffsetDeleteResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
 
         var topics = reader.ReadArray(
-            (ref KafkaProtocolReader r) => OffsetDeleteResponseTopic.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => OffsetDeleteResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: ResponseArrayLimits.MaxTopicCount) ?? [];
 
         return new OffsetDeleteResponse
         {
@@ -63,7 +66,10 @@ public sealed class OffsetDeleteResponseTopic
         var name = reader.ReadString() ?? string.Empty;
 
         var partitions = reader.ReadArray(
-            (ref KafkaProtocolReader r) => OffsetDeleteResponsePartition.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => OffsetDeleteResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: ResponseArrayLimits.MaxPartitionCount) ?? [];
 
         return new OffsetDeleteResponseTopic
         {

--- a/src/Dekaf/Protocol/ResponseArrayLimits.cs
+++ b/src/Dekaf/Protocol/ResponseArrayLimits.cs
@@ -1,0 +1,14 @@
+namespace Dekaf.Protocol;
+
+/// <summary>
+/// Finite semantic limits for broker-controlled response arrays. Minimum wire-size
+/// validation remains the proportional defense for every frame size.
+/// </summary>
+internal static class ResponseArrayLimits
+{
+    internal const int MaxGroupCount = 100_000;
+    internal const int MaxMemberCount = 100_000;
+    internal const int MaxCoordinatorCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
@@ -266,6 +266,253 @@ public sealed class ResponseArrayBoundsTests
             .Throws<MalformedProtocolDataException>();
     }
 
+    [Test]
+    public async Task ConsumerGroupDescribeResponse_Read_GroupCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupDescribeResponse(buffer));
+    }
+
+    [Test]
+    public async Task ConsumerGroupDescribeGroup_Read_MemberCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupDescribeGroup(buffer));
+    }
+
+    [Test]
+    public async Task ConsumerGroupDescribeMember_Read_SubscribedTopicCountExceedingAbsoluteCap_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactNullableString(null);
+        writer.WriteInt32(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        WriteCompactArrayAtAbsoluteCap(ref writer, ResponseArrayLimits.MaxTopicCount);
+
+        await AssertMaximumRejected(
+            () => ReadConsumerGroupDescribeMember(buffer),
+            ResponseArrayLimits.MaxTopicCount + 1,
+            ResponseArrayLimits.MaxTopicCount);
+    }
+
+    [Test]
+    public async Task ConsumerGroupDescribeAssignment_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupDescribeAssignment(buffer));
+    }
+
+    [Test]
+    public async Task ConsumerGroupDescribeTopicPartitions_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupDescribeTopicPartitions(buffer));
+    }
+
+    [Test]
+    public async Task ConsumerGroupHeartbeatAssignment_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupHeartbeatAssignment(buffer));
+    }
+
+    [Test]
+    public async Task ConsumerGroupHeartbeatTopicPartitions_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupHeartbeatTopicPartitions(buffer, version: 0));
+    }
+
+    [Test]
+    public async Task ConsumerGroupHeartbeatTopicPartitions_Read_NewPartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(HostilePayloadLength + 1);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadConsumerGroupHeartbeatTopicPartitions(buffer, version: 2));
+    }
+
+    [Test]
+    public async Task DeleteGroupsResponse_Read_ResultCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDeleteGroupsResponse(buffer));
+    }
+
+    [Test]
+    public async Task DescribeGroupsResponse_Read_GroupCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeGroupsResponse(buffer));
+    }
+
+    [Test]
+    public async Task DescribeGroupsResponse_Read_SegmentedGroupCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), splitAt: 5);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeGroupsResponse(sequence));
+    }
+
+    [Test]
+    public async Task DescribeGroupsResponseGroup_Read_MemberCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactNullableString(null);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeGroupsResponseGroup(buffer));
+    }
+
+    [Test]
+    public async Task FindCoordinatorResponse_Read_CoordinatorCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadFindCoordinatorResponse(buffer));
+    }
+
+    [Test]
+    [Arguments((short)4)]
+    [Arguments((short)5)]
+    public async Task LeaveGroupResponse_Read_MemberCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        if (LeaveGroupRequest.IsFlexibleVersion(version))
+        {
+            WriteHostileCompactArray(ref writer);
+        }
+        else
+        {
+            WriteHostileLegacyArray(ref writer);
+        }
+
+        await AssertMinimumSizeRejected(() => ReadLeaveGroupResponse(buffer, version));
+    }
+
+    [Test]
+    public async Task ListGroupsResponse_Read_GroupCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadListGroupsResponse(buffer));
+    }
+
+    [Test]
+    [Arguments((short)8)]
+    [Arguments((short)10)]
+    public async Task OffsetCommitResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadOffsetCommitResponse(buffer, version));
+    }
+
+    [Test]
+    public async Task OffsetCommitResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadOffsetCommitResponseTopic(buffer));
+    }
+
+    [Test]
+    public async Task OffsetDeleteResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        WriteHostileLegacyArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadOffsetDeleteResponse(buffer));
+    }
+
+    [Test]
+    public async Task OffsetDeleteResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteString(string.Empty);
+        WriteHostileLegacyArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadOffsetDeleteResponseTopic(buffer));
+    }
+
     private static void WriteHostileCompactArray(ref KafkaProtocolWriter writer)
     {
         writer.WriteUnsignedVarInt(HostileElementCount + 1);
@@ -276,6 +523,27 @@ public sealed class ResponseArrayBoundsTests
     {
         writer.WriteInt32(HostileElementCount);
         writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static void WriteCompactArrayAtAbsoluteCap(ref KafkaProtocolWriter writer, int maxCount)
+    {
+        writer.WriteUnsignedVarInt(maxCount + 2);
+        writer.WriteRawBytes(new byte[maxCount + 1]);
+    }
+
+    private static async Task AssertMinimumSizeRejected(Action read)
+    {
+        var exception = Assert.Throws<MalformedProtocolDataException>(read);
+        await Assert.That(exception.Message)
+            .IsEqualTo(
+                $"Invalid protocol data: claimed length {HostileElementCount} exceeds remaining data {HostilePayloadLength}");
+    }
+
+    private static async Task AssertMaximumRejected(Action read, int count, int maxCount)
+    {
+        var exception = Assert.Throws<MalformedProtocolDataException>(read);
+        await Assert.That(exception.Message)
+            .IsEqualTo($"Invalid protocol data: claimed element count {count} exceeds maximum {maxCount}");
     }
 
     private static void WriteShareFetchResponsePreamble(ref KafkaProtocolWriter writer)
@@ -385,5 +653,115 @@ public sealed class ResponseArrayBoundsTests
     {
         var reader = new KafkaProtocolReader(buffer.WrittenMemory);
         _ = DescribeShareGroupOffsetsRequestTopic.Read(ref reader);
+    }
+
+    private static void ReadConsumerGroupDescribeResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupDescribeResponse.Read(ref reader, version: 0);
+    }
+
+    private static void ReadConsumerGroupDescribeGroup(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupDescribeGroup.Read(ref reader, version: 0);
+    }
+
+    private static void ReadConsumerGroupDescribeMember(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupDescribeMember.Read(ref reader, version: 0);
+    }
+
+    private static void ReadConsumerGroupDescribeAssignment(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupDescribeAssignment.Read(ref reader);
+    }
+
+    private static void ReadConsumerGroupDescribeTopicPartitions(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupDescribeTopicPartitions.Read(ref reader);
+    }
+
+    private static void ReadConsumerGroupHeartbeatAssignment(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupHeartbeatAssignment.Read(ref reader, version: 0);
+    }
+
+    private static void ReadConsumerGroupHeartbeatTopicPartitions(
+        ArrayBufferWriter<byte> buffer,
+        short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ConsumerGroupHeartbeatTopicPartitions.Read(ref reader, version);
+    }
+
+    private static void ReadDeleteGroupsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DeleteGroupsResponse.Read(ref reader, version: 2);
+    }
+
+    private static void ReadDescribeGroupsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeGroupsResponse.Read(ref reader, version: 5);
+    }
+
+    private static void ReadDescribeGroupsResponse(ReadOnlySequence<byte> sequence)
+    {
+        var reader = new KafkaProtocolReader(sequence);
+        _ = DescribeGroupsResponse.Read(ref reader, version: 5);
+    }
+
+    private static void ReadDescribeGroupsResponseGroup(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeGroupsResponseGroup.Read(ref reader, version: 5);
+    }
+
+    private static void ReadFindCoordinatorResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = FindCoordinatorResponse.Read(ref reader, version: 4);
+    }
+
+    private static void ReadLeaveGroupResponse(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = LeaveGroupResponse.Read(ref reader, version);
+    }
+
+    private static void ReadListGroupsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ListGroupsResponse.Read(ref reader, version: 3);
+    }
+
+    private static void ReadOffsetCommitResponse(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetCommitResponse.Read(ref reader, version);
+    }
+
+    private static void ReadOffsetCommitResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetCommitResponseTopic.Read(ref reader, version: 10);
+    }
+
+    private static void ReadOffsetDeleteResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetDeleteResponse.Read(ref reader, version: 0);
+    }
+
+    private static void ReadOffsetDeleteResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = OffsetDeleteResponseTopic.Read(ref reader, version: 0);
     }
 }

--- a/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ResponseArrayBoundsTests.cs
@@ -432,6 +432,7 @@ public sealed class ResponseArrayBoundsTests
     }
 
     [Test]
+    [Arguments((short)3)]
     [Arguments((short)4)]
     [Arguments((short)5)]
     public async Task LeaveGroupResponse_Read_MemberCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using BenchmarkDotNet.Attributes;
 using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -8,6 +9,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class ResponseArrayBoundsBenchmarks
 {
     private ReadOnlyMemory<byte> _payload;
+    private ReadOnlyMemory<byte> _consumerGroupDescribePayload;
+    private ReadOnlyMemory<byte> _describeGroupsPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -18,6 +21,44 @@ public class ResponseArrayBoundsBenchmarks
         for (var i = 0; i < 100; i++)
             writer.WriteInt32(i);
         _payload = buffer.WrittenMemory;
+
+        buffer = new ArrayBufferWriter<byte>();
+        writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(101);
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteInt16((short)ErrorCode.None);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteCompactNullableString(null);
+            writer.WriteCompactNullableString(null);
+            writer.WriteUnsignedVarInt(1);
+            writer.WriteInt32(0);
+            writer.WriteEmptyTaggedFields();
+        }
+        writer.WriteEmptyTaggedFields();
+        _describeGroupsPayload = buffer.WrittenMemory;
+
+        buffer = new ArrayBufferWriter<byte>();
+        writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(101);
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteInt16((short)ErrorCode.None);
+            writer.WriteCompactNullableString(null);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteInt32(0);
+            writer.WriteInt32(0);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteUnsignedVarInt(1);
+            writer.WriteInt32(0);
+            writer.WriteEmptyTaggedFields();
+        }
+        writer.WriteEmptyTaggedFields();
+        _consumerGroupDescribePayload = buffer.WrittenMemory;
     }
 
     [Benchmark(Baseline = true)]
@@ -52,5 +93,21 @@ public class ResponseArrayBoundsBenchmarks
             static (ref KafkaProtocolReader r) => r.ReadInt32(),
             minElementSize: 4,
             maxCount: 1_000_000);
+    }
+
+    [Benchmark]
+    public int ReadDescribeGroupsResponse()
+    {
+        var reader = new KafkaProtocolReader(_describeGroupsPayload);
+        var response = (DescribeGroupsResponse)DescribeGroupsResponse.Read(ref reader, version: 5);
+        return response.Groups.Count;
+    }
+
+    [Benchmark]
+    public int ReadConsumerGroupDescribeResponse()
+    {
+        var reader = new KafkaProtocolReader(_consumerGroupDescribePayload);
+        var response = (ConsumerGroupDescribeResponse)ConsumerGroupDescribeResponse.Read(ref reader, version: 0);
+        return response.Groups.Count;
     }
 }


### PR DESCRIPTION
## Summary

- validate all 19 broker-reachable classic group-coordination array allocations against exact, version-aware minimum wire sizes and finite semantic caps before allocation
- cover nested ConsumerGroupHeartbeat partition arrays, including the v2 tagged-field path, and add the missing bounded legacy state-reader overload
- replace touched capturing parser lambdas with static state delegates
- add contiguous/segmented hostile-count regressions and parser benchmarks

## Test plan

- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore` — 0 warnings/errors
- [x] `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/ResponseArrayBoundsTests/*"` — 44/44
- [x] full unit net10.0 — 6417/6417
- [x] full unit net8.0 — 6290/6290
- [x] scoped response-array audit — every selected and nested broker-reachable allocation has `minElementSize` + finite `maxCount`
- [x] `/simplify` — static state delegates remove captured closures; no further performance-safe simplification

## Performance

Immediately preceding product SHA: `b190e9bdbc873bc370c74305e387188af296869e`.
Candidate: `2de96060`.
Same machine/runtime, BenchmarkDotNet `[MemoryDiagnoser]`, serial runs:

| Benchmark | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| `ReadConsumerGroupDescribeResponse` (default job, 100 groups) | 1.953 us / 10.23 KB | 1.879 us / 7.87 KB | -3.8% latency / -2.36 KB |
| `ReadDescribeGroupsResponse` (short job, 100 groups) | 1.776 us / 8056 B | 1.686 us / 8056 B | -5.1% latency / 0 B |
| bounded compact-array helper (candidate short job) | — | 120.5 ns / 424 B | no new allocation |

No producer/consumer per-message path changed; no paid stress lane needed.

Closes #2406
