### PR TITLE
Bound admin and telemetry response arrays

### DIFF
--- a/src/Dekaf/Protocol/KafkaProtocolReader.cs
+++ b/src/Dekaf/Protocol/KafkaProtocolReader.cs
@@ -1056,6 +1056,34 @@ public ref struct KafkaProtocolReader
     }
 
     /// <summary>
+    /// Reads a nullable legacy array whose elements have a known minimum encoded size,
+    /// bounding hostile counts before the array allocation. State-passing overload to
+    /// avoid closure allocations.
+    /// </summary>
+    public T[]? ReadNullableArray<T, TState>(
+        ReadFunc<T, TState> readItem,
+        TState state,
+        int minElementSize,
+        int maxCount)
+    {
+        var length = ReadInt32();
+        if (length < 0)
+            return null;
+
+        if (length == 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this, state);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Reads a compact array with unsigned varint length prefix (flexible format).
     /// State-passing overload to avoid closure allocations.
     /// </summary>
@@ -1110,6 +1138,34 @@ public ref struct KafkaProtocolReader
             return [];
 
         ValidateReadableLength(length);
+
+        var result = new T[length];
+        for (var i = 0; i < length; i++)
+        {
+            result[i] = readItem(ref this, state);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Reads a compact nullable array whose elements have a known minimum encoded size,
+    /// bounding hostile counts before the array allocation. State-passing overload to
+    /// avoid closure allocations.
+    /// </summary>
+    public T[]? ReadCompactNullableArray<T, TState>(
+        ReadFunc<T, TState> readItem,
+        TState state,
+        int minElementSize,
+        int maxCount)
+    {
+        var length = ReadUnsignedVarInt() - 1;
+        if (length < 0)
+            return null;
+
+        if (length == 0)
+            return [];
+
+        ValidateReadableLength(length, minElementSize, maxCount);
 
         var result = new T[length];
         for (var i = 0; i < length; i++)

--- a/src/Dekaf/Protocol/Messages/AlterClientQuotasResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterClientQuotasResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterClientQuotasResponse : IKafkaResponse
 {
+    internal const int MaxEntryCount = 1_000_000;
+    internal const int MaxEntityCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterClientQuotas;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -27,10 +30,14 @@ public sealed class AlterClientQuotasResponse : IKafkaResponse
         var entries = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => AlterClientQuotasResponseEntry.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 5,
+                maxCount: MaxEntryCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => AlterClientQuotasResponseEntry.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 8,
+                maxCount: MaxEntryCount);
 
         if (flexible)
         {
@@ -73,10 +80,14 @@ public sealed class AlterClientQuotasResponseEntry
         var entity = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => ReadEntity(ref r, v),
-                version)
+                version,
+                minElementSize: 3,
+                maxCount: AlterClientQuotasResponse.MaxEntityCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => ReadEntity(ref r, v),
-                version);
+                version,
+                minElementSize: 4,
+                maxCount: AlterClientQuotasResponse.MaxEntityCount);
 
         if (flexible)
         {

--- a/src/Dekaf/Protocol/Messages/AlterConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterConfigsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterConfigsResponse : IKafkaResponse
 {
+    internal const int MaxResourceCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterConfigs;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 2;
@@ -26,7 +28,10 @@ public sealed class AlterConfigsResponse : IKafkaResponse
 
         IReadOnlyList<AlterConfigsResourceResponse> responses;
         responses = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => AlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => AlterConfigsResourceResponse.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: MaxResourceCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/AlterUserScramCredentialsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/AlterUserScramCredentialsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class AlterUserScramCredentialsResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.AlterUserScramCredentials;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -25,7 +27,10 @@ public sealed class AlterUserScramCredentialsResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
 
         var results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => AlterUserScramCredentialsResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => AlterUserScramCredentialsResult.Read(ref r, v),
+            version,
+            minElementSize: 5,
+            maxCount: MaxResultCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/CreateAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/CreateAclsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class CreateAclsResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.CreateAcls;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 3;
@@ -26,7 +28,10 @@ public sealed class CreateAclsResponse : IKafkaResponse
 
         IReadOnlyList<AclCreationResult> results;
         results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => AclCreationResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => AclCreationResult.Read(ref r, v),
+            version,
+            minElementSize: 4,
+            maxCount: MaxResultCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/CreatePartitionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/CreatePartitionsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class CreatePartitionsResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.CreatePartitions;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 3;
@@ -27,7 +29,10 @@ public sealed class CreatePartitionsResponse : IKafkaResponse
 
         IReadOnlyList<CreatePartitionsResponseResult> results;
         results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => CreatePartitionsResponseResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => CreatePartitionsResponseResult.Read(ref r, v),
+            version,
+            minElementSize: 5,
+            maxCount: MaxResultCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/CreateTopicsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/CreateTopicsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class CreateTopicsResponse : IKafkaResponse
 {
+    internal const int MaxTopicCount = 1_000_000;
+    internal const int MaxConfigCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.CreateTopics;
     public static short LowestSupportedVersion => 5;
     public static short HighestSupportedVersion => 7;
@@ -27,7 +30,10 @@ public sealed class CreateTopicsResponse : IKafkaResponse
 
         IReadOnlyList<CreateTopicsResponseTopic> topics;
         topics = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => CreateTopicsResponseTopic.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => CreateTopicsResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: version >= 7 ? 28 : 12,
+            maxCount: MaxTopicCount);
 
         reader.SkipTaggedFields();
 
@@ -95,7 +101,10 @@ public sealed class CreateTopicsResponseTopic
 
         IReadOnlyList<CreateTopicsResponseConfig>? configs = null;
         configs = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => CreateTopicsResponseConfig.Read(ref r, version));
+            static (ref KafkaProtocolReader r, short v) => CreateTopicsResponseConfig.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: CreateTopicsResponse.MaxConfigCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DelegationTokenMessages.cs
+++ b/src/Dekaf/Protocol/Messages/DelegationTokenMessages.cs
@@ -343,7 +343,7 @@ public sealed class DescribeDelegationTokenResponse : IKafkaResponse
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribedDelegationTokenData.Read(ref r, v),
                 version,
-                minElementSize: 32,
+                minElementSize: version >= 3 ? 32 : 30,
                 maxCount: MaxTokenCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribedDelegationTokenData.Read(ref r, v),

--- a/src/Dekaf/Protocol/Messages/DelegationTokenMessages.cs
+++ b/src/Dekaf/Protocol/Messages/DelegationTokenMessages.cs
@@ -324,6 +324,9 @@ public sealed class DescribeDelegationTokenRequest : IKafkaRequest<DescribeDeleg
 /// </summary>
 public sealed class DescribeDelegationTokenResponse : IKafkaResponse
 {
+    internal const int MaxTokenCount = 1_000_000;
+    internal const int MaxRenewerCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeDelegationToken;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 3;
@@ -339,10 +342,14 @@ public sealed class DescribeDelegationTokenResponse : IKafkaResponse
         var tokens = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribedDelegationTokenData.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 32,
+                maxCount: MaxTokenCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribedDelegationTokenData.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 38,
+                maxCount: MaxTokenCount);
         var throttleTimeMs = reader.ReadInt32();
 
         if (flexible)
@@ -434,10 +441,14 @@ public sealed class DescribedDelegationTokenData
         var renewers = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, bool f) => DelegationTokenPrincipalData.Read(ref r, f),
-                true)
+                true,
+                minElementSize: 3,
+                maxCount: DescribeDelegationTokenResponse.MaxRenewerCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, bool f) => DelegationTokenPrincipalData.Read(ref r, f),
-                false);
+                false,
+                minElementSize: 4,
+                maxCount: DescribeDelegationTokenResponse.MaxRenewerCount);
 
         if (flexible)
         {

--- a/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DeleteAclsResponse : IKafkaResponse
 {
+    internal const int MaxFilterResultCount = 1_000_000;
+    internal const int MaxMatchingAclCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DeleteAcls;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 3;
@@ -26,7 +29,10 @@ public sealed class DeleteAclsResponse : IKafkaResponse
 
         IReadOnlyList<DeleteAclsFilterResult> filterResults;
         filterResults = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteAclsFilterResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DeleteAclsFilterResult.Read(ref r, v),
+            version,
+            minElementSize: 5,
+            maxCount: MaxFilterResultCount);
 
         reader.SkipTaggedFields();
 
@@ -67,7 +73,10 @@ public sealed class DeleteAclsFilterResult
 
         IReadOnlyList<DeleteAclsMatchingAcl> matchingAcls;
         matchingAcls = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteAclsMatchingAcl.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DeleteAclsMatchingAcl.Read(ref r, v),
+            version,
+            minElementSize: 12,
+            maxCount: DeleteAclsResponse.MaxMatchingAclCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteAclsResponse.cs
@@ -75,7 +75,7 @@ public sealed class DeleteAclsFilterResult
         matchingAcls = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DeleteAclsMatchingAcl.Read(ref r, v),
             version,
-            minElementSize: 12,
+            minElementSize: 11,
             maxCount: DeleteAclsResponse.MaxMatchingAclCount);
 
         reader.SkipTaggedFields();

