### PR TITLE
Bound topology and quorum response arrays

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -912,6 +912,29 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a compact nullable array whose elements have a known minimum encoded size,
+    /// bounding hostile counts before the array allocation.
+    /// </summary>
+    public T[]? ReadCompactNullableArray<T>(ReadFunc<T> readItem, int minElementSize, int maxCount)
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        if (length == 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Skips tagged fields (for flexible versions).
     /// </summary>
     public void SkipTaggedFields()
@@ -977,6 +1000,30 @@ public ref struct KafkaProtocolReader
             return [];
 
         ValidateReadableLength(length);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this, state);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Reads a legacy array whose elements have a known minimum encoded size, bounding
+    /// hostile counts before the array allocation. State-passing overload avoids closures.
+    /// </summary>
+    public T[] ReadArray<T, TState>(
+        ReadFunc<T, TState> readItem,
+        TState state,
+        int minElementSize,
+        int maxCount)
+    {
+        var length = ReadInt32();
+        if (length <= 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
 
         var result = new T[length];
         for (var i = 0; i < length; i++)

--- a/src/Dekaf/Protocol/Messages/AlterPartitionReassignmentsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterPartitionReassignmentsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterPartitionReassignmentsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterPartitionReassignments;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -43,7 +46,9 @@ public sealed class AlterPartitionReassignmentsResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
         var responses = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => AlterPartitionReassignmentsResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 3,
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -78,7 +83,9 @@ public sealed class AlterPartitionReassignmentsResponseTopic
         var name = reader.ReadCompactString() ?? string.Empty;
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => AlterPartitionReassignmentsResponsePartition.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 8,
+            maxCount: AlterPartitionReassignmentsResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterReplicaLogDirsResponse.cs
@@ -5,6 +5,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterReplicaLogDirsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterReplicaLogDirs;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 2;
@@ -25,10 +28,14 @@ public sealed class AlterReplicaLogDirsResponse : IKafkaResponse
         var results = version >= 2
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponseTopic.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 3,
+                maxCount: MaxTopicCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponseTopic.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 6,
+                maxCount: MaxTopicCount);
 
         if (version >= 2)
         {
@@ -60,10 +67,14 @@ public sealed class AlterReplicaLogDirsResponseTopic
         var partitions = version >= 2
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponsePartition.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 7,
+                maxCount: AlterReplicaLogDirsResponse.MaxPartitionCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => AlterReplicaLogDirsResponsePartition.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 6,
+                maxCount: AlterReplicaLogDirsResponse.MaxPartitionCount);
 
         if (version >= 2)
         {

--- a/src/Dekaf/Protocol/Messages/DescribeLogDirsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeLogDirsResponse.cs
@@ -5,6 +5,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeLogDirsResponse : IKafkaResponse
 {
+    internal const int MaxLogDirCount = 100_000;
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeLogDirs;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 5;
@@ -28,14 +32,25 @@ public sealed class DescribeLogDirsResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = version >= 3 ? (ErrorCode)reader.ReadInt16() : ErrorCode.None;
+        var minLogDirSize = version switch
+        {
+            >= 5 => 22,
+            >= 4 => 21,
+            >= 2 => 5,
+            _ => 8
+        };
 
         var results = version >= 2
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseDir.Read(ref r, v),
-                version)
+                version,
+                minElementSize: minLogDirSize,
+                maxCount: MaxLogDirCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseDir.Read(ref r, v),
-                version);
+                version,
+                minElementSize: minLogDirSize,
+                maxCount: MaxLogDirCount);
 
         if (version >= 2)
         {
@@ -73,10 +88,14 @@ public sealed class DescribeLogDirsResponseDir
         var topics = version >= 2
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseTopic.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 3,
+                maxCount: DescribeLogDirsResponse.MaxTopicCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponseTopic.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 6,
+                maxCount: DescribeLogDirsResponse.MaxTopicCount);
 
         long? totalBytes = null;
         long? usableBytes = null;
