### PR TITLE
perf(consumer): trim buffered stream drain

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -165,6 +165,7 @@ internal sealed class PendingFetchData : IDisposable
     /// point the application requests more data (next MoveNextAsync/ConsumeOne call),
     /// which proves the previously yielded record or batch was handled.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MarkYieldedProcessed()
     {
         ProvenOffset = LastYieldedOffset;
@@ -2093,20 +2094,24 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             previousActivity?.Dispose();
                             previousActivity = null;
 
-                            var record = pending.CurrentRecord;
+                            ref readonly var record = ref pending.CurrentRecord;
 
                             // Use cached batch properties (updated once per batch transition
                             // in MoveNext) to avoid per-message property access overhead on
                             // RecordBatch (Volatile.Read + disposed check per access).
                             offset = pending.CurrentBaseOffset + record.OffsetDelta;
                             var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
-
-                            // Use batch-level cached timestamp type (computed once per batch
-                            // transition in CacheCurrentBatchState, not per message)
                             var timestampType = pending.CurrentTimestampType;
-
-                            var messageBytes = (record.IsKeyNull ? 0 : record.Key.Length) +
-                                               (record.IsValueNull ? 0 : record.Value.Length);
+                            // Hoist every record field before tracing or deserialization can run
+                            // user code that Seek/Assigns and recycles the pooled batch storage.
+                            var keyData = record.Key;
+                            var valueData = record.Value;
+                            var isKeyNull = record.IsKeyNull;
+                            var isValueNull = record.IsValueNull;
+                            var pooledHeaders = record.Headers;
+                            var pooledHeaderCount = record.HeaderCount;
+                            var messageBytes = (isKeyNull ? 0 : keyData.Length) +
+                                               (isValueNull ? 0 : valueData.Length);
 
                             // Start consumer tracing activity — skip all tracing work when no listener
                             // (~2ns HasListeners() check vs ~200ns Activity creation + tag boxing per message)
@@ -2115,12 +2120,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             if (hasTraceListeners)
                             {
                                 var headers = LazyConsumeHeaders.Create(
-                                    record.Headers,
-                                    record.HeaderCount,
+                                    pooledHeaders,
+                                    pooledHeaderCount,
                                     pending,
                                     pending.HeaderGeneration);
                                 activity = StartConsumeActivity(pending, headers, offset,
-                                    record.Value.Length, record.IsValueNull, isProcessSpan: true);
+                                    valueData.Length, isValueNull, isProcessSpan: true);
                                 if (activity is not null)
                                     previousActivity = activity;
                             }
@@ -2136,12 +2141,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                 ? await CreateResultWithAsyncDeserializationAsync(
                                     pending,
                                     offset,
-                                    record.Key,
-                                    record.IsKeyNull,
-                                    record.Value,
-                                    record.IsValueNull,
-                                    record.Headers,
-                                    record.HeaderCount,
+                                    keyData,
+                                    isKeyNull,
+                                    valueData,
+                                    isValueNull,
+                                    pooledHeaders,
+                                    pooledHeaderCount,
                                     timestampMs,
                                     timestampType,
                                     pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
@@ -2150,12 +2155,12 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     topic: pending.Topic,
                                     partition: pending.PartitionIndex,
                                     offset: offset,
-                                    keyData: record.Key,
-                                    isKeyNull: record.IsKeyNull,
-                                    valueData: record.Value,
-                                    isValueNull: record.IsValueNull,
-                                    pooledHeaders: record.Headers,
-                                    pooledHeaderCount: record.HeaderCount,
+                                    keyData: keyData,
+                                    isKeyNull: isKeyNull,
+                                    valueData: valueData,
+                                    isValueNull: isValueNull,
+                                    pooledHeaders: pooledHeaders,
+                                    pooledHeaderCount: pooledHeaderCount,
                                     headerOwner: pending,
                                     timestampMs: timestampMs,
                                     timestampType: timestampType,
@@ -2187,8 +2192,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             // Store raw byte references for DLQ lazy capture (zero-copy — just memory slices)
                             if (rawTrackingEnabled)
                             {
-                                _currentRawKey = record.IsKeyNull ? ReadOnlyMemory<byte>.Empty : record.Key;
-                                _currentRawValue = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;
+                                _currentRawKey = isKeyNull ? ReadOnlyMemory<byte>.Empty : keyData;
+                                _currentRawValue = isValueNull ? ReadOnlyMemory<byte>.Empty : valueData;
                             }
                         }
                         catch (OperationCanceledException) when (readingProtocolData)

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -105,6 +105,7 @@ internal sealed class PendingFetchData : IDisposable
     private int _batchIndex = -1;
     private int _recordIndex = -1;
     private int _disposed;
+    private int _referenceCount = 1;
     private int _headerGeneration;
     private bool _eagerParsed;
     private bool _hasBufferedCurrent;
@@ -283,10 +284,25 @@ internal sealed class PendingFetchData : IDisposable
     {
         if (Volatile.Read(ref s_pool).TryPop(out var instance))
         {
+            Volatile.Write(ref instance._referenceCount, 1);
             Volatile.Write(ref instance._disposed, 0);
             return instance;
         }
         return new PendingFetchData();
+    }
+
+    internal RetentionLease RetainForIteration()
+    {
+        Debug.Assert(
+            Volatile.Read(ref _disposed) == 0,
+            "RetainForIteration called after Dispose.");
+        Interlocked.Increment(ref _referenceCount);
+        return new RetentionLease(this);
+    }
+
+    internal readonly struct RetentionLease(PendingFetchData owner) : IDisposable
+    {
+        public void Dispose() => owner.ReleaseReference();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -630,6 +646,16 @@ internal sealed class PendingFetchData : IDisposable
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        ReleaseReference();
+    }
+
+    private void ReleaseReference()
+    {
+        var remaining = Interlocked.Decrement(ref _referenceCount);
+        Debug.Assert(remaining >= 0, "PendingFetchData reference count underflow.");
+        if (remaining != 0)
             return;
 
         // Dispose all batches to mark them as disposed.
@@ -1902,10 +1928,13 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // yield zero items on the second and third passes.
         var partitionList = partitions as IReadOnlyList<TopicPartition> ?? partitions.ToList();
 
-        RemoveAssignedPartitions(partitionList, clearAll: false);
+        RemoveAssignedPartitions(partitionList, clearAll: false, stagePendingClear: true);
     }
 
-    private void RemoveAssignedPartitions(IReadOnlyCollection<TopicPartition> partitions, bool clearAll)
+    private void RemoveAssignedPartitions(
+        IReadOnlyCollection<TopicPartition> partitions,
+        bool clearAll,
+        bool stagePendingClear = false)
     {
         if (partitions.Count == 0)
             return;
@@ -1936,7 +1965,10 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         }
 
         // Clear any pending fetch data for the removed partitions
-        ClearFetchBufferForPartitions(partitions, invalidateAllFetches: clearAll);
+        ClearFetchBufferForPartitions(
+            partitions,
+            invalidateAllFetches: clearAll,
+            stagePendingClear: stagePendingClear);
 
         if (hadPaused)
             PublishPausedSnapshot();
