### PR TITLE
Bound share and streams response arrays

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -912,6 +912,29 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a compact nullable array whose elements have a known minimum encoded size,
+    /// bounding hostile counts before the array allocation.
+    /// </summary>
+    public T[]? ReadCompactNullableArray<T>(ReadFunc<T> readItem, int minElementSize, int maxCount)
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        if (length == 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Skips tagged fields (for flexible versions).
     /// </summary>
     public void SkipTaggedFields()

--- a/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterShareGroupOffsetsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterShareGroupOffsetsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterShareGroupOffsets;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -38,7 +41,9 @@ public sealed class AlterShareGroupOffsetsResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
 
         var responses = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponseTopic.Read(ref r),
+            minElementSize: 19,
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -90,7 +95,9 @@ public sealed class AlterShareGroupOffsetsResponseTopic
         var topicId = reader.ReadUuid();
 
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponsePartition.Read(ref r));
+            static (ref KafkaProtocolReader r) => AlterShareGroupOffsetsResponsePartition.Read(ref r),
+            minElementSize: 8,
+            maxCount: AlterShareGroupOffsetsResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteShareGroupOffsetsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DeleteShareGroupOffsetsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DeleteShareGroupOffsets;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -38,7 +40,9 @@ public sealed class DeleteShareGroupOffsetsResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
 
         var responses = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DeleteShareGroupOffsetsResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => DeleteShareGroupOffsetsResponseTopic.Read(ref r),
+            minElementSize: 21,
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeShareGroupOffsetsResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeShareGroupOffsetsResponse : IKafkaResponse
 {
+    internal const int MaxGroupCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeShareGroupOffsets;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -27,7 +31,9 @@ public sealed class DescribeShareGroupOffsetsResponse : IKafkaResponse
 
         var groups = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponseGroup.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 6,
+            maxCount: MaxGroupCount);
 
         reader.SkipTaggedFields();
 
@@ -85,7 +91,9 @@ public sealed class DescribeShareGroupOffsetsResponseGroup
 
         var topics = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 19,
+            maxCount: DescribeShareGroupOffsetsResponse.MaxTopicCount);
 
         var errorCode = (ErrorCode)reader.ReadInt16();
         var errorMessage = reader.ReadCompactString();
@@ -142,7 +150,9 @@ public sealed class DescribeShareGroupOffsetsResponseTopic
 
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeShareGroupOffsetsResponsePartition.Read(ref r, v),
-            version);
+            version,
+            minElementSize: version >= 1 ? 28 : 20,
+            maxCount: DescribeShareGroupOffsetsResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareAcknowledgeResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ShareAcknowledgeResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxNodeEndpointCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.ShareAcknowledge;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 2;
@@ -53,10 +57,14 @@ public sealed class ShareAcknowledgeResponse : IKafkaResponse
         }
 
         var responses = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponseTopic.Read(ref r),
+            minElementSize: 18,
+            maxCount: MaxTopicCount);
 
         var nodeEndpoints = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareAcknowledgeNodeEndpoint.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeNodeEndpoint.Read(ref r),
+            minElementSize: 11,
+            maxCount: MaxNodeEndpointCount);
 
         reader.SkipTaggedFields();
 
@@ -91,7 +99,9 @@ public sealed class ShareAcknowledgeResponseTopic
     {
         var topicId = reader.ReadUuid();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponsePartition.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareAcknowledgeResponsePartition.Read(ref r),
+            minElementSize: 17,
+            maxCount: ShareAcknowledgeResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupDescribeResponse.cs
@@ -6,6 +6,11 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ShareGroupDescribeResponse : IKafkaResponse
 {
+    internal const int MaxGroupCount = 100_000;
+    internal const int MaxMemberCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ShareGroupDescribe;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 1;
@@ -26,7 +31,9 @@ public sealed class ShareGroupDescribeResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
 
         var groups = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareGroupDescribeGroup.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeGroup.Read(ref r),
+            minElementSize: 20,
+            maxCount: MaxGroupCount);
 
         reader.SkipTaggedFields();
 
@@ -118,7 +125,9 @@ public sealed class ShareGroupDescribeGroup
         var assignorName = reader.ReadCompactString();
 
         var members = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareGroupDescribeMember.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeMember.Read(ref r),
+            minElementSize: 12,
+            maxCount: ShareGroupDescribeResponse.MaxMemberCount);
 
         var authorizedOperations = reader.ReadInt32();
 
