### PR TITLE
perf(producer): pooled slow-path handoff for backpressured awaited produces — ProduceBatch 1MB row 339KB→67KB/op (-80%)

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -36,18 +36,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             .ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Sentinel return value from <see cref="TryProduceSyncCore"/> indicating that the
-    /// buffer is full and the caller should fall back to the async path (ReserveMemoryAsync).
-    /// Replaces the previous exception-based control flow to avoid ~5-10μs throw/catch
-    /// overhead per message under sustained backpressure.
-    /// </summary>
-    private enum SyncProduceResult : byte
-    {
-        Success,
-        BufferFull,
-    }
-
     private readonly ProducerOptions _options;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
@@ -673,10 +661,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // Fast path: Try synchronous produce if metadata is initialized and cached.
         // This bypasses channel overhead for 99%+ of calls after warmup.
-        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var completion))
+        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, cancellationToken, out var completion))
         {
-            // POST-QUEUE: Message appended to batch, committed to being sent
-            // Message WILL be delivered, but caller can stop waiting via cancellation token.
+            // POST-QUEUE: Message appended to a batch (committed to being sent, cancellation
+            // only stops the wait) or handed to the slow-path append worker under
+            // backpressure (pre-append timeout/cancellation still surfaces via the completion).
             if (activity is not null)
             {
                 return AwaitWithActivity(completion!, activity, message.Topic, cancellationToken);
@@ -866,10 +855,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             partition,
             timestamp,
             runContinuationsAsynchronously,
+            cancellationToken,
             out var completion))
         {
-            // POST-QUEUE: Message appended to batch, committed to being sent
-            // Message WILL be delivered, but caller can stop waiting via cancellation token.
+            // POST-QUEUE: Message appended to a batch (committed to being sent, cancellation
+            // only stops the wait) or handed to the slow-path append worker under
+            // backpressure (pre-append timeout/cancellation still surfaces via the completion).
             if (metricsEnabled)
             {
                 return AwaitWithMetrics(completion!, topic, cancellationToken);
@@ -881,7 +872,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return completion!.Task;
         }
 
-        // Cold path: allocate the full message only when async metadata/backpressure handling needs it.
+        // Cold path: metadata miss only — allocate the full message for the async metadata fetch.
         return ProduceAsyncSlow(new ProducerMessage<TKey, TValue>
         {
             Topic = topic,
@@ -1058,6 +1049,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private bool TryProduceSyncForAsync(
         ProducerMessage<TKey, TValue> message,
         bool runContinuationsAsynchronously,
+        CancellationToken cancellationToken,
         out PooledValueTaskSource<RecordMetadata>? completion)
         => TryProduceSyncForAsync(
             message.Topic,
@@ -1067,6 +1059,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             message.Partition,
             message.Timestamp,
             runContinuationsAsynchronously,
+            cancellationToken,
             out completion);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1078,6 +1071,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         int? partition,
         DateTimeOffset? timestamp,
         bool runContinuationsAsynchronously,
+        CancellationToken cancellationToken,
         out PooledValueTaskSource<RecordMetadata>? completion)
     {
         completion = null;
@@ -1112,10 +1106,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         // All checks passed - we can proceed synchronously
         completion = RentCompletion(runContinuationsAsynchronously);
-        var result = SyncProduceResult.Success;
         try
         {
-            result = TryProduceSyncCore(topic, key, value, headers, partition, timestamp, topicInfo, completion);
+            TryProduceSyncCore(topic, key, value, headers, partition, timestamp, topicInfo, completion, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1126,15 +1119,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             // Note: TryProduceSyncCore may have already called TrySetException, so use Try variant.
             // Don't re-throw here - let the caller await the ValueTask and get the exception.
             completion.TrySetException(ex);
-        }
-
-        if (result == SyncProduceResult.BufferFull)
-        {
-            // Buffer is full — fall back to async path which uses ReserveMemoryAsync
-            // (yields instead of blocking a thread, preventing thread pool starvation).
-            // TryProduceSyncCore already cleaned up and returned the completion source.
-            completion = null;
-            return false;
         }
 
         return true;
@@ -1156,7 +1140,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
 
         // Retry fast path - metadata should already be initialized via InitializeAsync()
-        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, out var fastCompletion))
+        if (TryProduceSyncForAsync(message, runContinuationsAsynchronously, cancellationToken, out var fastCompletion))
         {
             return await AwaitProduceCompletionAsync(fastCompletion!, activity, metricsEnabled, message.Topic, cancellationToken).ConfigureAwait(false);
         }
@@ -1356,13 +1340,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// <summary>
     /// Core synchronous produce logic for the ProduceAsync fast path (called from TryProduceSyncForAsync).
     /// Handles serialization, partitioning, and accumulator append with proper resource cleanup.
-    /// Returns <see cref="SyncProduceResult.BufferFull"/> when the buffer is full instead of
-    /// throwing an exception, avoiding ~5-10μs throw/catch overhead per message under backpressure.
+    /// Under BufferMemory or admission-window backpressure it hands the already-serialized
+    /// record to the slow-path append worker with the same completion source instead of
+    /// signalling the caller to restart on the allocating async path (issue #2444).
     /// </summary>
-    private SyncProduceResult TryProduceSyncCore(
+    private void TryProduceSyncCore(
         ProducerMessage<TKey, TValue> message,
         TopicInfo topicInfo,
-        PooledValueTaskSource<RecordMetadata> completion)
+        PooledValueTaskSource<RecordMetadata> completion,
+        CancellationToken cancellationToken)
         => TryProduceSyncCore(
             message.Topic,
             message.Key,
@@ -1371,7 +1357,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             message.Partition,
             message.Timestamp,
             topicInfo,
-            completion);
+            completion,
+            cancellationToken);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int GetUniformStickyPartitionCount(
@@ -1390,7 +1377,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return keyIsNull && _partitioner is IBatchCompletionAwarePartitioner ? partitionCount : 0;
     }
 
-    private SyncProduceResult TryProduceSyncCore(
+    private void TryProduceSyncCore(
         string topic,
         TKey? key,
         TValue value,
@@ -1398,7 +1385,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         int? partition,
         DateTimeOffset? timestamp,
         TopicInfo topicInfo,
-        PooledValueTaskSource<RecordMetadata> completion)
+        PooledValueTaskSource<RecordMetadata> completion,
+        CancellationToken cancellationToken)
     {
         Header[]? pooledHeaderArray = null;
         var customPartitionerKey = PooledMemory.Null;
@@ -1489,18 +1477,40 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 completion,
                 batchCompletionPartitionCount))
             {
-                // Clean up headers — the async slow path will re-serialize.
-                RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
-                completion.SetRunContinuationsAsynchronously(true);
-                _valueTaskSourcePool.Return(completion);
-                customPartitionerKey.Return();
-                customPartitionerValue.Return();
-                return SyncProduceResult.BufferFull;
+                // BufferMemory or admission-window backpressure. Hand the already-serialized
+                // record to the slow-path append worker with the same rented completion instead
+                // of restarting on the async path: that restart allocated a ProducerMessage plus
+                // async state machines per message and re-serialized the record (issue #2444).
+                // The accumulator owns every handed-off resource from this call on, including
+                // when it throws synchronously; null the locals so the catch below cannot
+                // double-return them.
+                var keyOwned = customPartitionerKey;
+                var valueOwned = customPartitionerValue;
+                customPartitionerKey = PooledMemory.Null;
+                customPartitionerValue = PooledMemory.Null;
+                var headersOwned = pooledHeaderArray;
+                pooledHeaderArray = null;
+
+                _accumulator.EnqueueAppendFromSpans(
+                    topic,
+                    resolvedPartition,
+                    timestampMs,
+                    keySpan,
+                    keyIsNull,
+                    keyOwned,
+                    valueSpan,
+                    valueIsNull,
+                    valueOwned,
+                    headersOwned,
+                    headerCount,
+                    completion,
+                    cancellationToken,
+                    batchCompletionPartitionCount);
+                return;
             }
 
             customPartitionerKey.Return();
             customPartitionerValue.Return();
