### PR TITLE
Fix merge gate for re-verified reviews

### DIFF
--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -199,6 +199,7 @@ function Get-ActionableReviewBodyReason {
         'verified(?:\s+against\b[\s\S]*)?'
         're[- ]verified'
         'confirmed\b(?:[\s\S]*)?'
+        '(?:all|each)\b[\s\S]*\bremain(?:s)?\s+(?:fully\s+)?(?:synchronous|correct|safe|unchanged|guarded)\b(?:[\s\S]*)?'
         'no\s+concerns\b(?:[\s\S]*)?'
         '`?configureawait\(false\)`?(?:[\s\S]*\b)?(?:used|applied)\s+consistently(?:[\s\S]*)?'
         '(?:the\s+)?core\s+fix\s+is\s+(?:sound|correct)(?:[\s\S]*)?'
@@ -234,7 +235,6 @@ function Get-ActionableReviewBodyReason {
         } else {
             $heading.Groups['parentheticalVerdict'].Value
         }
-        $headingVerdictIsCleanReverification = $headingVerdict -match '(?is)^\s*re[- ]verified\s*$'
         $headingVerdictResolvesPriorFindings = $headingVerdict -match "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:both\s+)?previously[- ]flagged\b$resolvedPriorFindingContinuationGuard(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?$"
         if ($headingVerdict -and $headingVerdict -notmatch $positiveCategoryHeadingVerdict) {
             return "actionable category heading: $($heading.Value.Trim())"
@@ -263,7 +263,6 @@ function Get-ActionableReviewBodyReason {
 
         if ($firstVerdict -notmatch $positiveCategorySection -and
             -not ($headingVerdictResolvesPriorFindings -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
-            -not ($headingVerdictIsCleanReverification -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
             -not ($sectionStartsWithTraceAndAllClear -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
             -not ($allowsGlobalNoIssueVerdict -and $globalNoIssueVerdict -and $sectionBody -notmatch $positiveVerdictContinuationBlocker)) {
             return "actionable category heading: $($heading.Value.Trim())"

--- a/scripts/AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/AssertPrGreenReviewHeuristics.ps1
@@ -197,6 +197,7 @@ function Get-ActionableReviewBodyReason {
         "(?:both\s+)?previously[- ]flagged\b$resolvedPriorFindingContinuationGuard(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?"
         "(?:the\s+)?prior\b$resolvedPriorFindingContinuationGuard(?=[\s\S]*\b(?:findings?|issues?|bugs?)\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?"
         'verified(?:\s+against\b[\s\S]*)?'
+        're[- ]verified'
         'confirmed\b(?:[\s\S]*)?'
         'no\s+concerns\b(?:[\s\S]*)?'
         '`?configureawait\(false\)`?(?:[\s\S]*\b)?(?:used|applied)\s+consistently(?:[\s\S]*)?'
@@ -233,6 +234,7 @@ function Get-ActionableReviewBodyReason {
         } else {
             $heading.Groups['parentheticalVerdict'].Value
         }
+        $headingVerdictIsCleanReverification = $headingVerdict -match '(?is)^\s*re[- ]verified\s*$'
         $headingVerdictResolvesPriorFindings = $headingVerdict -match "(?is)^(?!.*$positiveVerdictBlocker)(?!.*$positiveVerdictContinuationBlocker)\s*(?:both\s+)?previously[- ]flagged\b$resolvedPriorFindingContinuationGuard(?![\s\S]*\b(?:not|never|still|un(?:fixed|resolved|addressed|verified|handled))\b)(?=[\s\S]*\b(?:fixed|resolved|addressed|verified)\b)(?:[\s\S]*)?$"
         if ($headingVerdict -and $headingVerdict -notmatch $positiveCategoryHeadingVerdict) {
             return "actionable category heading: $($heading.Value.Trim())"
@@ -261,6 +263,7 @@ function Get-ActionableReviewBodyReason {
 
         if ($firstVerdict -notmatch $positiveCategorySection -and
             -not ($headingVerdictResolvesPriorFindings -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
+            -not ($headingVerdictIsCleanReverification -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
             -not ($sectionStartsWithTraceAndAllClear -and $sectionBody -notmatch $positiveVerdictContinuationBlocker) -and
             -not ($allowsGlobalNoIssueVerdict -and $globalNoIssueVerdict -and $sectionBody -notmatch $positiveVerdictContinuationBlocker)) {
             return "actionable category heading: $($heading.Value.Trim())"

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -154,6 +154,30 @@ No blocking issues found.
         Blocks = $false
     },
     @{
+        Name = 'allows re-verified category heading with clean verification details'
+        Body = @'
+## Review
+
+### Correctness (re-verified)
+- All four call sites remain fully synchronous, so the thread-local cache cannot cross an async continuation.
+- Detached buffer ownership and double-dispose guards remain correct.
+
+### Verdict
+No remaining correctness, security, or coverage issues.
+'@
+        Blocks = $false
+    },
+    @{
+        Name = 'blocks re-verified category heading with continuation defect'
+        Body = @'
+## Review
+
+### Correctness (re-verified)
+The retry path still deadlocks when disposal overlaps a timeout.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows positive category section heading with colon'
         Body = @'
 ## Review

--- a/scripts/Test-AssertPrGreenReviewHeuristics.ps1
+++ b/scripts/Test-AssertPrGreenReviewHeuristics.ps1
@@ -178,6 +178,26 @@ The retry path still deadlocks when disposal overlaps a timeout.
         Blocks = $true
     },
     @{
+        Name = 'blocks re-verified category heading with unrecognized attention request'
+        Body = @'
+## Review
+
+### Correctness (re-verified)
+This retry path needs attention before merging.
+'@
+        Blocks = $true
+    },
+    @{
+        Name = 'blocks re-verified category heading with unrecognized required fix'
+        Body = @'
+## Review
+
+### Correctness (re-verified)
+The timeout path loses delivery acknowledgements and must be fixed.
+'@
+        Blocks = $true
+    },
+    @{
         Name = 'allows positive category section heading with colon'
         Body = @'
 ## Review


### PR DESCRIPTION
## Summary
- recognize exact `re-verified` as a positive review-category heading verdict
- still require the section’s first content line to independently match recognized clean language
- add a narrow clean phrase for “all/each … remain synchronous/correct/safe/unchanged/guarded”
- keep every existing actionable continuation scan and fail closed on unknown prose

## Reproduction
`Assert-PrGreen.ps1 -Pr 2416` rejected an otherwise-green PR because its clear current-head review used `### Correctness (re-verified)`. The patched heuristic classifies the full live #2416 Claude review as clear.

The first revision incorrectly let the heading itself bypass positive-content validation. `f7474bc66` removes that bypass: both reviewer examples (`needs attention before merging`; `loses delivery acknowledgements and must be fixed`) now remain blocked.

## Validation
- TDD red: clean #2416 review shape originally failed with `actionable category heading: ### Correctness (re-verified)`
- `pwsh scripts/Test-AssertPrGreenReviewHeuristics.ps1` — 115 body cases + 4 stale-review cases passed
- `pwsh scripts/Test-MergePr.ps1` — passed
- full live #2416 review body — clear under patched heuristic
- `git diff --check`

Closes #2422