### PR TITLE
bench(consumer): decompose the post-#2097 CPU/msg climb — staging is free, value materialization is the floor (#2485)

### DIFF
--- a/src/Dekaf/Builders.cs
+++ b/src/Dekaf/Builders.cs
@@ -3146,8 +3146,8 @@ public sealed class ConsumerBuilder<TKey, TValue>
         {
             keyDeserializer = (IDeserializer<TKey>)(object)new CachingStringDeserializer(
                 stringSerde,
-                maxCachedBytes: 128,
-                maxCachedEntries: 16_384);
+                CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+                CachingStringDeserializer.DefaultKeyCacheMaxEntries);
         }
 
         if (_cacheStringValues && valueDeserializer is StringSerde valueStringSerde)

--- a/src/Dekaf/Serialization/CachingStringDeserializer.cs
+++ b/src/Dekaf/Serialization/CachingStringDeserializer.cs
@@ -30,6 +30,13 @@ namespace Dekaf.Serialization;
 /// </remarks>
 internal sealed class CachingStringDeserializer : ISerde<string>
 {
+    /// <summary>Shape of the default key-cache wrap <c>ConsumerBuilder</c> applies to the
+    /// built-in string key deserializer. Kept here (single source of truth) so benchmarks
+    /// measuring "the builder default" reference the same values instead of drifting
+    /// copies.</summary>
+    internal const int DefaultKeyCacheMaxBytes = 128;
+    internal const int DefaultKeyCacheMaxEntries = 16_384;
+
     /// <summary>Observe mode samples one of every this-many cache-eligible lookups.</summary>
     internal const int ObserveSampleStride = 8;
     /// <summary>Maximum slots in the observe-mode recent-hash table. The table is sized to

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/CachingStringDeserializerBenchmarks.cs
@@ -22,9 +22,13 @@ public class CachingStringDeserializerBenchmarks
         Component = SerializationComponent.Key
     };
     private readonly CachingStringDeserializer _repeatedDeserializer =
-        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+        new(Serializers.String,
+            CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+            CachingStringDeserializer.DefaultKeyCacheMaxEntries);
     private readonly CachingStringDeserializer _boundedDeserializer =
-        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+        new(Serializers.String,
+            CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+            CachingStringDeserializer.DefaultKeyCacheMaxEntries);
     private ReadOnlyMemory<byte>[] _uniqueKeys = null!;
     private ReadOnlyMemory<byte>[] _boundedKeys = null!;
     private ReadOnlyMemory<byte> _repeatedKey;
@@ -56,8 +60,10 @@ public class CachingStringDeserializerBenchmarks
         var characters = 0;
         for (var pass = 0; pass < UniquePassCount; pass++)
         {
-            var deserializer =
-                new CachingStringDeserializer(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+            var deserializer = new CachingStringDeserializer(
+                Serializers.String,
+                CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+                CachingStringDeserializer.DefaultKeyCacheMaxEntries);
             for (var i = 0; i < _uniqueKeys.Length; i++)
                 characters += deserializer.Deserialize(_uniqueKeys[i], _context).Length;
         }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncBufferedFastPathBenchmarks.cs
@@ -1,8 +1,7 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -91,29 +90,15 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
             },
             Serializers.RawBytes,
             Serializers.RawBytes);
