### PR TITLE
Retry Kafka image pulls for NativeAOT integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,8 @@ jobs:
     if: needs.changes.outputs.code == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.publish_nuget == true)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      KAFKA_TEST_IMAGE_TAG: '4.3.1'
 
     steps:
       - name: Add Swap Space
@@ -487,6 +489,9 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
+
+      - name: Pre-pull Kafka image
+        run: bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG"
 
       - name: Run NativeAOT integration smoke tests
         run: bash scripts/run-integration-categories.sh aot "Producer,Consumer,Messaging,Serialization"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
       - name: Pre-pull Kafka image
-        run: bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG"
+        run: bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG" 4.0.2
 
       - name: Run NativeAOT integration smoke tests
         run: bash scripts/run-integration-categories.sh aot "Producer,Consumer,Messaging,Serialization"

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -99,25 +99,14 @@ jobs:
       - name: Pre-pull Kafka image
         run: |
           case "${{ matrix.group }}" in
-            tls|security) kafka_tags="4.0.2" ;;
-            faults) kafka_tags="${{ inputs.kafka-tag }} 4.0.2 4.2.1" ;;
-            messaging) kafka_tags="${{ inputs.kafka-tag }} 4.0.2" ;;
-            consume) kafka_tags="${{ inputs.kafka-tag }} 4.2.1" ;;
-            produce) kafka_tags="${{ inputs.kafka-tag }} 4.2.1" ;;
-            *) kafka_tags="${{ inputs.kafka-tag }}" ;;
+            tls|security) kafka_tags=(4.0.2) ;;
+            faults) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2 4.2.1) ;;
+            messaging) kafka_tags=("${{ inputs.kafka-tag }}" 4.0.2) ;;
+            consume) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
+            produce) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
+            *) kafka_tags=("${{ inputs.kafka-tag }}") ;;
           esac
-
-          for tag in $(printf '%s\n' $kafka_tags | sort -u); do
-            for attempt in 1 2 3 4 5; do
-              docker pull "apache/kafka:$tag" && break
-              if [ "$attempt" -eq 5 ]; then
-                exit 1
-              fi
-              delay=$((attempt * 15))
-              echo "Kafka image pull failed for $tag (attempt $attempt); retrying in ${delay}s"
-              sleep "$delay"
-            done
-          done
+          bash scripts/prepull-kafka-images.sh "${kafka_tags[@]}"
 
       - name: Run integration tests
         env:

--- a/scripts/prepull-kafka-images.sh
+++ b/scripts/prepull-kafka-images.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <kafka-image-tag> [<kafka-image-tag> ...]" >&2
+  exit 2
+fi
+
+while IFS= read -r tag; do
+  for attempt in 1 2 3 4 5; do
+    if docker pull "apache/kafka:$tag"; then
+      break
+    fi
+
+    if [ "$attempt" -eq 5 ]; then
+      exit 1
+    fi
+
+    delay=$((attempt * 15))
+    echo "Kafka image pull failed for $tag (attempt $attempt); retrying in ${delay}s"
+    sleep "$delay"
+  done
+done < <(printf '%s\n' "$@" | sort -u)

--- a/scripts/prepull-kafka-images.sh
+++ b/scripts/prepull-kafka-images.sh
@@ -8,7 +8,7 @@ fi
 
 while IFS= read -r tag; do
   for attempt in 1 2 3 4 5; do
-    if docker pull "apache/kafka:$tag"; then
+    if timeout 60s docker pull "apache/kafka:$tag"; then
       break
     fi
 

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -6,9 +6,11 @@ temp_root="$(mktemp -d)"
 trap 'rm -rf "$temp_root"' EXIT
 
 mkdir -p "$temp_root/scripts" \
+  "$temp_root/fake-bin" \
   "$temp_root/artifacts/aot/integration" \
   "$temp_root/tests/Dekaf.Tests.Integration/bin/Release/net10.0"
 cp "$repo_root/scripts/run-integration-categories.sh" "$temp_root/scripts/"
+cp "$repo_root/scripts/prepull-kafka-images.sh" "$temp_root/scripts/"
 
 fake_runner='#!/usr/bin/env bash
 printf "%s\n" "$*" >> "$CALLS_FILE"'
@@ -33,5 +35,35 @@ grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
 grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
   "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