@@ -2055,6 +2087,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 while (_pendingFetches.Count > 0)
                 {
                     var pending = _pendingFetches.Peek();
+                    // Retain once per fetch, not per record. A deserializer can synchronously
+                    // Seek/Assign and dispose the queued owner while its record bytes are in use.
+                    using var pendingRetention = pending.RetainForIteration();
                     // A fresh ConsumeAsync stream is another pull and therefore proves any
                     // record retained when a previous stream was disposed at its yield point.
                     pending.MarkYieldedProcessed();
@@ -2102,6 +2137,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             offset = pending.CurrentBaseOffset + record.OffsetDelta;
                             var timestampMs = pending.CurrentBaseTimestamp + record.TimestampDelta;
                             var timestampType = pending.CurrentTimestampType;
+                            var topicPartition = pending.TopicPartition;
                             // Hoist every record field before tracing or deserialization can run
                             // user code that Seek/Assigns and recycles the pooled batch storage.
                             var keyData = record.Key;
@@ -2168,7 +2204,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                                     keyDeserializer: _keyDeserializer,
                                     valueDeserializer: _valueDeserializer);
 
-                            if (HasPendingFetchClear(pending.TopicPartition))
+                            if (HasPendingFetchClear(topicPartition))
                                 break;
 
                             // Apply OnConsume interceptors before yielding to user
@@ -2181,7 +2217,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                                 // An interceptor can run long enough for background prefetch to
                                 // publish a divergence reset. Do not mark that stale record consumed.
-                                if (HasPendingFetchClear(pending.TopicPartition))
+                                if (HasPendingFetchClear(topicPartition))
                                     break;
                             }
 
@@ -5030,7 +5066,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         // Keep invalidation, buffer drain, and position replacement atomic with prefetch publication.
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearFetchBufferForPartitions([tp]);
+            ClearFetchBufferForPartitions([tp], stagePendingClear: true);
 
             if (offset.LeaderEpoch >= 0)
                 SetLastConsumedLeaderEpoch(tp, offset.LeaderEpoch);
@@ -5046,7 +5082,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearFetchBufferForPartitions(partitions);
+            ClearFetchBufferForPartitions(partitions, stagePendingClear: true);
 
             foreach (var partition in partitions)
             {
@@ -5062,7 +5098,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     {
         lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
         {
-            ClearFetchBufferForPartitions(partitions);
+            ClearFetchBufferForPartitions(partitions, stagePendingClear: true);
 
             foreach (var partition in partitions)
             {
@@ -5125,6 +5161,27 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return pending;
     }
 
+    private void StagePendingFetchClear(TopicPartition partition)
+    {
+        // Publish before synchronous buffer disposal so an in-flight consume callback
+        // observes the clear without adding another fence to the per-record hot path.
+        lock (_coordinatorRevokedPartitionsPendingFetchClearLock)
+        {
+            _coordinatorRevokedPartitionsPendingFetchClear[partition] = 0;
+
+            _batchIterationEpoch.BeginPublication();
+            try
+            {
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearMarkerPresent, 1);
+                Volatile.Write(ref _coordinatorRevokedPartitionsPendingFetchClearPending, 1);
+            }
+            finally
+            {
+                _batchIterationEpoch.EndPublication();
+            }
+        }
+    }
+
     private void ClearFetchBuffer()
     {
         ClearActiveConsumedPosition();
@@ -5140,6 +5197,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         while (_pendingFetches.TryDequeue(out var pending))
         {
             Interlocked.Decrement(ref _pendingFetchDepth);
+            StagePendingFetchClear(pending.TopicPartition);
             DisposeQueuedFetch(pending);
         }
         // Also drain prefetched items that haven't been moved to _pendingFetches yet.
@@ -5155,7 +5213,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
     private void ClearFetchBufferForPartitions(
         IEnumerable<TopicPartition> partitionsToRemove,
-        bool invalidateAllFetches = false)
+        bool invalidateAllFetches = false,
+        bool stagePendingClear = false)
     {
         // Create a set for efficient lookup
         var removeSet = partitionsToRemove is HashSet<TopicPartition> set
@@ -5200,6 +5259,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             else
             {
                 // Dispose removed items to release pooled memory
+                if (stagePendingClear)
+                    StagePendingFetchClear(pending.TopicPartition);
                 DisposeQueuedFetch(pending);
             }
         }

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -980,6 +980,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     // Pending fetch responses for lazy record iteration
     private readonly Queue<PendingFetchData> _pendingFetches = new();
     private int _pendingFetchDepth;
+    // ConsumeOne callbacks run on the documented single application thread. If one
+    // reentrantly clears the queue, defer this fetch's disposal until all borrowed
+    // record memory is out of user code. Plain references avoid per-message atomics.
+    private PendingFetchData? _activeConsumeOneFetch;
+    private PendingFetchData? _deferredConsumeOneFetchDisposal;
     // Auto-commit reads this snapshot from its background task instead of touching _pendingFetches.
     private string? _activeConsumedTopic;
     private int _activeConsumedPartition;
@@ -4342,6 +4347,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             EagerParsePendingOrRemove(pending);
 
             System.Diagnostics.Activity? activity = null;
+            var pendingDisposed = false;
             try
             {
                 while (true)
@@ -4373,18 +4379,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (hasTraceListeners)
                         {
-                            var headers = LazyConsumeHeaders.Create(
+                            activity = StartProtectedConsumeOneActivity(
+                                pending,
                                 pooledHeaders,
                                 pooledHeaderCount,
-                                pending,
-                                pending.HeaderGeneration);
-                            activity = StartConsumeActivity(pending, headers, offset,
-                                valueData.Length, isValueNull, isProcessSpan: false);
+                                offset,
+                                valueData.Length,
+                                isValueNull,
+                                out pendingDisposed);
+
+                            if (pendingDisposed)
+                                break;
                         }
 
                         // User deserialization begins in this constructor. Its exceptions
                         // must propagate even when their type also occurs in protocol codecs.
                         readingProtocolData = false;
+                        BeginConsumeOneFetchUse(pending);
                         result = new ConsumeResult<TKey, TValue>(
                             topic: pending.Topic,
                             partition: pending.PartitionIndex,
@@ -4401,18 +4412,27 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             leaderEpoch: pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
                             keyDeserializer: _keyDeserializer,
                             valueDeserializer: _valueDeserializer);
+                        pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                        if (HasPendingFetchClear(pending.TopicPartition))
+                        if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
+                        {
+                            pendingDisposed = true;
                             break;
+                        }
 
                         if (hasInterceptors)
                         {
+                            BeginConsumeOneFetchUse(pending);
                             runningInterceptor = true;
                             result = ApplyOnConsumeInterceptors(result);
                             runningInterceptor = false;
+                            pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                            if (HasPendingFetchClear(pending.TopicPartition))
+                            if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
+                            {
+                                pendingDisposed = true;
                                 break;
+                            }
                         }
 
                         TrackConsumedPosition(pending, offset, messageBytes);
@@ -4447,6 +4467,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 activity?.Dispose();
             }
+
+            if (pendingDisposed)
+                continue;
 
             FlushConsumedPositions(pending);
 
@@ -4499,6 +4522,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             EagerParsePendingOrRemove(pending);
 
             System.Diagnostics.Activity? activity = null;
+            var pendingDisposed = false;
             try
             {
                 while (true)
@@ -4528,18 +4552,23 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
 
                         if (hasTraceListeners)
                         {
-                            var headers = LazyConsumeHeaders.Create(
+                            activity = StartProtectedConsumeOneActivity(
+                                pending,
                                 pooledHeaders,
                                 pooledHeaderCount,
-                                pending,
-                                pending.HeaderGeneration);
-                            activity = StartConsumeActivity(pending, headers, offset,
-                                valueData.Length, isValueNull, isProcessSpan: false);
+                                offset,
+                                valueData.Length,
+                                isValueNull,
+                                out pendingDisposed);
+
+                            if (pendingDisposed)
+                                break;
                         }
 
                         // User deserialization begins in this await. Its exceptions must
                         // propagate even when their type also occurs in protocol codecs.
                         readingProtocolData = false;
+                        BeginConsumeOneFetchUse(pending);
                         var result = await CreateResultWithAsyncDeserializationAsync(
                             pending,
                             offset,
@@ -4553,16 +4582,25 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                             timestampType,
                             pending.CurrentPartitionLeaderEpoch >= 0 ? pending.CurrentPartitionLeaderEpoch : null,
                             cancellationToken).ConfigureAwait(false);
+                        pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                        if (HasPendingFetchClear(pending.TopicPartition))
+                        if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
+                        {
+                            pendingDisposed = true;
                             break;
+                        }
 
                         if (hasInterceptors)
                         {
+                            BeginConsumeOneFetchUse(pending);
                             result = ApplyOnConsumeInterceptors(result);
+                            pendingDisposed |= EndConsumeOneFetchUse(pending);
 
-                            if (HasPendingFetchClear(pending.TopicPartition))
+                            if (pendingDisposed || HasPendingFetchClear(pending.TopicPartition))
+                            {
+                                pendingDisposed = true;
                                 break;
+                            }
                         }
 
                         TrackConsumedPosition(pending, offset, messageBytes);
@@ -4587,7 +4625,15 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                     }
                     catch (Exception) when (!readingProtocolData)
                     {
-                        RewindAfterDeliveryFailure(pending, offset);
+                        try
+                        {
+                            if (!HasPendingFetchClear(pending.TopicPartition))
+                                RewindAfterDeliveryFailure(pending, offset);
+                        }
+                        finally
+                        {
+                            EndConsumeOneFetchUseIfActive(pending);
+                        }
                         throw;
                     }
                 }
@@ -4596,6 +4642,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             {
                 activity?.Dispose();
             }
+
+            if (pendingDisposed)
+                continue;
 
             FlushConsumedPositions(pending);
 
@@ -4629,28 +4678,36 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         bool hasAsyncDeserializers,
         Exception exception)
     {
-        if (!runningInterceptor && !hasAsyncDeserializers && exception is not OperationCanceledException)
+        try
         {
-            ref readonly var record = ref pending.CurrentRecord;
-            exception = ConsumeResult<TKey, TValue>.CreateDeserializationException(
-                ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
-                pending.Topic,
-                pending.PartitionIndex,
-                offset,
-                pending.CurrentBaseTimestamp + record.TimestampDelta,
-                pending.CurrentTimestampType,
-                record.Key,
-                record.IsKeyNull,
-                record.Value,
-                record.IsValueNull,
-                headers: null,
-                record.Headers,
-                record.HeaderCount,
-                exception);
+            if (!runningInterceptor && !hasAsyncDeserializers && exception is not OperationCanceledException)
+            {
+                ref readonly var record = ref pending.CurrentRecord;
+                exception = ConsumeResult<TKey, TValue>.CreateDeserializationException(
+                    ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
+                    pending.Topic,
+                    pending.PartitionIndex,
+                    offset,
+                    pending.CurrentBaseTimestamp + record.TimestampDelta,
+                    pending.CurrentTimestampType,
+                    record.Key,
+                    record.IsKeyNull,
+                    record.Value,
+                    record.IsValueNull,
+                    headers: null,
+                    record.Headers,
+                    record.HeaderCount,
+                    exception);
+            }
+
+            if (!HasPendingFetchClear(pending.TopicPartition))
+                RewindAfterDeliveryFailure(pending, offset);
+        }
+        finally
+        {
+            EndConsumeOneFetchUseIfActive(pending);
         }
 
-        if (!HasPendingFetchClear(pending.TopicPartition))
-            RewindAfterDeliveryFailure(pending, offset);
         ExceptionDispatchInfo.Capture(exception).Throw();
     }
 
