### PR TITLE
fix: separate append worker lifetime

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -28,6 +28,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 {
     internal ValueTask CloseConnectionsForTestingAsync() => _connectionPool.CloseAllAsync();
 
+    internal async ValueTask StopSenderLoopsForTestingAsync()
+    {
+        await _senderCts.CancelAsync().ConfigureAwait(false);
+        await Task.WhenAll(_senderTask, _lingerTask).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Sentinel return value from <see cref="TryProduceSyncCore"/> indicating that the
     /// buffer is full and the caller should fall back to the async path (ReserveMemoryAsync).
@@ -72,6 +78,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private readonly bool _ownsInfrastructure;
 
     private readonly CancellationTokenSource _senderCts;
+    private readonly CancellationTokenSource _appendWorkerCts;
     private readonly Task _senderTask;
     private readonly Task _lingerTask;
     private readonly ConcurrentDictionary<Task, byte> _partitionEnrollmentTasks = new();
@@ -490,7 +497,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default).Unwrap();
-        _accumulator.StartAppendWorkers(_senderCts.Token);
+        // Sender-loop cancellation is also a test seam. Keep append admission alive until
+        // accumulator disposal completes its channels and owns draining any unread work.
+        _appendWorkerCts = CancellationTokenSource.CreateLinkedTokenSource(_accumulator.DisposalToken);
+        _accumulator.StartAppendWorkers(_appendWorkerCts.Token);
 
         _stateSource = new ProducerStateSource(options.ClientId, _accumulator, _brokerSenders);
         DekafMetrics.RegisterProducerState(_stateSource);
@@ -4891,8 +4901,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // Has internal 5s+5s timeouts for workers and in-flight batches, but at this point
         // BrokerSenders are already disposed so it should complete quickly.
         // Reserve half the remaining budget for subsequent disposals (pool, network).
+        _appendWorkerCts.Cancel();
         await DisposeWithBudgetAsync(
             _accumulator.DisposeAsync(), Math.Max(500, RemainingMs() / 2), "accumulator");
+        _appendWorkerCts.Dispose();
 
         // Stop the inflight tracker's pruning timer to prevent callbacks after disposal.
         _inflightTracker.Dispose();

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -31,7 +31,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     internal async ValueTask StopSenderLoopsForTestingAsync()
     {
         await _senderCts.CancelAsync().ConfigureAwait(false);
-        await Task.WhenAll(_senderTask, _lingerTask).ConfigureAwait(false);
+        await Task.WhenAll(_senderTask, _lingerTask)
+            .WaitAsync(TimeSpan.FromSeconds(5))
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1378,6 +1378,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // capacity is ratcheted up to match the workload's actual cold-path depth.
     private long _lastPoolRatchetPressure;
     private readonly CancellationTokenSource _disposalCts = new();
+    internal CancellationToken DisposalToken => _disposalCts.Token;
     // Broadcast signal for buffer space waiters. When buffer space is freed, the current
     // TCS is completed (waking ALL waiters simultaneously), then swapped for a fresh one.
     // This eliminates the serial convoy problem of SemaphoreSlim(0,1) where N waiters
@@ -6857,8 +6858,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         {
             while (channel.Reader.TryRead(out var workItem))
             {
-                CleanupWorkItemResources(in workItem);
-                PooledCompletionSource.TrySetException(workItem.Completion, disposedException);
+                try
+                {
+                    CleanupWorkItemResources(in workItem);
+                    PooledCompletionSource.TrySetException(workItem.Completion, disposedException);
+                }
+                finally
+                {
+                    DecrementSlowPathAppendCount(workItem.Topic, workItem.Partition);
+                }
             }
         }
 

--- a/tests/Dekaf.Tests.Unit/Performance/HotPathAllocationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Performance/HotPathAllocationTests.cs
@@ -286,15 +286,8 @@ public class HotPathAllocationTests
         });
     }
 
-    private static async Task StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
-    {
-        var cancellation = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
-        var senderTask = GetInstanceField<Task>(producer, "_senderTask");
-        var lingerTask = GetInstanceField<Task>(producer, "_lingerTask");
-
-        await cancellation.CancelAsync();
-        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5));
-    }
+    private static ValueTask StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
+        => producer.StopSenderLoopsForTestingAsync();
 
     private static T GetInstanceField<T>(object target, string name)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppendWorkerAffinityTests.cs
@@ -47,6 +47,113 @@ public class AppendWorkerAffinityTests
         return readyCount > 0;
     }
 
