### PR TITLE
test: pin Snappy codec reuse contract ahead of #2352; document upstream allocation blocker

### DIFF
--- a/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
+++ b/src/Dekaf.Compression.Snappy/SnappyCompressionCodec.cs
@@ -16,6 +16,12 @@ namespace Dekaf.Compression.Snappy;
 /// </summary>
 public sealed class SnappyCompressionCodec : ICompressionCodec
 {
+    // Allocation note (#2214): Snappier's static block helpers allocate a small internal
+    // driver object per call (~48 B compress / ~80 B decompress as of 1.3.1); its reusable
+    // compressor types are internal upstream, and reflection or vendoring is ruled out
+    // (Native AOT + trimming), so instance reuse is blocked on #2352. These are per-block
+    // (i.e. per-batch) costs, not per-message.
+
     // Xerial-snappy magic header
     private static ReadOnlySpan<byte> XerialMagic => [0x82, 0x53, 0x4e, 0x41, 0x50, 0x50, 0x59, 0x00];
 

--- a/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Dekaf.Compression;
 using Dekaf.Compression.Snappy;
 using Dekaf.Protocol.Records;
+using Dekaf.Tests.Unit.Protocol;
 
 namespace Dekaf.Tests.Unit.Compression;
 
@@ -269,6 +270,74 @@ public class SnappyCompressionCodecTests
 
         await Assert.That(decompressedBuffer.WrittenSpan.ToArray()).IsEquivalentTo(original);
     }
+
+    [Test]
+    public async Task Compress_ReusedCodec_ProducesIdenticalOutputToFreshInstance()
+    {
+        // Pins that the codec's thread-cached scratch state (multi-segment compression
+        // buffer, decompression destination tracker) never leaks between operations.
+        // Guards the reuse contract that #2352 (pooled Snappier instances) must preserve.
+        var payload = new byte[8192];
+        new Random(42).NextBytes(payload);
+        var reused = new SnappyCompressionCodec(blockSize: 1024);
+
+        var reusedOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            reusedOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
+            reused.Compress(CreateMultiSegmentSequence(payload), reusedOutput);
+            var warmDecompressed = new ArrayBufferWriter<byte>(payload.Length);
+            reused.Decompress(new ReadOnlySequence<byte>(reusedOutput.WrittenMemory), warmDecompressed);
+
+            await Assert.That(warmDecompressed.WrittenSpan.SequenceEqual(payload)).IsTrue();
+        }
+
+        var freshOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
+        new SnappyCompressionCodec(blockSize: 1024).Compress(CreateMultiSegmentSequence(payload), freshOutput);
+
+        await Assert.That(reusedOutput.WrittenSpan.SequenceEqual(freshOutput.WrittenSpan)).IsTrue();
+    }
+
+    [Test]
+    public async Task CompressDecompress_ParallelWorkers_DoNotCorruptEachOther()
+    {
+        // Pins thread-safety of the codec's [ThreadStatic] scratch state: concurrent
+        // batches compressed and decompressed through one shared codec instance must
+        // round-trip independently. Catches cross-thread corruption if the thread-local
+        // caches are ever replaced with a shared pool without proper ownership handoff.
+        var codec = new SnappyCompressionCodec(blockSize: 4096);
+        var failures = 0;
+
+        Parallel.For(0, 8, worker =>
+        {
+            var random = new Random(worker);
+            for (var iteration = 0; iteration < 50; iteration++)
+            {
+                var payload = new byte[random.Next(1, 16384)];
+                random.NextBytes(payload);
+                var source = iteration % 2 == 0
+                    ? new ReadOnlySequence<byte>(payload)
+                    : CreateMultiSegmentSequence(payload);
+
+                var compressed = new ArrayBufferWriter<byte>(payload.Length + 128);
+                codec.Compress(source, compressed);
+                var decompressed = new ArrayBufferWriter<byte>(payload.Length);
+                codec.Decompress(new ReadOnlySequence<byte>(compressed.WrittenMemory), decompressed);
+
+                if (!decompressed.WrittenSpan.SequenceEqual(payload))
+                {
+                    Interlocked.Increment(ref failures);
+                }
+            }
+        });
+
+        await Assert.That(failures).IsEqualTo(0);
+    }
+
+    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] payload)
+        => payload.Length < 2
+            ? new ReadOnlySequence<byte>(payload)
+            : SequenceTestHelpers.CreateMultiSegmentSequence(payload, payload.Length / 2);
 
     private static int CountXerialBlocks(ReadOnlySpan<byte> compressed)
     {

--- a/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
+++ b/tests/Dekaf.Tests.Unit/Compression/SnappyCompressionCodecTests.cs
@@ -281,11 +281,17 @@ public class SnappyCompressionCodecTests
         new Random(42).NextBytes(payload);
         var reused = new SnappyCompressionCodec(blockSize: 1024);
 
-        var reusedOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
+        // Split deliberately off a block boundary: 8192 bytes in 1024-byte blocks means an
+        // aligned split (4096) leaves every block inside one segment, so Compress would take
+        // the IsSingleSegment fast path and never touch the thread-cached scratch buffer this
+        // test exists to pin. 4097 straddles the fifth block across both segments.
+        var straddlingSplit = (payload.Length / 2) + 1;
+
+        ArrayBufferWriter<byte> reusedOutput = null!;
         for (var cycle = 0; cycle < 3; cycle++)
         {
             reusedOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
-            reused.Compress(CreateMultiSegmentSequence(payload), reusedOutput);
+            reused.Compress(CreateMultiSegmentSequence(payload, straddlingSplit), reusedOutput);
             var warmDecompressed = new ArrayBufferWriter<byte>(payload.Length);
             reused.Decompress(new ReadOnlySequence<byte>(reusedOutput.WrittenMemory), warmDecompressed);
 
@@ -293,7 +299,8 @@ public class SnappyCompressionCodecTests
         }
 
         var freshOutput = new ArrayBufferWriter<byte>(payload.Length + 128);
-        new SnappyCompressionCodec(blockSize: 1024).Compress(CreateMultiSegmentSequence(payload), freshOutput);
+        new SnappyCompressionCodec(blockSize: 1024)
+            .Compress(CreateMultiSegmentSequence(payload, straddlingSplit), freshOutput);
 
         await Assert.That(reusedOutput.WrittenSpan.SequenceEqual(freshOutput.WrittenSpan)).IsTrue();
     }