--- a/src/Dekaf/Protocol/Messages/DeleteTopicsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DeleteTopicsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DeleteTopicsResponse : IKafkaResponse
 {
+    internal const int MaxResponseCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DeleteTopics;
     public static short LowestSupportedVersion => 4;
     public static short HighestSupportedVersion => 6;
@@ -27,7 +29,10 @@ public sealed class DeleteTopicsResponse : IKafkaResponse
 
         IReadOnlyList<DeleteTopicsResponseTopic> responses;
         responses = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DeleteTopicsResponseTopic.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DeleteTopicsResponseTopic.Read(ref r, v),
+            version,
+            minElementSize: version >= 6 ? 21 : version >= 5 ? 5 : 4,
+            maxCount: MaxResponseCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeAclsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeAclsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeAclsResponse : IKafkaResponse
 {
+    internal const int MaxResourceCount = 1_000_000;
+    internal const int MaxAclCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeAcls;
     public static short LowestSupportedVersion => 2;
     public static short HighestSupportedVersion => 3;
@@ -40,7 +43,10 @@ public sealed class DescribeAclsResponse : IKafkaResponse
 
         IReadOnlyList<DescribeAclsResource> resources;
         resources = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DescribeAclsResource.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DescribeAclsResource.Read(ref r, v),
+            version,
+            minElementSize: 5,
+            maxCount: MaxResourceCount);
 
         reader.SkipTaggedFields();
 
@@ -90,7 +96,10 @@ public sealed class DescribeAclsResource
 
         IReadOnlyList<AclDescription> acls;
         acls = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => AclDescription.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => AclDescription.Read(ref r, v),
+            version,
+            minElementSize: 5,
+            maxCount: DescribeAclsResponse.MaxAclCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeClientQuotasResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeClientQuotasResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeClientQuotasResponse : IKafkaResponse
 {
+    internal const int MaxEntryCount = 1_000_000;
+    internal const int MaxEntityCount = 1_000_000;
+    internal const int MaxValueCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeClientQuotas;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 1;
@@ -40,10 +44,14 @@ public sealed class DescribeClientQuotasResponse : IKafkaResponse
         var entries = flexible
             ? reader.ReadCompactNullableArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasResponseEntry.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 3,
+                maxCount: MaxEntryCount)
             : reader.ReadNullableArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasResponseEntry.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 8,
+                maxCount: MaxEntryCount);
 
         if (flexible)
         {
@@ -87,18 +95,26 @@ public sealed class DescribeClientQuotasResponseEntry
         var entity = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasEntityData.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 3,
+                maxCount: DescribeClientQuotasResponse.MaxEntityCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasEntityData.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 4,
+                maxCount: DescribeClientQuotasResponse.MaxEntityCount);
 
         var values = flexible
             ? reader.ReadCompactArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasValueData.Read(ref r, v),