@@ -4747,6 +4804,38 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             timestampMs,
             timestampType,
             leaderEpoch);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private System.Diagnostics.Activity? StartProtectedConsumeOneActivity(
+        PendingFetchData pending,
+        Header[]? pooledHeaders,
+        int pooledHeaderCount,
+        long offset,
+        int valueLength,
+        bool isValueNull,
+        out bool pendingDisposed)
+    {
+        BeginConsumeOneFetchUse(pending);
+        try
+        {
+            var headers = LazyConsumeHeaders.Create(
+                pooledHeaders,
+                pooledHeaderCount,
+                pending,
+                pending.HeaderGeneration);
+            return StartConsumeActivity(
+                pending,
+                headers,
+                offset,
+                valueLength,
+                isValueNull,
+                isProcessSpan: false);
+        }
+        finally
+        {
+            pendingDisposed = EndConsumeOneFetchUse(pending);
+        }
     }
 
     /// <summary>
@@ -5146,8 +5235,52 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     private void DisposeQueuedFetch(PendingFetchData pending)
     {
         Interlocked.Increment(ref _pendingFetchesVersion);
+        if (ReferenceEquals(pending, _activeConsumeOneFetch))
+        {
+            Debug.Assert(
+                _deferredConsumeOneFetchDisposal is null
+                || ReferenceEquals(_deferredConsumeOneFetchDisposal, pending),
+                "A different ConsumeOne fetch already awaits deferred disposal.");
+            _deferredConsumeOneFetchDisposal = pending;
+            return;
+        }
+
         pending.Dispose();
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void BeginConsumeOneFetchUse(PendingFetchData pending)
+    {
+        Debug.Assert(_activeConsumeOneFetch is null, "Nested ConsumeOne fetch use is unsupported.");
+        _activeConsumeOneFetch = pending;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool EndConsumeOneFetchUse(PendingFetchData pending)
+    {
+        Debug.Assert(
+            ReferenceEquals(_activeConsumeOneFetch, pending),
+            "ConsumeOne fetch-use scope ended out of order.");
+        _activeConsumeOneFetch = null;
+
+        if (!ReferenceEquals(_deferredConsumeOneFetchDisposal, pending))
+            return false;
+
+        return CompleteDeferredConsumeOneFetchDisposal(pending);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool CompleteDeferredConsumeOneFetchDisposal(PendingFetchData pending)
+    {
+        _deferredConsumeOneFetchDisposal = null;
+        pending.Dispose();
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool EndConsumeOneFetchUseIfActive(PendingFetchData pending) =>
+        ReferenceEquals(_activeConsumeOneFetch, pending)
+        && EndConsumeOneFetchUse(pending);
 
     private void EnqueuePendingFetch(PendingFetchData pending)
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4649,7 +4649,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 exception);
         }
 
-        RewindAfterDeliveryFailure(pending, offset);
+        if (!HasPendingFetchClear(pending.TopicPartition))
+            RewindAfterDeliveryFailure(pending, offset);
         ExceptionDispatchInfo.Capture(exception).Throw();
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -263,6 +263,51 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_ConsumeOneSeekDuringDeserialization_ResumesAtRequestedOffset()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("consume-one-reentrant-seek-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition.Partition,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+
+        var deserializer = new CallbackOnceStringDeserializer();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("consume-one-reentrant-seek-consumer")
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 0));
+        deserializer.SetCallback(
+            () => consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 3)));
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cancellation.Token);
+
+        await Assert.That(deserializer.CallbackCount).IsEqualTo(1);
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.Value.Offset).IsEqualTo(3);
+        await Assert.That(consumed.Value.Value).IsEqualTo("value-3");
+    }
+
+    [Test]
     public async Task Consumer_SeekDuringFailedDeserialization_PreservesRequestedOffset()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -263,6 +263,66 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
     }
 
     [Test]