@@ -334,10 +341,10 @@ public class SnappyCompressionCodecTests
         await Assert.That(failures).IsEqualTo(0);
     }
 
-    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] payload)
+    private static ReadOnlySequence<byte> CreateMultiSegmentSequence(byte[] payload, int splitAt = -1)
         => payload.Length < 2
             ? new ReadOnlySequence<byte>(payload)
-            : SequenceTestHelpers.CreateMultiSegmentSequence(payload, payload.Length / 2);
+            : SequenceTestHelpers.CreateMultiSegmentSequence(payload, splitAt < 0 ? payload.Length / 2 : splitAt);
 
     private static int CountXerialBlocks(ReadOnlySpan<byte> compressed)
     {

--- a/tests/Dekaf.Tests.Unit/Protocol/DetachableBufferWriterTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/DetachableBufferWriterTests.cs
@@ -34,6 +34,30 @@ public sealed class DetachableBufferWriterTests
     }
 
     [Test]
+    public async Task Rent_WhileOutstanding_ReturnsIndependentWriter()
+    {
+        // Pins the documented single-slot cache invariant: a nested Rent while another
+        // writer is outstanding must return a distinct wrapper instead of sharing
+        // live state (RecordBatch.cs cache comment).
+        var pool = ArrayPool<byte>.Create();
+        var outer = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        var inner = DetachableBufferWriter.Rent(pool, initialCapacity: 16);
+        try
+        {
+            await Assert.That(inner).IsNotSameReferenceAs(outer);
+
+            inner.GetSpan(1)[0] = 2;
+            inner.Advance(1);
+            await Assert.That(outer.WrittenSpan.Length).IsEqualTo(0);
+        }
+        finally
+        {
+            inner.Dispose();
+            outer.Dispose();
+        }
+    }
+
+    [Test]
     public async Task Rent_AfterDisposeWithoutDetach_ReusesClearedWrapper()
     {
         var pool = ArrayPool<byte>.Create();


### PR DESCRIPTION
## Summary

Investigated #2214 ("last zero-alloc leftovers") to implementation. Findings changed the shape of the work:

| #2214 item | Status |
|---|---|
| Pool `DetachableBufferWriter` in `PreCompress` | **Already shipped on main** — PR #2416 (2026-07-27) added the `Rent` + `[ThreadStatic]` single-slot wrapper cache; producer pre-serialization measured 40 B → 0 B there. Nothing left to do. |
| Reuse Snappier compressor/decompressor instances | **Blocked upstream.** Snappier 1.3.1 keeps `SnappyCompressor`/`SnappyDecompressor` `internal`; every public static entry point allocates a fresh driver per call (~48 B compress / ~80 B decompress). #2352 rules out reflection and vendoring (Native AOT + trimming). Upstream brantburnett/Snappier#148 is still open — the swap needs it merged and released, then a package bump. |

So no product perf change is possible right now. This PR lands what is useful while blocked:

- **Source comment** in `SnappyCompressionCodec` classifying the residual allocations as per-block (per-batch) costs with the upstream blocker, so future zero-alloc audits don't misdiagnose them or "fix" them the forbidden way.
- **Contract-pinning tests** the eventual #2352 swap must keep green:
  - `Compress_ReusedCodec_ProducesIdenticalOutputToFreshInstance` — thread-cached scratch never leaks across compress/decompress cycles.
  - `CompressDecompress_ParallelWorkers_DoNotCorruptEachOther` — 8 workers × 50 batches through one shared codec, single- and multi-segment inputs; catches ownership bugs if thread-local caches are ever converted to a shared pool incorrectly.
  - `Rent_WhileOutstanding_ReturnsIndependentWriter` — pins `DetachableBufferWriter`'s documented single-slot cache invariant from #2416.

Reviewed via /simplify (4 agents): segment-building now delegates to the shared `SequenceTestHelpers`, writers pre-sized, comment trimmed to durable facts. Efficiency review specifically verified the parallel test cannot perturb the pool-warmth-sensitive `TransactionalProduceAllocationTests` gate (NotInParallel + disjoint pool buckets + its windowed design).

## Test plan

- [x] `dotnet build Dekaf.sln -c Release -p:TreatWarningsAsErrors=true` — 0 warnings/errors
- [x] Full unit suite green; new tests pass (Snappy class 20/20, DetachableBufferWriter class 3/3)

No behavioral `src/` change (comment only) — no benchmark numbers required. Suggest keeping #2214 open (or re-scoping it onto #2352) until upstream ships.