### PR TITLE
bench(consumer): correct PollSingle measurement shape

### DIFF
--- a/.github/scripts/test_benchmark_docs.py
+++ b/.github/scripts/test_benchmark_docs.py
@@ -74,6 +74,35 @@ class BenchmarkDocsTests(unittest.TestCase):
 
         self.assertEqual([], rolling_comparisons(entries))
 
+    def test_current_measurement_shape_excludes_older_shape(self):
+        prefix = "Dekaf.Benchmarks.Benchmarks.Client.ConsumerPollBenchmarks"
+        old_parameters = "(MessageSize: 100)"
+        current_parameters = "(PollsPerIteration: 400000, MessageSize: 100)"
+        entries = [
+            {
+                "benches": [
+                    benchmark(f"{prefix}.Dekaf_PollSingle{old_parameters}", 200),
+                    benchmark(f"{prefix}.Confluent_PollSingle{old_parameters}", 100),
+                ]
+            },
+            {
+                "benches": [
+                    benchmark(f"{prefix}.Dekaf_PollSingle{current_parameters}", 50),
+                    benchmark(f"{prefix}.Confluent_PollSingle{current_parameters}", 100),
+                ]
+            },
+        ]
+
+        comparisons = rolling_comparisons(entries)
+
+        self.assertEqual(1, len(comparisons))
+        self.assertEqual(1, comparisons[0]["runs"])
+        self.assertEqual(0.5, comparisons[0]["median"])
+        self.assertEqual(
+            "PollsPerIteration: 400000, MessageSize: 100",
+            comparisons[0]["parameters"],
+        )
+
     def test_latest_ratio_sd_is_visibly_flagged(self):
         table = [
             "| Method | Ratio | RatioSD |",

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
@@ -71,20 +71,17 @@ public class ConsumerBenchmarks
 
         var value = new string('x', MessageSize);
         var totalMessages = MessageCount + PrimeMessages;
+        var deliveryTracker = new ConfluentSeedDeliveryTracker();
         for (var i = 0; i < totalMessages; i++)
         {
             _confluentProducer.Produce(_topic, new Confluent.Kafka.Message<string, string>
             {
                 Key = $"key-{i}",
                 Value = value
-            });
+            }, deliveryTracker.Handler);
         }
         var undeliveredMessages = _confluentProducer.Flush(SeedFlushTimeout);
-        if (undeliveredMessages != 0)
-        {
-            throw new InvalidOperationException(
-                $"Benchmark seed flush timed out with {undeliveredMessages} undelivered messages.");
-        }
+        deliveryTracker.EnsureComplete(totalMessages, undeliveredMessages);
     }
 
     [IterationSetup(Targets = [nameof(Confluent_ConsumeAll)])]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerBenchmarks.cs
@@ -34,6 +34,7 @@ public class ConsumerBenchmarks
     private const string TopicPrefix = "benchmark-consumer-";
     private const int PrimeMessages = 1;
     private static readonly TimeSpan ConsumeTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SeedFlushTimeout = TimeSpan.FromMinutes(2);
 
     private string _topic = null!;
 
@@ -78,7 +79,12 @@ public class ConsumerBenchmarks
                 Value = value
             });
         }
-        _confluentProducer.Flush(TimeSpan.FromSeconds(30));
+        var undeliveredMessages = _confluentProducer.Flush(SeedFlushTimeout);
+        if (undeliveredMessages != 0)
+        {
+            throw new InvalidOperationException(
+                $"Benchmark seed flush timed out with {undeliveredMessages} undelivered messages.");
+        }
     }
 
     [IterationSetup(Targets = [nameof(Confluent_ConsumeAll)])]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -20,8 +20,9 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 /// three cold single-shot samples per case — the call graph never reaches the tiered
 /// compilation promotion threshold, so the managed poll path runs unoptimized Tier-0
 /// code while Confluent's native librdkafka path is unaffected, and one scheduler
-/// preemption distorts the whole statistic. Thousands of warm polls per iteration give
-/// both clients Tier-1 code and real statistics.
+/// preemption distorts the whole statistic. Hundreds of thousands of warm polls per
+/// iteration give both clients Tier-1 code and keep measured iterations above
+/// BenchmarkDotNet's 100 ms recommendation.
 /// </remarks>
 [MemoryDiagnoser]
 [Config(typeof(PollJobConfig))]
