### PR TITLE
perf(networking): stamp receive-timeout deadline instead of re-arming timer per request

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -151,6 +151,7 @@ public sealed partial class KafkaConnection :
     private Timer? _receiveTimeoutTimer;
     private long _receiveTimeoutDeadlineTimestamp;
     private int _receiveTimeoutExpired;
+    private int _receiveTimeoutArmed;
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private readonly object _disposeGate = new();
     private Task? _disposeTask;
@@ -2458,7 +2459,7 @@ public sealed partial class KafkaConnection :
         }
 
         Interlocked.Increment(ref _pendingRequestCount);
-        RefreshReceiveTimeout();
+        StampReceiveTimeoutDeadline();
     }
 
     private bool TryGetPendingRequest(int correlationId, out PendingRequestEntry entry)
@@ -2487,8 +2488,8 @@ public sealed partial class KafkaConnection :
             if (remaining == 0 && Volatile.Read(ref _disposed) != 0)
                 Volatile.Read(ref _pendingRequestsDrained)?.TrySetResult();
 
-            RefreshReceiveTimeout();
-
+            // No timer work on the response path: the armed timer evaluates the
+            // stamped deadline when it fires and goes dormant if nothing is pending.
             ReleasePendingRequestSlot();
         }
 
@@ -2555,30 +2556,39 @@ public sealed partial class KafkaConnection :
         public void Dispose() => connection.EndTrackedOperation();
     }
 
-    private void RefreshReceiveTimeout()
+    /// <summary>
+    /// Extends the receive-timeout deadline for a newly pending request. The deadline is a
+    /// plain stamp — the timer is only armed when it was dormant, so steady traffic costs
+    /// two volatile writes per request instead of a lock plus <see cref="Timer.Change(TimeSpan, TimeSpan)"/>
+    /// on every send and response (worst-case TimerQueue churn at in-flight depth ≤ 1).
+    /// When the timer fires early it re-arms for the stamped remainder (see
+    /// <see cref="OnReceiveTimeout"/>), so the deadline stays authoritative.
+    /// </summary>
+    private void StampReceiveTimeoutDeadline()
+    {
+        Volatile.Write(ref _receiveTimeoutExpired, 0);
+        Volatile.Write(ref _receiveTimeoutDeadlineTimestamp, GetReceiveTimeoutDeadlineTimestamp());
+
+        // Full fence: pairs with the dormant handoff in OnReceiveTimeout so either this
+        // CAS arms the timer or the callback observes the deadline stamped above.
+        if (Interlocked.CompareExchange(ref _receiveTimeoutArmed, 1, 0) == 0)
+            ArmReceiveTimeoutTimer(_options.RequestTimeout);
+    }
+
+    private void ArmReceiveTimeoutTimer(TimeSpan dueTime)
     {
         lock (_receiveTimeoutGate)
         {
-            if (GetPendingRequestCount() == 0)
-                DisarmReceiveTimeout();
-            else
-                ArmReceiveTimeout();
-        }
-    }
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
 
-    private void ArmReceiveTimeout()
-    {
-        if (Volatile.Read(ref _disposed) != 0)
-            return;
-
-        Volatile.Write(ref _receiveTimeoutExpired, 0);
-        Volatile.Write(ref _receiveTimeoutDeadlineTimestamp, GetReceiveTimeoutDeadlineTimestamp());
-        try
-        {
-            GetOrCreateReceiveTimeoutTimer().Change(_options.RequestTimeout, Timeout.InfiniteTimeSpan);
-        }
-        catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
-        {
+            try
+            {
+                GetOrCreateReceiveTimeoutTimer().Change(dueTime, Timeout.InfiniteTimeSpan);
+            }
+            catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
+            {
+            }
         }
     }
 