-                version)
+                version,
+                minElementSize: 10,
+                maxCount: DescribeClientQuotasResponse.MaxValueCount)
             : reader.ReadArray(
                 static (ref KafkaProtocolReader r, short v) => DescribeClientQuotasValueData.Read(ref r, v),
-                version);
+                version,
+                minElementSize: 10,
+                maxCount: DescribeClientQuotasResponse.MaxValueCount);
 
         if (flexible)
         {

--- a/src/Dekaf/Protocol/Messages/DescribeClusterResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeClusterResponse.cs
@@ -5,6 +5,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeClusterResponse : IKafkaResponse
 {
+    internal const int MaxNodeCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeCluster;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 2;
@@ -30,7 +32,9 @@ public sealed class DescribeClusterResponse : IKafkaResponse
         var controllerId = reader.ReadInt32();
         var nodes = reader.ReadCompactArray(
             static (ref KafkaProtocolReader r, short v) => DescribeClusterNode.Read(ref r, v),
-            version);
+            version,
+            minElementSize: version >= 2 ? 12 : 11,
+            maxCount: MaxNodeCount);
         var clusterAuthorizedOperations = reader.ReadInt32();
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/DescribeConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeConfigsResponse.cs
@@ -6,6 +6,10 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeConfigsResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 1_000_000;
+    internal const int MaxConfigCount = 1_000_000;
+    internal const int MaxSynonymCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeConfigs;
     public static short LowestSupportedVersion => 4;
     public static short HighestSupportedVersion => 4;
@@ -26,7 +30,10 @@ public sealed class DescribeConfigsResponse : IKafkaResponse
 
         IReadOnlyList<DescribeConfigsResult> results;
         results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DescribeConfigsResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DescribeConfigsResult.Read(ref r, v),
+            version,
+            minElementSize: 7,
+            maxCount: MaxResultCount);
 
         reader.SkipTaggedFields();
 
@@ -82,7 +89,10 @@ public sealed class DescribeConfigsResult
 
         IReadOnlyList<DescribeConfigsResourceResult> configs;
         configs = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DescribeConfigsResourceResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DescribeConfigsResourceResult.Read(ref r, v),
+            version,
+            minElementSize: 9,
+            maxCount: DescribeConfigsResponse.MaxConfigCount);
 
         reader.SkipTaggedFields();
 
@@ -167,7 +177,10 @@ public sealed class DescribeConfigsResourceResult
 
         IReadOnlyList<DescribeConfigsSynonym>? synonyms = null;
         synonyms = reader.ReadCompactArray(
-(ref KafkaProtocolReader r) => DescribeConfigsSynonym.Read(ref r, version));
+            static (ref KafkaProtocolReader r, short v) => DescribeConfigsSynonym.Read(ref r, v),
+            version,
+            minElementSize: 4,
+            maxCount: DescribeConfigsResponse.MaxSynonymCount);
 
         sbyte configType = 0;
         string? documentation = null;

--- a/src/Dekaf/Protocol/Messages/DescribeUserScramCredentialsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/DescribeUserScramCredentialsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class DescribeUserScramCredentialsResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 1_000_000;
+    internal const int MaxCredentialCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.DescribeUserScramCredentials;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -37,7 +40,10 @@ public sealed class DescribeUserScramCredentialsResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
 
         var results = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => DescribeUserScramCredentialsResult.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => DescribeUserScramCredentialsResult.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: MaxResultCount);
 
         reader.SkipTaggedFields();
 
@@ -83,7 +89,10 @@ public sealed class DescribeUserScramCredentialsResult
         var errorMessage = reader.ReadCompactString();
 
         var credentialInfos = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => CredentialInfo.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => CredentialInfo.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: DescribeUserScramCredentialsResponse.MaxCredentialCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/GetTelemetrySubscriptionsResponse.cs
@@ -6,6 +6,9 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class GetTelemetrySubscriptionsResponse : IKafkaResponse
 {
+    internal const int MaxCompressionTypeCount = 256;
+    internal const int MaxRequestedMetricCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.GetTelemetrySubscriptions;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -61,11 +64,17 @@ public sealed class GetTelemetrySubscriptionsResponse : IKafkaResponse
         var errorCode = (ErrorCode)reader.ReadInt16();
         var clientInstanceId = reader.ReadUuid();
         var subscriptionId = reader.ReadInt32();
-        var acceptedCompressionTypes = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadInt8());
+        var acceptedCompressionTypes = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadInt8(),
+            minElementSize: 1,
+            maxCount: MaxCompressionTypeCount);
         var pushIntervalMs = reader.ReadInt32();
         var telemetryMaxBytes = reader.ReadInt32();
         var deltaTemporality = reader.ReadBoolean();
