### PR TITLE
perf(txn): remove per-message allocations from the transactional produce path

### DIFF
--- a/src/Dekaf/NetStandardPolyfillGaps.cs
+++ b/src/Dekaf/NetStandardPolyfillGaps.cs
@@ -219,6 +219,12 @@ internal static class ConcurrentCollectionCompatibilityExtensions
         where TKey : notnull
         => ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Remove(item);
 
+    /// <summary>
+    /// Allocation-free implementation of the factoryArgument overload (netstandard2.0 lacks it).
+    /// Callers use this overload with static lambdas precisely to avoid per-call closures on hot
+    /// paths, so the polyfill must not reintroduce them by wrapping the BCL two-delegate overload;
+    /// it mirrors the BCL retry-loop semantics instead (factories may run more than once on races).
+    /// </summary>
     public static TValue AddOrUpdate<TKey, TValue, TArg>(
         this ConcurrentDictionary<TKey, TValue> dictionary,
         TKey key,
@@ -226,10 +232,23 @@ internal static class ConcurrentCollectionCompatibilityExtensions
         Func<TKey, TValue, TArg, TValue> updateValueFactory,
         TArg factoryArgument)
         where TKey : notnull
-        => dictionary.AddOrUpdate(
-            key,
-            k => addValueFactory(k, factoryArgument),
-            (k, existing) => updateValueFactory(k, existing, factoryArgument));
+    {
+        while (true)
+        {
+            if (dictionary.TryGetValue(key, out var existing))
+            {
+                var updated = updateValueFactory(key, existing, factoryArgument);
+                if (dictionary.TryUpdate(key, updated, existing))
+                    return updated;
+            }
+            else
+            {
+                var added = addValueFactory(key, factoryArgument);
+                if (dictionary.TryAdd(key, added))
+                    return added;
+            }
+        }
+    }
 }
 }
 

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -538,13 +538,29 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
     /// <para>See <see cref="ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/> for
     /// the continuation-inlining behavior shared by all transactional produces.</para>
     /// <para>Implementations may optimize this overload to avoid allocating a
-    /// <see cref="ProducerMessage{TKey, TValue}"/> object on the hot path.</para>
+    /// <see cref="ProducerMessage{TKey, TValue}"/> object on the hot path; Dekaf's own
+    /// transaction does. On modern TFMs a default implementation forwards to the
+    /// <see cref="ProducerMessage{TKey, TValue}"/> overload so existing external
+    /// implementations keep compiling and loading; netstandard2.0 cannot express default
+    /// interface members, so implementations targeting it must add this member.</para>
     /// </remarks>
     ValueTask<RecordMetadata> ProduceAsync(
         string topic,
         TKey? key,
         TValue value,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default)
+#if NET
+        => ProduceAsync(
+            new ProducerMessage<TKey, TValue>
+            {
+                Topic = topic,
+                Key = key,
+                Value = value,
+            },
+            cancellationToken);
+#else
+        ;
+#endif
 
     /// <summary>
     /// Commits the transaction.

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -532,6 +532,21 @@ public interface ITransaction<TKey, TValue> : IAsyncDisposable
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Produces a message to the specified topic within the transaction.
+    /// </summary>
+    /// <remarks>
+    /// <para>See <see cref="ProduceAsync(ProducerMessage{TKey, TValue}, CancellationToken)"/> for
+    /// the continuation-inlining behavior shared by all transactional produces.</para>
+    /// <para>Implementations may optimize this overload to avoid allocating a
+    /// <see cref="ProducerMessage{TKey, TValue}"/> object on the hot path.</para>
+    /// </remarks>
+    ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Commits the transaction.
     /// </summary>
     ValueTask CommitAsync(CancellationToken cancellationToken = default);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -550,12 +550,34 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken = default)
         => ProduceAsync(message, ProduceContinuationMode.Async, cancellationToken);
 
+    /// <summary>Continuation policy shared by every transactional produce overload.</summary>
+    private ProduceContinuationMode TransactionContinuationMode
+        => _options.InlineTransactionCompletions ? ProduceContinuationMode.Inline : ProduceContinuationMode.Async;
+
     internal ValueTask<RecordMetadata> ProduceTransactionAsync(
         ProducerMessage<TKey, TValue> message,
         CancellationToken cancellationToken)