+    public async Task Consumer_SeekDuringFailedDeserialization_PreservesRequestedOffset()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("seek-during-failed-deserialization-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition.Partition,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+
+        var deserializer = new CallbackOnceStringDeserializer();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("seek-during-failed-deserialization-consumer")
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 0));
+        deserializer.SetCallback(() =>
+        {
+            consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 3));
+            throw new InvalidOperationException("Expected deserializer failure.");
+        });
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await Assert.That(async () =>
+        {
+            await foreach (var _ in consumer.ConsumeAsync(cancellation.Token))
+            {
+            }
+        }).Throws<RecordDeserializationException>();
+
+        ConsumeResult<string, string>? consumed = null;
+        await foreach (var result in consumer.ConsumeAsync(cancellation.Token))
+        {
+            consumed = result;
+            break;
+        }
+
+        await Assert.That(deserializer.CallbackCount).IsEqualTo(1);
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.Value.Offset).IsEqualTo(3);
+        await Assert.That(consumed.Value.Value).IsEqualTo("value-3");
+    }
+
+    [Test]
     public async Task Consumer_SeekToBeginning_ConsumesFromStart()
     {
         // Arrange

--- a/tests/Dekaf.Tests.Integration/ConsumerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerTests.cs
@@ -11,6 +11,28 @@ namespace Dekaf.Tests.Integration;
 [Category("Consumer")]
 public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
+    private sealed class CallbackOnceStringDeserializer : IDeserializer<string>
+    {
+        private Action? _callback;
+
+        public int CallbackCount { get; private set; }
+
+        public void SetCallback(Action callback) => _callback = callback;
+
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            var value = Serializers.String.Deserialize(data, context);
+            var callback = Interlocked.Exchange(ref _callback, null);
+            if (callback is not null)
+            {
+                CallbackCount++;
+                callback();
+            }
+
+            return value;
+        }
+    }
+
     [Test]
     public async Task Consumer_SubscribeAndConsume_ReceivesMessages()
     {
@@ -185,6 +207,59 @@ public class ConsumerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafk
         var r = result!.Value;
         await Assert.That(r.Offset).IsEqualTo(3);
         await Assert.That(r.Value).IsEqualTo("value-3");
+    }
+
+    [Test]
+    public async Task Consumer_SeekDuringDeserialization_DropsStaleRecordAndResumesAtOffset()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var partition = new TopicPartition(topic, 0);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("seek-during-deserialization-producer")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        for (var i = 0; i < 5; i++)
+        {
+            await producer.ProduceAsync(new ProducerMessage<string, string>
+            {
+                Topic = topic,
+                Partition = partition.Partition,
+                Key = $"key-{i}",
+                Value = $"value-{i}"
+            }, CancellationToken.None);
+        }
+
+        var deserializer = new CallbackOnceStringDeserializer();
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("seek-during-deserialization-consumer")
+            .WithValueDeserializer(deserializer)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        consumer.Assign(partition);
+        consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 0));
+        deserializer.SetCallback(
+            () => consumer.Seek(new TopicPartitionOffset(topic, partition.Partition, 3)));
+
+        var consumed = new List<ConsumeResult<string, string>>(2);
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await foreach (var result in consumer.ConsumeAsync(cancellation.Token))
+        {
+            consumed.Add(result);
+            if (consumed.Count == 2)
+                break;
+        }
+
+        await Assert.That(deserializer.CallbackCount).IsEqualTo(1);
+        await Assert.That(consumed).Count().IsEqualTo(2);
+        await Assert.That(consumed[0].Offset).IsEqualTo(3);
+        await Assert.That(consumed[0].Value).IsEqualTo("value-3");
+        await Assert.That(consumed[1].Offset).IsEqualTo(4);
+        await Assert.That(consumed[1].Value).IsEqualTo("value-4");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -95,17 +95,19 @@ public sealed class ConsumeAsyncRecoveryTests
     }
 
     [Test]
-    public async Task ConsumeAsync_DeserializerSeeks_RecordSnapshotRemainsValid()
+    public async Task ConsumeAsync_DeserializerInvalidatesRecordStorage_RecordSnapshotRemainsValid()
     {
         var record = CreateRecord(0, "original-key", "original-value");
+        var records = new SingleRecordList(record);
         var fetch = PendingFetchData.Create(
             Topic,
             Partition,
-            [CreateBatch(0, new SingleRecordList(record))]);
-        KafkaConsumer<string, string>? consumer = null;
-        var keyDeserializer = new CallbackStringDeserializer(() =>
-            consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 0)));
-        consumer = CreateConsumerWithPendingFetchesCore(
+            [CreateBatch(0, records)]);
+        // Invalidate the fallback record storage without returning the fetch to its shared pool
+        // while ConsumeAsync still owns it.
+        var keyDeserializer = new CallbackStringDeserializer(
+            () => ClearFallbackCurrentRecord(fetch));
+        var consumer = CreateConsumerWithPendingFetchesCore(
             loggerFactory: null,
             Topic,
             Partition,
@@ -127,6 +129,15 @@ public sealed class ConsumeAsyncRecoveryTests
             await Assert.That(consumed!.Value.Key).IsEqualTo("original-key");
             await Assert.That(consumed.Value.Value).IsEqualTo("original-value");
         }
+    }
+
+    private static void ClearFallbackCurrentRecord(PendingFetchData fetch)
+    {
+        var field = typeof(PendingFetchData).GetField(
+            "_fallbackCurrentRecord",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_fallbackCurrentRecord field not found.");
+        field.SetValue(fetch, default(Record));
     }
 
     private static int GetPendingFetchCount(KafkaConsumer<string, string> consumer)

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -171,6 +171,40 @@ public sealed class ConsumeAsyncRecoveryTests
         }
     }
 
+    [Test]
+    public async Task ConsumeAsync_DeserializerSeeksThenThrows_PreservesRequestedOffset()
+    {
+        var fetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(0, CreateRecord(0, "original-key", "original-value"))]);
+        KafkaConsumer<string, string>? consumer = null;
+        var keyDeserializer = new CallbackStringDeserializer(() =>
+        {
+            consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 7));
+            throw new InvalidOperationException("Expected deserializer failure.");
+        });
+        consumer = CreateConsumerWithPendingFetchesCore(
+            loggerFactory: null,
+            Topic,
+            Partition,
+            OffsetCommitMode.Manual,
+            keyDeserializer,
+            Serializers.String,
+            fetch);
+
+        await using (consumer)
+        {
+            await Assert.That(async () =>
+            {
+                await foreach (var _ in consumer.ConsumeAsync())
+                {
+                }
+            }).Throws<RecordDeserializationException>();
+            await Assert.That(consumer.GetPosition(new TopicPartition(Topic, Partition))).IsEqualTo(7);
+        }
+    }
+
     private static void ClearFallbackCurrentRecord(PendingFetchData fetch)
     {
         var field = typeof(PendingFetchData).GetField(

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -131,6 +131,46 @@ public sealed class ConsumeAsyncRecoveryTests
         }
     }
 
