### PR TITLE
perf(stress): make round-trip harness allocation-free per message, attribute the 306 B/msg

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -893,6 +893,7 @@ jobs:
           output.append("- **Delivery Latency Sampling**: 1 in 1000 produced messages is awaited end-to-end to record true broker round-trip latency")
           output.append("- **Round-Trip Correctness**: Bounded sequenced payloads are consumed back and checked for corruption, wrong partitions, gaps, duplicates, and reordering")
           output.append("- **Round-Trip CPU Scope**: CPU time covers both bulk production and consumer validation; it is not a producer-only metric")
+          output.append("- **Round-Trip Alloc Scope**: the GC/alloc window likewise spans production plus consume-side validation; values are deliberately consumed as byte[] on both clients for parity, so each consumed payload is materialized as a fresh array (~152 B at 128 B messages) — the expected allocation floor for this lane, not a leak")
           output.append("- **CPU Efficiency**: CPU time per message differentiates client efficiency even at equal throughput")
           output.append("- **Noise-Aware Trends**: each scenario is compared with its last 10 matching runs using a median ± 2×MAD band; one adverse excursion warns and two consecutive regressions fail the workflow")
           output.append("- **Parallel Execution**: Each scenario runs in its own isolated environment")

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -80,6 +80,10 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     ///
     /// <para>To ensure all messages are delivered, call <see cref="FlushAsync"/> before disposing the producer.</para>
     ///
+    /// <para>Key and value are serialized into producer-owned buffers before the returned
+    /// <see cref="ValueTask"/> completes, so callers may reuse or mutate input buffers
+    /// (e.g. a pooled <c>byte[]</c> value) once the returned task has been awaited.</para>
+    ///
     /// <para>Errors during delivery will be logged but not thrown. For reliable delivery with error handling,
     /// use the callback overload or <see cref="ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/>.</para>
     /// </remarks>
@@ -98,6 +102,10 @@ public interface IKafkaProducer<TKey, TValue> : IInitializableKafkaClient, IAsyn
     /// with zero allocation.</para>
     ///
     /// <para>To ensure all messages are delivered, call <see cref="FlushAsync"/> before disposing the producer.</para>
+    ///
+    /// <para>Key and value are serialized into producer-owned buffers before the returned
+    /// <see cref="ValueTask"/> completes, so callers may reuse or mutate input buffers
+    /// (e.g. a pooled <c>byte[]</c> value) once the returned task has been awaited.</para>
     ///
     /// <para>Errors during delivery will be logged but not thrown. For reliable delivery with error handling,
     /// use the callback overload or <see cref="ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/>.</para>

--- a/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Stress/RoundTripMessageCodecTests.cs
@@ -99,6 +99,110 @@ public class RoundTripMessageCodecTests
     }
 
     [Test]
