### PR TITLE
perf(consumer): cache polling serialization context

### DIFF
--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -502,30 +502,21 @@ public readonly struct ConsumeResult<TKey, TValue>
         long timestampMs,
         TimestampType timestampType,
         int? leaderEpoch)
-        : this(
-            topic,
-            partition,
-            offset,
-            keyData: default,
-            isKeyNull: true,
-            valueData: default,
-            isValueNull: true,
-            headers: null,
-            pooledHeaders,
-            pooledHeaderCount,
-            headerOwner,
-            headerOwner.HeaderGeneration,
-            timestampMs,
-            timestampType,
-            leaderEpoch,
-            keyDeserializer: null,
-            valueDeserializer: null,
-            isPartitionEof: false)
     {
-        // The chained call above leaves Key/Value at default (both deserializers are null);
-        // the awaited async deserialization already produced the real values.
+        Topic = topic;
+        Partition = partition;
+        Offset = offset;
         Key = key;
         Value = value;
+        _headers = null;
+        _pooledHeaders = pooledHeaders;
+        _pooledHeaderCount = pooledHeaderCount;
+        _headerOwner = headerOwner;
+        _headerGeneration = headerOwner.HeaderGeneration;
+        _timestampMs = timestampMs;
+        TimestampType = timestampType;
+        LeaderEpoch = leaderEpoch;
+        IsPartitionEof = false;
     }
 
     private ConsumeResult(
@@ -662,21 +653,25 @@ public readonly struct ConsumeResult<TKey, TValue>
     public static ConsumeResult<TKey, TValue> CreatePartitionEof(string topic, int partition, long offset)
 #pragma warning restore CA1000
     {
-        return new ConsumeResult<TKey, TValue>(
-            topic: topic,
-            partition: partition,
-            offset: offset,
-            keyData: default,
-            isKeyNull: true,
-            valueData: default,
-            isValueNull: true,
-            headers: null,
-            timestampMs: 0,
-            timestampType: TimestampType.NotAvailable,
-            leaderEpoch: null,
-            keyDeserializer: null,
-            valueDeserializer: null,
-            isPartitionEof: true);
+        return new ConsumeResult<TKey, TValue>(topic, partition, offset);
+    }
+
+    private ConsumeResult(string topic, int partition, long offset)
+    {
+        Topic = topic;
+        Partition = partition;
+        Offset = offset;
+        Key = default;
+        Value = default!;
+        _headers = null;
+        _pooledHeaders = null;
+        _pooledHeaderCount = 0;
+        _headerOwner = null;
+        _headerGeneration = 0;
+        _timestampMs = 0;
+        TimestampType = TimestampType.NotAvailable;
+        LeaderEpoch = null;
+        IsPartitionEof = true;
     }
 
     /// <summary>

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -561,6 +561,10 @@ public readonly struct ConsumeResult<TKey, TValue>
         LeaderEpoch = leaderEpoch;
         IsPartitionEof = isPartitionEof;
 
+        // Resolve the thread-static address once; each direct field access otherwise
+        // emits another TLS lookup before setting or copying the context.
+        ref var serializationContext = ref t_serializationContext;
+
         // Eagerly deserialize to avoid storing deserializer references (saves 16 bytes per struct)
         if (isPartitionEof || keyDeserializer is null)
         {
@@ -573,12 +577,12 @@ public readonly struct ConsumeResult<TKey, TValue>
         }
         else
         {
-            t_serializationContext.Topic = topic;
-            t_serializationContext.Component = SerializationComponent.Key;
-            t_serializationContext.Headers = null;
-            t_serializationContext.IsNull = false;
+            serializationContext.Topic = topic;
+            serializationContext.Component = SerializationComponent.Key;
+            serializationContext.Headers = null;
+            serializationContext.IsNull = false;
 
-            Key = keyDeserializer.Deserialize(keyData, t_serializationContext);
+            Key = keyDeserializer.Deserialize(keyData, serializationContext);
         }
 
         if (isPartitionEof || valueDeserializer is null)
@@ -587,14 +591,14 @@ public readonly struct ConsumeResult<TKey, TValue>
         }
         else
         {
-            t_serializationContext.Topic = topic;
-            t_serializationContext.Component = SerializationComponent.Value;
-            t_serializationContext.Headers = null;
-            t_serializationContext.IsNull = isValueNull;
+            serializationContext.Topic = topic;
+            serializationContext.Component = SerializationComponent.Value;
+            serializationContext.Headers = null;
+            serializationContext.IsNull = isValueNull;
 
             Value = isValueNull
-                ? valueDeserializer.Deserialize(ReadOnlyMemory<byte>.Empty, t_serializationContext)
-                : valueDeserializer.Deserialize(valueData, t_serializationContext);
+                ? valueDeserializer.Deserialize(ReadOnlyMemory<byte>.Empty, serializationContext)
+                : valueDeserializer.Deserialize(valueData, serializationContext);
         }
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeResultConstructionBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeResultConstructionBenchmarks.cs
@@ -1,0 +1,93 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures eager, already-deserialized, and partition-EOF <see cref="ConsumeResult{TKey,TValue}"/>
+/// construction without network or broker noise.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(ConstructionJobConfig))]
+public class ConsumeResultConstructionBenchmarks
+{
+    private const int InvocationsPerIteration = 20_000_000;
+    private static readonly byte[] Data = "benchmark-value"u8.ToArray();
+    private PendingFetchData _headerOwner = null!;
+
+    private sealed class ConstructionJobConfig : ManualConfig
+    {
+        public ConstructionJobConfig()
+        {
+            AddJob(Job.Default
+                .WithStrategy(RunStrategy.Throughput)
+                .WithLaunchCount(1)
+                .WithWarmupCount(8)
+                .WithIterationCount(15)
+                .WithInvocationCount(InvocationsPerIteration)
+                .WithUnrollFactor(1));
+        }
+    }
+
+    [GlobalSetup]
+    public void Setup() =>
+        _headerOwner = PendingFetchData.Create(
+            "benchmark-topic",
+            partitionIndex: 0,
+            Array.Empty<RecordBatch>());
+
+    [GlobalCleanup]
+    public void Cleanup() => _headerOwner.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public ConsumeResult<string, string> SynchronousDeserializers() =>
+        Create(Serializers.String, Serializers.String);
+
+    [Benchmark]
+    public ConsumeResult<string, string> NullDeserializers() =>
+        Create(keyDeserializer: null, valueDeserializer: null);
+
+    [Benchmark]
+    public ConsumeResult<string, string> AlreadyDeserializedConstructor() =>
+        new(
+            topic: "benchmark-topic",
+            partition: 0,
+            offset: 1,
+            key: "benchmark-key",
+            value: "benchmark-value",
+            pooledHeaders: null,
+            pooledHeaderCount: 0,
+            _headerOwner,
+            timestampMs: 0,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null);
+
+    [Benchmark]
+    public ConsumeResult<string, string> PartitionEof() =>
+        ConsumeResult<string, string>.CreatePartitionEof("benchmark-topic", partition: 0, offset: 1);
+
+    private static ConsumeResult<string, string> Create(
+        IDeserializer<string>? keyDeserializer,
+        IDeserializer<string>? valueDeserializer,
+        bool isPartitionEof = false) =>
+        new(
+            topic: "benchmark-topic",
+            partition: 0,
+            offset: 1,
+            keyData: Data,
+            isKeyNull: false,
+            valueData: Data,
+            isValueNull: false,
+            headers: null,
+            timestampMs: 0,
+            timestampType: TimestampType.CreateTime,
+            leaderEpoch: null,
+            keyDeserializer,
+            valueDeserializer,
+            isPartitionEof);
+}