@@ -127,10 +146,14 @@ public sealed class DescribeLogDirsResponseTopic
         var partitions = version >= 2
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponsePartition.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 22,
+                maxCount: DescribeLogDirsResponse.MaxPartitionCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeLogDirsResponsePartition.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 21,
+                maxCount: DescribeLogDirsResponse.MaxPartitionCount);
 
         if (version >= 2)
         {

--- a/src/Dekaf/Protocol/Messages/DescribeQuorumResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeQuorumResponse.cs
@@ -6,6 +6,12 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeQuorumResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxReplicaCount = 100_000;
+    internal const int MaxNodeCount = 100_000;
+    internal const int MaxListenerCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeQuorum;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 2;
@@ -21,9 +27,14 @@ public sealed class DescribeQuorumResponse : IKafkaResponse
         var errorMessage = version >= 2 ? reader.ReadCompactString() : null;
         var topics = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeQuorumResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 3,
+            maxCount: MaxTopicCount);
         var nodes = version >= 2
-            ? reader.ReadCompactArray(static (ref KafkaProtocolReader r) => DescribeQuorumResponseNode.Read(ref r))
+            ? reader.ReadCompactArray(
+                static (ref KafkaProtocolReader r) => DescribeQuorumResponseNode.Read(ref r),
+                minElementSize: 6,
+                maxCount: MaxNodeCount)
             : [];
 
         reader.SkipTaggedFields();
@@ -48,7 +59,9 @@ public sealed class DescribeQuorumResponseTopic
         var topicName = reader.ReadCompactString() ?? string.Empty;
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeQuorumResponsePartition.Read(ref r, v),
-            version);
+            version,
+            minElementSize: version >= 2 ? 26 : 25,
+            maxCount: DescribeQuorumResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 
@@ -79,12 +92,22 @@ public sealed class DescribeQuorumResponsePartition
         var leaderId = reader.ReadInt32();
         var leaderEpoch = reader.ReadInt32();
         var highWatermark = reader.ReadInt64();
+        var minReplicaSize = version switch
+        {
+            >= 2 => 45,
+            >= 1 => 29,
+            _ => 13
+        };
         var currentVoters = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeQuorumReplicaState.Read(ref r, v),
-            version);
+            version,
+            minElementSize: minReplicaSize,
+            maxCount: DescribeQuorumResponse.MaxReplicaCount);
         var observers = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeQuorumReplicaState.Read(ref r, v),
-            version);
+            version,
+            minElementSize: minReplicaSize,
+            maxCount: DescribeQuorumResponse.MaxReplicaCount);
 
         reader.SkipTaggedFields();
 
@@ -139,7 +162,10 @@ public sealed class DescribeQuorumResponseNode
     public static DescribeQuorumResponseNode Read(ref KafkaProtocolReader reader)
     {
         var nodeId = reader.ReadInt32();
-        var listeners = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => RaftVoterEndpointData.Read(ref r));
+        var listeners = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => RaftVoterEndpointData.Read(ref r),
+            minElementSize: 5,
+            maxCount: DescribeQuorumResponse.MaxListenerCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeTopicPartitionsResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeTopicPartitionsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxReplicaCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeTopicPartitions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -18,7 +22,9 @@ public sealed class DescribeTopicPartitionsResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
         var topics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponseTopic.Read(ref r),
+            minElementSize: 26,
+            maxCount: MaxTopicCount);
         var nextCursor = DescribeTopicPartitionsResponseCursor.ReadNullable(ref reader);
 
         reader.SkipTaggedFields();
@@ -48,7 +54,9 @@ public sealed class DescribeTopicPartitionsResponseTopic
         var topicId = reader.ReadUuid();
         var isInternal = reader.ReadBoolean();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponsePartition.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeTopicPartitionsResponsePartition.Read(ref r),