@@ -2617,31 +2627,48 @@ public sealed partial class KafkaConnection :
 
     private void OnReceiveTimeout()
     {
-        if (Volatile.Read(ref _disposed) != 0 || !HasPendingRequests())
-            return;
-
-        var deadlineTimestamp = Volatile.Read(ref _receiveTimeoutDeadlineTimestamp);
-        if (deadlineTimestamp == 0)
-            return;
-
-        var remainingTimestamp = deadlineTimestamp - Stopwatch.GetTimestamp();
-        if (remainingTimestamp > 0)
+        while (true)
         {
-            // Byte progress moved the deadline forward since the timer was armed
-            // (OnReceiveLoopBytesRead only stamps the deadline) — sleep out the remainder.
-            RearmReceiveTimeoutForRemainder(remainingTimestamp);
-            return;
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+
+            var deadlineTimestamp = Volatile.Read(ref _receiveTimeoutDeadlineTimestamp);
+            if (HasPendingRequests() && deadlineTimestamp != 0)
+            {
+                var remainingTimestamp = deadlineTimestamp - Stopwatch.GetTimestamp();
+                if (remainingTimestamp > 0)
+                {
+                    // New sends and byte progress only stamp the deadline forward
+                    // (StampReceiveTimeoutDeadline / OnReceiveLoopBytesRead) — sleep out
+                    // the remainder; the timer stays armed.
+                    RearmReceiveTimeoutForRemainder(remainingTimestamp);
+                    return;
+                }
+
+                Volatile.Write(ref _receiveTimeoutExpired, 1);
+
+                // Reads are not cancellable — aborting the source is how the timer interrupts an
+                // in-flight read (see ResponseFrameReader.Abort). The receive loop observes the
+                // faulted read together with the expired flag and tears the connection down.
+                // The pending-request check above keeps a drained connection alive; the remaining
+                // race window (last request completing between that check and the abort) at worst
+                // tears down a connection the pool would replace anyway.
+                _frameReader?.Abort();
+                return;
+            }
+
+            // Nothing pending: go dormant instead of rescheduling. The full-fence
+            // exchange pairs with StampReceiveTimeoutDeadline's CAS — either a
+            // concurrent send's CAS re-arms the timer after this release, or the
+            // re-check below observes its stamped deadline and this callback
+            // reclaims the armed slot and loops to evaluate it.
+            Interlocked.Exchange(ref _receiveTimeoutArmed, 0);
+            if (!HasPendingRequests() || Volatile.Read(ref _receiveTimeoutDeadlineTimestamp) == 0)
+                return;
+
+            if (Interlocked.CompareExchange(ref _receiveTimeoutArmed, 1, 0) != 0)
+                return;
         }
-
-        Volatile.Write(ref _receiveTimeoutExpired, 1);
-
-        // Reads are not cancellable — aborting the source is how the timer interrupts an
-        // in-flight read (see ResponseFrameReader.Abort). The receive loop observes the
-        // faulted read together with the expired flag and tears the connection down.
-        // The pending-request check above keeps a drained connection alive; the remaining
-        // race window (last request completing between that check and the abort) at worst
-        // tears down a connection the pool would replace anyway.
-        _frameReader?.Abort();
     }
 
     private void RearmReceiveTimeoutForRemainder(long remainingTimestamp)

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -151,6 +151,11 @@ public sealed partial class KafkaConnection :
     private Timer? _receiveTimeoutTimer;
     private long _receiveTimeoutDeadlineTimestamp;
     private int _receiveTimeoutExpired;
+    // 1 while a receive-timeout callback is scheduled or executing. Invariant: a pending
+    // request implies armed — established by StampReceiveTimeoutDeadline's CAS and the
+    // dormant handoff in OnReceiveTimeout. Not reset on teardown; _disposed guards every
+    // arm/fire path, and any future connection-reuse work must re-initialize this under
+    // _receiveTimeoutGate after sends are fenced.
     private int _receiveTimeoutArmed;
     private OAuthBearerTokenProvider? _ownedTokenProvider;
     private readonly object _disposeGate = new();