+        => ProduceAsync(message, TransactionContinuationMode, cancellationToken);
+
+    /// <summary>
+    /// Componentwise transactional produce: routes through the message-free fast path so the
+    /// serial-awaited EOS shape (1 message per request) does not pay a per-message
+    /// <see cref="ProducerMessage{TKey, TValue}"/> allocation (issue #2471). Falls back to the
+    /// message-based path only when interceptors, retry policy, or tracing require the object.
+    /// </summary>
+    internal ValueTask<RecordMetadata> ProduceTransactionAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken)
         => ProduceAsync(
-            message,
-            _options.InlineTransactionCompletions ? ProduceContinuationMode.Inline : ProduceContinuationMode.Async,
+            topic,
+            key,
+            value,
+            headers: null,
+            partition: null,
+            timestamp: null,
+            TransactionContinuationMode,
             cancellationToken);
 
     private ValueTask<RecordMetadata> ProduceAsync(
@@ -766,7 +788,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ProduceContinuationMode continuationMode,
         CancellationToken cancellationToken)
     {
-        if (_retryPolicy is not null || _interceptors is not null || Diagnostics.DekafDiagnostics.Source.HasListeners())
+        if (_retryPolicy is not null
+            || _interceptors is not null
+            || (Diagnostics.DekafDiagnostics.Source.HasListeners()
+                && !_options.SkipProduceActivityListenerCheckForTesting))
         {
             return ProduceAsync(new ProducerMessage<TKey, TValue>
             {
@@ -5137,13 +5162,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
     {
         try
         {
-            ThrowIfProducerDisposed();
-            _producer.ThrowIfFatalTransactionError("Cannot produce");
-
-            if (_committed || _aborted)
-                throw new InvalidOperationException("Transaction is already completed");
-
-            _producer.ThrowIfInPreparedTransaction();
+            ThrowIfCannotProduce();
 
             // Partition registration with AddPartitionsToTxn is handled automatically
             // by BrokerSender before the ProduceRequest is sent to the broker.
@@ -5151,20 +5170,68 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         }
         catch (OperationCanceledException exception)
         {
-            var canceledToken = exception.CancellationToken.IsCancellationRequested
-                ? exception.CancellationToken
-                : cancellationToken.IsCancellationRequested
-                    ? cancellationToken
-                    : new CancellationToken(canceled: true);
-            return new ValueTask<RecordMetadata>(Task.FromCanceled<RecordMetadata>(canceledToken));
+            return CanceledProduce(exception, cancellationToken);
         }
         catch (Exception exception)
         {
-            // Preserve async-method exception timing: validation failures fault the returned
-            // ValueTask instead of escaping synchronously from ProduceAsync.
-            return new ValueTask<RecordMetadata>(Task.FromException<RecordMetadata>(exception));
+            return FaultedProduce(exception);
         }
     }
+
+    public ValueTask<RecordMetadata> ProduceAsync(
+        string topic,
+        TKey? key,
+        TValue value,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            ThrowIfCannotProduce();
+
+            // Componentwise fast path: no ProducerMessage allocation per message (issue #2471).
+            // Partition registration with AddPartitionsToTxn is handled automatically
+            // by BrokerSender before the ProduceRequest is sent to the broker.
+            return _producer.ProduceTransactionAsync(topic, key, value, cancellationToken);
+        }
+        catch (OperationCanceledException exception)
+        {
+            return CanceledProduce(exception, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            return FaultedProduce(exception);
+        }
+    }
+
+    private void ThrowIfCannotProduce()
+    {
+        ThrowIfProducerDisposed();
+        _producer.ThrowIfFatalTransactionError("Cannot produce");
+
+        if (_committed || _aborted)
+            throw new InvalidOperationException("Transaction is already completed");
+
+        _producer.ThrowIfInPreparedTransaction();
+    }
+
+    private static ValueTask<RecordMetadata> CanceledProduce(
+        OperationCanceledException exception,
+        CancellationToken cancellationToken)
+    {
+        var canceledToken = exception.CancellationToken.IsCancellationRequested
+            ? exception.CancellationToken
+            : cancellationToken.IsCancellationRequested
+                ? cancellationToken
+                : new CancellationToken(canceled: true);
+        return new ValueTask<RecordMetadata>(Task.FromCanceled<RecordMetadata>(canceledToken));
+    }
+
+    /// <summary>
+    /// Preserves async-method exception timing: validation failures fault the returned
+    /// ValueTask instead of escaping synchronously from ProduceAsync.
+    /// </summary>
+    private static ValueTask<RecordMetadata> FaultedProduce(Exception exception)
+        => new(Task.FromException<RecordMetadata>(exception));
 
     public ValueTask CommitAsync(CancellationToken cancellationToken = default) =>
         CommitCoreAsync(afterRequestWrittenAsync: null, cancellationToken);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5203,10 +5203,12 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         }
     }
 
-    private void ThrowIfCannotProduce()
+    private void ThrowIfCannotProduce() => ThrowIfTransactionUnusable("Cannot produce");
+
+    private void ThrowIfTransactionUnusable(string operation)
     {
         ThrowIfProducerDisposed();
-        _producer.ThrowIfFatalTransactionError("Cannot produce");
+        _producer.ThrowIfFatalTransactionError(operation);
 
         if (_committed || _aborted)
             throw new InvalidOperationException("Transaction is already completed");
@@ -5331,13 +5333,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         string consumerGroupId,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfProducerDisposed();
-        _producer.ThrowIfFatalTransactionError("Cannot send offsets to transaction");
-
-        if (_committed || _aborted)
-            throw new InvalidOperationException("Transaction is already completed");
-
-        _producer.ThrowIfInPreparedTransaction();
+        ThrowIfTransactionUnusable("Cannot send offsets to transaction");
 
         await _producer.SendOffsetsToTransactionInternalAsync(offsets, consumerGroupId, cancellationToken)
             .ConfigureAwait(false);
@@ -5348,13 +5344,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
         ConsumerGroupMetadata consumerGroupMetadata,
         CancellationToken cancellationToken = default)
     {
-        ThrowIfProducerDisposed();
-        _producer.ThrowIfFatalTransactionError("Cannot send offsets to transaction");
-
-        if (_committed || _aborted)
-            throw new InvalidOperationException("Transaction is already completed");
-
-        _producer.ThrowIfInPreparedTransaction();
+        ThrowIfTransactionUnusable("Cannot send offsets to transaction");
         ArgumentNullException.ThrowIfNull(consumerGroupMetadata);
 
         await _producer.SendOffsetsToTransactionInternalAsync(

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -166,12 +166,30 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         // reference (allocation-free); that capture only takes effect on the exceptional
         // cancellation-fire path, and the awaiting caller's own state machine already retains
         // the same context for the message's lifetime.
+        //
+        // Pool-reuse safety of the mutable token field: GetResult's finally disposes this
+        // registration before the field is cleared and the source is re-rented, and on
+        // .NET Framework CancellationTokenRegistration.Dispose is documented to deregister a
+        // not-yet-started callback (it never runs) and to block until an executing callback
+        // completes (unless called from that callback's own thread, which GetResult never is).
+        // So no callback from a previous rental can fire after reuse on a compliant runtime.
+        // The IsCancellationRequested guard below is defense-in-depth for runtimes that deviate
+        // from those documented semantics: a stale fire re-reads the CURRENT field, which by
+        // then holds default (cleared) or the next operation's token — uncancelled means no-op,
+        // and a cancelled current token makes cancelling the current operation the correct
+        // outcome anyway (its own registration would do the same; TrySetCanceled CAS makes the
+        // race benign). On the legitimate fire path the guard is always true, so behavior is
+        // unchanged there.
         _registeredCancellationToken = cancellationToken;
         _cancellationRegistration = cancellationToken.Register(
             static state =>
             {
                 var source = (PooledValueTaskSource<T>)state!;
-                source.TrySetCanceled(source._registeredCancellationToken);
+                var token = source._registeredCancellationToken;
+                if (token.IsCancellationRequested)
+                {
+                    source.TrySetCanceled(token);
+                }
             },
             this);
 #endif

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -159,32 +159,21 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         // netstandard2.0: the Polyfill package's UnsafeRegister shim wraps the (state, token)
         // callback in a per-call closure (~176 B per awaited produce, issue #2471). Use the BCL
         // single-state overload with a static delegate and carry the token in a field instead.
-        // Suppress ExecutionContext flow around Register to match UnsafeRegister semantics on
-        // the NET branch: no per-message AsyncLocal capture, and cancellation continuations do
-        // not run under the caller's ambient context.
+        // Deliberately NO ExecutionContext.SuppressFlow() here (unlike the shim and the NET
+        // UnsafeRegister branch): under a non-default ambient context SuppressFlow shallow-clones
+        // the ExecutionContext on every registration — a per-message heap allocation the
+        // zero-alloc produce gate rejects. Register instead captures the caller's context by
+        // reference (allocation-free); that capture only takes effect on the exceptional
+        // cancellation-fire path, and the awaiting caller's own state machine already retains
+        // the same context for the message's lifetime.
         _registeredCancellationToken = cancellationToken;
-        var restoreFlow = false;
-        if (!ExecutionContext.IsFlowSuppressed())
-        {
-            ExecutionContext.SuppressFlow();
-            restoreFlow = true;
-        }
-
-        try
-        {
-            _cancellationRegistration = cancellationToken.Register(
-                static state =>
-                {
-                    var source = (PooledValueTaskSource<T>)state!;
-                    source.TrySetCanceled(source._registeredCancellationToken);
-                },
-                this);
-        }
-        finally
-        {
-            if (restoreFlow)
-                ExecutionContext.RestoreFlow();
-        }
+        _cancellationRegistration = cancellationToken.Register(
+            static state =>
+            {
+                var source = (PooledValueTaskSource<T>)state!;
+                source.TrySetCanceled(source._registeredCancellationToken);
+            },
+            this);
 #endif
     }
 

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -22,6 +22,10 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
     private ValueTaskSourcePool<T>? _pool;
     private Action<T, Exception?>? _deliveryHandler;
     private CancellationTokenRegistration _cancellationRegistration;
+#if !NET
+    // netstandard2.0 only: token observed by the closure-free cancellation callback.
+    private CancellationToken _registeredCancellationToken;
+#endif
     private int _hasCompleted; // 0 = not completed, 1 = completed
 
     /// <summary>
@@ -147,9 +151,23 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
             return;
 
         _cancellationRegistration.Dispose();
+#if NET
         _cancellationRegistration = cancellationToken.UnsafeRegister(
             static (state, token) => ((PooledValueTaskSource<T>)state!).TrySetCanceled(token),
             this);
+#else
+        // netstandard2.0: the Polyfill package's UnsafeRegister shim wraps the (state, token)
+        // callback in a per-call closure (~176 B per awaited produce, issue #2471). Use the BCL
+        // single-state overload with a static delegate and carry the token in a field instead.
+        _registeredCancellationToken = cancellationToken;
+        _cancellationRegistration = cancellationToken.Register(
+            static state =>
+            {
+                var source = (PooledValueTaskSource<T>)state!;
+                source.TrySetCanceled(source._registeredCancellationToken);
+            },
+            this);
+#endif
     }
 
     /// <summary>
@@ -181,6 +199,9 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         {
             _cancellationRegistration.Dispose();
             _cancellationRegistration = default;
+#if !NET
+            _registeredCancellationToken = default;
+#endif
 
             // Clear handler before returning to pool
             _deliveryHandler = null;

--- a/src/Dekaf/Producer/PooledValueTaskSource.cs
+++ b/src/Dekaf/Producer/PooledValueTaskSource.cs
@@ -159,14 +159,32 @@ public sealed class PooledValueTaskSource<T> : IValueTaskSource<T>
         // netstandard2.0: the Polyfill package's UnsafeRegister shim wraps the (state, token)
         // callback in a per-call closure (~176 B per awaited produce, issue #2471). Use the BCL
         // single-state overload with a static delegate and carry the token in a field instead.
+        // Suppress ExecutionContext flow around Register to match UnsafeRegister semantics on
+        // the NET branch: no per-message AsyncLocal capture, and cancellation continuations do
+        // not run under the caller's ambient context.
         _registeredCancellationToken = cancellationToken;
-        _cancellationRegistration = cancellationToken.Register(
-            static state =>
-            {
-                var source = (PooledValueTaskSource<T>)state!;
-                source.TrySetCanceled(source._registeredCancellationToken);
-            },
-            this);
+        var restoreFlow = false;
+        if (!ExecutionContext.IsFlowSuppressed())
+        {
+            ExecutionContext.SuppressFlow();
+            restoreFlow = true;
+        }
+
+        try
+        {
+            _cancellationRegistration = cancellationToken.Register(
+                static state =>
+                {
+                    var source = (PooledValueTaskSource<T>)state!;
+                    source.TrySetCanceled(source._registeredCancellationToken);
+                },
+                this);
+        }
+        finally
+        {
+            if (restoreFlow)
+                ExecutionContext.RestoreFlow();
+        }
 #endif
     }
 

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -662,6 +662,16 @@ public sealed class ProducerOptions
     internal bool EnableDeliveryDiagnostics { get; init; }
 
     /// <summary>
+    /// Test seam for broker-free allocation gates: skips the ActivitySource listener check on
+    /// the componentwise produce path so a gate can pin the no-listener fast path (the shape
+    /// the stress lanes measure) even when the test host installs a process-wide
+    /// sample-everything ActivityListener (e.g. TUnit's OTel span tracker). Never set outside
+    /// allocation-gate tests; setting it suppresses produce span creation for the componentwise
+    /// overloads.
+    /// </summary>
+    internal bool SkipProduceActivityListenerCheckForTesting { get; init; }
+
+    /// <summary>
     /// Enable adaptive connection scaling based on buffer pressure.
     /// When enabled, the producer will automatically increase connections per broker
     /// when sustained buffer backpressure is detected, improving drain throughput.

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2766,16 +2766,28 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     {
         foreach (var kvp in _partitionDeques)
         {
-            var pd = kvp.Value;
-            {
-                using var guard = new SpinLockGuard(ref pd.Lock);
-                var b = pd.PollFirst();
-                if (b is not null)
-                {
-                    batch = b;
-                    return true;
-                }
-            }
+            if (TryDrainBatch(kvp.Key, out batch))
+                return true;
+        }
+
+        batch = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Drains one ReadyBatch from the given partition's deque. Like <see cref="TryDrainBatch(out ReadyBatch?)"/>
+    /// this is a test-only sender-loop stand-in, but partition-targeted so strict allocation-gate
+    /// tests can drain without the all-deques enumerator allocation on the measuring thread.
+    /// </summary>
+    internal bool TryDrainBatch(
+        TopicPartition topicPartition,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out ReadyBatch? batch)
+    {
+        if (_partitionDeques.TryGetValue(topicPartition, out var pd))
+        {
+            using var guard = new SpinLockGuard(ref pd.Lock);
+            batch = pd.PollFirst();
+            return batch is not null;
         }
 
         batch = null;
@@ -5523,10 +5535,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             SignalBufferSpaceAvailable();
         }
 
+        // factoryArgument overload with static lambdas: the capturing (_, current) => ... form
+        // allocated a closure + delegate per batch, which de-amortizes to per-message at the
+        // transactional 1-message-per-batch shape (issue #2471; enter-side twin fixed by #1914).
         _partitionQueueBytes.AddOrUpdate(
             batch.TopicPartition,
-            0,
-            (_, current) => Math.Max(0, current - batch.DataSize));
+            static (_, _) => 0,
+            static (_, current, batch) => Math.Max(0, current - batch.DataSize),
+            batch);
 
         if (_options.EnableDeliveryDiagnostics)
             batch.AppendDiag('X');

--- a/tests/Dekaf.Tests.Integration/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionTests.cs
@@ -128,6 +128,55 @@ public class TransactionTests(KafkaTestContainer kafka) : TransactionalKafkaInte
     }
 
     [Test]
+    public async Task Transaction_ComponentwiseProduce_CommitAndAbortSemantics()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync();
+        var txnId = $"txn-componentwise-{Guid.NewGuid():N}";
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithTransactionalId(txnId)
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+        await producer.InitTransactionsAsync();
+
+        // Aborted componentwise produce must not be visible to read_committed consumers
+        await using (var txn = producer.BeginTransaction())
+        {
+            await txn.ProduceAsync(topic, "aborted-key", "aborted-value", CancellationToken.None);
+            await txn.AbortAsync();
+        }
+
+        // Committed componentwise produce must round-trip key and value
+        await using (var txn2 = producer.BeginTransaction())
+        {
+            var metadata = await txn2.ProduceAsync(
+                topic, "committed-key", "committed-value", CancellationToken.None);
+            await Assert.That(metadata.Offset).IsGreaterThanOrEqualTo(0);
+
+            await txn2.CommitAsync();
+        }
+
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithGroupId($"txn-consumer-{Guid.NewGuid():N}")
+            .WithAutoOffsetReset(Consumer.AutoOffsetReset.Earliest)
+            .WithIsolationLevel(IsolationLevel.ReadCommitted)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory()).BuildAsync();
+
+        consumer.Subscribe(topic);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var consumed = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(30), cts.Token);
+
+        await Assert.That(consumed).IsNotNull();
+        await Assert.That(consumed!.Value.Key).IsEqualTo("committed-key");
+        await Assert.That(consumed!.Value.Value).IsEqualTo("committed-value");
+    }
+
+    [Test]
     public async Task Transaction_MultipleMessages_AllCommitted()
     {
         var topic = await KafkaContainer.CreateTestTopicAsync();

--- a/tests/Dekaf.Tests.Unit/Performance/TransactionalProduceAllocationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Performance/TransactionalProduceAllocationTests.cs
@@ -25,19 +25,24 @@ namespace Dekaf.Tests.Unit.Performance;
 public class TransactionalProduceAllocationTests
 {
     private const string Topic = "txn-allocation-gate";
-    private const int WarmupIterations = 128;
+    private const int WarmupIterations = 4_096;
     private const int MeasuredIterations = 1_024;
 
     /// <summary>
     /// A produce cycle's steady state must allocate exactly zero bytes. The only tolerated
     /// nonzero cycles are the rare, bursty <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/>
     /// segment allocations from the accumulator's linger/ready partition queues — production
-    /// enqueues those per sealed batch too, so the growth is a real (amortized ~40 B/batch)
-    /// per-batch cost, but it surfaces as one segment per few hundred batches, not per cycle.
-    /// Any per-message or deterministic per-batch allocation makes every cycle nonzero and
-    /// fails the burst-count gate immediately.
+    /// enqueues those per sealed batch too, so the growth is a real amortized per-batch cost.
+    /// Segment sizes double per allocation, so after the long warmup the measured window can
+    /// see at most a segment boundary or two (one per queue), never a recurring cadence: a
+    /// deterministic every-N-cycles allocation exceeds the burst cap, and any small per-cycle
+    /// allocation (closures, boxing, message objects) fails both the burst cap and the
+    /// per-burst minimum below — a real queue segment at post-warmup sizes is tens of KiB,
+    /// so bursts smaller than <see cref="MinQueueSegmentAllocationBytes"/> cannot be segment
+    /// growth and fail the gate outright.
     /// </summary>
-    private const int MaxQueueSegmentGrowthBursts = 24;
+    private const int MaxQueueSegmentGrowthBursts = 3;
+    private const long MinQueueSegmentAllocationBytes = 1_024;
     private const long MaxTotalAllocatedBytes = 256 * 1024;
 
     [Test]
@@ -71,6 +76,13 @@ public class TransactionalProduceAllocationTests
         await Assert.That(measurement.Checksum).IsEqualTo(WarmupIterations + MeasuredIterations);
         await Assert.That(measurement.NonZeroCycles).IsLessThanOrEqualTo(MaxQueueSegmentGrowthBursts);
         await Assert.That(measurement.AllocatedBytes).IsLessThanOrEqualTo(MaxTotalAllocatedBytes);
+        if (measurement.NonZeroCycles > 0)
+        {
+            // Every tolerated burst must look like queue-segment growth, not a small
+            // recurring hot-path allocation slipping under the burst cap.
+            await Assert.That(measurement.MinNonZeroCycleBytes)
+                .IsGreaterThanOrEqualTo(MinQueueSegmentAllocationBytes);
+        }
     }
 
     /// <summary>
@@ -195,6 +207,7 @@ public class TransactionalProduceAllocationTests
 
         long allocatedBytes = 0;
         var nonZeroCycles = 0;
+        var minNonZeroCycleBytes = long.MaxValue;
         for (var i = 0; i < measuredIterations; i++)
         {
             var before = GC.GetAllocatedBytesForCurrentThread();
@@ -202,11 +215,15 @@ public class TransactionalProduceAllocationTests
             var cycleBytes = GC.GetAllocatedBytesForCurrentThread() - before;
             allocatedBytes += cycleBytes;
             if (cycleBytes != 0)
+            {
                 nonZeroCycles++;
+                minNonZeroCycleBytes = Math.Min(minNonZeroCycleBytes, cycleBytes);
+            }
         }
 
-        return new AllocationMeasurement(allocatedBytes, nonZeroCycles, checksum);
+        return new AllocationMeasurement(allocatedBytes, nonZeroCycles, minNonZeroCycleBytes, checksum);
     }
 
