### PR TITLE
feat: Add unbounded max-rate lane to 24h soak tests

### DIFF
--- a/.github/workflows/soak-tests.yml
+++ b/.github/workflows/soak-tests.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: '60'
       messages_per_second:
-        description: 'Target mixed-load message rate'
+        description: 'Target mixed-load message rate (use run_unbounded for max-rate)'
         required: false
         default: '1000'
       warmup_minutes:
@@ -21,6 +21,11 @@ on:
         description: 'Minimum post-warmup samples (one sample per minute)'
         required: false
         default: '30'
+      run_unbounded:
+        description: 'Also run the unbounded max-rate soak jobs'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: soak-tests
@@ -98,6 +103,86 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: soak-results-${{ matrix.brokers }}brokers-segment-${{ matrix.segment }}
+          path: tools/Dekaf.StressTests/results/
+          if-no-files-found: warn
+          retention-days: 90
+
+  soak-test-unbounded:
+    name: Unbounded Soak (${{ matrix.brokers }} broker${{ matrix.brokers == 1 && '' || 's' }})
+    # The paced segments isolate time-proportional effects at a deterministic rate;
+    # this lane produces as fast as admission control allows so per-message leak
+    # classes, sustained BufferMemory backpressure, and late-run throughput decay
+    # get long-duration coverage too. One segment per topology: 4h48m is already
+    # the longest continuous window the six-hour public runner permits.
+    if: github.event_name == 'schedule' || inputs.run_unbounded
+    runs-on: ubuntu-latest
+    timeout-minutes: 355
+    strategy:
+      fail-fast: false
+      matrix:
+        brokers: [1, 3]
+    env:
+      # Unbounded ingest pushes each broker at the full client byte rate. Byte-bounded
+      # retention caps steady-state data (64 MB x 6 partitions per broker) but the
+      # 500ms sweep interval allows rate-proportional overshoot, so the tmpfs needs
+      # headroom beyond the paced lane's 2g; the paced 768m heap starves the broker
+      # request path at max throughput. Three 1g-heap brokers plus tmpfs still fit
+      # the 16 GB public runner alongside the client process.
+      STRESS_BROKER_TMPFS: 3g
+      STRESS_BROKER_HEAP: -Xmx1g -Xms1g
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build Soak Runner
+        run: dotnet build tools/Dekaf.StressTests --configuration Release
+
+      - name: Run Unbounded Soak
+        env:
+          SOAK_DURATION_MINUTES: ${{ github.event_name == 'schedule' && '288' || inputs.duration_minutes }}
+          SOAK_WARMUP_MINUTES: ${{ github.event_name == 'schedule' && '30' || inputs.warmup_minutes }}
+          SOAK_MINIMUM_SAMPLES: ${{ inputs.minimum_samples || '30' }}
+        run: |
+          mkdir -p tools/Dekaf.StressTests/results
+          echo "Duration: ${SOAK_DURATION_MINUTES} minutes"
+          echo "Target rate: unbounded"
+          echo "Brokers: ${{ matrix.brokers }}"
+
+          # Trend gates run twice as wide as the paced lane's: max-rate runs carry
+          # allocator and noisy-neighbor variance a fixed 1000 msg/s lane never sees.
+          # Tighten once scheduled history establishes the real bands.
+          dotnet run \
+            --project tools/Dekaf.StressTests \
+            --configuration Release \
+            --no-build -- \
+            --duration "${SOAK_DURATION_MINUTES}" \
+            --message-size 1000 \
+            --scenario soak \
+            --client dekaf \
+            --brokers ${{ matrix.brokers }} \
+            --connections-per-broker 1 \
+            --soak-messages-per-second 0 \
+            --resource-sample-seconds 60 \
+            --soak-warmup-minutes "${SOAK_WARMUP_MINUTES}" \
+            --soak-minimum-samples "${SOAK_MINIMUM_SAMPLES}" \
+            --max-working-set-slope-mib-per-hour 16 \
+            --max-gc-heap-slope-mib-per-hour 8 \
+            --max-loh-slope-mib-per-hour 8 \
+            --max-throughput-decay-percent-per-hour 10 \
+            --producer-delivery-diagnostics \
+            --output tools/Dekaf.StressTests/results/unbounded
+
+      - name: Upload Soak Results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: soak-results-unbounded-${{ matrix.brokers }}brokers
           path: tools/Dekaf.StressTests/results/
           if-no-files-found: warn
           retention-days: 90

