### PR TITLE
test(producer): seed saturation before victims

### DIFF
--- a/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerLeakEdgeCaseTests.cs
@@ -70,6 +70,14 @@ public sealed class ProducerLeakEdgeCaseTests
                     cancellationToken);
 
             var survivorTasks = new[] { StartAppender(0, cancellationToken), StartAppender(1, cancellationToken) };
+
+            // Establish real BufferMemory saturation before starting the victims. Otherwise
+            // their one-shot signals can observe transient FIFO contention that clears before
+            // cancellation, leaving the test without an actively blocked victim.
+            await LeakGateHarness.WaitForSaturationAsync(
+                accumulator, survivorTasks, cancellationToken);
+            await Assert.That(accumulator.BufferPressureEvents).IsGreaterThan(0L);
+
             var victimWaitSignals = new[]
             {
                 new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
@@ -104,7 +112,6 @@ public sealed class ProducerLeakEdgeCaseTests
 
             // The victims must actually have been interrupted mid-run for the test to
             // exercise cancellation inside the reservation wait.
-            await Assert.That(accumulator.BufferPressureEvents).IsGreaterThan(0L);
             foreach (var victim in victimResults)
             {
                 await Assert.That(victim.WasCancelled).IsTrue();


### PR DESCRIPTION
Closes #2436

## What

- establish actual BufferMemory saturation with survivor appenders before starting cancellation victims
- move the existing pressure assertion beside that precondition
- retain the per-victim slow-path gates and every drained/accepted/residue invariant

## Why

PR #2433 CI exposed the recurrence: `CancelledAppendersUnderSaturation_NoPhantomRecordsOrResidue` failed with one victim reporting `WasCancelled == false` while 6,566 other tests passed.

#2402 waited for each victim's first incomplete append, but victims started concurrently with survivors. Transient per-partition FIFO contention could therefore satisfy a one-shot signal before durable saturation. Starting victims only after buffer pressure is proven makes each later slow-path signal represent the intended saturated reservation wait.

No sleeps, timeout widening, retries, or relaxed assertions.

## Validation

- Release unit build: 0 warnings/errors
- exact saturation test: 100/100 consecutive passes
- full net10 unit suite: 6566/6566
- required `/simplify`: complete