+    private static int GetSlowPathAppendCount(object deques, TopicPartition tp)
+    {
+        var tryGetValueMethod = deques.GetType().GetMethod("TryGetValue");
+        var parameters = new object[] { tp, null! };
+        var found = (bool)tryGetValueMethod!.Invoke(deques, parameters)!;
+        if (!found)
+            return 0;
+
+        return (int)parameters[1]!.GetType().GetField("SlowPathAppendCount")!.GetValue(parameters[1])!;
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task StopSenderLoopsForTestingAsync_DoesNotStopAppendWorkers(
+        CancellationToken cancellationToken)
+    {
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        await using var producer = (KafkaProducer<string, string>)Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientId("append-worker-lifetime-test")
+            .WithBufferMemory(ulong.MaxValue)
+            .WithBatchSize(1_048_576)
+            .WithLinger(TimeSpan.Zero)
+            .WithCloseTimeout(TimeSpan.FromMilliseconds(100))
+            .Build();
+
+        await producer.StopSenderLoopsForTestingAsync();
+
+        var accumulator = producer.RecordAccumulator;
+        var completion = pool.Rent();
+        accumulator.EnqueueAppend(
+            "test-topic",
+            partition: 0,
+            timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            key: PooledMemory.Null,
+            value: PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            completion: completion,
+            cancellationToken: CancellationToken.None);
+
+        var deques = GetPartitionDeques(accumulator);
+        await TestWait.UntilAsync(
+            () => HasBatchForPartition(deques, new TopicPartition("test-topic", 0)),
+            cancellationToken,
+            TimeSpan.FromMilliseconds(25));
+
+        await producer.DisposeAsync();
+    }
+
+    [Test]
+    [Timeout(120_000)]
+    public async Task DisposeAsync_FaultsBackpressuredAppendQueueAndClearsOwnership(
+        CancellationToken cancellationToken)
+    {
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        await using var producer = (KafkaProducer<string, string>)Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .WithClientId("append-worker-disposal-test")
+            .WithBufferMemory(1)
+            .WithBatchSize(4_096)
+            .WithCloseTimeout(TimeSpan.FromMilliseconds(100))
+            .Build();
+
+        var accumulator = producer.RecordAccumulator;
+        var firstCompletion = pool.Rent();
+        var firstTask = firstCompletion.Task.AsTask();
+        accumulator.EnqueueAppend(
+            "test-topic",
+            partition: 0,
+            timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            key: PooledMemory.Null,
+            value: LeakGateHarness.RentPooled(128, seed: 1),
+            headers: null,
+            headerCount: 0,
+            completion: firstCompletion,
+            cancellationToken: CancellationToken.None);
+
+        await TestWait.UntilAsync(
+            () => accumulator.BufferPressureEvents > 0,
+            cancellationToken,
+            TimeSpan.FromMilliseconds(1));
+
+        var secondCompletion = pool.Rent();
+        var secondTask = secondCompletion.Task.AsTask();
+        accumulator.EnqueueAppend(
+            "test-topic",
+            partition: 0,
+            timestamp: DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            key: PooledMemory.Null,
+            value: LeakGateHarness.RentPooled(128, seed: 2),
+            headers: null,
+            headerCount: 0,
+            completion: secondCompletion,
+            cancellationToken: CancellationToken.None);
+
+        await producer.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+
+        await Assert.That(async () => await firstTask).Throws<ObjectDisposedException>();
+        await Assert.That(async () => await secondTask).Throws<ObjectDisposedException>();
+        await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(0);
+        await Assert.That(accumulator.BufferedBytes).IsEqualTo(0);
+        await Assert.That(GetSlowPathAppendCount(
+            GetPartitionDeques(accumulator),
+            new TopicPartition("test-topic", 0))).IsEqualTo(0);
+    }
+
     [Test]
     [Timeout(120_000)]
     public async Task EnqueueAppend_SamePartition_ProcessedSequentially(CancellationToken cancellationToken)

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -658,15 +658,8 @@ public class KafkaProducerFastPathTests
         throw new InvalidOperationException("Partition deque did not contain a current or sealed batch.");
     }
 
-    private static async Task StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
-    {
-        var cts = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
-        var senderTask = GetInstanceField<Task>(producer, "_senderTask");
-        var lingerTask = GetInstanceField<Task>(producer, "_lingerTask");
-
-        await cts.CancelAsync();
-        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5));
-    }
+    private static ValueTask StopProducerBackgroundLoopsAsync(KafkaProducer<string, string> producer)
+        => producer.StopSenderLoopsForTestingAsync();
 
     private static T GetInstanceField<T>(object target, string name)
     {

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerAsyncPreparerTests.cs
@@ -247,12 +247,7 @@ public class ProducerAsyncPreparerTests
     // initialized, so ProduceAsync reaches the preparer gate instead of the not-initialized guard.
     private static async Task ReadyProducerAsync(KafkaProducer<string, string> producer)
     {
-        var cts = GetField<CancellationTokenSource>(producer, "_senderCts");
-        var senderTask = GetField<Task>(producer, "_senderTask");
-        var lingerTask = GetField<Task>(producer, "_lingerTask");
-
-        await cts.CancelAsync();
-        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5));
+        await producer.StopSenderLoopsForTestingAsync();
 
         SetField(producer, "_initialized", true);
     }