### PR DESCRIPTION
Closes #2428

## What

- bind the thread-static `SerializationContext` once while constructing synchronous `ConsumeResult` values
- reuse that ref local for key/value setters and byte copies
- construct already-deserialized async results and partition-EOF results directly, so they never touch synchronous TLS state
- preserve deserialization, header ownership, and EOF semantics exactly

This removes repeated TLS-base lookup overhead from the buffered PollSingle path without adding allocations, virtual calls, or async work.

## Performance

Same machine/runtime, exact immediately preceding product SHA `de3b1eab3` → candidate `269e175a7`, `ConsumeOneBufferedFastPathBenchmarks`, 15 warmups + 20 measured iterations.

| Mode | Payload | Baseline | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|---:|
| No group/manual commit | 100 B | 621.339 ns | 549.046 ns | **-11.63%** | 264 B → 264 B |
| No group/manual commit | 1000 B | 809.635 ns | 679.649 ns | **-16.06%** | 2064 B → 2064 B |
| Grouped/autocommit | 100 B | 610.971 ns | 579.291 ns | **-5.18%** | 264 B → 264 B |
| Grouped/autocommit | 1000 B | 756.409 ns | 740.025 ns | **-2.17%** | 2064 B → 2064 B |

The grouped 1000 B row is noisy but remains directionally positive. The 100 B acceptance target is met in both modes with unchanged allocations.

JIT disassembly confirms the causal mechanism: `GetGCThreadStaticBase` calls in the per-record synchronous constructor fall from 10 to 1.

### Review follow-up

Exact PR-head comparison `269e175a7` → `e966f93d4`, `ConsumeResultConstructionBenchmarks`, 20,000,000 invocations/iteration, 8 warmups + 15 measured iterations:

| Constructor path | Baseline | Candidate | Delta | Allocated |
|---|---:|---:|---:|---:|
| Synchronous deserializers | 39.415 ns | 40.095 ns | +1.73% (overlapping confidence intervals; implementation byte-for-byte unchanged) | 112 B → 112 B |
| Null deserializers | 11.211 ns | 11.208 ns | -0.03% | 0 B → 0 B |
| Already-deserialized async result | 11.004 ns | 0.619 ns | **-94.37%** | 0 B → 0 B |
| Partition EOF | 11.009 ns | 0.444 ns | **-95.97%** | 0 B → 0 B |

The initially-considered unconditional early return regressed the null-deserializer path by 6.9% and was rejected. The shipped specialization leaves generic synchronous/null construction unchanged and removes TLS access only from the actual async-result and EOF factories.

## Validation

- unit project Release build: 0 warnings/errors
- focused consumer tests: 39/39
- full net10 unit suite: 6566/6566
- integration project Release build: 0 warnings/errors
- ConsumerTests + CustomSerializerErrorTests against Kafka 4.3.1: 34/34
- `ConsumeResultConstructionBenchmarks` with `[MemoryDiagnoser]`: no allocation regression
- required `/simplify`: complete; constructor duplication retained intentionally to avoid reintroducing TLS work

The published PollSingle ratio ≤1.5x across multiple scheduled runs remains the final cross-run acceptance gate; no paid stress run was dispatched for this local causal optimization.