### PR TITLE
Bound fetch and transaction response arrays

### DIFF
--- a/src/Dekaf/Protocol/Messages/DeleteRecordsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteRecordsResponse.cs
@@ -25,9 +25,11 @@ public sealed class DeleteRecordsResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
 
-        IReadOnlyList<DeleteRecordsResponseTopic> topics;
-        topics = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteRecordsResponseTopic.Read(ref r, version)) ?? [];
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DeleteRecordsResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -58,9 +60,11 @@ public sealed class DeleteRecordsResponseTopic
     {
         var name = reader.ReadCompactString() ?? string.Empty;
 
-        IReadOnlyList<DeleteRecordsResponsePartition> partitions;
-        partitions = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteRecordsResponsePartition.Read(ref r, version)) ?? [];
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => DeleteRecordsResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 15,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeProducersResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeProducersResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeProducersResponse : IKafkaResponse
 {
+    internal const int MaxActiveProducerCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeProducers;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -17,7 +19,9 @@ public sealed class DescribeProducersResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
         var topics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeProducersResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeProducersResponseTopic.Read(ref r),
+            minElementSize: 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -41,7 +45,9 @@ public sealed class DescribeProducersResponseTopic
     {
         var name = reader.ReadCompactNonNullableString();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeProducersResponsePartition.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeProducersResponsePartition.Read(ref r),
+            minElementSize: 9,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 
@@ -69,7 +75,9 @@ public sealed class DescribeProducersResponsePartition
         var errorCode = (ErrorCode)reader.ReadInt16();
         var errorMessage = reader.ReadCompactString();
         var activeProducers = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeProducersResponseProducer.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeProducersResponseProducer.Read(ref r),
+            minElementSize: 37,
+            maxCount: DescribeProducersResponse.MaxActiveProducerCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeTransactionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeTransactionsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeTransactionsResponse : IKafkaResponse
 {
+    internal const int MaxTransactionCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeTransactions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -18,7 +20,9 @@ public sealed class DescribeTransactionsResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
         var transactionStates = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeTransactionsResponseState.Read(ref r, v),
-            version);
+            version,
+            minElementSize: version >= 1 ? 36 : 28,
+            maxCount: MaxTransactionCount);
 
         reader.SkipTaggedFields();
 
@@ -56,7 +60,9 @@ public sealed class DescribeTransactionsResponseState
         var producerId = reader.ReadInt64();
         var producerEpoch = reader.ReadInt16();
         var topics = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => DescribeTransactionsResponseTopic.Read(ref r));
+            static (ref KafkaProtocolReader r) => DescribeTransactionsResponseTopic.Read(ref r),
+            minElementSize: 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -87,7 +93,9 @@ public sealed class DescribeTransactionsResponseTopic
     {
         var topic = reader.ReadCompactNonNullableString();
         var partitions = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadInt32());
