### PR TITLE
bench(consumer): raise fast-path micro-bench iterations above the BDN 100 ms floor

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -838,6 +838,14 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     /// cancellation and timeout handling (~10 checks per second).
     /// </summary>
     private const int AllPartitionsPausedDelayMs = 100;
+
+    /// <summary>
+    /// How many streamed records the buffered drain yields between cancellation/refresh
+    /// checks. Internal so benchmarks can keep their seeded record totals off this
+    /// boundary instead of hard-coding a copy that drifts.
+    /// </summary>
+    internal const int PollRefreshRecordInterval = 32;
+
     private const int MaxConsecutivePrefetchErrors = 50;
     private const int MaxConsecutiveEmptyParsedFetches = 3;
     private const int MaxRepeatedDeterministicPrefetchFailures = 3;
@@ -2086,8 +2094,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                 var hasInterceptors = _interceptors is not null;
                 var rawTrackingEnabled = _rawRecordTrackingEnabled;
                 var hasAsyncDeserializers = _hasAsyncDeserializers;
-                const int pollRefreshRecordInterval = 32;
-                var recordsUntilPollRefresh = pollRefreshRecordInterval;
+                var recordsUntilPollRefresh = PollRefreshRecordInterval;
 
                 while (_pendingFetches.Count > 0)
                 {
@@ -2277,7 +2284,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
                         if (--recordsUntilPollRefresh == 0)
                         {
                             await RecordPollAsync(cancellationToken).ConfigureAwait(false);
-                            recordsUntilPollRefresh = pollRefreshRecordInterval;
+                            recordsUntilPollRefresh = PollRefreshRecordInterval;
                         }
                     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -22,11 +22,22 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 15, iterationCount: 10)]
 public class ConsumeAsyncBufferedFastPathBenchmarks
 {
-    // Keep the total off the 32-record poll-refresh boundary so cancellation happens
-    // only after the final pending fetch is exhausted, flushed, dequeued, and disposed.
+    // Keep the total off the poll-refresh boundary (asserted against
+    // KafkaConsumer.PollRefreshRecordInterval in Setup) so cancellation happens only after
+    // the final pending fetch is exhausted, flushed, dequeued, and disposed.
+    // ~64-90 ns/record × ~2M records keeps measured iterations comfortably above
+    // BenchmarkDotNet's 100 ms recommendation (issue #2445) even if the per-record cost
+    // drops further; the prior 100,100-record shape produced 6-9 ms iterations whose
+    // tier-transition bimodality blurred 5-15% causal deltas. BatchCount must stay at or
+    // below the RecordBatch pool capacity (2048) or every iteration setup allocates the
+    // excess batches.
     private const int RecordsPerBatch = 1_001;
-    private const int BatchCount = 100;
+    private const int BatchCount = 2_000;
     private const int MessageCount = RecordsPerBatch * BatchCount;
+    // Distinct Record[] seed arrays are cycled across batches: batch disposal only nulls the
+    // batch's own record-list reference, never the array contents, so sharing is safe and
+    // keeps GlobalSetup memory flat while BatchCount grows.
+    private const int SeedArrayCount = 100;
     private const string Topic = "consume-async-fast-path";
     private const int Partition = 0;
 
@@ -40,9 +51,15 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+        if (MessageCount % KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>.PollRefreshRecordInterval == 0)
+        {
+            throw new InvalidOperationException(
+                "MessageCount must stay off the poll-refresh boundary so cancellation lands after final fetch cleanup.");
+        }
+
         var value = Encoding.UTF8.GetBytes(new string('x', MessageSize));
-        _batchRecords = new Record[BatchCount][];
-        for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
+        _batchRecords = new Record[SeedArrayCount][];
+        for (var batchIndex = 0; batchIndex < SeedArrayCount; batchIndex++)
         {
             var records = new Record[RecordsPerBatch];
             for (var recordIndex = 0; recordIndex < RecordsPerBatch; recordIndex++)
@@ -92,7 +109,7 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
             batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
             batch.LastOffsetDelta = RecordsPerBatch - 1;
             batch.Attributes = RecordBatchAttributes.None;
-            batch.Records = _batchRecords[batchIndex];
+            batch.Records = _batchRecords[batchIndex % SeedArrayCount];
             batches[batchIndex] = batch;
         }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
@@ -29,9 +29,19 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [Config(typeof(FastPathJobConfig))]
 public class ConsumeOneBufferedFastPathBenchmarks
 {
-    private const int PollsPerIteration = 10_000;
+    // ~130 ns/poll × 1.5M polls keeps measured iterations comfortably above BenchmarkDotNet's
+    // 100 ms recommendation (issue #2445) even if the per-poll cost drops further; shorter
+    // iterations made 5-15% causal deltas unreadable. The old 10k-poll shape also warmed up
+    // on only 30k calls, so it measured partly-tiered code and reported ~2.5x the
+    // steady-state per-poll cost. PollsPerIteration is derived as a product so the seeded
+    // record count can never silently truncate away from the invocation count.
     private const int RecordsPerBatch = 1_000;
-    private const int BatchCount = PollsPerIteration / RecordsPerBatch;
+    private const int BatchCount = 1_500;
+    private const int PollsPerIteration = BatchCount * RecordsPerBatch;
+    // Distinct Record[] seed arrays are cycled across batches: batch disposal only nulls the
+    // batch's own record-list reference, never the array contents, so sharing is safe and
+    // keeps GlobalSetup memory flat while BatchCount grows.
+    private const int SeedArrayCount = 10;
     private const string Topic = "consume-one-fast-path";
     private const int Partition = 0;
     private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
@@ -63,8 +73,8 @@ public class ConsumeOneBufferedFastPathBenchmarks
     {
         var value = Encoding.UTF8.GetBytes(new string('x', MessageSize));
 
-        _batchRecords = new Record[BatchCount][];
-        for (var b = 0; b < BatchCount; b++)
+        _batchRecords = new Record[SeedArrayCount][];
+        for (var b = 0; b < SeedArrayCount; b++)
         {
             var records = new Record[RecordsPerBatch];
             for (var i = 0; i < RecordsPerBatch; i++)
@@ -155,7 +165,7 @@ public class ConsumeOneBufferedFastPathBenchmarks
             batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
             batch.LastOffsetDelta = RecordsPerBatch - 1;
             batch.Attributes = RecordBatchAttributes.None;
-            batch.Records = _batchRecords[b];
+            batch.Records = _batchRecords[b % SeedArrayCount];
             batches[b] = batch;
         }
 


### PR DESCRIPTION
Closes #2445

## What

- raise `ConsumeOneBufferedFastPathBenchmarks` to 1.5M polls/iteration (was 10k) and `ConsumeAsyncBufferedFastPathBenchmarks` to 2,002,000 records/iteration (was 100,100), putting measured iterations above BenchmarkDotNet's 100 ms recommendation with headroom for future per-op improvements
- cycle a fixed set of `Record[]` seed arrays across batches (`SeedArrayCount`), so GlobalSetup memory stays flat while batch counts grow; batch disposal only nulls the batch's own record-list reference, never the shared array contents
- derive `PollsPerIteration` as `BatchCount * RecordsPerBatch` — a product cannot silently truncate the seeded record count away from the invocation count the way the old quotient could (a truncated edit would send shortfall polls to a dead `localhost:9092` with a 10 s timeout and no diagnostic)
- hoist the buffered drain's poll-refresh interval to `internal const KafkaConsumer.PollRefreshRecordInterval` and assert in the drain benchmark's `[GlobalSetup]` that `MessageCount` stays off that boundary (2,002,000 ≡ 16 mod 32), replacing a prose-only invariant that silently spanned two constants in two files
- document the RecordBatch pool-capacity constraint (`BatchCount` ≤ 2048) so iteration setup stays allocation-free on rentals

The `src/` change is a compile-time constant hoist (`const int` local → `internal const` field, both call sites): identical IL in the drain loop, no behavior change; the benchmark runs below exercise the changed method.

## Why

These two benchmarks are the local causal gate for consumer fast-path PRs (#2433 and #2435 both used them). Their iterations were 3.3–9 ms — far below BDN's 100 ms floor — so run-to-run variance sat in exactly the 5–15% range the gate is supposed to adjudicate, and BDN warned on every run. PR #2433 hit this concretely: its committed rows were "tier-transition bimodal because measured iterations are only 6-9 ms".

The old 10k-poll shape had a second, worse defect: with `WarmupCount = 3` it warmed up on only 30k calls — not enough for tiered PGO to finish promoting the poll path — so it measured partly-tiered code and **overstated the steady-state per-poll cost ~2.5x**. Every historical "local floor" figure from this benchmark (597 ns on 07-27; the 549–621 ns rows in #2435) carried that inflation.

## Performance (measurement-quality change; same machine/runtime, i7-12700K)

`ConsumeOneBufferedFastPathBenchmarks` (RawBytes):

| Mode | Payload | Before (10k polls/iter) | After (1.5M polls/iter) | Iteration time | Allocated |
|---|---:|---:|---:|---:|---:|
| Grouped/auto | 100 B | 352.9 ns (StdDev 5.03) | **140.6 ns (StdDev 1.28)** | ~211 ms | 0 B → 0 B |
| No-group/manual | 100 B | 333.3 ns (StdDev 5.83) | **124.4 ns (StdDev 1.08)** | ~187 ms | 0 B → 0 B |
| Grouped/auto | 1000 B | 350.0 ns (StdDev 7.29) | **139.7 ns (StdDev 0.92)** | ~210 ms | 0 B → 0 B |
| No-group/manual | 1000 B | 332.1 ns (StdDev 5.13) | **126.8 ns (StdDev 2.11)** | ~190 ms | 0 B → 0 B |

`ConsumeAsyncBufferedFastPathBenchmarks` (RawBytes):

| Payload | Before (100,100 rec/iter) | After (2,002,000 rec/iter) | Iteration time | Allocated |
|---|---:|---:|---:|---:|
| 100 B | ~67–70 ns/record (bimodal, 6–9 ms iters) | **66.19 ns (StdDev 2.60)** | ~133 ms | 0 B → 0 B |
| 1000 B | ~84–93 ns/record (bimodal) | **64.93 ns (StdDev 0.76)** | ~130 ms | 0 B → 0 B |

The before/after per-op delta is the warmup/tiering artifact being removed, not a product-code change — no hot-path code changed in this PR. The BDN `MinIterationTime` warning is gone on every row, and StdDev/mean tightened to ≤1.7% on all PollOne rows.

Implication for #2443: the true local steady-state floor is ~125–141 ns/poll and ~65 ns/record (RawBytes), not the ~350/597 ns previously recorded — residual-gap work should baseline against these numbers.

## Validation

- src + benchmarks Release build: 0 warnings/errors
- full net10 unit suite: 6571/6571 (one unrelated pre-existing load flake in `PooledPendingRequestTests` surfaced on a first run and is root-caused + filed as #2446; it passes 5×34 isolated and the suite passes clean on rerun)
- `[MemoryDiagnoser]`: 0 B/op unchanged on all rows
- poll-refresh boundary assert verified: 2,002,000 mod 32 = 16
- required `/simplify`: complete — its findings (truncating-derivation inversion, poll-refresh-boundary assert against the hoisted library constant, headroom sizing) are folded into this PR