-        InitializeForBufferedFastPath(_consumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_consumer, Topic, Partition);
     }
 
     [IterationSetup]
     public void IterationSetup()
     {
-        DrainPendingFetches();
         _iterationCancellation = new CancellationTokenSource();
-
-        var batches = new RecordBatch[BatchCount];
-        for (var batchIndex = 0; batchIndex < BatchCount; batchIndex++)
-        {
-            var batch = RecordBatch.RentFromPool();
-            batch.BaseOffset = (long)batchIndex * RecordsPerBatch;
-            batch.BaseTimestamp = 1_700_000_000_000L;
-            batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
-            batch.LastOffsetDelta = RecordsPerBatch - 1;
-            batch.Attributes = RecordBatchAttributes.None;
-            batch.Records = _batchRecords[batchIndex % SeedArrayCount];
-            batches[batchIndex] = batch;
-        }
-
-        GetPendingFetches().Enqueue(PendingFetchData.Create(Topic, Partition, batches));
+        BufferedConsumerHarness.ReseedPendingFetches(
+            _consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
     }
 
     [IterationCleanup]
@@ -143,51 +128,7 @@ public class ConsumeAsyncBufferedFastPathBenchmarks
     [GlobalCleanup]
     public async Task Cleanup()
     {
-        DrainPendingFetches();
+        BufferedConsumerHarness.DrainPendingFetches(_consumer);
         await _consumer.DisposeAsync().ConfigureAwait(false);
     }
-
-    private void DrainPendingFetches()
-    {
-        var pendingFetches = GetPendingFetches();
-        while (pendingFetches.Count > 0)
-            pendingFetches.Dequeue().Dispose();
-    }
-
-    private static void InitializeForBufferedFastPath(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-    {
-        SetPrivateField(consumer, "_initialized", true);
-
-        var topicPartition = new TopicPartition(Topic, Partition);
-        consumer.Assign(topicPartition);
-        GetFetchPositions(consumer)[topicPartition] = 0;
-
-        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
-        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
-    }
-
-    private Queue<PendingFetchData> GetPendingFetches() =>
-        (Queue<PendingFetchData>)GetPrivateField(_consumer, "_pendingFetches")!;
-
-    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer) =>
-        (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
-
-    private static object? GetPrivateField(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
-        string fieldName) =>
-        RequireField(fieldName).GetValue(consumer);
-
-    private static void SetPrivateField(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
-        string fieldName,
-        object? value) =>
-        RequireField(fieldName).SetValue(consumer, value);
-
-    private static FieldInfo RequireField(string fieldName) =>
-        typeof(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>).GetField(
-            fieldName,
-            BindingFlags.NonPublic | BindingFlags.Instance)
-        ?? throw new InvalidOperationException($"{fieldName} field not found.");
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
@@ -1,0 +1,273 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Docker-free decomposition of the streaming <c>ConsumeAsync</c> per-message CPU budget
+/// for issue #2485: isolates (a) proven-offset staging overhead (at-least-once default,
+/// added by #2097) and (b) string value materialization for 1000-byte payloads (the
+/// post-#2097 plain-decode cost), against the raw drain-loop floor.
+/// </summary>
+/// <remarks>
+/// Row deltas, not absolute values, are the measurement:
+/// <list type="bullet">
+/// <item><c>Raw_AutoCommitAtLeastOnce</c> − <c>Raw_ManualCommit</c> = per-message
+/// proven-offset staging (active-position seqlock publish).</item>
+/// <item><c>Raw_AutoCommitAtMostOnce</c> − <c>Raw_ManualCommit</c> = the opt-in
+/// OnDelivery eager per-message offset store, for comparison with the default.</item>
+/// <item><c>ConstantStringValue_AutoCommit</c> − <c>Raw_AutoCommitAtLeastOnce</c> = the
+/// <c>string</c>-vs-value-type generic instantiation shape (shared-generic dispatch,
+/// result-struct width) with no decode or allocation.</item>
+/// <item><c>StringValue_AutoCommit</c> − <c>ConstantStringValue_AutoCommit</c> = pure
+/// value materialization at 1000 B (UTF-8 decode + ~2 KB string allocation + GC).</item>
+/// <item><c>StressShape_AutoCommit</c> − <c>StringValue_AutoCommit</c> = key-side cost at
+/// key-cache steady state (bounded 10,010-key set mirroring the stress lane's
+/// PreAllocatedKeys(10_000); promotion is forced in setup so the row cannot silently
+/// measure the observe regime).</item>
+/// <item><c>Utf8Decode_Control</c> = the irreducible cost of
+/// <see cref="Encoding.UTF8.GetString(ReadOnlySpan{byte})"/> for the same 1000 B payload
+/// under the same job and engine configuration.</item>
+/// </list>
+/// Seeding and warmup mirror <see cref="ConsumeAsyncBufferedFastPathBenchmarks"/>: the
+/// extended warmup lets tiered PGO finish recompiling the async iterator, and the batch
+/// count stays under the RecordBatch pool capacity (2048).
+/// </remarks>
+[MemoryDiagnoser]
+[ThroughputJob(warmupCount: 15)]
+public class ConsumeAsyncStagingSerdeBenchmarks
+{
+    // 1,501,500 records/iteration keeps the raw rows above BenchmarkDotNet's 100 ms
+    // recommendation (~70-90 ns/record) and stays off the poll-refresh boundary
+    // (asserted in Setup) so cancellation lands after final fetch cleanup.
+    private const int RecordsPerBatch = 1_001;
+    private const int BatchCount = 1_500;
+    private const int MessageCount = RecordsPerBatch * BatchCount;
+    // 10 arrays × 1,001 records = 10,010 distinct keys, matching the stress lane's
+    // bounded PreAllocatedKeys(10_000) working set so the default key cache serves the
+    // stress-shape row from hit steady state.
+    private const int SeedArrayCount = 10;
+    // The stress consumer lane's message size (1 broker / 1000 B / consumer): the shape
+    // issue #2485 targets.
+    private const int MessageSize = 1_000;
+    private const string Topic = "consume-async-staging-serde";
+    private const int Partition = 0;
+
+    private Record[][] _batchRecords = null!;
+    private byte[] _valueBytes = null!;
+    private KafkaConsumer<Ignore, ReadOnlyMemory<byte>> _rawManualConsumer = null!;
+    private KafkaConsumer<Ignore, ReadOnlyMemory<byte>> _rawAtLeastOnceConsumer = null!;
+    private KafkaConsumer<Ignore, ReadOnlyMemory<byte>> _rawAtMostOnceConsumer = null!;
+    private KafkaConsumer<Ignore, string> _constantStringConsumer = null!;
+    private KafkaConsumer<Ignore, string> _stringValueConsumer = null!;
+    private KafkaConsumer<string, string> _stressShapeConsumer = null!;
+    private CancellationTokenSource? _iterationCancellation;
+
+    /// <summary>
+    /// Returns one cached string without touching the payload: the value-side null
+    /// measurement that separates the <c>string</c> instantiation shape from the actual
+    /// UTF-8 decode + allocation.
+    /// </summary>
+    private sealed class ConstantStringDeserializer : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) => "constant";
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (MessageCount % KafkaConsumer<Ignore, ReadOnlyMemory<byte>>.PollRefreshRecordInterval == 0)
+        {
+            throw new InvalidOperationException(
+                "MessageCount must stay off the poll-refresh boundary so cancellation lands after final fetch cleanup.");
+        }
+
+        // One identical value instance across every record, like the seeded stress topic.
+        _valueBytes = Encoding.UTF8.GetBytes(new string('x', MessageSize));
+        var keyPayloads = new ReadOnlyMemory<byte>[SeedArrayCount * RecordsPerBatch];
+        _batchRecords = new Record[SeedArrayCount][];
+        for (var batchIndex = 0; batchIndex < SeedArrayCount; batchIndex++)
+        {
+            var records = new Record[RecordsPerBatch];
+            for (var recordIndex = 0; recordIndex < RecordsPerBatch; recordIndex++)
+            {
+                var keyIndex = batchIndex * RecordsPerBatch + recordIndex;
+                var key = Encoding.UTF8.GetBytes($"key-{keyIndex}");
+                keyPayloads[keyIndex] = key;
+                records[recordIndex] = new Record
+                {
+                    OffsetDelta = recordIndex,
+                    TimestampDelta = recordIndex,
+                    Key = key,
+                    IsKeyNull = false,
+                    Value = _valueBytes,
+                    IsValueNull = false,
+                    Headers = null,
+                    HeaderCount = 0,
+                };
+            }
+
+            _batchRecords[batchIndex] = records;
+        }
+
+        _rawManualConsumer = CreateConsumer(
+            OffsetCommitMode.Manual, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.RawBytes);
+        _rawAtLeastOnceConsumer = CreateConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.RawBytes);
+        _rawAtMostOnceConsumer = CreateConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.OnDelivery, Serializers.Ignore, Serializers.RawBytes);
+        _constantStringConsumer = CreateConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.AfterProcessing, Serializers.Ignore,
+            new ConstantStringDeserializer());
+        _stringValueConsumer = CreateConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.String);
+
+        // Key deserializer matches the ConsumerBuilder default wrap exactly (same
+        // constants), and promotion is driven to completion here so the measured
+        // iterations start in the cached steady state the row's name claims — if the
+        // 10,010-key set ever stops promoting, setup fails loudly instead of silently
+        // measuring the observe regime.
+        var stressShapeKeyDeserializer = new CachingStringDeserializer(
+            Serializers.String,
+            CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+            CachingStringDeserializer.DefaultKeyCacheMaxEntries);
+        CachingDeserializerWarmup.PromoteOrThrow(
+            stressShapeKeyDeserializer,
+            new SerializationContext { Topic = Topic, Component = SerializationComponent.Key },
+            keyPayloads);
+        _stressShapeConsumer = CreateConsumer(
+            OffsetCommitMode.Auto, OffsetStoreTiming.AfterProcessing, stressShapeKeyDeserializer,
+            Serializers.String);
+    }
+
+    private static KafkaConsumer<TKey, TValue> CreateConsumer<TKey, TValue>(
+        OffsetCommitMode commitMode,
+        OffsetStoreTiming storeTiming,
+        IDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer)
+    {
+        var consumer = new KafkaConsumer<TKey, TValue>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = commitMode,
+                OffsetStoreTiming = storeTiming,
+                QueuedMinMessages = 1,
+                FetchMaxWaitMs = 200,
+            },
+            keyDeserializer,
+            valueDeserializer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(consumer, Topic, Partition);
+        return consumer;
+    }
+
+    [IterationSetup(Targets = [nameof(Raw_ManualCommit)])]
+    public void RawManualIterationSetup() => ReseedPendingFetches(_rawManualConsumer);
+
+    [IterationSetup(Targets = [nameof(Raw_AutoCommitAtLeastOnce)])]
+    public void RawAtLeastOnceIterationSetup() => ReseedPendingFetches(_rawAtLeastOnceConsumer);
+
+    [IterationSetup(Targets = [nameof(Raw_AutoCommitAtMostOnce)])]
+    public void RawAtMostOnceIterationSetup() => ReseedPendingFetches(_rawAtMostOnceConsumer);
+
+    [IterationSetup(Targets = [nameof(ConstantStringValue_AutoCommit)])]
+    public void ConstantStringIterationSetup() => ReseedPendingFetches(_constantStringConsumer);
+
+    [IterationSetup(Targets = [nameof(StringValue_AutoCommit)])]
+    public void StringValueIterationSetup() => ReseedPendingFetches(_stringValueConsumer);
+
+    [IterationSetup(Targets = [nameof(StressShape_AutoCommit)])]
+    public void StressShapeIterationSetup() => ReseedPendingFetches(_stressShapeConsumer);
+
+    // Empty on purpose: an IterationSetup forces the same engine configuration
+    // (InvocationCount = 1, UnrollFactor = 1) as the drain rows, so the control's
+    // overhead subtraction and per-op allocation accounting match the rows it is
+    // subtracted from.
+    [IterationSetup(Targets = [nameof(Utf8Decode_Control)])]
+    public void Utf8DecodeControlIterationSetup()
+    {
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _iterationCancellation?.Dispose();
+        _iterationCancellation = null;
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = MessageCount)]
+    public Task<int> Raw_ManualCommit() => DrainAsync(_rawManualConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public Task<int> Raw_AutoCommitAtLeastOnce() => DrainAsync(_rawAtLeastOnceConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public Task<int> Raw_AutoCommitAtMostOnce() => DrainAsync(_rawAtMostOnceConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public Task<int> ConstantStringValue_AutoCommit() => DrainAsync(_constantStringConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public Task<int> StringValue_AutoCommit() => DrainAsync(_stringValueConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public Task<int> StressShape_AutoCommit() => DrainAsync(_stressShapeConsumer);
+
+    [Benchmark(OperationsPerInvoke = MessageCount)]
+    public int Utf8Decode_Control()
+    {
+        var bytes = _valueBytes;
+        var lengthSum = 0;
+        for (var i = 0; i < MessageCount; i++)
+            lengthSum += Encoding.UTF8.GetString(bytes).Length;
+        return lengthSum;
+    }
+
+    private async Task<int> DrainAsync<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
+    {
+        var count = 0;
+        try
+        {
+            await foreach (var _ in consumer.ConsumeAsync(_iterationCancellation!.Token).ConfigureAwait(false))
+            {
+                if (++count == MessageCount)
+                    _iterationCancellation.Cancel();
+            }
+        }
+        catch (OperationCanceledException) when (_iterationCancellation!.IsCancellationRequested)
+        {
+            // ConsumeAsync polls indefinitely once buffered data is drained. The token ends
+            // the invocation only after the pending-fetch cleanup measured above completes.
+        }
+
+        return count;
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await DisposeConsumerAsync(_rawManualConsumer);
+        await DisposeConsumerAsync(_rawAtLeastOnceConsumer);
+        await DisposeConsumerAsync(_rawAtMostOnceConsumer);
+        await DisposeConsumerAsync(_constantStringConsumer);
+        await DisposeConsumerAsync(_stringValueConsumer);
+        await DisposeConsumerAsync(_stressShapeConsumer);
+    }
+
+    private static async Task DisposeConsumerAsync<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
+    {
+        BufferedConsumerHarness.DrainPendingFetches(consumer);
+        await consumer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private void ReseedPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
+    {
+        _iterationCancellation = new CancellationTokenSource();
+        BufferedConsumerHarness.ReseedPendingFetches(
+            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
@@ -234,10 +234,12 @@ public class ConsumeAsyncStagingSerdeBenchmarks
     [Benchmark(OperationsPerInvoke = MessageCount)]
     public int Utf8Decode_Control()
     {
-        var bytes = _valueBytes;
+        // ReadOnlyMemory + .Span mirrors StringSerde.Deserialize exactly — the span
+        // overload, not GetString(byte[]), so the subtraction isolates the same call.
+        ReadOnlyMemory<byte> bytes = _valueBytes;
         var lengthSum = 0;
         for (var i = 0; i < MessageCount; i++)
-            lengthSum += Encoding.UTF8.GetString(bytes).Length;
+            lengthSum += Encoding.UTF8.GetString(bytes.Span).Length;
         return lengthSum;
     }
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
@@ -16,9 +16,17 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// <remarks>
 /// Row deltas, not absolute values, are the measurement:
 /// <list type="bullet">
-/// <item><c>Raw_AutoCommitAtLeastOnce</c> − <c>Raw_ManualCommit</c> = per-message
-/// proven-offset staging (active-position seqlock publish).</item>
-/// <item><c>Raw_AutoCommitAtMostOnce</c> − <c>Raw_ManualCommit</c> = the opt-in
+/// <item><c>Raw_AutoCommitAtLeastOnce</c> − <c>Raw_ManualCommit</c> = the at-least-once
+/// default's per-message staging cost: the active-position seqlock publish (gated on
+/// <c>OffsetCommitMode.Auto</c>) plus the fetch-boundary proven-offset store (the
+/// baseline runs with <c>EnableAutoOffsetStore = false</c>, so the auto row pays it
+/// alone). The store executes once per pending fetch — once per seeded 1.5M-record fetch
+/// here, once per ~1000-record fetch in production — so its amortized share is sub-0.1
+/// ns/msg in either shape; the per-message component is the publish. The proven-offset
+/// marks themselves (<c>MarkYieldedProcessed</c>, two plain field writes) run
+/// unconditionally on every consume path and are therefore part of every row's floor,
+/// not of this delta.</item>
+/// <item><c>Raw_AutoCommitAtMostOnce</c> − <c>Raw_AutoCommitAtLeastOnce</c> = the opt-in
 /// OnDelivery eager per-message offset store, for comparison with the default.</item>
 /// <item><c>ConstantStringValue_AutoCommit</c> − <c>Raw_AutoCommitAtLeastOnce</c> = the
 /// <c>string</c>-vs-value-type generic instantiation shape (shared-generic dispatch,
@@ -114,8 +122,11 @@ public class ConsumeAsyncStagingSerdeBenchmarks
             _batchRecords[batchIndex] = records;
         }
 
+        // The floor row disables offset storage entirely so the auto rows' deltas carry
+        // the whole at-least-once staging cost (publish + fetch-boundary store).
         _rawManualConsumer = CreateConsumer(
-            OffsetCommitMode.Manual, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.RawBytes);
+            OffsetCommitMode.Manual, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.RawBytes,
+            enableAutoOffsetStore: false);
         _rawAtLeastOnceConsumer = CreateConsumer(
             OffsetCommitMode.Auto, OffsetStoreTiming.AfterProcessing, Serializers.Ignore, Serializers.RawBytes);
         _rawAtMostOnceConsumer = CreateConsumer(
@@ -148,7 +159,8 @@ public class ConsumeAsyncStagingSerdeBenchmarks
         OffsetCommitMode commitMode,
         OffsetStoreTiming storeTiming,
         IDeserializer<TKey> keyDeserializer,
-        IDeserializer<TValue> valueDeserializer)
+        IDeserializer<TValue> valueDeserializer,
+        bool enableAutoOffsetStore = true)
     {
         var consumer = new KafkaConsumer<TKey, TValue>(
             new ConsumerOptions
@@ -156,6 +168,7 @@ public class ConsumeAsyncStagingSerdeBenchmarks
                 BootstrapServers = ["localhost:9092"],
                 OffsetCommitMode = commitMode,
                 OffsetStoreTiming = storeTiming,
+                EnableAutoOffsetStore = enableAutoOffsetStore,
                 QueuedMinMessages = 1,
                 FetchMaxWaitMs = 200,
             },

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeAsyncStagingSerdeBenchmarks.cs
@@ -43,7 +43,8 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 /// </list>
 /// Seeding and warmup mirror <see cref="ConsumeAsyncBufferedFastPathBenchmarks"/>: the
 /// extended warmup lets tiered PGO finish recompiling the async iterator, and the batch
-/// count stays under the RecordBatch pool capacity (2048).
+/// count stays under the RecordBatch pool's pre-ratchet capacity (2048; consumer
+/// construction ratchets it higher).
 /// </remarks>
 [MemoryDiagnoser]
 [ThroughputJob(warmupCount: 15)]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneBufferedFastPathBenchmarks.cs
@@ -1,10 +1,9 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -105,12 +104,12 @@ public class ConsumeOneBufferedFastPathBenchmarks
             },
             Serializers.RawBytes,
             Serializers.RawBytes);
-        InitializeForBufferedFastPath(_groupedConsumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_groupedConsumer, Topic, Partition);
 
         // CanUseBufferedConsumeOneFastPath requires a live auto-commit loop in Auto mode.
         // A surrogate incomplete task satisfies IsAutoCommitRunning without network I/O.
         _autoCommitSurrogate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        SetPrivateField(_groupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
+        BufferedConsumerHarness.SetPrivateField(_groupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
 
         _noGroupConsumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new ConsumerOptions
@@ -122,7 +121,7 @@ public class ConsumeOneBufferedFastPathBenchmarks
             },
             Serializers.RawBytes,
             Serializers.RawBytes);
-        InitializeForBufferedFastPath(_noGroupConsumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_noGroupConsumer, Topic, Partition);
     }
 
     [IterationSetup(Targets = [nameof(PollOne_Grouped_AutoCommit)])]
@@ -145,76 +144,14 @@ public class ConsumeOneBufferedFastPathBenchmarks
     public void Cleanup()
     {
         _autoCommitSurrogate.TrySetResult();
-        DrainPendingFetches(_groupedConsumer);
-        DrainPendingFetches(_noGroupConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_groupedConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_noGroupConsumer);
         _groupedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _noGroupConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 
     private void ReseedPendingFetches(
         KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-    {
-        DrainPendingFetches(consumer);
-
-        var batches = new RecordBatch[BatchCount];
-        for (var b = 0; b < BatchCount; b++)
-        {
-            var batch = RecordBatch.RentFromPool();
-            batch.BaseOffset = (long)b * RecordsPerBatch;
-            batch.BaseTimestamp = 1_700_000_000_000L;
-            batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
-            batch.LastOffsetDelta = RecordsPerBatch - 1;
-            batch.Attributes = RecordBatchAttributes.None;
-            batch.Records = _batchRecords[b % SeedArrayCount];
-            batches[b] = batch;
-        }
-
-        GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(Topic, Partition, batches));
-    }
-
-    private static void DrainPendingFetches(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-    {
-        var pendingFetches = GetPendingFetches(consumer);
-        while (pendingFetches.Count > 0)
-            pendingFetches.Dequeue().Dispose();
-    }
-
-    private static void InitializeForBufferedFastPath(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-    {
-        SetPrivateField(consumer, "_initialized", true);
-
-        var tp = new TopicPartition(Topic, Partition);
-        consumer.Assign(tp);
-        GetFetchPositions(consumer)[tp] = 0;
-
-        // Mark the manual assignment as acknowledged so the fast path's currency check passes.
-        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
-        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
-    }
-
-    private static Queue<PendingFetchData> GetPendingFetches(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-        => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
-
-    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
-        => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
-
-    private static object? GetPrivateField(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
-        string fieldName)
-        => RequireField(fieldName).GetValue(consumer);
-
-    private static void SetPrivateField(
-        KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer,
-        string fieldName,
-        object? value)
-        => RequireField(fieldName).SetValue(consumer, value);
-
-    private static FieldInfo RequireField(string fieldName)
-        => typeof(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>)
-               .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
-           ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        => BufferedConsumerHarness.ReseedPendingFetches(
+            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneStringSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneStringSerdeBenchmarks.cs
@@ -162,9 +162,9 @@ public class ConsumeOneStringSerdeBenchmarks
     public void Cleanup()
     {
         _autoCommitSurrogate.TrySetResult();
-        DrainPendingFetches(_stringGroupedConsumer);
-        DrainPendingFetches(_stringNoGroupConsumer);
-        DrainPendingFetches(_rawBytesConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_stringGroupedConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_stringNoGroupConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_rawBytesConsumer);
         _stringGroupedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _stringNoGroupConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _rawBytesConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
@@ -180,7 +180,4 @@ public class ConsumeOneStringSerdeBenchmarks
         new(Serializers.String,
             CachingStringDeserializer.DefaultKeyCacheMaxBytes,
             CachingStringDeserializer.DefaultKeyCacheMaxEntries);
-
-    private static void DrainPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
-        => BufferedConsumerHarness.DrainPendingFetches(consumer);
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneStringSerdeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ConsumeOneStringSerdeBenchmarks.cs
@@ -1,10 +1,9 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Jobs;
+using Dekaf.Benchmarks.Infrastructure;
 using Dekaf.Consumer;
 using Dekaf.Protocol.Records;
 using Dekaf.Serialization;
@@ -103,12 +102,12 @@ public class ConsumeOneStringSerdeBenchmarks
             },
             CreatePollSingleKeyDeserializer(),
             Serializers.String);
-        InitializeForBufferedFastPath(_stringGroupedConsumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_stringGroupedConsumer, Topic, Partition);
 
         // CanUseBufferedConsumeOneFastPath requires a live auto-commit loop in Auto mode.
         // A surrogate incomplete task satisfies IsAutoCommitRunning without network I/O.
         _autoCommitSurrogate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        SetPrivateField(_stringGroupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
+        BufferedConsumerHarness.SetPrivateField(_stringGroupedConsumer, "_autoCommitTask", _autoCommitSurrogate.Task);
 
         _stringNoGroupConsumer = new KafkaConsumer<string, string>(
             new ConsumerOptions
@@ -120,7 +119,7 @@ public class ConsumeOneStringSerdeBenchmarks
             },
             CreatePollSingleKeyDeserializer(),
             Serializers.String);
-        InitializeForBufferedFastPath(_stringNoGroupConsumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_stringNoGroupConsumer, Topic, Partition);
 
         _rawBytesConsumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
             new ConsumerOptions
@@ -132,7 +131,7 @@ public class ConsumeOneStringSerdeBenchmarks
             },
             Serializers.RawBytes,
             Serializers.RawBytes);
-        InitializeForBufferedFastPath(_rawBytesConsumer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(_rawBytesConsumer, Topic, Partition);
     }
 
     [IterationSetup(Targets = [nameof(String_Grouped_AutoCommit)])]
@@ -172,68 +171,16 @@ public class ConsumeOneStringSerdeBenchmarks
     }
 
     private void ReseedPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
-    {
-        DrainPendingFetches(consumer);
+        => BufferedConsumerHarness.ReseedPendingFetches(
+            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
 
-        var batches = new RecordBatch[BatchCount];
-        for (var b = 0; b < BatchCount; b++)
-        {
-            var batch = RecordBatch.RentFromPool();
-            batch.BaseOffset = (long)b * RecordsPerBatch;
-            batch.BaseTimestamp = 1_700_000_000_000L;
-            batch.MaxTimestamp = 1_700_000_000_000L + RecordsPerBatch - 1;
-            batch.LastOffsetDelta = RecordsPerBatch - 1;
-            batch.Attributes = RecordBatchAttributes.None;
-            batch.Records = _batchRecords[b % SeedArrayCount];
-            batches[b] = batch;
-        }
-
-        // Create attaches this PendingFetchData's owner/generation to every batch.
-        // Draining and disposing it therefore returns all rented batches to the pool.
-        GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(Topic, Partition, batches));
-    }
-
+    // Mirrors the ConsumerBuilder default key wrap; the constants are shared so a builder
+    // retune cannot leave this benchmark silently measuring a stale configuration.
     private static CachingStringDeserializer CreatePollSingleKeyDeserializer() =>
-        new(Serializers.String, maxCachedBytes: 128, maxCachedEntries: 16_384);
+        new(Serializers.String,
+            CachingStringDeserializer.DefaultKeyCacheMaxBytes,
+            CachingStringDeserializer.DefaultKeyCacheMaxEntries);
 
     private static void DrainPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
-    {
-        var pendingFetches = GetPendingFetches(consumer);
-        while (pendingFetches.Count > 0)
-            pendingFetches.Dequeue().Dispose();
-    }
-
-    private static void InitializeForBufferedFastPath<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
-    {
-        SetPrivateField(consumer, "_initialized", true);
-
-        var tp = new TopicPartition(Topic, Partition);
-        consumer.Assign(tp);
-        GetFetchPositions(consumer)[tp] = 0;
-
-        // Mark the manual assignment as acknowledged so the fast path's currency check passes.
-        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
-        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
-    }
-
-    private static Queue<PendingFetchData> GetPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
-        => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
-
-    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
-        KafkaConsumer<TKey, TValue> consumer)
-        => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
-
-    private static object? GetPrivateField<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer, string fieldName)
-        => RequireField<TKey, TValue>(fieldName).GetValue(consumer);
-
-    private static void SetPrivateField<TKey, TValue>(
-        KafkaConsumer<TKey, TValue> consumer,
-        string fieldName,
-        object? value)
-        => RequireField<TKey, TValue>(fieldName).SetValue(consumer, value);
-
-    private static FieldInfo RequireField<TKey, TValue>(string fieldName)
-        => typeof(KafkaConsumer<TKey, TValue>)
-               .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
-           ?? throw new InvalidOperationException($"{fieldName} field not found.");
+        => BufferedConsumerHarness.DrainPendingFetches(consumer);
 }

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -17,7 +17,9 @@ namespace Dekaf.Benchmarks.Infrastructure;
 /// <c>_assignmentEnsureVersion</c>, <c>_lastManualAssignmentEnsureVersion</c>); a rename
 /// there fails these helpers at runtime, which is why the contract lives in exactly one
 /// place. Callers must keep their seeded batch count at or below the
-/// <see cref="RecordBatch"/> pool capacity (2048) or every reseed allocates the excess.
+/// <see cref="RecordBatch"/> pool capacity or every reseed allocates the excess; the
+/// pool defaults to 2048 and constructing a consumer ratchets it upward, so staying
+/// under the pre-ratchet 2048 is always safe.
 /// </remarks>
 internal static class BufferedConsumerHarness
 {

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Infrastructure;
+
+/// <summary>
+/// Shared reflection-seeding harness for Docker-free consumer benchmarks: initializes a
+/// <see cref="KafkaConsumer{TKey, TValue}"/> for the buffered fast path and seeds its
+/// pending-fetch queue directly, so benchmarks measure the drain/poll paths without a
+/// broker (#2211 lineage).
+/// </summary>
+/// <remarks>
+/// This is a stringly-typed contract against private <c>KafkaConsumer</c> fields
+/// (<c>_pendingFetches</c>, <c>_fetchPositions</c>, <c>_initialized</c>,
+/// <c>_assignmentEnsureVersion</c>, <c>_lastManualAssignmentEnsureVersion</c>); a rename
+/// there fails these helpers at runtime, which is why the contract lives in exactly one
+/// place. Callers must keep their seeded batch count at or below the
+/// <see cref="RecordBatch"/> pool capacity (2048) or every reseed allocates the excess.
+/// </remarks>
+internal static class BufferedConsumerHarness
+{
+    /// <summary>
+    /// Marks the consumer initialized, assigns the partition, and acknowledges the manual
+    /// assignment so the buffered fast path's currency check passes.
+    /// </summary>
+    public static void InitializeForBufferedFastPath<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer,
+        string topic,
+        int partition)
+    {
+        SetPrivateField(consumer, "_initialized", true);
+
+        var topicPartition = new TopicPartition(topic, partition);
+        consumer.Assign(topicPartition);
+        GetFetchPositions(consumer)[topicPartition] = 0;
+
+        var ensureVersion = GetPrivateField(consumer, "_assignmentEnsureVersion");
+        SetPrivateField(consumer, "_lastManualAssignmentEnsureVersion", ensureVersion);
+    }
+
+    /// <summary>
+    /// Drains any leftover pending fetch, then enqueues one <see cref="PendingFetchData"/>
+    /// of <paramref name="batchCount"/> pooled batches cycling the given seed record
+    /// arrays. Batch disposal only nulls the batch's own record-list reference, never the
+    /// array contents, so seed arrays are safely shared across batches and iterations.
+    /// </summary>
+    public static void ReseedPendingFetches<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer,
+        string topic,
+        int partition,
+        Record[][] seedRecordArrays,
+        int batchCount,
+        int recordsPerBatch)
+    {
+        DrainPendingFetches(consumer);
+
+        var batches = new RecordBatch[batchCount];
+        for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
+        {
+            var batch = RecordBatch.RentFromPool();
+            batch.BaseOffset = (long)batchIndex * recordsPerBatch;
+            batch.BaseTimestamp = 1_700_000_000_000L;
+            batch.MaxTimestamp = 1_700_000_000_000L + recordsPerBatch - 1;
+            batch.LastOffsetDelta = recordsPerBatch - 1;
+            batch.Attributes = RecordBatchAttributes.None;
+            batch.Records = seedRecordArrays[batchIndex % seedRecordArrays.Length];
+            batches[batchIndex] = batch;
+        }
+
+        // Create attaches this PendingFetchData's owner/generation to every batch, so
+        // draining and disposing it returns all rented batches to the pool.
+        GetPendingFetches(consumer).Enqueue(PendingFetchData.Create(topic, partition, batches));
+    }
+
+    public static void DrainPendingFetches<TKey, TValue>(KafkaConsumer<TKey, TValue> consumer)
+    {
+        var pendingFetches = GetPendingFetches(consumer);
+        while (pendingFetches.Count > 0)
+            pendingFetches.Dequeue().Dispose();
+    }
+
+    public static Queue<PendingFetchData> GetPendingFetches<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer)
+        => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
+
+    public static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer)
+        => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
+
+    public static object? GetPrivateField<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer,
+        string fieldName)
+        => RequireField<TKey, TValue>(fieldName).GetValue(consumer);
+
+    public static void SetPrivateField<TKey, TValue>(
+        KafkaConsumer<TKey, TValue> consumer,
+        string fieldName,
+        object? value)
+        => RequireField<TKey, TValue>(fieldName).SetValue(consumer, value);
+
+    private static FieldInfo RequireField<TKey, TValue>(string fieldName)
+        => typeof(KafkaConsumer<TKey, TValue>)
+               .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+           ?? throw new InvalidOperationException($"{fieldName} field not found.");
+}