@@ -2559,18 +2564,23 @@ public sealed partial class KafkaConnection :
     /// <summary>
     /// Extends the receive-timeout deadline for a newly pending request. The deadline is a
     /// plain stamp — the timer is only armed when it was dormant, so steady traffic costs
-    /// two volatile writes per request instead of a lock plus <see cref="Timer.Change(TimeSpan, TimeSpan)"/>
-    /// on every send and response (worst-case TimerQueue churn at in-flight depth ≤ 1).
-    /// When the timer fires early it re-arms for the stamped remainder (see
-    /// <see cref="OnReceiveTimeout"/>), so the deadline stays authoritative.
+    /// two volatile writes and one uncontended CAS per request instead of a lock plus
+    /// <see cref="Timer.Change(TimeSpan, TimeSpan)"/> on every send and response
+    /// (worst-case TimerQueue churn at in-flight depth ≤ 1). When the timer fires early
+    /// it re-arms for the stamped remainder (see <see cref="OnReceiveTimeout"/>), so the
+    /// deadline stays authoritative.
     /// </summary>
     private void StampReceiveTimeoutDeadline()
     {
         Volatile.Write(ref _receiveTimeoutExpired, 0);
         Volatile.Write(ref _receiveTimeoutDeadlineTimestamp, GetReceiveTimeoutDeadlineTimestamp());
 
-        // Full fence: pairs with the dormant handoff in OnReceiveTimeout so either this
-        // CAS arms the timer or the callback observes the deadline stamped above.
+        // Full-fence RMW even when it fails: pairs with the dormant handoff in
+        // OnReceiveTimeout so either this CAS arms the timer or the callback observes the
+        // deadline stamped above. Do not weaken to a test-and-test-and-set: without the
+        // RMW the deadline store (release) and the armed load (acquire) may reorder, and
+        // a callback reclaiming the armed slot could evaluate a stale past deadline with
+        // a request pending and spuriously expire the connection.
         if (Interlocked.CompareExchange(ref _receiveTimeoutArmed, 1, 0) == 0)
             ArmReceiveTimeoutTimer(_options.RequestTimeout);
     }
@@ -2673,20 +2683,14 @@ public sealed partial class KafkaConnection :
 
     private void RearmReceiveTimeoutForRemainder(long remainingTimestamp)
     {
-        var remaining = TimeSpan.FromSeconds(remainingTimestamp / (double)Stopwatch.Frequency);
-        lock (_receiveTimeoutGate)
-        {
-            if (Volatile.Read(ref _disposed) != 0 || Volatile.Read(ref _receiveTimeoutDeadlineTimestamp) == 0)
-                return;
+        // Teardown belt: DisarmReceiveTimeout is the only writer of 0 and runs only
+        // after _disposed is set, so a zero deadline means mid-teardown, never idle.
+        // The gate never ordered this lock-free field; the _disposed check inside
+        // ArmReceiveTimeoutTimer is the real protection.
+        if (Volatile.Read(ref _receiveTimeoutDeadlineTimestamp) == 0)
+            return;
 
-            try
-            {
-                GetOrCreateReceiveTimeoutTimer().Change(remaining, Timeout.InfiniteTimeSpan);
-            }
-            catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
-            {
-            }
-        }
+        ArmReceiveTimeoutTimer(TimeSpan.FromSeconds(remainingTimestamp / (double)Stopwatch.Frequency));
     }
 
     private bool ConsumeReceiveTimeoutExpired()

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionPipelinedTests.cs
@@ -234,7 +234,7 @@ public sealed class KafkaConnectionPipelinedTests
     }
 
     [Test]