+    [Test]
+    public async Task ConsumeAsync_DeserializerSeeks_DefersFetchDisposal()
+    {
+        var memoryOwner = new TrackingPooledMemory();
+        var fetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(0, CreateRecord(0, "original-key", "original-value"))],
+            memoryOwner: memoryOwner);
+        using var cancellation = new CancellationTokenSource();
+        KafkaConsumer<string, string>? consumer = null;
+        var keyDeserializer = new CallbackStringDeserializer(
+            () => consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 0)));
+        var disposeCountDuringValueDeserialization = -1;
+        var valueDeserializer = new CallbackStringDeserializer(() =>
+        {
+            disposeCountDuringValueDeserialization = memoryOwner.DisposeCount;
+            cancellation.Cancel();
+        });
+        consumer = CreateConsumerWithPendingFetchesCore(
+            loggerFactory: null,
+            Topic,
+            Partition,
+            OffsetCommitMode.Manual,
+            keyDeserializer,
+            valueDeserializer,
+            fetch);
+
+        await using (consumer)
+        {
+            var yielded = 0;
+            await foreach (var _ in consumer.ConsumeAsync(cancellation.Token))
+                yielded++;
+
+            await Assert.That(yielded).IsEqualTo(0);
+            await Assert.That(disposeCountDuringValueDeserialization).IsEqualTo(0);
+            await Assert.That(memoryOwner.DisposeCount).IsEqualTo(1);
+        }
+    }
+
     private static void ClearFallbackCurrentRecord(PendingFetchData fetch)
     {
         var field = typeof(PendingFetchData).GetField(
@@ -755,6 +795,14 @@ public sealed class ConsumeAsyncRecoveryTests
             callback();
             return Encoding.UTF8.GetString(data.Span);
         }
+    }
+
+    private sealed class TrackingPooledMemory : IPooledMemory
+    {
+        public int DisposeCount { get; private set; }
+        public ReadOnlyMemory<byte> Memory => ReadOnlyMemory<byte>.Empty;
+
+        public void Dispose() => DisposeCount++;
     }
 
     private sealed class SingleRecordList(Record record) : IReadOnlyList<Record>

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeAsyncRecoveryTests.cs
@@ -94,6 +94,41 @@ public sealed class ConsumeAsyncRecoveryTests
         await Assert.That(result.Key).IsEqualTo("next");
     }
 
+    [Test]
+    public async Task ConsumeAsync_DeserializerSeeks_RecordSnapshotRemainsValid()
+    {
+        var record = CreateRecord(0, "original-key", "original-value");
+        var fetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(0, new SingleRecordList(record))]);
+        KafkaConsumer<string, string>? consumer = null;
+        var keyDeserializer = new CallbackStringDeserializer(() =>
+            consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 0)));
+        consumer = CreateConsumerWithPendingFetchesCore(
+            loggerFactory: null,
+            Topic,
+            Partition,
+            OffsetCommitMode.Manual,
+            keyDeserializer,
+            Serializers.String,
+            fetch);
+
+        await using (consumer)
+        {
+            ConsumeResult<string, string>? consumed = null;
+            await foreach (var result in consumer.ConsumeAsync())
+            {
+                consumed = result;
+                break;
+            }
+
+            await Assert.That(consumed).IsNotNull();
+            await Assert.That(consumed!.Value.Key).IsEqualTo("original-key");
+            await Assert.That(consumed.Value.Value).IsEqualTo("original-value");
+        }
+    }
+
     private static int GetPendingFetchCount(KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>)
@@ -112,6 +147,8 @@ public sealed class ConsumeAsyncRecoveryTests
         string topic,
         int partition,
         OffsetCommitMode offsetCommitMode,
+        IDeserializer<string> keyDeserializer,
+        IDeserializer<string> valueDeserializer,
         params PendingFetchData[] fetches)
     {
         var options = new ConsumerOptions
@@ -123,8 +160,8 @@ public sealed class ConsumeAsyncRecoveryTests
 
         var consumer = new KafkaConsumer<string, string>(
             options,
-            Serializers.String,
-            Serializers.String,
+            keyDeserializer,
+            valueDeserializer,
             loggerFactory);
 
         // Use Assign to set the assignment (no coordinator needed)
@@ -165,6 +202,8 @@ public sealed class ConsumeAsyncRecoveryTests
             topic,
             partition,
             OffsetCommitMode.Manual,
+            Serializers.String,
+            Serializers.String,
             fetches);
 
     private static KafkaConsumer<string, string> CreateConsumerWithPendingFetches(
@@ -180,6 +219,8 @@ public sealed class ConsumeAsyncRecoveryTests
             Topic,
             Partition,
             offsetCommitMode,
+            Serializers.String,
+            Serializers.String,
             fetches);
 
     private static ConcurrentDictionary<TopicPartition, long> GetPositions(
@@ -196,6 +237,9 @@ public sealed class ConsumeAsyncRecoveryTests
     /// Creates a valid RecordBatch with the specified records.
     /// </summary>
     private static RecordBatch CreateBatch(long baseOffset, params Record[] records)
+        => CreateBatch(baseOffset, (IReadOnlyList<Record>)records);
+
+    private static RecordBatch CreateBatch(long baseOffset, IReadOnlyList<Record> records)
     {
         return new RecordBatch
         {
@@ -692,6 +736,31 @@ public sealed class ConsumeAsyncRecoveryTests
     #endregion
 
     #region Test Helpers
+
+    private sealed class CallbackStringDeserializer(Action callback) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            callback();
+            return Encoding.UTF8.GetString(data.Span);
+        }
+    }
+
+    private sealed class SingleRecordList(Record record) : IReadOnlyList<Record>
+    {
+        public int Count => 1;
+
+        public Record this[int index] => index == 0
+            ? record
+            : throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<Record> GetEnumerator()
+        {
+            yield return record;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 
     /// <summary>
     /// An IReadOnlyList&lt;Record&gt; that throws ArgumentOutOfRangeException when

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumeOneFastPathTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Dekaf.Consumer;
 using Dekaf.Diagnostics;
 using Dekaf.Errors;
+using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
 using Dekaf.Tests.Unit.Producer;
@@ -582,6 +583,82 @@ public sealed class ConsumeOneFastPathTests
             .Throws<OperationCanceledException>();
     }
 
+    [Test]
+    public async Task ConsumeOneAsync_KeyDeserializerSeeks_DefersDisposalThroughValueDeserializer()
+    {
+        var keyBytes = Encoding.UTF8.GetBytes("original-key");
+        var valueBytes = Encoding.UTF8.GetBytes("original-value");
+        var memoryOwner = new TrackingPooledMemory(() => valueBytes.AsSpan().Clear());
+        var fetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(0, CreateRecord(0, keyBytes, valueBytes))],
+            memoryOwner: memoryOwner);
+        KafkaConsumer<string, string>? consumer = null;
+        var keyDeserializer = new CallbackStringDeserializer(
+            () => consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 7)));
+        var disposeCountDuringValueDeserialization = -1;
+        string? observedValue = null;
+        var valueDeserializer = new CallbackStringDeserializer(() =>
+        {
+            disposeCountDuringValueDeserialization = memoryOwner.DisposeCount;
+            observedValue = Encoding.UTF8.GetString(valueBytes);
+        });
+        consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            keyDeserializer,
+            valueDeserializer);
+
+        await using (consumer)
+        {
+            var consumed = TryConsumeOneFromPendingFetches(consumer, out _);
+
+            await Assert.That(consumed).IsFalse();
+            await Assert.That(observedValue).IsEqualTo("original-value");
+            await Assert.That(disposeCountDuringValueDeserialization).IsEqualTo(0);
+            await Assert.That(memoryOwner.DisposeCount).IsEqualTo(1);
+            await Assert.That(consumer.GetPosition(new TopicPartition(Topic, Partition))).IsEqualTo(7);
+        }
+    }
+
+    [Test]
+    public async Task ConsumeOneAsync_AsyncDeserializerSeeksThenThrows_PreservesRequestedOffset()
+    {
+        var valueBytes = Encoding.UTF8.GetBytes("original-value");
+        var memoryOwner = new TrackingPooledMemory(() => valueBytes.AsSpan().Clear());
+        var fetch = PendingFetchData.Create(
+            Topic,
+            Partition,
+            [CreateBatch(0, CreateRecord(0, Encoding.UTF8.GetBytes("key"), valueBytes))],
+            memoryOwner: memoryOwner);
+        KafkaConsumer<string, string>? consumer = null;
+        var disposeCountAfterYield = -1;
+        string? observedValue = null;
+        var valueDeserializer = new CallbackAsyncStringDeserializer(async (data, _, _) =>
+        {
+            consumer!.Seek(new TopicPartitionOffset(Topic, Partition, 7));
+            await Task.Yield();
+            disposeCountAfterYield = memoryOwner.DisposeCount;
+            observedValue = Encoding.UTF8.GetString(data.Span);
+            throw new InvalidDataException("Expected async deserializer failure.");
+        });
+        consumer = CreateInitializedConsumerWithDeserializers(
+            fetch,
+            asyncValueDeserializer: valueDeserializer);
+
+        await using (consumer)
+        {
+            await Assert.That(async () =>
+                    await ConsumeOneFromPendingFetchesAsync(consumer))
+                .Throws<RecordDeserializationException>();
+
+            await Assert.That(observedValue).IsEqualTo("original-value");
+            await Assert.That(disposeCountAfterYield).IsEqualTo(0);
+            await Assert.That(memoryOwner.DisposeCount).IsEqualTo(1);
+            await Assert.That(consumer.GetPosition(new TopicPartition(Topic, Partition))).IsEqualTo(7);
+        }
+    }
+
     private static KafkaConsumer<string, string> CreateInitializedConsumer(params PendingFetchData[] fetches)
     {
         return CreateInitializedConsumer(queuedMinMessages: 1, fetchMaxWaitMs: 200, fetches);
@@ -744,6 +821,38 @@ public sealed class ConsumeOneFastPathTests
             => ValueTask.FromException<string>(new OperationCanceledException(cancellationToken));
     }
 