--- a/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ProducerCancellationTests.cs
@@ -60,15 +60,13 @@ public class ProducerCancellationTests
     }
 
     [Test]
-    public async Task Cancellation_StopsActiveLingerWaitPromptly()
+    public async Task StopSenderLoopsForTestingAsync_StopsActiveLingerWaitPromptly()
     {
-        var producer = Kafka.CreateProducer<string, string>()
+        var producer = (KafkaProducer<string, string>)Kafka.CreateProducer<string, string>()
             .WithBootstrapServers("localhost:9092")
             .WithLinger(TimeSpan.FromMinutes(1))
             .Build();
-        var accumulator = GetField<RecordAccumulator>(producer, "_accumulator");
-        var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
-        var lingerTask = GetField<Task>(producer, "_lingerTask");
+        var accumulator = producer.RecordAccumulator;
         var activeLingerWaitEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         SetField(
             producer,
@@ -92,14 +90,12 @@ public class ProducerCancellationTests
             await Assert.That(accumulator.HasPendingLingerBatches).IsTrue();
 
             await activeLingerWaitEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
-            senderCts.Cancel();
-
-            await lingerTask.WaitAsync(TimeSpan.FromSeconds(5));
-            await Assert.That(lingerTask.IsCompletedSuccessfully).IsTrue();
+            await producer.StopSenderLoopsForTestingAsync()
+                .AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(5));
         }
         finally
         {
-            senderCts.Cancel();
             await accumulator.DisposeAsync();
             await producer.DisposeAsync();
         }
@@ -335,11 +331,6 @@ public class ProducerCancellationTests
             await accumulator.DisposeAsync();
         }
     }
-
-    private static T GetField<T>(object instance, string name)
-        => (T)instance.GetType()
-            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(instance)!;
 
     private static void SetField<T>(object instance, string name, T value)
         => instance.GetType()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -43,11 +43,7 @@ public class TransactionalProduceAllocationBenchmarks
             .WithBufferMemory(ulong.MaxValue)
             .Build();
         var producer = (KafkaProducer<string, string>)_producer;
-        var senderCts = GetField<CancellationTokenSource>(producer, "_senderCts");
-        await senderCts.CancelAsync();
-        await Task.WhenAll(
-            GetField<Task>(producer, "_senderTask"),
-            GetField<Task>(producer, "_lingerTask"));
+        await producer.StopSenderLoopsForTestingAsync();
 
         SeedMetadata(GetField<MetadataManager>(producer, "_metadataManager"));
         SetField(producer, "_initialized", true);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -145,15 +145,8 @@ public class ProducerFireHotPathBenchmarks
         });
     }
 
-    private static async Task StopBackgroundLoopsAsync(KafkaProducer<string, string> producer)
-    {
-        var cancellation = GetInstanceField<CancellationTokenSource>(producer, "_senderCts");
-        var senderTask = GetInstanceField<Task>(producer, "_senderTask");
-        var lingerTask = GetInstanceField<Task>(producer, "_lingerTask");
-
-        await cancellation.CancelAsync().ConfigureAwait(false);
-        await Task.WhenAll(senderTask, lingerTask).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-    }
+    private static ValueTask StopBackgroundLoopsAsync(KafkaProducer<string, string> producer)
+        => producer.StopSenderLoopsForTestingAsync();
 
     private static T GetInstanceField<T>(object target, string name)
     {


### PR DESCRIPTION
## Summary
- isolate append-worker cancellation from sender/linger-loop cancellation
- cancel append workers only during accumulator disposal, then fault unread completions, return pooled resources, and clear slow-path ownership
- add `StopSenderLoopsForTestingAsync()` and migrate all reflection-based test/benchmark helpers
- deterministically cover a blocked append plus an unread queued append during forceful disposal

## Performance
`ProducerFireHotPathBenchmarks` (`MessageSize=1000`, baseline → candidate → baseline → exact candidate repeat):

| DeliveryLatencyTargetMs | Baseline 1 | Candidate 1 | Baseline 2 | Candidate 2 | Allocated |
|---:|---:|---:|---:|---:|---:|
| 0 | 322.8 ns | 352.9 ns | 309.3 ns | 315.0 ns | 0 B |
| 10 | 937.4 ns | 932.2 ns | 934.2 ns | 936.0 ns | 0 B |

The first 0-ms candidate sample was a runner outlier; the exact repeat landed inside the bracketing baseline range. No message-path code changed and all rows remain zero-allocation.

## Test plan
- [x] full Release solution build (26 projects, 0 warnings/errors)
- [x] full unit suite (6,573 passed)
- [x] `AppendWorkerAffinityTests` (7 passed)
- [x] Testcontainers Kafka `Producer_DisposalAfterProduction_CompletesWithinReasonableTime`

Closes #2449