+    public async Task Factory_Create_ReusesPartitionBufferWithFreshSequence()
+    {
+        var factory = new RoundTripMessageFactory("reuse-run", partitionCount: 2, payloadSize: 128);
+
+        var first = factory.Create(partition: 0);
+        var firstCopy = first.Retain();
+        var otherPartition = factory.Create(partition: 1);
+        var second = factory.Create(partition: 0);
+
+        // Same partition reuses the same buffer; other partitions never alias it.
+        await Assert.That(ReferenceEquals(first.Value, second.Value)).IsTrue();
+        await Assert.That(ReferenceEquals(first.Value, otherPartition.Value)).IsFalse();
+
+        await Assert.That(RoundTripMessageCodec.TryDecode(second.Key, second.Value, out var secondMetadata)).IsTrue();
+        await Assert.That(secondMetadata.Sequence).IsEqualTo(1);
+        await Assert.That(RoundTripMessageCodec.TryDecode(firstCopy.Key, firstCopy.Value, out var firstMetadata)).IsTrue();
+        await Assert.That(firstMetadata.Sequence).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Factory_Create_SteadyState_IsAllocationFreePerMessage()
+    {
+        // The produce loop runs factory.Create per message inside the lane's measured
+        // GC window; a fresh 128-byte payload here was 152 B/msg of the 306 B/msg
+        // reported in #2472. Guard the zero-allocation contract directly.
+        // GC.GetAllocatedBytesForCurrentThread is exact, so one warmup pass retires
+        // JIT/static-init allocations and any per-message allocation is decisive.
+        var factory = new RoundTripMessageFactory("alloc-run", partitionCount: 2, payloadSize: 128);
+        for (var i = 0; i < 16; i++)
+        {
+            _ = factory.Create(i % 2);
+        }
+
+        const int iterations = 5_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < iterations; i++)
+        {
+            _ = factory.Create(i % 2);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        await Assert.That(allocated).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Validator_Record_SteadyState_IsAllocationFreePerMessage()
+    {
+        // Record runs per consumed message inside the measured GC window at ~1M msg/s;
+        // it must never allocate (no boxing, strings, or growing collections).
+        const int partitionCount = 2;
+        const int messagesPerPartition = 500;
+        var factory = new RoundTripMessageFactory("validator-alloc", partitionCount, payloadSize: 128);
+        var messages = new RoundTripMessage[partitionCount * messagesPerPartition];
+        for (var i = 0; i < messages.Length; i++)
+        {
+            messages[i] = factory.Create(i % partitionCount).Retain();
+        }
+
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        var offsets = new long[partitionCount];
+        // Warm every Record path (decode, key partition hash, bitmap) before measuring.
+        validator.Record(messages[0].Key, messages[0].Value, messages[0].ExpectedPartition, offsets[messages[0].ExpectedPartition]++);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 1; i < messages.Length; i++)
+        {
+            var message = messages[i];
+            validator.Record(message.Key, message.Value, message.ExpectedPartition, offsets[message.ExpectedPartition]++);
+        }
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+        await Assert.That(allocated).IsEqualTo(0);
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(messages.Length);
+        await Assert.That(snapshot.IsSuccess).IsTrue();
+    }
+
+    [Test]
+    public async Task Validator_DetectsDuplicateBeyondFirstBitmapWord()
+    {
+        // The seen-set is a ulong bitmap; make sure duplicate detection works past the
+        // first 64 sequences of a partition (cross-word indexing).
+        const int total = 100;
+        var factory = new RoundTripMessageFactory("bitmap-run", partitionCount: 1, payloadSize: 128);
+        var messages = new RoundTripMessage[total];
+        for (var i = 0; i < total; i++)
+        {
+            messages[i] = factory.Create(partition: 0).Retain();
+        }
+
+        var validator = new RoundTripValidator(factory.ExpectedPerPartition);
+        for (var i = 0; i < total; i++)
+        {
+            validator.Record(messages[i].Key, messages[i].Value, actualPartition: 0, actualOffset: i);
+        }
+        validator.Record(messages[70].Key, messages[70].Value, actualPartition: 0, actualOffset: total);
+
+        var snapshot = validator.CreateSnapshot(timedOut: false);
+        await Assert.That(snapshot.DuplicateMessages).IsEqualTo(1);
+        await Assert.That(snapshot.MissingMessages).IsEqualTo(0);
+        await Assert.That(snapshot.ConsumedMessages).IsEqualTo(total + 1);
+    }
+
+    [Test]
     public async Task TryDecode_WhenPayloadOrKeyChanges_RejectsMessage()
     {
         var factory = new RoundTripMessageFactory("test-run", partitionCount: 3, payloadSize: 128);
@@ -117,10 +221,10 @@ public class RoundTripMessageCodecTests
     public async Task Validator_ReportsGapsDuplicatesReorderingAndMispartitioning()
     {
         var factory = new RoundTripMessageFactory("validator-run", partitionCount: 2, payloadSize: 128);
-        var sequenceZero = factory.Create(partition: 0);
-        var sequenceOne = factory.Create(partition: 0);
+        var sequenceZero = factory.Create(partition: 0).Retain();
+        var sequenceOne = factory.Create(partition: 0).Retain();
         _ = factory.Create(partition: 0);
-        var sequenceThree = factory.Create(partition: 0);
+        var sequenceThree = factory.Create(partition: 0).Retain();
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
 
         validator.Record(sequenceOne.Key, sequenceOne.Value, actualPartition: 0, actualOffset: 0);
@@ -144,7 +248,7 @@ public class RoundTripMessageCodecTests
     {
         var factory = new RoundTripMessageFactory("complete-run", partitionCount: 3, payloadSize: 128);
         var messages = Enumerable.Range(0, 3)
-            .SelectMany(_ => Enumerable.Range(0, 3).Select(factory.Create))
+            .SelectMany(_ => Enumerable.Range(0, 3).Select(partition => factory.Create(partition).Retain()))
             .ToArray();
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
         var offsets = new long[3];
@@ -171,12 +275,8 @@ public class RoundTripMessageCodecTests
     {
         var factory = new RoundTripMessageFactory("ordinal-run", partitionCount: 2, payloadSize: 128);
         var message = factory.Create(partition: 0);
-        var payload = RoundTripMessageCodec.Encode(
-            message.Key,
-            partition: 0,
-            sequence: 0,
-            ordinal: 9,
-            payloadSize: 128);
+        var payload = new byte[128];
+        RoundTripMessageCodec.EncodeInto(payload, message.Key, partition: 0, sequence: 0, ordinal: 9);
         var validator = new RoundTripValidator(factory.ExpectedPerPartition);
 
         validator.Record(message.Key, payload, actualPartition: 0, actualOffset: 0);

--- a/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/ProducerRoundTripStressTest.cs
@@ -116,6 +116,8 @@ internal sealed class ProducerRoundTripStressTest : IStressTestScenario
                     break;
                 }
 
+                // Safe to reuse the factory's per-partition buffer: FireAsync copies
+                // key/value before its ValueTask completes (#2472).
                 var message = factory.Create(ordinal % options.Partitions);
                 estimatedLogBytes += RoundTripScenarioHelpers.EstimateLogBytes(message);
                 try
@@ -351,6 +353,10 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
         // skew the acks-all scenario avoids (see ConfluentStressTestHelpers). Lost messages
         // still fail the run via the consume-side completion tracker + CRC validation.
         Console.WriteLine(RoundTripScenarioHelpers.GetProduceDescription(options, "Confluent.Kafka"));
+        // One reused envelope: librdkafka copies key/value during Produce, so neither
+        // the envelope nor the factory's reused payload buffer needs a fresh allocation
+        // per message (#2472).
+        var envelope = new ConfluentKafka.Message<string, byte[]>();
         var estimatedLogBytes = 0L;
         int ordinal;
         for (ordinal = 0;
@@ -372,16 +378,14 @@ internal sealed class ConfluentProducerRoundTripStressTest : IStressTestScenario
 
             var message = factory.Create(ordinal % options.Partitions);
             estimatedLogBytes += RoundTripScenarioHelpers.EstimateLogBytes(message);
+            envelope.Key = message.Key;
+            envelope.Value = message.Value;
             try
             {
                 ConfluentStressTestHelpers.ProduceWithBackpressure(
                     producer,
                     options.Topic,
-                    new ConfluentKafka.Message<string, byte[]>
-                    {
-                        Key = message.Key,
-                        Value = message.Value
-                    },
+                    envelope,
                     deliveryHandler: null,
                     produceTimeout.Token);
                 throughput.RecordMessage(message.Value.Length);

--- a/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
+++ b/tools/Dekaf.StressTests/Scenarios/RoundTripMessageCodec.cs
@@ -9,7 +9,15 @@ internal readonly record struct RoundTripMessage(
     string Key,
     byte[] Value,
     int ExpectedPartition,
-    long Sequence);
+    long Sequence)
+{
+    /// <summary>
+    /// Copies <see cref="Value"/> out of the factory's reused per-partition buffer.
+    /// Required before retaining a message past the next
+    /// <see cref="RoundTripMessageFactory.Create"/> call for the same partition.
+    /// </summary>
+    public RoundTripMessage Retain() => this with { Value = Value.ToArray() };
+}
 
 internal readonly record struct RoundTripMessageMetadata(
     int Partition,
@@ -19,10 +27,15 @@ internal readonly record struct RoundTripMessageMetadata(
 internal sealed class RoundTripMessageFactory
 {
     private readonly int _partitionCount;
-    private readonly int _payloadSize;
     private readonly string[] _partitionKeys;
+    private readonly uint[] _partitionKeyChecksums;
     private readonly long[] _nextSequences;
     private readonly long[] _expectedPerPartition;
+    // Reusable per-partition payload buffers and precomputed key checksums keep Create
+    // allocation-free and cheap per message, so the lane's GC/CPU tables measure the
+    // client rather than the harness (#2472: a fresh byte[128] here was 152 B/msg of
+    // the reported 306 B/msg).
+    private readonly byte[][] _payloadBuffers;
 
     public RoundTripMessageFactory(string runId, int partitionCount, int payloadSize)
     {
@@ -31,16 +44,31 @@ internal sealed class RoundTripMessageFactory
         ArgumentOutOfRangeException.ThrowIfLessThan(payloadSize, RoundTripMessageCodec.MinimumPayloadSize);
 
         _partitionCount = partitionCount;
-        _payloadSize = payloadSize;
         _partitionKeys = Enumerable.Range(0, partitionCount)
             .Select(partition => RoundTripMessageCodec.FindKeyForPartition(runId, partition, partitionCount))
             .ToArray();
+        _partitionKeyChecksums = new uint[partitionCount];
+        _payloadBuffers = new byte[partitionCount][];
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            _partitionKeyChecksums[partition] = RoundTripMessageCodec.ComputeUtf8Checksum(_partitionKeys[partition]);
+            _payloadBuffers[partition] = new byte[payloadSize];
+        }
         _nextSequences = new long[partitionCount];
         _expectedPerPartition = new long[partitionCount];
     }
 
     public IReadOnlyList<long> ExpectedPerPartition => _expectedPerPartition;
 
+    /// <summary>
+    /// Encodes the next sequenced message for <paramref name="partition"/> into that
+    /// partition's reused payload buffer. The returned <see cref="RoundTripMessage.Value"/>
+    /// is only valid until the next <see cref="Create"/> call for the same partition;
+    /// callers that retain it longer must use <see cref="RoundTripMessage.Retain"/>.
+    /// The produce loops rely on <c>FireAsync</c>/<c>Produce</c> copying key and value
+    /// before their awaited call completes, so awaiting each send before the next
+    /// Create makes the reuse safe.
+    /// </summary>
     public RoundTripMessage Create(int partition)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(partition);
@@ -51,11 +79,9 @@ internal sealed class RoundTripMessageFactory
         var ordinal = checked((sequence * _partitionCount) + partition);
         _expectedPerPartition[partition]++;
 
-        return new RoundTripMessage(
-            key,
-            RoundTripMessageCodec.Encode(key, partition, sequence, ordinal, _payloadSize),
-            partition,
-            sequence);
+        var payload = _payloadBuffers[partition];
+        RoundTripMessageCodec.EncodeInto(payload, _partitionKeyChecksums[partition], partition, sequence, ordinal);
+        return new RoundTripMessage(key, payload, partition, sequence);
     }
 }
 
@@ -155,39 +181,54 @@ internal static class RoundTripMessageCodec
         return (int)((hash & 0x7fff_ffff) % (uint)partitionCount);
     }
 
-    public static byte[] Encode(
+    /// <summary>
+    /// Encodes a sequenced message into <paramref name="payload"/> without allocating.
+    /// Every byte of the destination is overwritten.
+    /// </summary>
+    public static void EncodeInto(
+        Span<byte> payload,
         string key,
         int partition,
         long sequence,
-        long ordinal,
-        int payloadSize)
+        long ordinal) =>
+        EncodeInto(payload, ComputeUtf8Checksum(key), partition, sequence, ordinal);
+
+    /// <summary>
+    /// Core encode with a precomputed key checksum, so per-partition callers skip the
+    /// per-message UTF-8 transcode + CRC of a fixed key.
+    /// </summary>
+    public static void EncodeInto(
+        Span<byte> payload,
+        uint keyChecksum,
+        int partition,
+        long sequence,
+        long ordinal)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(partition);
         ArgumentOutOfRangeException.ThrowIfNegative(sequence);
         ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
-        ArgumentOutOfRangeException.ThrowIfLessThan(payloadSize, MinimumPayloadSize);
+        ArgumentOutOfRangeException.ThrowIfLessThan(payload.Length, MinimumPayloadSize, nameof(payload));
 
-        var payload = new byte[payloadSize];
-        var span = payload.AsSpan();
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, Magic);
+        payload[sizeof(uint)] = Version;
+        BinaryPrimitives.WriteInt32LittleEndian(payload[PartitionOffset..], partition);
+        BinaryPrimitives.WriteInt64LittleEndian(payload[SequenceOffset..], sequence);
+        BinaryPrimitives.WriteInt64LittleEndian(payload[OrdinalOffset..], ordinal);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[KeyChecksumOffset..], keyChecksum);
 
-        BinaryPrimitives.WriteUInt32LittleEndian(span, Magic);
-        span[sizeof(uint)] = Version;
-        BinaryPrimitives.WriteInt32LittleEndian(span[PartitionOffset..], partition);
-        BinaryPrimitives.WriteInt64LittleEndian(span[SequenceOffset..], sequence);
-        BinaryPrimitives.WriteInt64LittleEndian(span[OrdinalOffset..], ordinal);
-        BinaryPrimitives.WriteUInt32LittleEndian(span[KeyChecksumOffset..], ComputeUtf8Checksum(key));
-
-        var checksumOffset = payloadSize - ChecksumSize;
+        var checksumOffset = payload.Length - ChecksumSize;
+        // Filler byte at index i is (ordinal*31 + partition*13 + i*17) mod 256; the
+        // running accumulator is the strength-reduced form of that same expression.
+        var filler = unchecked((byte)((ordinal * 31) + (partition * 13) + (HeaderSize * 17)));
         for (var index = HeaderSize; index < checksumOffset; index++)
         {
-            span[index] = unchecked((byte)((ordinal * 31) + (partition * 13) + (index * 17)));
+            payload[index] = filler;
+            filler = unchecked((byte)(filler + 17));
         }
 
         BinaryPrimitives.WriteUInt32LittleEndian(
-            span[checksumOffset..],
-            Crc32.HashToUInt32(span[..checksumOffset]));
-
-        return payload;
+            payload[checksumOffset..],
+            Crc32.HashToUInt32(payload[..checksumOffset]));
     }
 
     public static bool TryDecode(
@@ -227,7 +268,7 @@ internal static class RoundTripMessageCodec
         return true;
     }
 
