### PR TITLE
test(networking): detect inline request continuations deterministically

### DIFF
--- a/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/PooledPendingRequestTests.cs
@@ -934,32 +934,34 @@ public class PooledPendingRequestTests
         var reused = pool.Rent();
         reused.Initialize(responseHeaderVersion: 0, CancellationToken.None);
 
-        // Verify TryComplete returns BEFORE the continuation runs.
-        // With RunContinuationsAsynchronously = true, SetResult queues the
-        // continuation and returns immediately. With false, the continuation
-        // would run inline inside TryComplete, and the flag below would be
-        // true before TryComplete returns.
-        var continuationRanInline = false;
+        // Verify the continuation does not run inline on the completing thread.
+        // A queued continuation may legitimately run on another thread before
+        // TryComplete returns, or later on this same thread after it returns.
+        var completingThreadId = Environment.CurrentManagedThreadId;
+        var insideTryComplete = 1;
+        var continuationRanInline = 0;
         var continuationRan = new TaskCompletionSource();
 
         var vt = reused.AsValueTask();
         vt.GetAwaiter().UnsafeOnCompleted(() =>
         {
-            continuationRanInline = true;
+            if (Environment.CurrentManagedThreadId == completingThreadId
+                && Volatile.Read(ref insideTryComplete) != 0)
+            {
+                Volatile.Write(ref continuationRanInline, 1);
+            }
+
             continuationRan.SetResult();
         });
 
         var testData2 = new byte[] { 0, 0, 0, 2, 20 };
         var buffer2 = new PooledResponseBuffer(testData2, testData2.Length, isPooled: false);
         reused.TryComplete(buffer2);
-
-        // If RunContinuationsAsynchronously is true, the continuation hasn't
-        // run yet at this point — it was queued to the thread pool.
-        var ranBeforeTryCompleteReturned = continuationRanInline;
+        Volatile.Write(ref insideTryComplete, 0);
 
         await continuationRan.Task.ConfigureAwait(false);
 
-        await Assert.That(ranBeforeTryCompleteReturned).IsFalse();
+        await Assert.That(Volatile.Read(ref continuationRanInline)).IsEqualTo(0);
 
         pool.Return(reused);
     }


### PR DESCRIPTION
## Summary
- replace the racy “continuation has not run yet” assertion with the guarantee actually provided by `RunContinuationsAsynchronously`
- detect only a continuation executing on the completing thread while `TryComplete` is still active
- allow valid queued execution on another thread before return, or later reuse of the same thread after return

Closes #2446.

## Why thread ID alone is insufficient

The issue proposed comparing continuation and completing thread IDs. That can falsely fail: after `TryComplete` returns and the async test yields, the same thread-pool thread may legitimately execute the queued continuation. Combining thread identity with a volatile “inside `TryComplete`” flag distinguishes actual inline execution from that valid scheduling case.

## Validation
- [x] Release unit build: 0 warnings/errors
- [x] `PooledPendingRequestTests`: 34/34 passed
- [x] full parallel unit suite: 6,571/6,571 passed
- [x] `$code-simplifier` final review

Test-only change; no product or hot-path code changed.