### PR TITLE
perf(networking): zero-copy segmented socket write for multi-batch produce requests

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -124,6 +124,14 @@ public sealed partial class KafkaConnection :
     internal const int DefaultPreSerializeInitialCapacity = 4096;
     private const int MessageSizePrefixLength = 4;
     private const int RequestHeaderSizeSlack = 128;
+
+    // Per-entry estimates for sizing the segmented produce metadata buffer so typical
+    // coalesced requests never grow it mid-serialization (RentedBufferWriter growth is the
+    // safety net for outliers such as very long topic names). A topic contributes a UUID or
+    // compact name plus partition-array framing and tagged fields; a partition contributes
+    // its index, records-length varint, and tagged fields.
+    private const int SegmentedTopicMetadataSizeEstimate = 40;
+    private const int SegmentedPartitionMetadataSizeEstimate = 24;
     private static int s_globalCorrelationId;
     private readonly PendingRequestShard[] _pendingRequestShards;
     private readonly SemaphoreSlim _pendingRequestSlots;
@@ -1607,45 +1615,84 @@ public sealed partial class KafkaConnection :
     {
         if (!_isTls
             && _socket is not null
-            && request is ProduceRequest produceRequest
-            && TryPreSerializeSingleBatchProduceRequest(
-                produceRequest,
-                correlationId,
-                apiVersion,
-                headerVersion,
-                out var metadataArray,
-                out var prefixLength,
-                out var encodedRecords,
-                out var suffixOffset,
-                out var suffixLength))
+            && request is ProduceRequest produceRequest)
         {
-            try
+            if (TryPreSerializeSingleBatchProduceRequest(
+                    produceRequest,
+                    correlationId,
+                    apiVersion,
+                    headerVersion,
+                    out var metadataArray,
+                    out var prefixLength,
+                    out var encodedRecords,
+                    out var suffixOffset,
+                    out var suffixLength))
             {
-                await SemaphoreHelper.AcquireOrThrowDisposedAsync(
-                        _writeLock,
-                        nameof(KafkaConnection),
+                try
+                {
+                    await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                            _writeLock,
+                            nameof(KafkaConnection),
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+                    DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+                    throw;
+                }
+
+                var segmentedWriteTask = WriteSegmentedFrameHoldingLockAsync(
+                    metadataArray,
+                    prefixLength,
+                    encodedRecords,
+                    suffixOffset,
+                    suffixLength);
+                await AwaitBorrowedFrameWriteAsync(
+                        segmentedWriteTask,
+                        correlationId,
+                        callerOwnsTimeout,
                         cancellationToken)
                     .ConfigureAwait(false);
-            }
-            catch
-            {
-                DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
-                throw;
+                return;
             }
 
-            var segmentedWriteTask = WriteSegmentedFrameHoldingLockAsync(
-                metadataArray,
-                prefixLength,
-                encodedRecords,
-                suffixOffset,
-                suffixLength);
-            await AwaitBorrowedFrameWriteAsync(
-                    segmentedWriteTask,
+            if (TryPreSerializeSegmentedProduceRequest(
+                    produceRequest,
                     correlationId,
-                    callerOwnsTimeout,
-                    cancellationToken)
-                .ConfigureAwait(false);
-            return;
+                    apiVersion,
+                    headerVersion,
+                    out var segmentedMetadataArray,
+                    out var frameSegments,
+                    out var frameSegmentCount))
+            {
+                try
+                {
+                    await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                            _writeLock,
+                            nameof(KafkaConnection),
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+                    ReturnFrameSegments(frameSegments, frameSegmentCount);
+                    DekafPools.SerializationBuffers.Return(segmentedMetadataArray, clearArray: false);
+                    throw;
+                }
+
+                var segmentedFrameWriteTask = WriteSegmentedFrameHoldingLockAsync(
+                    segmentedMetadataArray,
+                    frameSegments,
+                    frameSegmentCount);
+                await AwaitBorrowedFrameWriteAsync(
+                        segmentedFrameWriteTask,
+                        correlationId,
+                        callerOwnsTimeout,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+            }
         }
 
         var (serializedArray, serializedLength) = PreSerializeRequest<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion);
@@ -1696,21 +1743,8 @@ public sealed partial class KafkaConnection :
             DefaultPreSerializeInitialCapacity,
             MessageSizePrefixLength);
         var writer = new KafkaProtocolWriter(metadataWriter);
-        var header = new RequestHeader
-        {
-            ApiKey = ApiKey.Produce,
-            ApiVersion = apiVersion,
-            CorrelationId = correlationId,
-            ClientId = _clientId,
-            HeaderVersion = headerVersion
-        };
-
-        header.Write(ref writer);
-        var headerLength = writer.BytesWritten;
-
-        writer.WriteCompactNullableString(request.TransactionalId);
-        writer.WriteInt16(request.Acks);
-        writer.WriteInt32(request.TimeoutMs);
+        var headerLength = WriteProduceHeaderAndPreamble(
+            ref writer, request, correlationId, apiVersion, headerVersion);
         writer.WriteUnsignedVarInt(2); // one topic, compact count is item count + 1
         if (apiVersion >= ProduceRequest.TopicIdVersion)
             writer.WriteUuid(topic.TopicId);
@@ -1758,18 +1792,311 @@ public sealed partial class KafkaConnection :
         suffixOffset = prefixLength;
         suffixLength = metadataWriter.WrittenCount - prefixLength;
 