-    private static uint ComputeUtf8Checksum(string value)
+    internal static uint ComputeUtf8Checksum(string value)
     {
         var byteCount = Encoding.UTF8.GetByteCount(value);
         byte[]? rented = null;
@@ -253,7 +294,10 @@ internal static class RoundTripMessageCodec
 internal sealed class RoundTripValidator
 {
     private readonly long[] _expectedPerPartition;
-    private readonly bool[][] _seen;
+    // Bit per expected sequence: an eager bool[] costs 1 B per expected message inside
+    // the lane's measured GC window (~1 B/msg of the #2472 attribution); the bitmap
+    // amortizes to ~0.125 B/msg with the same O(1) duplicate check.
+    private readonly ulong[][] _seen;
     private readonly long[] _lastSequence;
     private readonly long[] _lastOffset;
     private long _consumedMessages;
@@ -269,7 +313,7 @@ internal sealed class RoundTripValidator
         ArgumentOutOfRangeException.ThrowIfLessThan(expectedPerPartition.Count, 1);
 
         _expectedPerPartition = [.. expectedPerPartition];
-        _seen = new bool[_expectedPerPartition.Length][];
+        _seen = new ulong[_expectedPerPartition.Length][];
         _lastSequence = new long[_expectedPerPartition.Length];
         _lastOffset = new long[_expectedPerPartition.Length];
         Array.Fill(_lastSequence, -1);
@@ -277,7 +321,8 @@ internal sealed class RoundTripValidator
 
         for (var partition = 0; partition < _expectedPerPartition.Length; partition++)
         {
-            _seen[partition] = new bool[checked((int)_expectedPerPartition[partition])];
+            var expected = checked((int)_expectedPerPartition[partition]);
+            _seen[partition] = new ulong[(expected + 63) >> 6];
         }
     }
 
@@ -313,13 +358,15 @@ internal sealed class RoundTripValidator
         }
 
         var sequence = checked((int)message.Sequence);
