### PR TITLE
ci: Reduce benchmark noise at zero added runtime

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -97,9 +97,15 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           dotnet-quality: 'preview'
 
+      # Broker and benchmark process are pinned to disjoint cores (0-1 vs 2-3 on the
+      # 4-vCPU runner) so scheduler interference between them stops randomizing the
+      # timed regions — the same discipline the stress runners use. Ratios stay
+      # comparable (both clients measured under the same pinning), but absolute
+      # times will step-change against pre-pinning history.
       - name: Start Kafka
         run: |
           docker run -d --name kafka \
+            --cpuset-cpus 0,1 \
             -p 9092:9092 \
             apache/kafka:latest
 
@@ -121,7 +127,7 @@ jobs:
           KAFKA_BOOTSTRAP_SERVERS: localhost:9092
         run: |
           cd tools/Dekaf.Benchmarks
-          dotnet run -c Release --no-build -- --filter "*Client*" --exporters json --artifacts ./BenchmarkResults/Client
+          taskset -c 2,3 dotnet run -c Release --no-build -- --filter "*Client*" --exporters json --artifacts ./BenchmarkResults/Client
 
       - name: Stop Kafka
         if: always()
@@ -387,6 +393,13 @@ jobs:
                           for bench in data.get('Benchmarks', []):
                               stats = bench.get('Statistics')
                               if stats is not None and stats.get('Mean') is not None:
+                                  # Publish the median as the tracked value: the
+                                  # github-action-benchmark extractor reads Statistics.Mean,
+                                  # but client benchmarks are heavy-tailed on shared runners
+                                  # (single-invocation iterations produce Error > Mean rows),
+                                  # so the median is a far more stable cross-run signal.
+                                  if stats.get('Median') is not None:
+                                      stats['Mean'] = stats['Median']
                                   combined['Benchmarks'].append(bench)
                               else:
                                   print(f"  Skipping (null Statistics): {bench.get('DisplayInfo', bench.get('Method', 'unknown'))}")
@@ -441,6 +454,7 @@ jobs:
           python3 .github/scripts/benchmark_docs.py
           --results-dir benchmark-results
           --history "$RUNNER_TEMP/benchmark-data.js"
+          --window 10
           --output docs/docs/benchmarks.md
 
       - name: Create Pull Request for Benchmark Results


### PR DESCRIPTION
## Summary

Follow-up to #2499: three benchmark-confidence improvements chosen specifically to add **zero billable runner minutes** — no extra jobs, samples, or iterations.

### 1. Track per-run median instead of mean in history

The `github-action-benchmark` extractor reads `Statistics.Mean`. Client benchmarks are heavy-tailed on shared runners — consumer rows routinely show **Error > Mean** (e.g. ConsumeAll 1000×1000: mean 1,700 μs ± 1,596 μs) because `[IterationSetup]` forces single-invocation iterations and any co-tenant hiccup lands directly in one sample. The combine step now copies `Statistics.Median` into the tracked value, so rolling Dekaf/Confluent ratios are built from medians. This is the single biggest spread reducer available without buying more samples.

### 2. Pin broker and benchmark process to disjoint cores

`--cpuset-cpus 0,1` for the Kafka container, `taskset -c 2,3` for the benchmark run (affinity inherits to BDN child processes and librdkafka threads). Same discipline the stress runners use (broker cores 0-5, client 6-7 there). Stops broker/client scheduler interference from randomizing timed regions on the shared 4-vCPU runner.

### 3. Rolling docs window 5 → 10 runs

More samples per median and spread estimate on the published page. Passed as `--window 10` at the call site; the generator's headings and text pick it up dynamically, so this composes cleanly with #2499 in either merge order.

## Expected effects

- One-time downward step in the history chart from the median switch (median ≤ mean on right-skewed data) — an apparent improvement, so no 150% regression alert fires.
- One-time step from core pinning as contention disappears.
- **Ratios are unaffected by both steps**: Dekaf and Confluent change together within each run, and cross-run comparisons pair values from the same run.
- Runtime unchanged; pinning may slightly speed the client job by removing contention.

## Test plan

- [x] Workflow YAML validated (`yaml.safe_load`)
- [x] Median swap is guarded (`Statistics.Median` present check) — falls back to mean unchanged
- [x] `--window` is an existing generator flag with dynamic headings; works with both the current and #2499 generator
- [ ] First main run after merge: confirm history entry stores medians and client job passes with pinning