### PR TITLE
test: consolidate duplicate wait helpers into shared TestWait with descriptive timeouts

### DIFF
--- a/tests/Dekaf.Tests.Integration/AdminClientTests.cs
+++ b/tests/Dekaf.Tests.Integration/AdminClientTests.cs
@@ -21,27 +21,6 @@ public class AdminClientTests(KafkaTestContainer kafka) : KafkaIntegrationTest(k
             .Build();
     }
 
-    /// <summary>
-    /// Waits for a condition to become true with exponential backoff.
-    /// Admin operations in Kafka have eventual consistency - changes may not be immediately visible.
-    /// </summary>
-    private static async Task<T> WaitForConditionAsync<T>(
-        Func<Task<T>> check,
-        Func<T, bool> condition,
-        int maxRetries = 5,
-        int initialDelayMs = 500)
-    {
-        T result = default!;
-        for (var i = 0; i < maxRetries; i++)
-        {
-            await Task.Delay(initialDelayMs * (i + 1)).ConfigureAwait(false);
-            result = await check().ConfigureAwait(false);
-            if (condition(result))
-                return result;
-        }
-        return result;
-    }
-
     #region DescribeConfigs Tests
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/ConcurrentAdminTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConcurrentAdminTests.cs
@@ -23,27 +23,6 @@ public class ConcurrentAdminTests(KafkaTestContainer kafka) : KafkaIntegrationTe
             .Build();
     }
 
-    /// <summary>
-    /// Waits for a condition to become true with linear backoff.
-    /// Admin operations in Kafka have eventual consistency.
-    /// </summary>
-    private static async Task<T> WaitForConditionAsync<T>(
-        Func<Task<T>> check,
-        Func<T, bool> condition,
-        int maxRetries = 5,
-        int initialDelayMs = 500)
-    {
-        T result = default!;
-        for (var i = 0; i < maxRetries; i++)
-        {
-            await Task.Delay(initialDelayMs * (i + 1)).ConfigureAwait(false);
-            result = await check().ConfigureAwait(false);
-            if (condition(result))
-                return result;
-        }
-        return result;
-    }
-
     #region Concurrent CreateTopics
 
     [Test]

--- a/tests/Dekaf.Tests.Integration/DeleteRecordsTests.cs
+++ b/tests/Dekaf.Tests.Integration/DeleteRecordsTests.cs
@@ -21,27 +21,6 @@ public class DeleteRecordsTests(KafkaTestContainer kafka) : KafkaIntegrationTest
     }
 
     /// <summary>
-    /// Waits for a condition to become true with linear backoff.
-    /// Admin operations in Kafka have eventual consistency - changes may not be immediately visible.
-    /// </summary>
-    private static async Task<T> WaitForConditionAsync<T>(
-        Func<Task<T>> check,
-        Func<T, bool> condition,
-        int maxRetries = 10,
-        int initialDelayMs = 500)
-    {
-        T result = default!;
-        for (var i = 0; i < maxRetries; i++)
-        {
-            await Task.Delay(initialDelayMs * (i + 1)).ConfigureAwait(false);
-            result = await check().ConfigureAwait(false);
-            if (condition(result))
-                return result;
-        }
-        return result;
-    }
-
-    /// <summary>
     /// Produces the specified number of messages to a single-partition topic.
     /// </summary>
     private async Task ProduceMessagesAsync(string topic, int count, int partition = 0)

--- a/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
+++ b/tests/Dekaf.Tests.Integration/KafkaIntegrationTest.cs
@@ -88,19 +88,20 @@ public abstract class KafkaIntegrationTest(KafkaTestContainer kafkaTestContainer
         }
     }
 