@@ -205,7 +214,9 @@ public sealed class ShareGroupDescribeMember
         var clientHost = reader.ReadCompactString() ?? string.Empty;
 
         var subscribedTopicNames = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty,
+            minElementSize: 1,
+            maxCount: ShareGroupDescribeResponse.MaxTopicCount);
 
         var assignment = ShareGroupDescribeAssignment.Read(ref reader);
 
@@ -247,7 +258,9 @@ public sealed class ShareGroupDescribeAssignment
     public static ShareGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
     {
         var topicPartitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareGroupDescribeTopicPartitions.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareGroupDescribeTopicPartitions.Read(ref r),
+            minElementSize: 19,
+            maxCount: ShareGroupDescribeResponse.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -293,7 +306,9 @@ public sealed class ShareGroupDescribeTopicPartitions
         var topicId = reader.ReadUuid();
         var topicName = reader.ReadCompactString();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ShareGroupDescribeResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ShareGroupHeartbeatResponse.cs
@@ -7,6 +7,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ShareGroupHeartbeatResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ShareGroupHeartbeat;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 1;
@@ -95,7 +98,9 @@ public sealed class ShareGroupHeartbeatAssignment
     public static ShareGroupHeartbeatAssignment Read(ref KafkaProtocolReader reader)
     {
         var topicPartitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ShareGroupHeartbeatTopicPartitions.Read(ref r));
+            static (ref KafkaProtocolReader r) => ShareGroupHeartbeatTopicPartitions.Read(ref r),
+            minElementSize: 18,
+            maxCount: ShareGroupHeartbeatResponse.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -134,7 +139,9 @@ public sealed class ShareGroupHeartbeatTopicPartitions
     {
         var topicId = reader.ReadUuid();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ShareGroupHeartbeatResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/StreamsGroupDescribeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/StreamsGroupDescribeResponse.cs
@@ -6,6 +6,15 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class StreamsGroupDescribeResponse : IKafkaResponse
 {
+    internal const int MaxGroupCount = 100_000;
+    internal const int MaxMemberCount = 100_000;
+    internal const int MaxSubtopologyCount = 1_000_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxTopicConfigCount = 100_000;
+    internal const int MaxClientTagCount = 100_000;
+    internal const int MaxTaskCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.StreamsGroupDescribe;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -35,7 +44,9 @@ public sealed class StreamsGroupDescribeResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
 
         var groups = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeGroup.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeGroup.Read(ref r),
+            minElementSize: 20,
+            maxCount: MaxGroupCount);
 
         reader.SkipTaggedFields();
 
@@ -88,7 +99,9 @@ public sealed class StreamsGroupDescribeGroup
         var assignmentEpoch = reader.ReadInt32();
         var topology = StreamsGroupDescribeTopology.ReadNullable(ref reader);
         var members = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeMember.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeMember.Read(ref r),
+            minElementSize: 28,
+            maxCount: StreamsGroupDescribeResponse.MaxMemberCount);
         var authorizedOperations = reader.ReadInt32();
 
         reader.SkipTaggedFields();
@@ -147,7 +160,9 @@ public sealed class StreamsGroupDescribeTopology
 
         var epoch = reader.ReadInt32();
         var subtopologies = reader.ReadCompactNullableArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeSubtopology.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeSubtopology.Read(ref r),
+            minElementSize: 6,
+            maxCount: StreamsGroupDescribeResponse.MaxSubtopologyCount);
 
         reader.SkipTaggedFields();
 