-        if (_seen[message.Partition][sequence])
+        ref var seenWord = ref _seen[message.Partition][sequence >> 6];
+        var seenBit = 1UL << (sequence & 63);
+        if ((seenWord & seenBit) != 0)
         {
             _duplicateMessages++;
         }
         else
         {
-            _seen[message.Partition][sequence] = true;
+            seenWord |= seenBit;
             _uniqueMessages++;
         }
 


### PR DESCRIPTION
## Summary

Root-causes and fixes the round-trip lane's reported **306 B/msg** (run 30441232202). The issue's UTF-16-string hypothesis was **wrong**: the lane consumes `<string, byte[]>`, so values are never materialized as strings, and the 6 per-partition keys are served by the `CachingStringDeserializer` (near-zero amortized). The number was two `byte[128]` materializations — one harness, one client — plus the validator's seen-set.

## Attribution (128 B messages, Alloc/msg = whole-window allocations / produced messages; window spans produce + consume-validation phases)

| Source | Phase | B/msg | Verdict |
|---|---|---:|---|
| Harness `RoundTripMessageCodec.Encode` — fresh `byte[128]` per produced message | produce | 152.00 | **Harness cost — eliminated in this PR** |
| Client `ByteArraySerde.Deserialize` — `data.ToArray()` per consumed record | consume | 152.00 | Benign: the deserializing consumer must hand the user an owned `byte[]`; deliberate parity with the Confluent side (`IConsumer<string, byte[]>`), documented in the stress docs template |
| Harness validator `_seen` `bool[]` (1 B per expected message, allocated in-window) | consume | ~1.00 | Harness cost — reduced 8x to a `ulong` bitmap (~0.125 B/msg) |
| Key strings (6 stable keys, caching deserializer) + per-batch client costs + trackers | both | ~1 | Benign residual |
| **Total** | | **≈306** | Matches the reported 306 B/msg |