-    /// <summary>
-    /// Polls until a condition is true, replacing fixed <c>Task.Delay</c> waits.
-    /// Returns as soon as the condition is met, avoiding unnecessary delays.
-    /// </summary>
-    protected static async Task WaitForConditionAsync(
+    /// <inheritdoc cref="TestWait.WaitForConditionAsync(Func{bool}, TimeSpan, int, string?)"/>
+    protected static Task WaitForConditionAsync(
         Func<bool> condition,
         TimeSpan timeout,
-        int pollIntervalMs = 100)
-    {
-        using var cts = new CancellationTokenSource(timeout);
-        while (!condition())
-        {
-            await Task.Delay(pollIntervalMs, cts.Token).ConfigureAwait(false);
-        }
-    }
+        int pollIntervalMs = 100,
+        string? description = null)
+        => TestWait.WaitForConditionAsync(condition, timeout, pollIntervalMs, description);
+
+    /// <inheritdoc cref="TestWait.WaitForConditionAsync{T}(Func{Task{T}}, Func{T, bool}, int, int, string?)"/>
+    protected static Task<T> WaitForConditionAsync<T>(
+        Func<Task<T>> check,
+        Func<T, bool> condition,
+        int maxRetries = 10,
+        int initialDelayMs = 500,
+        string? description = null)
+        => TestWait.WaitForConditionAsync(check, condition, maxRetries, initialDelayMs, description);
 }

--- a/tests/Dekaf.Tests.Integration/PartitionExpansionTests.cs
+++ b/tests/Dekaf.Tests.Integration/PartitionExpansionTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Dekaf.Admin;
 using Dekaf.Consumer;
 using Dekaf.Producer;
@@ -19,27 +20,6 @@ public sealed class PartitionExpansionTests(KafkaTestContainer kafka) : KafkaInt
             .WithClientId("test-admin-client")
             .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
             .Build();
-    }
-
-    /// <summary>
-    /// Waits for a condition to become true with exponential backoff.
-    /// Kafka operations have eventual consistency - changes may not be immediately visible.
-    /// </summary>
-    private static async Task<T> WaitForConditionAsync<T>(
-        Func<Task<T>> check,
-        Func<T, bool> condition,
-        int maxRetries = 5,
-        int initialDelayMs = 500)
-    {
-        T result = default!;
-        for (var i = 0; i < maxRetries; i++)
-        {
-            await Task.Delay(initialDelayMs * (i + 1)).ConfigureAwait(false);
-            result = await check().ConfigureAwait(false);
-            if (condition(result))
-                return result;
-        }
-        return result;
     }
 
     /// <summary>
@@ -480,12 +460,15 @@ public sealed class PartitionExpansionTests(KafkaTestContainer kafka) : KafkaInt
             Partition = 2
         }, CancellationToken.None).ConfigureAwait(false);
 
-        // Wait briefly for any potential auto-detection
-        await WaitForConditionAsync(
-            () => Task.FromResult(consumer.Assignment.Count),
-            count => count > 2,
-            maxRetries: 3,
-            initialDelayMs: 500).ConfigureAwait(false);
+        // Observation window: give auto-detection a chance to (wrongly) occur. This is a
+        // negative check — the assignment must NOT grow, even transiently — so poll the
+        // invariant throughout the window rather than sampling it once at the end.
+        var observationStart = Stopwatch.GetTimestamp();
+        while (Stopwatch.GetElapsedTime(observationStart) < TimeSpan.FromSeconds(3))
+        {
+            await Assert.That(consumer.Assignment).Count().IsEqualTo(2);
+            await Task.Delay(100).ConfigureAwait(false);
+        }
 
         // Assert - manual assignment should NOT auto-detect new partitions
         // The consumer should still only be assigned partitions 0 and 1

--- a/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/RealWorld/BackpressureIntegrationTests.cs
@@ -46,7 +46,14 @@ public sealed class BackpressureIntegrationTests(KafkaTestContainer kafka) : Kaf
                 () => accumulator.PendingAppendDrainEntryCountForTest > pendingBefore,
                 TimeSpan.FromSeconds(5));
             await Assert.That(enteredDrain).IsTrue();
