### PR TITLE
Pre-pull Testcontainers Ryuk in integration CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,8 +490,13 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
-      - name: Pre-pull Kafka image
-        run: bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG" 4.0.2
+      # Keep the Ryuk image aligned with DotNet.Testcontainers in Directory.Packages.props.
+      - name: Pre-pull integration images
+        run: |
+          bash scripts/prepull-kafka-images.sh \
+            "$KAFKA_TEST_IMAGE_TAG" \
+            4.0.2 \
+            "testcontainers/ryuk:0.14.0@sha256:7c1a8a9a47c780ed0f983770a662f80deb115d95cce3e2daa3d12115b8cd28f0"
 
       - name: Run NativeAOT integration smoke tests
         run: bash scripts/run-integration-categories.sh aot "Producer,Consumer,Messaging,Serialization"

--- a/.github/workflows/integration-groups.yml
+++ b/.github/workflows/integration-groups.yml
@@ -96,7 +96,8 @@ jobs:
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env['ACTIONS_RUNTIME_TOKEN']);
             core.exportVariable('ACTIONS_RESULTS_URL', process.env['ACTIONS_RESULTS_URL']);
 
-      - name: Pre-pull Kafka image
+      # Keep the Ryuk image aligned with DotNet.Testcontainers in Directory.Packages.props.
+      - name: Pre-pull integration images
         run: |
           case "${{ matrix.group }}" in
             tls|security) kafka_tags=(4.0.2) ;;
@@ -106,7 +107,9 @@ jobs:
             produce) kafka_tags=("${{ inputs.kafka-tag }}" 4.2.1) ;;
             *) kafka_tags=("${{ inputs.kafka-tag }}") ;;
           esac
-          bash scripts/prepull-kafka-images.sh "${kafka_tags[@]}"
+          bash scripts/prepull-kafka-images.sh \
+            "${kafka_tags[@]}" \
+            "testcontainers/ryuk:0.14.0@sha256:7c1a8a9a47c780ed0f983770a662f80deb115d95cce3e2daa3d12115b8cd28f0"
 
       - name: Run integration tests
         env:

--- a/scripts/prepull-kafka-images.sh
+++ b/scripts/prepull-kafka-images.sh
@@ -6,7 +6,7 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
-max_attempts=8
+max_attempts=3
 
 while IFS= read -r image_or_tag; do
   if [[ "$image_or_tag" == */* ]]; then
@@ -17,6 +17,23 @@ while IFS= read -r image_or_tag; do
 
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if timeout 60s docker pull "$image"; then
+      break
+    fi
+
+    mirror_image="mirror.gcr.io/$image"
+    if timeout 30s docker pull "$mirror_image"; then
+      docker tag "$mirror_image" "${image%@*}"
+
+      if [[ "$image" == testcontainers/ryuk:* ]]; then
+        if [ -z "${GITHUB_ENV:-}" ]; then
+          echo "GITHUB_ENV is required to use the digest-pinned Ryuk mirror fallback" >&2
+          exit 1
+        fi
+
+        printf 'TESTCONTAINERS_RYUK_CONTAINER_IMAGE=%s\n' "$mirror_image" >> "$GITHUB_ENV"
+      fi
+
+      echo "Pulled $image from the Docker Hub cache at mirror.gcr.io"
       break
     fi
 

--- a/scripts/prepull-kafka-images.sh
+++ b/scripts/prepull-kafka-images.sh
@@ -6,6 +6,8 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+max_attempts=8
+
 while IFS= read -r image_or_tag; do
   if [[ "$image_or_tag" == */* ]]; then
     image="$image_or_tag"
@@ -13,16 +15,20 @@ while IFS= read -r image_or_tag; do
     image="apache/kafka:$image_or_tag"
   fi
 
-  for attempt in 1 2 3 4 5; do
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if timeout 60s docker pull "$image"; then
       break
     fi
 
-    if [ "$attempt" -eq 5 ]; then
+    if [ "$attempt" -eq "$max_attempts" ]; then
       exit 1
     fi
 
     delay=$((attempt * 15))
+    if [ "$delay" -gt 60 ]; then
+      delay=60
+    fi
+
     echo "Image pull failed for $image (attempt $attempt); retrying in ${delay}s"
     sleep "$delay"
   done

--- a/scripts/prepull-kafka-images.sh
+++ b/scripts/prepull-kafka-images.sh
@@ -2,13 +2,19 @@
 set -euo pipefail
 
 if [ "$#" -eq 0 ]; then
-  echo "Usage: $0 <kafka-image-tag> [<kafka-image-tag> ...]" >&2
+  echo "Usage: $0 <kafka-image-tag-or-image> [<kafka-image-tag-or-image> ...]" >&2
   exit 2
 fi
 