Numbers are empirical (`GC.GetAllocatedBytesForCurrentThread` probes, 1M iterations each): `new byte[128]` = 152.00 B, 128 B `ToArray()` = 152.00 B. Even a worst-case *uncached* UTF-16 key string would only be 136 B/msg — the hypothesis could never have produced the observed split. Client produce/consume paths allocate nothing else per message (consistent with pure producer lanes at 0–1 B/msg and raw consumer lanes at 0 B/msg), so there is **no Rule-1 client defect** here.

Expected lane numbers after this PR: Dekaf ≈ **152–154 B/msg** (client value materialization + residual), and that floor is now documented so it stops reading as a leak.

## What changed

- **`RoundTripMessageFactory`** encodes each message into one reused buffer per partition via a new `RoundTripMessageCodec.EncodeInto` (allocating `Encode` deleted; per-partition key checksums precomputed so `Create` also skips the per-message UTF-8 transcode + CRC of a fixed key). Reuse is safe because the produce loops are strictly sequential and both clients copy key/value out before the awaited call completes: Dekaf serializes into producer-owned thread-local buffers before `FireAsync`'s ValueTask completes (`SerializeAndAppendFromSpansAsync` runs serialization synchronously in every path, including `FireAsyncSlow`), and librdkafka copies during `Produce`.
- **`RoundTripValidator`** seen-set: `bool[][]` → `ulong[][]` bitmap. Same O(1) duplicate check; validation semantics unchanged.
- **Confluent round-trip loop** reuses a single `Message<string, byte[]>` envelope.
- **`RoundTripMessage.Retain()`** is the sanctioned copy for callers that outlive the reused buffer (unit tests use it; never called in produce loops).
- **`IKafkaProducer.FireAsync` XML docs** now state the input-buffer reuse contract the harness relies on ("key/value are serialized into producer-owned buffers before the returned ValueTask completes") — doc-only `src/` change, no runtime code touched.
- **Stress docs template** (`stress-tests.yml`, the generator for `docs/docs/stress-tests.md` — generated file untouched): new "Round-Trip Alloc Scope" bullet documenting the ~152 B/msg consume-side materialization floor and the byte[]-parity rationale.