+    private sealed class CallbackStringDeserializer(Action callback) : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context)
+        {
+            callback();
+            return Encoding.UTF8.GetString(data.Span);
+        }
+    }
+
+    private sealed class CallbackAsyncStringDeserializer(
+        Func<ReadOnlyMemory<byte>, SerializationContext, CancellationToken, ValueTask<string>> callback)
+        : IAsyncDeserializer<string>
+    {
+        public ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+            => callback(data, context, cancellationToken);
+    }
+
+    private sealed class TrackingPooledMemory(Action onDispose) : IPooledMemory
+    {
+        public int DisposeCount { get; private set; }
+        public ReadOnlyMemory<byte> Memory => ReadOnlyMemory<byte>.Empty;
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            onDispose();
+        }
+    }
+
     private static void AssignTestPartition(KafkaConsumer<string, string> consumer)
     {
         var tp = new TopicPartition(Topic, Partition);
@@ -870,6 +979,18 @@ public sealed class ConsumeOneFastPathTests
         return consumed;
     }
 
+    private static ValueTask<ConsumeResult<string, string>?> ConsumeOneFromPendingFetchesAsync(
+        KafkaConsumer<string, string> consumer)
+    {
+        var method = typeof(KafkaConsumer<string, string>)
+            .GetMethod("ConsumeOneFromPendingFetchesAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeOneFromPendingFetchesAsync method not found.");
+
+        return (ValueTask<ConsumeResult<string, string>?>)method.Invoke(
+            consumer,
+            [CancellationToken.None])!;
+    }
+
     private static MpscFetchBuffer GetPrefetchBuffer(KafkaConsumer<string, string> consumer)
     {
         var field = typeof(KafkaConsumer<string, string>)
@@ -937,14 +1058,25 @@ public sealed class ConsumeOneFastPathTests
     }
 
     private static Record CreateRecord(int offsetDelta, string key, string value, Header[]? headers = null)
+        => CreateRecord(
+            offsetDelta,
+            Encoding.UTF8.GetBytes(key),
+            Encoding.UTF8.GetBytes(value),
+            headers);
+
+    private static Record CreateRecord(
+        int offsetDelta,
+        ReadOnlyMemory<byte> key,
+        ReadOnlyMemory<byte> value,
+        Header[]? headers = null)
     {
         return new Record
         {
             OffsetDelta = offsetDelta,
             TimestampDelta = 0,
-            Key = Encoding.UTF8.GetBytes(key),
+            Key = key,
             IsKeyNull = false,
-            Value = Encoding.UTF8.GetBytes(value),
+            Value = value,
             IsValueNull = false,
             Headers = headers,
             HeaderCount = headers?.Length ?? 0

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -30,6 +30,7 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
 
     private Record[][] _batchRecords = null!;
     private KafkaConsumer<string, string> _consumer = null!;
+    private CancellationTokenSource _iterationCancellation = null!;
 
     [Params(100, 1000)]
     public int MessageSize { get; set; }
@@ -78,6 +79,7 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
     public void IterationSetup()
     {
         DrainPendingFetches();
+        _iterationCancellation = new CancellationTokenSource();
 
         var batches = new RecordBatch[BatchCount];
         for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
@@ -95,14 +97,17 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
         GetPendingFetches().Enqueue(PendingFetchData.Create(Topic, Partition, batches));
     }
 
+    [IterationCleanup]
+    public void IterationCleanup() => _iterationCancellation.Dispose();
+
     [Benchmark(OperationsPerInvoke = MessageCount)]
     public async Task<int> ConsumeBufferedStream()
     {
         var count = 0;
-        await foreach (var _ in _consumer.ConsumeAsync().ConfigureAwait(false))
+        await foreach (var _ in _consumer.ConsumeAsync(_iterationCancellation.Token).ConfigureAwait(false))
         {
             if (++count == MessageCount)
-                break;
+                _iterationCancellation.Cancel();
         }
 
         return count;

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Docker-free benchmark for the streaming <c>ConsumeAsync</c> buffered drain loop.
+/// Pending records are seeded directly so the result isolates per-record iteration,
+/// deserialization, result construction, position tracking, and async-iterator overhead.
+/// </summary>
+/// <remarks>
+/// The extended warmup is intentional: tiered PGO recompiles the async iterator through
+/// several stages, and fewer warmups measure those transitions instead of steady state.
+/// </remarks>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 15, iterationCount: 10)]
+public class ConsumeAsyncBufferedFastPathBenchmarks
+{
+    private const int RecordsPerBatch = 1_000;
+    private const int BatchCount = 100;
+    private const int MessageCount = RecordsPerBatch * BatchCount;
+    private const string Topic = "consume-async-fast-path";
+    private const int Partition = 0;
+
+    private Record[][] _batchRecords = null!;
+    private KafkaConsumer<string, string> _consumer = null!;
+
+    [Params(100, 1000)]
+    public int MessageSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var value = Encoding.UTF8.GetBytes(new string('x', MessageSize));
+        _batchRecords = new Record[BatchCount][];
+        for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
+        {
+            var records = new Record[RecordsPerBatch];
+            for (var recordIndex = 0; recordIndex < RecordsPerBatch; recordIndex++)
+            {
+                var messageIndex = batchIndex * RecordsPerBatch + recordIndex;
+                records[recordIndex] = new Record
+                {
+                    OffsetDelta = recordIndex,
+                    TimestampDelta = recordIndex,
+                    Key = Encoding.UTF8.GetBytes($"key-{messageIndex}"),
+                    IsKeyNull = false,
+                    Value = value,
+                    IsValueNull = false,
+                    Headers = null,
+                    HeaderCount = 0,
+                };
+            }
+
+            _batchRecords[batchIndex] = records;
+        }
+
+        _consumer = new KafkaConsumer<string, string>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Auto,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200,
+            },
+            Serializers.String,
+            Serializers.String);
+        InitializeForBufferedFastPath(_consumer);
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        DrainPendingFetches();
+
+        var batches = new RecordBatch[BatchCount];
+        for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
+        {
+            var batch = RecordBatch.RentFromPool();
+            batch.BaseOffset = (long)batchIndex * RecordsPerBatch;
+            batch.BaseTimestamp = 1_700_000_000_000L;
+            batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
+            batch.LastOffsetDelta = RecordsPerBatch - 1;
+            batch.Attributes = RecordBatchAttributes.None;
+            batch.Records = _batchRecords[batchIndex];
+            batches[batchIndex] = batch;
+        }
+
+        GetPendingFetches().Enqueue(PendingFetchData.Create(Topic, Partition, batches));
+    }
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public async Task<int> ConsumeBufferedStream()
+    {
+        var count = 0;
+        await foreach (var _ in _consumer.ConsumeAsync().ConfigureAwait(false))
+        {
+            if (++count == MessageCount)
+                break;
+        }
+
+        return count;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        DrainPendingFetches();
+        await _consumer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void DrainPendingFetches()
+    {
+        var pendingFetches = GetPendingFetches();
+        while (pendingFetches.Count > 0)
+            pendingFetches.Dequeue().Dispose();
+    }
+
+    private static void InitializeForBufferedFastPath(KafkaConsumer<string, string> consumer)
+    {
+        SetPrivateField(consumer, "_initialized", true);
+
+        var topicPartition = new TopicPartition(Topic, Partition);
+        consumer.Assign(topicPartition);
+        GetFetchPositions(consumer)[topicPartition] = 0;
+
+        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
+        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
+    }
+
+    private Queue<PendingFetchData> GetPendingFetches() =>
+        (Queue<PendingFetchData>)GetPrivateField(_consumer, "_pendingFetches")!;
+
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
+        KafkaConsumer<string, string> consumer) =>
+        (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
+
+    private static object? GetPrivateField(KafkaConsumer<string, string> consumer, string fieldName) =>
+        RequireField(fieldName).GetValue(consumer);
+
+    private static void SetPrivateField(
+        KafkaConsumer<string, string> consumer,
+        string fieldName,
+        object? value) =>
+        RequireField(fieldName).SetValue(consumer, value);
+
+    private static FieldInfo RequireField(string fieldName) =>
+        typeof(KafkaConsumer<string, string>).GetField(
+            fieldName,
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException($"{fieldName} field not found.");
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -22,14 +22,16 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 15, iterationCount: 10)]
 public class ConsumeAsyncBufferedFastPathBenchmarks
 {
-    private const int RecordsPerBatch = 1_000;
+    // Keep the total off the 32-record poll-refresh boundary so cancellation happens
+    // only after the final pending fetch is exhausted, flushed, dequeued, and disposed.
+    private const int RecordsPerBatch = 1_001;
     private const int BatchCount = 100;
     private const int MessageCount = RecordsPerBatch * BatchCount;
     private const string Topic = "consume-async-fast-path";
     private const int Partition = 0;
 
     private Record[][] _batchRecords = null!;
-    private KafkaConsumer<string, string> _consumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _consumer = null!;
     private CancellationTokenSource _iterationCancellation = null!;
 
     [Params(100, 1000)]
@@ -62,7 +64,7 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
             _batchRecords[batchIndex] = records;
         }
 
-        _consumer = new KafkaConsumer<string, string>(
+        _consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
@@ -70,8 +72,8 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200,
             },
-            Serializers.String,
-            Serializers.String);
+            Serializers.RawBytes,
+            Serializers.RawBytes);
         InitializeForBufferedFastPath(_consumer);
     }
 