@@ -29,7 +30,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 [CategoriesColumn]
 public class ConsumerPollBenchmarks
 {
-    private const int PollsPerIteration = 10_000;
+    private const int PollsPerIteration = 400_000;
     private const int PrimeMessages = 1;
     private const string TopicPrefix = "benchmark-poll-";
     private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
@@ -67,7 +68,9 @@ public class ConsumerPollBenchmarks
         var confluentConfig = new Confluent.Kafka.ProducerConfig
         {
             BootstrapServers = _kafka.BootstrapServers,
-            ClientId = "benchmark-seeder"
+            ClientId = "benchmark-seeder",
+            QueueBufferingMaxMessages = PollsPerIteration + PrimeMessages,
+            QueueBufferingMaxKbytes = 512 * 1024
         };
         _confluentProducer = new Confluent.Kafka.ProducerBuilder<string, string>(confluentConfig).Build();
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -34,6 +34,7 @@ public class ConsumerPollBenchmarks
     private const int PrimeMessages = 1;
     private const string TopicPrefix = "benchmark-poll-";
     private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan SeedFlushTimeout = TimeSpan.FromMinutes(2);
 
     private sealed class PollJobConfig : ManualConfig
     {
@@ -93,7 +94,12 @@ public class ConsumerPollBenchmarks
                 Value = value
             });
         }
-        _confluentProducer.Flush(TimeSpan.FromSeconds(30));
+        var undeliveredMessages = _confluentProducer.Flush(SeedFlushTimeout);
+        if (undeliveredMessages != 0)
+        {
+            throw new InvalidOperationException(
+                $"Benchmark seed flush timed out with {undeliveredMessages} undelivered messages.");
+        }
     }
 
     [IterationSetup(Targets = [nameof(Confluent_PollSingle)])]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -30,7 +30,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Client;
 [CategoriesColumn]
 public class ConsumerPollBenchmarks
 {
-    private const int PollsPerIteration = 400_000;
+    private const int ConfiguredPollsPerIteration = 400_000;
     private const int PrimeMessages = 1;
     private const string TopicPrefix = "benchmark-poll-";
     private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
@@ -45,7 +45,7 @@ public class ConsumerPollBenchmarks
                 .WithLaunchCount(1)
                 .WithWarmupCount(5)
                 .WithIterationCount(10)
-                .WithInvocationCount(PollsPerIteration)
+                .WithInvocationCount(ConfiguredPollsPerIteration)
                 .WithUnrollFactor(1));
         }
     }
@@ -57,6 +57,11 @@ public class ConsumerPollBenchmarks
 
     private Confluent.Kafka.IConsumer<string, string>? _confluentPollConsumer;
     private DekafConsumer.IKafkaConsumer<string, string>? _dekafPollConsumer;
+
+    // Keep the measurement shape in the benchmark identity so rolling history never
+    // mixes this 400k-poll epoch with obsolete runs that used a shorter invocation count.
+    [Params(ConfiguredPollsPerIteration)]
+    public int PollsPerIteration { get; set; }
 
     [Params(100, 1000)]
     public int MessageSize { get; set; }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/ConsumerPollBenchmarks.cs
@@ -91,20 +91,17 @@ public class ConsumerPollBenchmarks
 
         var value = new string('x', MessageSize);
         var totalMessages = PollsPerIteration + PrimeMessages;
+        var deliveryTracker = new ConfluentSeedDeliveryTracker();
         for (var i = 0; i < totalMessages; i++)
         {
             _confluentProducer.Produce(_topic, new Confluent.Kafka.Message<string, string>
             {
                 Key = $"key-{i}",
                 Value = value
-            });
+            }, deliveryTracker.Handler);
         }
         var undeliveredMessages = _confluentProducer.Flush(SeedFlushTimeout);
-        if (undeliveredMessages != 0)
-        {
-            throw new InvalidOperationException(
-                $"Benchmark seed flush timed out with {undeliveredMessages} undelivered messages.");
-        }
+        deliveryTracker.EnsureComplete(totalMessages, undeliveredMessages);
     }
 
     [IterationSetup(Targets = [nameof(Confluent_PollSingle)])]

