### PR TITLE
Cache detachable record-batch writers

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -190,14 +190,35 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
 {
     private const int MinimumInitialCapacity = 256;
 
-    private readonly ArrayPool<byte> _pool;
-    private byte[] _buffer;
-    private int _written;
+    [ThreadStatic]
+    private static DetachableBufferWriter? t_cachedWriter;
 
-    public DetachableBufferWriter(ArrayPool<byte> pool, int initialCapacity)
+    private ArrayPool<byte>? _arrayPool;
+    private byte[] _buffer = [];
+    private int _written;
+    private bool _returnedToCache;
+
+    private DetachableBufferWriter()
     {
-        _pool = pool;
-        _buffer = pool.Rent(Math.Max(MinimumInitialCapacity, initialCapacity));
+    }
+
+    public static DetachableBufferWriter Rent(ArrayPool<byte> arrayPool, int initialCapacity)
+    {
+        var writer = t_cachedWriter;
+        if (writer is null)
+        {
+            writer = new DetachableBufferWriter();
+        }
+        else
+        {
+            t_cachedWriter = null;
+        }
+
+        writer._arrayPool = arrayPool;
+        writer._buffer = arrayPool.Rent(Math.Max(MinimumInitialCapacity, initialCapacity));
+        writer._written = 0;
+        writer._returnedToCache = false;
+        return writer;
     }
 
     public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
@@ -235,11 +256,19 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
 
     public void Dispose()
     {
+        if (_returnedToCache)
+            return;
+
         var buf = _buffer;
+        var arrayPool = _arrayPool!;
         _buffer = [];
         _written = 0;
+        _arrayPool = null;
+        _returnedToCache = true;
         if (buf.Length > 0)
-            _pool.Return(buf, clearArray: false);
+            arrayPool.Return(buf, clearArray: false);
+
+        t_cachedWriter ??= this;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -264,9 +293,10 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
         if (newSize <= _buffer.Length)
             throw new InvalidOperationException("Cannot grow buffer: maximum size reached.");
 
-        var newBuffer = _pool.Rent(newSize);
+        var arrayPool = _arrayPool!;
+        var newBuffer = arrayPool.Rent(newSize);
         _buffer.AsSpan(0, _written).CopyTo(newBuffer);
-        _pool.Return(_buffer, clearArray: false);
+        arrayPool.Return(_buffer, clearArray: false);
         _buffer = newBuffer;
     }
 }
@@ -759,7 +789,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             }
 
             var uncompressedRecords = Records;
