### PR TITLE
feat(testing): accept IAsync serdes in in-memory clients

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -44,6 +44,36 @@ consumer.Subscribe("orders");
 var record = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
 ```
 
+## Asynchronous serializers
+
+Serdes that perform per-message I/O (`IAsyncSerializer<T>`, `IAsyncDeserializer<T>`, `IAsyncSerde<T>`)
+can be passed to the in-memory clients, so code built around them is unit-testable without a broker.
+Each component is independent — mix a synchronous serializer for the key with an asynchronous one for
+the value if that is how the real client is configured:
+
+```csharp
+using Dekaf.Serialization;
+using Dekaf.Testing;
+
+var cluster = new InMemoryKafkaCluster();
+IAsyncSerde<Order> orderSerde = new EncryptingOrderSerde(keyVault);
+
+var producer = new InMemoryProducer<string, Order>(cluster, Serializers.String, orderSerde);
+var consumer = new InMemoryConsumer<string, Order>(
+    cluster,
+    Serializers.String,
+    orderSerde,
+    new InMemoryConsumerOptions
+    {
+        GroupId = "orders-service",
+        AutoOffsetReset = AutoOffsetReset.Earliest
+    });
+```
+
+The in-memory clients await asynchronous serdes exactly where the real clients do: on
+`ProduceAsync`/`FireAsync` and on `ConsumeAsync`/`ConsumeOneAsync` (and `PollAsync` for the share
+consumer). `InMemoryShareConsumer<TKey, TValue>` accepts the same combinations.
+
 ## Dependency Injection
 
 Use `AddDekafInMemory()` to replace producer, consumer, share consumer, and admin client registrations with in-memory doubles backed by one shared cluster:

--- a/src/Dekaf.Testing/InMemoryConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryConsumer.cs
@@ -21,6 +21,12 @@ public sealed class InMemoryConsumer<TKey, TValue> :
     private readonly InMemoryKafkaCluster _cluster;
     private readonly IDeserializer<TKey> _keyDeserializer;
     private readonly IDeserializer<TValue> _valueDeserializer;
+    // Non-null when the caller configured an IAsyncDeserializer for that component. The matching
+    // synchronous slot then holds a throwing placeholder, mirroring KafkaConsumer: reaching it
+    // means a consume path missed the asynchronous divert and must fail loudly.
+    private readonly IAsyncDeserializer<TKey>? _asyncKeyDeserializer;
+    private readonly IAsyncDeserializer<TValue>? _asyncValueDeserializer;
+    private readonly bool _hasAsyncDeserializers;
     private readonly InMemoryConsumerOptions _options;
     private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
     private readonly HashSet<TopicPartition> _assignment = [];
@@ -70,10 +76,121 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
         InMemoryConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            asyncKeyDeserializer: null,
+            asyncValueDeserializer: null,
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer that awaits <see cref="IAsyncDeserializer{T}"/> for both components.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer that awaits <see cref="IAsyncDeserializer{T}"/> for both components.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer,
+        InMemoryConsumerOptions options)
+        : this(
+            cluster,
+            keyDeserializer: null,
+            valueDeserializer: null,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer with a synchronous key deserializer and an asynchronous value deserializer.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer with a synchronous key deserializer and an asynchronous value deserializer.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer,
+        InMemoryConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            valueDeserializer: null,
+            asyncKeyDeserializer: null,
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer with an asynchronous key deserializer and a synchronous value deserializer.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a consumer with an asynchronous key deserializer and a synchronous value deserializer.
+    /// </summary>
+    public InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        InMemoryConsumerOptions options)
+        : this(
+            cluster,
+            keyDeserializer: null,
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            asyncValueDeserializer: null,
+            options)
+    {
+    }
+
+    private InMemoryConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey>? keyDeserializer,
+        IDeserializer<TValue>? valueDeserializer,
+        IAsyncDeserializer<TKey>? asyncKeyDeserializer,
+        IAsyncDeserializer<TValue>? asyncValueDeserializer,
+        InMemoryConsumerOptions options)
     {
         _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
-        _keyDeserializer = keyDeserializer ?? throw new ArgumentNullException(nameof(keyDeserializer));
-        _valueDeserializer = valueDeserializer ?? throw new ArgumentNullException(nameof(valueDeserializer));
+        _asyncKeyDeserializer = asyncKeyDeserializer;
+        _asyncValueDeserializer = asyncValueDeserializer;
+        _keyDeserializer = asyncKeyDeserializer is null
+            ? keyDeserializer!
+            : AsyncOnlyDeserializerPlaceholder<TKey>.Instance;
+        _valueDeserializer = asyncValueDeserializer is null
+            ? valueDeserializer!
+            : AsyncOnlyDeserializerPlaceholder<TValue>.Instance;
+        _hasAsyncDeserializers = asyncKeyDeserializer is not null || asyncValueDeserializer is not null;
         _options = options ?? throw new ArgumentNullException(nameof(options));
         // Match KafkaConsumer, which treats an empty GroupId as "no consumer group"
         // (no coordinator, no commits). Normalizing here keeps every group-dependent
@@ -278,8 +395,15 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (TryConsumeOne(out var result))
+            if (_hasAsyncDeserializers)
+            {
+                if (await TryConsumeOneAsync(cancellationToken).ConfigureAwait(false) is { } asyncResult)
+                    return asyncResult;
+            }
+            else if (TryConsumeOne(out var result))
+            {
                 return result;
+            }
 
             if (deadline is null)
             {
@@ -630,39 +754,7 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         var previousRecordProven = false;
         while (true)
         {
-            InMemoryRecord? selected = null;
-            TopicPartition selectedPartition = default;
-            long selectedPosition = -1;
-
-            lock (_gate)
-            {
-                if (!previousRecordProven)
-                {
-                    // A new consume call proves the previously delivered record was processed
-                    // (poll contract) — stage it before selecting the next one.
-                    ProveInDoubtRecordUnderLock();
-                    previousRecordProven = true;
-                }
-
-                foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
-                {
-                    if (_paused.Contains(partition))
-                        continue;
-
-                    if (!_positions.TryGetValue(partition, out var position))
-                        continue;
-
-                    if (!_cluster.TryRead(partition, position, out var record))
-                        continue;
-
-                    selected = record;
-                    selectedPartition = partition;
-                    selectedPosition = position;
-                    break;
-                }
-            }
-
-            if (selected is null)
+            if (!TrySelectRecord(ref previousRecordProven, out var partition, out var record, out var position))
             {
                 result = default;
                 return false;
@@ -670,34 +762,104 @@ public sealed class InMemoryConsumer<TKey, TValue> :
 
             // Run user deserializers before advancing any delivery or commit state. A failure
             // leaves the selected offset untouched so the next consume retries the record.
-            var selectedResult = ToConsumeResult(selectedPartition, selected);
+            var selectedResult = ToConsumeResult(partition, record);
 
-            lock (_gate)
-            {
-                // Assignment/seek or another consumer call may have changed the position while
-                // user code deserialized. Retry selection instead of publishing a stale result.
-                if (!_positions.TryGetValue(selectedPartition, out var currentPosition)
-                    || currentPosition != selectedPosition)
-                {
-                    continue;
-                }
-
-                _positions[selectedPartition] = selected.Offset + 1;
-                if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
-                {
-                    if (_options.EnableAutoOffsetStore)
-                        _storedOffsets[selectedPartition] = selected.Offset + 1;
-                    if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
-                        CommitStoredOffsets();
-                }
-                else
-                {
-                    _inDoubtPartition = selectedPartition;
-                    _inDoubtNextOffset = selected.Offset + 1;
-                }
-            }
+            if (!TryAdvancePosition(partition, record, position))
+                continue;
 
             result = selectedResult;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Consume path used when at least one component has an <see cref="IAsyncDeserializer{T}"/>.
+    /// Deliberate mirror of <see cref="TryConsumeOne"/>: both drive the same selection and
+    /// delivery bookkeeping helpers so their offset semantics cannot drift apart.
+    /// </summary>
+    private async ValueTask<ConsumeResult<TKey, TValue>?> TryConsumeOneAsync(CancellationToken cancellationToken)
+    {
+        var previousRecordProven = false;
+        while (true)
+        {
+            if (!TrySelectRecord(ref previousRecordProven, out var partition, out var record, out var position))
+                return null;
+
+            var selectedResult = await ToConsumeResultAsync(partition, record, cancellationToken).ConfigureAwait(false);
+
+            if (!TryAdvancePosition(partition, record, position))
+                continue;
+
+            return selectedResult;
+        }
+    }
+
+    private bool TrySelectRecord(
+        ref bool previousRecordProven,
+        out TopicPartition selectedPartition,
+        out InMemoryRecord selectedRecord,
+        out long selectedPosition)
+    {
+        lock (_gate)
+        {
+            if (!previousRecordProven)
+            {
+                // A new consume call proves the previously delivered record was processed
+                // (poll contract) — stage it before selecting the next one.
+                ProveInDoubtRecordUnderLock();
+                previousRecordProven = true;
+            }
+
+            foreach (var partition in GetCurrentAssignmentUnderLock().OrderBy(item => item.Topic, StringComparer.Ordinal).ThenBy(item => item.Partition))
+            {
+                if (_paused.Contains(partition))
+                    continue;
+
+                if (!_positions.TryGetValue(partition, out var position))
+                    continue;
+
+                if (!_cluster.TryRead(partition, position, out var record))
+                    continue;
+
+                selectedPartition = partition;
+                selectedRecord = record;
+                selectedPosition = position;
+                return true;
+            }
+        }
+
+        selectedPartition = default;
+        selectedRecord = null!;
+        selectedPosition = -1;
+        return false;
+    }
+
+    /// <summary>
+    /// Publishes a delivered record's offset state. Returns false when the position moved while
+    /// user deserializers ran, in which case the caller must reselect instead of publishing a
+    /// stale result.
+    /// </summary>
+    private bool TryAdvancePosition(TopicPartition partition, InMemoryRecord record, long expectedPosition)
+    {
+        lock (_gate)
+        {
+            if (!_positions.TryGetValue(partition, out var currentPosition) || currentPosition != expectedPosition)
+                return false;
+
+            _positions[partition] = record.Offset + 1;
+            if (_options.OffsetStoreTiming == OffsetStoreTiming.OnDelivery)
+            {
+                if (_options.EnableAutoOffsetStore)
+                    _storedOffsets[partition] = record.Offset + 1;
+                if (_options.OffsetCommitMode == OffsetCommitMode.Auto)
+                    CommitStoredOffsets();
+            }
+            else
+            {
+                _inDoubtPartition = partition;
+                _inDoubtNextOffset = record.Offset + 1;
+            }
+
             return true;
         }
     }
@@ -747,23 +909,100 @@ public sealed class InMemoryConsumer<TKey, TValue> :
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            throw ConsumeResult<TKey, TValue>.CreateDeserializationException(
+            throw CreateDeserializationException(
                 ConsumeResult<TKey, TValue>.LastDeserializationOrigin,
-                topicPartition.Topic,
-                topicPartition.Partition,
-                record.Offset,
-                record.TimestampMs,
-                TimestampType.CreateTime,
-                record.Key,
-                record.IsKeyNull,
-                record.Value,
-                record.IsValueNull,
-                record.Headers,
-                pooledHeaders: null,
-                pooledHeaderCount: 0,
+                topicPartition,
+                record,
                 ex);
         }
     }
+
+    /// <summary>
+    /// Deserializes a record via the configured <see cref="IAsyncDeserializer{T}"/> implementations
+    /// (falling back to the synchronous deserializer for a component without one) and builds the
+    /// result from the awaited values. Null-ness semantics mirror the eager
+    /// <see cref="ConsumeResult{TKey,TValue}"/> constructor used by the synchronous path: null keys
+    /// skip the deserializer, null values invoke it with empty data and <c>IsNull = true</c>.
+    /// </summary>
+    private async ValueTask<ConsumeResult<TKey, TValue>> ToConsumeResultAsync(
+        TopicPartition topicPartition,
+        InMemoryRecord record,
+        CancellationToken cancellationToken)
+    {
+        TKey? key = default;
+        if (!record.IsKeyNull)
+        {
+            var keyContext = new SerializationContext
+            {
+                Topic = topicPartition.Topic,
+                Component = SerializationComponent.Key,
+                IsNull = false
+            };
+
+            try
+            {
+                key = _asyncKeyDeserializer is not null
+                    ? await _asyncKeyDeserializer.DeserializeAsync(record.Key, keyContext, cancellationToken).ConfigureAwait(false)
+                    : _keyDeserializer.Deserialize(record.Key, keyContext);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw CreateDeserializationException(DeserializationExceptionOrigin.Key, topicPartition, record, ex);
+            }
+        }
+
+        var valueContext = new SerializationContext
+        {
+            Topic = topicPartition.Topic,
+            Component = SerializationComponent.Value,
+            IsNull = record.IsValueNull
+        };
+        var valueData = record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value;
+
+        TValue value;
+        try
+        {
+            value = _asyncValueDeserializer is not null
+                ? await _asyncValueDeserializer.DeserializeAsync(valueData, valueContext, cancellationToken).ConfigureAwait(false)
+                : _valueDeserializer.Deserialize(valueData, valueContext);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw CreateDeserializationException(DeserializationExceptionOrigin.Value, topicPartition, record, ex);
+        }
+
+        return new ConsumeResult<TKey, TValue>(
+            topicPartition.Topic,
+            topicPartition.Partition,
+            record.Offset,
+            key,
+            value,
+            record.Headers,
+            record.TimestampMs,
+            TimestampType.CreateTime,
+            leaderEpoch: null);
+    }
+
+    private static RecordDeserializationException CreateDeserializationException(
+        DeserializationExceptionOrigin origin,
+        TopicPartition topicPartition,
+        InMemoryRecord record,
+        Exception innerException) =>
+        ConsumeResult<TKey, TValue>.CreateDeserializationException(
+            origin,
+            topicPartition.Topic,
+            topicPartition.Partition,
+            record.Offset,
+            record.TimestampMs,
+            TimestampType.CreateTime,
+            record.Key,
+            record.IsKeyNull,
+            record.Value,
+            record.IsValueNull,
+            record.Headers,
+            pooledHeaders: null,
+            pooledHeaderCount: 0,
+            innerException);
 
     private void ReplaceAssignment(IEnumerable<TopicPartition> partitions)
     {

--- a/src/Dekaf.Testing/InMemoryProducer.cs
+++ b/src/Dekaf.Testing/InMemoryProducer.cs
@@ -13,6 +13,12 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     private readonly InMemoryKafkaCluster _cluster;
     private readonly ISerializer<TKey> _keySerializer;
     private readonly ISerializer<TValue> _valueSerializer;
+    // Non-null when the caller configured an IAsyncSerializer for that component. The matching
+    // synchronous slot then holds a throwing placeholder, mirroring KafkaProducer: reaching it
+    // means a produce path missed the asynchronous divert and must fail loudly.
+    private readonly IAsyncSerializer<TKey>? _asyncKeySerializer;
+    private readonly IAsyncSerializer<TValue>? _asyncValueSerializer;
+    private readonly bool _hasAsyncSerializers;
     private bool _disposed;
 
     public InMemoryProducer(InMemoryKafkaCluster cluster)
@@ -27,10 +33,80 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         InMemoryKafkaCluster cluster,
         ISerializer<TKey> keySerializer,
         ISerializer<TValue> valueSerializer)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keySerializer, nameof(keySerializer)),
+            InMemorySerdeResolver.Required(valueSerializer, nameof(valueSerializer)),
+            asyncKeySerializer: null,
+            asyncValueSerializer: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a producer that awaits <see cref="IAsyncSerializer{T}"/> for both components.
+    /// </summary>
+    public InMemoryProducer(
+        InMemoryKafkaCluster cluster,
+        IAsyncSerializer<TKey> keySerializer,
+        IAsyncSerializer<TValue> valueSerializer)
+        : this(
+            cluster,
+            keySerializer: null,
+            valueSerializer: null,
+            InMemorySerdeResolver.Required(keySerializer, nameof(keySerializer)),
+            InMemorySerdeResolver.Required(valueSerializer, nameof(valueSerializer)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a producer with a synchronous key serializer and an asynchronous value serializer.
+    /// </summary>
+    public InMemoryProducer(
+        InMemoryKafkaCluster cluster,
+        ISerializer<TKey> keySerializer,
+        IAsyncSerializer<TValue> valueSerializer)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keySerializer, nameof(keySerializer)),
+            valueSerializer: null,
+            asyncKeySerializer: null,
+            InMemorySerdeResolver.Required(valueSerializer, nameof(valueSerializer)))
+    {
+    }
+
+    /// <summary>
+    /// Creates a producer with an asynchronous key serializer and a synchronous value serializer.
+    /// </summary>
+    public InMemoryProducer(
+        InMemoryKafkaCluster cluster,
+        IAsyncSerializer<TKey> keySerializer,
+        ISerializer<TValue> valueSerializer)
+        : this(
+            cluster,
+            keySerializer: null,
+            InMemorySerdeResolver.Required(valueSerializer, nameof(valueSerializer)),
+            InMemorySerdeResolver.Required(keySerializer, nameof(keySerializer)),
+            asyncValueSerializer: null)
+    {
+    }
+
+    private InMemoryProducer(
+        InMemoryKafkaCluster cluster,
+        ISerializer<TKey>? keySerializer,
+        ISerializer<TValue>? valueSerializer,
+        IAsyncSerializer<TKey>? asyncKeySerializer,
+        IAsyncSerializer<TValue>? asyncValueSerializer)
     {
         _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
-        _keySerializer = keySerializer ?? throw new ArgumentNullException(nameof(keySerializer));
-        _valueSerializer = valueSerializer ?? throw new ArgumentNullException(nameof(valueSerializer));
+        _asyncKeySerializer = asyncKeySerializer;
+        _asyncValueSerializer = asyncValueSerializer;
+        _keySerializer = asyncKeySerializer is null
+            ? keySerializer!
+            : AsyncOnlySerializerPlaceholder<TKey>.Instance;
+        _valueSerializer = asyncValueSerializer is null
+            ? valueSerializer!
+            : AsyncOnlySerializerPlaceholder<TValue>.Instance;
+        _hasAsyncSerializers = asyncKeySerializer is not null || asyncValueSerializer is not null;
     }
 
     public ValueTask InitializeAsync(CancellationToken cancellationToken = default)
@@ -213,6 +289,18 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
 
+        if (_hasAsyncSerializers)
+        {
+            return ProduceWithAsyncSerializersAsync(
+                topic,
+                partition,
+                key,
+                value,
+                headers,
+                timestamp,
+                cancellationToken);
+        }
+
         var keyBytes = Serialize(_keySerializer, key, topic, SerializationComponent.Key, headers, out var isKeyNull);
         var valueBytes = Serialize(_valueSerializer, value, topic, SerializationComponent.Value, headers, out var isValueNull);
 
@@ -245,6 +333,88 @@ public sealed class InMemoryProducer<TKey, TValue> : IKafkaProducer<TKey, TValue
         {
             // Matches IKafkaProducer fire-and-forget delivery semantics: failures are not surfaced.
         }
+    }
+
+    /// <summary>
+    /// Produce path used when at least one component has an <see cref="IAsyncSerializer{T}"/>.
+    /// Components without one still encode through their synchronous serializer, so mixed
+    /// configurations behave exactly like the production producer.
+    /// </summary>
+    private async ValueTask<RecordMetadata> ProduceWithAsyncSerializersAsync(
+        string topic,
+        int? partition,
+        TKey? key,
+        TValue value,
+        Headers? headers,
+        DateTimeOffset timestamp,
+        CancellationToken cancellationToken)
+    {
+        // Null components skip their serializer entirely, matching the synchronous path.
+        var isKeyNull = key is null;
+        byte[] keyBytes = isKeyNull
+            ? []
+            : await SerializeAsync(
+                _asyncKeySerializer,
+                _keySerializer,
+                key!,
+                topic,
+                SerializationComponent.Key,
+                headers,
+                cancellationToken).ConfigureAwait(false);
+
+        var isValueNull = value is null;
+        byte[] valueBytes = isValueNull
+            ? []
+            : await SerializeAsync(
+                _asyncValueSerializer,
+                _valueSerializer,
+                value,
+                topic,
+                SerializationComponent.Value,
+                headers,
+                cancellationToken).ConfigureAwait(false);
+
+        return await _cluster.AppendAsync(
+            topic,
+            partition,
+            keyBytes,
+            isKeyNull,
+            valueBytes,
+            isValueNull,
+            headers?.ToList(),
+            timestamp,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Encodes one non-null component, awaiting <paramref name="asyncSerializer"/> when the caller
+    /// configured one and falling back to the synchronous serializer otherwise, so mixed
+    /// configurations encode each component with its own serializer.
+    /// </summary>
+    private static async ValueTask<byte[]> SerializeAsync<T>(
+        IAsyncSerializer<T>? asyncSerializer,
+        ISerializer<T> serializer,
+        T value,
+        string topic,
+        SerializationComponent component,
+        Headers? headers,
+        CancellationToken cancellationToken)
+    {
+        var writer = new ArrayBufferWriter<byte>();
+        var context = new SerializationContext
+        {
+            Topic = topic,
+            Component = component,
+            Headers = headers,
+            IsNull = false
+        };
+
+        if (asyncSerializer is null)
+            serializer.Serialize(value, ref writer, context);
+        else
+            await asyncSerializer.SerializeAsync(value, writer, context, cancellationToken).ConfigureAwait(false);
+
+        return writer.WrittenSpan.ToArray();
     }
 
     private static byte[] Serialize<T>(

--- a/src/Dekaf.Testing/InMemorySerdeResolver.cs
+++ b/src/Dekaf.Testing/InMemorySerdeResolver.cs
@@ -14,6 +14,14 @@ internal static class InMemorySerdeResolver
         return Serde<T>();
     }
 
+    /// <summary>
+    /// Null-checks a constructor argument that is forwarded to a private constructor overload,
+    /// where the argument arrives as a nullable parameter and would otherwise lose its name.
+    /// </summary>
+    public static T Required<T>(T? value, string paramName)
+        where T : class =>
+        value ?? throw new ArgumentNullException(paramName);
+
     private static ISerde<T> Serde<T>()
     {
         var type = typeof(T);

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -334,7 +334,18 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
                 continue;
 
-            return RegisterPending(partition, record, ToShareResult(record, deliveryCount));
+            ShareConsumeResult<TKey, TValue> result;
+            try
+            {
+                result = ToShareResult(record, deliveryCount);
+            }
+            catch
+            {
+                ReleaseAcquiredRecord(partition, record);
+                throw;
+            }
+
+            return RegisterPending(partition, record, result);
         }
 
         return null;
@@ -353,7 +364,17 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
                 continue;
 
-            var result = await ToShareResultAsync(record, deliveryCount, cancellationToken).ConfigureAwait(false);
+            ShareConsumeResult<TKey, TValue> result;
+            try
+            {
+                result = await ToShareResultAsync(record, deliveryCount, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                ReleaseAcquiredRecord(partition, record);
+                throw;
+            }
+
             return RegisterPending(partition, record, result);
         }
 
@@ -385,6 +406,18 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
             out record,
             out deliveryCount);
     }
+
+    /// <summary>
+    /// Releases a record acquired for delivery that never became a pending result — a deserializer
+    /// threw or was cancelled. Without this the lease has no owner in <c>_pending</c>, so no
+    /// acknowledge, commit, unsubscribe or close path can ever release it and the record stays
+    /// unavailable to the group's other members.
+    /// </summary>
+    private void ReleaseAcquiredRecord(TopicPartition partition, InMemoryRecord record) =>
+        _cluster.ReleaseShareRecords(
+            _options.GroupId,
+            _memberId,
+            [new TopicPartitionOffset(partition.Topic, partition.Partition, record.Offset)]);
 
     private ShareConsumeResult<TKey, TValue> RegisterPending(
         TopicPartition partition,

--- a/src/Dekaf.Testing/InMemoryShareConsumer.cs
+++ b/src/Dekaf.Testing/InMemoryShareConsumer.cs
@@ -13,6 +13,12 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
     private readonly InMemoryKafkaCluster _cluster;
     private readonly IDeserializer<TKey> _keyDeserializer;
     private readonly IDeserializer<TValue> _valueDeserializer;
+    // Non-null when the caller configured an IAsyncDeserializer for that component. The matching
+    // synchronous slot then holds a throwing placeholder so a missed asynchronous divert fails
+    // loudly instead of silently decoding nothing.
+    private readonly IAsyncDeserializer<TKey>? _asyncKeyDeserializer;
+    private readonly IAsyncDeserializer<TValue>? _asyncValueDeserializer;
+    private readonly bool _hasAsyncDeserializers;
     private readonly InMemoryShareConsumerOptions _options;
     private readonly HashSet<string> _subscription = new(StringComparer.Ordinal);
     private readonly HashSet<TopicPartition> _assignment = [];
@@ -53,13 +59,124 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         IDeserializer<TKey> keyDeserializer,
         IDeserializer<TValue> valueDeserializer,
         InMemoryShareConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            asyncKeyDeserializer: null,
+            asyncValueDeserializer: null,
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer that awaits <see cref="IAsyncDeserializer{T}"/> for both components.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryShareConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer that awaits <see cref="IAsyncDeserializer{T}"/> for both components.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer,
+        InMemoryShareConsumerOptions options)
+        : this(
+            cluster,
+            keyDeserializer: null,
+            valueDeserializer: null,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer with a synchronous key deserializer and an asynchronous value deserializer.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryShareConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer with a synchronous key deserializer and an asynchronous value deserializer.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey> keyDeserializer,
+        IAsyncDeserializer<TValue> valueDeserializer,
+        InMemoryShareConsumerOptions options)
+        : this(
+            cluster,
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            valueDeserializer: null,
+            asyncKeyDeserializer: null,
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            options)
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer with an asynchronous key deserializer and a synchronous value deserializer.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer)
+        : this(cluster, keyDeserializer, valueDeserializer, new InMemoryShareConsumerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Creates a share consumer with an asynchronous key deserializer and a synchronous value deserializer.
+    /// </summary>
+    public InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IAsyncDeserializer<TKey> keyDeserializer,
+        IDeserializer<TValue> valueDeserializer,
+        InMemoryShareConsumerOptions options)
+        : this(
+            cluster,
+            keyDeserializer: null,
+            InMemorySerdeResolver.Required(valueDeserializer, nameof(valueDeserializer)),
+            InMemorySerdeResolver.Required(keyDeserializer, nameof(keyDeserializer)),
+            asyncValueDeserializer: null,
+            options)
+    {
+    }
+
+    private InMemoryShareConsumer(
+        InMemoryKafkaCluster cluster,
+        IDeserializer<TKey>? keyDeserializer,
+        IDeserializer<TValue>? valueDeserializer,
+        IAsyncDeserializer<TKey>? asyncKeyDeserializer,
+        IAsyncDeserializer<TValue>? asyncValueDeserializer,
+        InMemoryShareConsumerOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentException.ThrowIfNullOrWhiteSpace(options.GroupId);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxPollRecords, 1);
         _cluster = cluster ?? throw new ArgumentNullException(nameof(cluster));
-        _keyDeserializer = keyDeserializer ?? throw new ArgumentNullException(nameof(keyDeserializer));
-        _valueDeserializer = valueDeserializer ?? throw new ArgumentNullException(nameof(valueDeserializer));
+        _asyncKeyDeserializer = asyncKeyDeserializer;
+        _asyncValueDeserializer = asyncValueDeserializer;
+        _keyDeserializer = asyncKeyDeserializer is null
+            ? keyDeserializer!
+            : AsyncOnlyDeserializerPlaceholder<TKey>.Instance;
+        _valueDeserializer = asyncValueDeserializer is null
+            ? valueDeserializer!
+            : AsyncOnlyDeserializerPlaceholder<TValue>.Instance;
+        _hasAsyncDeserializers = asyncKeyDeserializer is not null || asyncValueDeserializer is not null;
         _options = options;
         _memberId = _options.MemberId ?? Guid.NewGuid().ToString("N");
     }
@@ -146,7 +263,9 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
         for (var i = 0; i < _options.MaxPollRecords; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var record = TryTakeAvailableRecord();
+            var record = _hasAsyncDeserializers
+                ? await TryTakeAvailableRecordAsync(cancellationToken).ConfigureAwait(false)
+                : TryTakeAvailableRecord();
             if (record is null)
                 yield break;
 
@@ -210,44 +329,119 @@ public sealed class InMemoryShareConsumer<TKey, TValue> : IKafkaShareConsumer<TK
 
     private ShareConsumeResult<TKey, TValue>? TryTakeAvailableRecord()
     {
-        TopicPartition[] assignment;
-
-        lock (_gate)
+        foreach (var partition in OrderedAssignment())
         {
-            assignment = _assignment
-                .OrderBy(item => item.Topic, StringComparer.Ordinal)
-                .ThenBy(item => item.Partition)
-                .ToArray();
-        }
-
-        foreach (var partition in assignment)
-        {
-            long offset;
-            lock (_gate)
-                offset = GetNextOffsetUnderLock(partition);
-
-            if (!_cluster.TryAcquireShareRecord(
-                    _options.GroupId,
-                    _memberId,
-                    partition,
-                    offset,
-                    out var record,
-                    out var deliveryCount))
-            {
+            if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
                 continue;
-            }
 
-            var result = ToShareResult(record, deliveryCount);
-            var pending = new PendingShareRecord(partition, record.Offset, record.Offset + 1);
-
-            lock (_gate)
-                _pending[result] = pending;
-
-            return result;
+            return RegisterPending(partition, record, ToShareResult(record, deliveryCount));
         }
 
         return null;
     }
+
+    /// <summary>
+    /// Poll path used when at least one component has an <see cref="IAsyncDeserializer{T}"/>.
+    /// Deliberate mirror of <see cref="TryTakeAvailableRecord"/>: both drive the same acquisition
+    /// and pending-record bookkeeping helpers.
+    /// </summary>
+    private async ValueTask<ShareConsumeResult<TKey, TValue>?> TryTakeAvailableRecordAsync(
+        CancellationToken cancellationToken)
+    {
+        foreach (var partition in OrderedAssignment())
+        {
+            if (!TryAcquireRecord(partition, out var record, out var deliveryCount))
+                continue;
+
+            var result = await ToShareResultAsync(record, deliveryCount, cancellationToken).ConfigureAwait(false);
+            return RegisterPending(partition, record, result);
+        }
+
+        return null;
+    }
+
+    private TopicPartition[] OrderedAssignment()
+    {
+        lock (_gate)
+        {
+            return _assignment
+                .OrderBy(item => item.Topic, StringComparer.Ordinal)
+                .ThenBy(item => item.Partition)
+                .ToArray();
+        }
+    }
+
+    private bool TryAcquireRecord(TopicPartition partition, out InMemoryRecord record, out int deliveryCount)
+    {
+        long offset;
+        lock (_gate)
+            offset = GetNextOffsetUnderLock(partition);
+
+        return _cluster.TryAcquireShareRecord(
+            _options.GroupId,
+            _memberId,
+            partition,
+            offset,
+            out record,
+            out deliveryCount);
+    }
+
+    private ShareConsumeResult<TKey, TValue> RegisterPending(
+        TopicPartition partition,
+        InMemoryRecord record,
+        ShareConsumeResult<TKey, TValue> result)
+    {
+        var pending = new PendingShareRecord(partition, record.Offset, record.Offset + 1);
+
+        lock (_gate)
+            _pending[result] = pending;
+
+        return result;
+    }
+
+    private async ValueTask<ShareConsumeResult<TKey, TValue>> ToShareResultAsync(
+        InMemoryRecord record,
+        int deliveryCount,
+        CancellationToken cancellationToken)
+    {
+        var key = record.IsKeyNull
+            ? default
+            : await DeserializeAsync(
+                _asyncKeyDeserializer,
+                _keyDeserializer,
+                record.Key,
+                Context(record.Topic, SerializationComponent.Key, record.Headers, isNull: false),
+                cancellationToken).ConfigureAwait(false);
+
+        var value = await DeserializeAsync(
+            _asyncValueDeserializer,
+            _valueDeserializer,
+            record.IsValueNull ? ReadOnlyMemory<byte>.Empty : record.Value,
+            Context(record.Topic, SerializationComponent.Value, record.Headers, isNull: record.IsValueNull),
+            cancellationToken).ConfigureAwait(false);
+
+        return new ShareConsumeResult<TKey, TValue>
+        {
+            Topic = record.Topic,
+            Partition = record.Partition,
+            Offset = record.Offset,
+            Key = key,
+            Value = value,
+            Headers = record.Headers,
+            TimestampMs = record.TimestampMs,
+            DeliveryCount = deliveryCount
+        };
+    }
+
+    private static ValueTask<T> DeserializeAsync<T>(
+        IAsyncDeserializer<T>? asyncDeserializer,
+        IDeserializer<T> deserializer,
+        ReadOnlyMemory<byte> data,
+        SerializationContext context,
+        CancellationToken cancellationToken) =>
+        asyncDeserializer is not null
+            ? asyncDeserializer.DeserializeAsync(data, context, cancellationToken)
+            : ValueTask.FromResult(deserializer.Deserialize(data, context));
 
     private ShareConsumeResult<TKey, TValue> ToShareResult(InMemoryRecord record, int deliveryCount)
     {

--- a/src/Dekaf/Consumer/IKafkaConsumer.cs
+++ b/src/Dekaf/Consumer/IKafkaConsumer.cs
@@ -519,6 +519,38 @@ public readonly struct ConsumeResult<TKey, TValue>
         IsPartitionEof = false;
     }
 
+    /// <summary>
+    /// Creates a ConsumeResult from already-deserialized key and value with caller-owned headers.
+    /// Used by in-memory test doubles running an <see cref="IAsyncDeserializer{T}"/>, which await
+    /// deserialization before construction and have no pooled fetch buffers to reference.
+    /// </summary>
+    internal ConsumeResult(
+        string topic,
+        int partition,
+        long offset,
+        TKey? key,
+        TValue value,
+        IReadOnlyList<Header>? headers,
+        long timestampMs,
+        TimestampType timestampType,
+        int? leaderEpoch)
+    {
+        Topic = topic;
+        Partition = partition;
+        Offset = offset;
+        Key = key;
+        Value = value;
+        _headers = headers;
+        _pooledHeaders = null;
+        _pooledHeaderCount = 0;
+        _headerOwner = null;
+        _headerGeneration = 0;
+        _timestampMs = timestampMs;
+        TimestampType = timestampType;
+        LeaderEpoch = leaderEpoch;
+        IsPartitionEof = false;
+    }
+
     private ConsumeResult(
         string topic,
         int partition,

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -326,6 +326,63 @@ public sealed class InMemoryAsyncSerdeTests
     }
 
     [Test]
+    public async Task ShareConsumer_AsyncDeserializerFailure_ReleasesRecordForOtherMembers()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var failing = new AsyncPrefixSerde(string.Empty) { FailDeserializeOnCall = 1 };
+        var failingMember = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            failing,
+            new InMemoryShareConsumerOptions { GroupId = "share-failure", MemberId = "member-1" });
+        var otherMember = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-failure", MemberId = "member-2" });
+
+        await producer.ProduceAsync("shared", "k", "v");
+        failingMember.Subscribe("shared");
+        otherMember.Subscribe("shared");
+
+        await Assert.That(async () => await failingMember.PollAsync().FirstAsync())
+            .Throws<InvalidOperationException>();
+
+        // The failed record never became a pending result, so nothing else can release its
+        // lease — the poll path must release it or it is stranded for the rest of the run.
+        var record = await otherMember.PollAsync().FirstAsync();
+
+        await Assert.That(record.Value).IsEqualTo("v");
+        await Assert.That(record.DeliveryCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ShareConsumer_SyncDeserializerFailure_ReleasesRecordForOtherMembers()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var producer = new InMemoryProducer<string, string>(cluster);
+        var failingMember = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            new ThrowingDeserializer(),
+            new InMemoryShareConsumerOptions { GroupId = "share-sync-failure", MemberId = "member-1" });
+        var otherMember = new InMemoryShareConsumer<string, string>(
+            cluster,
+            new InMemoryShareConsumerOptions { GroupId = "share-sync-failure", MemberId = "member-2" });
+
+        await producer.ProduceAsync("shared", "k", "v");
+        failingMember.Subscribe("shared");
+        otherMember.Subscribe("shared");
+
+        await Assert.That(async () => await failingMember.PollAsync().FirstAsync())
+            .Throws<InvalidOperationException>();
+
+        var record = await otherMember.PollAsync().FirstAsync();
+
+        await Assert.That(record.Value).IsEqualTo("v");
+        await Assert.That(record.DeliveryCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task AsyncSerdeConstructors_RejectNullSerdes()
     {
         var cluster = new InMemoryKafkaCluster();
@@ -346,6 +403,12 @@ public sealed class InMemoryAsyncSerdeTests
                 new AsyncPrefixSerde("v:"),
                 new InMemoryShareConsumerOptions { GroupId = "g" }))
             .Throws<ArgumentNullException>();
+    }
+
+    private sealed class ThrowingDeserializer : IDeserializer<string>
+    {
+        public string Deserialize(ReadOnlyMemory<byte> data, SerializationContext context) =>
+            throw new InvalidOperationException("Deserialization failed.");
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
+++ b/tests/Dekaf.Tests.Unit/Testing/InMemoryAsyncSerdeTests.cs
@@ -1,0 +1,403 @@
+using System.Buffers;
+using System.Text;
+using Dekaf.Admin;
+using Dekaf.Consumer;
+using Dekaf.Errors;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.ShareConsumer;
+using Dekaf.Testing;
+
+namespace Dekaf.Tests.Unit.Testing;
+
+/// <summary>
+/// Covers <see cref="IAsyncSerializer{T}"/>/<see cref="IAsyncDeserializer{T}"/> support in the
+/// in-memory test doubles, including mixed sync/async configurations (issue #2518).
+/// </summary>
+public sealed class InMemoryAsyncSerdeTests
+{
+    [Test]
+    public async Task Producer_AsyncSerializers_RoundTripThroughAsyncDeserializers()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var keySerde = new AsyncPrefixSerde("key:");
+        var valueSerde = new AsyncPrefixSerde("value:");
+        var producer = new InMemoryProducer<string, string>(cluster, keySerde, valueSerde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            keySerde,
+            valueSerde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "async-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync(new ProducerMessage<string, string>
+        {
+            Topic = "orders",
+            Key = "order-1",
+            Value = "created",
+            Headers = Headers.Create("trace-id", "abc")
+        });
+        consumer.Subscribe("orders");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        // The stored bytes carry the prefix, proving the asynchronous serializer produced them.
+        var stored = cluster.ReadRecords("orders")[0];
+        await Assert.That(Encoding.UTF8.GetString(stored.Key)).IsEqualTo("key:order-1");
+        await Assert.That(Encoding.UTF8.GetString(stored.Value)).IsEqualTo("value:created");
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Value.Key).IsEqualTo("order-1");
+        await Assert.That(result.Value.Value).IsEqualTo("created");
+        await Assert.That(result.Value.Headers.Single().GetValueAsString()).IsEqualTo("abc");
+        await Assert.That(keySerde.SerializeCalls).IsEqualTo(1);
+        await Assert.That(valueSerde.SerializeCalls).IsEqualTo(1);
+        await Assert.That(keySerde.DeserializeCalls).IsEqualTo(1);
+        await Assert.That(valueSerde.DeserializeCalls).IsEqualTo(1);
+        await Assert.That(keySerde.LastSerializeContext.Component).IsEqualTo(SerializationComponent.Key);
+        await Assert.That(valueSerde.LastSerializeContext.Component).IsEqualTo(SerializationComponent.Value);
+        await Assert.That(valueSerde.LastSerializeContext.Headers!.Single().GetValueAsString()).IsEqualTo("abc");
+    }
+
+    [Test]
+    public async Task Producer_SyncKeyAsyncValue_EncodesEachComponentWithItsOwnSerializer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var valueSerde = new AsyncPrefixSerde("value:");
+        var producer = new InMemoryProducer<string, string>(cluster, Serializers.String, valueSerde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            valueSerde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "mixed-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders", "order-1", "created");
+        consumer.Subscribe("orders");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        var stored = cluster.ReadRecords("orders")[0];
+        await Assert.That(Encoding.UTF8.GetString(stored.Key)).IsEqualTo("order-1");
+        await Assert.That(Encoding.UTF8.GetString(stored.Value)).IsEqualTo("value:created");
+        await Assert.That(result!.Value.Key).IsEqualTo("order-1");
+        await Assert.That(result.Value.Value).IsEqualTo("created");
+    }
+
+    [Test]
+    public async Task Producer_AsyncKeySyncValue_EncodesEachComponentWithItsOwnSerializer()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var keySerde = new AsyncPrefixSerde("key:");
+        var producer = new InMemoryProducer<string, string>(cluster, keySerde, Serializers.String);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            keySerde,
+            Serializers.String,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "mixed-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders", "order-1", "created");
+        consumer.Subscribe("orders");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        var stored = cluster.ReadRecords("orders")[0];
+        await Assert.That(Encoding.UTF8.GetString(stored.Key)).IsEqualTo("key:order-1");
+        await Assert.That(Encoding.UTF8.GetString(stored.Value)).IsEqualTo("created");
+        await Assert.That(result!.Value.Key).IsEqualTo("order-1");
+        await Assert.That(result.Value.Value).IsEqualTo("created");
+    }
+
+    [Test]
+    public async Task AsyncSerdes_NullKeyAndValue_MatchSynchronousNullSemantics()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var keySerde = new AsyncPrefixSerde("key:");
+        var valueSerde = new AsyncPrefixSerde("value:");
+        var producer = new InMemoryProducer<string, string>(cluster, keySerde, valueSerde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            keySerde,
+            valueSerde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "null-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders", key: null, value: null!);
+        consumer.Subscribe("orders");
+
+        var result = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+
+        var stored = cluster.ReadRecords("orders")[0];
+        await Assert.That(stored.IsKeyNull).IsTrue();
+        await Assert.That(stored.IsValueNull).IsTrue();
+        // Null components skip the serializer entirely, and a null key skips the deserializer —
+        // the same contract the synchronous eager ConsumeResult constructor implements.
+        await Assert.That(keySerde.SerializeCalls).IsEqualTo(0);
+        await Assert.That(valueSerde.SerializeCalls).IsEqualTo(0);
+        await Assert.That(keySerde.DeserializeCalls).IsEqualTo(0);
+        await Assert.That(valueSerde.DeserializeCalls).IsEqualTo(1);
+        await Assert.That(valueSerde.LastDeserializeContext.IsNull).IsTrue();
+        await Assert.That(valueSerde.LastDeserializedLength).IsEqualTo(0);
+        await Assert.That(result!.Value.Key).IsNull();
+    }
+
+    [Test]
+    public async Task FireAsync_AsyncSerializers_DeliversRecord()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, serde, serde);
+
+        await producer.FireAsync("orders", "order-1", "created");
+        await producer.FlushAsync();
+
+        var stored = cluster.ReadRecords("orders")[0];
+        await Assert.That(Encoding.UTF8.GetString(stored.Value)).IsEqualTo("v:created");
+    }
+
+    [Test]
+    public async Task ProduceAsync_AsyncSerializer_ObservesCancellationToken()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, serde, serde);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () => await producer.ProduceAsync("orders", "k", "v", cts.Token))
+            .Throws<OperationCanceledException>();
+        await Assert.That(cluster.ReadRecords("orders")).IsEmpty();
+    }
+
+    [Test]
+    public async Task AsyncDeserializer_Failure_SurfacesOriginAndLeavesOffsetForRetry()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var valueSerde = new AsyncPrefixSerde("value:") { FailDeserializeOnCall = 1 };
+        var producer = new InMemoryProducer<string, string>(cluster, Serializers.String, valueSerde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            valueSerde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "failing-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders", "order-1", "created");
+        consumer.Subscribe("orders");
+
+        var exception = await Assert.That(async () => await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1)))
+            .Throws<RecordDeserializationException>();
+
+        await Assert.That(exception!.Origin).IsEqualTo(DeserializationExceptionOrigin.Value);
+        await Assert.That(exception.Offset).IsEqualTo(0);
+
+        // The failed record kept its position, so the next consume redelivers it.
+        var retry = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        await Assert.That(retry!.Value.Offset).IsEqualTo(0);
+        await Assert.That(retry.Value.Value).IsEqualTo("created");
+    }
+
+    [Test]
+    public async Task AsyncDeserializers_AdvanceOffsetsAndCommit()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, Serializers.String, serde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            serde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "committing-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                OffsetCommitMode = OffsetCommitMode.Manual
+            });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync("orders", "a", "one");
+        await producer.ProduceAsync("orders", "b", "two");
+        consumer.Subscribe("orders");
+
+        var first = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        var second = await consumer.ConsumeOneAsync(TimeSpan.FromSeconds(1));
+        await consumer.CommitAsync();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("committing-workers");
+
+        await Assert.That(first!.Value.Value).IsEqualTo("one");
+        await Assert.That(second!.Value.Value).IsEqualTo("two");
+        await Assert.That(offsets[new TopicPartition("orders", 0)]).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ConsumeAsync_AsyncDeserializers_StreamsRecords()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, Serializers.String, serde);
+        var consumer = new InMemoryConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            serde,
+            new InMemoryConsumerOptions
+            {
+                GroupId = "streaming-workers",
+                AutoOffsetReset = AutoOffsetReset.Earliest
+            });
+
+        await producer.ProduceAsync("orders", "a", "one");
+        await producer.ProduceAsync("orders", "b", "two");
+        consumer.Subscribe("orders");
+
+        var values = new List<string>();
+        using var cts = new CancellationTokenSource();
+        await foreach (var record in consumer.ConsumeAsync(cts.Token))
+        {
+            values.Add(record.Value);
+            if (values.Count == 2)
+                await cts.CancelAsync();
+        }
+
+        await Assert.That(values).IsEquivalentTo(["one", "two"]);
+    }
+
+    [Test]
+    public async Task ShareConsumer_AsyncDeserializers_RoundTripAndAcknowledge()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var serde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, serde, serde);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            serde,
+            serde,
+            new InMemoryShareConsumerOptions { GroupId = "async-share" });
+        var admin = new InMemoryAdminClient(cluster);
+
+        await producer.ProduceAsync("shared", "k", "v");
+        shareConsumer.Subscribe("shared");
+
+        var record = await shareConsumer.PollAsync().FirstAsync();
+        shareConsumer.Acknowledge(record);
+        await shareConsumer.CommitAsync();
+
+        var offsets = await admin.ListConsumerGroupOffsetsAsync("async-share");
+
+        await Assert.That(record.Key).IsEqualTo("k");
+        await Assert.That(record.Value).IsEqualTo("v");
+        await Assert.That(offsets[new TopicPartition("shared", 0)]).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShareConsumer_SyncKeyAsyncValue_RoundTrips()
+    {
+        var cluster = new InMemoryKafkaCluster();
+        var valueSerde = new AsyncPrefixSerde("v:");
+        var producer = new InMemoryProducer<string, string>(cluster, Serializers.String, valueSerde);
+        var shareConsumer = new InMemoryShareConsumer<string, string>(
+            cluster,
+            Serializers.String,
+            valueSerde,
+            new InMemoryShareConsumerOptions { GroupId = "mixed-share" });
+
+        await producer.ProduceAsync("shared", "k", "v");
+        shareConsumer.Subscribe("shared");
+
+        var record = await shareConsumer.PollAsync().FirstAsync();
+
+        await Assert.That(record.Key).IsEqualTo("k");
+        await Assert.That(record.Value).IsEqualTo("v");
+    }
+
+    [Test]
+    public async Task AsyncSerdeConstructors_RejectNullSerdes()
+    {
+        var cluster = new InMemoryKafkaCluster();
+
+        await Assert.That(() => new InMemoryProducer<string, string>(
+                cluster,
+                (IAsyncSerializer<string>)null!,
+                new AsyncPrefixSerde("v:")))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => new InMemoryConsumer<string, string>(
+                cluster,
+                new AsyncPrefixSerde("v:"),
+                (IAsyncDeserializer<string>)null!))
+            .Throws<ArgumentNullException>();
+        await Assert.That(() => new InMemoryShareConsumer<string, string>(
+                cluster,
+                (IAsyncDeserializer<string>)null!,
+                new AsyncPrefixSerde("v:"),
+                new InMemoryShareConsumerOptions { GroupId = "g" }))
+            .Throws<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// Serde whose encode/decode genuinely suspends, so a caller that forgets to await it observes
+    /// the wrong bytes. The prefix makes the asynchronous path visible on the wire.
+    /// </summary>
+    private sealed class AsyncPrefixSerde : IAsyncSerde<string>
+    {
+        private readonly string _prefix;
+
+        public AsyncPrefixSerde(string prefix) => _prefix = prefix;
+
+        public int SerializeCalls { get; private set; }
+        public int DeserializeCalls { get; private set; }
+        public int LastDeserializedLength { get; private set; }
+        public SerializationContext LastSerializeContext { get; private set; }
+        public SerializationContext LastDeserializeContext { get; private set; }
+
+        /// <summary>1-based deserialize call that should throw, or 0 to never throw.</summary>
+        public int FailDeserializeOnCall { get; init; }
+
+        public async ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+
+            SerializeCalls++;
+            LastSerializeContext = context;
+            destination.Write(Encoding.UTF8.GetBytes(_prefix + value));
+        }
+
+        public async ValueTask<string> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+
+            DeserializeCalls++;
+            LastDeserializeContext = context;
+            LastDeserializedLength = data.Length;
+
+            if (FailDeserializeOnCall == DeserializeCalls)
+                throw new InvalidOperationException("Deserialization failed.");
+
+            var text = Encoding.UTF8.GetString(data.Span);
+            return text.StartsWith(_prefix, StringComparison.Ordinal) ? text[_prefix.Length..] : text;
+        }
+    }
+}


### PR DESCRIPTION
Closes #2518

## Problem

`InMemoryProducer<TKey, TValue>`, `InMemoryConsumer<TKey, TValue>` and `InMemoryShareConsumer<TKey, TValue>` only accepted `ISerializer<T>`/`IDeserializer<T>`. Applications using the per-message-I/O serdes added in #2309 (`IAsyncSerializer<T>`, `IAsyncDeserializer<T>`, `IAsyncSerde<T>`) had no way to unit test against the in-memory doubles — the real `ProducerBuilder`/`ConsumerBuilder` accept them, the test doubles did not.

## Change

Constructor overloads on all three in-memory clients for asynchronous serdes, including mixed sync/async per component (sync key + async value and vice versa), matching the flexibility of the real builders:

```csharp
IAsyncSerde<Order> orderSerde = new EncryptingOrderSerde(keyVault);

