### PR TITLE
perf(producer): app-limited linger bypass — seal sole awaited produce at append (#2510)

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -3253,6 +3253,10 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     : DateTimeOffset.UtcNow;
                 try { CompleteInflightEntry(batch); }
                 catch (Exception cleanupEx) { LogBatchCleanupStepFailed(cleanupEx, _brokerId); }
+                // Before CompleteSend: the completion resumes a serial awaited caller whose
+                // next append reads the undelivered count (app-limited bypass, #2510) —
+                // decrementing after would lose that race on nearly every message.
+                _accumulator.MarkBatchDeliveryComplete(batch);
                 batch.CompleteSend(partitionResponse.BaseOffset, timestamp);
                 try
                 {
@@ -3860,6 +3864,8 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                         }
 
                         CompleteInflightEntry(batch);
+                        // Same pre-CompleteSend ordering as the acked path (#2510).
+                        _accumulator.MarkBatchDeliveryComplete(batch);
                         batch.CompleteSend(-1, fireAndForgetTimestamp);
                         try { _onAcknowledgement?.Invoke(batch.TopicPartition, -1, fireAndForgetTimestamp, batch.CompletionSourcesCount, null); }
                         catch (Exception ackEx) { LogBatchCleanupStepFailed(ackEx, _brokerId); }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1863,6 +1863,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         var completion = ProduceAllCompletion.Rent(messageList.Count);
+        // Bulk scope: these registrations are awaited as an aggregate, so the accumulator's
+        // app-limited immediate-seal gate must stay off while their appends land (#2510).
+        // Held through the aggregate await, not just the loop: metadata-miss and
+        // backpressure appends run after registration returns.
+        using var bulkScope = _accumulator.EnterBulkProduceScope();
         for (var i = 0; i < messageList.Count; i++)
         {
             try
@@ -1902,6 +1907,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
 
         var completion = ProduceAllCompletion.Rent(messageList.Count);
+        // Bulk scope held through the aggregate await: see the message-list overload (#2510).
+        using var bulkScope = _accumulator.EnterBulkProduceScope();
         for (var i = 0; i < messageList.Count; i++)
         {
             var (key, value) = messageList[i];

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -5588,7 +5588,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             batch.EnableDeliveryDiagnostics();
             batch.AppendDiag('E');
         }
-        batch.DeliveryAccountingExited = 0;
+        batch.DeliveryAccountingArmed = 1;
         Interlocked.Increment(ref _undeliveredBatchCount);
         Interlocked.Increment(ref _inFlightBatchCount);
         InFlightBatchListAdd(batch);
@@ -5596,14 +5596,16 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     /// <summary>
     /// Marks a pipeline batch's delivery as complete for the app-limited bypass gate
-    /// (#2510). Idempotent per flight (flag-guarded): the sender calls this immediately
-    /// before CompleteSend on the ack path so a serial awaited caller's next append sees
-    /// zero undelivered batches; OnBatchExitsPipeline calls it as the fallback covering
-    /// every failure, purge, sweep, and dispose path.
+    /// (#2510). Idempotent per flight: only the call that disarms
+    /// <see cref="ReadyBatch.DeliveryAccountingArmed"/> decrements, and batches that never
+    /// entered the pipeline are unarmed no-ops. The sender calls this immediately before
+    /// CompleteSend on the ack path so a serial awaited caller's next append sees zero
+    /// undelivered batches; OnBatchExitsPipeline calls it as the fallback covering every
+    /// failure, purge, sweep, and dispose path.
     /// </summary>
     internal void MarkBatchDeliveryComplete(ReadyBatch batch)
     {
-        if (Interlocked.Exchange(ref batch.DeliveryAccountingExited, 1) != 0)
+        if (Interlocked.Exchange(ref batch.DeliveryAccountingArmed, 0) != 1)
             return;
 
         var count = Interlocked.Decrement(ref _undeliveredBatchCount);
@@ -8785,12 +8787,14 @@ internal sealed class ReadyBatch
     internal int UnackedBudgetPipelineTracked;
 
     /// <summary>
-    /// 1 once this pipeline flight has been subtracted from the accumulator's undelivered
-    /// count (app-limited bypass gate, #2510). Guards the decrement so the sender's
-    /// pre-CompleteSend call and OnBatchExitsPipeline's fallback can both run.
-    /// Re-armed to 0 by OnBatchEntersPipeline at the start of every flight.
+    /// 1 while this flight is counted in the accumulator's undelivered-batch count
+    /// (app-limited bypass gate, #2510). Armed by OnBatchEntersPipeline; the first
+    /// MarkBatchDeliveryComplete call (sender pre-CompleteSend, or the
+    /// OnBatchExitsPipeline fallback) disarms it and decrements. Batches that never
+    /// entered the pipeline (e.g. test harnesses enqueueing straight into a sender)
+    /// stay at 0, so completion marking is a no-op for them.
     /// </summary>
-    internal int DeliveryAccountingExited;
+    internal int DeliveryAccountingArmed;
 
     // Intrusive linked list pointers for RecordAccumulator._inFlightBatchList.
     // Using embedded pointers eliminates per-batch ConcurrentDictionary.Node allocations

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1218,6 +1218,21 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     // active linger queue when this counter is non-zero. Count is per batch, not per message.
     private int _pendingAwaitedProduceCount;
 
+    // Non-zero while a ProduceAllAsync registration loop is appending. Bulk registrations
+    // carry per-message completion sources but are awaited as an aggregate, not serially,
+    // so the app-limited immediate-seal gate must not fire on their first message (#2510).
+    // Incremented/decremented once per bulk call, never per message.
+    private int _bulkProduceScopeCount;
+
+    // Sealed batches whose delivery has not yet completed. Unlike _inFlightBatchCount —
+    // which is decremented in OnBatchExitsPipeline, AFTER CompleteSend has already resumed
+    // the awaiting caller (so a serial awaited caller's next append races the sender's
+    // bookkeeping and loses ~99% of the time) — this counter is decremented by the sender
+    // immediately BEFORE completion sources fire, so that next append deterministically
+    // observes zero. Read only by the app-limited bypass gate (#2510); flush/dispose
+    // continue to key on _inFlightBatchCount.
+    private long _undeliveredBatchCount;
+
     // Push-based notification queue for partitions with an unsealed CurrentBatch.
     // Linger drains this instead of scanning _partitionDeques every 1ms, making awaited-produce
     // checks O(active unsealed partitions) instead of O(all partitions ever touched).
@@ -3389,7 +3404,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
-                                if (ShouldSealAppendedBatch(currentBatch))
+                                if (ShouldSealAppendedBatch(currentBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
                                     ownsRotation = true;
@@ -3432,7 +3447,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
-                                if (ShouldSealAppendedBatch(newBatch))
+                                if (ShouldSealAppendedBatch(newBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
                                     ownsRotation = true;
@@ -3968,7 +3983,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 if (reservedFirstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
 
-                                if (ShouldSealAppendedBatch(reservedAppendBatch))
+                                if (ShouldSealAppendedBatch(reservedAppendBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, reservedAppendBatch);
                                     ownsRotation = true;
@@ -4323,7 +4338,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (result.FirstCompletionSourceInBatch)
                 TrackPendingAwaitedProduceBatch();
 
-            if (ShouldSealAppendedBatch(currentBatch))
+            if (ShouldSealAppendedBatch(currentBatch, completionSource))
             {
                 batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
             }
@@ -4531,12 +4546,82 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return result < current ? long.MaxValue : result;
     }
 
+    // No ShouldFlush conjunct: every call site runs on the appending thread immediately
+    // after a successful append, so RecordCount >= 1 and ShouldFlush(now, 0) is true on
+    // both the awaited (lingerMs == 0 => true) and fire-and-forget (elapsed >= 0) branches —
+    // calling it would only spend a Stopwatch.GetTimestamp() per append for a constant.
+    //
+    // The bypass branch checks only the mute set, not ShouldDeferPartialBatchSeal: with
+    // zero undelivered batches producer-wide (a gate condition), a non-zero
+    // _partitionQueueBytes entry is bookkeeping lag from the previous delivery
+    // (decremented in OnBatchExitsPipeline, after CompleteSend resumed the caller),
+    // never a real pipeline batch.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldSealAppendedBatch(PartitionBatch batch)
-        => batch.IsExactlyAtSizeLimit
-            || (_options.LingerMs == 0
-                && !ShouldDeferPartialBatchSeal(batch)
-                && batch.ShouldFlush(Stopwatch.GetTimestamp(), _options.LingerMs));
+    private bool ShouldSealAppendedBatch(PartitionBatch batch, PooledValueTaskSource<RecordMetadata>? completionSource)
+    {
+        if (batch.IsExactlyAtSizeLimit)
+            return true;
+
+        if (_options.LingerMs == 0)
+            return !ShouldDeferPartialBatchSeal(batch);
+
+        return IsAppLimitedAwaitedAppend(batch, completionSource)
+            && !_mutedPartitions.ContainsKey(batch.TopicPartition);
+    }
+
+    /// <summary>
+    /// App-limited awaited produce detection (#2510): a caller that serially awaits each
+    /// message can never coalesce anything into the open batch while it waits, so the
+    /// awaited linger window (min(2ms, LingerMs/2)) buys no batching — only latency and
+    /// linger-throttled throughput. When the appended message is provably the only demand
+    /// in the whole producer, seal and dispatch immediately instead of waiting.
+    ///
+    /// Every condition is required so batching under load is untouched (protected metric):
+    /// - completion source present: fire-and-forget appends keep full linger batching;
+    /// - sole record in this batch: nothing has coalesced, and no fire-and-forget records
+    ///   would ship early (with the just-appended record being the only one and carrying
+    ///   the completion source, it is also the batch's sole completion source);
+    /// - sole awaited batch producer-wide, sole unsealed batch, zero undelivered sealed
+    ///   batches: no concurrent demand exists that this batch could ride along with in a
+    ///   multi-partition produce request (undelivered — not _inFlightBatchCount, whose
+    ///   post-CompleteSend decrement loses the race against a serial caller's next append);
+    /// - no bulk produce scope open: ProduceAllAsync demand must batch normally, not
+    ///   ship 1-record requests.
+    /// Racy counter reads only make the gate conservative (skip bypass) or fire it at the
+    /// instant load begins (one small request) — the seal itself runs under the deque lock
+    /// on the existing LingerMs==0 machinery.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsAppLimitedAwaitedAppend(PartitionBatch batch, PooledValueTaskSource<RecordMetadata>? completionSource)
+        => completionSource is not null
+            && batch.RecordCount == 1
+            && Volatile.Read(ref _pendingAwaitedProduceCount) == 1
+            && Volatile.Read(ref _unsealedBatchCount) == 1
+            && Volatile.Read(ref _undeliveredBatchCount) == 0
+            && Volatile.Read(ref _bulkProduceScopeCount) == 0;
+
+    /// <summary>
+    /// Opens a bulk produce scope so aggregate-awaited registrations (ProduceAllAsync) are
+    /// not mistaken for app-limited serial awaited produce. The scope must stay open until
+    /// the aggregate completes: metadata-miss and backpressure appends land after the
+    /// registration loop, and pending bulk delivery is still aggregate demand. See
+    /// <see cref="IsAppLimitedAwaitedAppend"/>.
+    /// </summary>
+    internal BulkProduceScope EnterBulkProduceScope()
+    {
+        Interlocked.Increment(ref _bulkProduceScopeCount);
+        return new BulkProduceScope(this);
+    }
+
+    /// <summary>Counter guard returned by <see cref="EnterBulkProduceScope"/>.</summary>
+    internal readonly struct BulkProduceScope(RecordAccumulator accumulator) : IDisposable
+    {
+        public void Dispose()
+        {
+            var count = Interlocked.Decrement(ref accumulator._bulkProduceScopeCount);
+            Debug.Assert(count >= 0, "Bulk produce scope disposed more times than entered; a negative count silently disables the app-limited bypass.");
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldDeferPartialBatchSeal(PartitionBatch batch)
@@ -5503,8 +5588,26 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             batch.EnableDeliveryDiagnostics();
             batch.AppendDiag('E');
         }
+        batch.DeliveryAccountingExited = 0;
+        Interlocked.Increment(ref _undeliveredBatchCount);
         Interlocked.Increment(ref _inFlightBatchCount);
         InFlightBatchListAdd(batch);
+    }
+
+    /// <summary>
+    /// Marks a pipeline batch's delivery as complete for the app-limited bypass gate
+    /// (#2510). Idempotent per flight (flag-guarded): the sender calls this immediately
+    /// before CompleteSend on the ack path so a serial awaited caller's next append sees
+    /// zero undelivered batches; OnBatchExitsPipeline calls it as the fallback covering
+    /// every failure, purge, sweep, and dispose path.
+    /// </summary>
+    internal void MarkBatchDeliveryComplete(ReadyBatch batch)
+    {
+        if (Interlocked.Exchange(ref batch.DeliveryAccountingExited, 1) != 0)
+            return;
+
+        var count = Interlocked.Decrement(ref _undeliveredBatchCount);
+        Debug.Assert(count >= 0, $"Undelivered batch count went negative ({count}) — mismatched enter/complete accounting");
     }
 
     /// <summary>
@@ -5520,6 +5623,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         // concurrent cleanup paths (e.g., DisposeAsync racing with SendLoopAsync's finally block).
         if (!InFlightBatchListRemove(batch))
             return false;
+
+        // Fallback for paths that never reached the sender's pre-CompleteSend call
+        // (failures, purge, sweeps, dispose). No-op when already marked.
+        MarkBatchDeliveryComplete(batch);
 
         if (Interlocked.Exchange(ref batch.UnackedBudget, null) is { } unackedBudget)
         {
@@ -8676,6 +8783,14 @@ internal sealed class ReadyBatch
     internal int UnackedReservedBytes;
     internal long AdmissionGeneration;
     internal int UnackedBudgetPipelineTracked;
+
+    /// <summary>
+    /// 1 once this pipeline flight has been subtracted from the accumulator's undelivered
+    /// count (app-limited bypass gate, #2510). Guards the decrement so the sender's
+    /// pre-CompleteSend call and OnBatchExitsPipeline's fallback can both run.
+    /// Re-armed to 0 by OnBatchEntersPipeline at the start of every flight.
+    /// </summary>
+    internal int DeliveryAccountingExited;
 
     // Intrusive linked list pointers for RecordAccumulator._inFlightBatchList.
     // Using embedded pointers eliminates per-batch ConcurrentDictionary.Node allocations

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -14,6 +14,38 @@ namespace Dekaf.Tests.Unit.Producer;
 internal static class AccumulatorTestHelpers
 {
     /// <summary>
+    /// Suppresses the app-limited immediate-seal bypass (#2510) for the accumulator's
+    /// remaining lifetime by holding it in a bulk produce scope (the scope is deliberately
+    /// never disposed). Tests that use a sole awaited append as setup and then reach into
+    /// the still-open CurrentBatch (or expect the linger loop to own the seal) call this
+    /// right after constructing the accumulator; without it the bypass seals the batch at
+    /// append and CurrentBatch is already null.
+    /// </summary>
+    public static void KeepBatchesOpenDespiteAppLimitedBypass(RecordAccumulator accumulator)
+        => _ = accumulator.EnterBulkProduceScope();
+
+    /// <summary>
+    /// Appends one null-key/null-value record carrying a freshly rented completion source
+    /// (an awaited produce). Returns the append result.
+    /// </summary>
+    public static bool AppendAwaitedNullRecord(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> pool,
+        string topic,
+        int partition = 0)
+    {
+        return accumulator.TryAppendWithCompletion(
+            topic,
+            partition,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            PooledMemory.Null,
+            PooledMemory.Null,
+            headers: null,
+            headerCount: 0,
+            pool.Rent());
+    }
+
+    /// <summary>
     /// Reads a private instance field via reflection.
     /// </summary>
     public static T GetPrivateField<T>(object instance, string fieldName)

--- a/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AppLimitedLingerBypassTests.cs
@@ -1,0 +1,295 @@
+using Dekaf.Metadata;
+using Dekaf.Networking;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Tests for the app-limited linger bypass (#2510): a serially-awaited produce that is
+/// provably the only demand in the producer seals and dispatches immediately instead of
+/// waiting the awaited linger window (min(2ms, LingerMs/2)). Every guard condition gets a
+/// negative test proving batching is untouched the moment any concurrent demand exists.
+/// </summary>
+public class AppLimitedLingerBypassTests
+{
+    private const string Topic = "bypass-topic";
+
+    private static ProducerOptions CreateOptions(int lingerMs = 5_000) => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "test-producer",
+        BufferMemory = ulong.MaxValue,
+        BatchSize = 1_000_000,
+        LingerMs = lingerMs,
+        EnableIdempotence = false
+    };
+
+    private static bool AppendAwaited(
+        RecordAccumulator accumulator,
+        ValueTaskSourcePool<RecordMetadata> pool,
+        int partition = 0)
+        => AccumulatorTestHelpers.AppendAwaitedNullRecord(accumulator, pool, Topic, partition);
+
+    [Test]
+    public async Task SoleAwaitedProduce_SealsImmediately_WithoutWaitingLinger()
+    {
+        // A huge linger makes the outcome unambiguous: only the bypass can seal this batch
+        // within the lifetime of the test.
+        var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 5_000));
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            var appended = AppendAwaited(accumulator, pool);
+
+            await Assert.That(appended).IsTrue();
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(0);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task FireAndForgetAppend_DoesNotSealImmediately()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+
+        try
+        {
+            var appended = await AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, Topic);
+
+            await Assert.That(appended).IsTrue();
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task BulkProduceScope_SuppressesImmediateSeal()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            using (accumulator.EnterBulkProduceScope())
+            {
+                AppendAwaited(accumulator, pool);
+                await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+            }
+
+            // Once the bulk scope exits, a fresh sole awaited produce would bypass again,
+            // but the batch left open by the bulk append keeps the unsealed count at 1,
+            // so a second awaited append to the same partition coalesces instead.
+            AppendAwaited(accumulator, pool);
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task ConcurrentUnsealedAwaitedBatch_SuppressesImmediateSeal()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            // Leave an unsealed awaited batch on partition 0 (bulk scope keeps it open).
+            using (accumulator.EnterBulkProduceScope())
+            {
+                AppendAwaited(accumulator, pool, partition: 0);
+            }
+
+            // A second awaited produce on partition 1 is NOT app-limited: another awaited
+            // batch exists that a produce request could carry alongside this one.
+            AppendAwaited(accumulator, pool, partition: 1);
+
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(2);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task InFlightBatch_SuppressesImmediateSeal()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            // First sole awaited produce bypasses and enters the pipeline (in-flight = 1).
+            AppendAwaited(accumulator, pool, partition: 0);
+            await Assert.That(accumulator.InFlightBatchCount).IsEqualTo(1);
+
+            // With a batch still in flight the producer is not app-limited (nothing has
+            // awaited that delivery yet), so the next awaited append must keep batching.
+            AppendAwaited(accumulator, pool, partition: 1);
+
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// End-to-end regression for the stress lane shape (#2510): serial awaited transactional
+    /// produce at LingerMs=5 must seal at append on every cycle — including cycles where the
+    /// previous batch was delivered and retired the way BrokerSender does. On failure the
+    /// message dumps every gate input so the blocking condition is visible.
+    /// Not parallel: full-producer tests emit thread-pool continuations that can land on
+    /// the allocation gate's measuring thread (see TransactionalProduceAllocationTests).
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task TransactionalSerialProduce_AppLimited_SealsAtAppend()
+    {
+        await using var producer = new KafkaProducer<string, string>(
+            CreateTransactionalOptions(),
+            Serializers.String,
+            Serializers.String);
+        await producer.StopSenderLoopsForTestingAsync();
+        SeedProducerMetadata(producer);
+        InitializeTransactionalState(producer);
+
+        var transaction = producer.BeginTransaction();
+        var accumulator = producer.RecordAccumulator;
+        var topicPartition = new TopicPartition(TxnTopic, 0);
+
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            var produce = transaction.ProduceAsync(TxnTopic, "key", "value", CancellationToken.None);
+
+            if (accumulator.UnsealedBatchCount != 0)
+            {
+                var pendingAwaited = AccumulatorTestHelpers.GetPrivateField<int>(accumulator, "_pendingAwaitedProduceCount");
+                var bulkScope = AccumulatorTestHelpers.GetPrivateField<int>(accumulator, "_bulkProduceScopeCount");
+                Assert.Fail(
+                    $"cycle {cycle}: batch not sealed at append — unsealed={accumulator.UnsealedBatchCount}, " +
+                    $"inFlight={accumulator.InFlightBatchCount}, pendingAwaited={pendingAwaited}, bulkScope={bulkScope}");
+            }
+
+            await Assert.That(accumulator.TryDrainBatch(topicPartition, out var batch)).IsTrue();
+            LeakGateHarness.RetireBatch(accumulator, batch!, offset: cycle * 10);
+            var metadata = await produce;
+            await Assert.That(metadata.Partition).IsEqualTo(0);
+        }
+
+        // Never committed (no broker); return to Ready so DisposeAsync skips the coordinator abort.
+        producer._transactionState = TransactionState.Ready;
+    }
+
+    private const string TxnTopic = "bypass-txn-topic";
+
+    private static ProducerOptions CreateTransactionalOptions() => new()
+    {
+        BootstrapServers = ["localhost:9092"],
+        ClientId = "bypass-txn",
+        TransactionalId = "bypass-txn",
+        EnableIdempotence = true,
+        Acks = Acks.All,
+        BufferMemory = 32UL * 1024 * 1024,
+        BatchSize = 1_048_576,
+        LingerMs = 5,
+        RequestTimeoutMs = 500,
+        DeliveryTimeoutMs = 1_000,
+        CloseTimeoutMs = 1_000,
+        // The test host installs a process-wide sample-everything ActivityListener; the stress
+        // lane this mirrors runs without listeners — pin that branch.
+        SkipProduceActivityListenerCheckForTesting = true,
+    };
+
+    private static void InitializeTransactionalState(KafkaProducer<string, string> producer)
+    {
+        AccumulatorTestHelpers.SetPrivateField(producer, "_initialized", true);
+        var metadataManager = AccumulatorTestHelpers.GetPrivateField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.ObserveClusterCapabilities(
+            "bypass-txn-cluster",
+            KafkaConnectionCapabilities.Create(new ApiVersionsResponse
+            {
+                ErrorCode = ErrorCode.None,
+                ApiKeys = [],
+                FinalizedFeaturesEpoch = 1,
+                FinalizedFeatures =
+                [
+                    new FinalizedFeature("transaction.version", 2, 2)
+                ]
+            }));
+        producer._transactionState = TransactionState.Ready;
+    }
+
+    private static void SeedProducerMetadata(KafkaProducer<string, string> producer)
+    {
+        var metadataManager = AccumulatorTestHelpers.GetPrivateField<MetadataManager>(producer, "_metadataManager");
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers =
+            [
+                new BrokerMetadata { NodeId = 0, Host = "localhost", Port = 9092 },
+            ],
+            ClusterId = "bypass-txn-cluster",
+            ControllerId = 0,
+            Topics =
+            [
+                new TopicMetadata
+                {
+                    ErrorCode = ErrorCode.None,
+                    Name = TxnTopic,
+                    Partitions =
+                    [
+                        new PartitionMetadata
+                        {
+                            ErrorCode = ErrorCode.None,
+                            PartitionIndex = 0,
+                            LeaderId = 0,
+                            ReplicaNodes = [0],
+                            IsrNodes = [0],
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    [Test]
+    public async Task SecondRecordInBatch_DoesNotRetriggerSeal()
+    {
+        var accumulator = new RecordAccumulator(CreateOptions());
+        var pool = new ValueTaskSourcePool<RecordMetadata>();
+
+        try
+        {
+            // Fire-and-forget record opens a batch; the awaited record that lands second is
+            // not the sole record, so sealing it early would ship the FnF record early too.
+            await AccumulatorTestHelpers.AppendNullRecordAsync(accumulator, Topic);
+            AppendAwaited(accumulator, pool);
+
+            await Assert.That(accumulator.UnsealedBatchCount).IsEqualTo(1);
+        }
+        finally
+        {
+            await accumulator.DisposeAsync();
+            await pool.DisposeAsync();
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FireAndForgetDeliveryErrorMetricTests.cs
@@ -53,6 +53,7 @@ public sealed class FireAndForgetDeliveryErrorMetricTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
 
         try

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerFastPathTests.cs
@@ -37,6 +37,7 @@ public class KafkaProducerFastPathTests
             Serializers.String,
             Serializers.String);
         await StopProducerBackgroundLoopsAsync(producer);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(producer.RecordAccumulator);
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicInfo = CreateTopicInfo();
         var innerCompletion = pool.Rent();

--- a/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/LingerDeadlineWaitTests.cs
@@ -79,6 +79,7 @@ public class LingerDeadlineWaitTests
     public async Task AwaitedBatch_WaitShrinksToAwaitedWindow()
     {
         var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
         try
         {
@@ -171,6 +172,7 @@ public class LingerDeadlineWaitTests
     public async Task LingerSweep_RaisesOldestBatchHintToSurvivingBatch(CancellationToken cancellationToken)
     {
         var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
         try
         {
@@ -205,6 +207,7 @@ public class LingerDeadlineWaitTests
     public async Task BatchQueuedAfterSweepSnapshot_SignalsLingerWakeup(CancellationToken cancellationToken)
     {
         var accumulator = new RecordAccumulator(CreateOptions(lingerMs: 60_000));
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
         using var snapshotTaken = new ManualResetEventSlim();
         using var continueSweep = new ManualResetEventSlim();

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -446,6 +446,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -491,6 +492,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var poisonedPartition = new TopicPartition("test-topic", 0);
         var healthyPartition = new TopicPartition("test-topic", 1);
@@ -717,6 +719,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -759,6 +762,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var poisonedPartition = new TopicPartition("test-topic", 0);
         var healthyPartition = new TopicPartition("test-topic", 1);
@@ -1806,6 +1810,7 @@ public class RecordAccumulatorTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -1870,6 +1875,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -1922,6 +1928,7 @@ public class RecordAccumulatorTests
     {
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
         ReadyBatch? drainedBatch = null;
@@ -2237,6 +2244,7 @@ public class RecordAccumulatorTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -2310,6 +2318,7 @@ public class RecordAccumulatorTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -3088,6 +3097,7 @@ public class RecordAccumulatorTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 
@@ -3148,6 +3158,7 @@ public class RecordAccumulatorTests
 
         var options = CreateTestOptions();
         var accumulator = new RecordAccumulator(options);
+        AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass(accumulator);
         var pool = new ValueTaskSourcePool<RecordMetadata>();
         var topicPartition = new TopicPartition("test-topic", 0);
 


### PR DESCRIPTION
# perf(producer): app-limited linger bypass — seal sole awaited produce at append (#2510)

Closes #2510.

## What

A serially-awaited produce that is provably the only demand in the producer now seals and
dispatches its batch at append time instead of waiting the awaited linger window
(`min(2ms, LingerMs/2)`). Maintainer decision on #2510: always-on, no knob, strictly gated.

Gate (`IsAppLimitedAwaitedAppend`, evaluated at the existing `ShouldSealAppendedBatch`
sites under the deque lock — all conditions required):

- append carries a completion source (fire-and-forget keeps full linger batching)
- sole record in the batch (which, with the append's own source, makes it the sole completion source)
- sole awaited unsealed batch producer-wide (`_pendingAwaitedProduceCount == 1`)
- sole unsealed batch producer-wide (`_unsealedBatchCount == 1`)
- zero undelivered sealed batches (new `_undeliveredBatchCount`, see below)
- no ProduceAllAsync in flight (new bulk produce scope, held through the aggregate await)
- partition not muted

Under any load, at least one condition fails and batching is unchanged. The seal reuses the
existing LingerMs==0 append-path machinery.

## The counter that made it work

The first cut gated on `_inFlightBatchCount == 0` and was **inert in the real flow** (local
diagnostic: 3,866 of 3,907 appends blocked): BrokerSender fires `CompleteSend` — resuming
the awaiting caller — *before* `OnBatchExitsPipeline` decrements in-flight and
`_partitionQueueBytes`, so the caller's next append reads stale bookkeeping ~99% of the
time. Fix: `_undeliveredBatchCount`, incremented at pipeline entry and decremented
exactly once per flight (flag-guarded) by the sender immediately **before** completion
sources fire, with `OnBatchExitsPipeline` as the fallback covering failure/purge/sweep/
dispose paths. Flush and dispose still key on `_inFlightBatchCount`, preserving the
"completions fire before flush observes done" contract.

## Why

The transactional stress lane (serial awaited produce, 1 msg/batch) is linger-bound: linger
suppresses the message rate, so fixed standing CPU divides over few messages — ~23% of the
lane's 400 µs/msg and most of the 1.46x CPU/msg optics gap vs Confluent (#2510
decomposition). Dekaf already beats Confluent 2.1x on throughput in that lane; this makes
the app-limited shape dispatch immediately without touching loaded batching.

## Evidence

**Local stress, producer-transactional (2-min runs, Docker, same machine, 3 runs each):**

| | Median msg/s | CPU µs/msg | EOS verification |
|---|---|---|---|
| main | 65 / 65 / 65 | 760.7 / 653.4 / 470.8 | PASS ×3 |
| branch | 917 / 1,175 / 1,363 | 202.9 / 194.3 / 178.2 | PASS ×3 |

**Median-of-medians: 65 → 1,175 msg/s (18×); CPU/msg 653 → 194 (−70%).** Gate telemetry
from an instrumented run: 75,007/75,007 appends passed; zero duplicates, aborted-record
leaks, or shortfall across all runs. (The local baseline floor is Windows timer-quantum
bound at ~65 msg/s, so the local multiplier overstates the CI lane's; the CI lane —
currently ~349 msg/s, 2.1x Confluent — should move toward its RTT-bound ceiling and its
CPU/msg optics should drop accordingly. Sunday's weekly paired run shows the real number.)

**Benchmarks (before/after, MemoryDiagnoser, InProcess, same machine):**

| Benchmark | main | branch |
|---|---|---|
| AccumulatorAppend hot path, 100B | 102.6 ns / 0 B | 96.6 ns / 0 B |
| AccumulatorAppend hot path, 1000B | 251.9 ns / 0 B | 245.7 ns / 0 B |
| Txn componentwise cycle | 1.043 µs / 0 B | 1.025 µs / 0 B |

Fire-and-forget append cost of the gate: one null check (short-circuits before any counter
read); LingerMs==0 configs short-circuit before the gate entirely. The seal predicate also
*dropped* a per-append `Stopwatch.GetTimestamp()` on the LingerMs==0 path (its `ShouldFlush`
conjunct was constant-true at every call site).

**Tests:** full unit suite 6,598/6,598 green. New `AppLimitedLingerBypassTests`: bypass
fires on the sole-awaited shape and on a broker-free reproduction of the transactional
serial flow (append → drain → sender-style retirement, 3 cycles); negative tests per gate
condition (FnF, bulk scope, concurrent awaited batch, undelivered batch, multi-record
batch). Txn zero-alloc gate passes. 16 existing tests that used a sole awaited append as
setup now hold a bulk produce scope via
`AccumulatorTestHelpers.KeepBatchesOpenDespiteAppLimitedBypass`, preserving their intent.

## Notes for review

- `ProduceAllAsync` exclusion uses a producer-global bulk scope counter (2 interlocked ops
  per bulk call, never per message) held through the aggregate await, so metadata-miss and
  backpressure appends that land after the registration loop stay covered.
  `ProduceContinuationMode` was rejected as the discriminator — it upgrades to `Async`
  under metrics/activity.
- Known one-shot races (two first-awaited appends at load onset can each ship a 1-record
  request) are bounded and documented at the gate.
- `TransactionalProduceAllocationTests` remains order-sensitive in-suite (measuring-thread
  contamination by neighboring tests' continuations — observed once, passes isolated and
  on rerun; pre-existing exposure). The new full-producer test is `[NotInParallel]` for
  that reason.

## Not in this PR

- ~150–350 B/msg unattributed allocation at 1 msg/request (#2510 "also measured") — needs
  MemoryDiagnoser attribution; unchanged here.
- ProduceAllAsync bulk-of-1 could skip the scope and get the bypass — free follow-up.
- CI acceptance: txn lane is not A-B-A eligible; producer-1b exact-SHA A-B-A to be
  dispatched post-merge per rule 7; Sunday's weekly paired run shows the txn lane effect.