-            using var encodedBuffer = new DetachableBufferWriter(
+            using var encodedBuffer = DetachableBufferWriter.Rent(
                 ProducerDataPool.BytePool, GetEncodedRecordsLength(uncompressedRecords));
             var writer = new KafkaProtocolWriter(encodedBuffer);
             WriteRecords(uncompressedRecords, ref writer);
@@ -775,7 +805,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         var codec = registry.GetCodec(compression);
         if (_hasPreEncodedRecords)
         {
-            using var compressedBuffer = new DetachableBufferWriter(
+            using var compressedBuffer = DetachableBufferWriter.Rent(
                 ProducerDataPool.BytePool,
                 GetPreEncodedRecordsLength());
             codec.Compress(GetPreEncodedRecordsSequence(), compressedBuffer);
@@ -795,7 +825,9 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             var records = Records;
 
             WriteRecords(records, ref recordsWriter);
-            using var serializedCompressedBuffer = new DetachableBufferWriter(ProducerDataPool.BytePool, recordsBuffer.WrittenCount);
+            using var serializedCompressedBuffer = DetachableBufferWriter.Rent(
+                ProducerDataPool.BytePool,
+                recordsBuffer.WrittenCount);
             codec.Compress(new ReadOnlySequence<byte>(recordsBuffer.WrittenMemory), serializedCompressedBuffer);
             PreCompressedRecordsCrc = Crc32C.Compute(serializedCompressedBuffer.WrittenSpan);
             PreCompressedRecords = serializedCompressedBuffer.DetachBuffer(out var serializedCompressedLength);
@@ -1505,7 +1537,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             var registry = codecs ?? CompressionCodecRegistry.Default;
             var codec = registry.GetCodec(compression);
             var estimatedSize = recordsLength * 4; // Estimate 4x expansion
-            using var decompressWriter = new DetachableBufferWriter(ArrayPool<byte>.Shared, estimatedSize);
+            using var decompressWriter = DetachableBufferWriter.Rent(ArrayPool<byte>.Shared, estimatedSize);
             codec.Decompress(new ReadOnlySequence<byte>(rawRecordData), decompressWriter);
 
             // Transfer ownership of the pooled array — Dispose is a no-op after DetachBuffer.

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -190,6 +190,7 @@ internal sealed class DetachableBufferWriter : IBufferWriter<byte>, IDisposable
 {
     private const int MinimumInitialCapacity = 256;
 
+    // Single-slot cache: nested rents safely allocate another wrapper instead of sharing live state.
     [ThreadStatic]
     private static DetachableBufferWriter? t_cachedWriter;
 

--- a/tests/Dekaf.Tests.Unit/Protocol/DetachableBufferWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/DetachableBufferWriterTests.cs
@@ -1,0 +1,55 @@
+using System.Buffers;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Protocol;
+
+[NotInParallel]
+public sealed class DetachableBufferWriterTests
+{
+    [Test]
+    public async Task Rent_AfterDispose_ReusesWrapperAndPreservesDetachedBufferOwnership()
+    {
+        var pool = ArrayPool<byte>.Create();
+        var first = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        var span = first.GetSpan(1);
+        span[0] = 42;
+        first.Advance(1);
+        var detached = first.DetachBuffer(out var detachedLength);
+        first.Dispose();
+
+        var second = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        try
+        {
+            await Assert.That(second).IsSameReferenceAs(first);
+            await Assert.That(second.WrittenSpan.Length).IsEqualTo(0);
+            await Assert.That(detachedLength).IsEqualTo(1);
+            await Assert.That(detached[0]).IsEqualTo((byte)42);
+            await Assert.That(second.GetSpan(1).Length).IsGreaterThanOrEqualTo(1);
+        }
+        finally
+        {
+            second.Dispose();
+            pool.Return(detached);
+        }
+    }
+
+    [Test]
+    public async Task Rent_AfterDisposeWithoutDetach_ReusesClearedWrapper()
+    {
+        var pool = ArrayPool<byte>.Create();
+        var first = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        first.Advance(1);
+        first.Dispose();
+
+        var second = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        try
+        {
+            await Assert.That(second).IsSameReferenceAs(first);
+            await Assert.That(second.WrittenSpan.Length).IsEqualTo(0);
+        }
+        finally
+        {
+            second.Dispose();
+        }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProtocolBenchmarks.cs
@@ -24,6 +24,7 @@ public class ProtocolBenchmarks
     private byte[] _int32Data = null!;
     private byte[] _varIntData = null!;
     private byte[] _recordBatchBytes = null!;
+    private byte[] _compressedRecordBatchBytes = null!;
     private RecordBatch _writeBatch = null!;
     private string _testString = null!;
     private string _longString = null!;
@@ -71,6 +72,10 @@ public class ProtocolBenchmarks
         };
         batch.Write(tempBuffer);
         _recordBatchBytes = tempBuffer.WrittenSpan.ToArray();
+
+        tempBuffer.Clear();
+        batch.Write(tempBuffer, CompressionType.Gzip);
+        _compressedRecordBatchBytes = tempBuffer.WrittenSpan.ToArray();
 
         _writeBatch = CreateTenRecordBatch();
     }
@@ -234,6 +239,16 @@ public class ProtocolBenchmarks
     public long ReadRecordBatch()
     {
         var reader = new KafkaProtocolReader(_recordBatchBytes);
+        var batch = RecordBatch.Read(ref reader);
+        var baseOffset = batch.BaseOffset;
+        batch.DisposeAndReturnUnownedConsumerBatch();
+        return baseOffset;
+    }
+
+    [Benchmark(Description = "Read Gzip RecordBatch (10 records)")]
+    public long ReadCompressedRecordBatch()
+    {
+        var reader = new KafkaProtocolReader(_compressedRecordBatchBytes);
         var batch = RecordBatch.Read(ref reader);
         var baseOffset = batch.BaseOffset;
         batch.DisposeAndReturnUnownedConsumerBatch();


### PR DESCRIPTION
## Summary
- reuse the allocation-only `DetachableBufferWriter` wrapper through a thread-local cache
- keep every pooled byte-array lifecycle unchanged: detached arrays remain caller-owned; non-detached arrays return on `Dispose`
- cover producer pre-compression and consumer record-batch decompression call sites
- add producer serialization and Gzip consumer decompression `[MemoryDiagnoser]` evidence

The cached wrapper contains no byte buffer between uses, avoiding the large thread-local retention problem that motivated bounded serialization caches.

## Tests
- TDD red: new lifecycle tests failed to compile before `Rent` existed
- focused writer/producer encoding tests: 15 passed
- full unit suite net10.0: 6433 passed
- full unit suite net8.0: 6306 passed
- post-rebase benchmark project build: 0 warnings, 0 errors

## Performance

Environment: Windows 11, Intel i7-12700K, .NET 10.0.10, BenchmarkDotNet 0.15.8, `ThroughputJob` (5 warmups, 10 iterations), `[MemoryDiagnoser]`.

### Producer pre-serialization

`ProtocolBenchmarks.WriteRecordBatchPreSerialized`:

| Commit | Mean | Allocated |
|---|---:|---:|
| `3946d5f2` exact parent | 494.3 ns | 40 B |
| `c3234ff6` candidate | 437.4 ns | 0 B |

Mean: -11.5%; allocation: -40 B/op. The exact-parent baseline was noisy; against the earlier stable baseline (`3ddd994f`, 466.3 ns/40 B), the candidate is still -6.2% and -40 B/op.

### Consumer Gzip decompression

`ProtocolBenchmarks.ReadCompressedRecordBatch`, added in `58fbe487e`, constructs compressed input in `[GlobalSetup]`, then benchmarks `RecordBatch.Read` and pooled disposal:

| Commit | Mean | Error | StdDev | Allocated |
|---|---:|---:|---:|---:|
| `3946d5f2` exact parent | 1.086 us | 0.0819 us | 0.0542 us | 352 B |
| `58fbe487e` candidate | 1.049 us | 0.0222 us | 0.0132 us | 312 B |

Mean: -3.4%; allocation: -40 B/op (-11.4%). Confidence intervals overlap, so latency is treated as unchanged rather than an improvement; the protected allocation metric improves deterministically by the wrapper's 40 B. No protected metric regressed.

Refs #2214

The Snappier half of #2214 remains blocked by #2352 pending upstream merge/release.