+            static (ref KafkaProtocolReader r) => r.ReadInt32(),
+            minElementSize: 4,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/FetchResponse.cs
+++ b/src/Dekaf/Protocol/Messages/FetchResponse.cs
@@ -10,6 +10,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class FetchResponse : IKafkaResponse
 {
+    internal const int MaxNodeEndpointCount = ProduceResponse.MaxNodeEndpointCount;
+
     // Pool to reuse FetchResponse instances across fetch cycles.
     // One instance per fetch cycle, so a small pool suffices.
     private static readonly FetchResponsePool s_pool = new();
@@ -141,7 +143,10 @@ public sealed class FetchResponse : IKafkaResponse
 
             if (tag == 0 && version >= 16)
             {
-                nodeEndpoints = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => NodeEndpoint.Read(ref r));
+                nodeEndpoints = reader.ReadCompactArray(
+                    static (ref KafkaProtocolReader r) => NodeEndpoint.Read(ref r),
+                    minElementSize: 11,
+                    maxCount: MaxNodeEndpointCount);
             }
             else
             {

--- a/src/Dekaf/Protocol/Messages/ListOffsetsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ListOffsetsResponse.cs
@@ -5,6 +5,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ListOffsetsResponse : IKafkaResponse
 {
+    internal const int MaxOldStyleOffsetCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ListOffsets;
     public static short LowestSupportedVersion => 6;
     public static short HighestSupportedVersion => 11;
@@ -23,9 +25,11 @@ public sealed class ListOffsetsResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
 
-        IReadOnlyList<ListOffsetsResponseTopic> topics;
-        topics = reader.ReadCompactArray((ref KafkaProtocolReader r) =>
-    ListOffsetsResponseTopic.Read(ref r, version));
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ListOffsetsResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
         reader.SkipTaggedFields();
 
         return new ListOffsetsResponse
@@ -48,9 +52,11 @@ public sealed class ListOffsetsResponseTopic
     {
         var name = reader.ReadCompactString()!;
 
-        IReadOnlyList<ListOffsetsResponsePartition> partitions;
-        partitions = reader.ReadCompactArray((ref KafkaProtocolReader r) =>
-    ListOffsetsResponsePartition.Read(ref r, version));
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => ListOffsetsResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: version == 0 ? 11 : 27,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
         reader.SkipTaggedFields();
 
         return new ListOffsetsResponseTopic
@@ -102,7 +108,10 @@ public sealed class ListOffsetsResponsePartition
         if (version == 0)
         {
             // v0 has array of offsets
-            oldStyleOffsets = reader.ReadArray((ref KafkaProtocolReader r) => r.ReadInt64());
+            oldStyleOffsets = reader.ReadArray(
+                static (ref KafkaProtocolReader r) => r.ReadInt64(),
+                minElementSize: 8,
+                maxCount: ListOffsetsResponse.MaxOldStyleOffsetCount);
             if (oldStyleOffsets.Count > 0)
             {
                 offset = oldStyleOffsets[0];

--- a/src/Dekaf/Protocol/Messages/ListTransactionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/ListTransactionsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class ListTransactionsResponse : IKafkaResponse
 {
+    internal const int MaxUnknownStateFilterCount = 100_000;
+    internal const int MaxTransactionCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.ListTransactions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 2;
@@ -20,9 +23,13 @@ public sealed class ListTransactionsResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = (ErrorCode)reader.ReadInt16();
         var unknownStateFilters = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => r.ReadCompactNonNullableString());
+            static (ref KafkaProtocolReader r) => r.ReadCompactNonNullableString(),
+            minElementSize: 1,
+            maxCount: MaxUnknownStateFilterCount);
         var transactionStates = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ListTransactionsResponseState.Read(ref r));
+            static (ref KafkaProtocolReader r) => ListTransactionsResponseState.Read(ref r),
+            minElementSize: 11,
+            maxCount: MaxTransactionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/TxnOffsetCommitResponse.cs
+++ b/src/Dekaf/Protocol/Messages/TxnOffsetCommitResponse.cs
@@ -23,7 +23,11 @@ public sealed class TxnOffsetCommitResponse : IKafkaResponse
     {
         var throttleTimeMs = reader.ReadInt32();
 
-        var topics = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => TxnOffsetCommitResponseTopic.Read(ref r, v), version);
+        var topics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => TxnOffsetCommitResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: version >= TxnOffsetCommitRequest.TopicIdVersion ? 18 : 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -53,7 +57,11 @@ public sealed class TxnOffsetCommitResponseTopic
             ? reader.ReadUuid()
             : Guid.Empty;
 
-        var partitions = reader.ReadCompactArray(static (ref KafkaProtocolReader r, short v) => TxnOffsetCommitResponsePartition.Read(ref r, v), version);
+        var partitions = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r, short v) => TxnOffsetCommitResponsePartition.Read(ref r, v),
+            version,
+            minElementSize: 7,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/WriteTxnMarkersResponse.cs
+++ b/src/Dekaf/Protocol/Messages/WriteTxnMarkersResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class WriteTxnMarkersResponse : IKafkaResponse
 {
+    internal const int MaxMarkerCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.WriteTxnMarkers;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 2;
@@ -16,7 +18,9 @@ public sealed class WriteTxnMarkersResponse : IKafkaResponse
     {
         var markers = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponseMarker.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 10,
+            maxCount: MaxMarkerCount);
 
         reader.SkipTaggedFields();
 
@@ -40,7 +44,9 @@ public sealed class WriteTxnMarkersResponseMarker
         var producerId = reader.ReadInt64();
         var topics = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponseTopic.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 3,
+            maxCount: ResponseArrayLimits.MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -65,7 +71,9 @@ public sealed class WriteTxnMarkersResponseTopic
         var name = reader.ReadCompactNonNullableString();
         var partitions = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => WriteTxnMarkersResponsePartition.Read(ref r, v),
-            version);
+            version,
+            minElementSize: 7,
+            maxCount: ResponseArrayLimits.MaxPartitionCount);
 
         reader.SkipTaggedFields();
 

--- a/tests/Dekaf.Tests.Unit/Protocol/TransactionResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/TransactionResponseArrayBoundsTests.cs
@@ -1,0 +1,396 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class TransactionResponseArrayBoundsTests
+{
+    private const int HostileElementCount = 40;
+    private const int HostilePayloadLength = 60;
+
+    [Test]
+    public async Task DeleteRecordsResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDeleteRecordsResponse(buffer));
+    }
+
+    [Test]
+    public async Task DeleteRecordsResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDeleteRecordsResponseTopic(buffer));
+    }
+
+    [Test]
+    public async Task FetchResponse_Read_SegmentedNodeEndpointCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(HostilePayloadLength + 1);
+        WriteHostileCompactArray(ref writer);
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(buffer.WrittenSpan.ToArray(), splitAt: 11);
+
+        await AssertMinimumSizeRejected(() => ReadFetchResponse(sequence));
+    }
+
+    [Test]
+    public async Task ListOffsetsResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadListOffsetsResponse(buffer));
+    }
+
+    [Test]
+    [Arguments((short)0)]
+    [Arguments((short)6)]
+    public async Task ListOffsetsResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadListOffsetsResponseTopic(buffer, version));
+    }
+
+    [Test]
+    public async Task ListOffsetsResponsePartition_Read_OldStyleOffsetCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        WriteHostileLegacyArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadListOffsetsResponsePartition(buffer));
+    }
+
+    [Test]
+    public async Task DescribeProducersResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeProducersResponse(buffer));
+    }
+
+    [Test]
+    public async Task DescribeProducersResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeProducersResponseTopic(buffer));
+    }
+
+    [Test]
+    public async Task DescribeProducersResponsePartition_Read_ProducerCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeProducersResponsePartition(buffer));
+    }
+
+    [Test]
+    [Arguments((short)0)]
+    [Arguments((short)1)]
+    public async Task DescribeTransactionsResponse_Read_StateCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeTransactionsResponse(buffer, version));
+    }
+
+    [Test]
+    public async Task DescribeTransactionsResponseState_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt32(0);
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        writer.WriteInt16(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeTransactionsResponseState(buffer));
+    }
+
+    [Test]
+    public async Task DescribeTransactionsResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadDescribeTransactionsResponseTopic(buffer));
+    }
+
+    [Test]
+    public async Task ListTransactionsResponse_Read_UnknownFilterCountExceedingAbsoluteCap_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        WriteCompactArrayAtAbsoluteCap(
+            ref writer,
+            maxCount: ListTransactionsResponse.MaxUnknownStateFilterCount);
+
+        await AssertMaximumRejected(
+            () => ReadListTransactionsResponse(buffer),
+            count: ListTransactionsResponse.MaxUnknownStateFilterCount + 1,
+            maxCount: ListTransactionsResponse.MaxUnknownStateFilterCount);
+    }
+
+    [Test]
+    public async Task ListTransactionsResponse_Read_StateCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(1);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadListTransactionsResponse(buffer));
+    }
+
+    [Test]
+    [Arguments((short)3)]
+    [Arguments((short)6)]
+    public async Task TxnOffsetCommitResponse_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation(
+        short version)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadTxnOffsetCommitResponse(buffer, version));
+    }
+
+    [Test]
+    public async Task TxnOffsetCommitResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteUuid(Guid.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadTxnOffsetCommitResponseTopic(buffer));
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersResponse_Read_MarkerCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadWriteTxnMarkersResponse(buffer));
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersResponseMarker_Read_TopicCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt64(0);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadWriteTxnMarkersResponseMarker(buffer));
+    }
+
+    [Test]
+    public async Task WriteTxnMarkersResponseTopic_Read_PartitionCountExceedingMinimumEncodedSize_RejectsBeforeAllocation()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteCompactString(string.Empty);
+        WriteHostileCompactArray(ref writer);
+
+        await AssertMinimumSizeRejected(() => ReadWriteTxnMarkersResponseTopic(buffer));
+    }
+
+    private static void WriteHostileCompactArray(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteUnsignedVarInt(HostileElementCount + 1);
+        writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static void WriteHostileLegacyArray(ref KafkaProtocolWriter writer)
+    {
+        writer.WriteInt32(HostileElementCount);
+        writer.WriteRawBytes(new byte[HostilePayloadLength]);
+    }
+
+    private static void WriteCompactArrayAtAbsoluteCap(ref KafkaProtocolWriter writer, int maxCount)
+    {
+        writer.WriteUnsignedVarInt(maxCount + 2);
+        writer.WriteRawBytes(new byte[maxCount + 1]);
+    }
+
+    private static async Task AssertMinimumSizeRejected(Action read)
+    {
+        var exception = Assert.Throws<MalformedProtocolDataException>(read);
+        await Assert.That(exception.Message)
+            .IsEqualTo(
+                $"Invalid protocol data: claimed length {HostileElementCount} exceeds remaining data {HostilePayloadLength}");
+    }
+
+    private static async Task AssertMaximumRejected(Action read, int count, int maxCount)
+    {
+        var exception = Assert.Throws<MalformedProtocolDataException>(read);
+        await Assert.That(exception.Message)
+            .IsEqualTo($"Invalid protocol data: claimed element count {count} exceeds maximum {maxCount}");
+    }
+
+    private static void ReadDeleteRecordsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DeleteRecordsResponse.Read(ref reader, version: 2);
+    }
+
+    private static void ReadDeleteRecordsResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DeleteRecordsResponseTopic.Read(ref reader, version: 2);
+    }
+
+    private static void ReadFetchResponse(ReadOnlySequence<byte> sequence)
+    {
+        var reader = new KafkaProtocolReader(sequence);
+        _ = FetchResponse.Read(ref reader, version: 16);
+    }
+
+    private static void ReadListOffsetsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ListOffsetsResponse.Read(ref reader, version: 6);
+    }
+
+    private static void ReadListOffsetsResponseTopic(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ListOffsetsResponseTopic.Read(ref reader, version);
+    }
+
+    private static void ReadListOffsetsResponsePartition(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ListOffsetsResponsePartition.Read(ref reader, version: 0);
+    }
+
+    private static void ReadDescribeProducersResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeProducersResponse.Read(ref reader, version: 0);
+    }
+
+    private static void ReadDescribeProducersResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeProducersResponseTopic.Read(ref reader);
+    }
+
+    private static void ReadDescribeProducersResponsePartition(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeProducersResponsePartition.Read(ref reader);
+    }
+
+    private static void ReadDescribeTransactionsResponse(
+        ArrayBufferWriter<byte> buffer,
+        short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeTransactionsResponse.Read(ref reader, version);
+    }
+
+    private static void ReadDescribeTransactionsResponseState(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeTransactionsResponseState.Read(ref reader, version: 1);
+    }
+
+    private static void ReadDescribeTransactionsResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = DescribeTransactionsResponseTopic.Read(ref reader);
+    }
+
+    private static void ReadListTransactionsResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = ListTransactionsResponse.Read(ref reader, version: 2);
+    }
+
+    private static void ReadTxnOffsetCommitResponse(ArrayBufferWriter<byte> buffer, short version)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = TxnOffsetCommitResponse.Read(ref reader, version);
+    }
+
+    private static void ReadTxnOffsetCommitResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = TxnOffsetCommitResponseTopic.Read(ref reader, version: 6);
+    }
+
+    private static void ReadWriteTxnMarkersResponse(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = WriteTxnMarkersResponse.Read(ref reader, version: 2);
+    }
+
+    private static void ReadWriteTxnMarkersResponseMarker(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = WriteTxnMarkersResponseMarker.Read(ref reader, version: 2);
+    }
+
+    private static void ReadWriteTxnMarkersResponseTopic(ArrayBufferWriter<byte> buffer)
+    {
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        _ = WriteTxnMarkersResponseTopic.Read(ref reader, version: 2);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionResponseArrayBoundsBenchmarks.cs
@@ -8,7 +8,11 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [MemoryDiagnoser]
 public class TransactionResponseArrayBoundsBenchmarks
 {
+    private const int NodeEndpointCount = 100;
+    private const int NodeEndpointMinSize = 11;
+
     private ReadOnlyMemory<byte> _deleteRecordsPayload;
+    private ReadOnlyMemory<byte> _fetchPayload;
 
     [GlobalSetup]
     public void Setup()
@@ -25,6 +29,27 @@ public class TransactionResponseArrayBoundsBenchmarks
         }
         writer.WriteUnsignedVarInt(0);
         _deleteRecordsPayload = buffer.WrittenMemory;
+
+        buffer = new ArrayBufferWriter<byte>();
+        writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteUnsignedVarInt(0);
+        writer.WriteUnsignedVarInt(1 + (NodeEndpointCount * NodeEndpointMinSize));
+        writer.WriteUnsignedVarInt(NodeEndpointCount + 1);
+        for (var i = 0; i < NodeEndpointCount; i++)
+        {
+            writer.WriteInt32(i);
+            writer.WriteCompactString(string.Empty);
+            writer.WriteInt32(9092);
+            writer.WriteCompactString(null);
+            writer.WriteUnsignedVarInt(0);
+        }
+
+        _fetchPayload = buffer.WrittenMemory;
     }
 
     [Benchmark]