--- a/tools/Dekaf.Benchmarks/Infrastructure/ConfluentSeedDeliveryTracker.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/ConfluentSeedDeliveryTracker.cs
@@ -1,0 +1,42 @@
+using Confluent.Kafka;
+
+namespace Dekaf.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Verifies that every fire-and-forget benchmark seed produce reached the broker.
+/// </summary>
+internal sealed class ConfluentSeedDeliveryTracker
+{
+    private int _completedCount;
+    private int _failedCount;
+
+    public ConfluentSeedDeliveryTracker()
+    {
+        Handler = OnDelivery;
+    }
+
+    /// <summary>
+    /// Gets the cached handler shared by every seed produce.
+    /// </summary>
+    public Action<DeliveryReport<string, string>> Handler { get; }
+
+    public void EnsureComplete(int expectedCount, int undeliveredCount)
+    {
+        var completedCount = Volatile.Read(ref _completedCount);
+        var failedCount = Volatile.Read(ref _failedCount);
+        if (undeliveredCount == 0 && completedCount == expectedCount && failedCount == 0)
+            return;
+
+        throw new InvalidOperationException(
+            $"Benchmark seed delivery failed: expected {expectedCount} reports, received {completedCount}, " +
+            $"with {failedCount} failed and {undeliveredCount} still undelivered.");
+    }
+
+    private void OnDelivery(DeliveryReport<string, string> report)
+    {
+        if (report.Error.IsError)
+            Interlocked.Increment(ref _failedCount);
+
+        Interlocked.Increment(ref _completedCount);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using DotNet.Testcontainers.Configurations;
 using Testcontainers.Kafka;
 
 namespace Dekaf.Benchmarks.Infrastructure;
@@ -8,6 +10,18 @@ namespace Dekaf.Benchmarks.Infrastructure;
 /// </summary>
 public sealed class KafkaTestEnvironment : IAsyncDisposable
 {
+    private const string KafkaImage = "apache/kafka:4.3.1";
+
+    // Testcontainers.Kafka emits a trailing comma in KAFKA_ADVERTISED_LISTENERS
+    // when no extra listener is configured. Kafka 4.2+ rejects that empty value.
+    private static readonly byte[] RunWrapperScript = Encoding.UTF8.GetBytes(
+        "#!/bin/bash\n" +
+        ". /etc/kafka/docker/bash-config\n" +
+        "export KAFKA_ADVERTISED_LISTENERS=$(echo \"$KAFKA_ADVERTISED_LISTENERS\" | sed 's/,$//')\n" +
+        ". /etc/kafka/docker/configureDefaults\n" +
+        ". /etc/kafka/docker/configure\n" +
+        ". /etc/kafka/docker/launch\n");
+
     private KafkaContainer? _container;
     private bool _disposed;
     private bool _externalKafka;
@@ -36,13 +50,32 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
 
         Console.WriteLine("Starting Kafka container via Testcontainers...");
 
-        _container = new KafkaBuilder("confluentinc/cp-kafka:7.5.0")
+        _container = new KafkaBuilder(KafkaImage)
             .WithPortBinding(9092, true)
+            .WithResourceMapping(
+                RunWrapperScript,
+                "/etc/kafka/docker/run",
+                0,
+                0,
+                UnixFileModes.UserRead | UnixFileModes.UserWrite | UnixFileModes.UserExecute |
+                UnixFileModes.GroupRead | UnixFileModes.GroupExecute |
+                UnixFileModes.OtherRead | UnixFileModes.OtherExecute)
             .Build();
 
         await _container.StartAsync().ConfigureAwait(false);
 
-        BootstrapServers = _container.GetBootstrapAddress();
+        var rawBootstrap = _container.GetBootstrapAddress();
+        if (Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0)
+        {
+            var host = bootstrapUri.HostNameType == UriHostNameType.IPv6
+                ? $"[{bootstrapUri.DnsSafeHost}]"
+                : bootstrapUri.Host;
+            BootstrapServers = $"{host}:{bootstrapUri.Port}";
+        }
+        else
+        {
+            BootstrapServers = rawBootstrap;
+        }
         Console.WriteLine($"Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);
@@ -83,48 +116,27 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
 
     public async Task CreateTopicAsync(string topic, int partitions = 1)
     {
-        if (_externalKafka)
-        {
-            using var adminClient = new Confluent.Kafka.AdminClientBuilder(
-                new Confluent.Kafka.AdminClientConfig { BootstrapServers = BootstrapServers })
-                .Build();
+        using var adminClient = new Confluent.Kafka.AdminClientBuilder(
+            new Confluent.Kafka.AdminClientConfig { BootstrapServers = BootstrapServers })
+            .Build();
 
-            try
-            {
-                await adminClient.CreateTopicsAsync([
-                    new Confluent.Kafka.Admin.TopicSpecification
-                    {
-                        Name = topic,
-                        NumPartitions = partitions,
-                        ReplicationFactor = 1
-                    }
-                ]).ConfigureAwait(false);
-            }
-            catch (Confluent.Kafka.Admin.CreateTopicsException ex)
-            {
-                if (!ex.Message.Contains("already exists"))
+        try
+        {
+            await adminClient.CreateTopicsAsync([
+                new Confluent.Kafka.Admin.TopicSpecification
                 {
-                    Console.WriteLine($"Warning: Failed to create topic {topic}: {ex.Message}");
+                    Name = topic,
+                    NumPartitions = partitions,
+                    ReplicationFactor = 1
                 }
-            }
-            return;
+            ]).ConfigureAwait(false);
         }
-
-        if (_container is null)
-            throw new InvalidOperationException("Container not started");
-
-        var result = await _container.ExecAsync([
-            "kafka-topics",
-            "--bootstrap-server", "localhost:9092",
-            "--create",
-            "--topic", topic,
-            "--partitions", partitions.ToString(),
-            "--replication-factor", "1"
-        ]).ConfigureAwait(false);
-
-        if (result.ExitCode != 0)
+        catch (Confluent.Kafka.Admin.CreateTopicsException ex)
         {
-            Console.WriteLine($"Warning: Failed to create topic {topic}: {result.Stderr}");
+            if (!ex.Message.Contains("already exists"))
+            {
+                Console.WriteLine($"Warning: Failed to create topic {topic}: {ex.Message}");
+            }
         }
     }
 

--- a/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/KafkaTestEnvironment.cs
@@ -64,18 +64,7 @@ public sealed class KafkaTestEnvironment : IAsyncDisposable
 
         await _container.StartAsync().ConfigureAwait(false);
 
-        var rawBootstrap = _container.GetBootstrapAddress();
-        if (Uri.TryCreate(rawBootstrap, UriKind.Absolute, out var bootstrapUri) && bootstrapUri.Port >= 0)
-        {
-            var host = bootstrapUri.HostNameType == UriHostNameType.IPv6
-                ? $"[{bootstrapUri.DnsSafeHost}]"
-                : bootstrapUri.Host;
-            BootstrapServers = $"{host}:{bootstrapUri.Port}";
-        }
-        else
-        {
-            BootstrapServers = rawBootstrap;
-        }
+        BootstrapServers = BootstrapServerList.Parse(_container.GetBootstrapAddress()).Normalized;
         Console.WriteLine($"Kafka started at {BootstrapServers}");
 
         await WaitForKafkaAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary

- Raise `ConsumerPollBenchmarks` from 10,000 to 400,000 invocations so every measured row clears BenchmarkDotNet's 100 ms recommendation.
- Size the Confluent seeder queue for the larger topic.
- Verify bounded seed completion in both consumer benchmark families: queue drain, callback count, and delivery errors; partial or permanently failed topics now fail setup instead of corrupting measured iterations.
- Restore local client benchmarks on Dekaf-supported Apache Kafka 4.3.1, including the Kafka 4.2+ Testcontainers wrapper.
- Create topics through AdminClient so local and external-broker paths exercise the same reachable endpoint.
- Include the fixed 400,000-poll shape in BenchmarkDotNet parameter identity so rolling history cannot mix corrected rows with obsolete 10,000-poll rows.

Contributes to #2443. This intentionally does not close it: the stated gate remains corrected published aggregate median <=1.5x or a maintainer-accepted floor.

## Evidence

Base: `9109f0e09`; i7-12700K; .NET 10.0.10; Kafka 4.3.1; shared external broker; profiling off.

| Message size | Confluent median | Dekaf median | Confluent mean/alloc | Dekaf mean/alloc |
|---:|---:|---:|---:|---:|
| 100 B | 2.075 us | 279 ns | 2.064 us / 654 B | 288 ns / 276 B |
| 1000 B | 3.204 us | 1.672 us | 5.231 us / 2454 B | 1.694 us / 2081 B |

No minimum-iteration warning remained at 400k. Dekaf StdDev was 21 ns / 140 ns. Confluent remained strongly multimodal (MValue 4.0 / 3.33), so this proves the published 2.5x loss is measurement-shape driven; it does not claim the local 2–8x apparent win is precise.

The full variance comparison and stop/repeat decision are recorded on #2443. No product code changed; CPU and latency percentiles are outside this benchmark lane, so no protected-metric trade is accepted.

## History identity

The one-value `PollsPerIteration` parameter starts a distinct rolling-history epoch. A docs-pipeline regression test proves older measurement shapes are excluded from the current aggregate.

## Validation

- [x] `dotnet build tools/Dekaf.Benchmarks --configuration Release` — 0 warnings/errors
- [x] Full paired `ConsumerPollBenchmarks` against one shared Kafka 4.3.1 broker
- [x] Local Testcontainers Kafka 4.3.1 startup, topic creation, seeding, and all benchmark execution paths
- [x] Both Dekaf PollSingle rows export `PollsPerIteration: 400000` and show no minimum-iteration warning
- [x] Benchmark-docs tests — 9/9
- [x] `$code-simplifier` final review