-        var bodyLength = writer.BytesWritten - headerLength;
+        ThrowIfProduceBodySizeHintMismatch(request, writer.BytesWritten - headerLength);
+
+        var totalLength = checked(metadataWriter.WrittenCount + encodedRecordsLength);
+        (metadataArray, _) = metadataWriter.DetachBuffer();
+        BinaryPrimitives.WriteInt32BigEndian(metadataArray, totalLength - MessageSizePrefixLength);
+        return true;
+    }
+
+    /// <summary>
+    /// Generalization of <see cref="TryPreSerializeSingleBatchProduceRequest"/> to coalesced
+    /// (multi-batch, multi-partition, multi-topic) produce requests. All request metadata —
+    /// size prefix, request header, topic/partition framing, each batch's 61-byte record-batch
+    /// header, and the trailing tagged fields — is serialized into one rented metadata array;
+    /// record payload bytes stay in their caller-owned buffers (accumulator memory or
+    /// pre-compressed arrays). The out parameters describe the exact wire interleaving as an
+    /// ordered pooled list of segments: metadata slice, record bytes, metadata slice, ...,
+    /// final metadata slice. The assembled segments are byte-identical to
+    /// <see cref="PreSerializeRequest{TRequest,TResponse}"/> output for the same request.
+    /// </summary>
+    /// <remarks>
+    /// All-or-nothing: if any batch cannot write segmented for its partition's compression, or
+    /// any record buffer is not array-backed, the method returns false without side effects and
+    /// the caller uses the copying path for the whole request. On success the caller owns
+    /// <paramref name="metadataArray"/> (return to <see cref="DekafPools.SerializationBuffers"/>)
+    /// and <paramref name="frameSegments"/> (return via <see cref="ReturnFrameSegments"/>,
+    /// which clears the written prefix so pooled descriptor arrays do not root record buffers).
+    /// </remarks>
+    internal bool TryPreSerializeSegmentedProduceRequest(
+        ProduceRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion,
+        out byte[] metadataArray,
+        out SegmentedFrameSegment[] frameSegments,
+        out int frameSegmentCount)
+    {
+        metadataArray = null!;
+        frameSegments = null!;
+        frameSegmentCount = 0;
+
+        // All-or-nothing precheck: every batch must be segment-eligible before any
+        // serialization work happens, so a mixed request takes the copying path whole. The
+        // same walk gathers the counts that size the metadata buffer and the frame-segment
+        // array exactly (each batch caches its chunk count at seal time), so neither grows
+        // mid-serialization on typical requests.
+        var topicCount = request.TopicEntryCount;
+        var totalPartitionCount = 0;
+        var totalBatchCount = 0;
+        var recordSegmentHint = 0;
+        for (var t = 0; t < topicCount; t++)
+        {
+            var topic = request.GetTopicEntry(t);
+            var partitionCount = topic.PartitionEntryCount;
+            for (var p = 0; p < partitionCount; p++)
+            {
+                var partition = topic.GetPartitionEntry(p);
+                var records = partition.Records;
+                for (var b = 0; b < records.Count; b++)
+                {
+                    var batch = records[b];
+                    if (!batch.CanWriteSegmented(partition.Compression))
+                        return false;
+
+                    recordSegmentHint += batch.SegmentedRecordsSegmentCountHint;
+                }
+
+                totalBatchCount += records.Count;
+            }
+
+            totalPartitionCount += partitionCount;
+        }
+
+        if (totalBatchCount == 0)
+            return false;
+
+        var metadataCapacity = Math.Max(
+            DefaultPreSerializeInitialCapacity,
+            checked(RequestHeaderSizeSlack
+                + (topicCount * SegmentedTopicMetadataSizeEstimate)
+                + (totalPartitionCount * SegmentedPartitionMetadataSizeEstimate)
+                + (totalBatchCount * RecordBatch.TotalBatchHeaderSize)));
+        using var metadataWriter = new RentedBufferWriter(
+            metadataCapacity,
+            MessageSizePrefixLength);
+        var writer = new KafkaProtocolWriter(metadataWriter);
+        var headerLength = WriteProduceHeaderAndPreamble(
+            ref writer, request, correlationId, apiVersion, headerVersion);
+        writer.WriteUnsignedVarInt(topicCount + 1);
+
+        // One metadata slice per batch (closed by that batch's header), one record segment per
+        // encoded chunk (hinted per batch at seal time), plus the final tagged-fields slice.
+        // AppendFrameSegment growth remains the safety net if a batch changes concurrently.
+        var frameSegmentCapacity = totalBatchCount + recordSegmentHint + 1;
+        var segments = ArrayPool<SegmentedFrameSegment>.Shared.Rent(frameSegmentCapacity);
+        var segmentCount = 0;
+        var metadataSliceStart = 0;
+        var detached = false;
+        try
+        {
+            for (var t = 0; t < topicCount; t++)
+            {
+                var topic = request.GetTopicEntry(t);
+                if (apiVersion >= ProduceRequest.TopicIdVersion)
+                    writer.WriteUuid(topic.TopicId);
+                else
+                    writer.WriteCompactString(topic.Name);
+
+                var partitionCount = topic.PartitionEntryCount;
+                writer.WriteUnsignedVarInt(partitionCount + 1);
+                for (var p = 0; p < partitionCount; p++)
+                {
+                    var partition = topic.GetPartitionEntry(p);
+                    writer.WriteInt32(partition.Index);
+
+                    var records = partition.Records;
+                    var recordsLength = 0;
+                    for (var b = 0; b < records.Count; b++)
+                        recordsLength = checked(recordsLength + records[b].GetEncodedSize(partition.Compression));
+
+                    // COMPACT_RECORDS uses COMPACT_NULLABLE_BYTES encoding (length+1, 0 = null).
+                    writer.WriteUnsignedVarInt(checked(recordsLength + 1));
+
+                    var actualRecordsLength = 0;
+                    for (var b = 0; b < records.Count; b++)
+                    {
+                        if (!records[b].TryWriteSegmentedHeader(
+                                metadataWriter,
+                                partition.Compression,
+                                out var encodedRecords))
+                        {
+                            return false;
+                        }
+
+                        // Close the pending metadata slice; it ends with the batch header
+                        // TryWriteSegmentedHeader just wrote.
+                        AppendFrameSegment(
+                            ref segments,
+                            ref segmentCount,
+                            new SegmentedFrameSegment(
+                                null,
+                                metadataSliceStart,
+                                metadataWriter.WrittenCount - metadataSliceStart));
+
+                        var encodedRecordsLength = 0;
+                        foreach (var memory in encodedRecords)
+                        {
+                            if (memory.Length == 0)
+                                continue;
+
+                            if (!MemoryMarshal.TryGetArray(memory, out var recordsSegment))
+                                return false;
+
+                            AppendFrameSegment(
+                                ref segments,
+                                ref segmentCount,
+                                new SegmentedFrameSegment(
+                                    recordsSegment.Array,
+                                    recordsSegment.Offset,
+                                    recordsSegment.Count));
+                            encodedRecordsLength = checked(encodedRecordsLength + memory.Length);
+                        }
+
+                        metadataSliceStart = metadataWriter.WrittenCount;
+
+                        var encodedBatchSize = RecordBatch.TotalBatchHeaderSize + encodedRecordsLength;
+                        writer.AddBytesWritten(encodedBatchSize);
+                        actualRecordsLength = checked(actualRecordsLength + encodedBatchSize);
+                    }
+
+                    if (actualRecordsLength != recordsLength)
+                    {
+                        throw new KafkaException(
+                            ErrorCode.CorruptMessage,
+                            $"PRODUCE segmented framing mismatch for partition {partition.Index}: " +
+                            $"declared records length {recordsLength} but segmented headers and records " +
+                            $"total {actualRecordsLength} bytes across {records.Count} batch(es).");
+                    }
+
+                    writer.WriteEmptyTaggedFields(); // partition
+                }
+
+                writer.WriteEmptyTaggedFields(); // topic
+            }
+
+            writer.WriteEmptyTaggedFields(); // request
+
+            ThrowIfProduceBodySizeHintMismatch(request, writer.BytesWritten - headerLength);
+
+            // Close the final metadata slice (partition/topic/request tagged fields).
+            AppendFrameSegment(
+                ref segments,
+                ref segmentCount,
+                new SegmentedFrameSegment(
+                    null,
+                    metadataSliceStart,
+                    metadataWriter.WrittenCount - metadataSliceStart));
+
+#if DEBUG
+            var frameLength = 0L;
+            for (var i = 0; i < segmentCount; i++)
+                frameLength += segments[i].Count;
+            Debug.Assert(frameLength == MessageSizePrefixLength + writer.BytesWritten,
+                "Segmented produce frame segments do not add up to the full frame length");
+#endif
+
+            (metadataArray, _) = metadataWriter.DetachBuffer();
+            detached = true;
+            BinaryPrimitives.WriteInt32BigEndian(metadataArray, writer.BytesWritten);
+            frameSegments = segments;
+            frameSegmentCount = segmentCount;
+            return true;
+        }
+        finally
+        {
+            // Any bail-out (ineligible batch, non-array-backed records, framing mismatch throw)
+            // must return the pooled descriptor array; the using-disposal above returns the
+            // metadata buffer. Record buffers are untouched, so the copying path stays valid.
+            if (!detached)
+                ReturnFrameSegments(segments, segmentCount);
+        }
+    }
+
+    /// <summary>
+    /// Writes the request header and the produce body preamble (transactional id, acks,
+    /// timeout) shared by both segmented produce pre-serializers. Returns the serialized
+    /// header length so callers can validate the body length against the request size hint.
+    /// </summary>
+    private int WriteProduceHeaderAndPreamble(
+        ref KafkaProtocolWriter writer,
+        ProduceRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion)
+    {
+        var header = new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = _clientId,
+            HeaderVersion = headerVersion
+        };
+
+        header.Write(ref writer);
+        var headerLength = writer.BytesWritten;
+
+        writer.WriteCompactNullableString(request.TransactionalId);
+        writer.WriteInt16(request.Acks);
+        writer.WriteInt32(request.TimeoutMs);
+        return headerLength;
+    }
+
+    private static void ThrowIfProduceBodySizeHintMismatch(ProduceRequest request, int bodyLength)
+    {
         if (request.RequestBodySizeHint > 0 && bodyLength != request.RequestBodySizeHint)
         {
             throw new KafkaException(
                 ErrorCode.CorruptMessage,
                 $"PRODUCE segmented body mismatch: size hint {request.RequestBodySizeHint} but serialized {bodyLength} bytes.");
         }
+    }
 
