### PR TITLE
docs: Simplify benchmarks page with plain-English at-a-glance summary

### DIFF
--- a/.github/scripts/benchmark_docs.py
+++ b/.github/scripts/benchmark_docs.py
@@ -17,6 +17,19 @@ _BENCHMARK_NAME = re.compile(
     r"(?P<client>Dekaf|Confluent)_(?P<operation>[^()]+)"
     r"(?P<parameters>\(.*\))?$"
 )
+_DEKAF_METHOD = re.compile(r"Dekaf_(?P<operation>\w+)")
+
+# Ratios inside this band are indistinguishable from CI noise.
+_PARITY_LOW = 0.83
+_PARITY_HIGH = 1.20
+
+_SCENARIO_LABELS = {
+    ("ProducerBenchmarks", "ProduceSingle"): ("Produce — one message at a time (awaited)", 0),
+    ("ProducerBenchmarks", "ProduceBatch"): ("Produce — batches", 1),
+    ("ProducerBenchmarks", "FireAndForget"): ("Produce — fire-and-forget", 2),
+    ("ConsumerBenchmarks", "ConsumeAll"): ("Consume — drain a topic", 3),
+    ("ConsumerPollBenchmarks", "PollSingle"): ("Consume — poll a single message", 4),
+}
 
 
 def load_history(path):
@@ -95,6 +108,144 @@ def rolling_comparisons(entries, window=DEFAULT_WINDOW):
     )
 
 
