### PR TITLE
fix: validate bootstrap server endpoints

### DIFF
--- a/src/Dekaf/BootstrapServerList.cs
+++ b/src/Dekaf/BootstrapServerList.cs
@@ -1,7 +1,13 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+
 namespace Dekaf;
 
 internal static class BootstrapServerList
 {
+    internal readonly record struct Endpoint(string Normalized, string Host, int Port);
+
     internal static string[] FromCommaSeparated(string servers)
     {
         ArgumentNullException.ThrowIfNull(servers);
@@ -22,13 +28,99 @@ internal static class BootstrapServerList
             if (server is null)
                 throw new ArgumentException("Bootstrap server entries cannot be null.", nameof(servers));
 
-            var trimmed = server.Trim();
-            if (trimmed.Length == 0)
-                throw new ArgumentException("Bootstrap server entries cannot be empty.", nameof(servers));
-
-            normalized[i] = trimmed;
+            normalized[i] = Parse(server, nameof(servers)).Normalized;
         }
 
         return normalized;
     }
+
+    internal static Endpoint Parse(string server, string paramName = "bootstrapServers")
+    {
+        ArgumentNullException.ThrowIfNull(server);
+
+        var value = server.Trim();
+        if (value.Length == 0)
+            throw new ArgumentException("Bootstrap server entries cannot be empty.", paramName);
+
+        var schemeSeparator = value.IndexOf("://", StringComparison.Ordinal);
+        if (schemeSeparator >= 0)
+        {
+            if (!IsValidScheme(value.AsSpan(0, schemeSeparator)))
+                throw InvalidEntry(server, paramName);
+
+            // The prefix is syntax only. TLS and SASL remain controlled by their builder options.
+            value = value[(schemeSeparator + 3)..];
+        }
+
+        value = value.TrimEnd('/');
+        if (value.Length == 0)
+            throw InvalidEntry(server, paramName);
+
+        string host;
+        string portText;
+        var isIpv6 = value[0] == '[';
+        if (isIpv6)
+        {
+            var closingBracket = value.IndexOf(']');
+            if (closingBracket <= 1
+                || closingBracket + 2 >= value.Length
+                || value[closingBracket + 1] != ':')
+            {
+                throw InvalidEntry(server, paramName);
+            }
+
+            host = value.Substring(1, closingBracket - 1);
+            if (!IPAddress.TryParse(host, out var address)
+                || address.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                throw InvalidEntry(server, paramName);
+            }
+
+            portText = value[(closingBracket + 2)..];
+        }
+        else
+        {
+            var colonIndex = value.LastIndexOf(':');
+            if (colonIndex <= 0 || colonIndex != value.IndexOf(':'))
+                throw InvalidEntry(server, paramName);
+
+            host = value[..colonIndex];
+            if (Uri.CheckHostName(host) is not (UriHostNameType.Dns or UriHostNameType.IPv4))
+                throw InvalidEntry(server, paramName);
+
+            portText = value[(colonIndex + 1)..];
+        }
+
+        if (!int.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port)
+            || port is < 1 or > 65_535)
+        {
+            throw InvalidEntry(server, paramName);
+        }
+
+        var normalized = isIpv6 ? $"[{host}]:{port}" : $"{host}:{port}";
+        return new Endpoint(normalized, host, port);
+    }
+
+    private static bool IsValidScheme(ReadOnlySpan<char> scheme)
+    {
+        if (scheme.IsEmpty || !char.IsLetter(scheme[0]))
+            return false;
+
+        for (var i = 1; i < scheme.Length; i++)
+        {
+            var character = scheme[i];
+            if (!char.IsLetterOrDigit(character)
+                && character is not ('+' or '-' or '.' or '_'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ArgumentException InvalidEntry(string server, string paramName) =>
+        new(
+            $"Invalid bootstrap server '{server}'. Expected [PROTOCOL://]host:port or [PROTOCOL://][ipv6]:port.",
+            paramName);
 }

--- a/src/Dekaf/Metadata/MetadataManager.cs
+++ b/src/Dekaf/Metadata/MetadataManager.cs
@@ -129,24 +129,14 @@ public sealed partial class MetadataManager : IAsyncDisposable
             observerPool.SetConnectionCapabilityObserver(ObserveConnectionCapabilities);
 
         // Pre-parse bootstrap servers to avoid allocation in hot path
+        ArgumentNullException.ThrowIfNull(bootstrapServers);
         _bootstrapEndpoints = new List<(string Host, int Port)>();
         _originalBootstrapHostnames = new List<string>();
         foreach (var server in bootstrapServers)
         {
-            var colonIndex = server.IndexOf(':');
-            if (colonIndex > 0 && colonIndex < server.Length - 1)
-            {
-                var host = server.Substring(0, colonIndex);
-#if NETSTANDARD2_0
-                if (int.TryParse(server.Substring(colonIndex + 1), out var port))
-#else
-                if (int.TryParse(server.AsSpan(colonIndex + 1), out var port))
-#endif
-                {
-                    _bootstrapEndpoints.Add((host, port));
-                    _originalBootstrapHostnames.Add(server);
-                }
-            }
+            var endpoint = BootstrapServerList.Parse(server);
+            _bootstrapEndpoints.Add((endpoint.Host, endpoint.Port));
+            _originalBootstrapHostnames.Add(endpoint.Normalized);
         }
     }
 

--- a/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerCoordinatorFailoverIntegrationTests.cs
@@ -15,7 +15,7 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
     private const int MessagesPerPartition = 20;
     private const int MessageCount = PartitionCount * MessagesPerPartition;
     private static readonly TimeSpan SessionTimeout = TimeSpan.FromSeconds(15);
-    private static readonly TimeSpan CoordinatorRecoveryObservationPeriod = TimeSpan.FromSeconds(18);
+    private static readonly TimeSpan CoordinatorRecoveryTimeout = TimeSpan.FromSeconds(45);
 
     [Test]
     [Timeout(240_000)]
@@ -704,20 +704,27 @@ public sealed class ConsumerCoordinatorFailoverIntegrationTests(RackAwareKafkaCo
         IReadOnlyList<Task> pollTasks,
         CancellationToken cancellationToken)
     {
-        await Task.Delay(CoordinatorRecoveryObservationPeriod, cancellationToken).ConfigureAwait(false);
-        var failed = pollTasks.FirstOrDefault(static task => task.IsFaulted);
-        if (failed is not null)
-            await failed.ConfigureAwait(false);
-
         await using var admin = kafka.CreateAdminClient();
-        var groups = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken)
-            .ConfigureAwait(false);
-        if (!groups.TryGetValue(groupId, out var group) || group.Members.Count != 2)
+        var startedAt = TimeProvider.System.GetTimestamp();
+        var memberCount = 0;
+
+        while (TimeProvider.System.GetElapsedTime(startedAt) < CoordinatorRecoveryTimeout)
         {
-            throw new InvalidOperationException(
-                $"Expected both group members to survive coordinator failover; actual count " +
-                $"{(groups.TryGetValue(groupId, out group) ? group.Members.Count : 0)}.");
+            var failed = pollTasks.FirstOrDefault(static task => task.IsFaulted);
+            if (failed is not null)
+                await failed.ConfigureAwait(false);
+
+            var groups = await admin.DescribeConsumerGroupsAsync([groupId], cancellationToken)
+                .ConfigureAwait(false);
+            memberCount = groups.TryGetValue(groupId, out var group) ? group.Members.Count : 0;
+            if (memberCount == 2)
+                return;
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
         }
+
+        throw new InvalidOperationException(
+            $"Expected both group members to survive coordinator failover; actual count {memberCount}.");
     }
 
     private static async Task WaitForAssignmentCountAsync(

--- a/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaTestContainer.cs
@@ -99,9 +99,7 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
             ResetContainerAsync,
             ContainerStartupRetry.IsKnownTransient).ConfigureAwait(false);
 
-        var rawAddress = _container!.GetBootstrapAddress();
-        // GetBootstrapAddress() may return "plaintext://host:port/" - extract just host:port
-        BootstrapServers = ExtractHostPort(rawAddress);
+        BootstrapServers = _container!.GetBootstrapAddress();
 
         Console.WriteLine($"[KafkaTestContainer] Kafka started at {BootstrapServers}");
 
@@ -109,33 +107,19 @@ public abstract class KafkaTestContainer : IAsyncInitializer, IAsyncDisposable
         await OnAfterInitializeAsync().ConfigureAwait(false);
     }
 