@@ -104,10 +106,18 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
     public async Task<int> ConsumeBufferedStream()
     {
         var count = 0;
-        await foreach (var _ in _consumer.ConsumeAsync(_iterationCancellation.Token).ConfigureAwait(false))
+        try
         {
-            if (++count == MessageCount)
-                _iterationCancellation.Cancel();
+            await foreach (var _ in _consumer.ConsumeAsync(_iterationCancellation.Token).ConfigureAwait(false))
+            {
+                if (++count == MessageCount)
+                    _iterationCancellation.Cancel();
+            }
+        }
+        catch (OperationCanceledException) when (_iterationCancellation.IsCancellationRequested)
+        {
+            // ConsumeAsync polls indefinitely once buffered data is drained. The token ends
+            // the invocation only after the pending-fetch cleanup measured above completes.
         }
 
         return count;
@@ -127,7 +137,8 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
             pendingFetches.Dequeue().Dispose();
     }
 
-    private static void InitializeForBufferedFastPath(KafkaConsumer<string, string> consumer)
+    private static void InitializeForBufferedFastPath(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
     {
         SetPrivateField(consumer, "_initialized", true);
 
@@ -143,20 +154,22 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
         (Queue<PendingFetchData>)GetPrivateField(_consumer, "_pendingFetches")!;
 
     private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
-        KafkaConsumer<string, string> consumer) =>
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer) =>
         (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
 
-    private static object? GetPrivateField(KafkaConsumer<string, string> consumer, string fieldName) =>
+    private static object? GetPrivateField(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
+        string fieldName) =>
         RequireField(fieldName).GetValue(consumer);
 
     private static void SetPrivateField(
-        KafkaConsumer<string, string> consumer,
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
         string fieldName,
         object? value) =>
         RequireField(fieldName).SetValue(consumer, value);
 
     private static FieldInfo RequireField(string fieldName) =>
-        typeof(KafkaConsumer<string, string>).GetField(
+        typeof(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>).GetField(
             fieldName,
             BindingFlags.NonPublic | BindingFlags.Instance)
         ?? throw new InvalidOperationException($"{fieldName} field not found.");

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
@@ -54,8 +54,8 @@ public class ConsumeOneBufferedFastPathBenchmarks
     public int MessageSize { get; set; }
 
     private Record[][] _batchRecords = null!;
-    private KafkaConsumer<string, string> _groupedConsumer = null!;
-    private KafkaConsumer<string, string> _noGroupConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _groupedConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _noGroupConsumer = null!;
     private TaskCompletionSource _autoCommitSurrogate = null!;
 
     [GlobalSetup]
@@ -84,7 +84,7 @@ public class ConsumeOneBufferedFastPathBenchmarks
             _batchRecords[b] = records;
         }
 
-        _groupedConsumer = new KafkaConsumer<string, string>(
+        _groupedConsumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
@@ -93,8 +93,8 @@ public class ConsumeOneBufferedFastPathBenchmarks
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200,
             },
-            Serializers.String,
-            Serializers.String);
+            Serializers.RawBytes,
+            Serializers.RawBytes);
         InitializeForBufferedFastPath(_groupedConsumer);
 
         // CanUseBufferedConsumeOneFastPath requires a live auto-commit loop in Auto mode.
@@ -102,7 +102,7 @@ public class ConsumeOneBufferedFastPathBenchmarks
         _autoCommitSurrogate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         SetPrivateField(_groupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
 
-        _noGroupConsumer = new KafkaConsumer<string, string>(
+        _noGroupConsumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new ConsumerOptions
             {
                 BootstrapServers = ["localhost:9092"],
@@ -110,8 +110,8 @@ public class ConsumeOneBufferedFastPathBenchmarks
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200,
             },
-            Serializers.String,
-            Serializers.String);
+            Serializers.RawBytes,
+            Serializers.RawBytes);
         InitializeForBufferedFastPath(_noGroupConsumer);
     }
 