+def _scenario_label(group, operation):
+    return _SCENARIO_LABELS.get((group, operation), (f"{group}.{operation}", 99))
+
+
+def _times(value):
+    return f"{value:.0f}×" if value >= 9.95 else f"{value:.1f}×"
+
+
+def describe_speed(ratio):
+    if ratio < _PARITY_LOW:
+        return f"{_times(1 / ratio)} faster"
+    if ratio <= _PARITY_HIGH:
+        return "on par"
+    return f"{_times(ratio)} slower"
+
+
+def describe_speed_range(best, worst):
+    best_text = describe_speed(best)
+    worst_text = describe_speed(worst)
+    if best_text == worst_text:
+        return best_text
+    if best_text.endswith("faster") and worst_text.endswith("faster"):
+        return f"{_times(1 / worst)}–{_times(1 / best)} faster"
+    if best_text.endswith("slower") and worst_text.endswith("slower"):
+        return f"{_times(best)}–{_times(worst)} slower"
+    return f"{worst_text} to {best_text}"
+
+
+def describe_memory(alloc_ratio):
+    if alloc_ratio is None:
+        return "—"
+    if alloc_ratio <= 0:
+        return "zero allocations"
+    if alloc_ratio < _PARITY_LOW:
+        return f"{_times(1 / alloc_ratio)} less"
+    if alloc_ratio <= _PARITY_HIGH:
+        return "on par"
+    return f"{_times(alloc_ratio)} more"
+
+
+def summarize_scenarios(comparisons, variance_threshold=DEFAULT_VARIANCE_THRESHOLD):
+    scenarios = {}
+    for comparison in comparisons:
+        key = (comparison["group"], comparison["operation"])
+        scenarios.setdefault(key, []).append(comparison)
+
+    summaries = []
+    for (group, operation), rows in scenarios.items():
+        medians = [row["median"] for row in rows]
+        stable = sum(
+            1
+            for row in rows
+            if row["runs"] >= 2 and row["relative_spread"] <= variance_threshold
+        )
+        summaries.append(
+            {
+                "group": group,
+                "operation": operation,
+                "best": min(medians),
+                "worst": max(medians),
+                "median": median(medians),
+                "stable_rows": stable,
+                "total_rows": len(rows),
+            }
+        )
+
+    def sort_key(item):
+        label, order = _scenario_label(item["group"], item["operation"])
+        return (order, label)
+
+    return sorted(summaries, key=sort_key)
+
+
+def latest_alloc_ratios(paths):
+    """Median Dekaf-vs-Confluent allocation ratio per operation from latest-run tables."""
+    ratios = {}
+    for markdown_path in paths:
+        method_index = None
+        alloc_index = None
+        for line in Path(markdown_path).read_text(encoding="utf-8").splitlines():
+            if not line.startswith("|"):
+                continue
+            cells = [_cell_text(cell) for cell in line.strip().strip("|").split("|")]
+            if "Method" in cells:
+                method_index = cells.index("Method")
+                alloc_index = (
+                    cells.index("Alloc Ratio") if "Alloc Ratio" in cells else None
+                )
+                continue
+            if method_index is None or alloc_index is None or len(cells) <= alloc_index:
+                continue
+            match = _DEKAF_METHOD.search(cells[method_index])
+            if match is None:
+                continue
+            try:
+                value = float(cells[alloc_index])
+            except ValueError:
+                continue
+            ratios.setdefault(match.group("operation"), []).append(value)
+
+    return {operation: median(values) for operation, values in ratios.items()}
+
+
+def _confidence_label(stable_rows, total_rows):
+    if total_rows == 0:
+        return "⚠ Insufficient history"
+    if stable_rows == total_rows:
+        return "Stable"
+    if stable_rows == 0:
+        return "⚠ Noisy"
+    return "Mixed"
+
+
+def format_summary_table(summaries, alloc_ratios):
+    lines = [
+        "| Scenario | Speed vs Confluent | Memory vs Confluent | Confidence |",
+        "|---|---|---|---|",
+    ]
+
+    for summary in summaries:
+        label, _ = _scenario_label(summary["group"], summary["operation"])
+        lines.append(
+            "| {label} | {speed} | {memory} | {confidence} |".format(
+                label=label,
+                speed=describe_speed_range(summary["best"], summary["worst"]),
+                memory=describe_memory(alloc_ratios.get(summary["operation"])),
+                confidence=_confidence_label(
+                    summary["stable_rows"], summary["total_rows"]
+                ),
+            )
+        )
+
+    if not summaries:
+        lines.append("| No comparable history yet | — | — | ⚠ Insufficient history |")
+
+    return lines
+
+
 def format_rolling_table(comparisons, variance_threshold):
     lines = [
         "| Benchmark | Parameters | Runs | Median Ratio | Ratio Range | Run Spread | Confidence |",
@@ -171,7 +322,8 @@ def annotate_ratio_confidence(lines, variance_threshold):
     return output
 
 
-def append_tables(output, paths, variance_threshold=None):
+def collect_tables(paths, variance_threshold=None):
+    output = []
     for markdown_path in paths:
         lines = Path(markdown_path).read_text(encoding="utf-8").splitlines()
         if variance_threshold is not None:
@@ -179,6 +331,18 @@ def append_tables(output, paths, variance_threshold=None):
         else:
             output.extend(line for line in lines if line.startswith("|"))
         output.append("")
+    return output
+
+
+def _details_section(summary, body_lines):
+    return [
+        "<details>",
+        f"<summary>{summary}</summary>",
+        "",
+        *body_lines,
+        "</details>",
+        "",
+    ]
 
 
 def generate_document(
@@ -192,6 +356,15 @@ def generate_document(
     comparisons = rolling_comparisons(history, window)
     result_pattern = str(Path(results_dir))
 
+    producer_md = sorted(
+        glob.glob(f"{result_pattern}/Client/results/*ProducerBenchmarks*-github.md")
+    )
+    consumer_md = sorted(
+        glob.glob(f"{result_pattern}/Client/results/*Consumer*Benchmarks*-github.md")
+    )
+    alloc_ratios = latest_alloc_ratios(producer_md + consumer_md)
+    summaries = summarize_scenarios(comparisons, variance_threshold)
+
     output = [
         "---",
         "sidebar_position: 13",
@@ -199,109 +372,104 @@ def generate_document(
         "",
         "# Benchmark Results",
         "",
-        "Live benchmark comparisons between Dekaf and Confluent.Kafka, automatically updated on every commit to main.",
+        "How Dekaf compares to Confluent.Kafka, measured with BenchmarkDotNet on GitHub Actions and refreshed on every commit to main.",
         "",
         f"**Last Updated:** {updated_at}",
         "",
-        ":::info",
-        "These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. ",
-        "Ratio semantics differ per table — see 'How to Read These Results' below.",
-        ":::",
+        "## At a glance",
         "",
-        f"## Rolling comparison (last {window} runs)",
+        f"Each scenario is the median Dekaf-vs-Confluent result over the last {window} CI runs (both clients measured on the same runner), aggregated across message and batch sizes. Memory compares heap allocations per operation from the latest run.",
         "",
-        "Each ratio pairs Dekaf and Confluent means from the same runner, then reports the median across recent comparable runs. Lower is better; `< 1.0` means Dekaf is faster.",
+        *format_summary_table(summaries, alloc_ratios),
         "",
-        f"Rows with run spread above {variance_threshold:.0%} are marked low-confidence. Run spread is `(maximum ratio - minimum ratio) / median ratio`.",
+        '"On par" means within ±20% — differences that small are runner noise. A range means the result depends on message or batch size; the per-parameter tables below have the detail.',
         "",
-        *format_rolling_table(comparisons, variance_threshold),
+        "## Full results",
         "",
-        "## Latest run",
-        "",
-        "Latest-run tables retain BenchmarkDotNet's within-run `RatioSD`. Rows above the confidence threshold are marked low-confidence.",
-        "",
+        *_details_section(
+            f"Cross-run comparison — last {window} runs, per parameter set",
+            [
+                "Each ratio pairs Dekaf and Confluent means from the same runner, then reports the median across recent comparable runs. Lower is better; `< 1.0` means Dekaf is faster.",
+                "",
+                f"Rows with run spread above {variance_threshold:.0%} are marked low-confidence. Run spread is `(maximum ratio - minimum ratio) / median ratio`.",
+                "",
+                *format_rolling_table(comparisons, variance_threshold),
+                "",
+            ],
+        ),
     ]
 
-    producer_md = sorted(
-        glob.glob(f"{result_pattern}/Client/results/*ProducerBenchmarks*-github.md")
-    )
     if producer_md:
         output.extend(
-            [
-                "### Producer Benchmarks",
-                "",
-                "Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.",
-                "",
-            ]
+            _details_section(
+                "Latest run — producer benchmarks",
+                collect_tables(producer_md, variance_threshold),
+            )
         )
-        append_tables(output, producer_md, variance_threshold)
 
-    consumer_md = sorted(
-        glob.glob(f"{result_pattern}/Client/results/*Consumer*Benchmarks*-github.md")
-    )
     if consumer_md:
         output.extend(
-            [
-                "### Consumer Benchmarks",
-                "",
-                "Comparing Dekaf vs Confluent.Kafka for message consumption.",
-                "",
-            ]
+            _details_section(
+                "Latest run — consumer benchmarks",
+                collect_tables(consumer_md, variance_threshold),
+            )
         )
-        append_tables(output, consumer_md, variance_threshold)
 
     protocol_md = sorted(
         glob.glob(f"{result_pattern}/Unit/results/*ProtocolBenchmarks*-github.md")
     )
     if protocol_md:
         output.extend(
-            [
-                "## Protocol Benchmarks",
-                "",
-                "Zero-allocation wire protocol serialization/deserialization.",
-                "",
-                ":::tip",
-                "**Allocated = `-` means zero heap allocations** - the goal of Dekaf's design!",
-                ":::",
-                "",
-            ]
+            _details_section(
+                "Protocol serialization — Dekaf internals",
+                [
+                    "Wire protocol serialization/deserialization. **Allocated = `-` means zero heap allocations** — the goal of Dekaf's design.",
+                    "",
+                    *collect_tables(protocol_md),
+                ],
+            )
         )
-        append_tables(output, protocol_md)
 
     serializer_md = sorted(
         glob.glob(f"{result_pattern}/Unit/results/*SerializerBenchmarks*-github.md")
     )
     if serializer_md:
-        output.extend(["## Serializer Benchmarks", ""])
-        append_tables(output, serializer_md)
+        output.extend(
+            _details_section(
+                "Serializers — Dekaf internals", collect_tables(serializer_md)
+            )
+        )
 
     compression_md = sorted(
         glob.glob(f"{result_pattern}/Unit/results/*CompressionBenchmarks*-github.md")
     )
     if compression_md:
-        output.extend(["## Compression Benchmarks", ""])
-        append_tables(output, compression_md)
+        output.extend(
+            _details_section(
+                "Compression — Dekaf internals", collect_tables(compression_md)
+            )
+        )
 
     output.extend(
-        [
-            "---",
-            "",
-            "## How to Read These Results",
-            "",
-            "- **Mean**: Average execution time",
-            "- **Error**: Half of 99.9% confidence interval",
-            "- **StdDev**: Standard deviation of all measurements",
-            "- **Ratio**: Performance relative to that table's baseline row",
-            "  - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster",
-            "  - Unit tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent",
-            "- **RatioSD**: BenchmarkDotNet's uncertainty for the latest run's ratio",
-            f"- **Confidence**: `⚠ Low` when latest `RatioSD > {variance_threshold:.2f}` or rolling run spread exceeds {variance_threshold:.0%}",
-            "- **Allocated**: Heap memory allocated per operation",
-            "  - `-` = Zero allocations (ideal!)",
-            "",
-            "*Benchmarks are automatically run on every push to main.*",
-        ]
+        _details_section(
+            "How to read these tables",
+            [
+                "- **Mean**: Average execution time",
+                "- **Error**: Half of 99.9% confidence interval",
+                "- **StdDev**: Standard deviation of all measurements",
+                "- **Ratio**: Performance relative to that table's baseline row",
+                "  - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster",
+                "  - Dekaf-internals tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent",
+                "- **RatioSD**: BenchmarkDotNet's uncertainty for the latest run's ratio",
+                f"- **Confidence**: `⚠ Low` when latest `RatioSD > {variance_threshold:.2f}` or rolling run spread exceeds {variance_threshold:.0%}",
+                "- **Allocated**: Heap memory allocated per operation",
+                "  - `-` = Zero allocations (ideal!)",
+                "",
+            ],
+        )
     )
+
+    output.append("*Benchmarks are automatically run on every push to main.*")
 
     return "\n".join(output)
 

--- a/.github/scripts/test_benchmark_docs.py
+++ b/.github/scripts/test_benchmark_docs.py
@@ -5,10 +5,16 @@ from pathlib import Path
 
 from benchmark_docs import (
     annotate_ratio_confidence,
+    describe_memory,
+    describe_speed,
+    describe_speed_range,
     format_rolling_table,
+    format_summary_table,
     generate_document,
+    latest_alloc_ratios,
     load_history,
     rolling_comparisons,
+    summarize_scenarios,
 )
 
 
@@ -145,6 +151,72 @@ class BenchmarkDocsTests(unittest.TestCase):
         self.assertIn("100%", table[2])
         self.assertIn("⚠ Low", table[2])
 
+    def test_describe_speed_maps_ratio_to_plain_english(self):
+        self.assertEqual("2.1× faster", describe_speed(0.47))
+        self.assertEqual("11× faster", describe_speed(0.09))
+        self.assertEqual("on par", describe_speed(1.05))
+        self.assertEqual("on par", describe_speed(0.95))
+        self.assertEqual("1.5× slower", describe_speed(1.50))
+
+    def test_describe_speed_range_collapses_matching_verdicts(self):
+        self.assertEqual("2.1× faster", describe_speed_range(0.47, 0.47))
+        self.assertEqual("2.7×–11× faster", describe_speed_range(0.09, 0.37))
+        self.assertEqual("on par to 2.3× faster", describe_speed_range(0.43, 1.02))
+        self.assertEqual("1.3×–1.8× slower", describe_speed_range(1.30, 1.80))
+
+    def test_describe_memory_maps_alloc_ratio_to_plain_english(self):
+        self.assertEqual("—", describe_memory(None))
+        self.assertEqual("zero allocations", describe_memory(0.0))
+        self.assertEqual("20× less", describe_memory(0.05))
+        self.assertEqual("on par", describe_memory(1.0))
+        self.assertEqual("2.0× more", describe_memory(2.0))
+
+    def test_summarize_scenarios_aggregates_parameter_permutations(self):
+        prefix = "Dekaf.Benchmarks.Benchmarks.Client.ProducerBenchmarks"
+        entries = [
+            {
+                "benches": [
+                    benchmark(f"{prefix}.Dekaf_ProduceBatch(BatchSize: 100)", 40),
+                    benchmark(f"{prefix}.Confluent_ProduceBatch(BatchSize: 100)", 100),
+                    benchmark(f"{prefix}.Dekaf_ProduceBatch(BatchSize: 1000)", 110),
+                    benchmark(f"{prefix}.Confluent_ProduceBatch(BatchSize: 1000)", 100),
+                ]
+            }
+        ] * 2
+
+        summaries = summarize_scenarios(rolling_comparisons(entries))
+
+        self.assertEqual(1, len(summaries))
+        summary = summaries[0]
+        self.assertEqual("ProducerBenchmarks", summary["group"])
+        self.assertEqual("ProduceBatch", summary["operation"])
+        self.assertEqual(0.4, summary["best"])
+        self.assertEqual(1.1, summary["worst"])
+        self.assertEqual(2, summary["stable_rows"])
+        self.assertEqual(2, summary["total_rows"])
+
+    def test_latest_alloc_ratios_reads_dekaf_rows(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ProducerBenchmarks-report-github.md"
+            path.write_text(
+                "| Method | Ratio | RatioSD | Alloc Ratio |\n"
+                "|---|---:|---:|---:|\n"
+                "| **Confluent_ProduceBatch** | **1.00** | **0.02** | **1.00** |\n"
+                "| Dekaf_ProduceBatch | 0.43 | 0.01 | 0.05 |\n"
+                "| Dekaf_ProduceBatch | 0.53 | 0.01 | 0.03 |\n"
+                "| Dekaf_FireAndForget | 1.13 | 0.13 | ? |\n",
+                encoding="utf-8",
+            )
+
+            ratios = latest_alloc_ratios([path])
+
+        self.assertEqual({"ProduceBatch": 0.04}, ratios)
+
+    def test_summary_table_without_history_reports_placeholder(self):
+        table = format_summary_table([], {})
+
+        self.assertIn("No comparable history yet", table[2])
+
     def test_document_contains_rolling_and_latest_confidence_context(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -176,9 +248,16 @@ class BenchmarkDocsTests(unittest.TestCase):
                 "2026-07-27 18:00 UTC",
             )
 
-        self.assertIn("## Rolling comparison (last 5 runs)", document)
+        self.assertIn("## At a glance", document)
+        self.assertIn("Consume — poll a single message", document)
+        self.assertIn("2.1× slower", document)
+        self.assertIn("<details>", document)
+        self.assertIn(
+            "<summary>Cross-run comparison — last 5 runs, per parameter set</summary>",
+            document,
+        )
         self.assertIn("ConsumerPollBenchmarks.PollSingle", document)
-        self.assertIn("## Latest run", document)
+        self.assertIn("<summary>Latest run — consumer benchmarks</summary>", document)
         self.assertIn("⚠ Low", document)
         self.assertIn("RatioSD", document)
 

--- a/docs/docs/benchmarks.md
+++ b/docs/docs/benchmarks.md
@@ -4,16 +4,28 @@ sidebar_position: 13
 
 # Benchmark Results
 
-Live benchmark comparisons between Dekaf and Confluent.Kafka, automatically updated on every commit to main.
+How Dekaf compares to Confluent.Kafka, measured with BenchmarkDotNet on GitHub Actions and refreshed on every commit to main.
 
 **Last Updated:** 2026-08-02 04:49 UTC
 
-:::info
-These benchmarks run on GitHub Actions (ubuntu-latest) using BenchmarkDotNet. 
-Ratio semantics differ per table — see 'How to Read These Results' below.
-:::
+## At a glance
 
-## Rolling comparison (last 5 runs)
+Each scenario is the median Dekaf-vs-Confluent result over the last 5 CI runs (both clients measured on the same runner), aggregated across message and batch sizes. Memory compares heap allocations per operation from the latest run.
+
+| Scenario | Speed vs Confluent | Memory vs Confluent | Confidence |
+|---|---|---|---|
+| Produce — one message at a time (awaited) | 2.1× faster | 2.4× less | Stable |
+| Produce — batches | on par to 2.3× faster | 22× less | Mixed |
+| Produce — fire-and-forget | on par | 100× less | Mixed |
+| Consume — drain a topic | on par to 1.4× faster | 1.6× less | Mixed |
+| Consume — poll a single message | 2.7×–12× faster | 1.6× less | Mixed |
+
+"On par" means within ±20% — differences that small are runner noise. A range means the result depends on message or batch size; the per-parameter tables below have the detail.
+
+## Full results
+
+<details>
+<summary>Cross-run comparison — last 5 runs, per parameter set</summary>
 
 Each ratio pairs Dekaf and Confluent means from the same runner, then reports the median across recent comparable runs. Lower is better; `< 1.0` means Dekaf is faster.
 
@@ -40,13 +52,10 @@ Rows with run spread above 30% are marked low-confidence. Run spread is `(maximu
 | ProducerBenchmarks.ProduceSingle | MessageSize: 1000, BatchSize: 100 | 5 | 0.47 | 0.46–0.47 | 4% | Stable |
 | ProducerBenchmarks.ProduceSingle | MessageSize: 1000, BatchSize: 1000 | 5 | 0.47 | 0.46–0.47 | 4% | Stable |
 
-## Latest run
+</details>
 
-Latest-run tables retain BenchmarkDotNet's within-run `RatioSD`. Rows above the confidence threshold are marked low-confidence.
-
-### Producer Benchmarks
-
-Comparing Dekaf vs Confluent.Kafka for message production across different scenarios.
+<details>
+<summary>Latest run — producer benchmarks</summary>
 
 | Method                  | Categories    | MessageSize | BatchSize | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0     | Gen1    | Allocated | Alloc Ratio | Confidence |
 |------------------------ |-------------- |------------ |---------- |------------:|----------:|----------:|------:|--------:|---------:|--------:|----------:|------------:|---|
@@ -86,9 +95,10 @@ Comparing Dekaf vs Confluent.Kafka for message production across different scena
 | **Confluent_ProduceSingle** | **SingleProduce** | **1000**        | **1000**      |  **5,479.2 μs** |  **34.73 μs** |  **22.97 μs** |  **1.00** |    **0.01** |        **-** |       **-** |    **2098 B** |        **1.00** | Stable |
 | Dekaf_ProduceSingle     | SingleProduce | 1000        | 1000      |  2,507.3 μs |  11.94 μs |   7.90 μs |  0.46 |    0.00 |        - |       - |     624 B |        0.30 | Stable |
 
-### Consumer Benchmarks
+</details>
 
-Comparing Dekaf vs Confluent.Kafka for message consumption.
+<details>
+<summary>Latest run — consumer benchmarks</summary>
 
 | Method               | MessageCount | MessageSize | Mean       | Error       | StdDev    | Median     | Ratio | RatioSD | Allocated | Alloc Ratio | Confidence |
 |--------------------- |------------- |------------ |-----------:|------------:|----------:|-----------:|------:|--------:|----------:|------------:|---|
@@ -112,13 +122,12 @@ Comparing Dekaf vs Confluent.Kafka for message consumption.
 | **Confluent_PollSingle** | **400000**            | **1000**        | **2,817.3 ns** | **1,568.47 ns** | **1,037.45 ns** | **3,594.1 ns** |  **1.17** |    **0.67** | **0.1450** |    **2454 B** |        **1.00** | ⚠ Low |
 | Dekaf_PollSingle     | 400000            | 1000        | 1,159.8 ns |    89.57 ns |    59.24 ns | 1,152.3 ns |  0.48 |    0.21 | 0.1225 |    2075 B |        0.85 | Stable |
 
-## Protocol Benchmarks
+</details>
 
-Zero-allocation wire protocol serialization/deserialization.
+<details>
+<summary>Protocol serialization — Dekaf internals</summary>
 
-:::tip
-**Allocated = `-` means zero heap allocations** - the goal of Dekaf's design!
-:::
+Wire protocol serialization/deserialization. **Allocated = `-` means zero heap allocations** — the goal of Dekaf's design.
 
 | Method                     | Mean      | Error    | StdDev   | Gen0   | Allocated |
 |--------------------------- |----------:|---------:|---------:|-------:|----------:|
@@ -164,7 +173,10 @@ Zero-allocation wire protocol serialization/deserialization.
 | &#39;Read Gzip RecordBatch (10 records)&#39;            | 1,737.5 ns |  3.93 ns |  2.60 ns | 0.0172 |     312 B |
 | &#39;Read + Iterate RecordBatch (10 records)&#39;       | 1,299.9 ns |  2.88 ns |  1.71 ns |      - |         - |
 
-## Serializer Benchmarks
+</details>
+
+<details>
+<summary>Serializers — Dekaf internals</summary>
 
 | Method                               | Categories | Mean         | Error      | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
 |------------------------------------- |----------- |-------------:|-----------:|----------:|------:|--------:|-------:|----------:|------------:|
@@ -179,7 +191,10 @@ Zero-allocation wire protocol serialization/deserialization.
 | &#39;ArrayBufferWriter + Copy&#39;           | Writer     |    108.12 ns |   2.658 ns |  1.582 ns |  1.00 |    0.02 | 0.0535 |     896 B |        1.00 |
 | &#39;ReusableBufferWriter Direct&#39;        | Writer     |     54.49 ns |   0.172 ns |  0.114 ns |  0.50 |    0.01 |      - |         - |        0.00 |
 
-## Compression Benchmarks
+</details>
+
+<details>
+<summary>Compression — Dekaf internals</summary>
 
 | Method                  | Mean         | Error     | StdDev    | Gen0   | Allocated |
 |------------------------ |-------------:|----------:|----------:|-------:|----------:|
@@ -188,19 +203,22 @@ Zero-allocation wire protocol serialization/deserialization.
 | &#39;Snappy Decompress 1KB&#39; |     222.1 ns |   0.34 ns |   0.20 ns | 0.0048 |      80 B |
 | &#39;Snappy Decompress 1MB&#39; | 126,543.3 ns | 183.00 ns |  95.71 ns |      - |      80 B |
 
----
+</details>
 
-## How to Read These Results
+<details>
+<summary>How to read these tables</summary>
 
 - **Mean**: Average execution time
 - **Error**: Half of 99.9% confidence interval
 - **StdDev**: Standard deviation of all measurements
 - **Ratio**: Performance relative to that table's baseline row
   - Producer/Consumer tables: baseline is Confluent.Kafka, so `< 1.0` = Dekaf is faster, `> 1.0` = Confluent is faster
-  - Unit tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent
+  - Dekaf-internals tables (Protocol/Serializer/Compression): baseline is an internal reference implementation, not Confluent
 - **RatioSD**: BenchmarkDotNet's uncertainty for the latest run's ratio
 - **Confidence**: `⚠ Low` when latest `RatioSD > 0.30` or rolling run spread exceeds 30%
 - **Allocated**: Heap memory allocated per operation
   - `-` = Zero allocations (ideal!)
+
+</details>
 
 *Benchmarks are automatically run on every push to main.*


### PR DESCRIPTION
## Summary

The benchmarks docs page was information overload: it led with dense BenchmarkDotNet tables (Mean/Error/StdDev/RatioSD/Gen0...) that most users can't quickly parse. This restructures the generated page so users can compare Dekaf vs Confluent at a glance, while keeping every existing table available.

### New page structure

**At a glance** (top of page) — one row per scenario, plain English:

| Scenario | Speed vs Confluent | Memory vs Confluent | Confidence |
|---|---|---|---|
| Produce — one message at a time (awaited) | 2.1× faster | 2.4× less | Stable |
| Produce — batches | on par to 2.3× faster | 22× less | Mixed |
| Produce — fire-and-forget | on par | 100× less | Mixed |
| Consume — drain a topic | on par to 1.4× faster | 1.6× less | Mixed |
| Consume — poll a single message | 2.7×–12× faster | 1.6× less | Mixed |

**Full results** — everything the page had before (rolling per-parameter comparison, latest-run BDN tables, protocol/serializer/compression internals, glossary), each collapsed into a `<details>` block. Nothing deleted.

### How the summary is computed

- **Speed**: median Dekaf/Confluent ratio over the last 5 CI runs (same-runner pairs), aggregated across message/batch-size permutations. Ratios within ±20% read as "on par" — inside CI noise. When permutations disagree, a range is shown instead of hiding the variance.
- **Memory**: median of BDN's Alloc Ratio from Dekaf rows in the latest run.
- **Confidence**: Stable / Mixed / ⚠ Noisy derived from the existing rolling run-spread flags.
- Scenario display names live in a single `_SCENARIO_LABELS` dict; unmapped benchmarks fall back to their raw name so new benchmarks still appear.

### Changes

- `.github/scripts/benchmark_docs.py`: new summary builder (`summarize_scenarios`, `latest_alloc_ratios`, `describe_speed`/`describe_memory`), sections wrapped in `<details>`. Same CLI and stdlib-only — the benchmarks workflow needs no changes.
- `.github/scripts/test_benchmark_docs.py`: 6 new tests covering the summary helpers and new document shape.
- `docs/docs/benchmarks.md`: regenerated in the new format from real gh-pages history and the latest-run tables, so the new layout is live immediately (next CI push to main regenerates from artifacts as usual).

## Test plan

- [x] `python -m unittest discover -s .github/scripts -p 'test_*.py'` — 158/158 pass (same command CI runs)
- [x] `npm run build` in `docs/` — Docusaurus/MDX compiles; verified all 12 tables render as HTML inside the 7 collapsed sections in the built page