-    private readonly record struct AllocationMeasurement(long AllocatedBytes, int NonZeroCycles, int Checksum);
+    private readonly record struct AllocationMeasurement(
+        long AllocatedBytes, int NonZeroCycles, long MinNonZeroCycleBytes, int Checksum);
 }

--- a/tests/Dekaf.Tests.Unit/Performance/TransactionalProduceAllocationTests.cs
+++ b/tests/Dekaf.Tests.Unit/Performance/TransactionalProduceAllocationTests.cs
@@ -1,0 +1,212 @@
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+using Dekaf.Tests.Unit.Producer;
+
+namespace Dekaf.Tests.Unit.Performance;
+
+/// <summary>
+/// Broker-free allocation regression gate for the transactional produce caller path (issue #2471).
+/// </summary>
+/// <remarks>
+/// <para>The transactional EOS stress lane runs serial-awaited produces at ~1 message per batch,
+/// so every per-batch cost lands per message. This gate drives the full caller-side cycle at that
+/// exact shape — componentwise <c>ITransaction.ProduceAsync(topic, key, value)</c> → serialize →
+/// arena append → linger seal → drain → sender-style retirement → pooled completion await — on a
+/// single thread, and asserts the steady state allocates zero bytes per cycle after warmup.</para>
+/// <para>Out of scope (needs a socket): BrokerSender's send loop, KafkaConnection write/receive,
+/// and the EndTxn commit path. Those are pooled per-request paths measured by the stress lane's
+/// Memory &amp; GC table and by <c>TransactionalProduceAllocationBenchmarks</c>.</para>
+/// </remarks>
+[NotInParallel]
+public class TransactionalProduceAllocationTests
+{
+    private const string Topic = "txn-allocation-gate";
+    private const int WarmupIterations = 128;
+    private const int MeasuredIterations = 1_024;
+
+    /// <summary>
+    /// A produce cycle's steady state must allocate exactly zero bytes. The only tolerated
+    /// nonzero cycles are the rare, bursty <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/>
+    /// segment allocations from the accumulator's linger/ready partition queues — production
+    /// enqueues those per sealed batch too, so the growth is a real (amortized ~40 B/batch)
+    /// per-batch cost, but it surfaces as one segment per few hundred batches, not per cycle.
+    /// Any per-message or deterministic per-batch allocation makes every cycle nonzero and
+    /// fails the burst-count gate immediately.
+    /// </summary>
+    private const int MaxQueueSegmentGrowthBursts = 24;
+    private const long MaxTotalAllocatedBytes = 256 * 1024;
+
+    [Test]
+    public async Task TransactionalProduceAsync_ComponentwiseAwaitedCycle_AllocatesZeroBytes()
+    {
+        await using var producer = new KafkaProducer<string, string>(
+            CreateTransactionalProducerOptions(),
+            Serializers.String,
+            Serializers.String);
+        await producer.StopSenderLoopsForTestingAsync();
+        SeedProducerMetadata(producer);
+        InitializeTransactionalState(producer);
+
+        var transaction = producer.BeginTransaction();
+        var accumulator = producer.RecordAccumulator;
+        var topicPartition = new TopicPartition(Topic, 0);
+        using var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
+        var offset = 0L;
+
+        // The closure display class is allocated once here, before the measured window.
+        var measurement = WarmAndMeasure(
+            () => ProduceDrainAwaitOne(transaction, accumulator, topicPartition, offset++, cancellationToken),
+            WarmupIterations,
+            MeasuredIterations);
+
+        // The transaction is never committed (there is no broker); return the producer to
+        // Ready so DisposeAsync does not attempt a coordinator abort.
+        producer._transactionState = TransactionState.Ready;
+
+        await Assert.That(measurement.Checksum).IsEqualTo(WarmupIterations + MeasuredIterations);
+        await Assert.That(measurement.NonZeroCycles).IsLessThanOrEqualTo(MaxQueueSegmentGrowthBursts);
+        await Assert.That(measurement.AllocatedBytes).IsLessThanOrEqualTo(MaxTotalAllocatedBytes);
+    }
+
+    /// <summary>
+    /// One serial-awaited transactional produce cycle at the EOS stress shape (1 message per
+    /// batch): produce, seal via the linger sweep, drain, retire the batch the way BrokerSender
+    /// does, then await the caller's completion. Everything runs on the measuring thread so the
+    /// awaited ValueTask is already completed when observed (no thread-pool dispatch).
+    /// </summary>
+    private static int ProduceDrainAwaitOne(
+        ITransaction<string, string> transaction,
+        RecordAccumulator accumulator,
+        TopicPartition topicPartition,
+        long offset,
+        CancellationToken cancellationToken)
+    {
+        var produce = transaction.ProduceAsync(Topic, "allocation-key", "allocation-value", cancellationToken);
+
+        // LingerMs = 0: the sweep seals the just-appended batch immediately.
+        var seal = accumulator.ExpireLingerAsync(CancellationToken.None);
+        if (!seal.IsCompletedSuccessfully)
+            return 0;
+        seal.GetAwaiter().GetResult();
+
+        if (!accumulator.TryDrainBatch(topicPartition, out var batch))
+            return 0;
+
+        LeakGateHarness.RetireBatch(accumulator, batch, offset);
+
+        var metadata = produce.GetAwaiter().GetResult();
+        return metadata.Partition == topicPartition.Partition ? 1 : 0;
+    }
+
+    private static ProducerOptions CreateTransactionalProducerOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "txn-allocation-gate",
+        TransactionalId = "txn-allocation-gate",
+        EnableIdempotence = true,
+        Acks = Acks.All,
+        BufferMemory = 32UL * 1024 * 1024,
+        BatchSize = 1_048_576,
+        LingerMs = 0,
+        RequestTimeoutMs = 500,
+        DeliveryTimeoutMs = 1_000,
+        CloseTimeoutMs = 1_000,
+        // The test host (TUnit) installs a process-wide sample-everything ActivityListener for
+        // its OTel report, which would divert every produce onto the tracing path. The stress
+        // lane this gate mirrors runs without listeners; pin that branch.
+        SkipProduceActivityListenerCheckForTesting = true,
+    };
+
+    /// <summary>
+    /// Puts the producer in the state InitTransactionsAsync would leave it in against a
+    /// TV2 (KIP-890) broker, without a coordinator round trip. BeginTransaction derives
+    /// <c>_currentTransactionUsesTV2</c> from the published finalized feature.
+    /// </summary>
+    private static void InitializeTransactionalState(KafkaProducer<string, string> producer)
+    {
+        AccumulatorTestHelpers.SetPrivateField(producer, "_initialized", true);
+        var metadataManager = AccumulatorTestHelpers.GetPrivateField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.ObserveClusterCapabilities(
+            "txn-allocation-gate-cluster",
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = [],
+                FinalizedFeaturesEpoch = 1,
+                FinalizedFeatures =
+                [
+                    new FinalizedFeature("transaction.version", 2, 2)
+                ]
+            }));
+        producer._transactionState = TransactionState.Ready;
+    }
+
+    private static void SeedProducerMetadata(KafkaProducer<string, string> producer)
+    {
+        var metadataManager = AccumulatorTestHelpers.GetPrivateField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata
+                {
+                    NodeId = 0,
+                    Host = "localhost",
+                    Port = 9092,
+                },
+            ],
+            ClusterId = "txn-allocation-gate-cluster",
+            ControllerId = 0,
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = Topic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0],
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    private static AllocationMeasurement WarmAndMeasure(
+        Func<int> operation,
+        int warmupIterations,
+        int measuredIterations)
+    {
+        var checksum = 0;
+        for (var i = 0; i < warmupIterations; i++)
+            checksum += operation();
+
+        long allocatedBytes = 0;
+        var nonZeroCycles = 0;
+        for (var i = 0; i < measuredIterations; i++)
+        {
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            checksum += operation();
+            var cycleBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+            allocatedBytes += cycleBytes;
+            if (cycleBytes != 0)
+                nonZeroCycles++;
+        }
+
+        return new AllocationMeasurement(allocatedBytes, nonZeroCycles, checksum);
+    }
+
+    private readonly record struct AllocationMeasurement(long AllocatedBytes, int NonZeroCycles, int Checksum);
+}

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -102,6 +102,8 @@ public sealed class TransactionTests
 
         await Assert.That(() => transaction.ProduceAsync(message).AsTask())
             .Throws<FatalTransactionException>();