-        var requestedMetrics = reader.ReadCompactArray(static (ref KafkaProtocolReader r) => r.ReadCompactNonNullableString());
+        var requestedMetrics = reader.ReadCompactArray(
+            static (ref KafkaProtocolReader r) => r.ReadCompactNonNullableString(),
+            minElementSize: 1,
+            maxCount: MaxRequestedMetricCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsResponse.cs
+++ b/src/Dekaf/Protocol/Messages/IncrementalAlterConfigsResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class IncrementalAlterConfigsResponse : IKafkaResponse
 {
+    internal const int MaxResourceCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.IncrementalAlterConfigs;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 1;
@@ -26,7 +28,10 @@ public sealed class IncrementalAlterConfigsResponse : IKafkaResponse
 
         IReadOnlyList<IncrementalAlterConfigsResourceResponse> responses;
         responses = reader.ReadCompactArray(
-            (ref KafkaProtocolReader r) => IncrementalAlterConfigsResourceResponse.Read(ref r, version)) ?? [];
+            static (ref KafkaProtocolReader r, short v) => IncrementalAlterConfigsResourceResponse.Read(ref r, v),
+            version,
+            minElementSize: 6,
+            maxCount: MaxResourceCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ListClientMetricsResourcesMessages.cs
+++ b/src/Dekaf/Protocol/Messages/ListClientMetricsResourcesMessages.cs
@@ -21,6 +21,8 @@ public sealed class ListClientMetricsResourcesRequest : IKafkaRequest<ListClient
 /// </summary>
 public sealed class ListClientMetricsResourcesResponse : IKafkaResponse
 {
+    internal const int MaxResourceCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ListClientMetricsResources;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 0;
@@ -34,7 +36,9 @@ public sealed class ListClientMetricsResourcesResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = (ErrorCode)reader.ReadInt16();
         var clientMetricsResources = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ListClientMetricsResource.Read(ref r));
+            static (ref KafkaProtocolReader r) => ListClientMetricsResource.Read(ref r),
+            minElementSize: 2,
+            maxCount: MaxResourceCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/ListConfigResourcesMessages.cs
+++ b/src/Dekaf/Protocol/Messages/ListConfigResourcesMessages.cs
@@ -28,6 +28,8 @@ public sealed class ListConfigResourcesRequest : IKafkaRequest<ListConfigResourc
 /// </summary>
 public sealed class ListConfigResourcesResponse : IKafkaResponse
 {
+    internal const int MaxResourceCount = 1_000_000;
+
     public static ApiKey ApiKey => ApiKey.ListClientMetricsResources;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 1;
@@ -41,7 +43,9 @@ public sealed class ListConfigResourcesResponse : IKafkaResponse
         var throttleTimeMs = reader.ReadInt32();
         var errorCode = (ErrorCode)reader.ReadInt16();
         var configResources = reader.ReadCompactArray(
-            static (ref KafkaProtocolReader r) => ListConfigResource.Read(ref r));
+            static (ref KafkaProtocolReader r) => ListConfigResource.Read(ref r),
+            minElementSize: 3,
+            maxCount: MaxResourceCount);
 
         reader.SkipTaggedFields();
 

--- a/src/Dekaf/Protocol/Messages/SaslHandshakeResponse.cs
+++ b/src/Dekaf/Protocol/Messages/SaslHandshakeResponse.cs
@@ -6,6 +6,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class SaslHandshakeResponse : IKafkaResponse
 {
+    internal const int MaxMechanismCount = 65_536;
+
     public static ApiKey ApiKey => ApiKey.SaslHandshake;
     public static short LowestSupportedVersion => 1;
     public static short HighestSupportedVersion => 1;
@@ -23,7 +25,10 @@ public sealed class SaslHandshakeResponse : IKafkaResponse
     public static IKafkaResponse Read(ref KafkaProtocolReader reader, short version)
     {
         var errorCode = (ErrorCode)reader.ReadInt16();
-        var mechanisms = reader.ReadArray((ref KafkaProtocolReader r) => r.ReadString()!);
+        var mechanisms = reader.ReadArray(
+            static (ref KafkaProtocolReader r) => r.ReadString()!,
+            minElementSize: 2,
+            maxCount: MaxMechanismCount);
 
         return new SaslHandshakeResponse
         {

--- a/src/Dekaf/Protocol/Messages/UpdateFeaturesResponse.cs
+++ b/src/Dekaf/Protocol/Messages/UpdateFeaturesResponse.cs
@@ -5,6 +5,8 @@ namespace Dekaf.Protocol.Messages;
 /// </summary>
 public sealed class UpdateFeaturesResponse : IKafkaResponse
 {
+    internal const int MaxResultCount = 100_000;
+
     public static ApiKey ApiKey => ApiKey.UpdateFeatures;
     public static short LowestSupportedVersion => 0;
     public static short HighestSupportedVersion => 2;
@@ -21,7 +23,9 @@ public sealed class UpdateFeaturesResponse : IKafkaResponse
         var errorMessage = reader.ReadCompactString();
         var results = version <= 1
             ? reader.ReadCompactArray(
-                static (ref KafkaProtocolReader r) => UpdateFeatureResult.Read(ref r)) ?? []
+                static (ref KafkaProtocolReader r) => UpdateFeatureResult.Read(ref r),
+                minElementSize: 5,
+                maxCount: MaxResultCount)
             : [];
 
         reader.SkipTaggedFields();

--- a/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/PendingFetchDataTests.cs
@@ -167,7 +167,7 @@ public class PendingFetchDataTests
 
         // Try to ratchet down — should be no-op
         PendingFetchData.RatchetPoolSize(1);
-        await Assert.That(PendingFetchData.MaxPoolSizeValue).IsEqualTo(current);
+        await Assert.That(PendingFetchData.MaxPoolSizeValue).IsGreaterThanOrEqualTo(current);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1562,8 +1562,10 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     [Timeout(120_000)]
     public async Task SendLoop_PipelinedProduce_UsesConnectionOwnedTimeoutsForConcurrentSends(CancellationToken cancellationToken)
     {
-        var tcs1 = new TaskCompletionSource<ProduceResponse>();
-        var tcs2 = new TaskCompletionSource<ProduceResponse>();
+        var tcs1 = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs2 = new TaskCompletionSource<ProduceResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
         responseQueue.Enqueue(tcs1);
         responseQueue.Enqueue(tcs2);
@@ -2245,7 +2247,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var responseQueue = new Queue<TaskCompletionSource<ProduceResponse>>();
         responseQueue.Enqueue(tcs);
 
-        var requestSent = new TaskCompletionSource();
+        var requestSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var (pool, _) = CreateMockConnection(responseQueue, onSend: () => requestSent.TrySetResult());
         cancellationToken = GuardUnscriptedSends(cancellationToken);
         var options = CreateOptions();
@@ -2307,7 +2309,7 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
         var vtPool = new ValueTaskSourcePool<RecordMetadata>();
 
         var ackOffsets = new List<long>();
-        var allAcknowledged = new TaskCompletionSource();
+        var allAcknowledged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var sender = CreateSender(pool, options, accumulator, (_, offset, _, _, ex) =>
         {

--- a/tests/Dekaf.Tests.Unit/Protocol/AdminResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/AdminResponseArrayBoundsTests.cs
@@ -63,6 +63,63 @@ public sealed class AdminResponseArrayBoundsTests
             .ThrowsExactly<MalformedProtocolDataException>();
     }
 
+    [Test]
+    public async Task DescribeDelegationTokenResponse_Read_V2MinimumToken_AcceptsExactWireSize()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactBytes([]);
+        writer.WriteUnsignedVarInt(1);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteInt32(0);
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var response = (DescribeDelegationTokenResponse)DescribeDelegationTokenResponse.Read(
+            ref reader,
+            version: 2);
+        var remaining = reader.Remaining;
+
+        await Assert.That(response.Tokens).Count().IsEqualTo(1);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DeleteAclsFilterResult_Read_MinimumMatchingAcl_AcceptsExactWireSize()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteUnsignedVarInt(2);
+        writer.WriteInt16((short)ErrorCode.None);
+        writer.WriteCompactNullableString(null);
+        writer.WriteInt8(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt8(0);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteCompactString(string.Empty);
+        writer.WriteInt8(0);
+        writer.WriteInt8(0);
+        writer.WriteEmptyTaggedFields();
+        writer.WriteEmptyTaggedFields();
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var result = DeleteAclsFilterResult.Read(ref reader, version: 3);
+        var remaining = reader.Remaining;
+
+        await Assert.That(result.MatchingAcls).Count().IsEqualTo(1);
+        await Assert.That(remaining).IsEqualTo(0);
+    }
+
     private static byte[] CreatePayload(ArrayTarget target)
     {
         var buffer = new ArrayBufferWriter<byte>();

--- a/tests/Dekaf.Tests.Unit/Protocol/AdminResponseArrayBoundsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/AdminResponseArrayBoundsTests.cs
@@ -1,0 +1,459 @@
+using System.Buffers;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+public sealed class AdminResponseArrayBoundsTests
+{
+    private const int HostileElementCount = 40;
+    private const int HostilePayloadLength = 60;
+    private const int HostileOneByteElementCount = 1_000_001;
+
+    [Test]
+    [Arguments(ArrayTarget.AlterClientEntriesLegacy)]
+    [Arguments(ArrayTarget.AlterClientEntriesFlexible)]
+    [Arguments(ArrayTarget.AlterClientEntityLegacy)]
+    [Arguments(ArrayTarget.AlterClientEntityFlexible)]
+    [Arguments(ArrayTarget.AlterConfigsResources)]
+    [Arguments(ArrayTarget.IncrementalAlterConfigsResources)]
+    [Arguments(ArrayTarget.CreateAclResults)]
+    [Arguments(ArrayTarget.DeleteAclFilterResults)]
+    [Arguments(ArrayTarget.DeleteAclMatchingAcls)]
+    [Arguments(ArrayTarget.DescribeAclResources)]
+    [Arguments(ArrayTarget.DescribeAclEntries)]
+    [Arguments(ArrayTarget.CreatePartitionsResults)]
+    [Arguments(ArrayTarget.CreateTopicsV5)]
+    [Arguments(ArrayTarget.CreateTopicsV7)]
+    [Arguments(ArrayTarget.CreateTopicConfigs)]
+    [Arguments(ArrayTarget.DeleteTopicsV4)]
+    [Arguments(ArrayTarget.DeleteTopicsV5)]
+    [Arguments(ArrayTarget.DeleteTopicsV6)]
+    [Arguments(ArrayTarget.AlterScramResults)]
+    [Arguments(ArrayTarget.DescribeScramResults)]
+    [Arguments(ArrayTarget.DescribeScramCredentials)]
+    [Arguments(ArrayTarget.DelegationTokensLegacy)]
+    [Arguments(ArrayTarget.DelegationTokensFlexible)]
+    [Arguments(ArrayTarget.DelegationRenewersLegacy)]
+    [Arguments(ArrayTarget.DelegationRenewersFlexible)]
+    [Arguments(ArrayTarget.SaslMechanisms)]
+    [Arguments(ArrayTarget.QuotaEntriesLegacy)]
+    [Arguments(ArrayTarget.QuotaEntriesFlexible)]
+    [Arguments(ArrayTarget.QuotaEntityLegacy)]
+    [Arguments(ArrayTarget.QuotaEntityFlexible)]
+    [Arguments(ArrayTarget.QuotaValuesLegacy)]
+    [Arguments(ArrayTarget.QuotaValuesFlexible)]
+    [Arguments(ArrayTarget.ClusterNodesV0)]
+    [Arguments(ArrayTarget.ClusterNodesV2)]
+    [Arguments(ArrayTarget.DescribeConfigsResults)]
+    [Arguments(ArrayTarget.DescribeConfigsEntries)]
+    [Arguments(ArrayTarget.DescribeConfigsSynonyms)]
+    [Arguments(ArrayTarget.TelemetryCompressionTypes)]
+    [Arguments(ArrayTarget.TelemetryRequestedMetrics)]
+    [Arguments(ArrayTarget.ClientMetricsResources)]
+    [Arguments(ArrayTarget.ConfigResources)]
+    [Arguments(ArrayTarget.UpdateFeatureResults)]
+    public async Task Read_HostileArrayCount_RejectsBeforeAllocation(ArrayTarget target)
+    {
+        var payload = CreatePayload(target);
+
+        await Assert.That(() => ReadContiguous(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>();
+        await Assert.That(() => ReadSegmented(payload, target))
+            .ThrowsExactly<MalformedProtocolDataException>();
+    }
+
+    private static byte[] CreatePayload(ArrayTarget target)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+
+        switch (target)
+        {
+            case ArrayTarget.AlterClientEntriesLegacy:
+            case ArrayTarget.AlterClientEntriesFlexible:
+            case ArrayTarget.AlterConfigsResources:
+            case ArrayTarget.IncrementalAlterConfigsResources:
+            case ArrayTarget.CreateAclResults:
+            case ArrayTarget.DeleteAclFilterResults:
+            case ArrayTarget.CreatePartitionsResults:
+            case ArrayTarget.CreateTopicsV5:
+            case ArrayTarget.CreateTopicsV7:
+            case ArrayTarget.DeleteTopicsV4:
+            case ArrayTarget.DeleteTopicsV5:
+            case ArrayTarget.DeleteTopicsV6:
+            case ArrayTarget.AlterScramResults:
+            case ArrayTarget.DescribeConfigsResults:
+                writer.WriteInt32(0);
+                break;
+            case ArrayTarget.AlterClientEntityLegacy:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteString(null);
+                break;
+            case ArrayTarget.AlterClientEntityFlexible:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.DeleteAclMatchingAcls:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.DescribeAclResources:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.DescribeAclEntries:
+                writer.WriteInt8(0);
+                writer.WriteCompactString(string.Empty);
+                writer.WriteInt8(0);
+                break;
+            case ArrayTarget.CreateTopicConfigs:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                writer.WriteInt32(0);
+                writer.WriteInt16(0);
+                break;
+            case ArrayTarget.DescribeScramCredentials:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.DescribeScramResults:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.DelegationTokensLegacy:
+            case ArrayTarget.DelegationTokensFlexible:
+                writer.WriteInt16((short)ErrorCode.None);
+                break;
+            case ArrayTarget.DelegationRenewersLegacy:
+                WriteDelegationTokenPreamble(ref writer, flexible: false);
+                break;
+            case ArrayTarget.DelegationRenewersFlexible:
+                WriteDelegationTokenPreamble(ref writer, flexible: true);
+                break;
+            case ArrayTarget.SaslMechanisms:
+                writer.WriteInt16((short)ErrorCode.None);
+                break;
+            case ArrayTarget.QuotaEntriesLegacy:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteString(null);
+                break;
+            case ArrayTarget.QuotaEntriesFlexible:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.QuotaValuesLegacy:
+                writer.WriteInt32(0);
+                break;
+            case ArrayTarget.QuotaValuesFlexible:
+                writer.WriteUnsignedVarInt(1);
+                break;
+            case ArrayTarget.ClusterNodesV0:
+            case ArrayTarget.ClusterNodesV2:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                if (target is ArrayTarget.ClusterNodesV2)
+                    writer.WriteInt8(0);
+                writer.WriteCompactString(string.Empty);
+                writer.WriteInt32(0);
+                break;
+            case ArrayTarget.DescribeConfigsEntries:
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                writer.WriteInt8(0);
+                writer.WriteCompactString(string.Empty);
+                break;
+            case ArrayTarget.DescribeConfigsSynonyms:
+                writer.WriteCompactString(string.Empty);
+                writer.WriteCompactNullableString(null);
+                writer.WriteBoolean(false);
+                writer.WriteInt8(0);
+                writer.WriteBoolean(false);
+                break;
+            case ArrayTarget.TelemetryCompressionTypes:
+            case ArrayTarget.TelemetryRequestedMetrics:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteUuid(Guid.Empty);
+                writer.WriteInt32(0);
+                if (target is ArrayTarget.TelemetryRequestedMetrics)
+                {
+                    writer.WriteUnsignedVarInt(1);
+                    writer.WriteInt32(0);
+                    writer.WriteInt32(0);
+                    writer.WriteBoolean(false);
+                }
+                break;
+            case ArrayTarget.ClientMetricsResources:
+            case ArrayTarget.ConfigResources:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                break;
+            case ArrayTarget.UpdateFeatureResults:
+                writer.WriteInt32(0);
+                writer.WriteInt16((short)ErrorCode.None);
+                writer.WriteCompactNullableString(null);
+                break;
+            case ArrayTarget.QuotaEntityLegacy:
+            case ArrayTarget.QuotaEntityFlexible:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+
+        WriteHostileArray(ref writer, target);
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteDelegationTokenPreamble(ref KafkaProtocolWriter writer, bool flexible)
+    {
+        WriteString(ref writer, string.Empty, flexible);
+        WriteString(ref writer, string.Empty, flexible);
+        if (flexible)
+        {
+            WriteString(ref writer, string.Empty, true);
+            WriteString(ref writer, string.Empty, true);
+        }
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        writer.WriteInt64(0);
+        WriteString(ref writer, string.Empty, flexible);
+        if (flexible)
+            writer.WriteCompactBytes([]);
+        else
+            writer.WriteBytes([]);
+    }
+
+    private static void WriteString(ref KafkaProtocolWriter writer, string value, bool flexible)
+    {
+        if (flexible)
+            writer.WriteCompactString(value);
+        else
+            writer.WriteString(value);
+    }
+
+    private static void WriteHostileArray(ref KafkaProtocolWriter writer, ArrayTarget target)
+    {
+        var count = target is ArrayTarget.TelemetryCompressionTypes
+            ? 257
+            : target is ArrayTarget.TelemetryRequestedMetrics
+                ? HostileOneByteElementCount
+                : HostileElementCount;
+
+        if (UsesLegacyEncoding(target))
+            writer.WriteInt32(count);
+        else
+            writer.WriteUnsignedVarInt(count + 1);
+
+        var payloadLength = target is ArrayTarget.TelemetryCompressionTypes
+            or ArrayTarget.TelemetryRequestedMetrics
+                ? count
+                : HostilePayloadLength;
+        writer.WriteRawBytes(new byte[payloadLength]);
+    }
+
+    private static bool UsesLegacyEncoding(ArrayTarget target) =>
+        target is ArrayTarget.AlterClientEntriesLegacy
+            or ArrayTarget.AlterClientEntityLegacy
+            or ArrayTarget.DelegationTokensLegacy
+            or ArrayTarget.DelegationRenewersLegacy
+            or ArrayTarget.SaslMechanisms
+            or ArrayTarget.QuotaEntriesLegacy
+            or ArrayTarget.QuotaEntityLegacy
+            or ArrayTarget.QuotaValuesLegacy;
+
+    private static void ReadContiguous(byte[] payload, ArrayTarget target)
+    {
+        var reader = new KafkaProtocolReader(payload);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadSegmented(byte[] payload, ArrayTarget target)
+    {
+        var sequence = SequenceTestHelpers.CreateMultiSegmentSequence(payload, payload.Length / 2);
+        var reader = new KafkaProtocolReader(sequence);
+        ReadTarget(ref reader, target);
+    }
+
+    private static void ReadTarget(ref KafkaProtocolReader reader, ArrayTarget target)
+    {
+        switch (target)
+        {
+            case ArrayTarget.AlterClientEntriesLegacy:
+                _ = AlterClientQuotasResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.AlterClientEntriesFlexible:
+                _ = AlterClientQuotasResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.AlterClientEntityLegacy:
+                _ = AlterClientQuotasResponseEntry.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.AlterClientEntityFlexible:
+                _ = AlterClientQuotasResponseEntry.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.AlterConfigsResources:
+                _ = AlterConfigsResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.IncrementalAlterConfigsResources:
+                _ = IncrementalAlterConfigsResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.CreateAclResults:
+                _ = CreateAclsResponse.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.DeleteAclFilterResults:
+                _ = DeleteAclsResponse.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.DeleteAclMatchingAcls:
+                _ = DeleteAclsFilterResult.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.DescribeAclResources:
+                _ = DescribeAclsResponse.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.DescribeAclEntries:
+                _ = DescribeAclsResource.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.CreatePartitionsResults:
+                _ = CreatePartitionsResponse.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.CreateTopicsV5:
+                _ = CreateTopicsResponse.Read(ref reader, version: 5);
+                break;
+            case ArrayTarget.CreateTopicsV7:
+                _ = CreateTopicsResponse.Read(ref reader, version: 7);
+                break;
+            case ArrayTarget.CreateTopicConfigs:
+                _ = CreateTopicsResponseTopic.Read(ref reader, version: 5);
+                break;
+            case ArrayTarget.DeleteTopicsV4:
+                _ = DeleteTopicsResponse.Read(ref reader, version: 4);
+                break;
+            case ArrayTarget.DeleteTopicsV5:
+                _ = DeleteTopicsResponse.Read(ref reader, version: 5);
+                break;
+            case ArrayTarget.DeleteTopicsV6:
+                _ = DeleteTopicsResponse.Read(ref reader, version: 6);
+                break;
+            case ArrayTarget.AlterScramResults:
+                _ = AlterUserScramCredentialsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.DescribeScramResults:
+                _ = DescribeUserScramCredentialsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.DescribeScramCredentials:
+                _ = DescribeUserScramCredentialsResult.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.DelegationTokensLegacy:
+                _ = DescribeDelegationTokenResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.DelegationTokensFlexible:
+                _ = DescribeDelegationTokenResponse.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.DelegationRenewersLegacy:
+                _ = DescribedDelegationTokenData.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.DelegationRenewersFlexible:
+                _ = DescribedDelegationTokenData.Read(ref reader, version: 3);
+                break;
+            case ArrayTarget.SaslMechanisms:
+                _ = SaslHandshakeResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.QuotaEntriesLegacy:
+                _ = DescribeClientQuotasResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.QuotaEntriesFlexible:
+                _ = DescribeClientQuotasResponse.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.QuotaEntityLegacy:
+            case ArrayTarget.QuotaValuesLegacy:
+                _ = DescribeClientQuotasResponseEntry.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.QuotaEntityFlexible:
+            case ArrayTarget.QuotaValuesFlexible:
+                _ = DescribeClientQuotasResponseEntry.Read(ref reader, version: 1);
+                break;
+            case ArrayTarget.ClusterNodesV0:
+                _ = DescribeClusterResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ClusterNodesV2:
+                _ = DescribeClusterResponse.Read(ref reader, version: 2);
+                break;
+            case ArrayTarget.DescribeConfigsResults:
+                _ = DescribeConfigsResponse.Read(ref reader, version: 4);
+                break;
+            case ArrayTarget.DescribeConfigsEntries:
+                _ = DescribeConfigsResult.Read(ref reader, version: 4);
+                break;
+            case ArrayTarget.DescribeConfigsSynonyms:
+                _ = DescribeConfigsResourceResult.Read(ref reader, version: 4);
+                break;
+            case ArrayTarget.TelemetryCompressionTypes:
+            case ArrayTarget.TelemetryRequestedMetrics:
+                _ = GetTelemetrySubscriptionsResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ClientMetricsResources:
+                _ = ListClientMetricsResourcesResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.ConfigResources:
+                _ = ListConfigResourcesResponse.Read(ref reader, version: 0);
+                break;
+            case ArrayTarget.UpdateFeatureResults:
+                _ = UpdateFeaturesResponse.Read(ref reader, version: 1);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(target), target, null);
+        }
+    }
+
+    public enum ArrayTarget
+    {
+        AlterClientEntriesLegacy,
+        AlterClientEntriesFlexible,
+        AlterClientEntityLegacy,
+        AlterClientEntityFlexible,
+        AlterConfigsResources,
+        IncrementalAlterConfigsResources,
+        CreateAclResults,
+        DeleteAclFilterResults,
+        DeleteAclMatchingAcls,
+        DescribeAclResources,
+        DescribeAclEntries,
+        CreatePartitionsResults,
+        CreateTopicsV5,
+        CreateTopicsV7,
+        CreateTopicConfigs,
+        DeleteTopicsV4,
+        DeleteTopicsV5,
+        DeleteTopicsV6,
+        AlterScramResults,
+        DescribeScramResults,
+        DescribeScramCredentials,
+        DelegationTokensLegacy,
+        DelegationTokensFlexible,
+        DelegationRenewersLegacy,
+        DelegationRenewersFlexible,
+        SaslMechanisms,
+        QuotaEntriesLegacy,
+        QuotaEntriesFlexible,
+        QuotaEntityLegacy,
+        QuotaEntityFlexible,
+        QuotaValuesLegacy,
+        QuotaValuesFlexible,
+        ClusterNodesV0,
+        ClusterNodesV2,
+        DescribeConfigsResults,
+        DescribeConfigsEntries,
+        DescribeConfigsSynonyms,
+        TelemetryCompressionTypes,
+        TelemetryRequestedMetrics,
+        ClientMetricsResources,
+        ConfigResources,
+        UpdateFeatureResults
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/ArrayEncodingTests.cs
@@ -235,6 +235,92 @@ public class ArrayEncodingTests
         await Assert.That(result).IsEquivalentTo([1, 2, 3]);
     }
 
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task BoundedNullableArray_WithState_Null_PreservesNull(bool compact)
+    {
+        var data = compact
+            ? new byte[] { 0 }
+            : new byte[] { 0xff, 0xff, 0xff, 0xff };
+        var reader = new KafkaProtocolReader(data);
+
+        var result = compact
+            ? reader.ReadCompactNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10)
+            : reader.ReadNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task BoundedNullableArray_WithState_Empty_PreservesEmpty(bool compact)
+    {
+        var data = compact
+            ? new byte[] { 1 }
+            : new byte[] { 0, 0, 0, 0 };
+        var reader = new KafkaProtocolReader(data);
+
+        var result = compact
+            ? reader.ReadCompactNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10)
+            : reader.ReadNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10);
+
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task BoundedNullableArray_WithState_NonNull_PreservesValues(bool compact)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new KafkaProtocolWriter(buffer);
+        if (compact)
+        {
+            writer.WriteCompactNullableArray<int>(
+                [1, 2],
+                static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        }
+        else
+        {
+            writer.WriteNullableArray<int>(
+                [1, 2],
+                static (ref KafkaProtocolWriter w, int value) => w.WriteInt32(value));
+        }
+
+        var reader = new KafkaProtocolReader(buffer.WrittenMemory);
+        var result = compact
+            ? reader.ReadCompactNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10)
+            : reader.ReadNullableArray(
+                static (ref KafkaProtocolReader r, int state) => r.ReadInt32() + state,
+                1,
+                minElementSize: 4,
+                maxCount: 10);
+
+        await Assert.That(result).IsEquivalentTo([2, 3]);
+    }
+
     #endregion
 
     #region Nested Array Tests


### PR DESCRIPTION
## Summary
- bound all admin, config, security, quota, and telemetry response-array allocations by exact minimum wire size and finite semantic caps
- add state-passing bounded legacy/nullable reader overloads and replace capturing parser lambdas
- preserve nullable null/empty/non-null wire semantics

## Tests
- red proof on the parent: hostile-count matrix failed 40/42 cases with late `InsufficientDataException`; the remaining one-byte cases were tightened to exercise absolute caps
- `AdminResponseArrayBoundsTests` + `ArrayEncodingTests`: 67 passed
- full unit suite net10.0: 6479 passed
- full unit suite net8.0: 6352 passed

## Performance
`ResponseArrayBoundsBenchmarks` (`ShortRun`, .NET 10, MemoryDiagnoser):

| Case | Before | After | Allocated |
|---|---:|---:|---:|
| Compact unbounded control | 153.7 ns | 148.0 ns | 424 B |
| Compact minimum-size bound | 162.9 ns | 128.2 ns | 424 B |
| Compact nullable unbounded | n/a on parent | 144.9 ns | 424 B |
| Compact nullable minimum-size bound | n/a on parent | 144.4 ns | 424 B |

The returned 100-element array accounts for 424 B in every case. Guard allocation delta: 0 B. Same-run guarded parsers show no throughput regression.

Closes #2405


## Post-review validation
- corrected DescribeDelegationToken v2 minimum (`30 B`) and matching ACL minimum (`11 B`)
- added valid exact-minimum boundary fixtures for both review regressions
- fixed the net8 timeout root by preventing inline test continuation re-entry into sender disposal
- focused net8: `AdminResponseArrayBoundsTests` 44/44; timed-out send-loop regression 1/1
- full unit suite: net8 6393/6393; net10 6520/6520; builds 0 warnings

Post-rebase `ResponseArrayBoundsBenchmarks` (`ShortRun`, .NET 10, MemoryDiagnoser):

| Case | Mean | Allocated |
|---|---:|---:|
| Compact unbounded control | 146.6 ns | 424 B |
| Compact minimum-size bound | 136.5 ns | 424 B |
| Compact nullable unbounded | 171.2 ns | 424 B |
| Compact nullable minimum-size bound | 149.1 ns | 424 B |

Guard allocation delta remains `0 B`; guarded paths do not regress the same-run controls.


### net8 parallel-ratchet CI fix
The current-head net8 run exposed a separate deterministic test bug: `RatchetPoolSize_DoesNotDecrease` required equality even though other parallel tests may legally increase the global monotonic ratchet. The assertion now verifies `after >= capturedCurrent`. Post-fix full suites: net8 6393/6393; net10 6520/6520; 0 build warnings.