-    protected static string ExtractHostPort(string address)
-    {
-        // Handle format like "plaintext://127.0.0.1:9092/" or just "127.0.0.1:9092"
-        if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
-        {
-            return $"{uri.Host}:{uri.Port}";
-        }
-        // Already in host:port format
-        return address.TrimEnd('/');
-    }
-
     private async Task WaitForKafkaAsync()
     {
         Console.WriteLine("[KafkaTestContainer] Waiting for Kafka to be ready...");
         const int maxAttempts = 30;
 
-        // Parse host and port from host:port format
-        var colonIndex = BootstrapServers.LastIndexOf(':');
-        var host = BootstrapServers[..colonIndex];
-        var port = int.Parse(BootstrapServers[(colonIndex + 1)..]);
+        var endpoint = BootstrapServerList.Parse(BootstrapServers);
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
             try
             {
                 using var client = new TcpClient();
-                await client.ConnectAsync(host, port).ConfigureAwait(false);
+                await client.ConnectAsync(endpoint.Host, endpoint.Port).ConfigureAwait(false);
                 Console.WriteLine("[KafkaTestContainer] Kafka is accepting connections");
                 return;
             }

--- a/tests/Dekaf.Tests.Integration/ProducerTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProducerTests.cs
@@ -12,6 +12,25 @@ namespace Dekaf.Tests.Integration;
 public class ProducerTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
 {
     [Test]
+    public async Task Producer_SchemePrefixedBootstrapServer_ProducesSuccessfully()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var endpoint = BootstrapServerList.Parse(KafkaContainer.BootstrapServers);
+        var bootstrapServer = $"PLAINTEXT://{endpoint.Normalized}/";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(bootstrapServer)
+            .WithClientId("test-producer-scheme-prefixed-bootstrap")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        var metadata = await producer.ProduceAsync(topic, "key", "value");
+
+        await Assert.That(metadata.Topic).IsEqualTo(topic);
+        await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
     public async Task Producer_MultiTopicProduce_UsesNegotiatedTopicEncoding()
     {
         var firstTopic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
+++ b/tests/Dekaf.Tests.Integration/ProtocolVersionTests.cs
@@ -16,8 +16,8 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
 {
     private static (string Host, int Port) ParseBootstrapEndpoint(string bootstrapServers)
     {
-        var separator = bootstrapServers.LastIndexOf(':');
-        return (bootstrapServers[..separator], int.Parse(bootstrapServers[(separator + 1)..]));
+        var endpoint = BootstrapServerList.Parse(bootstrapServers);
+        return (endpoint.Host, endpoint.Port);
     }
 
     private static async Task<ApiVersionsResponse> SendApiVersionsAsync(IKafkaConnection connection)
@@ -44,10 +44,10 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
             "api-versions-test",
             new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) },
             loggerFactory: null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
         var connection = await pool.GetConnectionAsync(
-            parts[0],
-            int.Parse(parts[1]),
+            host,
+            port,
             CancellationToken.None);
 
         var response = await SendApiVersionsAsync(connection);
@@ -69,9 +69,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -191,9 +189,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -222,9 +218,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -252,9 +246,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -290,9 +282,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -482,9 +472,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {
@@ -521,9 +509,7 @@ public class ProtocolVersionTests(KafkaTestContainer kafka) : KafkaIntegrationTe
         };
 
         var pool = new ConnectionPool("test-client", connectionOptions, null);
-        var parts = KafkaContainer.BootstrapServers.Split(':');
-        var host = parts[0];
-        var port = int.Parse(parts[1]);
+        var (host, port) = ParseBootstrapEndpoint(KafkaContainer.BootstrapServers);
 
         try
         {

--- a/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistryTestContainer.cs
@@ -82,7 +82,7 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
             .Build();
 
         await _kafkaContainer.StartAsync().ConfigureAwait(false);
-        _bootstrapServers = ExtractHostPort(_kafkaContainer.GetBootstrapAddress());
+        _bootstrapServers = _kafkaContainer.GetBootstrapAddress();
         Console.WriteLine($"[KafkaWithSchemaRegistry] Kafka started at {_bootstrapServers}");
 
         // Verify Kafka is accepting connections before starting Schema Registry.
@@ -111,30 +111,19 @@ public class KafkaWithSchemaRegistryContainer : IAsyncInitializer, IAsyncDisposa
         await WaitForServicesAsync().ConfigureAwait(false);
     }
 
-    private static string ExtractHostPort(string address)
-    {
-        if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
-        {
-            return $"{uri.Host}:{uri.Port}";
-        }
-        return address.TrimEnd('/');
-    }
-
     private async Task WaitForKafkaAsync()
     {
         Console.WriteLine("[KafkaWithSchemaRegistry] Waiting for Kafka to be ready...");
         const int maxAttempts = 30;
 
-        var colonIndex = _bootstrapServers.LastIndexOf(':');
-        var host = _bootstrapServers[..colonIndex];
-        var port = int.Parse(_bootstrapServers[(colonIndex + 1)..]);
+        var endpoint = BootstrapServerList.Parse(_bootstrapServers);
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
             try
             {
                 using var client = new TcpClient();
-                await client.ConnectAsync(host, port).ConfigureAwait(false);
+                await client.ConnectAsync(endpoint.Host, endpoint.Port).ConfigureAwait(false);
                 if (client.Connected)
                 {
                     Console.WriteLine("[KafkaWithSchemaRegistry] Kafka is accepting connections");

--- a/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/Security/TlsKafkaContainer.cs
@@ -122,8 +122,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
 
         await _container.StartAsync();
 
-        var rawAddress = _container.GetBootstrapAddress();
-        BootstrapServers = ExtractHostPort(rawAddress);
+        BootstrapServers = _container.GetBootstrapAddress();
 
         Console.WriteLine($"[TlsKafkaContainer] TLS Kafka started at {BootstrapServers}");
 
@@ -160,15 +159,6 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
         }
     }
 
-    private static string ExtractHostPort(string address)
-    {
-        if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
-        {
-            return $"{uri.Host}:{uri.Port}";
-        }
-        return address.TrimEnd('/');
-    }
-
     private static int GetFreeTcpPort()
     {
         var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
@@ -199,16 +189,14 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
     {
         Console.WriteLine("[TlsKafkaContainer] Waiting for Kafka SSL listener to be ready...");
 
-        var colonIndex = BootstrapServers.LastIndexOf(':');
-        var host = BootstrapServers[..colonIndex];
-        var port = int.Parse(BootstrapServers[(colonIndex + 1)..]);
+        var endpoint = BootstrapServerList.Parse(BootstrapServers);
 
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
             try
             {
                 using var client = new TcpClient();
-                await client.ConnectAsync(host, port);
+                await client.ConnectAsync(endpoint.Host, endpoint.Port);
                 if (client.Connected)
                 {
                     // Perform an actual TLS handshake to verify the SSL listener is fully ready.
@@ -224,7 +212,7 @@ public class TlsKafkaContainer : IAsyncInitializer, IAsyncDisposable
 
                     await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
                     {
-                        TargetHost = host
+                        TargetHost = endpoint.Host
                     });
 
                     Console.WriteLine("[TlsKafkaContainer] Kafka SSL listener is accepting TLS connections");

--- a/tests/Dekaf.Tests.Unit/Builder/BootstrapServerListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/BootstrapServerListTests.cs
@@ -19,6 +19,42 @@ public class BootstrapServerListTests
     }
 
     [Test]
+    public async Task FromValues_NormalizesSchemesTrailingSlashesAndIpv6()
+    {
+        var servers = BootstrapServerList.FromValues(
+            "broker1:9092",
+            "PLAINTEXT://broker2:9093/",
+            "sasl_ssl://broker3:9094///",
+            "[2001:db8::1]:9095",
+            "SSL://[2001:db8::2]:9096/");
+
+        await Assert.That(servers).IsEquivalentTo([
+            "broker1:9092",
+            "broker2:9093",
+            "broker3:9094",
+            "[2001:db8::1]:9095",
+            "[2001:db8::2]:9096",
+        ]);
+    }
+
+    [Test]
+    [Arguments("broker")]
+    [Arguments(":9092")]
+    [Arguments("broker:not-a-port")]
+    [Arguments("broker:0")]
+    [Arguments("broker:65536")]
+    [Arguments("broker:9092/path")]
+    [Arguments("://broker:9092")]
+    [Arguments("PLAINTEXT://")]
+    [Arguments("2001:db8::1:9092")]
+    [Arguments("[2001:db8::1]9092")]
+    [Arguments("[not-ipv6]:9092")]
+    public void FromValues_RejectsMalformedEntries(string server)
+    {
+        Assert.Throws<ArgumentException>(() => BootstrapServerList.FromValues(server));
+    }
+
+    [Test]
     public void FromCommaSeparated_RejectsEmptyEntries()
     {
         Assert.Throws<ArgumentException>(() =>

--- a/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Builder/ProducerBuilderValidationTests.cs
@@ -30,6 +30,16 @@ public class ProducerBuilderValidationTests
     }
 
     [Test]
+    public async Task WithBootstrapServers_InvalidEndpoint_ThrowsArgumentException()
+    {
+        var act = () => Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("not-an-endpoint");
+
+        await Assert.That(act).Throws<ArgumentException>()
+            .And.HasMessageContaining("Expected [PROTOCOL://]host:port");
+    }
+
+    [Test]
     public async Task Build_WithUnsupportedKeyType_ThrowsInvalidOperationException()
     {
         var builder = Kafka.CreateProducer<DateTime, string>()

--- a/tools/Dekaf.Profiling/Program.cs
+++ b/tools/Dekaf.Profiling/Program.cs
@@ -611,14 +611,7 @@ public static class Program
 
         await container.StartAsync().ConfigureAwait(false);
 
-        // GetBootstrapAddress returns format like "plaintext://127.0.0.1:9092/"
-        // Dekaf expects just "127.0.0.1:9092"
-        var rawAddress = container.GetBootstrapAddress();
-        var bootstrapServers = rawAddress;
-        if (Uri.TryCreate(rawAddress, UriKind.Absolute, out var uri))
-        {
-            bootstrapServers = $"{uri.Host}:{uri.Port}";
-        }
+        var bootstrapServers = container.GetBootstrapAddress();
         Console.WriteLine($"Kafka started at {bootstrapServers}");
 
         // Wait for Kafka to be ready by attempting to connect with a producer

--- a/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
+++ b/tools/Dekaf.StressTests/Infrastructure/KafkaEnvironment.cs
@@ -234,12 +234,7 @@ internal sealed class KafkaEnvironment : IAsyncDisposable
 
         await container.StartAsync().ConfigureAwait(false);
 
-        var rawAddress = container.GetBootstrapAddress();
-        var bootstrapServers = rawAddress;
-        if (Uri.TryCreate(rawAddress, UriKind.Absolute, out var uri))
-        {
-            bootstrapServers = $"{uri.Host}:{uri.Port}";
-        }
+        var bootstrapServers = container.GetBootstrapAddress();
 
         Console.WriteLine($"Kafka started at {bootstrapServers}");
         await WaitForKafkaAsync(bootstrapServers).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- normalize optional protocol prefixes and trailing slashes in `BootstrapServerList`
- validate DNS, IPv4, bracketed IPv6, and port ranges; malformed entries now fail during configuration
- keep scheme prefixes syntax-only; `UseTls` and SASL builder options remain authoritative
- delete duplicated Testcontainers bootstrap-address normalizers

## Performance
Construction/metadata initialization only; no serialization, produce, consume, or receive hot path changed.

## Test plan
- [x] `dotnet build --configuration Release --no-restore` (26 projects, 0 warnings/errors)
- [x] full unit suite (6,584 passed)
- [x] `Producer_SchemePrefixedBootstrapServer_ProducesSuccessfully` against Testcontainers Kafka

Closes #2448