+
+fake_docker='#!/usr/bin/env bash
+attempts="$(cat "$DOCKER_ATTEMPTS_FILE" 2>/dev/null || printf "0")"
+attempts=$((attempts + 1))
+printf "%s" "$attempts" > "$DOCKER_ATTEMPTS_FILE"
+printf "%s\n" "$*" >> "$DOCKER_CALLS_FILE"
+[ "$attempts" -gt "${DOCKER_FAIL_UNTIL:-0}" ]'
+fake_sleep='#!/usr/bin/env bash
+printf "%s\n" "$*" >> "$SLEEP_CALLS_FILE"'
+printf '%s\n' "$fake_docker" > "$temp_root/fake-bin/docker"
+printf '%s\n' "$fake_sleep" > "$temp_root/fake-bin/sleep"
+chmod +x "$temp_root/fake-bin/docker" "$temp_root/fake-bin/sleep"
+
+export PATH="$temp_root/fake-bin:$PATH"
+export DOCKER_ATTEMPTS_FILE="$temp_root/docker-attempts"
+export DOCKER_CALLS_FILE="$temp_root/docker-calls"
+export SLEEP_CALLS_FILE="$temp_root/sleep-calls"
+
+export DOCKER_FAIL_UNTIL=2
+bash scripts/prepull-kafka-images.sh 4.3.1
+[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 3 ]
+grep -qx '15' "$SLEEP_CALLS_FILE"
+grep -qx '30' "$SLEEP_CALLS_FILE"
+
+rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE"
+export DOCKER_FAIL_UNTIL=0
+bash scripts/prepull-kafka-images.sh 4.3.1 4.2.1 4.3.1
+[ "$(wc -l < "$DOCKER_CALLS_FILE")" -eq 2 ]
+grep -qx 'pull apache/kafka:4.2.1' "$DOCKER_CALLS_FILE"
+grep -qx 'pull apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
 
 echo "run-integration-categories tests passed"

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -35,6 +35,8 @@ grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
 grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
   "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
+grep -Fq 'bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG" 4.0.2' \
+  "$repo_root/.github/workflows/ci.yml"
 
 fake_docker='#!/usr/bin/env bash
 attempts="$(cat "$DOCKER_ATTEMPTS_FILE" 2>/dev/null || printf "0")"
@@ -44,26 +46,34 @@ printf "%s\n" "$*" >> "$DOCKER_CALLS_FILE"
 [ "$attempts" -gt "${DOCKER_FAIL_UNTIL:-0}" ]'
 fake_sleep='#!/usr/bin/env bash
 printf "%s\n" "$*" >> "$SLEEP_CALLS_FILE"'
+fake_timeout='#!/usr/bin/env bash
+printf "%s\n" "$1" >> "$TIMEOUT_CALLS_FILE"
+shift
+"$@"'
 printf '%s\n' "$fake_docker" > "$temp_root/fake-bin/docker"
 printf '%s\n' "$fake_sleep" > "$temp_root/fake-bin/sleep"
-chmod +x "$temp_root/fake-bin/docker" "$temp_root/fake-bin/sleep"
+printf '%s\n' "$fake_timeout" > "$temp_root/fake-bin/timeout"
+chmod +x "$temp_root/fake-bin/docker" "$temp_root/fake-bin/sleep" "$temp_root/fake-bin/timeout"
 
 export PATH="$temp_root/fake-bin:$PATH"
 export DOCKER_ATTEMPTS_FILE="$temp_root/docker-attempts"
 export DOCKER_CALLS_FILE="$temp_root/docker-calls"
 export SLEEP_CALLS_FILE="$temp_root/sleep-calls"
+export TIMEOUT_CALLS_FILE="$temp_root/timeout-calls"
 
 export DOCKER_FAIL_UNTIL=2
 bash scripts/prepull-kafka-images.sh 4.3.1
 [ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 3 ]
 grep -qx '15' "$SLEEP_CALLS_FILE"
 grep -qx '30' "$SLEEP_CALLS_FILE"
+[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 3 ]
 
-rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE"
+rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
 export DOCKER_FAIL_UNTIL=0
 bash scripts/prepull-kafka-images.sh 4.3.1 4.2.1 4.3.1
 [ "$(wc -l < "$DOCKER_CALLS_FILE")" -eq 2 ]
 grep -qx 'pull apache/kafka:4.2.1' "$DOCKER_CALLS_FILE"
 grep -qx 'pull apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
+[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 2 ]
 
 echo "run-integration-categories tests passed"


### PR DESCRIPTION
## Summary
- pre-pull every Kafka image used by NativeAOT integration smoke tests
- share the existing five-attempt retry behavior with regular integration lanes
- cap every `docker pull` attempt at 60 seconds so stalled connections reach later retries
- test retries, backoff, per-attempt timeout, duplicate-tag elimination, and the AOT image set deterministically

## Failure evidence
Run 30273373757 job 90002724952 failed all 131 NativeAOT smoke tests during shared fixture initialization because Docker Hub's auth request timed out. The AOT lane lacked the pre-pull/retry guard already used by regular integration jobs.

The `Serialization` category also starts the hard-coded `apache/kafka:4.0.2` Schema Registry fixture, so the AOT pre-pull now covers both the configured `4.3.1` image and `4.0.2`.

## Validation
- `bash -n scripts/prepull-kafka-images.sh scripts/tests/run-integration-categories-tests.sh`
- `bash scripts/tests/run-integration-categories-tests.sh`
- YAML parse for both changed workflows
- `git diff --check`

Closes #2418