-while IFS= read -r tag; do
+while IFS= read -r image_or_tag; do
+  if [[ "$image_or_tag" == */* ]]; then
+    image="$image_or_tag"
+  else
+    image="apache/kafka:$image_or_tag"
+  fi
+
   for attempt in 1 2 3 4 5; do
-    if timeout 60s docker pull "apache/kafka:$tag"; then
+    if timeout 60s docker pull "$image"; then
       break
     fi
 
@@ -17,7 +23,7 @@ while IFS= read -r tag; do
     fi
 
     delay=$((attempt * 15))
-    echo "Kafka image pull failed for $tag (attempt $attempt); retrying in ${delay}s"
+    echo "Image pull failed for $image (attempt $attempt); retrying in ${delay}s"
     sleep "$delay"
   done
 done < <(printf '%s\n' "$@" | sort -u)

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -42,11 +42,13 @@ grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/ci.yml"
 grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/integration-groups.yml"
 
 fake_docker='#!/usr/bin/env bash
-attempts="$(cat "$DOCKER_ATTEMPTS_FILE" 2>/dev/null || printf "0")"
-attempts=$((attempts + 1))
-printf "%s" "$attempts" > "$DOCKER_ATTEMPTS_FILE"
 printf "%s\n" "$*" >> "$DOCKER_CALLS_FILE"
-[ "$attempts" -gt "${DOCKER_FAIL_UNTIL:-0}" ]'
+if [ "$1" = "pull" ]; then
+  attempts="$(cat "$DOCKER_ATTEMPTS_FILE" 2>/dev/null || printf "0")"
+  attempts=$((attempts + 1))
+  printf "%s" "$attempts" > "$DOCKER_ATTEMPTS_FILE"
+  [ "$attempts" -gt "${DOCKER_FAIL_UNTIL:-0}" ]
+fi'
 fake_sleep='#!/usr/bin/env bash
 printf "%s\n" "$*" >> "$SLEEP_CALLS_FILE"'
 fake_timeout='#!/usr/bin/env bash
@@ -64,20 +66,35 @@ export DOCKER_CALLS_FILE="$temp_root/docker-calls"
 export SLEEP_CALLS_FILE="$temp_root/sleep-calls"
 export TIMEOUT_CALLS_FILE="$temp_root/timeout-calls"
 
-export DOCKER_FAIL_UNTIL=7
+export DOCKER_FAIL_UNTIL=1
 bash scripts/prepull-kafka-images.sh 4.3.1
-[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 8 ]
-[ "$(cat "$SLEEP_CALLS_FILE")" = $'15\n30\n45\n60\n60\n60\n60' ]
-[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 8 ]
+[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 2 ]
+[ ! -s "$SLEEP_CALLS_FILE" ]
+[ "$(cat "$TIMEOUT_CALLS_FILE")" = $'60s\n30s' ]
+grep -qx 'pull apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
+grep -qx 'pull mirror.gcr.io/apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
+grep -qx 'tag mirror.gcr.io/apache/kafka:4.3.1 apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
 
-rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
+rm -f "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
+export DOCKER_FAIL_UNTIL=2
+bash scripts/prepull-kafka-images.sh 4.3.1
+[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 3 ]
+[ "$(cat "$SLEEP_CALLS_FILE")" = '15' ]
+[ "$(cat "$TIMEOUT_CALLS_FILE")" = $'60s\n30s\n60s' ]
+
+rm -f "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
+export GITHUB_ENV="$temp_root/github-env"
+export DOCKER_FAIL_UNTIL=1
+bash scripts/prepull-kafka-images.sh "$ryuk_image"
+grep -Fqx "TESTCONTAINERS_RYUK_CONTAINER_IMAGE=mirror.gcr.io/$ryuk_image" "$GITHUB_ENV"
+grep -Fqx "pull $ryuk_image" "$DOCKER_CALLS_FILE"
+grep -Fqx "pull mirror.gcr.io/$ryuk_image" "$DOCKER_CALLS_FILE"
+grep -Fqx "tag mirror.gcr.io/$ryuk_image ${ryuk_image%@*}" "$DOCKER_CALLS_FILE"
+
+rm -f "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
 export DOCKER_FAIL_UNTIL=0
-bash scripts/prepull-kafka-images.sh \
-  4.3.1 \
-  4.2.1 \
-  4.3.1 \
-  "$ryuk_image"
-[ "$(wc -l < "$DOCKER_CALLS_FILE")" -eq 3 ]
+bash scripts/prepull-kafka-images.sh 4.3.1 4.2.1 4.3.1 "$ryuk_image"
+[ "$(grep -c '^pull ' "$DOCKER_CALLS_FILE")" -eq 3 ]
 grep -qx 'pull apache/kafka:4.2.1' "$DOCKER_CALLS_FILE"
 grep -qx 'pull apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
 grep -Fqx "pull $ryuk_image" "$DOCKER_CALLS_FILE"

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 temp_root="$(mktemp -d)"
+ryuk_image="testcontainers/ryuk:0.14.0@sha256:7c1a8a9a47c780ed0f983770a662f80deb115d95cce3e2daa3d12115b8cd28f0"
 trap 'rm -rf "$temp_root"' EXIT
 
 mkdir -p "$temp_root/scripts" \
@@ -35,8 +36,10 @@ grep -q 'Category=Serialization.*--maximum-parallel-tests 1' "$CALLS_FILE"
 
 grep -Eq 'MaximumParallelTests[[:space:]]*=>[[:space:]]*4' \
   "$repo_root/tools/Dekaf.Pipeline/Modules/RunProducerIntegrationTestsModule.cs"
-grep -Fq 'bash scripts/prepull-kafka-images.sh "$KAFKA_TEST_IMAGE_TAG" 4.0.2' \
-  "$repo_root/.github/workflows/ci.yml"
+grep -Fq 'PackageVersion Include="Testcontainers" Version="4.13.0"' \
+  "$repo_root/Directory.Packages.props"
+grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/ci.yml"
+grep -Fq "\"$ryuk_image\"" "$repo_root/.github/workflows/integration-groups.yml"
 
 fake_docker='#!/usr/bin/env bash
 attempts="$(cat "$DOCKER_ATTEMPTS_FILE" 2>/dev/null || printf "0")"
@@ -70,10 +73,15 @@ grep -qx '30' "$SLEEP_CALLS_FILE"
 
 rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
 export DOCKER_FAIL_UNTIL=0
-bash scripts/prepull-kafka-images.sh 4.3.1 4.2.1 4.3.1
-[ "$(wc -l < "$DOCKER_CALLS_FILE")" -eq 2 ]
+bash scripts/prepull-kafka-images.sh \
+  4.3.1 \
+  4.2.1 \
+  4.3.1 \
+  "$ryuk_image"
+[ "$(wc -l < "$DOCKER_CALLS_FILE")" -eq 3 ]
 grep -qx 'pull apache/kafka:4.2.1' "$DOCKER_CALLS_FILE"
 grep -qx 'pull apache/kafka:4.3.1' "$DOCKER_CALLS_FILE"
-[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 2 ]
+grep -Fqx "pull $ryuk_image" "$DOCKER_CALLS_FILE"
+[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 3 ]
 
 echo "run-integration-categories tests passed"

--- a/scripts/tests/run-integration-categories-tests.sh
+++ b/scripts/tests/run-integration-categories-tests.sh
@@ -64,12 +64,11 @@ export DOCKER_CALLS_FILE="$temp_root/docker-calls"
 export SLEEP_CALLS_FILE="$temp_root/sleep-calls"
 export TIMEOUT_CALLS_FILE="$temp_root/timeout-calls"
 
-export DOCKER_FAIL_UNTIL=2
+export DOCKER_FAIL_UNTIL=7
 bash scripts/prepull-kafka-images.sh 4.3.1
-[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 3 ]
-grep -qx '15' "$SLEEP_CALLS_FILE"
-grep -qx '30' "$SLEEP_CALLS_FILE"
-[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 3 ]
+[ "$(cat "$DOCKER_ATTEMPTS_FILE")" -eq 8 ]
+[ "$(cat "$SLEEP_CALLS_FILE")" = $'15\n30\n45\n60\n60\n60\n60' ]
+[ "$(grep -cx '60s' "$TIMEOUT_CALLS_FILE")" -eq 8 ]
 
 rm "$DOCKER_ATTEMPTS_FILE" "$DOCKER_CALLS_FILE" "$SLEEP_CALLS_FILE" "$TIMEOUT_CALLS_FILE"
 export DOCKER_FAIL_UNTIL=0


### PR DESCRIPTION
## Summary
- extend the bounded Kafka pre-pull helper to accept qualified container images
- pre-pull Testcontainers 4.13.0's exact Ryuk image in regular and NativeAOT integration jobs
- retry canonical Docker Hub pulls with bounded timeout/backoff
- fall back to Google's `mirror.gcr.io` Docker Hub cache and preserve Kafka local tags
- preserve Ryuk's exact digest through `TESTCONTAINERS_RYUK_CONTAINER_IMAGE` when the mirror wins
- assert dependency/image alignment, retry behavior, mirror fallback, retagging, and Ryuk override in the shell harness

## Validation
- `bash -n scripts/prepull-kafka-images.sh`
- `bash -n scripts/tests/run-integration-categories-tests.sh`
- `bash scripts/tests/run-integration-categories-tests.sh`
- real Docker pull/tag of the digest-qualified mirrored Ryuk image
- `git diff --check`

Google documents `mirror.gcr.io` as a Docker Hub cache insulated from Docker Hub outages: https://docs.cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images

Closes #2424