-        var totalLength = checked(metadataWriter.WrittenCount + encodedRecordsLength);
-        (metadataArray, _) = metadataWriter.DetachBuffer();
-        BinaryPrimitives.WriteInt32BigEndian(metadataArray, totalLength - MessageSizePrefixLength);
-        return true;
+    private static void AppendFrameSegment(
+        ref SegmentedFrameSegment[] segments,
+        ref int count,
+        in SegmentedFrameSegment segment)
+    {
+        if ((uint)count >= (uint)segments.Length)
+            GrowFrameSegments(ref segments, count);
+
+        segments[count++] = segment;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void GrowFrameSegments(ref SegmentedFrameSegment[] segments, int count)
+    {
+        var grown = ArrayPool<SegmentedFrameSegment>.Shared.Rent(segments.Length * 2);
+        Array.Copy(segments, grown, count);
+        ReturnFrameSegments(segments, count);
+        segments = grown;
+    }
+
+    /// <summary>
+    /// Returns a pooled frame-segment array after clearing only its written prefix — enough
+    /// to stop the pooled array GC-rooting MB-scale record buffers, without memclearing the
+    /// full rounded-up rented length the way <c>Return(clearArray: true)</c> would.
+    /// </summary>
+    private static void ReturnFrameSegments(SegmentedFrameSegment[] segments, int count)
+    {
+        Array.Clear(segments, 0, count);
+        ArrayPool<SegmentedFrameSegment>.Shared.Return(segments, clearArray: false);
+    }
+
+    /// <summary>
+    /// One wire segment of a segmented produce frame. <see cref="Array"/> is null for a slice
+    /// of the rented metadata array — resolved against it at send time because the metadata
+    /// buffer can be reallocated (grown) while later metadata is still being serialized — and
+    /// non-null for a slice of a caller-owned records buffer (accumulator memory or a
+    /// pre-compressed array).
+    /// </summary>
+    internal readonly struct SegmentedFrameSegment(byte[]? array, int offset, int count)
+    {
+        public byte[]? Array { get; } = array;
+        public int Offset { get; } = offset;
+        public int Count { get; } = count;
     }
 
     private async Task WriteSegmentedFrameHoldingLockAsync(
@@ -1836,6 +2163,76 @@ public sealed partial class KafkaConnection :
                 SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
             }
 
+            DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+            SemaphoreHelper.ReleaseSafely(_writeLock);
+        }
+    }
+
+    /// <summary>
+    /// Multi-batch counterpart of
+    /// <see cref="WriteSegmentedFrameHoldingLockAsync(byte[], int, ReadOnlySequence{byte}, int, int)"/>:
+    /// writes the frame described by <paramref name="frameSegments"/> — alternating rented-metadata
+    /// slices and borrowed record buffers — without copying record bytes. From entry this task owns
+    /// the write lock, the metadata array, and the pooled segment array, and releases all three
+    /// itself so a timed-out caller can abandon the wait without cancelling a socket write mid-frame
+    /// (see <see cref="AwaitBorrowedFrameWriteAsync"/>).
+    /// </summary>
+    private async Task WriteSegmentedFrameHoldingLockAsync(
+        byte[] metadataArray,
+        SegmentedFrameSegment[] frameSegments,
+        int frameSegmentCount)
+    {
+        var scatterGatherSenderLockHeld = false;
+        try
+        {
+            await _scatterGatherSenderLock.WaitAsync().ConfigureAwait(false);
+            scatterGatherSenderLockHeld = true;
+
+            var socket = _socket ?? throw new InvalidOperationException("Not connected");
+            if (_stream is null)
+                throw new InvalidOperationException("Not connected");
+
+            if (Volatile.Read(ref _disposed) != 0)
+                throw new ObjectDisposedException(nameof(KafkaConnection));
+
+            var sender = _scatterGatherSender ??= new SocketScatterGatherSender(frameSegmentCount);
+            sender.EnsurePendingSegmentCapacity(frameSegmentCount);
+            var pendingSegments = sender.PendingSegments;
+            for (var i = 0; i < frameSegmentCount; i++)
+            {
+                var segment = frameSegments[i];
+                pendingSegments.Add(new ArraySegment<byte>(
+                    segment.Array ?? metadataArray,
+                    segment.Offset,
+                    segment.Count));
+            }
+
+            sender.BeginPendingSend();
+            while (sender.HasPendingSegments)
+            {
+                sender.LoadSendWindow();
+                var bytesSent = await sender.SendAsync(socket).ConfigureAwait(false);
+                if (bytesSent <= 0)
+                    throw new IOException("Socket closed while writing a Kafka request frame.");
+
+                sender.ConsumeSentBytes(bytesSent);
+            }
+        }
+        catch
+        {
+            AbortAfterWriteFailure();
+            throw;
+        }
+        finally
+        {
+            if (scatterGatherSenderLockHeld)
+            {
+                _scatterGatherSender?.Segments.Clear();
+                _scatterGatherSender?.PendingSegments.Clear();
+                SemaphoreHelper.ReleaseSafely(_scatterGatherSenderLock);
+            }
+
+            ReturnFrameSegments(frameSegments, frameSegmentCount);
             DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
             SemaphoreHelper.ReleaseSafely(_writeLock);
         }

--- a/src/Dekaf/Protocol/Messages/ProduceRequest.cs
+++ b/src/Dekaf/Protocol/Messages/ProduceRequest.cs
@@ -93,8 +93,9 @@ public sealed class ProduceRequest : IKafkaRequest<ProduceResponse>, IKafkaReque
     /// <summary>
     /// Number of topic entries regardless of whether the request was populated through
     /// <see cref="TopicData"/> or the internal scratch arrays. Pairs with
-    /// <see cref="GetTopicEntry"/>; exists so tests can observe scratch-built requests
-    /// without reflecting into private fields.
+    /// <see cref="GetTopicEntry"/>; used by the segmented produce pre-serializer
+    /// (KafkaConnection) to walk coalesced requests, and by tests to observe scratch-built
+    /// requests without reflecting into private fields.
     /// </summary>
     internal int TopicEntryCount => _topicDataScratch is not null ? _topicDataScratchCount : TopicData.Count;
 
@@ -167,8 +168,9 @@ public sealed class ProduceRequestTopicData
     /// <summary>
     /// Number of partition entries regardless of whether the topic was populated through
     /// <see cref="PartitionData"/> or the internal scratch arrays. Pairs with
-    /// <see cref="GetPartitionEntry"/>; exists so tests can observe scratch-built requests
-    /// without reflecting into private fields.
+    /// <see cref="GetPartitionEntry"/>; used by the segmented produce pre-serializer
+    /// (KafkaConnection) to walk coalesced requests, and by tests to observe scratch-built
+    /// requests without reflecting into private fields.
     /// </summary>
     internal int PartitionEntryCount => _partitionDataScratch is not null ? _partitionDataScratchCount : PartitionData.Count;
 

--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -700,12 +700,26 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
 
     private ReadOnlyMemory<byte> _preEncodedRecords;
     private ReadOnlySequence<byte> _segmentedPreEncodedRecords;
+    private int _segmentedPreEncodedRecordsSegmentCount;
     private bool _hasSegmentedPreEncodedRecords;
     private bool _hasPreEncodedRecords;
     // Valid only while _preEncodedRecords remains retained for this batch and unmodified through Write().
     private uint _preEncodedRecordsCrc;
 
     internal bool HasPreEncodedRecords => _hasPreEncodedRecords;
+
+    /// <summary>
+    /// O(1) count of the wire segments this batch's encoded records contribute to a segmented
+    /// produce frame: 1 for pre-compressed or contiguous pre-encoded records, or the non-empty
+    /// chunk count cached at seal time for segmented pre-encoded records (Incremental-strategy
+    /// batches are chunked, e.g. at 16KB, so a large batch can span dozens of chunks). Lets the
+    /// segmented produce pre-serializer rent its frame-segment array exactly instead of growing
+    /// it per chunk.
+    /// </summary>
+    internal int SegmentedRecordsSegmentCountHint =>
+        _hasSegmentedPreEncodedRecords && PreCompressedRecords is null
+            ? _segmentedPreEncodedRecordsSegmentCount
+            : 1;
 
     internal int PreEncodedRecordsLength => _hasPreEncodedRecords ? GetPreEncodedRecordsLength() : 0;
 
@@ -751,6 +765,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
     {
         _preEncodedRecords = records;
         _segmentedPreEncodedRecords = default;
+        _segmentedPreEncodedRecordsSegmentCount = 0;
         _hasPreEncodedRecords = true;
         _hasSegmentedPreEncodedRecords = false;
         _preEncodedRecordsCrc = Crc32C.Compute(records.Span);
@@ -764,8 +779,19 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             return;
         }
 
+        // Count non-empty chunks once per batch seal so the segmented produce pre-serializer
+        // can size its frame-segment array without re-walking the sequence (see
+        // SegmentedRecordsSegmentCountHint).
+        var segmentCount = 0;
+        foreach (var memory in records)
+        {
+            if (memory.Length > 0)
+                segmentCount++;
+        }
+
         _preEncodedRecords = default;
         _segmentedPreEncodedRecords = records;
+        _segmentedPreEncodedRecordsSegmentCount = segmentCount;
         _hasPreEncodedRecords = true;
         _hasSegmentedPreEncodedRecords = true;
         _preEncodedRecordsCrc = Crc32C.Compute(records);
@@ -973,6 +999,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
             item.PreCompressedRecordsCrc = 0;
             item._preEncodedRecords = default;
             item._segmentedPreEncodedRecords = default;
+            item._segmentedPreEncodedRecordsSegmentCount = 0;
             item._hasPreEncodedRecords = false;
             item._hasSegmentedPreEncodedRecords = false;
             item._preEncodedRecordsCrc = 0;
@@ -1056,6 +1083,7 @@ public sealed class RecordBatch : IReadOnlyList<Record>, IDisposable
         batch.Records = Records;
         batch._preEncodedRecords = _preEncodedRecords;
         batch._segmentedPreEncodedRecords = _segmentedPreEncodedRecords;
+        batch._segmentedPreEncodedRecordsSegmentCount = _segmentedPreEncodedRecordsSegmentCount;
         batch._hasPreEncodedRecords = _hasPreEncodedRecords;
         batch._hasSegmentedPreEncodedRecords = _hasSegmentedPreEncodedRecords;
         batch._preEncodedRecordsCrc = _preEncodedRecordsCrc;

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -121,19 +121,7 @@ public sealed class KafkaConnectionTests
         short apiVersion)
     {
         var recordBytes = "arena-backed-records"u8.ToArray();
-        var batch = new RecordBatch
-        {
-            BaseOffset = 17,
-            PartitionLeaderEpoch = 3,
-            LastOffsetDelta = 0,
-            BaseTimestamp = 1234,
-            MaxTimestamp = 1234,
-            ProducerId = 42,
-            ProducerEpoch = 2,
-            BaseSequence = 7,
-            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
-        };
-        batch.SetPreEncodedRecords(recordBytes);
+        var batch = CreatePreEncodedBatch(17, recordBytes);
         batch.PreCompress(compression, null);
         var encodedRecordsBackingArray = batch.PreCompressedRecords ?? recordBytes;
 
@@ -160,20 +148,7 @@ public sealed class KafkaConnectionTests
         const int correlationId = 123;
         var headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
             .GetRequestHeaderVersion(apiVersion);
-        var expectedBody = new ArrayBufferWriter<byte>();
-        var expectedWriter = new KafkaProtocolWriter(expectedBody);
-        new RequestHeader
-        {
-            ApiKey = ApiKey.Produce,
-            ApiVersion = apiVersion,
-            CorrelationId = correlationId,
-            ClientId = "segment-client",
-            HeaderVersion = headerVersion
-        }.Write(ref expectedWriter);
-        request.Write(ref expectedWriter, apiVersion);
-        var expected = new byte[sizeof(int) + expectedWriter.BytesWritten];
-        BinaryPrimitives.WriteInt32BigEndian(expected, expectedWriter.BytesWritten);
-        expectedBody.WrittenSpan.CopyTo(expected.AsSpan(sizeof(int)));
+        var expected = BuildExpectedProduceFrame(request, correlationId, apiVersion, headerVersion, "segment-client");
 
         var connection = new KafkaConnection("localhost", 9092, "segment-client");
         var segmented = connection.TryPreSerializeSingleBatchProduceRequest(
@@ -296,6 +271,477 @@ public sealed class KafkaConnectionTests
 
         await Assert.That(segmented).IsFalse();
         await Assert.That(metadataArray).IsNull();
+    }
+
+    [Test]
+    [Arguments(CompressionType.None, (short)12)]
+    [Arguments(CompressionType.Gzip, (short)12)]
+    [Arguments(CompressionType.None, (short)13)]
+    [Arguments(CompressionType.Gzip, (short)13)]
+    public async Task MultiBatchProduceSegments_TwoPartitionsSameTopic_MatchContiguousSerialization(
+        CompressionType compression,
+        short apiVersion)
+    {
+        var firstRecordBytes = "first-partition-arena-records"u8.ToArray();
+        var secondRecordBytes = "second-partition-records-with-a-longer-payload"u8.ToArray();
+        var firstBatch = CreatePreEncodedBatch(17, firstRecordBytes);
+        var secondBatch = CreatePreEncodedBatch(29, secondRecordBytes);
+        firstBatch.PreCompress(compression, null);
+        secondBatch.PreCompress(compression, null);
+        var firstBackingArray = firstBatch.PreCompressedRecords ?? firstRecordBytes;
+        var secondBackingArray = secondBatch.PreCompressedRecords ?? secondRecordBytes;
+
+        // Scratch-array population mirrors the coalesced request shape BrokerSender builds.
+        var partitions = new[]
+        {
+            new ProduceRequestPartitionData { Index = 5, Records = [firstBatch], Compression = compression },
+            new ProduceRequestPartitionData { Index = 9, Records = [secondBatch], Compression = compression }
+        };
+        var topic = new ProduceRequestTopicData
+        {
+            Name = "segment-topic",
+            TopicId = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff")
+        };
+        topic.SetPartitionDataScratch(partitions, 0, 2);
+        var request = new ProduceRequest
+        {
+            TransactionalId = "tx-id",
+            Acks = -1,
+            TimeoutMs = 30_000
+        };
+        request.SetTopicDataScratch([topic], 1);
+
+        try
+        {
+            var (frameSegmentCount, recordArrays) = await AssertSegmentedProduceMatchesContiguousSerialization(
+                request, correlationId: 321, apiVersion, "segment-client");
+
+            // metadata, records, metadata, records, metadata
+            await Assert.That(frameSegmentCount).IsEqualTo(5);
+
+            // Zero-copy proof: record segments reference the batches' own buffers, in order.
+            await Assert.That(recordArrays.Count).IsEqualTo(2);
+            await Assert.That(recordArrays[0]).IsSameReferenceAs(firstBackingArray);
+            await Assert.That(recordArrays[1]).IsSameReferenceAs(secondBackingArray);
+        }
+        finally
+        {
+            firstBatch.ReturnPreCompressedBuffer();
+            secondBatch.ReturnPreCompressedBuffer();
+        }
+    }
+
+    [Test]
+    [Arguments((short)12)]
+    [Arguments((short)13)]
+    public async Task MultiBatchProduceSegments_TwoTopics_MatchContiguousSerialization(short apiVersion)
+    {
+        var alphaBatch = CreatePreEncodedBatch(3, "alpha-records"u8.ToArray());
+        var alphaSecondBatch = CreatePreEncodedBatch(11, "alpha-second-partition-larger-record-payload"u8.ToArray());
+        var betaBatch = CreatePreEncodedBatch(41, "beta-topic-record-bytes"u8.ToArray());
+
+        var request = new ProduceRequest
+        {
+            Acks = 1,
+            TimeoutMs = 15_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "alpha-topic",
+                    TopicId = Guid.Parse("11111111-2222-3333-4444-555555555555"),
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 0, Records = [alphaBatch] },
+                        new ProduceRequestPartitionData { Index = 1, Records = [alphaSecondBatch] }
+                    ]
+                },
+                new ProduceRequestTopicData
+                {
+                    Name = "beta-topic",
+                    TopicId = Guid.Parse("66666666-7777-8888-9999-aaaaaaaaaaaa"),
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 7, Records = [betaBatch] }
+                    ]
+                }
+            ]
+        };
+
+        await AssertSegmentedProduceMatchesContiguousSerialization(
+            request, correlationId: 654, apiVersion, clientId: null);
+    }
+
+    [Test]
+    public async Task MultiBatchProduceSegments_MultipleBatchesPerPartition_MatchContiguousSerialization()
+    {
+        var firstBatch = CreatePreEncodedBatch(0, "first-batch-in-partition"u8.ToArray());
+        var secondBatch = CreatePreEncodedBatch(1, "second-batch-in-the-same-partition-with-more-bytes"u8.ToArray());
+
+        var request = new ProduceRequest
+        {
+            Acks = -1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "multi-batch-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 4, Records = [firstBatch, secondBatch] }
+                    ]
+                }
+            ]
+        };
+
+        await AssertSegmentedProduceMatchesContiguousSerialization(
+            request, correlationId: 987, apiVersion: 12, clientId: null);
+    }
+
+    [Test]
+    public async Task MultiBatchProduceSegments_ChunkedRecordSequence_MatchContiguousSerialization()
+    {
+        // First batch's pre-encoded records span two arena chunks; the second is contiguous.
+        var chunkedRecordBytes = "chunked-record-bytes-spanning-two-arena-segments"u8.ToArray();
+        var chunkedBatch = CreatePreEncodedBatch(5, []);
+        chunkedBatch.SetPreEncodedRecords(
+            Protocol.SequenceTestHelpers.CreateMultiSegmentSequence(chunkedRecordBytes, splitAt: 17));
+        var contiguousBatch = CreatePreEncodedBatch(9, "contiguous-records"u8.ToArray());
+
+        var request = new ProduceRequest
+        {
+            Acks = -1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "chunked-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 0, Records = [chunkedBatch] },
+                        new ProduceRequestPartitionData { Index = 1, Records = [contiguousBatch] }
+                    ]
+                }
+            ]
+        };
+
+        var (frameSegmentCount, recordArrays) = await AssertSegmentedProduceMatchesContiguousSerialization(
+            request, correlationId: 555, apiVersion: 12, clientId: null);
+
+        // metadata, chunk 1, chunk 2, metadata, records, metadata
+        await Assert.That(frameSegmentCount).IsEqualTo(6);
+        await Assert.That(recordArrays.Count).IsEqualTo(3);
+        await Assert.That(recordArrays[0]).IsSameReferenceAs(chunkedRecordBytes);
+        await Assert.That(recordArrays[1]).IsSameReferenceAs(chunkedRecordBytes);
+    }
+
+    [Test]
+    public async Task MultiBatchProduceSegments_ManyChunkIncrementalSequence_MatchContiguousSerialization()
+    {
+        // Mirrors BufferMemoryAllocationStrategy.Incremental: a batch's pre-encoded records
+        // arrive as many bounded-size chunks (IncrementalBatchBuffer caps chunks at 16KB, so a
+        // large batch spans dozens of segments).
+        const int chunkCount = 24;
+        const int chunkSize = 64;
+        var chunkedRecordBytes = new byte[chunkCount * chunkSize];
+        for (var i = 0; i < chunkedRecordBytes.Length; i++)
+            chunkedRecordBytes[i] = (byte)i;
+
+        var chunkedBatch = CreatePreEncodedBatch(5, []);
+        chunkedBatch.SetPreEncodedRecords(CreateChunkedSequence(chunkedRecordBytes, chunkSize));
+        var contiguousBatch = CreatePreEncodedBatch(9, "contiguous-records"u8.ToArray());
+
+        // The seal-time hint drives the exact frame-segment array rent, so many-chunk batches
+        // never pay per-chunk descriptor-array growth.
+        await Assert.That(chunkedBatch.SegmentedRecordsSegmentCountHint).IsEqualTo(chunkCount);
+        await Assert.That(contiguousBatch.SegmentedRecordsSegmentCountHint).IsEqualTo(1);
+
+        var request = new ProduceRequest
+        {
+            Acks = -1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "incremental-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 0, Records = [chunkedBatch] },
+                        new ProduceRequestPartitionData { Index = 1, Records = [contiguousBatch] }
+                    ]
+                }
+            ]
+        };
+
+        var (frameSegmentCount, recordArrays) = await AssertSegmentedProduceMatchesContiguousSerialization(
+            request, correlationId: 777, apiVersion: 12, clientId: null);
+
+        // metadata + 24 chunks + metadata + records + metadata
+        await Assert.That(frameSegmentCount).IsEqualTo(chunkCount + 4);
+        await Assert.That(recordArrays.Count).IsEqualTo(chunkCount + 1);
+    }
+
+    [Test]
+    public async Task MultiBatchProduceSegments_UnpreparedCompressedBatch_FallsBack()
+    {
+        var preparedBatch = CreatePreEncodedBatch(1, "prepared-records"u8.ToArray());
+        var unpreparedBatch = new RecordBatch
+        {
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+
+        var request = new ProduceRequest
+        {
+            Acks = -1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "fallback-topic",
+                    PartitionData =
+                    [
+                        new ProduceRequestPartitionData { Index = 0, Records = [preparedBatch] },
+                        new ProduceRequestPartitionData
+                        {
+                            Index = 1,
+                            Records = [unpreparedBatch],
+                            Compression = CompressionType.Gzip
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var connection = new KafkaConnection("localhost", 9092);
+        var segmented = connection.TryPreSerializeSegmentedProduceRequest(
+            request,
+            correlationId: 1,
+            apiVersion: 12,
+            headerVersion: 2,
+            out var metadataArray,
+            out var frameSegments,
+            out var frameSegmentCount);
+
+        // All-or-nothing: one ineligible batch sends the whole request down the copying path.
+        await Assert.That(segmented).IsFalse();
+        await Assert.That(metadataArray).IsNull();
+        await Assert.That(frameSegments).IsNull();
+        await Assert.That(frameSegmentCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SendFireAndForgetAsync_MultiBatchProduce_WritesValidSegmentedFrame(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+
+            var firstBatch = CreatePreEncodedBatch(9, "borrowed-record-data-partition-two"u8.ToArray());
+            var secondBatch = CreatePreEncodedBatch(13, "borrowed-record-data-partition-three-longer"u8.ToArray());
+            var request = new ProduceRequest
+            {
+                Acks = 0,
+                TimeoutMs = 30_000,
+                TopicData =
+                [
+                    new ProduceRequestTopicData
+                    {
+                        Name = "socket-topic",
+                        PartitionData =
+                        [
+                            new ProduceRequestPartitionData { Index = 2, Records = [firstBatch] },
+                            new ProduceRequestPartitionData { Index = 3, Records = [secondBatch] }
+                        ]
+                    }
+                ]
+            };
+
+            const short apiVersion = 12;
+            await connection.SendFireAndForgetAsync<ProduceRequest, ProduceResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
+
+            var actual = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(actual.AsSpan(4));
+            var headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+                .GetRequestHeaderVersion(apiVersion);
+            var expected = BuildExpectedProduceFrame(request, correlationId, apiVersion, headerVersion, clientId: null);
+
+            await Assert.That(actual).IsEquivalentTo(expected.AsSpan(sizeof(int)).ToArray());
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static RecordBatch CreatePreEncodedBatch(long baseOffset, byte[] recordBytes)
+    {
+        var batch = new RecordBatch
+        {
+            BaseOffset = baseOffset,
+            PartitionLeaderEpoch = 3,
+            LastOffsetDelta = 0,
+            BaseTimestamp = 1234,
+            MaxTimestamp = 1234,
+            ProducerId = 42,
+            ProducerEpoch = 2,
+            BaseSequence = 7,
+            Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+        };
+        batch.SetPreEncodedRecords(recordBytes);
+        return batch;
+    }
+
+    private static byte[] BuildExpectedProduceFrame(
+        ProduceRequest request,
+        int correlationId,
+        short apiVersion,
+        short headerVersion,
+        string? clientId)
+    {
+        var expectedBody = new ArrayBufferWriter<byte>();
+        var expectedWriter = new KafkaProtocolWriter(expectedBody);
+        new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = apiVersion,
+            CorrelationId = correlationId,
+            ClientId = clientId,
+            HeaderVersion = headerVersion
+        }.Write(ref expectedWriter);
+        request.Write(ref expectedWriter, apiVersion);
+        var expected = new byte[sizeof(int) + expectedWriter.BytesWritten];
+        BinaryPrimitives.WriteInt32BigEndian(expected, expectedWriter.BytesWritten);
+        expectedBody.WrittenSpan.CopyTo(expected.AsSpan(sizeof(int)));
+        return expected;
+    }
+
+    private static byte[] AssembleSegmentedFrame(
+        byte[] metadataArray,
+        KafkaConnection.SegmentedFrameSegment[] frameSegments,
+        int frameSegmentCount)
+    {
+        var totalLength = 0;
+        for (var i = 0; i < frameSegmentCount; i++)
+            totalLength += frameSegments[i].Count;
+
+        var frame = new byte[totalLength];
+        var offset = 0;
+        for (var i = 0; i < frameSegmentCount; i++)
+        {
+            var segment = frameSegments[i];
+            var source = segment.Array ?? metadataArray;
+            source.AsSpan(segment.Offset, segment.Count).CopyTo(frame.AsSpan(offset));
+            offset += segment.Count;
+        }
+
+        return frame;
+    }
+
+    private static List<byte[]> CollectRecordSegmentArrays(
+        KafkaConnection.SegmentedFrameSegment[] frameSegments,
+        int frameSegmentCount)
+    {
+        var recordArrays = new List<byte[]>();
+        for (var i = 0; i < frameSegmentCount; i++)
+        {
+            if (frameSegments[i].Array is { } array)
+                recordArrays.Add(array);
+        }
+
+        return recordArrays;
+    }
+
+    /// <summary>
+    /// Runs the segmented pre-serializer on <paramref name="request"/>, asserts the assembled
+    /// frame is byte-identical to the contiguous (copying-path) serialization, returns the
+    /// pooled buffers, and hands back the segment count and record-segment backing arrays for
+    /// any test-specific structural assertions.
+    /// </summary>
+    private static async Task<(int FrameSegmentCount, List<byte[]> RecordSegmentArrays)>
+        AssertSegmentedProduceMatchesContiguousSerialization(
+            ProduceRequest request,
+            int correlationId,
+            short apiVersion,
+            string? clientId)
+    {
+        var headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+            .GetRequestHeaderVersion(apiVersion);
+        var expected = BuildExpectedProduceFrame(request, correlationId, apiVersion, headerVersion, clientId);
+
+        var connection = new KafkaConnection("localhost", 9092, clientId);
+        var segmented = connection.TryPreSerializeSegmentedProduceRequest(
+            request,
+            correlationId,
+            apiVersion,
+            headerVersion,
+            out var metadataArray,
+            out var frameSegments,
+            out var frameSegmentCount);
+
+        await Assert.That(segmented).IsTrue();
+        try
+        {
+            var actual = AssembleSegmentedFrame(metadataArray, frameSegments, frameSegmentCount);
+            await Assert.That(actual).IsEquivalentTo(expected);
+            return (frameSegmentCount, CollectRecordSegmentArrays(frameSegments, frameSegmentCount));
+        }
+        finally
+        {
+            ReturnSegmentedFrame(metadataArray, frameSegments, frameSegmentCount);
+        }
+    }
+
+    private static void ReturnSegmentedFrame(
+        byte[] metadataArray,
+        KafkaConnection.SegmentedFrameSegment[] frameSegments,
+        int frameSegmentCount)
+    {
+        // Mirror the production return contract: clear only the written prefix so the pooled
+        // descriptor array does not root record buffers.
+        Array.Clear(frameSegments, 0, frameSegmentCount);
+        ArrayPool<KafkaConnection.SegmentedFrameSegment>.Shared.Return(frameSegments, clearArray: false);
+        DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+    }
+
+    private static ReadOnlySequence<byte> CreateChunkedSequence(byte[] data, int chunkSize)
+    {
+        var first = new ChainedSegment(data.AsMemory(0, chunkSize));
+        var last = first;
+        for (var offset = chunkSize; offset < data.Length; offset += chunkSize)
+        {
+            var length = Math.Min(chunkSize, data.Length - offset);
+            last = last.Append(data.AsMemory(offset, length));
+        }
+
+        return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+    }
+
+    private sealed class ChainedSegment : ReadOnlySequenceSegment<byte>
+    {
+        public ChainedSegment(ReadOnlyMemory<byte> memory) => Memory = memory;
+
+        public ChainedSegment Append(ReadOnlyMemory<byte> memory)
+        {
+            var next = new ChainedSegment(memory) { RunningIndex = RunningIndex + Memory.Length };
+            Next = next;
+            return next;
+        }
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProduceRequestPreSerializeBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProduceRequestPreSerializeBenchmarks.cs
@@ -1,0 +1,144 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using BenchmarkDotNet.Attributes;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Networking;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Messages;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Compares the two ways KafkaConnection can turn a coalesced (multi-batch) produce request
+/// into wire bytes:
+/// <list type="bullet">
+/// <item><description><see cref="CopyingPreSerialize"/> — the fallback path: serialize the
+/// whole frame (record bytes included) into one rented array, mirroring
+/// <c>KafkaConnection.PreSerializeRequest</c>.</description></item>
+/// <item><description><see cref="SegmentedPreSerialize"/> — the zero-body-copy path:
+/// <c>TryPreSerializeSegmentedProduceRequest</c> serializes only metadata and references the
+/// record bytes in place.</description></item>
+/// </list>
+/// The workload mirrors the coalescing stress lane: one topic, 4 partitions, one sealed
+/// ~148KB batch each (~592KB of record bytes per request). The delta is the send-loop CPU and
+/// memory traffic the segmented path saves per produce request; both paths must report 0 B
+/// allocated (all buffers pooled).
+/// </summary>
+[MemoryDiagnoser]
+[ThroughputJob]
+public class ProduceRequestPreSerializeBenchmarks
+{
+    private const short ApiVersion = 12;
+    private const int PartitionCount = 4;
+    private const int RecordBytesPerBatch = 148 * 1024;
+
+    private KafkaConnection _connection = null!;
+    private ProduceRequest _request = null!;
+    private RequestHeader _header;
+    private short _headerVersion;
+    private int _frameLength;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var partitions = new ProduceRequestPartitionData[PartitionCount];
+        for (var p = 0; p < PartitionCount; p++)
+        {
+            var recordBytes = new byte[RecordBytesPerBatch];
+            Random.Shared.NextBytes(recordBytes);
+            var batch = new RecordBatch
+            {
+                BaseOffset = p * 1000,
+                LastOffsetDelta = 999,
+                BaseTimestamp = 1_700_000_000_000,
+                MaxTimestamp = 1_700_000_000_999,
+                ProducerId = 42,
+                ProducerEpoch = 2,
+                BaseSequence = p * 1000,
+                Records = [new Record { IsKeyNull = true, Value = "value"u8.ToArray() }]
+            };
+            batch.SetPreEncodedRecords(recordBytes);
+            partitions[p] = new ProduceRequestPartitionData
+            {
+                Index = p,
+                Records = [batch]
+            };
+        }
+
+        _request = new ProduceRequest
+        {
+            Acks = -1,
+            TimeoutMs = 30_000,
+            TopicData =
+            [
+                new ProduceRequestTopicData
+                {
+                    Name = "bench-topic",
+                    PartitionData = partitions
+                }
+            ]
+        };
+
+        _headerVersion = KafkaMessageMetadata<ProduceRequest, ProduceResponse>
+            .GetRequestHeaderVersion(ApiVersion);
+        _header = new RequestHeader
+        {
+            ApiKey = ApiKey.Produce,
+            ApiVersion = ApiVersion,
+            CorrelationId = 7,
+            ClientId = "bench-client",
+            HeaderVersion = _headerVersion
+        };
+
+        _connection = new KafkaConnection("localhost", 9092, "bench-client");
+
+        // Size the copying path's initial rent like production does (the request size hint
+        // covers the whole body), so neither benchmark pays RentedBufferWriter growth copies.
+        _frameLength = CopyingPreSerialize();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+        => _connection.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    [Benchmark(Baseline = true)]
+    public int CopyingPreSerialize()
+    {
+        var initialCapacity = _frameLength > 0 ? _frameLength : 4096;
+        using var writer = new RentedBufferWriter(initialCapacity, 4);
+        var protocolWriter = new KafkaProtocolWriter(writer);
+        _header.Write(ref protocolWriter);
+        _request.Write(ref protocolWriter, ApiVersion);
+        var (array, length) = writer.DetachBuffer();
+        BinaryPrimitives.WriteInt32BigEndian(array, protocolWriter.BytesWritten);
+        DekafPools.SerializationBuffers.Return(array, clearArray: false);
+        return length;
+    }
+
+    [Benchmark]
+    public int SegmentedPreSerialize()
+    {
+        if (!_connection.TryPreSerializeSegmentedProduceRequest(
+                _request,
+                correlationId: 7,
+                ApiVersion,
+                _headerVersion,
+                out var metadataArray,
+                out var frameSegments,
+                out var frameSegmentCount))
+        {
+            throw new InvalidOperationException("Segmented produce pre-serialization unexpectedly fell back.");
+        }
+
+        var totalLength = 0;
+        for (var i = 0; i < frameSegmentCount; i++)
+            totalLength += frameSegments[i].Count;
+
+        // Mirror the production return contract: clear only the written prefix.
+        Array.Clear(frameSegments, 0, frameSegmentCount);
+        ArrayPool<KafkaConnection.SegmentedFrameSegment>.Shared.Return(frameSegments, clearArray: false);
+        DekafPools.SerializationBuffers.Return(metadataArray, clearArray: false);
+        return totalLength;
+    }
+}


### PR DESCRIPTION
## Summary

Extends the existing single-batch segmented zero-copy write (`TryPreSerializeSingleBatchProduceRequest`) to **multi-batch, multi-partition, multi-topic coalesced produce requests** — the shape that carries essentially all producer traffic under coalescing (accumulator batches are always pre-encoded/pre-compressed at seal, so `CanWriteSegmented` holds for every real batch; verified in review).

Previously every coalesced request paid two full-body copies on the send loop (serialize into rented array, then into the socket) — ~1.7GB/s of avoidable memcpy at rig rates on the core that pegs 1.00 and is the 1-broker throughput ceiling (#1584). This was fix 2 of #2033, shipped then only for N=1.

## Design

- Metadata (header, preamble, topic/partition framing, 61-byte batch headers) serialized into one rented buffer; record bytes referenced in place via pooled `SegmentedFrameSegment` descriptors (null-array = metadata slice, resolved at send time since the metadata buffer can grow); existing 16-segment-windowed vectored send.
- **Single-batch fast path byte-for-byte untouched** — N=1 pays zero extra (descriptor rent can't be avoided in the general path since it must survive the await; keeping both paths verified as right altitude).
- All-or-nothing eligibility; ineligible requests pay only O(batches) field reads before falling back to the copying path.
- Descriptor arrays rented **exactly** via a per-batch segment-count hint cached at seal (`SegmentedRecordsSegmentCountHint`) — covers `BufferMemoryAllocationStrategy.Incremental`'s 16KB-chunked batches without grow churn — and cleared prefix-only on return (keeps the GC-rooting protection, drops the full-length memclear).
- Corruption guards (declared-vs-actual records length, `RequestBodySizeHint` mismatch) inherit the fail-closed posture of both existing paths; both fire pre-lock, pre-socket — blast radius one request.

## Evidence

**Micro-benchmark** (new `ProduceRequestPreSerializeBenchmarks`, 1-topic/4-partition/592KB coalesced request, `[MemoryDiagnoser]`, Default + InProcess toolchains agree):

| | Copying | Segmented | Ratio |
|---|---|---|---|
| Mean | 10,459–10,963 ns | 386–394 ns | **0.04 (~27x)** |
| Allocated | 32 B | 32 B | 1.00 |

(32 B = the pre-existing per-request `RentedBufferWriter` instance both production paths already allocate; per ~1000-message request. Zero new allocations.)

**Byte-identity**: 11 unit tests assert the segmented frame equals the copying serializer's output byte-for-byte — expectations built with the library's own `RequestHeader.Write` + `request.Write`, never hand-coded. Cover v12 name-based + v13 topic-id, compression, two topics, multi-batch-per-partition, 24-chunk incremental sequences (also pins the exact-rent arithmetic), fallback, and an end-to-end loopback socket write. Full suite 6623/6623.

**Local stress A-B (full disclosure)**: 2-min NAT-capped local lanes are structurally unable to show the benefit — the send loop idles at ~0.30 cores locally (vs pegged 1.00 on the rig), while any cost of coupling buffer lifetime to socket drain is exaggerated by the slow socket. Two paired p32 runs read median throughput -5..-7% locally within a ±10%-noisy environment (main's own tail swung p99 106→180ms, max 259→675ms between its two runs). CPU µs/msg overlapped. **The paired A-B-A gate on `producer-1b` (send-loop-bound lane) is the acceptance decider** — dispatching with `baseline_sha` set to the branch base; results will be posted here. Per rule 8: not mergeable before that comparison is posted and PASS.

## Review

/simplify ran with 4 agents; applied: exact descriptor sizing (Incremental-mode fix), prefix-only clearing, metadata buffer pre-sizing, produce-preamble + size-guard dedup between the two pre-serializers, test dedup + a vacuous assertion removed. Deliberately kept: the ~20-line send-loop duplication between the two write overloads (merging would regress N=1 or add an async state machine). Designated follow-up (not this PR): the produce framing now exists in three encoders (protocol `Write`, single-batch, segmented) — hoisting into the protocol layer is the deeper home; byte-identity tests guard the drift meanwhile.

## Risks

- Zero-copy holds batch buffers across the socket write (same property as the shipped single-batch path, now for all coalesced batches). If the A-B-A shows tail-latency cost on slow-drain shapes, that coupling is the suspect.
- `RequestBodySizeHint` mismatch now throws for multi-batch requests (was silently absorbed by the copying serializer's capacity-only use). Hint arithmetic verified exact for BrokerSender's coalesced shape; a throw here surfaces a sender-accounting bug loudly instead of masking it.