-    public async Task ReceiveTimeoutRefresh_StaleZeroRefresh_DoesNotDisarmLivePendingRequest()
+    public async Task ReceiveTimeout_StaleCallbackAfterRemoveAddCycle_DoesNotExpireLivePendingRequest()
     {
         var connection = new KafkaConnection(
             "localhost",
@@ -254,9 +254,13 @@ public sealed class KafkaConnectionPipelinedTests
         AddPendingRequest(connection, correlationId: 2, second);
         await Assert.That(GetPrivateField<int>(connection, "_pendingRequestCount")).IsEqualTo(1);
 
-        InvokeStaleZeroOrFreshReceiveTimeoutRefresh(connection);
+        // A timer callback racing the remove/add cycle must re-evaluate the stamped
+        // deadline (an hour out), stay armed, and leave the live request untouched.
+        InvokeReceiveTimeout(connection);
 
         await Assert.That(GetPrivateField<long>(connection, "_receiveTimeoutDeadlineTimestamp")).IsNotEqualTo(0);
+        await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutExpired")).IsEqualTo(0);
+        await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutArmed")).IsEqualTo(1);
         await Assert.That(TryRemovePendingRequest(connection, correlationId: 2)).IsTrue();
         await connection.DisposeAsync();
     }
@@ -452,29 +456,6 @@ public sealed class KafkaConnectionPipelinedTests
         var method = typeof(KafkaConnection).GetMethod(
             "OnReceiveTimeout",
             BindingFlags.NonPublic | BindingFlags.Instance)!;
-        method.Invoke(connection, []);
-    }
-
-    private static void InvokeStaleZeroOrFreshReceiveTimeoutRefresh(KafkaConnection connection)
-    {
-        var staleOverload = typeof(KafkaConnection).GetMethod(
-            "RefreshReceiveTimeout",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            binder: null,
-            types: [typeof(int)],
-            modifiers: null);
-        if (staleOverload is not null)
-        {
-            staleOverload.Invoke(connection, [0]);
-            return;
-        }
-
-        var method = typeof(KafkaConnection).GetMethod(
-            "RefreshReceiveTimeout",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            binder: null,
-            types: [],
-            modifiers: null)!;
         method.Invoke(connection, []);
     }
 

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -874,15 +874,37 @@ public sealed class KafkaConnectionTests
             });
             await Assert.That(thrown!.CancellationToken).IsEqualTo(callerCancellation.Token);
 
-            // Completion of the cancelled send synchronously removes its pending request and
-            // disarms the receive timeout. Invoke a late timer callback directly instead of
-            // racing caller cancellation against a one-second wall-clock timeout.
+            // Completion of the cancelled send synchronously removes its pending request.
+            // The response path no longer touches the timer, so the stamped deadline
+            // survives; a late timer callback must observe zero pending requests, go
+            // dormant without expiring, and leave the connection alive.
             await Assert.That(GetPrivateField<int>(connection, "_pendingRequestCount")).IsEqualTo(0);
-            await Assert.That(GetPrivateField<long>(connection, "_receiveTimeoutDeadlineTimestamp")).IsEqualTo(0);
             InvokeReceiveTimeout(connection);
 
             await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutExpired")).IsEqualTo(0);
+            await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutArmed")).IsEqualTo(0);
             await Assert.That(connection.IsConnected).IsTrue();
+
+            // A send after the timer went dormant must re-arm it, and a firing with the
+            // deadline still in the future must keep it armed without expiring.
+            using var secondCancellation = new CancellationTokenSource();
+            var secondSend = connection.SendAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                apiVersion: 3,
+                secondCancellation.Token).AsTask();
+            await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+
+            await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutArmed")).IsEqualTo(1);
+            InvokeReceiveTimeout(connection);
+            await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutExpired")).IsEqualTo(0);
+            await Assert.That(GetPrivateField<int>(connection, "_receiveTimeoutArmed")).IsEqualTo(1);
+            await Assert.That(connection.IsConnected).IsTrue();
+
+            await secondCancellation.CancelAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await secondSend.ConfigureAwait(false);
+            });
             await connection.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
         }
         finally