@@ -123,12 +123,12 @@ public class ConsumeOneBufferedFastPathBenchmarks
 
     [BenchmarkCategory("PollOneFastPath")]
     [Benchmark(Baseline = true)]
-    public ValueTask<ConsumeResult<string, string>?> PollOne_Grouped_AutoCommit()
+    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> PollOne_Grouped_AutoCommit()
         => _groupedConsumer.ConsumeOneAsync(PollTimeout);
 
     [BenchmarkCategory("PollOneFastPath")]
     [Benchmark]
-    public ValueTask<ConsumeResult<string, string>?> PollOne_NoGroup_ManualCommit()
+    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> PollOne_NoGroup_ManualCommit()
         => _noGroupConsumer.ConsumeOneAsync(PollTimeout);
 
     [GlobalCleanup]
@@ -141,7 +141,8 @@ public class ConsumeOneBufferedFastPathBenchmarks
         _noGroupConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 
-    private void ReseedPendingFetches(KafkaConsumer<string, string> consumer)
+    private void ReseedPendingFetches(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
     {
         DrainPendingFetches(consumer);
 
@@ -161,14 +162,16 @@ public class ConsumeOneBufferedFastPathBenchmarks
         GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(Topic, Partition, batches));
     }
 
-    private static void DrainPendingFetches(KafkaConsumer<string, string> consumer)
+    private static void DrainPendingFetches(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
     {
         var pendingFetches = GetPendingFetches(consumer);
         while (pendingFetches.Count > 0)
             pendingFetches.Dequeue().Dispose();
     }
 
-    private static void InitializeForBufferedFastPath(KafkaConsumer<string, string> consumer)
+    private static void InitializeForBufferedFastPath(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
     {
         SetPrivateField(consumer, "_initialized", true);
 
@@ -181,20 +184,27 @@ public class ConsumeOneBufferedFastPathBenchmarks
         SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
     }
 
-    private static Queue<PendingFetchData> GetPendingFetches(KafkaConsumer<string, string> consumer)
+    private static Queue<PendingFetchData> GetPendingFetches(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
         => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
 
     private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
-        KafkaConsumer<string, string> consumer)
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
         => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
 
-    private static object? GetPrivateField(KafkaConsumer<string, string> consumer, string fieldName)
+    private static object? GetPrivateField(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
+        string fieldName)
         => RequireField(fieldName).GetValue(consumer);
 
-    private static void SetPrivateField(KafkaConsumer<string, string> consumer, string fieldName, object? value)
+    private static void SetPrivateField(
+        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
+        string fieldName,
+        object? value)
         => RequireField(fieldName).SetValue(consumer, value);
 
     private static FieldInfo RequireField(string fieldName)
-        => typeof(KafkaConsumer<string, string>).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+        => typeof(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>)
+               .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
            ?? throw new InvalidOperationException($"{fieldName} field not found.");
 }


### PR DESCRIPTION
Closes #2429
Closes #2439

## What

- eliminate the streaming `ConsumeAsync` loop's ~80-byte `Record` struct copy by binding `PendingFetchData.CurrentRecord` by `ref readonly`
- hoist every pooled record field before tracing/deserialization can invoke user code and recycle the backing batch
- retain the current `PendingFetchData` once per fetch so reentrant `Seek`/`Assign` cannot release pooled bytes during deserialization; synchronous public clears publish the existing fetch-clear marker before disposal
- preserve a callback's explicit seek when deserialization subsequently throws, instead of rewinding to the failed record
- force-inline `MarkYieldedProcessed`, a two-field operation executed once per streamed record
- add a Docker-free, tiered-PGO-stabilized `[MemoryDiagnoser]` benchmark for the complete buffered `ConsumeAsync` drain, including final fetch cleanup
- add deterministic unit regressions for invalidated record storage, deferred pooled-buffer disposal, and seek-plus-failure position preservation
- add broker-backed coverage proving seeks inside successful and failed deserialization resume at the requested offset
- protect sync and async ConsumeOneAsync callbacks by deferring only the active fetch disposal, using plain references instead of per-message refcount atomics

No per-message allocation was added.

## Performance

Original causal before/after run (pre-review string-deserialization harness): same machine/runtime, baseline `7586c35a7`, candidate production change `e398d9ce4`, 100,000 buffered records per invocation, 15 warmups + 10 measured iterations. The harness includes the terminal `MoveNextAsync`, position flush, metrics, dequeue, and fetch disposal.

| Payload | Baseline | Candidate run 1 | Candidate repeat | Repeat delta | Allocated | StdDev baseline → repeat |
|---|---:|---:|---:|---:|---:|---:|
| 100 B | 112.329 ns/msg | 113.547 ns/msg | 108.117 ns/msg | **-3.75%** | 264 B → 264 B | 4.158 → 3.063 ns |
| 1000 B | 241.628 ns/msg | 191.592 ns/msg | 185.415 ns/msg | **-23.26%** | 2064 B → 2064 B | 22.708 → 5.371 ns |

The 100 B row is close to runner noise: the first candidate run was +1.08%, while the repeat was -3.75%. The 1000 B improvement reproduced independently. Allocations were unchanged in every causal comparison run.

Review follow-up changed the committed benchmark to `RawBytes` serializers so `[MemoryDiagnoser]` isolates the drain hot path. Exact immediate baseline `3ed709925` → production hot-path head `e648859d3`: 100 B = 88.12 → 66.98 ns/message (-24.0%); 1000 B = 89.20 → 84.26 ns/message (-5.5%); both remain 0 B/message. The 100,100-record count avoids the 32-record poll-refresh boundary, so cancellation occurs only after final flush/dequeue/disposal.

The final review fix in `b32493da0` changes only the no-inlined exception helper; the normal-path caller IL is unchanged. Post-fix reruns remained 0 B/message. Individual rows were tier-transition bimodal because measured iterations are only 6–9 ms (BenchmarkDotNet warns below its 100 ms recommendation), with observed plateaus matching the prior ~67–70 ns and ~87–93 ns bands; no normal-path code was added.

`ConsumeOneAsync` follow-up, exact benchmark-only baseline `3b261a222` → final head `8abb6f6bf` (`RawBytes`, 10,000 operations/iteration):

| Payload | Mode | Baseline | Candidate | Delta | Allocated |
|---|---|---:|---:|---:|---:|
| 100 B | grouped/auto | 368.6 ns | 362.5 ns | -1.7% | 0 B |
| 100 B | no-group/manual | 338.1 ns | 341.9 ns | +1.1% | 0 B |
| 1000 B | grouped/auto | 354.5 ns | 354.7 ns | +0.1% | 0 B |
| 1000 B | no-group/manual | 336.4 ns | 339.6 ns | +1.0% | 0 B |

All confidence intervals overlap. An independent same-SHA baseline repeat showed 2–4% runner variance; the candidate stays within that control range with zero allocations. Rare deferred disposal is split into a `NoInlining` cold helper, and no interlocked operation was added per message.

Rejected during iteration: conditional metric tracking and a widened iterator-local lifetime. Both regressed/noised the protected rows and were fully reverted before the final head.

## Validation

- benchmark project Release build: 0 warnings/errors
- focused reentrancy, rewind, and prior-hang unit gates: 41/41
- full net10 unit suite: 6571/6571
- consumer integration subset plus three broker-backed reentrant-seek cases, Kafka 4.3.1: prior 106/106 plus final `ConsumerTests` 33/33
- required `/simplify`: complete

The scheduled published ratio and consumer stress CPU/msg remain the cross-run acceptance checks; this PR supplies the local causal gate and unchanged allocation proof.