-            return SyncProduceResult.Success;
         }
         catch (Exception ex)
         {
@@ -1731,6 +1741,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var valueIsNull = message.Value is null;
         var key = PooledMemory.Null;
         var value = PooledMemory.Null;
+        Header[]? pooledHeaderArray = null;
         try
         {
             if (!keyIsNull)
@@ -1762,7 +1773,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             var timestampMs = timestamp.ToUnixTimeMilliseconds();
 
             // Convert headers with minimal allocations
-            Header[]? pooledHeaderArray = null;
             var headerCount = 0;
             if (message.Headers is not null && message.Headers.Count > 0)
             {
@@ -1789,6 +1799,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             // must return them here.
             key.Return();
             value.Return();
+            RecordAccumulator.ReturnPooledHeaders(pooledHeaderArray);
             throw;
         }
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3053,36 +3053,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         CancellationToken cancellationToken,
         int partitionCount = 0)
     {
-        PooledMemory key;
-        PooledMemory value;
-        try
-        {
-            key = keyOwned.IsNull
-                ? (keyIsNull ? PooledMemory.Null : CopySpanToPooledMemory(keyData))
-                : keyOwned;
-        }
-        catch
-        {
-            valueOwned.Return();
-            ReturnPooledHeaders(headers);
-            throw;
-        }
+        var key = keyOwned;
+        var value = valueOwned;
 
         try
         {
-            value = valueOwned.IsNull
-                ? (valueIsNull ? PooledMemory.Null : CopySpanToPooledMemory(valueData))
-                : valueOwned;
-        }
-        catch
-        {
-            key.Return();
-            ReturnPooledHeaders(headers);
-            throw;
-        }
+            if (key.IsNull && !keyIsNull)
+                key = CopySpanToPooledMemory(keyData);
+            if (value.IsNull && !valueIsNull)
+                value = CopySpanToPooledMemory(valueData);
 
-        try
-        {
             EnqueueAppend(topic, partition, timestamp, key, value, headers, headerCount,
                 completion, cancellationToken, partitionCount);
         }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3030,6 +3030,74 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     /// <summary>
+    /// Queues an already-serialized record for the slow-path append worker with the caller's
+    /// completion source (the ProduceAsync backpressure handoff, issue #2444). Copies the
+    /// spans to pooled memory, or adopts <paramref name="keyOwned"/>/<paramref name="valueOwned"/>
+    /// when the caller already holds pooled copies (custom-partitioner path). Owns cleanup of
+    /// every passed resource from this call on, including when it throws synchronously, so
+    /// callers never risk a double return.
+    /// </summary>
+    internal void EnqueueAppendFromSpans(
+        string topic,
+        int partition,
+        long timestamp,
+        ReadOnlySpan<byte> keyData,
+        bool keyIsNull,
+        PooledMemory keyOwned,
+        ReadOnlySpan<byte> valueData,
+        bool valueIsNull,
+        PooledMemory valueOwned,
+        Header[]? headers,
+        int headerCount,
+        PooledValueTaskSource<RecordMetadata> completion,
+        CancellationToken cancellationToken,
+        int partitionCount = 0)
+    {
+        PooledMemory key;
+        PooledMemory value;
+        try
+        {
+            key = keyOwned.IsNull
+                ? (keyIsNull ? PooledMemory.Null : CopySpanToPooledMemory(keyData))
+                : keyOwned;
+        }
+        catch
+        {
+            valueOwned.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
+
+        try
+        {
+            value = valueOwned.IsNull
+                ? (valueIsNull ? PooledMemory.Null : CopySpanToPooledMemory(valueData))
+                : valueOwned;
+        }
+        catch
+        {
+            key.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
+
+        try
+        {
+            EnqueueAppend(topic, partition, timestamp, key, value, headers, headerCount,
+                completion, cancellationToken, partitionCount);
+        }
+        catch
+        {
+            // EnqueueAppend owns cleanup once it accepts the work item; a synchronous
+            // throw (disposal race in worker startup) leaves ownership here.
+            key.Return();
+            value.Return();
+            ReturnPooledHeaders(headers);
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Rents a new PartitionBatch from the pool and configures it with current transaction state.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
@@ -14,6 +14,59 @@ namespace Dekaf.Tests.Integration.RealWorld;
 public sealed class BackpressureIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test, NotInParallel]
+    public async Task AwaitedProduce_BufferMemoryBackpressure_CompletesThroughBrokerAck()
+    {
+        const int bufferMemory = 65_536;
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+
+        await using var producer = (KafkaProducer<string, string>)await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId("test-producer-awaited-backpressure-handoff")
+            .WithBufferMemory(bufferMemory)
+            .WithMaxBlock(TimeSpan.FromSeconds(30))
+            .WithLinger(TimeSpan.Zero)
+            .WithIdempotence(false)
+            .WithAcks(Acks.Leader)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        // Warm metadata so the next ProduceAsync enters the synchronous fast path.
+        await producer.ProduceAsync(topic, "warmup-key", "warmup-value");
+
+        var accumulator = producer.RecordAccumulator;
+        await Assert.That(accumulator.TryReserveMemoryForTest(bufferMemory)).IsTrue();
+        var reservationHeld = true;
+
+        try
+        {
+            var pendingBefore = accumulator.PendingAppendDrainEntryCountForTest;
+            var produce = producer.ProduceAsync(topic, "backpressured-key", "backpressured-value");
+
+            var enteredDrain = SpinWait.SpinUntil(
+                () => accumulator.PendingAppendDrainEntryCountForTest > pendingBefore,
+                TimeSpan.FromSeconds(5));
+            await Assert.That(enteredDrain).IsTrue();
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(1);
+            await Assert.That(produce.IsCompleted).IsFalse();
+
+            accumulator.ReleaseMemory(bufferMemory);
+            reservationHeld = false;
+
+            var metadata = await produce.AsTask().WaitAsync(TimeSpan.FromSeconds(30));
+            await Assert.That(metadata.Topic).IsEqualTo(topic);
+            await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(1);
+            await Assert.That(accumulator.PendingAppendDrainEntryCountForTest)
+                .IsGreaterThan(pendingBefore);
+            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+        }
+        finally
+        {
+            if (reservationHeld)
+                accumulator.ReleaseMemory(bufferMemory);
+        }
+    }
+
+    [Test, NotInParallel]
     public async Task BufferFull_ProduceBlocks_UntilBatchSent()
     {
         // Arrange - very small buffer to trigger backpressure quickly

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -368,11 +368,6 @@ public class KafkaProducerFastPathTests
         await using var producer = await CreateBufferBoundaryProducerAsync(maxBlockMs: 30_000);
         var accumulator = producer.RecordAccumulator;
 
-        // StopProducerBackgroundLoopsAsync cancels _senderCts, which is also the append
-        // workers' token; hand the lazily-started workers a live token so the slow-path
-        // handoff under test can actually run. Disposal still stops them via channel completion.
-        accumulator.StartAppendWorkers(CancellationToken.None);
-
         await Assert.That(accumulator.TryReserveMemoryForTest(BufferMemoryLimit)).IsTrue();
         var syntheticReservationRemaining = BufferMemoryLimit;
 

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -46,23 +46,19 @@ public class KafkaProducerFastPathTests
 
         partitioner.OnFirstPartition = () =>
         {
-            var innerResult = InvokeTryProduceSyncCore(
+            // Throws on failure; a successful return means the inner record was appended.
+            InvokeTryProduceSyncCore(
                 producer,
                 new ProducerMessage<string, string> { Topic = Topic, Key = "inner", Value = "inner-value" },
                 topicInfo,
                 innerCompletion);
-
-            if (innerResult.ToString() != "Success")
-                throw new InvalidOperationException($"Unexpected inner result: {innerResult}");
         };
 
-        var outerResult = InvokeTryProduceSyncCore(
+        InvokeTryProduceSyncCore(
             producer,
             new ProducerMessage<string, string> { Topic = Topic, Key = "outer", Value = "outer-value" },
             topicInfo,
             outerCompletion);
-
-        await Assert.That(outerResult.ToString()).IsEqualTo("Success");
 
         var readyBatch = CompleteCurrentBatch(producer.RecordAccumulator, new TopicPartition(Topic, 0));
         await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(2);
@@ -367,66 +363,58 @@ public class KafkaProducerFastPathTests
     }
 
     [Test]
-    public async Task TransactionFastPath_BufferFull_RestoresAsyncModeBeforePoolReturn()
+    public async Task FastPath_BufferFull_QueuesSlowPathAppendWithSameCompletion()
     {
         await using var producer = await CreateBufferBoundaryProducerAsync(maxBlockMs: 30_000);
         var accumulator = producer.RecordAccumulator;
-        var pool = GetInstanceField<ValueTaskSourcePool<RecordMetadata>>(producer, "_valueTaskSourcePool");
+
+        // StopProducerBackgroundLoopsAsync cancels _senderCts, which is also the append
+        // workers' token; hand the lazily-started workers a live token so the slow-path
+        // handoff under test can actually run. Disposal still stops them via channel completion.
+        accumulator.StartAppendWorkers(CancellationToken.None);
+
         await Assert.That(accumulator.TryReserveMemoryForTest(BufferMemoryLimit)).IsTrue();
+        var syntheticReservationRemaining = BufferMemoryLimit;
 
         try
         {
-            var pooledBefore = pool.ApproximateCount;
             var usedFastPath = InvokeTryProduceSyncForAsync(
                 producer,
                 new ProducerMessage<string, string> { Topic = Topic, Key = "key", Value = "value" },
                 runContinuationsAsynchronously: false,
                 out var completion);
 
-            await Assert.That(usedFastPath).IsFalse();
-            await Assert.That(completion).IsNull();
-            await Assert.That(pool.ApproximateCount).IsEqualTo(pooledBefore + 1);
+            // Backpressure no longer bounces the caller onto the allocating async restart
+            // path (issue #2444): the already-serialized record is handed to the slow-path
+            // append worker and the caller keeps awaiting the same rented completion.
+            await Assert.That(usedFastPath).IsTrue();
+            await Assert.That(completion).IsNotNull();
+            var completionTask = completion!.Task;
 
-            var reused = pool.Rent();
-            var awaiter = reused.Task.GetAwaiter();
-            var continuationThreadId = 0;
-            var continuation = new TaskCompletionSource<RecordMetadata>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            awaiter.UnsafeOnCompleted(() =>
-            {
-                continuationThreadId = Environment.CurrentManagedThreadId;
-                try
-                {
-                    continuation.SetResult(awaiter.GetResult());
-                }
-                catch (Exception ex)
-                {
-                    continuation.SetException(ex);
-                }
-            });
-            var completionThreadId = 0;
-            var completionThread = new Thread(() =>
-            {
-                completionThreadId = Environment.CurrentManagedThreadId;
-                reused.SetResult(new RecordMetadata
-                {
-                    Topic = Topic,
-                    Partition = 0,
-                    Offset = 0,
-                    Timestamp = DateTimeOffset.UtcNow
-                });
-            }) { IsBackground = true };
+            await TestWait.UntilAsync(
+                () => accumulator.PendingAppendCountForTest == 1,
+                TimeSpan.FromSeconds(5));
+            await Assert.That(completionTask.IsCompleted).IsFalse();
 
-            completionThread.Start();
-            completionThread.Join();
-            var metadata = await continuation.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            accumulator.ReleaseMemory(BufferMemoryLimit);
+            syntheticReservationRemaining = 0;
 
+            await TestWait.UntilAsync(
+                () => accumulator.PendingAppendCountForTest == 0,
+                TimeSpan.FromSeconds(5));
+
+            var readyBatch = CompleteCurrentBatch(accumulator, new TopicPartition(Topic, 0));
+            await Assert.That(readyBatch.RecordBatch.Records.Count).IsEqualTo(1);
+            readyBatch.CompleteSend(baseOffset: 3, DateTimeOffset.UtcNow);
+
+            var metadata = await completionTask.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(metadata.Topic).IsEqualTo(Topic);
-            await Assert.That(continuationThreadId).IsNotEqualTo(completionThreadId);
+            await Assert.That(metadata.Offset).IsEqualTo(3);
         }
         finally
         {
-            accumulator.ReleaseMemory(BufferMemoryLimit);
+            if (syntheticReservationRemaining > 0)
+                accumulator.ReleaseMemory(syntheticReservationRemaining);
         }
     }
 
@@ -578,7 +566,7 @@ public class KafkaProducerFastPathTests
         throw new InvalidOperationException($"Could not find a key for partition {targetPartition}.");
     }
 
-    private static object InvokeTryProduceSyncCore(
+    private static void InvokeTryProduceSyncCore(
         KafkaProducer<string, string> producer,
         ProducerMessage<string, string> message,
         TopicInfo topicInfo,
@@ -588,12 +576,12 @@ public class KafkaProducerFastPathTests
             "TryProduceSyncCore",
             BindingFlags.NonPublic | BindingFlags.Instance,
             binder: null,
-            [typeof(ProducerMessage<string, string>), typeof(TopicInfo), typeof(PooledValueTaskSource<RecordMetadata>)],
+            [typeof(ProducerMessage<string, string>), typeof(TopicInfo), typeof(PooledValueTaskSource<RecordMetadata>), typeof(CancellationToken)],
             modifiers: null);
 
         try
         {
-            return method!.Invoke(producer, [message, topicInfo, completion])!;
+            method!.Invoke(producer, [message, topicInfo, completion, CancellationToken.None]);
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
@@ -615,15 +603,16 @@ public class KafkaProducerFastPathTests
             [
                 typeof(ProducerMessage<string, string>),
                 typeof(bool),
+                typeof(CancellationToken),
                 typeof(PooledValueTaskSource<RecordMetadata>).MakeByRefType()
             ],
             modifiers: null);
-        object?[] arguments = [message, runContinuationsAsynchronously, null];
+        object?[] arguments = [message, runContinuationsAsynchronously, CancellationToken.None, null];
 
         try
         {
             var result = (bool)method!.Invoke(producer, arguments)!;
-            completion = (PooledValueTaskSource<RecordMetadata>?)arguments[2];
+            completion = (PooledValueTaskSource<RecordMetadata>?)arguments[3];
             return result;
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)

--- a/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
@@ -50,9 +50,17 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
         // value when Testcontainers ever returns a plain host:port. Stopgap for #2448;
         // delete once the product parser accepts scheme-prefixed bootstrap entries.
         var rawBootstrap = _container.GetBootstrapAddress();
-        BootstrapServers = Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0
-            ? $"{bootstrapUri.Host}:{bootstrapUri.Port}"
-            : rawBootstrap;
+        if (Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0)
+        {
+            var host = bootstrapUri.HostNameType == UriHostNameType.IPv6
+                ? $"[{bootstrapUri.DnsSafeHost}]"
+                : bootstrapUri.Host;
+            BootstrapServers = $"{host}:{bootstrapUri.Port}";
+        }
+        else
+        {
+            BootstrapServers = rawBootstrap;
+        }
         Console.WriteLine($"Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);

--- a/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
@@ -42,25 +42,7 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
 
         await _container.StartAsync().ConfigureAwait(false);
 
-        // GetBootstrapAddress returns "plaintext://host:port/". Confluent accepts the
-        // scheme-prefixed form, but Dekaf's bootstrap list expects plain "host:port" —
-        // without normalization the Dekaf benchmarks fail their initial metadata fetch
-        // while the Confluent baseline connects, silently skewing local comparisons.
-        // Same tolerant idiom as KafkaTestContainer.ExtractHostPort: fall back to the raw
-        // value when Testcontainers ever returns a plain host:port. Stopgap for #2448;
-        // delete once the product parser accepts scheme-prefixed bootstrap entries.
-        var rawBootstrap = _container.GetBootstrapAddress();
-        if (Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0)
-        {
-            var host = bootstrapUri.HostNameType == UriHostNameType.IPv6
-                ? $"[{bootstrapUri.DnsSafeHost}]"
-                : bootstrapUri.Host;
-            BootstrapServers = $"{host}:{bootstrapUri.Port}";
-        }
-        else
-        {
-            BootstrapServers = rawBootstrap;
-        }
+        BootstrapServers = BootstrapServerList.Parse(_container.GetBootstrapAddress()).Normalized;
         Console.WriteLine($"Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);

--- a/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
@@ -42,7 +42,17 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
 
         await _container.StartAsync().ConfigureAwait(false);
 
-        BootstrapServers = _container.GetBootstrapAddress();
+        // GetBootstrapAddress returns "plaintext://host:port/". Confluent accepts the
+        // scheme-prefixed form, but Dekaf's bootstrap list expects plain "host:port" —
+        // without normalization the Dekaf benchmarks fail their initial metadata fetch
+        // while the Confluent baseline connects, silently skewing local comparisons.
+        // Same tolerant idiom as KafkaTestContainer.ExtractHostPort: fall back to the raw
+        // value when Testcontainers ever returns a plain host:port. Stopgap for #2448;
+        // delete once the product parser accepts scheme-prefixed bootstrap entries.
+        var rawBootstrap = _container.GetBootstrapAddress();
+        BootstrapServers = Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0
+            ? $"{bootstrapUri.Host}:{bootstrapUri.Port}"
+            : rawBootstrap;
         Console.WriteLine($"Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);


### PR DESCRIPTION
Closes #2444  ## What  - when the ProduceAsync sync fast path hits BufferMemory or admission-window backpressure, hand the **already-serialized** record to the slow-path append worker with the **same rented completion source**, instead of discarding the serialized spans and restarting on the async path - the removed restart path allocated, per backpressured message: a `ProducerMessage<TKey,TValue>`, the `ProduceAsyncSlow` + `ProduceInternalAsync` + `AwaitProduceCompletionAsync` async state machines, and re-serialized the key and value a second time - the handoff is encapsulated as `RecordAccumulator.EnqueueAppendFromSpans(...)`: it copies the spans to pooled memory (or adopts the custom-partitioner path's existing pooled copies instead of re-copying) and owns cleanup of every passed resource including on synchronous throw, so callers can't double-return pooled memory - `TryProduceSyncCore` becomes `void`; the `SyncProduceResult` enum and its BufferFull plumbing are deleted — `TryProduceSyncForAsync` now returns false only on a metadata miss - `CancellationToken` is threaded into `TryProduceSyncForAsync`/`TryProduceSyncCore` so the queued work item keeps the caller's pre-append cancellation semantics - fixes a pre-existing latent leak at the sibling `EnqueueAppend` call site (`ProduceInternalAsync`): its catch returned key/value but could not return the pooled header array - benchmark infra: after #2448 merged, `KafkaTestEnvironment` reuses `BootstrapServerList.Parse(...).Normalized`; scheme-prefixed and bracketed-IPv6 Testcontainers addresses now follow the same product parser used by clients  FIFO is preserved exactly like the previous fallback: `EnqueueAppend` increments the per-partition slow-path count synchronously before returning, so later sync-path appends refuse admission until the queue drains. Error semantics are unchanged — MaxBlockMs timeout, cancellation, and disposal all surface through the same pooled `PendingAppend`/worker path the old restart also ended in.  ## Root cause (investigation)  Published ProduceBatch rows allocate ~52-63 B/msg (the `RecordMetadata[]` result array plus per-batch costs) — except 1000B×1000 at **~346 B/msg**. That row's 1 MB payload over 16 KiB client batches (~63 batches) is the only benchmarked shape where appends outrun the admission window, so most of its messages fell off the sync fast path onto the allocating restart path.  Causal confirmation (same host, external Kafka 4.3.1, `[MemoryDiagnoser]`): disabling the admission window (`WithDeliveryLatencyTarget(0)`) collapsed the row's allocation from 339.15 KB/op to 93.06 KB/op with no other change — the backpressure fallback, not the batching machinery, was the dominant allocator.  ## Performance (i7-12700K, same-host external Kafka 4.3.1, like-for-like, `[MemoryDiagnoser]`)  | Row | Baseline (main) | Candidate | Delta | |---|---:|---:|---:| | **ProduceBatch 1000B×1000 Allocated** | **339.15 KB/op (~347 B/msg)** | **66.59-66.88 KB/op (~67 B/msg)** | **-80%** | | ProduceBatch 1000B×1000 Mean | 16.91 ms | 15.51 / 16.76 ms (two runs) | within noise | | ProduceBatch 1000B×100 Allocated | 6.24 KB/op | 6.21-6.30 KB/op | unchanged | | ProduceBatch 1000B×100 Mean | 16.08 ms | 15.51-15.53 ms | within noise |  The fixed row now sits at ~67 B/msg, in line with its non-backpressured siblings. The candidate also lands **below** the window-disabled control (93 KB/op) because the pooled handoff is cheaper than the old restart even for the residual slow-path traffic that control still paid.  Unaffected winning rows, candidate vs published main values (paths mechanically unchanged — signature-only edits without backpressure):  | Row | Published (main, `36bbdcc14`) | Candidate local | |---|---:|---:| | ProduceBatch 100B×100 Allocated | 5,576 B | 5,621 B | | ProduceBatch 100B×1000 Allocated | 51,762 B | 49,722 B | | ProduceSingle Allocated (all 4 rows) | 648 B | 648 B |  All local runs on one warm same-host broker; all-row means sit at the same-host ack floor (~15.5 ms), so time comparisons are only meaningful within this rig — the affected 1000B rows have direct local baselines above. No paid stress lane dispatched: the change strictly removes work from a cold branch, the sync-append success path's instruction count is net reduced (enum compare/branch deleted; token is an extra register arg, never dereferenced on the hot path), and the weekly scheduled run remains the cross-run acceptance check.  ## Validation  - post-rebase onto #2452/#2454: benchmark, unit, and integration Release builds: 0 warnings/errors; full net10 unit suite: 6586/6586; broker-backed awaited-backpressure regression: 1/1 - full net10 unit suite: 6571/6571 - `KafkaProducerFastPathTests` updated to the new contract: the old `TransactionFastPath_BufferFull_RestoresAsyncModeBeforePoolReturn` guarded mode restoration on the now-deleted BufferFull pool-return path (the normal `GetResult` return path restores async mode in `PooledValueTaskSource`); its replacement `FastPath_BufferFull_QueuesSlowPathAppendWithSameCompletion` proves the full new flow: backpressure → queued pending append with the same completion → space freed → drain → batch append → delivery metadata on the original awaited task. The test arms the lazily-started append workers with `StartAppendWorkers(CancellationToken.None)` because the test helper's sender-loop shutdown also cancels the workers' shared token — filed as #2449 (lifetime separation + proper test seam) - required `/simplify`: complete — applied its findings (handoff encapsulated in the accumulator, sibling-site header-leak fix, shared bootstrap parser) and removed the obsolete manual append-worker restart after integrating #2449 