+            minElementSize: 20,
+            maxCount: DescribeTopicPartitionsResponse.MaxPartitionCount);
         var topicAuthorizedOperations = reader.ReadInt32();
 
         reader.SkipTaggedFields();
@@ -83,11 +91,26 @@ public sealed class DescribeTopicPartitionsResponsePartition
         var partitionIndex = reader.ReadInt32();
         var leaderId = reader.ReadInt32();
         var leaderEpoch = reader.ReadInt32();
-        var replicaNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var isrNodes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var eligibleLeaderReplicas = reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var lastKnownElr = reader.ReadCompactNullableArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var offlineReplicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var replicaNodes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: DescribeTopicPartitionsResponse.MaxReplicaCount);
+        var isrNodes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: DescribeTopicPartitionsResponse.MaxReplicaCount);
+        var eligibleLeaderReplicas = reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: DescribeTopicPartitionsResponse.MaxReplicaCount);
+        var lastKnownElr = reader.ReadCompactNullableArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: DescribeTopicPartitionsResponse.MaxReplicaCount);
+        var offlineReplicas = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: DescribeTopicPartitionsResponse.MaxReplicaCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ElectLeadersResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ElectLeadersResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ElectLeadersResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ElectLeaders;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 2;
@@ -32,9 +35,11 @@ public sealed class ElectLeadersResponse : IKafkaResponse
         // ErrorCode is only in v1+
         var errorCode = (ErrorCode)reader.ReadInt16();
 
-        IReadOnlyList<ElectLeadersResponseTopic> results;
-        results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => ElectLeadersResponseTopic.Read(ref r, version)) ?? [];
+        var results = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ElectLeadersResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: 3,
+            maxCount: MaxTopicCount);
         reader.SkipTaggedFields();
 
         return new ElectLeadersResponse
@@ -65,9 +70,11 @@ public sealed class ElectLeadersResponseTopic
     {
         var topic = reader.ReadCompactString() ?? string.Empty;
 
-        IReadOnlyList<ElectLeadersResponsePartition> partitions;
-        partitions = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => ElectLeadersResponsePartition.Read(ref r, version)) ?? [];
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ElectLeadersResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 8,
+            maxCount: ElectLeadersResponse.MaxPartitionCount);
         reader.SkipTaggedFields();
 
         return new ElectLeadersResponseTopic

--- a/src/Dekaf/Protocol/Messages/ListPartitionReassignmentsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ListPartitionReassignmentsResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ListPartitionReassignmentsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxPartitionCount = 1_000_000;
+    internal const int MaxReplicaCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.ListPartitionReassignments;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -37,7 +41,9 @@ public sealed class ListPartitionReassignmentsResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
         var topics = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => ListPartitionReassignmentsResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 3,
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -71,7 +77,9 @@ public sealed class ListPartitionReassignmentsResponseTopic
         var name = reader.ReadCompactString() ?? string.Empty;
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => OngoingPartitionReassignmentData.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 8,
+            maxCount: ListPartitionReassignmentsResponse.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 
@@ -111,9 +119,18 @@ public sealed class OngoingPartitionReassignmentData
     public static OngoingPartitionReassignmentData Read(ref KafkaProtocolReader reader, short version)
     {
         var partitionIndex = reader.ReadInt32();
-        var replicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var addingReplicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
-        var removingReplicas = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt32());
+        var replicas = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ListPartitionReassignmentsResponse.MaxReplicaCount);
+        var addingReplicas = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ListPartitionReassignmentsResponse.MaxReplicaCount);
+        var removingReplicas = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ListPartitionReassignmentsResponse.MaxReplicaCount);
 
         reader.SkipTaggedFields();
 