--- a/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
+++ b/tests/Dekaf.Tests.Unit/StressTests/SoakStressTestTests.cs
@@ -13,8 +13,7 @@ public sealed class SoakStressTestTests
     [Test]
     public async Task TrackMeasurementProgress_StallCapturesSoakProducerDiagnostics()
     {
-        var outputDirectory = Path.Combine(Path.GetTempPath(), $"dekaf-soak-watchdog-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(outputDirectory);
+        var outputDirectory = CreateOutputDirectory();
 
         try
         {
@@ -56,8 +55,7 @@ public sealed class SoakStressTestTests
     [Test]
     public async Task TrackConsumerMeasurementProgress_StallCapturesConsumerDiagnostics()
     {
-        var outputDirectory = Path.Combine(Path.GetTempPath(), $"dekaf-soak-consumer-watchdog-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(outputDirectory);
+        var outputDirectory = CreateOutputDirectory();
 
         try
         {
@@ -158,5 +156,125 @@ public sealed class SoakStressTestTests
 
         await Assert.That(result).IsEqualTo(expected);
     }
+
+    [Test]
+    [Arguments(0, true)]
+    [Arguments(1, false)]
+    [Arguments(5_000, false)]
+    public async Task SoakUnbounded_IsTrueOnlyForZeroTargetRate(int messagesPerSecond, bool expected)
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            using var watchdog = new ProgressWatchdog(outputDirectory);
+            var options = CreateOptions(watchdog, messagesPerSecond);
+
+            await Assert.That(options.SoakUnbounded).IsEqualTo(expected);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunUnboundedProducerAsync_ProducesUntilCancelled()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            using var watchdog = new ProgressWatchdog(outputDirectory);
+            var options = CreateOptions(watchdog, messagesPerSecond: 0);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var cts = new CancellationTokenSource();
+            var calls = 0;
+            var producer = Substitute.For<IKafkaProducer<string, string>>();
+            producer.FireAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(_ =>
+                {
+                    if (Interlocked.Increment(ref calls) >= 5)
+                    {
+                        cts.Cancel();
+                    }
+
+                    return ValueTask.CompletedTask;
+                });
+
+            await SoakStressTest.RunUnboundedProducerAsync(producer, options, "value", throughput, cts.Token);
+
+            var snapshot = throughput.GetSnapshot();
+            await Assert.That(throughput.MessageCount).IsEqualTo(5);
+            await Assert.That(snapshot.TotalErrors).IsEqualTo(0);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunUnboundedProducerAsync_RecordsProduceFailuresAndContinues()
+    {
+        var outputDirectory = CreateOutputDirectory();
+
+        try
+        {
+            using var watchdog = new ProgressWatchdog(outputDirectory);
+            var options = CreateOptions(watchdog, messagesPerSecond: 0);
+            var throughput = new ThroughputTracker();
+            throughput.Start();
+
+            using var cts = new CancellationTokenSource();
+            var calls = 0;
+            var producer = Substitute.For<IKafkaProducer<string, string>>();
+            producer.FireAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+                .Returns(_ =>
+                {
+                    var call = Interlocked.Increment(ref calls);
+                    if (call == 1)
+                    {
+                        throw new InvalidOperationException("transient produce failure");
+                    }
+
+                    if (call >= 3)
+                    {
+                        cts.Cancel();
+                    }
+
+                    return ValueTask.CompletedTask;
+                });
+
+            await SoakStressTest.RunUnboundedProducerAsync(producer, options, "value", throughput, cts.Token);
+
+            var snapshot = throughput.GetSnapshot();
+            await Assert.That(throughput.MessageCount).IsEqualTo(2);
+            await Assert.That(snapshot.TotalErrors).IsEqualTo(1);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateOutputDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"dekaf-soak-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static StressTestOptions CreateOptions(ProgressWatchdog watchdog, int messagesPerSecond) => new()
+    {
+        BootstrapServers = "localhost:9092",
+        Topic = "soak-topic",
+        DurationMinutes = 1,
+        MessageSizeBytes = 100,
+        ProgressWatchdog = watchdog,
+        SoakMessagesPerSecond = messagesPerSecond
+    };
 }
 #endif

--- a/tools/Dekaf.StressTests/Program.cs
+++ b/tools/Dekaf.StressTests/Program.cs
@@ -124,7 +124,9 @@ public static class Program
         Console.WriteLine($"Brokers: {options.Brokers}");
         if (options.Scenario.Equals("soak", StringComparison.OrdinalIgnoreCase))
         {
-            Console.WriteLine($"Soak target rate: {options.SoakMessagesPerSecond:N0} msg/s");
+            Console.WriteLine(options.SoakUnbounded
+                ? "Soak target rate: unbounded"
+                : $"Soak target rate: {options.SoakMessagesPerSecond:N0} msg/s");
             Console.WriteLine($"Resource sample interval: {options.ResourceSampleIntervalSeconds:N0} seconds");
         }
         Console.WriteLine($"Producer delivery diagnostics: {(options.EnableProducerDeliveryDiagnostics ? "enabled" : "disabled")}");
@@ -991,7 +993,7 @@ public static class Program
                     options.MessagesAfterFault = ParsePositiveInt(args[++i], "--messages-after-fault");
                     break;
                 case "--soak-messages-per-second":
-                    options.SoakMessagesPerSecond = ParsePositiveInt(args[++i], arg);
+                    options.SoakMessagesPerSecond = ParseNonNegativeInt(args[++i], arg);
                     break;
                 case "--resource-sample-seconds":
                     options.ResourceSampleIntervalSeconds = ParsePositiveDouble(args[++i], arg);
@@ -1040,6 +1042,17 @@ public static class Program
         return parsed;
     }
 
+    private static int ParseNonNegativeInt(string value, string optionName)
+    {
+        var parsed = int.Parse(value, CultureInfo.InvariantCulture);
+        if (parsed < 0)
+        {
+            throw new ArgumentException($"{optionName} must be at least 0");
+        }
+
+        return parsed;
+    }
+
     private static double ParsePositiveDouble(string value, string option)
     {
         var parsed = double.Parse(value, CultureInfo.InvariantCulture);
@@ -1079,7 +1092,7 @@ public static class Program
               --seed-messages <count> Messages pre-seeded into the consumer topic (default: 2000000)
               --producer-delivery-diagnostics  Capture Dekaf producer delivery diagnostics on message loss and watchdog stalls
               --consumer-fetch-diagnostics  Capture Dekaf consumer fetch diagnostics (debug runs only; adds Dekaf-only overhead)
-              --soak-messages-per-second <n>   Mixed soak target rate (default: 5000)
+              --soak-messages-per-second <n>   Mixed soak target rate; 0 = unbounded (default: 5000)
               --resource-sample-seconds <n>    Soak resource sample interval (default: 60)
               --soak-warmup-minutes <n>        Samples excluded before trend analysis (default: 60)
               --soak-minimum-samples <n>       Minimum post-warmup trend samples (default: 30)
@@ -1143,6 +1156,7 @@ public static class Program
         public int MessagesAfterFault { get; set; } = 2_000;
         public HashSet<string> AllowedFailureWindows { get; } = new(StringComparer.OrdinalIgnoreCase);
         public int SoakMessagesPerSecond { get; set; } = 5_000;
+        public bool SoakUnbounded => SoakMessagesPerSecond == 0;
         public double ResourceSampleIntervalSeconds { get; set; } = 60;
         public double SoakWarmupMinutes { get; set; } = 60;
         public int SoakMinimumSamples { get; set; } = 30;

--- a/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
+++ b/tools/Dekaf.StressTests/Scenarios/IStressTestScenario.cs
@@ -51,7 +51,14 @@ internal sealed class StressTestOptions
     /// </summary>
     public bool EnableConsumerFetchDiagnostics { get; init; }
     public required ProgressWatchdog ProgressWatchdog { get; init; }
+    /// <summary>
+    /// Target mixed-soak produce rate. 0 disables pacing entirely: the producer runs
+    /// as fast as admission control allows so long soaks exercise the sustained
+    /// backpressure and max-throughput regime instead of a fixed rate.
+    /// </summary>
     public int SoakMessagesPerSecond { get; init; } = 5_000;
+
+    public bool SoakUnbounded => SoakMessagesPerSecond == 0;
     public double ResourceSampleIntervalSeconds { get; init; } = 60;
     public ResourceTrendThresholds ResourceTrendThresholds { get; init; } = new()
     {

--- a/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
+++ b/tools/Dekaf.StressTests/Scenarios/SoakStressTest.cs
@@ -105,7 +105,7 @@ internal sealed class SoakStressTest : IStressTestScenario
             var startedAt = DateTime.UtcNow;
             Console.WriteLine(
                 $"  Running mixed Dekaf soak for {options.DurationMinutes:N0} minutes at " +
-                $"{options.SoakMessagesPerSecond:N0} msg/s...");
+                (options.SoakUnbounded ? "unbounded rate..." : $"{options.SoakMessagesPerSecond:N0} msg/s..."));
             Console.WriteLine(
                 $"  Resource samples every {options.ResourceSampleIntervalSeconds:N0}s; " +
                 $"trend warmup {options.ResourceTrendThresholds.WarmupMinutes:N0}m");
@@ -127,12 +127,10 @@ internal sealed class SoakStressTest : IStressTestScenario
                        consumerThroughput,
                        () => StressTestHelpers.CaptureConsumerDiagnostics(consumer)))
             {
-                await RunPacedProducerAsync(
-                    producer,
-                    options,
-                    messageValue,
-                    throughput,
-                    measurementCts.Token).ConfigureAwait(false);
+                await (options.SoakUnbounded
+                    ? RunUnboundedProducerAsync(producer, options, messageValue, throughput, measurementCts.Token)
+                    : RunPacedProducerAsync(producer, options, messageValue, throughput, measurementCts.Token))
+                    .ConfigureAwait(false);
             }
 
             try
@@ -152,7 +150,7 @@ internal sealed class SoakStressTest : IStressTestScenario
 
             var acceptedMessages = throughput.MessageCount;
             var acceptedRate = throughput.GetAverageMessagesPerSecond();
-            if (!MeetsMinimumPacingRate(acceptedRate, options.SoakMessagesPerSecond))
+            if (!options.SoakUnbounded && !MeetsMinimumPacingRate(acceptedRate, options.SoakMessagesPerSecond))
             {
                 var minimumRate = options.SoakMessagesPerSecond * MinimumPacingRateRatio;
                 throughput.RecordError(
@@ -187,14 +185,32 @@ internal sealed class SoakStressTest : IStressTestScenario
                     "Broker delivery verification");
             }
 
-            await WaitForConsumerCatchUpAsync(
-                () => Interlocked.Read(ref consumedMessages),
-                deliveredMessages,
-                consumerTask,
-                cancellationToken).ConfigureAwait(false);
+            if (!options.SoakUnbounded)
+            {
+                await WaitForConsumerCatchUpAsync(
+                    () => Interlocked.Read(ref consumedMessages),
+                    deliveredMessages,
+                    consumerTask,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             var finalConsumedMessages = Interlocked.Read(ref consumedMessages);
-            if (finalConsumedMessages != deliveredMessages)
+            if (options.SoakUnbounded)
+            {
+                // The unbounded producer outruns both the consumer and broker byte-bounded
+                // retention, so the consumer legitimately skips ahead through OffsetOutOfRange
+                // resets and can never account for every delivered offset. Completeness is
+                // replaced by the consumed-throughput decay gate in the resource trend plus
+                // this zero-progress check.
+                if (finalConsumedMessages == 0)
+                {
+                    throughput.RecordError(
+                        "ConsumerStalled",
+                        $"Unbounded soak consumed no messages while the broker accepted {deliveredMessages:N0}.",
+                        "Consumer progress verification");
+                }
+            }
+            else if (finalConsumedMessages != deliveredMessages)
             {
                 throughput.RecordError(
                     "ConsumerCountMismatch",
@@ -301,6 +317,43 @@ internal sealed class SoakStressTest : IStressTestScenario
         {
             warmupSeen.TrySetException(ex);
             throughput.RecordError(ex, "Mixed soak consume loop");
+        }
+    }
+
+    internal static async Task RunUnboundedProducerAsync(
+        IKafkaProducer<string, string> producer,
+        StressTestOptions options,
+        string value,
+        ThroughputTracker throughput,
+        CancellationToken cancellationToken)
+    {
+        var messageIndex = 0L;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await producer.FireAsync(
+                    options.Topic,
+                    StressTestHelpers.GetKey(messageIndex),
+                    value).ConfigureAwait(false);
+                throughput.RecordMessage(options.MessageSizeBytes);
+                messageIndex++;
+
+                // Yield periodically so the sampler, trend monitor, and consumer are
+                // never starved by an uninterrupted synchronous FireAsync fast path.
+                if (messageIndex % 100_000 == 0)
+                {
+                    await Task.Yield();
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                throughput.RecordError(ex, "Unbounded soak produce loop", messageIndex);
+            }
         }
     }
 


### PR DESCRIPTION
## Why

The 24h soak lane paces at 1000 msg/s, which isolates time-proportional effects (timer/handle leaks, metadata churn) but never exercises the sustained-load regime:

- **Per-message leak classes**: paced segments see ~17M messages; an unbounded segment sees billions — 300-500x coverage of buffer-pool fragmentation, sequence/epoch growth, and counter classes.
- **Sustained BufferMemory backpressure**: at max rate on a shared 4-core runner the broker saturates and the client lives in admission control for hours. The #1516 refund leak and the #2187 ArrayPool double-return family lived exactly in this regime; the paced lane structurally cannot see them.
- **Load-dependent late-run decay**: idle-reap collapse (#1910) and estimator ratchets only manifest under load.
- **Real hot-path alloc/msg**: the paced lane's 313 B/msg (3-broker) is per-request fixed cost amortized over tiny batches; at max rate alloc/msg becomes a meaningful zero-allocation check over billions of messages.

## What

**Harness** (`tools/Dekaf.StressTests`):
- `--soak-messages-per-second 0` now means unbounded: the producer runs a tight `FireAsync` loop (same shape as the `ProducerStressTest` reference loop) instead of the paced loop. Parsing accepts 0; help text and run banner updated.
- Gates adjusted for the retention-outpaced regime: the exact broker-delivery count gate (`accepted == end-offset delta`) **stays**; the pacing-rate gate is skipped; the consumer completeness gate is replaced by a zero-progress check — byte-bounded broker retention legitimately outruns the consumer at max rate, so it skips forward via OffsetOutOfRange resets by design. Consumer health is still gated by the existing consumed-throughput decay slope and the consumer progress watchdog.
- No changes under `src/` — client code is untouched.

**Workflow** (`.github/workflows/soak-tests.yml`):
- New `soak-test-unbounded` jobs (1 and 3 brokers, 288 min) on the weekly schedule, free `ubuntu-latest` runners only (no new paid jobs). One segment per topology — 4h48m is already the longest continuous window the 6h public-runner limit permits.
- Broker sizing fit for max-rate ingest: 3g tmpfs (retention-sweep overshoot headroom) and 1g heap (768m starves the broker request path at max throughput; 3×1g still fits the 16 GB runner).
- Trend gates start twice as wide as the paced lane's (WS 16 / heap 8 / LOH 8 MiB/h, decay 10 %/h) — max-rate runs carry allocator and noisy-neighbor variance a fixed-rate lane never sees. Tighten after scheduled history establishes real bands.
- Manual dispatches opt in via the new `run_unbounded` boolean input; the paced job is unchanged and remains the only consumer of `messages_per_second`.

## Validation

- Unit: 15/15 `SoakStressTestTests` pass, including 3 new tests (unbounded loop produces until cancelled with exact counts; produce failures recorded without killing the loop; `SoakUnbounded` sentinel).
- Local 1-minute Docker smoke of `--soak-messages-per-second 0`: unbounded loop, consumer progress, report generation, and trend gates all fire end-to-end (~3.5M messages produced and consumed; trend gate correctly failed the 1-minute window since it is all warmup transient — expected for a smoke run, not representative of CI behavior).
- No perf claims — the lane measures the client; nothing in `src/` changed.

First scheduled run will establish the real trend bands; expect to tighten the unbounded gates after 2-3 weeks of history.