+        await Assert.That(() => transaction.ProduceAsync("test-topic", "key", "value").AsTask())
+            .Throws<FatalTransactionException>();
         await Assert.That(() => transaction.SendOffsetsToTransactionAsync(
                 [new TopicPartitionOffset("test-topic", 0, 1)], "test-group").AsTask())
             .Throws<FatalTransactionException>();
@@ -430,6 +432,10 @@ public sealed class TransactionTests
                 Topic = "orders",
                 Value = "value"
             });
+        }).Throws<InvalidOperationException>();
+        await Assert.That(async () =>
+        {
+            await transaction.ProduceAsync("orders", key: null, "value");
         }).Throws<InvalidOperationException>();
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -33,6 +33,9 @@ public class TransactionalProduceAllocationBenchmarks
     private IKafkaProducer<string, string> _producer = null!;
     private ITransaction<string, string> _transaction = null!;
     private ProducerMessage<string, string> _message = null!;
+    private RecordAccumulator _accumulator = null!;
+    private TopicPartition _topicPartition;
+    private long _offset;
 
     [GlobalSetup]
     public async Task Setup()
@@ -41,6 +44,7 @@ public class TransactionalProduceAllocationBenchmarks
             .WithBootstrapServers("localhost:9092")
             .WithTransactionalId("benchmark-transaction-allocation")
             .WithBufferMemory(ulong.MaxValue)