@@ -33,5 +58,15 @@ public class TransactionResponseArrayBoundsBenchmarks
         var reader = new KafkaProtocolReader(_deleteRecordsPayload);
         var response = (DeleteRecordsResponse)DeleteRecordsResponse.Read(ref reader, version: 2);
         return response.Topics.Count;
+    }
+
+    [Benchmark]
+    public int ReadFetchResponseNodeEndpoints()
+    {
+        var reader = new KafkaProtocolReader(_fetchPayload);
+        var response = (FetchResponse)FetchResponse.Read(ref reader, version: 16);
+        var count = response.NodeEndpoints.Length;
+        response.ReturnToPool();
+        return count;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionResponseArrayBoundsBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TransactionResponseArrayBoundsBenchmarks.cs
@@ -1,0 +1,37 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+public class TransactionResponseArrayBoundsBenchmarks
+{
+    private ReadOnlyMemory<byte> _deleteRecordsPayload;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt32(0);
+        writer.WriteUnsignedVarInt(101);
+        for (var i = 0; i < 100; i++)
+        {
+            writer.WriteCompactString(string.Empty);
+            writer.WriteUnsignedVarInt(1);
+            writer.WriteUnsignedVarInt(0);
+        }
+        writer.WriteUnsignedVarInt(0);
+        _deleteRecordsPayload = buffer.WrittenMemory;
+    }
+
+    [Benchmark]
+    public int ReadDeleteRecordsResponse()
+    {
+        var reader = new KafkaProtocolReader(_deleteRecordsPayload);
+        var response = (DeleteRecordsResponse)DeleteRecordsResponse.Read(ref reader, version: 2);
+        return response.Topics.Count;
+    }
+}


