### PR TITLE
fix(stress): trend gate on median interval msg/s instead of whole-run mean

### DIFF
--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from statistics import median
 
 from stress_report import (
+    comparison_rate,
     cpu_micros_per_message,
     effective_rate,
     intra_run_throughput,
+    median_interval_rate,
     paired_order_identity,
     paired_latency_thresholds,
 )
@@ -38,7 +40,11 @@ _IDENTITY_FIELDS = (
 _METRICS = {
     "messagesPerSecond": {
         "label": "Messages/sec",
-        "extract": effective_rate,
+        # Trend on the same rate the docs tables rank on: the median sampled interval
+        # throughput when the run recorded interval samples, else the whole-run mean.
+        # A short shared stall depresses the mean of an otherwise steady run and
+        # produced a false repeated-regression fail (issue #2467).
+        "extract": comparison_rate,
         "lower_is_regression": True,
     },
     "cpuMicrosPerMessage": {
@@ -51,6 +57,20 @@ _METRICS = {
 
 def _finite_number(value):
     return isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(value)
+
+
+def _history_metric_value(observation, metric):
+    """Baseline value recorded by a stored history observation.
+
+    Throughput prefers the additively stored median interval rate so trailing bands
+    track the trended rate; entries written before that field existed fall back to
+    the whole-run mean they recorded.
+    """
+    if metric == "messagesPerSecond":
+        median_rate = median_interval_rate(observation)
+        if median_rate is not None:
+            return median_rate
+    return observation.get(metric)
 
 
 def _roundtrip_messages(result):
@@ -158,8 +178,8 @@ def _matching_control_ratios(runs, result, metric):
         if candidate is None or control is None:
             continue
 
-        candidate_value = candidate.get(metric)
-        control_value = control.get(metric)
+        candidate_value = _history_metric_value(candidate, metric)
+        control_value = _history_metric_value(control, metric)
         if (
             not _finite_number(candidate_value)
             or not _finite_number(control_value)
@@ -190,7 +210,7 @@ def _limit_observations_per_identity(runs):
             for metric in _METRICS:
                 baseline_key = (key, metric)
                 if (
-                    _finite_number(observation.get(metric))
+                    _finite_number(_history_metric_value(observation, metric))
                     and observation.get(f"{metric}Trend") != "regression"
                     and not observation.get("environmentShiftSuspected", False)
                     and retained_baseline_counts.get(baseline_key, 0) < HISTORY_LIMIT
@@ -326,7 +346,7 @@ def evaluate_and_update(history, current_results, run_started_at):
             # Keep warned observations for consecutive-trend detection, but do not let
             # them widen the clean baseline used to judge the next run.
             history_values = [
-                item.get(metric)
+                _history_metric_value(item, metric)
                 for item in prior
                 if item.get(trend_field) != "regression"
                 and not item.get("environmentShiftSuspected", False)
@@ -367,7 +387,14 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "repeatedRegression": repeated,
                 })
 
-            observation[metric] = value
+            if metric == "messagesPerSecond" and median_interval_rate(result) is not None:
+                # `value` is the median interval rate (comparison_rate prefers it);
+                # store it additively while the whole-run mean stays under the
+                # existing key so pre-existing entries and their readers stay valid.
+                observation["medianIntervalMessagesPerSecond"] = value
+                observation[metric] = effective_rate(result)
+            else:
+                observation[metric] = value
             observation[f"{metric}Trend"] = evaluation["status"]
 
             ratio_evaluation = None
@@ -511,6 +538,11 @@ def format_markdown(evaluations):
             "Paired Dekaf baseline regressions fail only when the same-run ratio also "
             "regresses; unpaired scenarios retain the consecutive-regression gate. "
             "Confluent regressions remain environment warnings."
+        ),
+        (
+            "Messages/sec trends on the median sampled interval rate when the run "
+            "recorded interval samples (the rate the docs tables rank on); results "
+            "and history entries without samples fall back to the whole-run mean."
         ),
     ]
 

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -445,11 +445,19 @@ def evaluate_and_update(history, current_results, run_started_at):
                     "repeatedRegression": repeated,
                 })
 
-            if metric == "messagesPerSecond" and median_interval_rate(result) is not None:
+            if metric == "messagesPerSecond" and backlog_substituted:
+                # The delivered mean was the trended value this run, so it must
+                # also be the stored baseline value. Persisting the (inflated)
+                # interval median would make _history_metric_value feed future
+                # bands and ratio history a rate the gate never accepted,
+                # ratcheting the baseline upward until the still-unchanged
+                # delivered rate reads as a false repeated regression.
+                observation[metric] = value
+                observation["backlogDrainSubstituted"] = True
+            elif metric == "messagesPerSecond" and median_interval_rate(result) is not None:
                 # Store the median additively while the whole-run mean stays under
                 # the existing key so pre-existing entries and their readers stay
-                # valid. Read from the result, not `value`: a backlog-drain
-                # substitution swaps `value` to the delivered mean.
+                # valid.
                 observation["medianIntervalMessagesPerSecond"] = median_interval_rate(result)
                 observation[metric] = effective_rate(result)
             else:

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -91,7 +91,14 @@ def _delivered_rate_if_backlogged(result, control):
     delivered mean instead so the backlog stays visible to the gate. Without a
     control (or without medians on either side) the median stands, matching
     the fail-open transition the issue chose.
+
+    Only producer results with broker-confirmed deliveries qualify: consumer
+    lanes have no deliveredMessages, so their effective rate is just the
+    client-side whole-run average and a mean/median divergence there is a
+    boundary-stall artifact, not a flush backlog.
     """
+    if result.get("deliveredMessages") is None:
+        return None
     median_rate = median_interval_rate(result)
     if median_rate is None or median_rate <= 0 or control is None:
         return None

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -22,6 +22,9 @@ HISTORY_LIMIT = 10
 MIN_BASELINE_RUNS = 3
 MAD_MULTIPLIER = 2.0
 RELATIVE_NOISE_FLOOR = 0.01
+# A candidate whose delivered/median drain ratio falls more than this far below
+# the same-run control's is treated as a delivery backlog, not a shared stall.
+DRAIN_RATIO_DIVERGENCE = 0.85
 
 _IDENTITY_FIELDS = (
     "scenario",
@@ -71,6 +74,45 @@ def _history_metric_value(observation, metric):
         if median_rate is not None:
             return median_rate
     return observation.get(metric)
+
+
+def _delivered_rate_if_backlogged(result, control):
+    """Whole-run delivered mean when the candidate's flush drain lags its control.
+
+    comparison_rate alone would hide delivery-backlog regressions: producer
+    interval samples stop at the configured duration while
+    EffectiveMessagesPerSecond keeps counting broker-confirmed deliveries
+    through the flush drain, so a candidate that appends fast but delivers
+    slowly shows a stable median with a collapsed delivered mean. A shared
+    environment stall depresses the delivered/median ratio for BOTH clients
+    proportionally (the #2467 false fail showed ~74% on each side), but a
+    backlog depresses only the candidate's. When the candidate's ratio falls
+    more than DRAIN_RATIO_DIVERGENCE below the same-run control's, trend the
+    delivered mean instead so the backlog stays visible to the gate. Without a
+    control (or without medians on either side) the median stands, matching
+    the fail-open transition the issue chose.
+    """
+    median_rate = median_interval_rate(result)
+    if median_rate is None or median_rate <= 0 or control is None:
+        return None
+    control_median = median_interval_rate(control)
+    control_mean = effective_rate(control)
+    if (
+        control_median is None
+        or control_median <= 0
+        or not _finite_number(control_mean)
+        or control_mean <= 0
+    ):
+        return None
+    delivered = effective_rate(result)
+    if not _finite_number(delivered) or delivered <= 0:
+        return None
+
+    candidate_drain = delivered / median_rate
+    control_drain = control_mean / control_median
+    if candidate_drain < control_drain * DRAIN_RATIO_DIVERGENCE:
+        return delivered
+    return None
 
 
 def _roundtrip_messages(result):
@@ -338,6 +380,14 @@ def evaluate_and_update(history, current_results, run_started_at):
 
         for metric, definition in _METRICS.items():
             value = definition["extract"](result)
+            backlog_substituted = False
+            if metric == "messagesPerSecond" and not is_confluent:
+                delivered = _delivered_rate_if_backlogged(
+                    result, controls.get(_pair_identity(result))
+                )
+                if delivered is not None:
+                    value = delivered
+                    backlog_substituted = True
             if not _finite_number(value):
                 continue
 
@@ -369,6 +419,7 @@ def evaluate_and_update(history, current_results, run_started_at):
                 "repeatedRegression": False,
                 "failureEligible": False,
                 "corroborated": None,
+                "backlogDrainSubstituted": backlog_substituted,
             }
 
             if len(history_values) >= MIN_BASELINE_RUNS:
@@ -388,10 +439,11 @@ def evaluate_and_update(history, current_results, run_started_at):
                 })
 
             if metric == "messagesPerSecond" and median_interval_rate(result) is not None:
-                # `value` is the median interval rate (comparison_rate prefers it);
-                # store it additively while the whole-run mean stays under the
-                # existing key so pre-existing entries and their readers stay valid.
-                observation["medianIntervalMessagesPerSecond"] = value
+                # Store the median additively while the whole-run mean stays under
+                # the existing key so pre-existing entries and their readers stay
+                # valid. Read from the result, not `value`: a backlog-drain
+                # substitution swaps `value` to the delivered mean.
+                observation["medianIntervalMessagesPerSecond"] = median_interval_rate(result)
                 observation[metric] = effective_rate(result)
             else:
                 observation[metric] = value
@@ -542,7 +594,11 @@ def format_markdown(evaluations):
         (
             "Messages/sec trends on the median sampled interval rate when the run "
             "recorded interval samples (the rate the docs tables rank on); results "
-            "and history entries without samples fall back to the whole-run mean."
+            "and history entries without samples fall back to the whole-run mean. "
+            "If a candidate's delivered/median drain ratio falls more than "
+            f"{1 - DRAIN_RATIO_DIVERGENCE:.0%} below its same-run control's, the "
+            "delivered whole-run mean is trended instead so delivery backlogs "
+            "hidden by the duration-window median stay visible."
         ),
     ]
 

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -274,6 +274,11 @@ def _order_balanced_aggregates(current_results):
 
     aggregates = []
     aggregated_metrics = {}
+    controls = {
+        _pair_identity(result): result
+        for result in current_results
+        if _is_confluent(result)
+    }
     for key, samples in groups.items():
         if _complete_order_pair(samples) is None:
             # Anything other than exactly one sample per order — a partial pair,
@@ -283,24 +288,41 @@ def _order_balanced_aggregates(current_results):
             # their own series rather than silently losing regression coverage.
             continue
 
-        metrics = {
-            metric: geometric_mean(
-                [definition["extract"](sample) for sample in samples]
-            )
-            for metric, definition in _METRICS.items()
-        }
+        # Backlog detection must run per ordered sample BEFORE aggregation: in
+        # order-balanced lanes the aggregate is the only trended result, and a
+        # geomean of interval medians would hide a client-specific delivery
+        # backlog in either order. Each ordered sample checks its own same-order
+        # control and contributes its delivered mean when backlogged.
+        metrics = {}
+        backlog_substituted = False
+        for metric, definition in _METRICS.items():
+            values = []
+            for sample in samples:
+                value = definition["extract"](sample)
+                if metric == "messagesPerSecond" and not _is_confluent(sample):
+                    delivered = _delivered_rate_if_backlogged(
+                        sample, controls.get(_pair_identity(sample))
+                    )
+                    if delivered is not None:
+                        value = delivered
+                        backlog_substituted = True
+                values.append(value)
+            metrics[metric] = geometric_mean(values)
         trended = frozenset(
             metric for metric, value in metrics.items() if value is not None
         )
         if not trended:
             continue
 
-        aggregates.append({
+        aggregate = {
             **_identity_record(samples[0]),
             "pairedClientOrder": None,
             "pairedSampleCount": len(samples),
             _AGGREGATE_METRICS_FIELD: metrics,
-        })
+        }
+        if backlog_substituted and "messagesPerSecond" in trended:
+            aggregate["aggregateBacklogSubstituted"] = True
+        aggregates.append(aggregate)
         aggregated_metrics[key] = trended
 
     return aggregates, aggregated_metrics
@@ -638,22 +660,24 @@ def evaluate_and_update(history, current_results, run_started_at):
         for metric, definition in _METRICS.items():
             value = _metric_value(result, metric, definition)
             backlog_substituted = False
-            # Backlog substitution applies only to directly trended raw results:
-            # synthetic aggregates have no raw delivery fields, and ordered
-            # diagnostics must store the same comparison_rate their family's
-            # aggregate geomeans.
-            if (
-                metric == "messagesPerSecond"
-                and not is_confluent
-                and not is_aggregate
-                and metric not in diagnostic_metrics
-            ):
-                delivered = _delivered_rate_if_backlogged(
-                    result, controls.get(_pair_identity(result))
-                )
-                if delivered is not None:
-                    value = delivered
-                    backlog_substituted = True
+            if metric == "messagesPerSecond" and not is_confluent:
+                if is_aggregate:
+                    # Substitution already ran per ordered sample inside
+                    # _order_balanced_aggregates (each order against its own
+                    # same-order control); surface its flag on the trended row.
+                    backlog_substituted = bool(
+                        result.get("aggregateBacklogSubstituted")
+                    )
+                elif metric not in diagnostic_metrics:
+                    # Directly trended raw results check their same-run control;
+                    # ordered diagnostics stay raw — their family's aggregate
+                    # already accounted for any backlog per sample.
+                    delivered = _delivered_rate_if_backlogged(
+                        result, controls.get(_pair_identity(result))
+                    )
+                    if delivered is not None:
+                        value = delivered
+                        backlog_substituted = True
             if not _finite_number(value):
                 continue
 

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -769,11 +769,13 @@ class StressTrendTests(unittest.TestCase):
                 result(
                     messages_per_second=400.0,
                     medianIntervalMessagesPerSecond=1000.0,
+                    deliveredMessages=360_000,
                 ),
                 result(
                     client="Confluent",
                     messages_per_second=480.0,
                     medianIntervalMessagesPerSecond=500.0,
+                    deliveredMessages=432_000,
                 ),
             ],
             "2026-07-29T02:00:00Z",
@@ -795,6 +797,39 @@ class StressTrendTests(unittest.TestCase):
         )
         self.assertEqual(400.0, observation["messagesPerSecond"])
         self.assertEqual(1000.0, observation["medianIntervalMessagesPerSecond"])
+
+    def test_result_without_delivered_messages_keeps_median_trending(self):
+        # Consumer lanes (and old producer result files) carry no
+        # broker-confirmed deliveredMessages: their effective rate is just the
+        # client-side whole-run average, so a mean/median divergence there is
+        # a boundary-stall artifact, never a flush backlog — no substitution.
+        runs = [paired_history_run(i) for i in range(1, 4)]
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(
+                    messages_per_second=400.0,
+                    medianIntervalMessagesPerSecond=1000.0,
+                ),
+                result(
+                    client="Confluent",
+                    messages_per_second=480.0,
+                    medianIntervalMessagesPerSecond=500.0,
+                ),
+            ],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and "Dekaf" in item["scenario"]
+        )
+        self.assertEqual(1000.0, throughput["current"])
+        self.assertFalse(throughput["backlogDrainSubstituted"])
+        self.assertEqual("stable", throughput["status"])
+        self.assertFalse(should_fail)
 
     def test_shared_stall_with_control_keeps_median_trending(self):
         # Both clients drained to the same ~74% delivered/median ratio (the

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -755,6 +755,79 @@ class StressTrendTests(unittest.TestCase):
         self.assertEqual("stable", ratio["status"])
         self.assertFalse(should_fail)
 
+    def test_client_specific_backlog_drain_trends_on_delivered_mean(self):
+        # A candidate that appends fast but delivers slowly shows a stable
+        # duration-window median while the broker-confirmed mean (which keeps
+        # counting through the flush drain) collapses. The control's drain
+        # ratio stays healthy, so the divergence swaps the trended value to
+        # the delivered mean and the regression stays visible.
+        runs = [paired_history_run(i) for i in range(1, 4)]
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(
+                    messages_per_second=400.0,
+                    medianIntervalMessagesPerSecond=1000.0,
+                ),
+                result(
+                    client="Confluent",
+                    messages_per_second=480.0,
+                    medianIntervalMessagesPerSecond=500.0,
+                ),
+            ],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and "Dekaf" in item["scenario"]
+        )
+        self.assertEqual(400.0, throughput["current"])
+        self.assertTrue(throughput["backlogDrainSubstituted"])
+        self.assertEqual("regression", throughput["status"])
+        # First adverse excursion still warns rather than fails.
+        self.assertFalse(should_fail)
+        observation = next(
+            item for item in updated["runs"][-1]["results"]
+            if item["client"] == "Dekaf"
+        )
+        self.assertEqual(400.0, observation["messagesPerSecond"])
+        self.assertEqual(1000.0, observation["medianIntervalMessagesPerSecond"])
+
+    def test_shared_stall_with_control_keeps_median_trending(self):
+        # Both clients drained to the same ~74% delivered/median ratio (the
+        # #2467 signature of a shared environment stall): no substitution,
+        # the steady median stays the trended value.
+        runs = [paired_history_run(i) for i in range(1, 4)]
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(
+                    messages_per_second=740.0,
+                    medianIntervalMessagesPerSecond=1000.0,
+                ),
+                result(
+                    client="Confluent",
+                    messages_per_second=370.0,
+                    medianIntervalMessagesPerSecond=500.0,
+                ),
+            ],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and "Dekaf" in item["scenario"]
+        )
+        self.assertEqual(1000.0, throughput["current"])
+        self.assertFalse(throughput["backlogDrainSubstituted"])
+        self.assertEqual("stable", throughput["status"])
+        self.assertFalse(should_fail)
+
     def test_warned_run_does_not_widen_next_baseline(self):
         runs = [
             history_run(1, messages_per_second=950.0),

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -795,8 +795,49 @@ class StressTrendTests(unittest.TestCase):
             item for item in updated["runs"][-1]["results"]
             if item["client"] == "Dekaf"
         )
+        # The trended (delivered) value is what future baselines and ratio
+        # history must see; the inflated interval median is deliberately not
+        # persisted for substituted runs.
         self.assertEqual(400.0, observation["messagesPerSecond"])
-        self.assertEqual(1000.0, observation["medianIntervalMessagesPerSecond"])
+        self.assertNotIn("medianIntervalMessagesPerSecond", observation)
+        self.assertTrue(observation["backlogDrainSubstituted"])
+
+    def test_persistent_backlog_does_not_ratchet_baseline(self):
+        # A steady-state backlog (accepted 2000, delivered 1000, every run)
+        # must stay "stable" forever: the substituted delivered rate is what
+        # gets persisted, so the baseline cannot drift toward the inflated
+        # interval median and later classify the unchanged delivered rate as
+        # a regression.
+        history = {"version": 1, "runs": [paired_history_run(i) for i in range(1, 4)]}
+        current = [
+            result(
+                messages_per_second=1000.0,
+                medianIntervalMessagesPerSecond=2000.0,
+                deliveredMessages=900_000,
+            ),
+            result(
+                client="Confluent",
+                messages_per_second=500.0,
+                medianIntervalMessagesPerSecond=500.0,
+                deliveredMessages=450_000,
+            ),
+        ]
+
+        for round_index in range(5):
+            evaluations, history, should_fail = evaluate_and_update(
+                history,
+                current,
+                f"2026-07-{10 + round_index:02d}T02:00:00Z",
+            )
+            throughput = next(
+                item for item in evaluations
+                if item["metric"] == "messagesPerSecond"
+                and "Dekaf" in item["scenario"]
+            )
+            self.assertTrue(throughput["backlogDrainSubstituted"])
+            self.assertEqual(1000.0, throughput["current"])
+            self.assertEqual("stable", throughput["status"], f"round {round_index}")
+            self.assertFalse(should_fail, f"round {round_index}")
 
     def test_result_without_delivered_messages_keeps_median_trending(self):
         # Consumer lanes (and old producer result files) carry no

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -71,9 +71,16 @@ def paired_history_run(
     return run
 
 
-def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
+def intra_run_result(
+    client="Dekaf",
+    steady_ratio=0.6,
+    slope=-8.0,
+    messages_per_second=1000.0,
+    **overrides,
+):
     value = result(
         client=client,
+        messages_per_second=messages_per_second,
         steadyStatePeakRatio=steady_ratio,
         intraRunDriftPercent=-35.9,
         throughputSlopePercentPerMinute=slope,
@@ -84,11 +91,27 @@ def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
         intraRunThroughputThresholdBreached=steady_ratio < 0.85 or slope < -1.0,
         throughput={
             "elapsedSeconds": 360,
-            "messagesPerSecondSamples": [1400, 1400, 1400],
+            # Samples derive from the fixture's rate so the trended median interval
+            # cannot drift out of sync with the whole-run mean.
+            "messagesPerSecondSamples": [messages_per_second] * 3,
         },
     )
     value.update(overrides)
     return value
+
+
+def stall_history_runs():
+    """Mean-only history reproducing the txn band from #2467: median 333, band 306-360."""
+    return [
+        history_run(1, messages_per_second=319.5),
+        history_run(2, messages_per_second=333.0),
+        history_run(3, messages_per_second=346.5),
+        history_run(
+            4,
+            messages_per_second=250.0,
+            messagesPerSecondTrend="regression",
+        ),
+    ]
 
 
 class StressTrendTests(unittest.TestCase):
@@ -243,7 +266,7 @@ class StressTrendTests(unittest.TestCase):
             [intra_run_result(
                 steady_ratio=0.7,
                 slope=0.1,
-                effectiveMessagesPerSecond=650.0,
+                messages_per_second=650.0,
             )],
             "2026-07-01T02:00:00Z",
         )
@@ -613,6 +636,124 @@ class StressTrendTests(unittest.TestCase):
         self.assertTrue(should_fail)
         repeated = {item["metric"] for item in evaluations if item["repeatedRegression"]}
         self.assertEqual({"messagesPerSecond", "cpuMicrosPerMessage"}, repeated)
+
+    def test_stall_distorted_mean_passes_when_median_interval_is_in_band(self):
+        # Reproduces run 30441232202 producer-transactional (#2467): whole-run mean
+        # 246 sits below the trailing band (~306-360) after a short shared stall,
+        # while the sampled median interval 332 is dead on the historical median.
+        runs = stall_history_runs()
+
+        evaluations, updated, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(
+                messages_per_second=246.0,
+                medianIntervalMessagesPerSecond=332.0,
+            )],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(332.0, throughput["current"])
+        self.assertEqual(333.0, throughput["median"])
+        self.assertEqual("stable", throughput["status"])
+        self.assertFalse(should_fail)
+        observation = updated["runs"][-1]["results"][0]
+        self.assertEqual(246.0, observation["messagesPerSecond"])
+        self.assertEqual(332.0, observation["medianIntervalMessagesPerSecond"])
+        self.assertEqual("stable", observation["messagesPerSecondTrend"])
+
+    def test_mean_only_result_still_fails_after_repeated_regression(self):
+        # Result files without interval samples keep the pre-#2467 mean behavior:
+        # the same numbers as the stall case above fail when no median is recorded.
+        runs = stall_history_runs()
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(messages_per_second=246.0)],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(246.0, throughput["current"])
+        self.assertEqual("regression", throughput["status"])
+        self.assertTrue(throughput["repeatedRegression"])
+        self.assertTrue(should_fail)
+
+    def test_median_interval_below_band_still_fails(self):
+        # A genuine steady-state regression (median interval also below the band)
+        # must keep failing.
+        runs = stall_history_runs()
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(
+                messages_per_second=246.0,
+                medianIntervalMessagesPerSecond=250.0,
+            )],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(250.0, throughput["current"])
+        self.assertEqual("regression", throughput["status"])
+        self.assertTrue(throughput["repeatedRegression"])
+        self.assertTrue(should_fail)
+
+    def test_history_median_interval_field_supplies_future_baselines(self):
+        runs = [
+            history_run(
+                index,
+                messages_per_second=250.0,
+                medianIntervalMessagesPerSecond=1000.0,
+            )
+            for index in range(1, 4)
+        ]
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [result(messages_per_second=1000.0)],
+            "2026-07-29T02:00:00Z",
+        )
+
+        throughput = next(
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        )
+        self.assertEqual(1000.0, throughput["median"])
+        self.assertEqual("stable", throughput["status"])
+        self.assertFalse(should_fail)
+
+    def test_control_ratio_uses_median_interval_rate_when_present(self):
+        runs = [paired_history_run(i) for i in range(1, 4)]
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            [
+                result(
+                    messages_per_second=700.0,
+                    medianIntervalMessagesPerSecond=1000.0,
+                ),
+                result(
+                    client="Confluent",
+                    messages_per_second=350.0,
+                    medianIntervalMessagesPerSecond=500.0,
+                ),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertEqual(2.0, ratio["current"])
+        self.assertEqual("stable", ratio["status"])
+        self.assertFalse(should_fail)
 
     def test_warned_run_does_not_widen_next_baseline(self):
         runs = [

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -1236,6 +1236,50 @@ class StressTrendTests(unittest.TestCase):
             self.assertEqual("stable", throughput["status"], f"round {round_index}")
             self.assertFalse(should_fail, f"round {round_index}")
 
+    def test_order_balanced_backlog_detected_inside_aggregate(self):
+        # In order-balanced lanes the aggregate is the only trended result, so
+        # backlog detection must run per ordered sample before aggregation: a
+        # client-specific backlog in one order (median 2449, delivered 1000,
+        # healthy same-order control) must pull the aggregate down to
+        # geomean(1000, 2449) and flag the substitution, not vanish into a
+        # geomean of interval medians.
+        runs = [paired_history_run(i, 2449.0, 1414.0) for i in range(1, 4)]
+
+        def ordered(order, client, mean, median, delivered):
+            return result(
+                client=client,
+                messages_per_second=mean,
+                medianIntervalMessagesPerSecond=median,
+                deliveredMessages=delivered,
+                pairedClientOrder=order,
+                pairedSampleCount=2,
+            )
+
+        samples = [
+            ordered("dekaf-first", "Dekaf", 1000.0, 2449.0, 900_000),
+            ordered("dekaf-first", "Confluent", 1400.0, 1414.0, 1_260_000),
+            ordered("confluent-first", "Dekaf", 2449.0, 2449.0, 2_204_100),
+            ordered("confluent-first", "Confluent", 1400.0, 1414.0, 1_260_000),
+        ]
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            samples,
+            "2026-07-29T02:00:00Z",
+        )
+
+        dekaf = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        self.assertTrue(dekaf["backlogDrainSubstituted"])
+        self.assertAlmostEqual((1000.0 * 2449.0) ** 0.5, dekaf["current"])
+        self.assertEqual("regression", dekaf["status"])
+        observation = next(
+            item for item in updated["runs"][-1]["results"]
+            if item["client"] == "Dekaf" and item.get("orderBalancedAggregate")
+        )
+        self.assertAlmostEqual((1000.0 * 2449.0) ** 0.5, observation["messagesPerSecond"])
+        self.assertTrue(observation["backlogDrainSubstituted"])
+        self.assertNotIn("medianIntervalMessagesPerSecond", observation)
+
     def test_result_without_delivered_messages_keeps_median_trending(self):
         # Consumer lanes (and old producer result files) carry no
         # broker-confirmed deliveredMessages: their effective rate is just the


### PR DESCRIPTION
## Problem

The trend gate (`stress_trend.py`) compared **whole-run mean** `messagesPerSecond` against the trailing median±2×MAD band, while the docs tables deliberately rank on the **median sampled interval rate** because a short stall distorts the mean. On run [30441232202](https://github.com/thomhurst/Dekaf/actions/runs/30441232202) this produced a false `Repeated regression (fail)` on producer-transactional: Dekaf whole-run mean 246 vs band 306–361, while the median interval (332) sat dead on the historical median (333) and Confluent showed the identical ~74% mean/median ratio — one shared environment stall depressed both means proportionally, with no steady-state regression.

## Chosen approach: trend on median interval msg/s (issue option 1)

The throughput metric now extracts via `comparison_rate` from `stress_report.py` — the median sampled interval rate when the run recorded interval samples, else the whole-run mean. This is the exact function the docs tables already rank and ratio on, so the gate and the docs now judge the same quantity. Chosen over option 2 (mean band + median corroboration before warning→fail escalation) because:

- It removes the mean/median split entirely instead of papering over it: the gate no longer *warns* on stall-distorted means either, so warned-run streak state stays clean too (a mean-only warning would still have primed the next run's `repeatedRegression`).
- It reuses the existing, tested selection policy (`comparison_rate` / `median_interval_rate`) rather than adding a second corroboration rule beside the paired-ratio one.
- Round-trip (message-bounded) scenarios are handled for free: `median_interval_rate` returns `None` for them (partial-window medians are invalid), so they keep trending on the mean unchanged.

**History schema (additive only):** observations keep the whole-run mean under the existing `messagesPerSecond` key and store the median additively under `medianIntervalMessagesPerSecond`. `_history_metric_value` prefers the median field for trailing bands, control-ratio history, and baseline retention, falling back to the stored mean for the 14 existing entries — the same "collecting baseline" transition the issue anticipated. CPU μs/msg trending is unchanged.

**Transition note:** until median history accumulates, a new run's median interval is compared against mean-based bands. For clean runs mean ≈ median (docs show +1–5%), and the bias direction is fail-open — matching the intent of fixing a false-fail class. The trend-table preamble now discloses the selection rule.

## Orthogonality with #2468

#2468 (order-balanced sample renaming resetting trend baselines) touches this script's **series keying** (`_identity` / `paired_order_identity`). This diff deliberately touches **metric selection only** — no identity, pairing, or keying lines changed — to keep the two mergeable in either order.

## Validation

All script tests (including 5 new ones covering the stall case, the genuine-regression case, mean-only fallback, median-field baselines, and median-based control ratios):

```
$ python -m unittest discover -s .github/scripts -p 'test_*.py'
.........................................................................................................................................
Ran 137 tests in 3.071s

OK
```

End-to-end replay against the **real committed** `.github/stress-history.json` (all 14 entries mean-only), feeding a synthetic merged-results file with the actual run's numbers and the run's own timestamp so same-run replacement reproduces the exact baseline the gate used:

```
=== NEW result file (median interval recorded): stall-distorted mean, steady median (exit code 0) ===
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec | 332.00 | 333.63 | 306.30 – 360.97 | Within band |
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec / Confluent | 2.00 | 3.27 | 3.19 – 3.35 | Regression (warning) |
| producer-transactional / Confluent / 3 brokers / 1000B / 15m | Messages/sec | 166.00 | 129.44 | 128.15 – 130.74 | Improvement |
stored Dekaf observation: {"messagesPerSecond": 245.597, "messagesPerSecondTrend": "stable", "medianIntervalMessagesPerSecond": 332.0}

=== OLD-style result file (mean only): identical means, no interval samples (exit code 1) ===
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec | 245.60 | 333.63 | 306.30 – 360.97 | Repeated regression (fail) |
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec / Confluent | 1.99 | 3.27 | 3.19 – 3.35 | Regression (corroborates fail) |
stored Dekaf observation: {"messagesPerSecond": 245.597, "messagesPerSecondTrend": "regression"}

=== GENUINE regression (median interval also below band) (exit code 1) ===
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec | 250.00 | 333.63 | 306.30 – 360.97 | Repeated regression (fail) |
| producer-transactional / Dekaf / 3 brokers / 1000B / 15m | Messages/sec / Confluent | 1.94 | 3.27 | 3.19 – 3.35 | Regression (corroborates fail) |
stored Dekaf observation: {"messagesPerSecond": 245.597, "messagesPerSecondTrend": "regression", "medianIntervalMessagesPerSecond": 250.0}

REPLAY OK: new=pass, mean-only replay=fail, genuine regression=fail
```

This confirms: (a) the old mean-only behavior reproduces the exact false fail (245.60 vs band 306.30–360.97, matching the run's `Repeated regression (fail)` verdict and the issue's 306–361 band); (b) with the recorded median interval (332) the same run passes as `Within band`; (c) a genuine steady-state regression (median 250, also below band) still fails with paired-ratio corroboration; (d) all 14 mean-only history entries parse and supply baselines end-to-end with no crash.

Fixes #2467
