### PR TITLE
docs(benchmarks): aggregate recent ratios

### DIFF
--- a/.github/scripts/benchmark_docs.py
+++ b/.github/scripts/benchmark_docs.py
@@ -1,0 +1,338 @@
+"""Generate benchmark documentation with noise-aware rolling comparisons."""
+
+import argparse
+import glob
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+
+
+DEFAULT_WINDOW = 5
+DEFAULT_VARIANCE_THRESHOLD = 0.30
+_DATA_PREFIX = "window.BENCHMARK_DATA = "
+_BENCHMARK_NAME = re.compile(
+    r"^(?P<class>.+\.Client\.[^.]+)\."
+    r"(?P<client>Dekaf|Confluent)_(?P<operation>[^()]+)"
+    r"(?P<parameters>\(.*\))?$"
+)
+
+
+def load_history(path):
+    text = Path(path).read_text(encoding="utf-8").strip()
+    if not text.startswith(_DATA_PREFIX):
+        raise ValueError("Benchmark history does not start with window.BENCHMARK_DATA")
+
+    payload = text[len(_DATA_PREFIX) :].rstrip(";").strip()
+    data = json.loads(payload)
+    return data.get("entries", {}).get("Dekaf Benchmarks", [])
+
+
+def _comparison_pairs(entry):
+    pairs = {}
+    for benchmark in entry.get("benches", []):
+        match = _BENCHMARK_NAME.match(benchmark.get("name", ""))
+        value = benchmark.get("value")
+        if match is None or not isinstance(value, (int, float)):
+            continue
+
+        key = (
+            match.group("class"),
+            match.group("operation"),
+            match.group("parameters") or "",
+        )
+        pairs.setdefault(key, {})[match.group("client")] = value
+    return pairs
+
+
+def rolling_comparisons(entries, window=DEFAULT_WINDOW):
+    if not entries:
+        return []
+
+    observations = {}
+    current_keys = {
+        key
+        for key, clients in _comparison_pairs(entries[-1]).items()
+        if clients.get("Dekaf") is not None and clients.get("Confluent") not in (None, 0)
+    }
+
+    for entry in entries:
+        for key, clients in _comparison_pairs(entry).items():
+            if key not in current_keys:
+                continue
+            dekaf = clients.get("Dekaf")
+            confluent = clients.get("Confluent")
+            if dekaf is None or confluent in (None, 0):
+                continue
+            observations.setdefault(key, []).append(dekaf / confluent)
+
+    comparisons = []
+    for (class_name, operation, parameters), ratios in observations.items():
+        recent = ratios[-window:]
+        ratio_median = median(recent)
+        ratio_min = min(recent)
+        ratio_max = max(recent)
+        relative_spread = (
+            (ratio_max - ratio_min) / ratio_median if ratio_median else float("inf")
+        )
+        comparisons.append(
+            {
+                "group": class_name.rsplit(".", 1)[-1],
+                "operation": operation,
+                "parameters": parameters[1:-1] if parameters else "—",
+                "runs": len(recent),
+                "median": ratio_median,
+                "minimum": ratio_min,
+                "maximum": ratio_max,
+                "relative_spread": relative_spread,
+            }
+        )
+
+    return sorted(
+        comparisons,
+        key=lambda item: (item["group"], item["operation"], item["parameters"]),
+    )
+
+
+def format_rolling_table(comparisons, variance_threshold):
+    lines = [
+        "| Benchmark | Parameters | Runs | Median Ratio | Ratio Range | Run Spread | Confidence |",
+        "|---|---|---:|---:|---:|---:|---|",
+    ]
+
+    for comparison in comparisons:
+        if comparison["runs"] < 2:
+            confidence = "⚠ Insufficient history"
+        elif comparison["relative_spread"] > variance_threshold:
+            confidence = "⚠ Low"
+        else:
+            confidence = "Stable"
+
+        lines.append(
+            "| {group}.{operation} | {parameters} | {runs} | {median:.2f} | "
+            "{minimum:.2f}–{maximum:.2f} | {spread:.0%} | {confidence} |".format(
+                group=comparison["group"],
+                operation=comparison["operation"],
+                parameters=comparison["parameters"].replace("|", r"\|"),
+                runs=comparison["runs"],
+                median=comparison["median"],
+                minimum=comparison["minimum"],
+                maximum=comparison["maximum"],
+                spread=comparison["relative_spread"],
+                confidence=confidence,
+            )
+        )
+
+    if not comparisons:
+        lines.append(
+            "| No comparable history available | — | 0 | — | — | — | "
+            "⚠ Insufficient history |"
+        )
+
+    return lines
+
+
+def _cell_text(cell):
+    return cell.replace("*", "").replace("`", "").strip()
+
+
+def annotate_ratio_confidence(lines, variance_threshold):
+    output = []
+    ratio_sd_index = None
+
+    for line in lines:
+        if not line.startswith("|"):
+            continue
+
+        cells = line.strip().strip("|").split("|")
+        normalized = [_cell_text(cell) for cell in cells]
+
+        if "Method" in normalized:
+            ratio_sd_index = (
+                normalized.index("RatioSD") if "RatioSD" in normalized else None
+            )
+            if ratio_sd_index is not None:
+                cells.append(" Confidence ")
+        elif ratio_sd_index is not None and all(
+            re.fullmatch(r"\s*:?-+:?\s*", cell) for cell in cells
+        ):
+            cells.append("---")
+        elif ratio_sd_index is not None:
+            value = _cell_text(cells[ratio_sd_index])
+            try:
+                confidence = "⚠ Low" if float(value) > variance_threshold else "Stable"
+            except ValueError:
+                confidence = "—"
+            cells.append(f" {confidence} ")
+
+        output.append("|" + "|".join(cells) + "|")
+
+    return output
+
+
+def append_tables(output, paths, variance_threshold=None):
+    for markdown_path in paths:
+        lines = Path(markdown_path).read_text(encoding="utf-8").splitlines()
+        if variance_threshold is not None:
+            output.extend(annotate_ratio_confidence(lines, variance_threshold))
+        else:
+            output.extend(line for line in lines if line.startswith("|"))
+        output.append("")
+
+
+def generate_document(
+    results_dir,
+    history_path,
+    updated_at,
+    window=DEFAULT_WINDOW,
+    variance_threshold=DEFAULT_VARIANCE_THRESHOLD,
+):
+    history = load_history(history_path)
+    comparisons = rolling_comparisons(history, window)
+    result_pattern = str(Path(results_dir))
+
+    output = [
+        "---",
+        "sidebar_position: 13",
+        "---",
+        "",
+        "# Benchmark Results",
+        "",
+        "Live benchmark comparisons between Dekaf and Confluent.Kafka, automatically updated on every commit to main.",
+        "",
+        f"**Last Updated:** {updated_at}",
+        "",
+        ":::info",
+        "These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. ",
+        "Ratio semantics differ per table — see 'How to Read These Results' below.",
+        ":::",
+        "",
+        f"## Rolling comparison (last {window} runs)",
+        "",
+        "Each ratio pairs Dekaf and Confluent means from the same runner, then reports the median across recent comparable runs. Lower is better; `< 1.0` means Dekaf is faster.",
+        "",
+        f"Rows with run spread above {variance_threshold:.0%} are marked low-confidence. Run spread is `(maximum ratio - minimum ratio) / median ratio`.",
+        "",
+        *format_rolling_table(comparisons, variance_threshold),
+        "",
+        "## Latest run",
+        "",
+        "Latest-run tables retain BenchmarkDotNet's within-run `RatioSD`. Rows above the confidence threshold are marked low-confidence.",
+        "",
+    ]
+
+    producer_md = sorted(
+        glob.glob(f"{result_pattern}/Client/results/*ProducerBenchmarks*-github.md")
+    )
+    if producer_md:
+        output.extend(
+            [
+                "### Producer Benchmarks",
+                "",
+                "Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.",
+                "",
+            ]
+        )
+        append_tables(output, producer_md, variance_threshold)
+
+    consumer_md = sorted(
+        glob.glob(f"{result_pattern}/Client/results/*Consumer*Benchmarks*-github.md")
+    )
+    if consumer_md:
+        output.extend(
+            [
+                "### Consumer Benchmarks",
+                "",
+                "Comparing Dekaf vs Confluent.Kafka for message consumption.",
+                "",
+            ]
+        )
+        append_tables(output, consumer_md, variance_threshold)
+
+    protocol_md = sorted(
+        glob.glob(f"{result_pattern}/Unit/results/*ProtocolBenchmarks*-github.md")
+    )
+    if protocol_md:
+        output.extend(
+            [
+                "## Protocol Benchmarks",
+                "",
+                "Zero-allocation wire protocol serialization/deserialization.",
+                "",
+                ":::tip",
+                "**Allocated = `-` means zero heap allocations** - the goal of Dekaf's design!",
+                ":::",
+                "",
+            ]
+        )
+        append_tables(output, protocol_md)
+
+    serializer_md = sorted(
+        glob.glob(f"{result_pattern}/Unit/results/*SerializerBenchmarks*-github.md")
+    )
+    if serializer_md:
+        output.extend(["## Serializer Benchmarks", ""])
+        append_tables(output, serializer_md)
+
+    compression_md = sorted(
+        glob.glob(f"{result_pattern}/Unit/results/*CompressionBenchmarks*-github.md")
+    )
+    if compression_md:
+        output.extend(["## Compression Benchmarks", ""])
+        append_tables(output, compression_md)
+
+    output.extend(
+        [
+            "---",
+            "",
+            "## How to Read These Results",
+            "",
+            "- **Mean**: Average execution time",
+            "- **Error**: Half of 99.9% confidence interval",
+            "- **StdDev**: Standard deviation of all measurements",
+            "- **Ratio**: Performance relative to that table's baseline row",
+            "  - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster",
+            "  - Unit tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent",
+            "- **RatioSD**: BenchmarkDotNet's uncertainty for the latest run's ratio",
+            f"- **Confidence**: `⚠ Low` when latest `RatioSD > {variance_threshold:.2f}` or rolling run spread exceeds {variance_threshold:.0%}",
+            "- **Allocated**: Heap memory allocated per operation",
+            "  - `-` = Zero allocations (ideal!)",
+            "",
+            "*Benchmarks are automatically run on every push to main.*",
+        ]
+    )
+
+    return "\n".join(output)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--history", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--window", type=int, default=DEFAULT_WINDOW)
+    parser.add_argument(
+        "--variance-threshold", type=float, default=DEFAULT_VARIANCE_THRESHOLD
+    )
+    parser.add_argument(
+        "--updated-at",
+        default=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    )
+    args = parser.parse_args()
+
+    document = generate_document(
+        args.results_dir,
+        args.history,
+        args.updated_at,
+        args.window,
+        args.variance_threshold,
+    )
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(document, encoding="utf-8")
+    print(f"Generated {output_path} with {len(document.splitlines())} lines")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_benchmark_docs.py
+++ b/.github/scripts/test_benchmark_docs.py
@@ -1,0 +1,158 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from benchmark_docs import (
+    annotate_ratio_confidence,
+    format_rolling_table,
+    generate_document,
+    load_history,
+    rolling_comparisons,
+)
+
+
+def benchmark(name, value):
+    return {"name": name, "value": value, "unit": "ns", "range": "± 1"}
+
+
+def history_entry(dekaf, confluent):
+    prefix = "Dekaf.Benchmarks.Benchmarks.Client.ConsumerPollBenchmarks"
+    parameters = "(MessageSize: 100)"
+    return {
+        "benches": [
+            benchmark(f"{prefix}.Dekaf_PollSingle{parameters}", dekaf),
+            benchmark(f"{prefix}.Confluent_PollSingle{parameters}", confluent),
+        ]
+    }
+
+
+class BenchmarkDocsTests(unittest.TestCase):
+    def test_load_history_parses_javascript_assignment(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "data.js"
+            payload = {"entries": {"Dekaf Benchmarks": [history_entry(200, 100)]}}
+            path.write_text(
+                f"window.BENCHMARK_DATA = {json.dumps(payload)};\n",
+                encoding="utf-8",
+            )
+
+            entries = load_history(path)
+
+        self.assertEqual(1, len(entries))
+
+    def test_rolling_comparison_uses_last_five_same_run_ratios(self):
+        entries = [history_entry(value, 100) for value in (100, 200, 300, 400, 500, 600)]
+
+        comparison = rolling_comparisons(entries, window=5)[0]
+
+        self.assertEqual(5, comparison["runs"])
+        self.assertEqual(4.0, comparison["median"])
+        self.assertEqual(2.0, comparison["minimum"])
+        self.assertEqual(6.0, comparison["maximum"])
+        self.assertEqual(1.0, comparison["relative_spread"])
+
+    def test_incomplete_pair_is_not_mixed_with_another_run(self):
+        prefix = "Dekaf.Benchmarks.Benchmarks.Client.ConsumerPollBenchmarks"
+        parameters = "(MessageSize: 100)"
+        entries = [
+            {"benches": [benchmark(f"{prefix}.Dekaf_PollSingle{parameters}", 200)]},
+            {
+                "benches": [
+                    benchmark(f"{prefix}.Confluent_PollSingle{parameters}", 100)
+                ]
+            },
+        ]
+
+        self.assertEqual([], rolling_comparisons(entries))
+
+    def test_comparison_missing_from_latest_run_is_not_published(self):
+        entries = [
+            history_entry(200, 100),
+            {"benches": []},
+        ]
+
+        self.assertEqual([], rolling_comparisons(entries))
+
+    def test_latest_ratio_sd_is_visibly_flagged(self):
+        table = [
+            "| Method | Ratio | RatioSD |",
+            "|---|---:|---:|",
+            "| Dekaf_Fast | 0.50 | 0.10 |",
+            "| Dekaf_Noisy | 1.50 | 0.31 |",
+        ]
+
+        annotated = annotate_ratio_confidence(table, variance_threshold=0.30)
+
+        self.assertIn(" Confidence ", annotated[0])
+        self.assertIn(" Stable ", annotated[2])
+        self.assertIn(" ⚠ Low ", annotated[3])
+
+    def test_table_without_ratio_sd_is_not_annotated(self):
+        tables = [
+            "| Method | Ratio | RatioSD |",
+            "|---|---:|---:|",
+            "| Dekaf_Noisy | 1.50 | 0.31 |",
+            "| Method | Mean | Allocated |",
+            "|---|---:|---:|",
+            "| Read | 10 ns | - |",
+        ]
+
+        annotated = annotate_ratio_confidence(tables, variance_threshold=0.30)
+
+        self.assertIn("⚠ Low", annotated[2])
+        self.assertEqual("| Method | Mean | Allocated |", annotated[3])
+        self.assertEqual("| Read | 10 ns | - |", annotated[5])
+
+    def test_rolling_table_flags_wide_cross_run_spread(self):
+        comparison = rolling_comparisons(
+            [history_entry(value, 100) for value in (100, 200, 300)],
+            window=5,
+        )
+
+        table = format_rolling_table(comparison, variance_threshold=0.30)
+
+        self.assertIn("1.00–3.00", table[2])
+        self.assertIn("100%", table[2])
+        self.assertIn("⚠ Low", table[2])
+
+    def test_document_contains_rolling_and_latest_confidence_context(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            history_path = root / "data.js"
+            history_payload = {
+                "entries": {
+                    "Dekaf Benchmarks": [
+                        history_entry(200, 100),
+                        history_entry(220, 100),
+                    ]
+                }
+            }
+            history_path.write_text(
+                f"window.BENCHMARK_DATA = {json.dumps(history_payload)};",
+                encoding="utf-8",
+            )
+            results = root / "results" / "Client" / "results"
+            results.mkdir(parents=True)
+            (results / "ConsumerPollBenchmarks-report-github.md").write_text(
+                "| Method | Ratio | RatioSD |\n"
+                "|---|---:|---:|\n"
+                "| Dekaf_PollSingle | 2.20 | 0.31 |\n",
+                encoding="utf-8",
+            )
+
+            document = generate_document(
+                root / "results",
+                history_path,
+                "2026-07-27 18:00 UTC",
+            )
+
+        self.assertIn("## Rolling comparison (last 5 runs)", document)
+        self.assertIn("ConsumerPollBenchmarks.PollSingle", document)
+        self.assertIn("## Latest run", document)
+        self.assertIn("⚠ Low", document)
+        self.assertIn("RatioSD", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -413,7 +413,7 @@ jobs:
   publish-to-docs:
     name: Publish Benchmarks to Documentation
     runs-on: ubuntu-latest
-    needs: [unit-benchmarks, client-benchmarks]
+    needs: [unit-benchmarks, client-benchmarks, benchmark-history]
     if: github.ref == 'refs/heads/main'
 
     permissions:
@@ -431,109 +431,17 @@ jobs:
           path: benchmark-results
           merge-multiple: true
 
-      - name: Generate Benchmarks Documentation
+      - name: Download Benchmark History
         run: |
-          python3 << 'EOF'
-          import os
-          import glob
-          from datetime import datetime
+          git fetch origin gh-pages --depth=1
+          git show FETCH_HEAD:dev/bench/data.js > "$RUNNER_TEMP/benchmark-data.js"
 
-          output = []
-          output.append("---")
-          output.append("sidebar_position: 13")
-          output.append("---")
-          output.append("")
-          output.append("# Benchmark Results")
-          output.append("")
-          output.append("Live benchmark comparisons between Dekaf and Confluent.Kafka, automatically updated on every commit to main.")
-          output.append("")
-          output.append(f"**Last Updated:** {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}")
-          output.append("")
-          output.append(":::info")
-          output.append("These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. ")
-          output.append("Ratio semantics differ per table — see 'How to Read These Results' below.")
-          output.append(":::")
-          output.append("")
-
-          def append_tables(paths):
-              # Extract the markdown tables (all '|' lines onward) from each report file.
-              for md in paths:
-                  with open(md) as f:
-                      in_table = False
-                      for line in f.read().split('\n'):
-                          if line.startswith('|'):
-                              in_table = True
-                          if in_table:
-                              output.append(line)
-                  output.append("")
-
-          # Producer benchmarks
-          producer_md = sorted(glob.glob("benchmark-results/Client/results/*ProducerBenchmarks*-github.md"))
-          if producer_md:
-              output.append("## Producer Benchmarks")
-              output.append("")
-              output.append("Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.")
-              output.append("")
-              append_tables(producer_md)
-
-          # Consumer benchmarks (ConsumerBenchmarks + ConsumerPollBenchmarks)
-          consumer_md = sorted(glob.glob("benchmark-results/Client/results/*Consumer*Benchmarks*-github.md"))
-          if consumer_md:
-              output.append("## Consumer Benchmarks")
-              output.append("")
-              output.append("Comparing Dekaf vs Confluent.Kafka for message consumption.")
-              output.append("")
-              append_tables(consumer_md)
-
-          # Protocol benchmarks (zero-allocation)
-          protocol_md = sorted(glob.glob("benchmark-results/Unit/results/*ProtocolBenchmarks*-github.md"))
-          if protocol_md:
-              output.append("## Protocol Benchmarks")
-              output.append("")
-              output.append("Zero-allocation wire protocol serialization/deserialization.")
-              output.append("")
-              output.append(":::tip")
-              output.append("**Allocated = `-` means zero heap allocations** - the goal of Dekaf's design!")
-              output.append(":::")
-              output.append("")
-              append_tables(protocol_md)
-
-          # Serializer benchmarks
-          serializer_md = sorted(glob.glob("benchmark-results/Unit/results/*SerializerBenchmarks*-github.md"))
-          if serializer_md:
-              output.append("## Serializer Benchmarks")
-              output.append("")
-              append_tables(serializer_md)
-
-          # Compression benchmarks
-          compression_md = sorted(glob.glob("benchmark-results/Unit/results/*CompressionBenchmarks*-github.md"))
-          if compression_md:
-              output.append("## Compression Benchmarks")
-              output.append("")
-              append_tables(compression_md)
-
-          output.append("---")
-          output.append("")
-          output.append("## How to Read These Results")
-          output.append("")
-          output.append("- **Mean**: Average execution time")
-          output.append("- **Error**: Half of 99.9% confidence interval")
-          output.append("- **StdDev**: Standard deviation of all measurements")
-          output.append("- **Ratio**: Performance relative to that table's baseline row")
-          output.append("  - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster")
-          output.append("  - Unit tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent")
-          output.append("- **Allocated**: Heap memory allocated per operation")
-          output.append("  - `-` = Zero allocations (ideal!)")
-          output.append("")
-          output.append("*Benchmarks are automatically run on every push to main.*")
-
-          # Write to docs
-          os.makedirs('docs/docs', exist_ok=True)
-          with open('docs/docs/benchmarks.md', 'w') as f:
-              f.write('\n'.join(output))
-
-          print(f"Generated benchmarks.md with {len(output)} lines")
-          EOF
+      - name: Generate Benchmarks Documentation
+        run: >-
+          python3 .github/scripts/benchmark_docs.py
+          --results-dir benchmark-results
+          --history "$RUNNER_TEMP/benchmark-data.js"
+          --output docs/docs/benchmarks.md
 
       - name: Create Pull Request for Benchmark Results
         id: cpr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,10 +542,10 @@ jobs:
         run: dotnet format --verify-no-changes --verbosity diagnostic
         continue-on-error: true  # Format check is informational
 
-      - name: Run Stress Report Unit Tests
+      - name: Run Python Script Unit Tests
         env:
           PYTHONPATH: .github/scripts
-        run: python3 -m unittest discover -s .github/scripts -p 'test_stress_*.py'
+        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
 
       - name: Test Integration Category Runner
         run: bash scripts/tests/run-integration-categories-tests.sh


### PR DESCRIPTION
## Summary
- publish median, range, and normalized spread for the last five same-run Dekaf/Confluent comparisons
- mark rolling rows with spread above 30% and latest rows with RatioSD above 0.30 as low-confidence
- generate benchmark docs through a tested Python script and include all Python script tests in CI

## Test plan
- [x] python -m unittest discover -s .github/scripts -p 'test_*.py' (131 tests)
- [x] python -m py_compile .github/scripts/benchmark_docs.py .github/scripts/test_benchmark_docs.py
- [x] Parse both changed workflows with PyYAML
- [x] Validate rolling output against current gh-pages benchmark history (18 current comparison rows)

No src/ changes; hot-path benchmark gate does not apply.

Closes #2431