--- a/tests/Dekaf.Tests.Unit/Protocol/TopologyResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TopologyResponseArrayBoundsTests.cs
@@ -1,0 +1,389 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class TopologyResponseArrayBoundsTests
+{
+    private const int HostileElementCount = 40;
+    private const int HostilePayloadLength = 60;
+
+    [Test]
+    [Arguments(ArrayTarget.AlterReassignmentTopicsV0)]
+    [Arguments(ArrayTarget.AlterReassignmentTopicsV1)]
+    [Arguments(ArrayTarget.AlterReassignmentPartitions)]
+    [Arguments(ArrayTarget.ListReassignmentTopics)]
+    [Arguments(ArrayTarget.ListReassignmentPartitions)]
+    [Arguments(ArrayTarget.ListReplicas)]
+    [Arguments(ArrayTarget.ListAddingReplicas)]
+    [Arguments(ArrayTarget.ListRemovingReplicas)]
+    [Arguments(ArrayTarget.AlterLogDirTopicsLegacy)]
+    [Arguments(ArrayTarget.AlterLogDirTopicsFlexible)]
+    [Arguments(ArrayTarget.AlterLogDirPartitionsLegacy)]
+    [Arguments(ArrayTarget.AlterLogDirPartitionsFlexible)]
+    [Arguments(ArrayTarget.DescribeLogDirsLegacy)]
+    [Arguments(ArrayTarget.DescribeLogDirsFlexibleV2)]
+    [Arguments(ArrayTarget.DescribeLogDirsFlexibleV4)]
+    [Arguments(ArrayTarget.DescribeLogDirsFlexibleV5)]
+    [Arguments(ArrayTarget.DescribeLogDirTopicsLegacy)]
+    [Arguments(ArrayTarget.DescribeLogDirTopicsFlexible)]
+    [Arguments(ArrayTarget.DescribeLogDirPartitionsLegacy)]
+    [Arguments(ArrayTarget.DescribeLogDirPartitionsFlexible)]
+    [Arguments(ArrayTarget.QuorumTopicsV0)]
+    [Arguments(ArrayTarget.QuorumTopicsV2)]
+    [Arguments(ArrayTarget.QuorumNodes)]
+    [Arguments(ArrayTarget.QuorumPartitionsV0)]
+    [Arguments(ArrayTarget.QuorumPartitionsV2)]
+    [Arguments(ArrayTarget.QuorumVotersV0)]
+    [Arguments(ArrayTarget.QuorumVotersV1)]
+    [Arguments(ArrayTarget.QuorumVotersV2)]
+    [Arguments(ArrayTarget.QuorumObserversV2)]
+    [Arguments(ArrayTarget.QuorumListeners)]
+    [Arguments(ArrayTarget.DescribeTopicTopics)]
+    [Arguments(ArrayTarget.DescribeTopicPartitions)]
+    [Arguments(ArrayTarget.DescribeTopicReplicas)]
+    [Arguments(ArrayTarget.DescribeTopicIsr)]
+    [Arguments(ArrayTarget.DescribeTopicEligibleLeaders)]
+    [Arguments(ArrayTarget.DescribeTopicLastKnownElr)]
+    [Arguments(ArrayTarget.DescribeTopicOfflineReplicas)]
+    [Arguments(ArrayTarget.ElectLeaderTopics)]
+    [Arguments(ArrayTarget.ElectLeaderPartitions)]
+    public async Task Read_HostileArrayCount_RejectsBeforeAllocation(ArrayTarget target)
+    {
+        var payload = CreatePayload(target);
+
+        await Assert.That(() => ReadContiguous(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>();
+        await Assert.That(() => ReadSegmented(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>();
+    }
+
+    private static byte[] CreatePayload(ArrayTarget target)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        switch (target)
+        {
+            case ArrayTarget.AlterReassignmentTopicsV0:
+            case ArrayTarget.AlterReassignmentTopicsV1:
+                writer.WriteInt32(0);
+                if (target is ArrayTarget.AlterReassignmentTopicsV1)
+                    writer.WriteBoolean(false);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.AlterReassignmentPartitions:
+            case ArrayTarget.ListReassignmentPartitions:
+            case ArrayTarget.ElectLeaderPartitions:
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ArrayTarget.ListReassignmentTopics:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.ListReplicas:
+            case ArrayTarget.ListAddingReplicas:
+            case ArrayTarget.ListRemovingReplicas:
+                writer.WriteInt32(0);
+                WriteEmptyCompactArrays(
+                    ref writer,
+                    target - ArrayTarget.ListReplicas);
+                break;
+            case ArrayTarget.AlterLogDirTopicsLegacy:
+            case ArrayTarget.AlterLogDirTopicsFlexible:
+            case ArrayTarget.DescribeLogDirsLegacy:
+            case ArrayTarget.DescribeLogDirsFlexibleV2:
+            case ArrayTarget.DescribeLogDirsFlexibleV4:
+            case ArrayTarget.DescribeLogDirsFlexibleV5:
+                writer.WriteInt32(0);
+                if (target is ArrayTarget.DescribeLogDirsFlexibleV4 or ArrayTarget.DescribeLogDirsFlexibleV5)
+                    writer.WriteInt16((short)ErrorCode.None);
+                break;
+            case ArrayTarget.AlterLogDirPartitionsLegacy:
+            case ArrayTarget.DescribeLogDirPartitionsLegacy:
+                writer.WriteString(string.Empty);
+                break;
+            case ArrayTarget.AlterLogDirPartitionsFlexible:
+            case ArrayTarget.DescribeLogDirPartitionsFlexible:
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ArrayTarget.DescribeLogDirTopicsLegacy:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteString(string.Empty);
+                break;
+            case ArrayTarget.DescribeLogDirTopicsFlexible:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ArrayTarget.QuorumTopicsV0:
+                writer.WriteInt16((short)ErrorCode.None);
+                break;
+            case ArrayTarget.QuorumTopicsV2:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.QuorumNodes:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                writer.WriteUnsignedVarInt(1);
+                break;
+            case ArrayTarget.QuorumPartitionsV0:
+            case ArrayTarget.QuorumPartitionsV2:
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ArrayTarget.QuorumVotersV0:
+                WriteQuorumPartitionPreamble(ref writer, version: 0);
+                break;
+            case ArrayTarget.QuorumVotersV1:
+                WriteQuorumPartitionPreamble(ref writer, version: 1);
+                break;
+            case ArrayTarget.QuorumVotersV2:
+            case ArrayTarget.QuorumObserversV2:
+                WriteQuorumPartitionPreamble(ref writer, version: 2);
+                if (target is ArrayTarget.QuorumObserversV2)
+                    writer.WriteUnsignedVarInt(1);
+                break;
+            case ArrayTarget.QuorumListeners:
+                writer.WriteInt32(0);
+                break;
+            case ArrayTarget.DescribeTopicTopics:
+                writer.WriteInt32(0);
+                break;
+            case ArrayTarget.DescribeTopicPartitions:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                writer.WriteUuid(Guid.Empty);
+                writer.WriteBoolean(false);
+                break;
+            case ArrayTarget.DescribeTopicReplicas:
+            case ArrayTarget.DescribeTopicIsr:
+            case ArrayTarget.DescribeTopicEligibleLeaders:
+            case ArrayTarget.DescribeTopicLastKnownElr:
+            case ArrayTarget.DescribeTopicOfflineReplicas:
+                WriteDescribeTopicPartitionPreamble(ref writer);
+                WriteEmptyCompactArrays(
+                    ref writer,
+                    target - ArrayTarget.DescribeTopicReplicas);
+                break;
+            case ArrayTarget.ElectLeaderTopics:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+
+        WriteHostileArray(ref writer, UsesLegacyEncoding(target));
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteQuorumPartitionPreamble(ref KafkaProtocolWriter writer, short version)
+    {
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        if (version >= 2)
+            writer.WriteCompactNullableString(null);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteInt64(0);
+    }
+
+    private static void WriteDescribeTopicPartitionPreamble(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+        writer.WriteInt32(0);
+    }
+
+    private static void WriteEmptyCompactArrays(ref KafkaProtocolWriter writer, int count)
+    {
+        for (var index = 0; index < count; index++)
+            writer.WriteUnsignedVarInt(1);
+    }
+
+    private static void WriteHostileArray(ref KafkaProtocolWriter writer, bool legacy)
+    {
+        if (legacy)
+            writer.WriteInt32(HostileElementCount);
+        else
+            writer.WriteUnsignedVarInt(HostileElementCount + 1);
+        writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static bool UsesLegacyEncoding(ArrayTarget target) =>
+        target is ArrayTarget.AlterLogDirTopicsLegacy
+            or ArrayTarget.AlterLogDirPartitionsLegacy
+            or ArrayTarget.DescribeLogDirsLegacy
+            or ArrayTarget.DescribeLogDirTopicsLegacy
+            or ArrayTarget.DescribeLogDirPartitionsLegacy;
+
+    private static void ReadContiguous(byte[] payload, ArrayTarget target)
+    {
+        var reader = new KafkaProtocolReader(payload);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadSegmented(byte[] payload, ArrayTarget target)
+    {
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(payload, payload.Length / 2);
+        var reader = new KafkaProtocolReader(sequence);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadTarget(ref KafkaProtocolReader reader, ArrayTarget target)
+    {
+        switch (target)
+        {
+            case ArrayTarget.AlterReassignmentTopicsV0:
+                _ = AlterPartitionReassignmentsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.AlterReassignmentTopicsV1:
+                _ = AlterPartitionReassignmentsResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.AlterReassignmentPartitions:
+                _ = AlterPartitionReassignmentsResponseTopic.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ListReassignmentTopics:
+                _ = ListPartitionReassignmentsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ListReassignmentPartitions:
+                _ = ListPartitionReassignmentsResponseTopic.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ListReplicas:
+            case ArrayTarget.ListAddingReplicas:
+            case ArrayTarget.ListRemovingReplicas:
+                _ = OngoingPartitionReassignmentData.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.AlterLogDirTopicsLegacy:
+                _ = AlterReplicaLogDirsResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.AlterLogDirTopicsFlexible:
+                _ = AlterReplicaLogDirsResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.AlterLogDirPartitionsLegacy:
+                _ = AlterReplicaLogDirsResponseTopic.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.AlterLogDirPartitionsFlexible:
+                _ = AlterReplicaLogDirsResponseTopic.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.DescribeLogDirsLegacy:
+                _ = DescribeLogDirsResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.DescribeLogDirsFlexibleV2:
+                _ = DescribeLogDirsResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.DescribeLogDirsFlexibleV4:
+                _ = DescribeLogDirsResponse.Read(ref reader, version: 4);
+                break;
+            case ArrayTarget.DescribeLogDirsFlexibleV5:
+                _ = DescribeLogDirsResponse.Read(ref reader, version: 5);
+                break;
+            case ArrayTarget.DescribeLogDirTopicsLegacy:
+                _ = DescribeLogDirsResponseDir.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.DescribeLogDirTopicsFlexible:
+                _ = DescribeLogDirsResponseDir.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.DescribeLogDirPartitionsLegacy:
+                _ = DescribeLogDirsResponseTopic.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.DescribeLogDirPartitionsFlexible:
+                _ = DescribeLogDirsResponseTopic.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.QuorumTopicsV0:
+                _ = DescribeQuorumResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.QuorumTopicsV2:
+            case ArrayTarget.QuorumNodes:
+                _ = DescribeQuorumResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.QuorumPartitionsV0:
+                _ = DescribeQuorumResponseTopic.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.QuorumPartitionsV2:
+                _ = DescribeQuorumResponseTopic.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.QuorumVotersV0:
+                _ = DescribeQuorumResponsePartition.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.QuorumVotersV1:
+                _ = DescribeQuorumResponsePartition.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.QuorumVotersV2:
+            case ArrayTarget.QuorumObserversV2:
+                _ = DescribeQuorumResponsePartition.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.QuorumListeners:
+                _ = DescribeQuorumResponseNode.Read(ref reader);
+                break;
+            case ArrayTarget.DescribeTopicTopics:
+                _ = DescribeTopicPartitionsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.DescribeTopicPartitions:
+                _ = DescribeTopicPartitionsResponseTopic.Read(ref reader);
+                break;
+            case ArrayTarget.DescribeTopicReplicas:
+            case ArrayTarget.DescribeTopicIsr:
+            case ArrayTarget.DescribeTopicEligibleLeaders:
+            case ArrayTarget.DescribeTopicLastKnownElr:
+            case ArrayTarget.DescribeTopicOfflineReplicas:
+                _ = DescribeTopicPartitionsResponsePartition.Read(ref reader);
+                break;
+            case ArrayTarget.ElectLeaderTopics:
+                _ = ElectLeadersResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.ElectLeaderPartitions:
+                _ = ElectLeadersResponseTopic.Read(ref reader, version: 2);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+    }
+
+    public enum ArrayTarget
+    {
+        AlterReassignmentTopicsV0,
+        AlterReassignmentTopicsV1,
+        AlterReassignmentPartitions,
+        ListReassignmentTopics,
+        ListReassignmentPartitions,
+        ListReplicas,
+        ListAddingReplicas,
+        ListRemovingReplicas,
+        AlterLogDirTopicsLegacy,
+        AlterLogDirTopicsFlexible,
+        AlterLogDirPartitionsLegacy,
+        AlterLogDirPartitionsFlexible,
+        DescribeLogDirsLegacy,
+        DescribeLogDirsFlexibleV2,
+        DescribeLogDirsFlexibleV4,
+        DescribeLogDirsFlexibleV5,
+        DescribeLogDirTopicsLegacy,
+        DescribeLogDirTopicsFlexible,
+        DescribeLogDirPartitionsLegacy,
+        DescribeLogDirPartitionsFlexible,
+        QuorumTopicsV0,
+        QuorumTopicsV2,
+        QuorumNodes,
+        QuorumPartitionsV0,
+        QuorumPartitionsV2,
+        QuorumVotersV0,
+        QuorumVotersV1,
+        QuorumVotersV2,
+        QuorumObserversV2,
+        QuorumListeners,
+        DescribeTopicTopics,
+        DescribeTopicPartitions,
+        DescribeTopicReplicas,
+        DescribeTopicIsr,
+        DescribeTopicEligibleLeaders,
+        DescribeTopicLastKnownElr,
+        DescribeTopicOfflineReplicas,
+        ElectLeaderTopics,
+        ElectLeaderPartitions
+    }
+}


### PR DESCRIPTION
## Summary
- bound all broker-controlled topology, reassignment, quorum, and log-dir response arrays by exact/version-aware minimum wire size and finite semantic count
- add bounded state-passing legacy-array and compact-nullable reader overloads
- remove ElectLeaders response closure allocations through state-passing delegates
- test every allocation site with hostile contiguous and segmented payloads

## Test plan
- [x] `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- [x] focused protocol suites: 63 passed
- [x] full unit tests net10.0: 6435 passed
- [x] full unit tests net8.0: 6308 passed
- [x] `ResponseArrayBoundsBenchmarks` ShortRun with `[MemoryDiagnoser]`

## Performance

Same machine/runtime (.NET 10.0.10, i7-12700K), BenchmarkDotNet ShortRun:

| Run | Unbounded | Bounded | Allocated |
|---|---:|---:|---:|
| Before | 160.4 ns | 122.8 ns | 424 B → 424 B |
| After | 180.4 ns | 132.4 ns | 424 B → 424 B |

Run-to-run movement affected both controls; within each run the guarded parser stayed faster. Returned 100-element `int[]` accounts for 424 B; guard allocation delta is 0 B. No material parser regression observed.

Closes #2409
