### PR TITLE
fix(stress): trend order-balanced pairs as one geomean series attached to pre-rename history

### DIFF
--- a/.github/scripts/stress_report.py
+++ b/.github/scripts/stress_report.py
@@ -320,6 +320,12 @@ def _latency_identity(result):
     )
 
 
+# The client orders a balanced pair must cover. Shared by the docs
+# "Order-Balanced Aggregate" table and the trend gate's aggregate series so the
+# two cannot silently disagree about what counts as a balanced pair.
+PAIRED_ORDER_LABELS = frozenset({'dekaf-first', 'confluent-first'})
+
+
 def paired_order_identity(result):
     """Use client order as an identity dimension only for repeated paired samples."""
     sample_count = result.get('pairedSampleCount')
@@ -347,11 +353,15 @@ def _latency_roundtrip_messages(result):
 
 def _latency_scenario_label(result):
     brokers = result.get('brokerCount', 1)
-    return (
+    label = (
         f"{result.get('scenario', 'unknown')} / {result.get('client', 'unknown')} / "
         f"{brokers} broker{'s' if brokers != 1 else ''} / "
         f"{result.get('messageSizeBytes', '?')}B / {result.get('durationMinutes', '?')}m"
     )
+    order = paired_order_identity(result)
+    if order is not None:
+        label += f" / {order}"
+    return label
 
 
 def comparison_rate(result):
@@ -399,9 +409,8 @@ def format_order_balanced_aggregate(results):
     if not dekaf or not confluent:
         return []
 
-    required_orders = {'dekaf-first', 'confluent-first'}
     if any(
-        not required_orders.issubset({
+        not PAIRED_ORDER_LABELS.issubset({
             str(result.get('pairedClientOrder', '')).casefold()
             for result in group['results']
         })

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from statistics import median
 
 from stress_report import (
+    PAIRED_ORDER_LABELS,
     cpu_micros_per_message,
     effective_rate,
+    geometric_mean,
     intra_run_throughput,
     paired_order_identity,
     paired_latency_thresholds,
@@ -85,7 +87,16 @@ def _consumer_connections_per_broker(result):
     return 1 if client.startswith("confluent") else 2
 
 
-def _identity(result):
+# WARNING: Every component below — most notably the client label — is a history
+# series key. Renaming a client label, or adding a new identity dimension (as the
+# order-balanced pairedClientOrder did in #2055), creates a fresh series with zero
+# history: the lane silently reports "Collecting baseline 0/3" and loses its
+# trailing regression band until MIN_BASELINE_RUNS clean runs re-accumulate
+# (issue #2468). If a label or identity dimension must change, either fold the new
+# form back onto the old series (see _order_balanced_aggregates) or migrate
+# .github/stress-history.json in the same PR.
+def _order_family_key(result):
+    """Series key ignoring client order: one family per (scenario, client, brokers, shape)."""
     return (
         str(result.get("scenario", "unknown")).casefold(),
         str(result.get("client", "unknown")).casefold(),
@@ -96,8 +107,11 @@ def _identity(result):
         _consumer_connections_per_broker(result),
         _roundtrip_messages(result),
         result.get("roundTripSteadySeconds"),
-        paired_order_identity(result),
     )
+
+
+def _identity(result):
+    return _order_family_key(result) + (paired_order_identity(result),)
 
 
 def _is_confluent(result):
@@ -120,6 +134,90 @@ def _pair_identity(result):
         result.get("roundTripSteadySeconds"),
         paired_order_identity(result),
     )
+
+
+# Synthetic order-balanced aggregates carry their trend metrics precomputed under
+# this key because the _METRICS extractors read raw result fields that the
+# synthetic rows do not have.
+_AGGREGATE_METRICS_FIELD = "orderBalancedAggregateMetrics"
+
+
+def _identity_record(result):
+    """Identity fields normalized exactly as history observations store them."""
+    record = {field: result.get(field) for field in _IDENTITY_FIELDS}
+    record["brokerCount"] = result.get("brokerCount", 1)
+    record["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
+    record["consumerConnectionsPerBroker"] = _consumer_connections_per_broker(result)
+    record["roundTripMessages"] = _roundtrip_messages(result)
+    return record
+
+
+def _metric_value(result, metric, definition):
+    """Trend value for a result: precomputed for synthetic aggregates, extracted otherwise."""
+    aggregate_metrics = result.get(_AGGREGATE_METRICS_FIELD)
+    if aggregate_metrics is not None:
+        return aggregate_metrics.get(metric)
+    return definition["extract"](result)
+
+
+def _order_balanced_aggregates(current_results):
+    """Collapse each order-balanced sample pair into one synthetic trend result.
+
+    Order-balanced acceptance (#2055) runs the flagship pairings once per client
+    order, which puts pairedClientOrder into every sample's history identity and
+    resets those lanes' trailing bands to zero (issue #2468). The trend series is
+    therefore the geometric mean of the ordered pair, mirroring the aggregation the
+    docs "Order-Balanced Aggregate" table introduced but applied to the trend
+    metrics (deliberately effective_rate / CPU per message rather than the docs'
+    comparison_rate — metric selection is owned by #2467). The synthetic row keeps
+    a None order component so it attaches to the pre-rename plain Dekaf/Confluent
+    history series and inherits the existing bands. Ordered samples become
+    non-trended diagnostics for the aggregated metrics; unpaired and single-sample
+    results (e.g. the "Dekaf (3conn)" control) are untouched.
+
+    Returns (aggregates, aggregated_metrics) where aggregated_metrics maps each
+    family's _order_family_key to the set of metric names its aggregate trends —
+    a metric that failed to aggregate (missing/zero sample value) keeps trending
+    on the per-order series instead of silently losing coverage.
+    """
+    groups = {}
+    for result in current_results:
+        if paired_order_identity(result) is not None:
+            groups.setdefault(_order_family_key(result), []).append(result)
+
+    aggregates = []
+    aggregated_metrics = {}
+    for key, samples in groups.items():
+        orders = {
+            str(sample.get("pairedClientOrder", "")).casefold() for sample in samples
+        }
+        if not PAIRED_ORDER_LABELS.issubset(orders):
+            # Partial pair (one order only): no balanced aggregate exists, so the
+            # ordered samples keep trending on their own series rather than
+            # silently losing regression coverage.
+            continue
+
+        metrics = {
+            metric: geometric_mean(
+                [definition["extract"](sample) for sample in samples]
+            )
+            for metric, definition in _METRICS.items()
+        }
+        trended = frozenset(
+            metric for metric, value in metrics.items() if value is not None
+        )
+        if not trended:
+            continue
+
+        aggregates.append({
+            **_identity_record(samples[0]),
+            "pairedClientOrder": None,
+            "pairedSampleCount": len(samples),
+            _AGGREGATE_METRICS_FIELD: metrics,
+        })
+        aggregated_metrics[key] = trended
+
+    return aggregates, aggregated_metrics
 
 
 def _matching_observations(runs, result):
@@ -225,6 +323,9 @@ def _scenario_label(result):
     roundtrip_messages = _roundtrip_messages(result)
     if roundtrip_messages is not None:
         label += f" / {roundtrip_messages} messages"
+    order = paired_order_identity(result)
+    if order is not None:
+        label += f" / {order}"
     return label
 
 
@@ -300,25 +401,43 @@ def evaluate_and_update(history, current_results, run_started_at):
     observations = []
     should_fail = False
     environment_shift_suspected = False
+    # Order-balanced pairs trend as one synthetic geomean aggregate per client
+    # family (attached to the pre-rename plain series); the aggregates are
+    # evaluated first so ordered diagnostics can borrow their family's verdict.
+    aggregates, aggregated_metrics = _order_balanced_aggregates(current_results)
+    trend_results = aggregates + list(current_results)
     controls = {
         _pair_identity(result): result
-        for result in current_results
+        for result in trend_results
         if _is_confluent(result)
     }
+    family_throughput_regression = {}
 
-    for result in current_results:
+    for result in trend_results:
         is_confluent = _is_confluent(result)
+        is_aggregate = _AGGREGATE_METRICS_FIELD in result
+        family_key = _order_family_key(result)
+        # Ordered samples stay as diagnostics for the metrics their family's
+        # aggregate trends: raw values are recorded, but they carry no band,
+        # cannot gate, and never grow parallel per-order history series.
+        diagnostic_metrics = (
+            aggregated_metrics.get(family_key, frozenset())
+            if not is_aggregate and paired_order_identity(result) is not None
+            else frozenset()
+        )
         prior = _matching_observations(baseline_runs, result)
-        observation = {field: result.get(field) for field in _IDENTITY_FIELDS}
-        observation["consumerSeedBatchSizeBytes"] = _consumer_seed_batch_size(result)
-        observation["consumerConnectionsPerBroker"] = _consumer_connections_per_broker(result)
-        observation["brokerCount"] = result.get("brokerCount", 1)
-        observation["roundTripMessages"] = _roundtrip_messages(result)
+        observation = _identity_record(result)
+        if is_aggregate:
+            observation["orderBalancedAggregate"] = True
         throughput_regression = False
 
         for metric, definition in _METRICS.items():
-            value = definition["extract"](result)
+            value = _metric_value(result, metric, definition)
             if not _finite_number(value):
+                continue
+
+            if metric in diagnostic_metrics:
+                observation[metric] = value
                 continue
 
             trend_field = f"{metric}Trend"
@@ -372,7 +491,9 @@ def evaluate_and_update(history, current_results, run_started_at):
 
             ratio_evaluation = None
             control = controls.get(_pair_identity(result)) if not is_confluent else None
-            control_value = definition["extract"](control) if control is not None else None
+            control_value = (
+                _metric_value(control, metric, definition) if control is not None else None
+            )
             if _finite_number(control_value) and control_value != 0:
                 ratio_evaluation = _control_ratio_evaluation(
                     baseline_runs,
@@ -405,6 +526,13 @@ def evaluate_and_update(history, current_results, run_started_at):
             should_fail = should_fail or evaluation["failureEligible"]
             if metric == "messagesPerSecond":
                 throughput_regression = evaluation["status"] == "regression"
+
+        if is_aggregate:
+            family_throughput_regression[family_key] = throughput_regression
+        elif "messagesPerSecond" in diagnostic_metrics:
+            # Ordered samples have no per-order band, so intra-run breaches borrow
+            # the family aggregate's throughput verdict for corroboration.
+            throughput_regression = family_throughput_regression.get(family_key, False)
 
         intra_run = intra_run_throughput(result)
         if intra_run is not None:
@@ -511,6 +639,11 @@ def format_markdown(evaluations):
             "Paired Dekaf baseline regressions fail only when the same-run ratio also "
             "regresses; unpaired scenarios retain the consecutive-regression gate. "
             "Confluent regressions remain environment warnings."
+        ),
+        (
+            "Order-balanced sample pairs (run once per client order) trend as a single "
+            "geometric-mean series per client that continues the pre-rename history "
+            "band; the individual ordered samples appear only as intra-run diagnostics."
         ),
     ]
 

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -160,6 +160,24 @@ def _metric_value(result, metric, definition):
     return definition["extract"](result)
 
 
+def _complete_order_pair(samples):
+    """The samples if they hold exactly one result per client order, else None.
+
+    Duplicate samples for one order (e.g. merged result files) would weight
+    that order more heavily in the geometric mean, so only an exactly balanced
+    pair qualifies for aggregation.
+    """
+    order_counts = {}
+    for sample in samples:
+        order = str(sample.get("pairedClientOrder", "")).casefold()
+        order_counts[order] = order_counts.get(order, 0) + 1
+    if set(order_counts) != set(PAIRED_ORDER_LABELS):
+        return None
+    if any(count != 1 for count in order_counts.values()):
+        return None
+    return samples
+
+
 def _order_balanced_aggregates(current_results):
     """Collapse each order-balanced sample pair into one synthetic trend result.
 
@@ -188,13 +206,12 @@ def _order_balanced_aggregates(current_results):
     aggregates = []
     aggregated_metrics = {}
     for key, samples in groups.items():
-        orders = {
-            str(sample.get("pairedClientOrder", "")).casefold() for sample in samples
-        }
-        if not PAIRED_ORDER_LABELS.issubset(orders):
-            # Partial pair (one order only): no balanced aggregate exists, so the
-            # ordered samples keep trending on their own series rather than
-            # silently losing regression coverage.
+        if _complete_order_pair(samples) is None:
+            # Anything other than exactly one sample per order — a partial pair,
+            # a duplicated/merged result, or an unknown label — has no
+            # well-defined balanced aggregate (the geomean would weight one
+            # order more heavily), so the ordered samples keep trending on
+            # their own series rather than silently losing regression coverage.
             continue
 
         metrics = {
@@ -222,15 +239,57 @@ def _order_balanced_aggregates(current_results):
 
 def _matching_observations(runs, result):
     key = _identity(result)
+    is_aggregate = _AGGREGATE_METRICS_FIELD in result
+    family_key = _order_family_key(result) if is_aggregate else None
     matches = []
     for run in runs:
         observation = next(
             (item for item in run.get("results", []) if _identity(item) == key),
             None,
         )
+        if observation is None and is_aggregate:
+            observation = _reconstructed_aggregate_observation(run, family_key)
         if observation is not None:
             matches.append(observation)
     return matches
+
+
+def _reconstructed_aggregate_observation(run, family_key):
+    """Geomean observation rebuilt from a historical run's ordered pair.
+
+    Runs recorded between the #2055 order rename and the synthetic aggregate
+    series carry the lane's data only as per-order observations. Rebuilding
+    their geometric mean keeps the aggregate's baseline continuous across that
+    window instead of skipping straight back to the last pre-rename entry.
+    The synthetic observation deliberately carries no trend fields: it extends
+    the baseline, but a stale pre-rename regression verdict must not pair with
+    a fresh aggregate one across intervening ordered runs to fake a
+    consecutive (repeatedRegression) failure. Metrics whose per-order series
+    flagged a regression in that run are omitted so they cannot widen the
+    clean baseline the trend filter otherwise excludes them from.
+    """
+    samples = [
+        item
+        for item in run.get("results", [])
+        if paired_order_identity(item) is not None
+        and _order_family_key(item) == family_key
+    ]
+    if not samples or _complete_order_pair(samples) is None:
+        return None
+
+    observation = {}
+    for metric in _METRICS:
+        if any(sample.get(f"{metric}Trend") == "regression" for sample in samples):
+            continue
+        value = geometric_mean([sample.get(metric) for sample in samples])
+        if value is not None:
+            observation[metric] = value
+    if not observation:
+        return None
+
+    if any(sample.get("environmentShiftSuspected", False) for sample in samples):
+        observation["environmentShiftSuspected"] = True
+    return observation
 
 
 def _matching_control_ratios(runs, result, metric):

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -314,7 +314,7 @@ def _matching_control_ratios(runs, result, metric):
             None,
         )
         control = next((item for item in matching_results if _is_confluent(item)), None)
-        if candidate is None or control is None:
+        if candidate is None:
             if is_aggregate:
                 ratio = _reconstructed_control_ratio(run, family_key, pair_key, metric)
                 if ratio is not None:
@@ -322,13 +322,21 @@ def _matching_control_ratios(runs, result, metric):
             continue
 
         candidate_value = candidate.get(metric)
-        control_value = control.get(metric)
         if (
             not _finite_number(candidate_value)
-            or not _finite_number(control_value)
-            or control_value == 0
             or candidate.get(trend_field) == "regression"
         ):
+            continue
+
+        control_value = control.get(metric) if control is not None else None
+        if not _finite_number(control_value) or control_value == 0:
+            # Interim ordered runs carry the Confluent control only as an
+            # ordered pair, which never matches an order-less pair key. Rebuild
+            # its geomean so order-less candidates (e.g. the "Dekaf (3conn)"
+            # control) keep a continuous ratio baseline across the rename
+            # window too.
+            control_value = _reconstructed_ordered_control_value(run, pair_key, metric)
+        if control_value is None:
             continue
 
         ratios.append(candidate_value / control_value)
@@ -348,24 +356,14 @@ def _reconstructed_control_ratio(run, family_key, pair_key, metric):
     Runs whose per-order ratio series flagged a regression are skipped,
     matching the trend filter applied to directly recorded ratios.
     """
-    shape_key = pair_key[:-1]
-    ordered = [
+    candidate_samples = [
         item
         for item in run.get("results", [])
         if paired_order_identity(item) is not None
         and not item.get("environmentShiftSuspected", False)
-        and _pair_identity(item)[:-1] == shape_key
+        and _order_family_key(item) == family_key
     ]
-    candidate_samples = [
-        item for item in ordered if _order_family_key(item) == family_key
-    ]
-    control_samples = [item for item in ordered if _is_confluent(item)]
-    if len({_order_family_key(item) for item in control_samples}) != 1:
-        return None
-    if (
-        _complete_order_pair(candidate_samples) is None
-        or _complete_order_pair(control_samples) is None
-    ):
+    if _complete_order_pair(candidate_samples) is None:
         return None
     if any(
         sample.get(f"{metric}ControlRatioTrend") == "regression"
@@ -376,12 +374,34 @@ def _reconstructed_control_ratio(run, family_key, pair_key, metric):
     candidate_value = geometric_mean(
         [sample.get(metric) for sample in candidate_samples]
     )
-    control_value = geometric_mean(
-        [sample.get(metric) for sample in control_samples]
-    )
-    if candidate_value is None or not control_value:
+    control_value = _reconstructed_ordered_control_value(run, pair_key, metric)
+    if candidate_value is None or control_value is None:
         return None
     return candidate_value / control_value
+
+
+def _reconstructed_ordered_control_value(run, pair_key, metric):
+    """Geomean control value rebuilt from a run's complete ordered Confluent pair.
+
+    Requires a single unambiguous ordered control family matching the pair's
+    shape; anything else (partial pair, duplicates, competing control
+    variants) yields None so no ratio is fabricated.
+    """
+    shape_key = pair_key[:-1]
+    control_samples = [
+        item
+        for item in run.get("results", [])
+        if paired_order_identity(item) is not None
+        and not item.get("environmentShiftSuspected", False)
+        and _is_confluent(item)
+        and _pair_identity(item)[:-1] == shape_key
+    ]
+    if len({_order_family_key(item) for item in control_samples}) != 1:
+        return None
+    if _complete_order_pair(control_samples) is None:
+        return None
+    value = geometric_mean([item.get(metric) for item in control_samples])
+    return value if value else None
 
 
 def _limit_observations_per_identity(runs):

--- a/.github/scripts/stress_trend.py
+++ b/.github/scripts/stress_trend.py
@@ -295,6 +295,8 @@ def _reconstructed_aggregate_observation(run, family_key):
 def _matching_control_ratios(runs, result, metric):
     pair_key = _pair_identity(result)
     candidate_key = _identity(result)
+    is_aggregate = _AGGREGATE_METRICS_FIELD in result
+    family_key = _order_family_key(result) if is_aggregate else None
     trend_field = f"{metric}ControlRatioTrend"
     ratios = []
 
@@ -313,6 +315,10 @@ def _matching_control_ratios(runs, result, metric):
         )
         control = next((item for item in matching_results if _is_confluent(item)), None)
         if candidate is None or control is None:
+            if is_aggregate:
+                ratio = _reconstructed_control_ratio(run, family_key, pair_key, metric)
+                if ratio is not None:
+                    ratios.append(ratio)
             continue
 
         candidate_value = candidate.get(metric)
@@ -328,6 +334,54 @@ def _matching_control_ratios(runs, result, metric):
         ratios.append(candidate_value / control_value)
 
     return ratios[-HISTORY_LIMIT:]
+
+
+def _reconstructed_control_ratio(run, family_key, pair_key, metric):
+    """Candidate/control ratio rebuilt from a historical run's ordered pairs.
+
+    Mirrors _reconstructed_aggregate_observation for the ratio series: interim
+    ordered runs record the pairing only under per-order pair identities, which
+    the synthetic aggregate's order-less pair key never matches. Rebuilding the
+    ordered geomean ratio keeps the ratio baseline continuous across the rename
+    window, so an aggregate regression is corroborated against the immediately
+    preceding comparable ratios instead of only the stale pre-rename level.
+    Runs whose per-order ratio series flagged a regression are skipped,
+    matching the trend filter applied to directly recorded ratios.
+    """
+    shape_key = pair_key[:-1]
+    ordered = [
+        item
+        for item in run.get("results", [])
+        if paired_order_identity(item) is not None
+        and not item.get("environmentShiftSuspected", False)
+        and _pair_identity(item)[:-1] == shape_key
+    ]
+    candidate_samples = [
+        item for item in ordered if _order_family_key(item) == family_key
+    ]
+    control_samples = [item for item in ordered if _is_confluent(item)]
+    if len({_order_family_key(item) for item in control_samples}) != 1:
+        return None
+    if (
+        _complete_order_pair(candidate_samples) is None
+        or _complete_order_pair(control_samples) is None
+    ):
+        return None
+    if any(
+        sample.get(f"{metric}ControlRatioTrend") == "regression"
+        for sample in candidate_samples
+    ):
+        return None
+
+    candidate_value = geometric_mean(
+        [sample.get(metric) for sample in candidate_samples]
+    )
+    control_value = geometric_mean(
+        [sample.get(metric) for sample in control_samples]
+    )
+    if candidate_value is None or not control_value:
+        return None
+    return candidate_value / control_value
 
 
 def _limit_observations_per_identity(runs):

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -596,6 +596,72 @@ class StressTrendTests(unittest.TestCase):
         self.assertEqual(6, dekaf["baselineCount"])
         self.assertFalse(should_fail)
 
+    def ordered_paired_history_run(self, index, dekaf_rate, confluent_rate):
+        def sample(client, order, rate):
+            return {
+                "scenario": "producer",
+                "client": client,
+                "brokerCount": 1,
+                "durationMinutes": 15,
+                "messageSizeBytes": 1000,
+                "pairedClientOrder": order,
+                "pairedSampleCount": 2,
+                "messagesPerSecond": rate,
+                "messagesPerSecondTrend": "stable",
+                "messagesPerSecondControlRatioTrend": "stable",
+            }
+
+        return {
+            "runStartedAtUtc": f"2026-06-{index:02d}T02:00:00Z",
+            "results": [
+                sample("Dekaf", "dekaf-first", dekaf_rate),
+                sample("Confluent", "dekaf-first", confluent_rate),
+                sample("Dekaf", "confluent-first", dekaf_rate),
+                sample("Confluent", "confluent-first", confluent_rate),
+            ],
+        }
+
+    def test_ratio_baseline_bridges_interim_ordered_runs(self):
+        # The Dekaf/Confluent ratio settled at ~1.414 during four interim
+        # ordered runs (Dekaf 2000 vs Confluent 1414), down from the stale
+        # pre-rename 1.732. A later Dekaf absolute regression whose current
+        # ratio matches the interim level must not be corroborated against
+        # the stale pre-rename ratio band into a gate failure.
+        runs = [paired_history_run(i, 2449.0, 1414.0) for i in range(1, 4)]
+        for index in range(4, 8):
+            runs.append(self.ordered_paired_history_run(index, 2000.0, 1414.0))
+
+        regressed = self.order_balanced_samples(
+            dekaf_first=1600.0,
+            dekaf_second=1600.0,
+            confluent_first=1131.4,
+            confluent_second=1131.4,
+        )
+
+        _, first_updated, first_should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            regressed,
+            "2026-07-01T02:00:00Z",
+        )
+        self.assertFalse(first_should_fail)
+
+        second_evaluations, _, second_should_fail = evaluate_and_update(
+            first_updated,
+            regressed,
+            "2026-07-08T02:00:00Z",
+        )
+
+        dekaf = client_metric(second_evaluations, "messagesPerSecond", "Dekaf")
+        ratio = next(
+            item for item in second_evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        )
+        self.assertEqual("regression", dekaf["status"])
+        self.assertTrue(dekaf["repeatedRegression"])
+        self.assertEqual("stable", ratio["status"])
+        self.assertFalse(dekaf["failureEligible"])
+        self.assertFalse(second_should_fail)
+
     def test_unrenamed_control_series_is_untouched_by_order_aggregation(self):
         runs = [history_run(i) for i in range(1, 5)]
         for run in runs:

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -662,6 +662,69 @@ class StressTrendTests(unittest.TestCase):
         self.assertFalse(dekaf["failureEligible"])
         self.assertFalse(second_should_fail)
 
+    def test_3conn_ratio_baseline_bridges_interim_ordered_runs(self):
+        # The order-less "Dekaf (3conn)" control kept running single-sample
+        # through the rename window, but its Confluent control was ordered in
+        # interim runs, so its ratio history skipped them. The reconstruction
+        # must combine the order-less candidate with the ordered control
+        # geomean so the restored current pairing is judged against the
+        # interim ratio level (1.414), not only the stale pre-rename 2.0.
+        def plain_3conn(rate):
+            return {
+                "scenario": "producer",
+                "client": "Dekaf (3conn)",
+                "brokerCount": 1,
+                "durationMinutes": 15,
+                "messageSizeBytes": 1000,
+                "messagesPerSecond": rate,
+                "messagesPerSecondTrend": "stable",
+            }
+
+        runs = []
+        for index in range(1, 4):
+            runs.append({
+                "runStartedAtUtc": f"2026-06-{index:02d}T02:00:00Z",
+                "results": [
+                    plain_3conn(1000.0),
+                    {**plain_3conn(500.0), "client": "Confluent"},
+                ],
+            })
+        for index in range(4, 8):
+            interim = self.ordered_paired_history_run(index, 2000.0, 707.0)
+            interim["results"] = [
+                item for item in interim["results"] if item["client"] == "Confluent"
+            ] + [plain_3conn(1000.0)]
+            runs.append(interim)
+
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            self.order_balanced_samples(
+                confluent_first=707.0,
+                confluent_second=707.0,
+            ) + [
+                {
+                    "scenario": "producer",
+                    "client": "Dekaf (3conn)",
+                    "brokerCount": 1,
+                    "durationMinutes": 15,
+                    "messageSizeBytes": 1000,
+                    "effectiveMessagesPerSecond": 1000.0,
+                    "cpuMicrosPerMessage": 2.0,
+                    "throughput": {},
+                },
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        ratio = next(
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+            and "3conn" in item["scenario"]
+        )
+        self.assertEqual(7, ratio["baselineCount"])
+        self.assertAlmostEqual(1000.0 / 707.0, ratio["current"])
+        self.assertEqual("stable", ratio["status"])
+
     def test_unrenamed_control_series_is_untouched_by_order_aggregation(self):
         runs = [history_run(i) for i in range(1, 5)]
         for run in runs:

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -91,6 +91,14 @@ def intra_run_result(client="Dekaf", steady_ratio=0.6, slope=-8.0, **overrides):
     return value
 
 
+def client_metric(evaluations, metric, client):
+    """First evaluation for a metric whose scenario label names the client."""
+    return next(
+        item for item in evaluations
+        if item["metric"] == metric and item["scenario"].split(" / ")[1] == client
+    )
+
+
 class StressTrendTests(unittest.TestCase):
     def test_steady_roundtrip_identity_uses_window_not_dynamic_message_count(self):
         dekaf = result(
@@ -389,63 +397,238 @@ class StressTrendTests(unittest.TestCase):
         self.assertEqual("stable", ratio["status"])
         self.assertFalse(should_fail)
 
-    def test_order_balanced_samples_use_their_matching_same_run_control(self):
-        samples = [
+    def order_balanced_samples(
+        self,
+        dekaf_first=2000.0,
+        dekaf_second=3000.0,
+        confluent_first=1000.0,
+        confluent_second=2000.0,
+    ):
+        return [
             result(
-                messages_per_second=2000.0,
+                messages_per_second=dekaf_first,
                 pairedClientOrder="dekaf-first",
                 pairedSampleCount=2,
             ),
             result(
                 client="Confluent",
-                messages_per_second=1000.0,
+                messages_per_second=confluent_first,
                 pairedClientOrder="dekaf-first",
                 pairedSampleCount=2,
             ),
             result(
                 client="Confluent",
-                messages_per_second=2000.0,
+                messages_per_second=confluent_second,
                 pairedClientOrder="confluent-first",
                 pairedSampleCount=2,
             ),
             result(
-                messages_per_second=3000.0,
+                messages_per_second=dekaf_second,
                 pairedClientOrder="confluent-first",
                 pairedSampleCount=2,
             ),
         ]
 
+    def test_order_balanced_pair_trends_as_single_geomean_aggregate(self):
         evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": []},
+            self.order_balanced_samples(),
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = [
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        ]
+        self.assertEqual(2, len(throughput))
+        self.assertAlmostEqual(
+            (2000.0 * 3000.0) ** 0.5,
+            client_metric(evaluations, "messagesPerSecond", "Dekaf")["current"],
+        )
+        self.assertAlmostEqual(
+            (1000.0 * 2000.0) ** 0.5,
+            client_metric(evaluations, "messagesPerSecond", "Confluent")["current"],
+        )
+
+        ratios = [
+            item["current"]
+            for item in evaluations
+            if item["metric"] == "messagesPerSecondControlRatio"
+        ]
+        self.assertEqual(1, len(ratios))
+        self.assertAlmostEqual(3.0 ** 0.5, ratios[0])
+
+        recorded = updated["runs"][-1]["results"]
+        aggregates = [
+            item for item in recorded if item.get("orderBalancedAggregate")
+        ]
+        self.assertEqual(2, len(aggregates))
+        for aggregate in aggregates:
+            self.assertIsNone(aggregate["pairedClientOrder"])
+            self.assertEqual(2, aggregate["pairedSampleCount"])
+        diagnostics = [
+            item for item in recorded if item.get("pairedClientOrder") is not None
+        ]
+        self.assertEqual(4, len(diagnostics))
+        for diagnostic in diagnostics:
+            self.assertIn("messagesPerSecond", diagnostic)
+            self.assertNotIn("messagesPerSecondTrend", diagnostic)
+
+    def test_order_balanced_aggregate_attaches_to_plain_label_history(self):
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": [history_run(i, 2449.0) for i in range(1, 5)]},
+            self.order_balanced_samples(),
+            "2026-07-01T02:00:00Z",
+        )
+
+        dekaf_throughput = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        self.assertEqual(4, dekaf_throughput["baselineCount"])
+        self.assertEqual("stable", dekaf_throughput["status"])
+
+    def test_order_balanced_aggregate_regression_flags_and_fails_when_repeated(self):
+        runs = [paired_history_run(i, 2449.0, 1414.0) for i in range(1, 5)]
+        regressed = self.order_balanced_samples(
+            dekaf_first=1200.0,
+            dekaf_second=1250.0,
+        )
+
+        first_evaluations, first_updated, first_should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            regressed,
+            "2026-07-01T02:00:00Z",
+        )
+        first_dekaf = client_metric(first_evaluations, "messagesPerSecond", "Dekaf")
+        self.assertEqual("regression", first_dekaf["status"])
+        self.assertFalse(first_dekaf["repeatedRegression"])
+        self.assertFalse(first_should_fail)
+
+        second_evaluations, _, second_should_fail = evaluate_and_update(
+            first_updated,
+            regressed,
+            "2026-07-08T02:00:00Z",
+        )
+        second_dekaf = client_metric(second_evaluations, "messagesPerSecond", "Dekaf")
+        self.assertTrue(second_dekaf["repeatedRegression"])
+        self.assertTrue(second_dekaf["failureEligible"])
+        self.assertTrue(second_should_fail)
+
+    def test_unrenamed_control_series_is_untouched_by_order_aggregation(self):
+        runs = [history_run(i) for i in range(1, 5)]
+        for run in runs:
+            run["results"].append({
+                **run["results"][0],
+                "client": "Dekaf (3conn)",
+            })
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            self.order_balanced_samples() + [
+                result(client="Dekaf (3conn)", messages_per_second=1000.0),
+            ],
+            "2026-07-01T02:00:00Z",
+        )
+
+        control_throughput = client_metric(
+            evaluations, "messagesPerSecond", "Dekaf (3conn)"
+        )
+        self.assertEqual(4, control_throughput["baselineCount"])
+        self.assertEqual("stable", control_throughput["status"])
+        control_observation = next(
+            item for item in updated["runs"][-1]["results"]
+            if item["client"] == "Dekaf (3conn)"
+        )
+        self.assertNotIn("orderBalancedAggregate", control_observation)
+
+    def test_partial_order_pair_keeps_trending_on_its_own_series(self):
+        evaluations, _, _ = evaluate_and_update(
+            {"version": 1, "runs": []},
+            [result(
+                messages_per_second=1000.0,
+                pairedClientOrder="dekaf-first",
+                pairedSampleCount=2,
+            )],
+            "2026-07-01T02:00:00Z",
+        )
+
+        throughput = [
+            item for item in evaluations if item["metric"] == "messagesPerSecond"
+        ]
+        self.assertEqual(1, len(throughput))
+        self.assertIn("dekaf-first", throughput[0]["scenario"])
+
+    def test_metric_that_fails_to_aggregate_keeps_per_order_trending(self):
+        samples = self.order_balanced_samples()
+        samples[0]["cpuMicrosPerMessage"] = None  # Dekaf dekaf-first sample
+
+        evaluations, _, _ = evaluate_and_update(
             {"version": 1, "runs": []},
             samples,
             "2026-07-01T02:00:00Z",
         )
 
-        ratios = sorted(
-            item["current"]
-            for item in evaluations
-            if item["metric"] == "messagesPerSecondControlRatio"
+        cpu = [
+            item for item in evaluations if item["metric"] == "cpuMicrosPerMessage"
+        ]
+        dekaf_cpu = [
+            item for item in cpu if item["scenario"].split(" / ")[1] == "Dekaf"
+        ]
+        # Dekaf CPU could not aggregate (one sample has no CPU data), so the
+        # remaining ordered sample keeps trending on its own per-order series.
+        self.assertEqual(1, len(dekaf_cpu))
+        self.assertIn("confluent-first", dekaf_cpu[0]["scenario"])
+        # Confluent CPU and both throughput series still trend via aggregates.
+        confluent_cpu = client_metric(evaluations, "cpuMicrosPerMessage", "Confluent")
+        self.assertNotIn("first", confluent_cpu["scenario"])
+        dekaf_throughput = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        self.assertNotIn("first", dekaf_throughput["scenario"])
+
+    def test_ordered_sample_intra_run_breach_corroborated_by_family_aggregate(self):
+        runs = [paired_history_run(i, 2449.0, 1414.0) for i in range(1, 5)]
+
+        def samples(dekaf_first_rate, dekaf_second_rate):
+            paired = dict(pairedClientOrder="dekaf-first", pairedSampleCount=2)
+            return [
+                intra_run_result(
+                    steady_ratio=0.7,
+                    slope=0.1,
+                    effectiveMessagesPerSecond=dekaf_first_rate,
+                    **paired,
+                ),
+                result(
+                    client="Confluent", messages_per_second=1414.0, **paired
+                ),
+                result(
+                    client="Confluent",
+                    messages_per_second=1414.0,
+                    pairedClientOrder="confluent-first",
+                    pairedSampleCount=2,
+                ),
+                result(
+                    messages_per_second=dekaf_second_rate,
+                    pairedClientOrder="confluent-first",
+                    pairedSampleCount=2,
+                ),
+            ]
+
+        def steady_breach(evaluations):
+            return next(
+                item for item in evaluations
+                if item["metric"] == "steadyStatePeakRatio"
+                and "dekaf-first" in item["scenario"]
+            )
+
+        healthy, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            samples(2449.0, 2449.0),
+            "2026-07-01T02:00:00Z",
         )
-        self.assertEqual([1.5, 2.0], ratios)
-        self.assertEqual(
-            [
-                "dekaf-first",
-                "dekaf-first",
-                "confluent-first",
-                "confluent-first",
-            ],
-            [
-                item["pairedClientOrder"]
-                for item in updated["runs"][-1]["results"]
-            ],
+        self.assertFalse(steady_breach(healthy)["corroborated"])
+
+        regressed, _, _ = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            samples(1200.0, 1250.0),
+            "2026-07-01T02:00:00Z",
         )
-        self.assertEqual(
-            [2, 2, 2, 2],
-            [
-                item["pairedSampleCount"]
-                for item in updated["runs"][-1]["results"]
-            ],
-        )
+        self.assertTrue(steady_breach(regressed)["corroborated"])
 
     def test_single_sample_order_does_not_split_existing_trend_history(self):
         evaluations, _, _ = evaluate_and_update(

--- a/.github/scripts/test_stress_trend.py
+++ b/.github/scripts/test_stress_trend.py
@@ -511,6 +511,91 @@ class StressTrendTests(unittest.TestCase):
         self.assertTrue(second_dekaf["failureEligible"])
         self.assertTrue(second_should_fail)
 
+    def test_duplicate_order_sample_disables_balanced_aggregate(self):
+        samples = self.order_balanced_samples() + [
+            result(
+                messages_per_second=9000.0,
+                pairedClientOrder="dekaf-first",
+                pairedSampleCount=2,
+            ),
+        ]
+
+        evaluations, updated, _ = evaluate_and_update(
+            {"version": 1, "runs": []},
+            samples,
+            "2026-07-01T02:00:00Z",
+        )
+
+        dekaf_throughput = [
+            item for item in evaluations
+            if item["metric"] == "messagesPerSecond"
+            and item["scenario"].split(" / ")[1] == "Dekaf"
+        ]
+        # The duplicated dekaf-first sample would weight that order more
+        # heavily in a geomean, so the Dekaf family gets no aggregate and each
+        # ordered sample trends on its own series instead.
+        self.assertEqual(3, len(dekaf_throughput))
+        for item in dekaf_throughput:
+            self.assertIn("first", item["scenario"])
+        recorded = updated["runs"][-1]["results"]
+        self.assertFalse(any(
+            item.get("orderBalancedAggregate") and item["client"] == "Dekaf"
+            for item in recorded
+        ))
+
+    def ordered_history_run(self, index, dekaf_first, dekaf_second):
+        base = {
+            "scenario": "producer",
+            "client": "Dekaf",
+            "brokerCount": 1,
+            "durationMinutes": 15,
+            "messageSizeBytes": 1000,
+            "pairedSampleCount": 2,
+            "cpuMicrosPerMessage": 2.0,
+        }
+        return {
+            "runStartedAtUtc": f"2026-06-{index:02d}T02:00:00Z",
+            "results": [
+                {
+                    **base,
+                    "pairedClientOrder": "dekaf-first",
+                    "messagesPerSecond": dekaf_first,
+                    "messagesPerSecondTrend": "stable",
+                },
+                {
+                    **base,
+                    "pairedClientOrder": "confluent-first",
+                    "messagesPerSecond": dekaf_second,
+                    "messagesPerSecondTrend": "stable",
+                },
+            ],
+        }
+
+    def test_stale_prerename_regression_is_not_repeated_across_ordered_runs(self):
+        # Last pre-rename observation was a regression, but two healthy ordered
+        # runs happened since: the fresh aggregate regression must not pair
+        # with the stale verdict as "consecutive", and the interim geomeans
+        # must extend the aggregate baseline.
+        runs = [paired_history_run(i, 2449.0, 1414.0) for i in range(1, 5)]
+        runs.append(paired_history_run(
+            5, 1200.0, 1414.0, messagesPerSecondTrend="regression",
+        ))
+        runs.append(self.ordered_history_run(6, 2000.0, 3000.0))
+        runs.append(self.ordered_history_run(7, 2000.0, 3000.0))
+
+        evaluations, _, should_fail = evaluate_and_update(
+            {"version": 1, "runs": runs},
+            self.order_balanced_samples(dekaf_first=1200.0, dekaf_second=1250.0),
+            "2026-07-01T02:00:00Z",
+        )
+
+        dekaf = client_metric(evaluations, "messagesPerSecond", "Dekaf")
+        self.assertEqual("regression", dekaf["status"])
+        self.assertFalse(dekaf["repeatedRegression"])
+        self.assertFalse(dekaf["failureEligible"])
+        self.assertEqual(6, dekaf["baselineCount"])
+        self.assertFalse(should_fail)
+
     def test_unrenamed_control_series_is_untouched_by_order_aggregation(self):
         runs = [history_run(i) for i in range(1, 5)]
         for run in runs:


### PR DESCRIPTION
## Problem

The order-balanced acceptance work (#2055) made `pairedClientOrder` part of the trend-history identity for repeated paired samples (`pairedSampleCount > 1`). Each flagship 1-broker producer lane therefore split into four fresh series (`Dekaf`/`Confluent` x `dekaf-first`/`confluent-first`) with zero history, and every producer / producer-acks-all / producer-idempotent 1b main-lane row has reported `Collecting baseline - 0/3 runs` since 2026-07-16.

It is worse than the "~3 weekly runs" the issue estimated: all five order-balanced runs so far (07-16, 07-17, 07-19, 07-26, 07-29) are `environmentShiftSuspected`, and env-shifted observations are excluded from absolute baselines — so the fresh per-order series were **never** going to accumulate a baseline. The flagship lanes were trend-blind indefinitely.

A second, previously unreported casualty of the rename: the `Dekaf (3conn)` 1b control lost its same-run Confluent control-ratio pairing (its pair identity has order `None`, which no longer matched any per-order Confluent row), silently turning it from a corroboration-gated paired scenario into an unpaired one.

## Approach (issue option 1)

`stress_trend.py` now collapses each complete order-balanced pair into **one synthetic trend result per (scenario, client family, brokerCount, workload shape)**:

- The synthetic row's trend metrics are the **geometric mean** of the ordered samples — mirroring the aggregation the docs "Order-Balanced Aggregate" table introduced, but applied to the trend metrics (`effective_rate` / CPU per message). Deliberately *not* the docs' `comparison_rate`: metric selection is owned by #2467 (see below).
- Its identity keeps a `None` order component, so it **attaches to the pre-rename plain `Dekaf`/`Confluent` history series** and inherits the existing 10-run bands and control-ratio history. That continuity is the point of the fix.
- Ordered samples stay recorded as **non-trended diagnostics**: raw values land in history, intra-run threshold checks (steady-state/slope) keep working per sample and borrow the family aggregate's throughput verdict for corroboration, but they carry no band, cannot gate, and no longer grow parallel per-order series.
- A metric that fails to aggregate (missing/zero sample value) falls back to per-order trending for that metric instead of silently losing coverage; a partial pair (one order only) is left trending on its own series.
- `Dekaf (3conn)` (never renamed) is untouched: same identity, same baselines, same bands. The synthetic Confluent aggregate additionally **restores** the severed 1b 3conn control-ratio pairing, resuming its pre-rename ratio series.
- Added the requested warning comment at the series-keying logic: client labels (and identity dimensions) are history keys; renames reset trailing bands.

**Attach-soundness check** (is the pair geomean offset from the old single-sample metric?): computed from the committed history, the aggregate sits inside the pre-rename band on every healthy order-balanced run:

```
producer / Dekaf / 1b pre-rename band: 1,398,282 - 1,814,756 (n=6)
  2026-07-16: geomean(1,535,742, 1,575,903) = 1,555,693 -> within band
  2026-07-17: geomean(1,562,032, 1,539,792) = 1,550,872 -> within band
  2026-07-19: geomean(1,509,735, 1,488,148) = 1,498,903 -> within band
  2026-07-26: geomean(1,543,399, 1,548,657) = 1,546,026 -> within band
  2026-07-29: geomean(1,268,062, 1,263,443) = 1,265,750 -> BELOW band   (real dip; 3conn control regressed the same runs)
producer / Confluent / 1b: 07-16..07-26 within band, 07-29 below (same-run environment dip)
producer-acks-all: Dekaf marginally below on 07-16/07-19 (-0.2%/-1.2%) but Confluent is below on the same runs,
  i.e. a both-clients environment level shift - exactly what the env-shift + control-ratio machinery absorbs.
```

No systematic offset; attaching is sound, so the issue's fallback option 2 was not needed.

### Orthogonality with #2467

#2467 (trend gate regresses on whole-run mean vs docs' median interval) touches **metric selection** in this same script. This diff deliberately keeps the `_METRICS` extractors untouched and aggregates whatever `definition["extract"]` yields per metric (`_metric_value` keys precomputed aggregate values by metric name, not by raw field). If #2467 changes the extractor, the geomean automatically follows the new metric — the two changes compose without overlap. The small `stress_report.py` diff here only exports the shared balanced-order vocabulary and adds the order suffix to latency-row labels; it does not touch `comparison_rate`/`median_interval_rate`.

## Validation

`python -m unittest discover -s .github/scripts -p 'test_*.py'` — **138 tests, OK** (7 new tests covering: geomean aggregate + single control ratio, attach to plain history, warning->repeated-fail progression, 3conn untouched, partial-pair fallback, per-metric aggregation fallback, diagnostic intra-run corroboration handoff).

Harness: synthetic current-result fixtures reconstructed from the real committed `.github/stress-history.json` (14 runs), run through the patched and unpatched (HEAD) CLIs.

**(a) 1b producer lanes trend against the pre-rename band instead of 0/3** — real 2026-07-29 run replayed:

Unpatched (every 1b main-lane row):
```
| producer / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,268,061.67 | - | 0/3 runs | Collecting baseline |
| producer / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,263,443.19 | - | 0/3 runs | Collecting baseline |
| producer-acks-all / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,353,024.98 | - | 0/3 runs | Collecting baseline |
... (18 such rows)
```

Patched (one aggregate row per client family, pre-rename band, real verdicts):
```
| producer / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,265,750.32 | 1,606,518.73 | 1,398,281.86 - 1,814,755.60 | Repeated regression (control-normalized warning) |
| producer / Dekaf / 1 broker / 1000B / 15m | Messages/sec / Confluent | 1.29 | 1.33 | 1.25 - 1.40 | Within band |
| producer / Confluent / 1 broker / 1000B / 15m | Messages/sec | 980,220.28 | 1,282,137.55 | 1,070,034.27 - 1,494,240.84 | Environment shift suspected (warning) |
| producer-acks-all / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,345,724.20 | 1,639,875.81 | 1,466,637.16 - 1,813,114.46 | Repeated regression (control-normalized warning) |
| producer-idempotent / Dekaf / 1 broker / 1000B / 15m | Messages/sec | 1,532,884.81 | 1,647,258.06 | 1,512,113.25 - 1,782,402.87 | Within band |
```
The 07-29 Dekaf dip is correctly detected, and correctly demoted to a control-normalized warning because Confluent dipped in the same run (ratio in band) — matching the 3conn control's independent regression signal.

**(b) Fabricated genuine regression is flagged** — producer 1b pair against the real history, three consecutive dispatches (Confluent held healthy so the ratio corroborates):
```
step1-healthy   (exit 0): | producer / Dekaf / 1b | Messages/sec | 1,554,799.02 | 1,606,518.73 | 1,398,281.86 - 1,814,755.60 | Within band |
step2-regressed (exit 0): | producer / Dekaf / 1b | Messages/sec | 1,009,950.49 | ... | Regression (warning) |
                          | Messages/sec / Confluent | 0.86 | 1.33 | 1.30 - 1.36 | Regression (warning) |
step3-regressed (exit 1): | producer / Dekaf / 1b | Messages/sec | 1,009,950.49 | ... | Repeated regression (fail) |
                          | Messages/sec / Confluent | 0.86 | ... | Regression (corroborates fail) |
::error title=Stress performance trend::Repeated regression: producer / Dekaf / 1 broker / 1000B / 15m Messages/sec=1009950.49; baseline 1554799.02, band 1303176.47-1806421.58
```

**(c) Legacy plain-label runs still parse and trend** — replayed the 2026-07-13 run (plain labels) against runs 1-8: patched and unpatched produce **byte-identical table rows, annotations, and exit code** (129 lines, exit 1).

**(d) `Dekaf (3conn)` unaffected** — all 8 absolute-metric 3conn rows (value / median / band) are identical between patched and unpatched. Two intentional, documented differences:
- 4 restored ratio rows on the 1b lanes (e.g. `producer / Dekaf (3conn) / 1b | Messages/sec / Confluent | 1.33 | 1.40 | 1.28 - 1.53 | Within band`) — the pre-rename ratio series resumes, proving the pairing the rename severed.
- Consequently the 07-29 3conn 1b repeated regressions demote from `Repeated regression (fail)` to `control-normalized warning`, because the restored ratio is in band (the drop tracks Confluent, i.e. environment). This is the designed pre-#2055 corroboration semantic for paired scenarios, not a loss of protection — the measured aggregate lanes now carry the band that the issue notes had fallen to the control group by accident.

History file shape after the patched run (no schema/version change; `orderBalancedAggregate: true` is an additive provenance flag):
```
Confluent | order=None | samples=2 | agg=True | mps=980220  | trend=regression
Dekaf     | order=None | samples=2 | agg=True | mps=1265750 | trend=regression
Dekaf     | order=confluent-first | samples=2 | mps=1268062 | trend=None   (diagnostic)
Dekaf     | order=dekaf-first     | samples=2 | mps=1263443 | trend=None   (diagnostic)
Dekaf (3conn) | order=None | samples=None | mps=1301440 | trend=regression (untouched)
```

## Notes

- The committed `.github/stress-history.json` is intentionally not migrated: the next scheduled run's aggregates attach to the pre-rename observations directly, and the dormant per-order observations from 07-16..07-29 age out via the existing retention pass.
- The replayed 07-29 run still exits 1 under the patch — from the pre-existing consumer-lane regressions and the producer-transactional false-fail that #2467 addresses, all on untouched plain-label series.

Fixes #2468