### PR DESCRIPTION
## What

`AddPendingRequest` and `TryRemovePendingRequest` re-armed the receive-timeout `Timer` (lock + `Timer.Change`) on **every send and every response**. At in-flight depth ≤ 1 the pending count oscillates 0→1→0, so the timer was fully disarmed and re-armed per request — worst-case TimerQueue churn. A CPU trace of the transactional stress lane showed the TimerQueue timer thread as the busiest thread in the process by event count.

The connection already had a deadline-lazy path for byte progress (stamp `_receiveTimeoutDeadlineTimestamp`; the callback sleeps out the remainder when it fires early). This moves sends onto the same path:

- **Sends** stamp the deadline (two volatile writes) and arm the `Timer` only when it was dormant (CAS on a new `_receiveTimeoutArmed` flag).
- **Responses** no longer touch the timer at all; the armed callback observes zero pending requests and goes dormant.
- The dormant handoff uses full-fence interlocked ops on both sides: a send racing the callback either arms the timer itself or is observed by the callback's re-check, which reclaims the armed slot and loops to evaluate the fresh deadline. (The CAS deliberately stays a full-fence RMW even when it fails — a TATAS variant lets the deadline store and armed load reorder and can spuriously expire a live connection; documented in-code.)

Timeout semantics preserved: the deadline stays authoritative ("no byte progress for `RequestTimeout` while requests are pending"), moved forward by sends and byte progress exactly as before. Steady state: ~2 lock+`Timer.Change` per request → one no-op callback per `RequestTimeout` (default 30s) per connection.

## Why now

Investigating the transactional 3-broker lane's standing CPU gap vs Confluent (Dekaf ~400 vs ~274 µs/msg at 1 msg/request, stable 1.46–1.54× for a month — successor to #2037). Profiling decomposed it as ~77% per-request path over ~5 threadpool hops + ~23% standing overhead; the per-request `Timer` disarm/re-arm was the largest single unnamed cost. High-throughput lanes shed the same 2 `Timer.Change`/request (~3.6k/s at fire-and-forget request rates).

## Before/after

Local identical A/B, transactional EOS lane (2 min, 1000B, Dekaf-only, interleaved A-B-A-B-A-B on one machine — same instrument as #2042):

| CPU µs/msg | run 1 | run 2 | run 3 | median |
|---|--:|--:|--:|--:|
| `main` | 740.67 | 604.71 | 698.05 | **698.05** |
| this branch | 641.03 | 574.92 | 600.65 | **600.65** |

**−97 µs/msg median (−14%)**; candidate below baseline in 8/9 pairwise comparisons; median throughput identical (64–65 msg/s); allocations flat (~570 B/msg harness scope); **EOS verification exact PASS on all six runs** (committed delivered exactly, 0 duplicates/shortfall/leaks).

Proposed CI acceptance per Rule 7: single `producer-transactional-3b` lane, exact-SHA A-B-A with `baseline_sha=85c0efb5a` (immediately preceding product SHA), 15-minute default.

## Tests

- Unit suite 6591/6591 (net10.0); KafkaConnection suites 107/107 on net10.0 and net8.0.
- `SendAsync_CallerCanceledRequest_...` extended: late callback after drain goes dormant without expiring; a subsequent send re-arms; early fire with a future deadline stays armed without expiring.
- `ReceiveTimeout_StaleCallbackAfterRemoveAddCycle_DoesNotExpireLivePendingRequest` pins the new invariant (the old `RefreshReceiveTimeout` stale-zero-refresh hazard it guarded is structurally gone — the response path no longer touches the timer).
- /simplify review applied: single timer-arming path, invariant comments; TATAS proposal rejected as unsound (reasoning in-code).

Part of the transactional-CPU investigation; profile also identified linger-bound dispatch as the dominant throughput lever and ~150–350 B/msg unattributed allocations — follow-up issues to be filed separately.