@@ -192,13 +207,21 @@ public sealed class StreamsGroupDescribeSubtopology
     {
         var subtopologyId = reader.ReadCompactString() ?? string.Empty;
         var sourceTopics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty,
+            minElementSize: 1,
+            maxCount: StreamsGroupDescribeResponse.MaxTopicCount);
         var repartitionSinkTopics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty);
+            static (ref KafkaProtocolReader r) => r.ReadCompactString() ?? string.Empty,
+            minElementSize: 1,
+            maxCount: StreamsGroupDescribeResponse.MaxTopicCount);
         var stateChangelogTopics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r),
+            minElementSize: 9,
+            maxCount: StreamsGroupDescribeResponse.MaxTopicCount);
         var repartitionSourceTopics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTopicInfo.Read(ref r),
+            minElementSize: 9,
+            maxCount: StreamsGroupDescribeResponse.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -240,7 +263,9 @@ public sealed class StreamsGroupDescribeTopicInfo
         var partitions = reader.ReadInt32();
         var replicationFactor = reader.ReadInt16();
         var topicConfigs = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r),
+            minElementSize: 3,
+            maxCount: StreamsGroupDescribeResponse.MaxTopicConfigCount);
 
         reader.SkipTaggedFields();
 
@@ -343,11 +368,17 @@ public sealed class StreamsGroupDescribeMember
         var processId = reader.ReadCompactString() ?? string.Empty;
         var userEndpoint = StreamsGroupDescribeEndpoint.ReadNullable(ref reader);
         var clientTags = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeKeyValue.Read(ref r),
+            minElementSize: 3,
+            maxCount: StreamsGroupDescribeResponse.MaxClientTagCount);
         var taskOffsets = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r),
+            minElementSize: 14,
+            maxCount: StreamsGroupDescribeResponse.MaxTaskCount);
         var taskEndOffsets = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskOffset.Read(ref r),
+            minElementSize: 14,
+            maxCount: StreamsGroupDescribeResponse.MaxTaskCount);
         var assignment = StreamsGroupDescribeAssignment.Read(ref reader);
         var targetAssignment = StreamsGroupDescribeAssignment.Read(ref reader);
         var isClassic = reader.ReadBoolean();
@@ -483,11 +514,17 @@ public sealed class StreamsGroupDescribeAssignment
     public static StreamsGroupDescribeAssignment Read(ref KafkaProtocolReader reader)
     {
         var activeTasks = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r),
+            minElementSize: 3,
+            maxCount: StreamsGroupDescribeResponse.MaxTaskCount);
         var standbyTasks = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r),
+            minElementSize: 3,
+            maxCount: StreamsGroupDescribeResponse.MaxTaskCount);
         var warmupTasks = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r));
+            static (ref KafkaProtocolReader r) => StreamsGroupDescribeTaskIds.Read(ref r),
+            minElementSize: 3,
+            maxCount: StreamsGroupDescribeResponse.MaxTaskCount);
 
         reader.SkipTaggedFields();
 
@@ -520,7 +557,10 @@ public sealed class StreamsGroupDescribeTaskIds
     public static StreamsGroupDescribeTaskIds Read(ref KafkaProtocolReader reader)
     {
         var subtopologyId = reader.ReadCompactString() ?? string.Empty;
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: StreamsGroupDescribeResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
@@ -200,6 +200,41 @@ public class ArrayEncodingTests
         await Assert.That(result).IsEquivalentTo([1, 2, 3]);
     }
 
+    [Test]
+    [Arguments(0, true)]
+    [Arguments(1, false)]
+    public async Task CompactNullableArray_Bounded_NullAndEmptyPreserveWireSemantics(
+        byte encodedLength,
+        bool expectNull)
+    {
+        var reader = new KafkaProtocolReader([encodedLength]);
+        var result = reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: 10);
+
+        if (expectNull)
+            await Assert.That(result).IsNull();
+        else
+            await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task CompactNullableArray_Bounded_NonNull_RoundTrip()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactNullableArray<int>([1, 2, 3], static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var result = reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: 10);
+
+        await Assert.That(result).IsEquivalentTo([1, 2, 3]);
+    }
+
     #endregion
 
     #region Nested Array Tests