-            await Assert.That(accumulator.PendingAppendCountForTest).IsEqualTo(1);
+            // The drain owner temporarily moves every candidate out of the pending-append
+            // queue while it evaluates admission, so a bare count read here races the scan
+            // and can observe 0 (CI flake). Wait for the parked op to be visible between
+            // scan windows; admission cannot succeed while the reservation holds all memory.
+            await WaitForConditionAsync(
+                () => accumulator.PendingAppendCountForTest == 1,
+                TimeSpan.FromSeconds(5),
+                description: "backpressured append never parked in the pending-append queue");
             await Assert.That(produce.IsCompleted).IsFalse();
 
             accumulator.ReleaseMemory(bufferMemory);

--- a/tests/Dekaf.Tests.Integration/RebalanceEdgeCaseTests.cs
+++ b/tests/Dekaf.Tests.Integration/RebalanceEdgeCaseTests.cs
@@ -268,7 +268,8 @@ public sealed class RebalanceEdgeCaseTests(KafkaTestContainer kafka) : KafkaInte
         await WaitForConditionAsync(
             () => listener2.AssignedCallCount >= 1,
             timeout: TimeSpan.FromSeconds(15),
-            pollInterval: TimeSpan.FromMilliseconds(500));
+            pollIntervalMs: 500,
+            description: "consumer 2 never received a partition assignment after consumer 1 left");
 
         // Verify the committed offsets are preserved by checking with a new consumer
         await using var verifier = await Kafka.CreateConsumer<string, string>()
@@ -489,27 +490,6 @@ public sealed class RebalanceEdgeCaseTests(KafkaTestContainer kafka) : KafkaInte
         // Total messages consumed across both consumers should account for all produced messages
         var totalConsumed = consumer1Messages.Count + consumer2Messages.Count;
         await Assert.That(totalConsumed).IsGreaterThanOrEqualTo(1);