### PR DESCRIPTION
Closes #2408

## Summary
- bound all 19 direct response-array allocation families in fetch, offset, producer, and transaction responses
- validate claimed counts against exact version-aware minimum encoded sizes and finite semantic caps before allocation
- replace captured DeleteRecords/ListOffsets parser delegates with static state delegates
- add hostile-count coverage, including segmented `ReadOnlySequence<byte>` and an absolute-cap case
- add a parser-level `[MemoryDiagnoser]` benchmark

## Validation
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release` — 0 warnings, 0 errors
- focused `TransactionResponseArrayBoundsTests` — 22/22 passed; stacked array-bound suites — 67/67 passed
- full net10 unit suite — 6417/6417 passed
- full net8 unit suite — 6290/6290 passed

## Performance
Exact immediately preceding product SHA: `405f6b33`

`TransactionResponseArrayBoundsBenchmarks.ReadDeleteRecordsResponse`, .NET 10.0.10, DefaultJob, same machine/config:

| Revision | Mean | Allocated |
|---|---:|---:|
| `405f6b33` | 1.444 us | 12.58 KB/op |
| `d73c2b54` | 754.9 ns | 3.96 KB/op |
| Delta | -47.7% | -8.62 KB/op |

The parser remains functionally allocating because it materializes response objects/arrays; this change removes captured-delegate allocations and adds pre-allocation validation. No protected metric regressed in the measured path.


`TransactionResponseArrayBoundsBenchmarks.ReadFetchResponseNodeEndpoints`, .NET 10.0.10, ShortRun, same machine/config; exact change parent `6891ab4a`:

| Revision | Mean | Allocated |
|---|---:|---:|
| `6891ab4a` | 1.047 us | 4.71 KB/op |
| `8670f772` + benchmark-only `1746fe45` | 1.052 us | 4.71 KB/op |
| Delta | +0.5% | 0 B/op |

The 4.71 KB is the expected materialized 100-element `NodeEndpoint` response graph. The minimum-size/count guard adds 0 B and the +0.5% mean difference is within ShortRun noise.


## Final main rebase validation
After #2410 merged, the branch was rebased onto exact product SHA `f187bec7`; the two now-upstream group-response commits dropped, leaving only this PR's 10 files.

- full unit suite: net8 6387/6387; net10 6514/6514; builds 0 warnings
- exact-main Fetch benchmark: parent `1.069 us`, candidate repeat `979.8 ns` (-8.3%); allocation unchanged at 4.71 KB/op
- first post-rebase candidate sample was noisy/inconclusive at `1.216 us` (5.15% iteration error) and is not averaged into the result
- prior equivalent-parent pair: `1.047 us` -> `1.052 us` (+0.5%), allocation unchanged

Across both comparable pairs, the guard adds `0 B` and no material parser regression is supported.