var producer = new InMemoryProducer<string, Order>(cluster, Serializers.String, orderSerde);
var consumer = new InMemoryConsumer<string, Order>(cluster, Serializers.String, orderSerde, options);
```

Implementation notes:

- **Placeholder invariant preserved.** When a component is configured async, its synchronous slot holds the throwing `AsyncOnlySerializerPlaceholder<T>`/`AsyncOnlyDeserializerPlaceholder<T>`, exactly as `KafkaProducer`/`KafkaConsumer` do. A missed divert fails loudly instead of silently encoding nothing.
- **Divert points.** `ProduceAsync`/`FireAsync` funnel through `ProduceCoreAsync`, which diverts to an awaited serialize path; `ConsumeOneAsync` (and therefore `ConsumeAsync`) diverts to an awaited deserialize path; `PollAsync` does the same for the share consumer.
- **Mirrors share their bookkeeping.** The sync and async consume paths both drive the same `TrySelectRecord`/`TryAdvancePosition` helpers (and `TryAcquireRecord`/`RegisterPending` for the share consumer), so the in-doubt/poll-contract offset semantics cannot drift between them — the drift hazard called out for `ConsumeOneFromPendingFetchesAsync` in the production consumer.
- **New internal `ConsumeResult` constructor** for pre-deserialized key/value with caller-owned headers. The existing async-path constructor requires a `PendingFetchData` header owner, which in-memory records do not have.
- **Null semantics unchanged.** Null key/value skip the serializer; a null key skips the deserializer; a null value is decoded from empty data with `IsNull = true` — the same contract the eager `ConsumeResult` constructor implements.

## Tests

New `InMemoryAsyncSerdeTests` (12 tests) covering async round trip, both mixed configurations, null key/value semantics, `FireAsync`, cancellation-token flow into the async serializer, deserialization failure surfacing `RecordDeserializationException` with the right `Origin` and leaving the offset for retry, offset advance + commit, `ConsumeAsync` streaming, share consumer round trip and mixed mode, and null-argument rejection on the new overloads.

- Unit suite: **6610/6610 pass** (net10.0), new tests also green on net8.0.
- Baseline check on clean `HEAD`: 6598/6598 — no pre-existing failures masked.

## Performance

No production hot path touched. `src/Dekaf` change is a single new internal `ConsumeResult` constructor used only by `Dekaf.Testing`; existing constructors and all producer/consumer paths are untouched, so no benchmark movement is expected or claimed.

## Docs

`docs/docs/testing.md` gains an "Asynchronous serializers" section.