-    }
-
-    /// <summary>
-    /// Polls a condition until it returns true, or until the timeout expires.
-    /// Preferred over hard-coded Task.Delay to reduce flakiness.
-    /// </summary>
-    private static async Task WaitForConditionAsync(
-        Func<bool> condition,
-        TimeSpan timeout,
-        TimeSpan pollInterval)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            if (condition())
-            {
-                return;
-            }
-
-            await Task.Delay(pollInterval);
-        }
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Integration/TestWait.cs
+++ b/tests/Dekaf.Tests.Integration/TestWait.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+
+namespace Dekaf.Tests.Integration;
+
+/// <summary>
+/// Shared polling waits for integration tests. Lives outside <see cref="KafkaIntegrationTest"/>
+/// so test classes bound to other container fixtures (rack-aware, scale-out, ACL, SASL) can use
+/// the same mechanism instead of hand-rolling per-class copies.
+/// </summary>
+internal static class TestWait
+{
+    /// <summary>
+    /// Polls until a condition is true, replacing fixed <c>Task.Delay</c> waits.
+    /// Returns as soon as the condition is met, avoiding unnecessary delays. On timeout it
+    /// throws a <see cref="TimeoutException"/> naming <paramref name="description"/> rather
+    /// than a bare cancellation, so a stuck test reports what it was waiting for.
+    /// </summary>
+    public static async Task WaitForConditionAsync(
+        Func<bool> condition,
+        TimeSpan timeout,
+        int pollIntervalMs = 100,
+        string? description = null)
+    {
+        var startedAt = Stopwatch.GetTimestamp();
+        while (!condition())
+        {
+            var remaining = timeout - Stopwatch.GetElapsedTime(startedAt);
+            if (remaining <= TimeSpan.Zero)
+            {
+                throw new TimeoutException(
+                    $"Condition not met within {timeout.TotalSeconds:F0}s" +
+                    $"{(description is null ? "" : $": {description}")}");
+            }
+
+            await Task.Delay(Math.Min(pollIntervalMs, (int)Math.Ceiling(remaining.TotalMilliseconds)));
+        }
+    }
+
+    /// <summary>
+    /// Polls an async check with linear backoff until the condition holds. Admin operations in
+    /// Kafka are eventually consistent, so a change may lag the acknowledged mutation. When the
+    /// retries are exhausted this throws a <see cref="TimeoutException"/> carrying the last
+    /// observed value instead of returning it, so an unmet condition fails here with the stale
+    /// state — not at a later assert, and never silently.
+    /// </summary>
+    public static async Task<T> WaitForConditionAsync<T>(
+        Func<Task<T>> check,
+        Func<T, bool> condition,
+        int maxRetries = 10,
+        int initialDelayMs = 500,
+        string? description = null)
+    {
+        T result = default!;
+        for (var i = 0; i < maxRetries; i++)
+        {
+            await Task.Delay(initialDelayMs * (i + 1));
+            result = await check();
+            if (condition(result))
+                return result;
+        }
+
+        throw new TimeoutException(
+            $"Condition not met after {maxRetries} checks" +
+            $"{(description is null ? "" : $": {description}")}; last observed: {result}");
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #2520: the integration test project had six near-duplicate wait/poll helpers, several with blind- or silent-failure shapes:

| Helper | Failure mode on timeout |
|---|---|
| `KafkaIntegrationTest.WaitForConditionAsync` (bool) | bare `TaskCanceledException`, no context |
| `AdminClientTests` / `ConcurrentAdminTests` / `DeleteRecordsTests` / `PartitionExpansionTests` private `<T>` copies | **silently returned the last unmet result** — call sites that discard the return value could pass with the condition never met |
| `RebalanceEdgeCaseTests` private void copy | **silently returned** on timeout |

## Changes

- New `internal static class TestWait` holds both helpers. It lives outside the base class deliberately: several polling test classes (rack-aware, scale-out, ACL fixtures) cannot derive from `KafkaIntegrationTest`, so a `protected` home could never absorb their copies. `KafkaIntegrationTest` keeps thin `protected static` forwarders — no call-site churn.
- Both helpers throw `TimeoutException` with an optional `description`; the generic overload includes the last observed value, so a stuck test names the state it was stuck in (the failure mode #2520 fixed case-by-case).
- The sync overload clamps its final poll delay so the timeout is not overshot by a poll interval.
- `ManualAssignment_DoesNotAutoDetect_NewPartitions` was using a condition wait as a *negative-check* grace window ("assignment must NOT grow") and only passed because of the silent unmet-return — the throwing helper caught this immediately. It now polls the invariant throughout the 3 s observation window (same idiom as `OffsetCommitSafetyTests`), which is strictly stronger: a transient wrong auto-detection now fails at the violation instant.
- `ConsumerCoordinatorFailoverIntegrationTests.WaitForConvergenceAsync` intentionally stays separate: it additionally watches background consume tasks and rethrows their real fault instead of masking a crash as a timeout.

Behavior note: the shared `<T>` default is `maxRetries: 10` (the old copies were split 5/10). This lengthens only the *failing* path; keeping the larger budget avoids shrinking DeleteRecordsTests' propagation patience.

## Follow-ups (not in this PR)

Hand-rolled same-mechanism waits that can now migrate to `TestWait`: `ShareConsumerTests.WaitForShareAssignmentAsync`, `QuotaAndRateLimitingTests.WaitForProducerQuotaAsync` (still has the bare-cancellation failure mode), the byte-identical `WaitUntilAsync` pair in `BrokerScaleOutIntegrationTests`/`PartitionReassignmentIntegrationTests`, `AclEnforcementTests.WaitForAclCountAsync`, `DynamicConfigurationIntegrationTests.WaitForTopicConfigAsync`.

## Test plan

- [x] `dotnet build tests/Dekaf.Tests.Integration -c Release -p:TreatWarningsAsErrors=true` — 0 warnings/errors
- [x] Local Docker runs: AdminClientTests 32/32, ConcurrentAdminTests 9/9, DeleteRecordsTests 5/5, PartitionExpansionTests 5/5 (+1 broker-version skip), RebalanceEdgeCaseTests 5/5

No `src/` changes — no performance surface touched.