## Validation

- New probe tests pin the contract: `Factory_Create_SteadyState_IsAllocationFreePerMessage` and `Validator_Record_SteadyState_IsAllocationFreePerMessage` assert **exactly 0 B** allocated across thousands of iterations via `GC.GetAllocatedBytesForCurrentThread`.
- Validation semantics proven unchanged: all pre-existing validator tests (gaps/duplicates/corruption/reorder/mispartition/unexpected) pass, plus new `Validator_DetectsDuplicateBeyondFirstBitmapWord` (cross-word bitmap indexing) and `Factory_Create_ReusesPartitionBufferWithFreshSequence` (aliasing contract).
- `Dekaf.Tests.Unit.Stress` (36) and `Dekaf.Tests.Unit.StressTests` (90) all pass locally in Release.
- Not run against a live broker: local Docker/Testcontainers validation was not part of this pass — attribution is from static tracing of the exact code paths plus deterministic allocation probes, which fully account for the reported number (152+152+1+~1 ≈ 306). The lane's next scheduled run will show the drop; no paid dispatch was consumed for this harness-only change.

## Skipped review suggestions (with reasons)

- Switching the consumer to `ReadOnlyMemory<byte>`/raw consumption to remove the remaining 152 B/msg: changes what the lane measures and breaks byte[] parity with Confluent (no zero-copy deserializer there) — the byte[] shape is deliberate.
- Skipping invariant header bytes on re-encode: would weaken `EncodeInto`'s "every byte overwritten" guarantee for negligible gain.
- `BitArray`/shared seen-set helper: the 3-line ref-word RMW is the tightest form on a ~1M msg/s path.

## Follow-up candidates (not in scope)

- The five other Confluent produce lanes still allocate a `Message<,>` envelope per message inside their measured GC windows (harness-side, Confluent column only).
- `RoundTripValidator.Record` transcodes the key to UTF-8 twice (pre-existing; CPU-only, no allocation).
- A pin test for the now-documented `FireAsync` buffer-reuse contract.

Fixes #2472