+            .WithLinger(TimeSpan.Zero)
             .Build();
         var producer = (KafkaProducer<string, string>)_producer;
         await producer.StopSenderLoopsForTestingAsync();
@@ -49,6 +53,8 @@ public class TransactionalProduceAllocationBenchmarks
         SetField(producer, "_initialized", true);
         SetField(producer, "_transactionState", TransactionState.Ready);
         _transaction = _producer.BeginTransaction();
+        _accumulator = producer.RecordAccumulator;
+        _topicPartition = new TopicPartition("benchmark-transaction-allocation", 0);
         _message = new ProducerMessage<string, string>
         {
             Topic = "benchmark-transaction-allocation",
@@ -60,15 +66,40 @@ public class TransactionalProduceAllocationBenchmarks
 
     [Benchmark(Baseline = true)]
     public void ProducerProduceAsync() =>
-        _ = _producer.ProduceAsync(_message);
+        CompleteCycle(_producer.ProduceAsync(_message));
 
     [Benchmark]
     public void TransactionProduceAsync() =>
-        _ = _transaction.ProduceAsync(_message);
+        CompleteCycle(_transaction.ProduceAsync(_message));
 
     [Benchmark]
     public void TransactionProduceAsyncComponentwise() =>
-        _ = _transaction.ProduceAsync("benchmark-transaction-allocation", "key", "value");
+        CompleteCycle(_transaction.ProduceAsync("benchmark-transaction-allocation", "key", "value"));
+
+    /// <summary>
+    /// Completes the serial-awaited one-message-per-batch lifecycle the EOS stress lane
+    /// runs (and the unit allocation gate mirrors): linger sweep seals the just-appended
+    /// batch, the batch is drained and retired the way BrokerSender does, and the caller's
+    /// awaited ValueTask is consumed so the pooled completion source returns to its pool.
+    /// Without this, every invocation would accumulate pending records and rent a fresh
+    /// source, measuring pool churn instead of the steady-state produce cycle.
+    /// </summary>
+    private void CompleteCycle(ValueTask<RecordMetadata> produce)
+    {
+        var seal = _accumulator.ExpireLingerAsync(CancellationToken.None);
+        if (seal.IsCompletedSuccessfully)
+            seal.GetAwaiter().GetResult();
+
+        if (_accumulator.TryDrainBatch(_topicPartition, out var batch))
+        {
+            batch.CompleteSend(_offset++, DateTimeOffset.UtcNow);
+            _accumulator.ReleaseBatchMemory(batch);
+            _accumulator.OnBatchExitsPipeline(batch);
+            _accumulator.ReturnReadyBatch(batch);
+        }
+
+        _ = produce.GetAwaiter().GetResult();
+    }
 
     private static void SeedMetadata(MetadataManager metadataManager) =>
         metadataManager.Metadata.Update(new MetadataResponse

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -66,6 +66,10 @@ public class TransactionalProduceAllocationBenchmarks
     public void TransactionProduceAsync() =>
         _ = _transaction.ProduceAsync(_message);
 
+    [Benchmark]
+    public void TransactionProduceAsyncComponentwise() =>
+        _ = _transaction.ProduceAsync("benchmark-transaction-allocation", "key", "value");
+
     private static void SeedMetadata(MetadataManager metadataManager) =>
         metadataManager.Metadata.Update(new MetadataResponse
         {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/TransactionalProduceAllocationBenchmarks.cs
@@ -36,6 +36,7 @@ public class TransactionalProduceAllocationBenchmarks
     private RecordAccumulator _accumulator = null!;
     private TopicPartition _topicPartition;
     private long _offset;
+    private CancellationTokenSource _cancellation = null!;
 
     [GlobalSetup]
     public async Task Setup()
@@ -55,13 +56,16 @@ public class TransactionalProduceAllocationBenchmarks
         _transaction = _producer.BeginTransaction();
         _accumulator = producer.RecordAccumulator;
         _topicPartition = new TopicPartition("benchmark-transaction-allocation", 0);
+        // No explicit Partition: every benchmark routes through the partitioner
+        // (single-partition topic) so the componentwise overload's partition
+        // selection cost is not asymmetrically absent from the message paths.
         _message = new ProducerMessage<string, string>
         {
             Topic = "benchmark-transaction-allocation",
-            Partition = 0,
             Key = "key",
             Value = "value"
         };
+        _cancellation = new CancellationTokenSource();
     }
 
     [Benchmark(Baseline = true)]
@@ -75,6 +79,16 @@ public class TransactionalProduceAllocationBenchmarks
     [Benchmark]
     public void TransactionProduceAsyncComponentwise() =>
         CompleteCycle(_transaction.ProduceAsync("benchmark-transaction-allocation", "key", "value"));
+
+    /// <summary>
+    /// Same cycle with a live cancellable token so RegisterCancellation runs per
+    /// produce (UnsafeRegister on modern TFMs); GetResult disposes the registration
+    /// each cycle, so the steady state must stay allocation-free.
+    /// </summary>
+    [Benchmark]
+    public void TransactionProduceAsyncComponentwiseCancellable() =>
+        CompleteCycle(_transaction.ProduceAsync(
+            "benchmark-transaction-allocation", "key", "value", _cancellation.Token));
 
     /// <summary>
     /// Completes the serial-awaited one-message-per-batch lifecycle the EOS stress lane

--- a/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs
@@ -89,12 +89,9 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
                         ? TransactionalSequenceOracle.CommittedKey(runId, ordinal)
                         : TransactionalSequenceOracle.AbortedKey(runId, ordinal);
 
-                    await transaction.ProduceAsync(new ProducerMessage<string, string>
-                    {
-                        Topic = options.Topic,
-                        Key = key,
-                        Value = messageValue
-                    }, cancellationToken).ConfigureAwait(false);
+                    // Componentwise overload: no per-message ProducerMessage allocation (#2471).
+                    await transaction.ProduceAsync(options.Topic, key, messageValue, cancellationToken)
+                        .ConfigureAwait(false);
 
                     transactionAccepted++;
                     throughput.RecordMessage(options.MessageSizeBytes);
@@ -199,12 +196,8 @@ internal sealed class TransactionalProducerStressTest : IStressTestScenario
     {
         Console.WriteLine("  Warming up Dekaf transactional producer...");
         await using var transaction = producer.BeginTransaction();
-        await transaction.ProduceAsync(new ProducerMessage<string, string>
-        {
-            Topic = topic,
-            Key = "transactional-warmup",
-            Value = "warmup"
-        }, cancellationToken).ConfigureAwait(false);
+        await transaction.ProduceAsync(topic, "transactional-warmup", "warmup", cancellationToken)
+            .ConfigureAwait(false);
         await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary

Attributes the 644 B/msg on the Transactional EOS stress lane (run 30441232202) and fixes the two per-message library allocations that are safely fixable. The lane's serial-awaited shape puts exactly 1 message in every batch/request, so **per-batch and per-request costs de-amortize to per-message** — the attribution below classifies each site accordingly. The stress figure is measured process-wide (`GcStats` wraps `GC.GetTotalAllocatedBytes`), so stress-harness allocations count toward the 644 B too.

## Attribution table

| Site | Class | Measured | Disposition |
|---|---|---:|---|
| `Transaction`/`ITransaction` forced a `ProducerMessage<K,V>` (sealed record) per produce — the only produce API with no componentwise overload | per message | ~80 B | **Fixed** — new `ITransaction.ProduceAsync(topic, key, value, ct)` routed through the existing message-free fast path; stress lane switched to it |
| `RecordAccumulator.OnBatchExitsPipeline`: `_partitionQueueBytes.AddOrUpdate` **capturing lambda** (closure + delegate per batch) — the exit-side twin of the enter-side #1914 fix, missed then; hits **every** producer workload per batch | per batch (= per message here) | 88 B/batch | **Fixed** — static lambdas + `factoryArgument` overload; gate is mutation-verified against this exact revert |
| netstandard2.0 `AddOrUpdate<TArg>` polyfill wrapped the BCL two-delegate overload with **two capturing lambdas** — every `factoryArgument` call site (this one, the #1914 enter side, consumer sites) silently allocated *more* on that TFM | per batch on ns2.0 | n/a (found by review) | **Fixed** — lambda-free `TryGetValue`/`TryUpdate`/`TryAdd` retry loop with BCL semantics |
| netstandard2.0 `PooledValueTaskSource.RegisterCancellation`: the Polyfill package's `UnsafeRegister` shim wraps the `(state, token)` callback in a **per-call closure** — every awaited cancellable produce on the ns2.0 asset (which net8 consumers get) paid it | per message on ns2.0 | 176 B/msg (net8 bisect: produce phase 218.8 → 42.8 after fix) | **Fixed** — `#if !NET` path uses the BCL single-state `Register` overload with a static delegate; token carried in a field |
| Accumulator `_lingerPartitions` + `_readyPartitions` (`ConcurrentQueue<TopicPartition>`) segment growth: ~2 enqueues per sealed batch, segments are single-use | per batch, bursty (amortized) | ~43 B/batch | **Left** — structural to `ConcurrentQueue`; ~0.04 B/msg at normal 1000-msg batches; an intrusive-list redesign of two hot structures is not P3-safe. Gate tolerates ≤24 burst cycles/1024 so any *deterministic* per-batch alloc still fails |
| BrokerSender + connection full cycle (send loop, per-request mute/unmute `ConcurrentDictionary` node ~48 B, event-channel segments, response processing) — measured broker-free with the real send loop + `TestKafkaConnection`, 1 batch/request serial-awaited | per request | ~282 B/cycle incl. ~100 B known test-double noise (`CastResponseTask` `Task`) → **~180 B/request** real | **Left** — the pipelined request/response path itself is pooled (#1925); the residual is mute-tracking dictionary nodes + queue segments; node-free redesign is a follow-up |
| Caller path: componentwise produce → serialize → arena append → linger seal → drain → sender-style retire → pooled completion await | per message | **0 B steady state** | **Locked in** by the new gate |
| Stress harness: oracle key `$"{runId}:c:{n}"` + `long.ToString` per message | per message (harness) | ~145 B | **Left** — the EOS verification oracle requires unique keys; this is harness measurement overhead, not library allocation |
| Per-commit: `FlushAsync`, EndTxn `SendAsync` Task + state machine, `Transaction` object, `BeginTransaction` bookkeeping | per commit (/100 msgs) | ≲10 B/msg amortized | **Left** — correctly amortized per the CLAUDE.md framework |

Reconciliation: ~168 B/msg of the 644 is removed by this PR (80 + 88); of the remainder, ~145 is harness-borne, ~43 + ~180 is per-batch/per-request structural cost in queues/mute tracking, ~10 per-commit, rest is real-connection specifics and background samplers not reachable broker-free. **The 644 B/msg stress figure gets re-measured on the next weekly scheduled run.**

## Evidence

Broker-free single-thread bisect (stopped sender loops, seeded metadata, TV2 txn state, 1024 measured cycles, `GC.GetAllocatedBytesForCurrentThread`):

| Phase | before | after fixes |
|---|---:|---:|
| produce (append + seal + batch open) | 42.8 B/cycle (bursty: 0 in a 96-cycle histogram) | 42.8 (queue segments only) |
| retire (CompleteSend → ReleaseBatchMemory → **OnBatchExitsPipeline** → ReturnReadyBatch) | 88.0 B/cycle, all in `OnBatchExitsPipeline` | **0.0** |
| seal / drain / await | 0.0 | 0.0 |

- Mutation check: reverting the `AddOrUpdate` fix makes every cycle nonzero and fails the gate's burst-count assertion immediately (observed: `Expected ≤ 24`, got 1024 nonzero cycles).
- Full sender-loop cycle (real `BrokerSender` + scripted `TestKafkaConnection`, serial-awaited, `GC.GetTotalAllocatedBytes(precise: true)`, idle control 0.2 KB/100 ms): 281.7 B/cycle.
- Measurement gotcha worth recording: TUnit's OTel report installs a process-wide sample-everything `ActivityListener`, which makes `DekafDiagnostics.Source.HasListeners()` true and diverts the componentwise produce onto the tracing path (~1,589 B/cycle of `Activity` + message + tracing-wrapper allocations). That is correct OTel behavior, not a leak — but it is not the shape the (listener-free) stress lane runs. The gate pins the no-listener branch via a new internal init-only `ProducerOptions.SkipProduceActivityListenerCheckForTesting` seam, short-circuited **after** `HasListeners()` so production codegen on the listener-free path is unchanged.

## Changes

- `src/Dekaf/Producer/RecordAccumulator.cs` — exit-side `AddOrUpdate` closure → static lambdas + `factoryArgument`; new partition-targeted `TryDrainBatch(TopicPartition, out ReadyBatch?)` test seam (the existing all-deques seam allocates a `ConcurrentDictionary` enumerator per call, unusable inside a strict allocation gate) with the all-deques overload delegating to it.
- `src/Dekaf/NetStandardPolyfillGaps.cs` — allocation-free `AddOrUpdate<TArg>` polyfill.
- `src/Dekaf/Producer/PooledValueTaskSource.cs` — closure-free ns2.0 cancellation registration (`#if !NET`); the net10 `UnsafeRegister` path is unchanged.
- `src/Dekaf/Producer/IKafkaProducer.cs` — `ITransaction<TKey,TValue>.ProduceAsync(string topic, TKey? key, TValue value, CancellationToken)`, mirroring `IKafkaProducer`'s componentwise overload. **Note:** interface addition = source-breaking for external `ITransaction` implementors (none in-repo besides the internal `Transaction`; `InMemoryProducer.BeginTransaction` throws `NotSupportedException`); tagged `+semver:minor`.
- `src/Dekaf/Producer/KafkaProducer.cs` — componentwise `ProduceTransactionAsync` (shared `TransactionContinuationMode`), `Transaction` implementation with shared `ThrowIfCannotProduce`/`CanceledProduce`/`FaultedProduce` helpers; componentwise divert condition consumes the new options seam.
- `src/Dekaf/Producer/ProducerOptions.cs` — internal `SkipProduceActivityListenerCheckForTesting` (init-only, follows the `EnableDeliveryDiagnostics` internal-knob precedent).
- `tests/Dekaf.Tests.Unit/Performance/TransactionalProduceAllocationTests.cs` — new broker-free allocation gate at the exact EOS 1-msg-per-batch shape: steady-state cycles must allocate exactly 0 bytes (≤24 bursty queue-segment cycles per 1024 tolerated, ≤256 KB total). Complements the existing `TransactionalProduceAllocationBenchmarks` (BDN) by running in PR CI.
- `tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs` — validation coverage for the new overload (fatal-error fail-fast, after-prepare rejection).
- `tools/Dekaf.StressTests/Scenarios/TransactionalProducerStressTest.cs` — main loop + warmup use the componentwise overload (sentinel produce keeps the message overload for its explicit `Partition`).

## Deliberately not fixed (follow-up candidates)

- `_partitionQueueBytes` keyed on `TopicPartition` hashes the topic string twice per batch (enter + exit); moving the counter onto `PartitionDeque` (already in scope at enter time) would remove both dictionary ops entirely.
- Per-request mute/unmute `ConcurrentDictionary` node (~48 B/request at 1 msg/request).
- Linger/ready partition queues' `ConcurrentQueue` segment churn (intrusive MPSC list of `PartitionDeque` nodes would be zero-alloc).
- Transactional validation reads `_transactionState` three times per produce across `Transaction` + `ThrowIfProduceCannotStart` (pre-existing; exception-type semantics differ per layer).

## Test results

- New gate runs on **both** TFMs (it caught the ns2.0 `RegisterCancellation` closure the first time it ran on net8) and passes on both.
- Full unit suite: net10.0 6582/6582 passed; net8.0 (netstandard2.0 Dekaf asset) 6455/6455 passed.
- No stress dispatch: P3, absolute pressure ~212 KB/s; the weekly scheduled run re-measures the lane figure (Rule 7 — no paid lane spend for this).

Fixes #2471