--- a/tests/Dekaf.Tests.Unit/Protocol/ShareResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ShareResponseArrayBoundsTests.cs
@@ -1,0 +1,366 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class ShareResponseArrayBoundsTests
+{
+    private const int HostileElementCount = 40;
+    private const int HostilePayloadLength = 60;
+    private const int MaxStringElementCount = 1_000_000;
+
+    [Test]
+    [Arguments(ResponseArrayTarget.AlterTopics)]
+    [Arguments(ResponseArrayTarget.AlterPartitions)]
+    [Arguments(ResponseArrayTarget.DeleteTopics)]
+    [Arguments(ResponseArrayTarget.DescribeOffsetGroups)]
+    [Arguments(ResponseArrayTarget.DescribeOffsetTopics)]
+    [Arguments(ResponseArrayTarget.DescribeOffsetPartitionsV0)]
+    [Arguments(ResponseArrayTarget.DescribeOffsetPartitionsV1)]
+    [Arguments(ResponseArrayTarget.AcknowledgeTopics)]
+    [Arguments(ResponseArrayTarget.AcknowledgeNodes)]
+    [Arguments(ResponseArrayTarget.AcknowledgePartitions)]
+    [Arguments(ResponseArrayTarget.ShareDescribeGroups)]
+    [Arguments(ResponseArrayTarget.ShareDescribeMembers)]
+    [Arguments(ResponseArrayTarget.ShareDescribeSubscribedTopics)]
+    [Arguments(ResponseArrayTarget.ShareDescribeTopicPartitions)]
+    [Arguments(ResponseArrayTarget.ShareDescribePartitions)]
+    [Arguments(ResponseArrayTarget.HeartbeatTopicPartitions)]
+    [Arguments(ResponseArrayTarget.HeartbeatPartitions)]
+    [Arguments(ResponseArrayTarget.StreamsGroups)]
+    [Arguments(ResponseArrayTarget.StreamsMembers)]
+    [Arguments(ResponseArrayTarget.StreamsSubtopologies)]
+    [Arguments(ResponseArrayTarget.StreamsSourceTopics)]
+    [Arguments(ResponseArrayTarget.StreamsRepartitionSinkTopics)]
+    [Arguments(ResponseArrayTarget.StreamsStateChangelogTopics)]
+    [Arguments(ResponseArrayTarget.StreamsRepartitionSourceTopics)]
+    [Arguments(ResponseArrayTarget.StreamsTopicConfigs)]
+    [Arguments(ResponseArrayTarget.StreamsClientTags)]
+    [Arguments(ResponseArrayTarget.StreamsTaskOffsets)]
+    [Arguments(ResponseArrayTarget.StreamsTaskEndOffsets)]
+    [Arguments(ResponseArrayTarget.StreamsActiveTasks)]
+    [Arguments(ResponseArrayTarget.StreamsStandbyTasks)]
+    [Arguments(ResponseArrayTarget.StreamsWarmupTasks)]
+    [Arguments(ResponseArrayTarget.StreamsTaskPartitions)]
+    public async Task Read_HostileArrayCount_RejectsBeforeAllocation(ResponseArrayTarget target)
+    {
+        var payload = CreatePayload(target);
+        var expectedMessage = UsesAbsoluteCap(target) ? "exceeds maximum" : "Invalid protocol data";
+
+        await Assert.That(() => ReadContiguous(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>()
+            .WithMessageContaining(expectedMessage);
+        await Assert.That(() => ReadSegmented(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>()
+            .WithMessageContaining(expectedMessage);
+    }
+
+    private static byte[] CreatePayload(ResponseArrayTarget target)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        switch (target)
+        {
+            case ResponseArrayTarget.AlterTopics:
+            case ResponseArrayTarget.DeleteTopics:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ResponseArrayTarget.AlterPartitions:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteUuid(Guid.Empty);
+                break;
+            case ResponseArrayTarget.DescribeOffsetGroups:
+            case ResponseArrayTarget.ShareDescribeGroups:
+            case ResponseArrayTarget.StreamsGroups:
+                writer.WriteInt32(0);
+                break;
+            case ResponseArrayTarget.DescribeOffsetTopics:
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ResponseArrayTarget.DescribeOffsetPartitionsV0:
+            case ResponseArrayTarget.DescribeOffsetPartitionsV1:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteUuid(Guid.Empty);
+                break;
+            case ResponseArrayTarget.AcknowledgeTopics:
+                WriteAcknowledgePreamble(ref writer);
+                break;
+            case ResponseArrayTarget.AcknowledgeNodes:
+                WriteAcknowledgePreamble(ref writer);
+                writer.WriteUnsignedVarInt(1);
+                break;
+            case ResponseArrayTarget.AcknowledgePartitions:
+                writer.WriteUuid(Guid.Empty);
+                break;
+            case ResponseArrayTarget.ShareDescribeMembers:
+                WriteShareDescribeGroupPreamble(ref writer);
+                break;
+            case ResponseArrayTarget.ShareDescribeSubscribedTopics:
+                WriteShareDescribeMemberPreamble(ref writer);
+                break;
+            case ResponseArrayTarget.ShareDescribeTopicPartitions:
+                break;
+            case ResponseArrayTarget.ShareDescribePartitions:
+                writer.WriteUuid(Guid.Empty);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ResponseArrayTarget.HeartbeatTopicPartitions:
+                break;
+            case ResponseArrayTarget.HeartbeatPartitions:
+                writer.WriteUuid(Guid.Empty);
+                break;
+            case ResponseArrayTarget.StreamsMembers:
+                WriteStreamsGroupPreamble(ref writer);
+                break;
+            case ResponseArrayTarget.StreamsSubtopologies:
+                writer.WriteInt8(1);
+                writer.WriteInt32(0);
+                break;
+            case ResponseArrayTarget.StreamsSourceTopics:
+            case ResponseArrayTarget.StreamsRepartitionSinkTopics:
+            case ResponseArrayTarget.StreamsStateChangelogTopics:
+            case ResponseArrayTarget.StreamsRepartitionSourceTopics:
+                writer.WriteCompactString(string.Empty);
+                WriteEmptyArraysBefore(ref writer, target - ResponseArrayTarget.StreamsSourceTopics);
+                break;
+            case ResponseArrayTarget.StreamsTopicConfigs:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteInt32(0);
+                writer.WriteInt16(0);
+                break;
+            case ResponseArrayTarget.StreamsClientTags:
+            case ResponseArrayTarget.StreamsTaskOffsets:
+            case ResponseArrayTarget.StreamsTaskEndOffsets:
+                WriteStreamsMemberPreamble(ref writer);
+                WriteEmptyArraysBefore(ref writer, target - ResponseArrayTarget.StreamsClientTags);
+                break;
+            case ResponseArrayTarget.StreamsActiveTasks:
+            case ResponseArrayTarget.StreamsStandbyTasks:
+            case ResponseArrayTarget.StreamsWarmupTasks:
+                WriteEmptyArraysBefore(ref writer, target - ResponseArrayTarget.StreamsActiveTasks);
+                break;
+            case ResponseArrayTarget.StreamsTaskPartitions:
+                writer.WriteCompactString(string.Empty);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+
+        if (UsesAbsoluteCap(target))
+        {
+            writer.WriteUnsignedVarInt(MaxStringElementCount + 2);
+            writer.WriteRawBytes(new byte[MaxStringElementCount + 1]);
+        }
+        else
+        {
+            writer.WriteUnsignedVarInt(HostileElementCount + 1);
+            writer.WriteRawBytes(new byte[HostilePayloadLength]);
+        }
+
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteAcknowledgePreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+    }
+
+    private static void WriteShareDescribeGroupPreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteCompactNullableString(null);
+    }
+
+    private static void WriteShareDescribeMemberPreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactNullableString(null);
+        writer.WriteInt32(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+    }
+
+    private static void WriteStreamsGroupPreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteInt8(-1);
+    }
+
+    private static void WriteStreamsMemberPreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactNullableString(null);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt8(-1);
+    }
+
+    private static void WriteEmptyArraysBefore(ref KafkaProtocolWriter writer, int count)
+    {
+        for (var index = 0; index < count; index++)
+            writer.WriteUnsignedVarInt(1);
+    }
+
+    private static bool UsesAbsoluteCap(ResponseArrayTarget target) =>
+        target is ResponseArrayTarget.ShareDescribeSubscribedTopics
+            or ResponseArrayTarget.StreamsSourceTopics
+            or ResponseArrayTarget.StreamsRepartitionSinkTopics;
+
+    private static void ReadContiguous(byte[] payload, ResponseArrayTarget target)
+    {
+        var reader = new KafkaProtocolReader(payload);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadSegmented(byte[] payload, ResponseArrayTarget target)
+    {
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(payload, payload.Length / 2);
+        var reader = new KafkaProtocolReader(sequence);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadTarget(ref KafkaProtocolReader reader, ResponseArrayTarget target)
+    {
+        switch (target)
+        {
+            case ResponseArrayTarget.AlterTopics:
+                _ = AlterShareGroupOffsetsResponse.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.AlterPartitions:
+                _ = AlterShareGroupOffsetsResponseTopic.Read(ref reader);
+                break;
+            case ResponseArrayTarget.DeleteTopics:
+                _ = DeleteShareGroupOffsetsResponse.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.DescribeOffsetGroups:
+                _ = DescribeShareGroupOffsetsResponse.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.DescribeOffsetTopics:
+                _ = DescribeShareGroupOffsetsResponseGroup.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.DescribeOffsetPartitionsV0:
+                _ = DescribeShareGroupOffsetsResponseTopic.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.DescribeOffsetPartitionsV1:
+                _ = DescribeShareGroupOffsetsResponseTopic.Read(ref reader, version: 1);
+                break;
+            case ResponseArrayTarget.AcknowledgeTopics:
+            case ResponseArrayTarget.AcknowledgeNodes:
+                _ = ShareAcknowledgeResponse.Read(ref reader, version: 1);
+                break;
+            case ResponseArrayTarget.AcknowledgePartitions:
+                _ = ShareAcknowledgeResponseTopic.Read(ref reader);
+                break;
+            case ResponseArrayTarget.ShareDescribeGroups:
+                _ = ShareGroupDescribeResponse.Read(ref reader, version: 1);
+                break;
+            case ResponseArrayTarget.ShareDescribeMembers:
+                _ = ShareGroupDescribeGroup.Read(ref reader);
+                break;
+            case ResponseArrayTarget.ShareDescribeSubscribedTopics:
+                _ = ShareGroupDescribeMember.Read(ref reader);
+                break;
+            case ResponseArrayTarget.ShareDescribeTopicPartitions:
+                _ = ShareGroupDescribeAssignment.Read(ref reader);
+                break;
+            case ResponseArrayTarget.ShareDescribePartitions:
+                _ = ShareGroupDescribeTopicPartitions.Read(ref reader);
+                break;
+            case ResponseArrayTarget.HeartbeatTopicPartitions:
+                _ = ShareGroupHeartbeatAssignment.Read(ref reader);
+                break;
+            case ResponseArrayTarget.HeartbeatPartitions:
+                _ = ShareGroupHeartbeatTopicPartitions.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsGroups:
+                _ = StreamsGroupDescribeResponse.Read(ref reader, version: 0);
+                break;
+            case ResponseArrayTarget.StreamsMembers:
+                _ = StreamsGroupDescribeGroup.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsSubtopologies:
+                _ = StreamsGroupDescribeTopology.ReadNullable(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsSourceTopics:
+            case ResponseArrayTarget.StreamsRepartitionSinkTopics:
+            case ResponseArrayTarget.StreamsStateChangelogTopics:
+            case ResponseArrayTarget.StreamsRepartitionSourceTopics:
+                _ = StreamsGroupDescribeSubtopology.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsTopicConfigs:
+                _ = StreamsGroupDescribeTopicInfo.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsClientTags:
+            case ResponseArrayTarget.StreamsTaskOffsets:
+            case ResponseArrayTarget.StreamsTaskEndOffsets:
+                _ = StreamsGroupDescribeMember.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsActiveTasks:
+            case ResponseArrayTarget.StreamsStandbyTasks:
+            case ResponseArrayTarget.StreamsWarmupTasks:
+                _ = StreamsGroupDescribeAssignment.Read(ref reader);
+                break;
+            case ResponseArrayTarget.StreamsTaskPartitions:
+                _ = StreamsGroupDescribeTaskIds.Read(ref reader);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+    }
+
+    public enum ResponseArrayTarget
+    {
+        AlterTopics,
+        AlterPartitions,
+        DeleteTopics,
+        DescribeOffsetGroups,
+        DescribeOffsetTopics,
+        DescribeOffsetPartitionsV0,
+        DescribeOffsetPartitionsV1,
+        AcknowledgeTopics,
+        AcknowledgeNodes,
+        AcknowledgePartitions,
+        ShareDescribeGroups,
+        ShareDescribeMembers,
+        ShareDescribeSubscribedTopics,
+        ShareDescribeTopicPartitions,
+        ShareDescribePartitions,
+        HeartbeatTopicPartitions,
+        HeartbeatPartitions,
+        StreamsGroups,
+        StreamsMembers,
+        StreamsSubtopologies,
+        StreamsSourceTopics,
+        StreamsRepartitionSinkTopics,
+        StreamsStateChangelogTopics,
+        StreamsRepartitionSourceTopics,
+        StreamsTopicConfigs,
+        StreamsClientTags,
+        StreamsTaskOffsets,
+        StreamsTaskEndOffsets,
+        StreamsActiveTasks,
+        StreamsStandbyTasks,
+        StreamsWarmupTasks,
+        StreamsTaskPartitions
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ResponseArrayBoundsBenchmarks.cs
@@ -36,4 +36,21 @@ public class ResponseArrayBoundsBenchmarks
             minElementSize: 4,
             maxCount: 1_000_000);
     }
+
+    [Benchmark]
+    public int[]? ReadCompactNullableArray_Unbounded()
+    {
+        var reader = new KafkaProtocolReader(_payload);
+        return reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+    }
+
+    [Benchmark]
+    public int[]? ReadCompactNullableArray_MinimumSizeBound()
+    {
+        var reader = new KafkaProtocolReader(_payload);
+        return reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: 1_000_000);
+    }
 }


### PR DESCRIPTION
## Summary
- bound every broker-controlled compact array in share-group and streams-group responses using exact minimum wire sizes and finite semantic caps
- add bounded compact-nullable array parsing while preserving null and empty encodings
- cover all 32 allocation targets with contiguous and segmented hostile-count tests

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused protocol suites: 193 passed
- [x] full unit tests net10.0: 6431 passed
- [x] full unit tests net8.0: 6304 passed
- [x] `ResponseArrayBoundsBenchmarks` ShortRun with `[MemoryDiagnoser]`

## Performance

Same machine/runtime (.NET 10.0.10, i7-12700K), BenchmarkDotNet ShortRun:

| Parser | Unbounded | Bounded | Delta | Allocated |
|---|---:|---:|---:|---:|
| Compact array | 156.7 ns | 125.4 ns | -20.0% | 424 B → 424 B |
| Compact nullable array | 147.2 ns | 141.1 ns | -4.1% | 424 B → 424 B |

Allocated bytes come from the returned 100-element `int[]`; guard allocation delta is 0 B. Pre-change control run likewise showed 424 B → 424 B (186.1 ns unbounded, 169.5 ns bounded). No parser regression observed.

Closes #2407