--- a/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/BufferedConsumerHarness.cs
@@ -81,15 +81,15 @@ internal static class BufferedConsumerHarness
             pendingFetches.Dequeue().Dispose();
     }
 
-    public static Queue<PendingFetchData> GetPendingFetches<TKey, TValue>(
+    private static Queue<PendingFetchData> GetPendingFetches<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer)
         => (Queue<PendingFetchData>)GetPrivateField(consumer, "_pendingFetches")!;
 
-    public static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
+    private static ConcurrentDictionary<TopicPartition, long> GetFetchPositions<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer)
         => (ConcurrentDictionary<TopicPartition, long>)GetPrivateField(consumer, "_fetchPositions")!;
 
-    public static object? GetPrivateField<TKey, TValue>(
+    private static object? GetPrivateField<TKey, TValue>(
         KafkaConsumer<TKey, TValue> consumer,
         string fieldName)
         => RequireField<TKey, TValue>(fieldName).GetValue(consumer);

--- a/tools/Dekaf.Benchmarks/Infrastructure/CachingDeserializerWarmup.cs
+++ b/tools/Dekaf.Benchmarks/Infrastructure/CachingDeserializerWarmup.cs
@@ -18,9 +18,13 @@ internal static class CachingDeserializerWarmup
         SerializationContext context,
         ReadOnlyMemory<byte>[] payloads)
     {
-        // One fill pass, then an all-hit stream needs stride * threshold samples;
-        // 8x slack absorbs window resets and sampling phase effects.
-        var maxLookups = payloads.Length
+        // Cycling a payload set of length L against 1-in-stride sampling phase-locks:
+        // the sampled position advances by (L mod stride) per pass, so a given position
+        // is re-sampled — the first opportunity for a tag hit — only after up to
+        // L * stride lookups (e.g. L = 10,010, stride = 8: every 4th pass). Cover that
+        // full coverage cycle, then an ~all-hit stream needs stride * threshold samples;
+        // 8x slack absorbs window resets and tag evictions.
+        var maxLookups = payloads.Length * CachingStringDeserializer.ObserveSampleStride
             + 8 * CachingStringDeserializer.ObserveSampleStride * CachingStringDeserializer.PromoteSampledHits;
 
         for (var i = 0; i < maxLookups && !deserializer.IsCacheEnabled; i++)


### PR DESCRIPTION
## Summary

First deliverable for #2485: `[MemoryDiagnoser]` micro-benchmarks that decompose the post-#2097 consumer CPU/msg climb into its hypothesized contributors — (a) proven-offset staging (the at-least-once default) and (b) 1000 B value string materialization — measured against the raw streaming drain-loop floor, with in-run controls for the pure UTF-8 decode and for the `string` generic-instantiation shape.

The measurements show the two named contributors resolve to **zero** and **the irreducible like-for-like decode cost** respectively, so per "measure, never assume" this PR ships the evidence and the decomposition harness rather than speculative hot-path churn. No behavioral `src/` change; the only `src/` diff is hoisting the builder's inline key-cache literals into named internal constants (`CachingStringDeserializer.DefaultKeyCacheMaxBytes/Entries`, IL-identical) so the benchmarks reference the same values instead of drifting copies.

## Changes

- **New `ConsumeAsyncStagingSerdeBenchmarks`** — Docker-free, seeds the streaming `ConsumeAsync` path directly, stress-lane shape: 1000 B single repeated value, bounded 10,010-key set mirroring `PreAllocatedKeys(10_000)`, key cache driven through promotion in setup via `CachingDeserializerWarmup.PromoteOrThrow` so the stress-shape row cannot silently measure the observe regime.
- **New `Infrastructure/BufferedConsumerHarness`** — the reflection-seeding consumer harness, extracted instead of pasting a fourth copy; `ConsumeAsyncBufferedFastPathBenchmarks`, `ConsumeOneBufferedFastPathBenchmarks`, and `ConsumeOneStringSerdeBenchmarks` migrated to it (mechanical, setup-only code — nothing in any measured region changed). The stringly-typed private-field contract against `KafkaConsumer` now lives in exactly one place.
- **`src/`**: key-cache default literals (128 / 16,384) promoted to named internal constants on `CachingStringDeserializer`; `ConsumerBuilder` and both "builder default" benchmarks reference them. Const-only, zero runtime effect.

## Results (i7-12700K, .NET 10.0.10, per message, 1000 B values)

Reported as **cross-run bands over five local runs** (three of the original shape, two after the review fix that gives the baseline `EnableAutoOffsetStore = false`), because single-run means on the string rows carry GC-driven StdDev up to ±34 ns:

| Row | Mean band | Alloc | Isolates |
|---|---:|---:|---|
| Raw_ManualCommit (floor, store disabled) | 62.1–67.4 ns | 0 B | streaming drain-loop floor |
| Raw_AutoCommitAtLeastOnce | 62.2–73.0 ns | 0 B | **(a) at-least-once staging (publish + fetch-boundary store) = +0.03 to +5.6 ns across all five runs** |
| Raw_AutoCommitAtMostOnce | 132.4–153.8 ns | 0 B | opt-in OnDelivery eager store = +70 to +81 ns vs the default |
| ConstantStringValue_AutoCommit | 66.3–81.7 ns | 0 B | `string` generic-instantiation shape = 0 to +14 ns (≈ noise) |
| StringValue_AutoCommit | 182.7–229.8 ns | 2,024 B | **(b) value materialization @1000 B = +117 to +157 ns** |
| StressShape_AutoCommit | 196.4–251.7 ns | 2,024 B | key side at cache steady state = −23 to +60 ns (straddles 0, noise-level) |
| Utf8Decode_Control | 93.9–146.7 ns | 2,024 B | pure `Encoding.UTF8.GetString(1000 B)`, same engine config |

(The fetch-boundary proven-offset store amortizes once per fetch — sub-0.1 ns/msg at production ~1000-record fetch cadence — so the per-message component of (a) is the active-position seqlock publish; `MarkYieldedProcessed` runs unconditionally and is part of every row's floor. Full report in `BenchmarkDotNet.Artifacts` on any run of `--filter "*ConsumeAsyncStagingSerde*"`.)

## Conclusions

1. **(a) Proven-offset staging is bounded at ≤ ~6 ns/msg** — 0.03–5.6 ns across five runs, i.e. under 2 % of the +360 ns/msg stress climb. The at-least-once default (#2097) is exonerated as a CPU contributor. What the delta isolates: the per-message active-position seqlock publish plus the fetch-boundary proven-offset store (baseline runs with offset storage disabled); the store amortizes per fetch and the unconditional `MarkYieldedProcessed` marks are part of every row's floor. (Verified there is no hidden auto-commit background activity: with no coordinator the auto-commit loop never starts.)
2. **(b) Value materialization is the whole climb, and it is already at the irreducible floor.** The string-value delta over the raw row decomposes into the `string`-instantiation shape (constant-string control) plus pure UTF-8 decode + 2,024 B string allocation (in-run `GetString` control); Dekaf-side overhead beyond those is noise-level. Allocation is exactly the returned string — zero hidden allocations. Confluent pays the same decode + allocation (plus a native→managed copy Dekaf doesn't). There is no like-for-like optimization available in this path, and the stress lane deliberately keeps value caching off for fairness (see `ConsumerStressTest`).
3. **Key-side cost at cache steady state is ~zero** (stress-shape row ≈ string-value row in time and allocation, with promotion now asserted) — #2461's evidence-first key cache holds up in the stress shape.
4. **Bonus finding:** the opt-in `WithAtMostOnceProcessing` (`OffsetStoreTiming.OnDelivery`) path costs ~+70 ns/msg (three `ConcurrentDictionary` writes per message) — over 2× the at-least-once default's tracking cost. The per-message dictionary writes are semantically required (committable-at-delivery), so this is documentation-by-benchmark, with a possible follow-up if that path ever matters at stress scale.

## Where the recovery must come from

A supplementary run under 2-logical-core affinity + Server GC (approximating the pinned stress client) shows the string rows' cost and variance balloon (up to ~345 ns with StdDev ± 72) while the raw rows stay ~flat vs the 20-core numbers — consistent with the stress runner's larger climb (+0.36 µs there vs +0.12–0.16 µs locally) being GC/memory-bandwidth amplification of the same 2 KB/msg, not additional Dekaf-side code cost. A DATAS on/off A/B in that shape was **inconclusive** locally (control rows moved contrary to the hypothesis; a 2-core desktop simulation is too noisy) — if stress-harness GC configuration is worth pursuing it needs a properly paired stress experiment and a maintainer decision, since it shifts every lane's bands for both clients.

The remaining Dekaf-side lever with real magnitude is the **base fetch-path cost shared with the raw lanes** (raw lane ≈ 0.47 µs/msg on the stress runner vs the ~64 ns local drain floor — fetch pipeline, parse, CRC, buffer management), which is separate from the two #2485-named contributors.

## Rule 7 note

No behavioral `src/` change → no stress dispatch spent on this PR. The benchmarks give future #2485 candidates a local causal gate before any paid lane run.

Refs #2485.
