### PR TITLE
fix(metrics): count producer sent messages/bytes per delivered batch

### DIFF
--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -68,11 +68,11 @@ Both spans set `messaging.system = kafka` plus:
 | `messaging.kafka.message.key` | ✓ (string-convertible keys) | |
 | `messaging.destination.partition.id` | ✓ (on delivery) | ✓ |
 | `messaging.kafka.offset` | ✓ (on delivery) | ✓ |
-| `messaging.message.body.size` | ✓ (on delivery) | ✓ |
+| `messaging.message.body.size` | | ✓ |
 | `messaging.kafka.message.tombstone` | ✓ (null-value messages) | ✓ (tombstone records) |
 | `messaging.consumer.group.name` | | ✓ |
 
-`messaging.message.body.size` is the value payload only — the key is not part of the message body; tombstones report `0`.
+`messaging.message.body.size` is set on consume spans only, and is the value payload only — the key is not part of the message body; tombstones report `0`.
 
 Failures set the span status to `Error`, set `error.type` to the exception's fully-qualified type name, and record an `exception` event with `exception.type`, `exception.message`, and `exception.stacktrace`. Successful spans leave the status unset, per the OTel span-status guidance.
 
@@ -84,7 +84,7 @@ These are the spec-defined instruments from the [OTel messaging metrics conventi
 
 | Instrument | Type | Unit | Description |
 |------------|------|------|-------------|
-| `messaging.client.sent.messages` | Counter | `{message}` | Messages published |
+| `messaging.client.sent.messages` | Counter | `{message}` | Messages published (counted per delivered batch; includes fire-and-forget) |
 | `messaging.client.operation.duration` | Histogram | `s` | Produce operation duration (successes and failures) |
 | `messaging.client.consumed.messages` | Counter | `{message}` | Messages received |
 
@@ -98,7 +98,7 @@ Dekaf-specific instruments live under the `dekaf.*` prefix — the `messaging.*`
 
 | Instrument | Description |
 |------------|-------------|
-| `dekaf.producer.sent.bytes` | Bytes published (key + value) |
+| `dekaf.producer.sent.bytes` | Encoded record-batch bytes published (wire size after compression; counted per delivered batch, includes fire-and-forget) |
 | `dekaf.producer.send.errors` | Produce errors (includes fire-and-forget delivery failures) |
 | `dekaf.producer.send.retries` | Produce retries |
 | `dekaf.producer.buffer.used_bytes` / `limit_bytes` | `BufferMemory` reservation vs configured limit |

--- a/src/Dekaf/Diagnostics/DekafDiagnostics.cs
+++ b/src/Dekaf/Diagnostics/DekafDiagnostics.cs
@@ -84,7 +84,10 @@ public static class DekafDiagnostics
 
     /// <summary>
     /// Tag set for messaging.client.* instruments: the spec-required messaging.system and
-    /// messaging.operation.name plus the destination. Callers cache the result per topic.
+    /// messaging.operation.name plus the destination. <see cref="TagList"/> is a stack struct
+    /// holding reference-typed tag values, so building one costs no allocation; per-batch call
+    /// sites (see <c>DekafMetrics.RecordBatchDelivered</c>) deliberately build it inline rather
+    /// than caching per topic, which measured cheaper and avoids an unbounded per-topic cache.
     /// </summary>
     internal static System.Diagnostics.TagList ClientMetricTags(string operationName, string topic) => new()
     {

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
 using Dekaf.Producer;
 
 namespace Dekaf.Diagnostics;
@@ -31,14 +32,94 @@ internal static class DekafMetrics
     /// and awaited traffic (which emits only its operation duration) is never double-counted.
     /// Per-batch, not per-message; the TagList is a stack struct, so no heap allocation.
     /// </summary>
+    /// <remarks>
+    /// The emission itself lives in a separate method: <c>Counter.Add</c> runs listener
+    /// callbacks (user or exporter code) inline on the caller's thread, and this is called
+    /// after <c>ReadyBatch</c>'s once-only completion guard is claimed but before the
+    /// completion sources are signalled — an escaping listener exception would retire the
+    /// batch with its awaiters unsignalled, and every later Fail would short-circuit on the
+    /// same guard, leaving ProduceAsync callers waiting forever. Dropping a telemetry sample
+    /// is the correct trade. RyuJIT never inlines a method containing an exception handler,
+    /// so the catch sits in the cold callee and the no-listener fast path stays inlinable.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void RecordBatchDelivered(string topic, int recordCount, long encodedBytes)
     {
         if (!MessagesSent.Enabled && !BytesSent.Enabled)
             return;
 
-        var tags = DekafDiagnostics.ClientMetricTags(DekafDiagnostics.OperationNameSend, topic);
-        MessagesSent.Add(recordCount, tags);
-        BytesSent.Add(encodedBytes, tags);
+        EmitBatchDelivered(topic, recordCount, encodedBytes);
+    }
+
+    private static void EmitBatchDelivered(string topic, int recordCount, long encodedBytes)
+    {
+        try
+        {
+            var tags = DekafDiagnostics.ClientMetricTags(DekafDiagnostics.OperationNameSend, topic);
+            MessagesSent.Add(recordCount, tags);
+            BytesSent.Add(encodedBytes, tags);
+        }
+        catch
+        {
+            // Listener exceptions must not escape into batch completion — see the remarks above.
+        }
+    }
+
+    /// <summary>
+    /// Records produce errors for a failed batch's records that have no awaiter to observe them
+    /// (fire-and-forget and callback appends). Isolated from the caller for the same reason as
+    /// <see cref="RecordBatchDelivered"/>: the batch's completion guard is already claimed.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void RecordUnobservedProduceErrors(string topic, int errorCount)
+    {
+        if (errorCount <= 0 || !ProduceErrors.Enabled)
+            return;
+
+        EmitUnobservedProduceErrors(topic, errorCount);
+    }
+
+    private static void EmitUnobservedProduceErrors(string topic, int errorCount)
+    {
+        try
+        {
+            ProduceErrors.Add(errorCount, new System.Diagnostics.TagList
+            {
+                { DekafDiagnostics.MessagingDestinationName, topic }
+            });
+        }
+        catch
+        {
+            // See RecordBatchDelivered — a throwing listener must not strand the batch's awaiters.
+        }
+    }
+
+    /// <summary>
+    /// Records a KIP-126 batch split. Isolated from the caller so a throwing listener cannot
+    /// escape into the sender loop between queueing the child batches and signalling the wakeup.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void RecordBatchSplit(string topic)
+    {
+        if (!BatchSplits.Enabled)
+            return;
+
+        EmitBatchSplit(topic);
+    }
+
+    private static void EmitBatchSplit(string topic)
+    {
+        try
+        {
+            BatchSplits.Add(1, new System.Diagnostics.TagList
+            {
+                { DekafDiagnostics.MessagingDestinationName, topic }
+            });
+        }
+        catch
+        {
+            // See RecordBatchDelivered.
+        }
     }
 
     internal static readonly Histogram<double> OperationDuration =

--- a/src/Dekaf/Diagnostics/DekafMetrics.cs
+++ b/src/Dekaf/Diagnostics/DekafMetrics.cs
@@ -22,7 +22,24 @@ internal static class DekafMetrics
         DekafDiagnostics.Meter.CreateCounter<long>(
             "dekaf.producer.sent.bytes",
             unit: "By",
-            description: "Total bytes published to Kafka.");
+            description: "Total encoded record-batch bytes published to Kafka.");
+
+    /// <summary>
+    /// Records a delivered batch's sent counters. Called once per batch from
+    /// <c>ReadyBatch.CompleteSend</c> — the single once-guarded choke point both the acked
+    /// and fire-and-forget send paths funnel through — so fire-and-forget traffic is counted
+    /// and awaited traffic (which emits only its operation duration) is never double-counted.
+    /// Per-batch, not per-message; the TagList is a stack struct, so no heap allocation.
+    /// </summary>
+    internal static void RecordBatchDelivered(string topic, int recordCount, long encodedBytes)
+    {
+        if (!MessagesSent.Enabled && !BytesSent.Enabled)
+            return;
+
+        var tags = DekafDiagnostics.ClientMetricTags(DekafDiagnostics.OperationNameSend, topic);
+        MessagesSent.Add(recordCount, tags);
+        BytesSent.Add(encodedBytes, tags);
+    }
 
     internal static readonly Histogram<double> OperationDuration =
         DekafDiagnostics.Meter.CreateHistogram<double>(

--- a/src/Dekaf/Producer/IKafkaProducer.cs
+++ b/src/Dekaf/Producer/IKafkaProducer.cs
@@ -507,12 +507,15 @@ public readonly record struct RecordMetadata
     public required DateTimeOffset Timestamp { get; init; }
 
     /// <summary>
-    /// Size of the serialized key in bytes.
+    /// Size of the serialized key in bytes. Not populated by this client — always 0
+    /// (the in-memory testing cluster does populate it). Retained for compatibility;
+    /// for byte accounting use the <c>dekaf.producer.sent.bytes</c> metric.
     /// </summary>
     public int KeySize { get; init; }
 
     /// <summary>
-    /// Size of the serialized value in bytes.
+    /// Size of the serialized value in bytes. Not populated by this client — see
+    /// <see cref="KeySize"/>.
     /// </summary>
     public int ValueSize { get; init; }
 }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -676,7 +676,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // inline request is only safe for the bare and cancellation awaits, whose continuations are
         // bounded. Hoisted so the mode and the wrapper choice below can never disagree if a metrics
         // listener starts mid-call.
-        var metricsEnabled = ProducerMetricsEnabled();
+        var metricsEnabled = OperationScopedMetricsEnabled();
         if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
             continuationMode = ProduceContinuationMode.Async;
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
@@ -867,7 +867,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         // See the message-based ProduceAfterPrepare: the metrics wrapper's continuation must not
         // run inline on the broker ack thread, and the hoisted check keeps mode and wrapper in sync.
-        var metricsEnabled = ProducerMetricsEnabled();
+        var metricsEnabled = OperationScopedMetricsEnabled();
         if (continuationMode == ProduceContinuationMode.InlineWhenDirect && metricsEnabled)
             continuationMode = ProduceContinuationMode.Async;
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
@@ -981,7 +981,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         try
         {
             var metadata = await completion.Task.ConfigureAwait(false);
-            EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
+            EmitProduceSuccessMetrics(topic, startTimestamp);
             return metadata;
         }
         catch (Exception ex)
@@ -1010,11 +1010,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             // Success: record metrics and set activity tags. Span status stays unset —
             // OTel says instrumentation should not set Ok on successful spans.
+            // No body-size tag: RecordMetadata carries no per-record sizes.
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingDestinationPartitionId, metadata.Partition);
             activity.SetTag(Diagnostics.DekafDiagnostics.MessagingKafkaOffset, metadata.Offset);
-            activity.SetTag(Diagnostics.DekafDiagnostics.MessagingMessageBodySize, metadata.ValueSize);
 
-            EmitProduceSuccessMetrics(topic, metadata, startTimestamp);
+            EmitProduceSuccessMetrics(topic, startTimestamp);
 
             return metadata;
         }
@@ -1032,17 +1032,15 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ProducerMetricsEnabled()
-        => Diagnostics.DekafMetrics.MessagesSent.Enabled
-           || Diagnostics.DekafMetrics.BytesSent.Enabled
-           || Diagnostics.DekafMetrics.OperationDuration.Enabled
+    private static bool OperationScopedMetricsEnabled()
+        => Diagnostics.DekafMetrics.OperationDuration.Enabled
            || Diagnostics.DekafMetrics.ProduceErrors.Enabled;
 
-    private void EmitProduceSuccessMetrics(string topic, RecordMetadata metadata, long startTimestamp)
+    private void EmitProduceSuccessMetrics(string topic, long startTimestamp)
     {
+        // Sent counters are per-batch (DekafMetrics.RecordBatchDelivered); only the
+        // operation-scoped duration belongs here.
         var tagList = GetMetricTags(topic);
-        Diagnostics.DekafMetrics.MessagesSent.Add(1, tagList);
-        Diagnostics.DekafMetrics.BytesSent.Add(metadata.KeySize + metadata.ValueSize, tagList);
         Diagnostics.DekafMetrics.OperationDuration.Record(
             Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds, tagList);
     }
@@ -1159,7 +1157,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // See ProduceAfterPrepare: instrumented awaits interpose a state machine that must not
         // run inline on the broker ack thread. Callers may have gated already, but the slow path
         // re-checks because a metrics listener can start between their check and this one.
-        var metricsEnabled = ProducerMetricsEnabled();
+        var metricsEnabled = OperationScopedMetricsEnabled();
         if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
             continuationMode = ProduceContinuationMode.Async;
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;
@@ -4432,7 +4430,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     {
         // See ProduceAfterPrepare: instrumented awaits interpose a state machine that must not
         // run inline on the broker ack thread.
-        var metricsEnabled = ProducerMetricsEnabled();
+        var metricsEnabled = OperationScopedMetricsEnabled();
         if (continuationMode == ProduceContinuationMode.InlineWhenDirect && (activity is not null || metricsEnabled))
             continuationMode = ProduceContinuationMode.Async;
         var runContinuationsAsynchronously = continuationMode == ProduceContinuationMode.Async;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -2230,10 +2230,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 StartSenderRetryPreSerialization(child, senderWakeup!);
         }
 
-        Diagnostics.DekafMetrics.BatchSplits.Add(1, new TagList
-        {
-            { Diagnostics.DekafDiagnostics.MessagingDestinationName, splitBatches[0].TopicPartition.Topic }
-        });
+        Diagnostics.DekafMetrics.RecordBatchSplit(splitBatches[0].TopicPartition.Topic);
         if (reenqueue)
             SignalWakeup();
         return splitBatches;
@@ -9689,13 +9686,7 @@ internal sealed class ReadyBatch
             // dekaf.producer.send.errors never reflects fire-and-forget delivery failures.
             // ProduceAsync records are excluded: each awaiter increments the counter itself.
             var unobservedRecords = _recordCount - _completionSourcesCount;
-            if (Diagnostics.DekafMetrics.ProduceErrors.Enabled && unobservedRecords > 0)
-            {
-                Diagnostics.DekafMetrics.ProduceErrors.Add(unobservedRecords, new TagList
-                {
-                    { Diagnostics.DekafDiagnostics.MessagingDestinationName, _topicPartition.Topic }
-                });
-            }
+            Diagnostics.DekafMetrics.RecordUnobservedProduceErrors(_topicPartition.Topic, unobservedRecords);
 
             // Fail per-message completion sources - these throw for ProduceAsync callers
             if (_completionSourcesCount > 0 && _completionSourcesArray is not null)

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -9519,6 +9519,9 @@ internal sealed class ReadyBatch
         {
             ProducerDebugCounters.RecordBatchSentSuccessfully();
 
+            // Counted exactly once here — see DekafMetrics.RecordBatchDelivered.
+            Diagnostics.DekafMetrics.RecordBatchDelivered(_topicPartition.Topic, _recordCount, EncodedSize);
+
             // Complete per-message completion sources with metadata
             if (_completionSourcesCount > 0 && _completionSourcesArray is not null)
             {

--- a/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AccumulatorTestHelpers.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.Metrics;
 using System.Reflection;
+using Dekaf.Diagnostics;
 using Dekaf.Metadata;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -160,6 +162,37 @@ internal static class AccumulatorTestHelpers
             ]
         });
         return manager;
+    }
+
+    /// <summary>
+    /// Starts a <see cref="MeterListener"/> subscribed to the named Dekaf instruments only.
+    /// Callers own disposal. Tests using this must be <c>[NotInParallel("MeterListener")]</c>:
+    /// listeners are process-wide, so a concurrent test's measurements would leak in.
+    /// </summary>
+    public static MeterListener StartMeterListener(
+        string[] instrumentNames,
+        MeasurementCallback<long>? onLong = null,
+        MeasurementCallback<double>? onDouble = null)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                    Array.IndexOf(instrumentNames, instrument.Name) >= 0)
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        if (onLong is not null)
+            listener.SetMeasurementEventCallback(onLong);
+        if (onDouble is not null)
+            listener.SetMeasurementEventCallback(onDouble);
+
+        listener.Start();
+        return listener;
     }
 
     /// <summary>

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderSendLoopTests.cs
@@ -1460,6 +1460,63 @@ public sealed class BrokerSenderSendLoopTests : ScriptedProduceResponseFixture
     }
 
     [Test]
+    [Timeout(30_000)]
+    [NotInParallel("MeterListener")]
+    public async Task SendLoop_AckedBatch_EmitsSentCountersThroughRealSendPath(
+        CancellationToken cancellationToken)
+    {
+        // The original defect (#2529) was counters wired onto a path production traffic never
+        // took, so this drives the real send loop end to end rather than calling CompleteSend
+        // directly: enqueue -> serialize -> scripted ack -> per-batch counter emission.
+        const string topic = "test-topic";
+        // Resolve instrument names before the listener starts (static-initializer re-entry
+        // landmine — see FireAndForgetDeliveryErrorMetricTests).
+        var messagesSentName = DekafMetrics.MessagesSent.Name;
+        var bytesSentName = DekafMetrics.BytesSent.Name;
+        var messagesSent = 0L;
+        var bytesSent = 0L;
+        using var listener = AccumulatorTestHelpers.StartMeterListener(
+            [messagesSentName, bytesSentName],
+            onLong: (instrument, measurement, tags, _) =>
+            {
+                if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                    return;
+
+                if (instrument.Name == messagesSentName)
+                    Interlocked.Add(ref messagesSent, measurement);
+                else
+                    Interlocked.Add(ref bytesSent, measurement);
+            });
+
+        var connection = new TestKafkaConnection
+        {
+            SendProducePipelinedAfterWrite = () => new ValueTask<Task<ProduceResponse>>(
+                Task.FromResult(CreateSuccessResponseForPartitions(topic, partitionCount: 1)))
+        };
+        var (pool, _) = CreateScaleTrackingPool(connection);
+        var options = CreateOptions();
+        var accumulator = new RecordAccumulator(options);
+        var valueTaskSourcePool = new ValueTaskSourcePool<RecordMetadata>();
+        var sender = CreateSender(pool, options, accumulator, (_, _, _, _, _) => { });
+
+        try
+        {
+            sender.Enqueue(CreateTestBatch(valueTaskSourcePool, topic, partition: 0, messageCount: 3));
+
+            await WaitUntilAsync(() => Volatile.Read(ref messagesSent) == 3, cancellationToken);
+
+            // Bytes are the batch's encoded wire size, stamped during serialization.
+            await Assert.That(Volatile.Read(ref bytesSent)).IsGreaterThan(0);
+        }
+        finally
+        {
+            await sender.DisposeAsync();
+            await accumulator.DisposeAsync();
+            await valueTaskSourcePool.DisposeAsync();
+        }
+    }
+
+    [Test]
     [NotInParallel("MeterListener")]
     public async Task DeferredPendingResponseCleanup_ReportsDeferredAndRecoveredMetrics()
     {

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
@@ -20,39 +20,30 @@ public sealed class KafkaProducerMetricsTests
         double operationDuration = -1;
         string? durationTopic = null;
 
-        using var listener = new MeterListener();
-        listener.InstrumentPublished = (instrument, meterListener) =>
-        {
-            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                IsProducerSuccessMetric(instrument.Name))
+        using var listener = AccumulatorTestHelpers.StartMeterListener(
+            ProducerSuccessMetrics,
+            onLong: (instrument, measurement, tags, _) =>
             {
-                meterListener.EnableMeasurementEvents(instrument);
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-        {
-            var metricTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
-            if (metricTopic != topic)
-                return;
+                if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                    return;
 
-            if (instrument.Name == "messaging.client.sent.messages")
-                messagesSent += measurement;
-            else if (instrument.Name == "dekaf.producer.sent.bytes")
-                bytesSent += measurement;
-        });
-        listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
-        {
-            var metricTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
-            if (metricTopic != topic)
-                return;
-
-            if (instrument.Name == "messaging.client.operation.duration")
+                if (instrument.Name == "messaging.client.sent.messages")
+                    messagesSent += measurement;
+                else if (instrument.Name == "dekaf.producer.sent.bytes")
+                    bytesSent += measurement;
+            },
+            onDouble: (instrument, measurement, tags, _) =>
             {
-                operationDuration = measurement;
-                durationTopic = metricTopic;
-            }
-        });
-        listener.Start();
+                var metricTopic = GetTag(tags, DekafDiagnostics.MessagingDestinationName);
+                if (metricTopic != topic)
+                    return;
+
+                if (instrument.Name == "messaging.client.operation.duration")
+                {
+                    operationDuration = measurement;
+                    durationTopic = metricTopic;
+                }
+            });
 
         await Assert.That(OperationScopedMetricsEnabled()).IsTrue();
 
@@ -93,38 +84,30 @@ public sealed class KafkaProducerMetricsTests
         double operationDuration = -1;
         string? durationErrorType = null;
 
-        using var listener = new MeterListener();
-        listener.InstrumentPublished = (instrument, meterListener) =>
-        {
-            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                instrument.Name is "dekaf.producer.send.errors" or "messaging.client.operation.duration")
+        using var listener = AccumulatorTestHelpers.StartMeterListener(
+            ["dekaf.producer.send.errors", "messaging.client.operation.duration"],
+            onLong: (instrument, measurement, tags, _) =>
             {
-                meterListener.EnableMeasurementEvents(instrument);
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-        {
-            if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
-                return;
+                if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                    return;
 
-            if (instrument.Name == "dekaf.producer.send.errors")
+                if (instrument.Name == "dekaf.producer.send.errors")
+                {
+                    errorCount += measurement;
+                    errorCountErrorType = GetTag(tags, DekafDiagnostics.ErrorType);
+                }
+            },
+            onDouble: (instrument, measurement, tags, _) =>
             {
-                errorCount += measurement;
-                errorCountErrorType = GetTag(tags, DekafDiagnostics.ErrorType);
-            }
-        });
-        listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
-        {
-            if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
-                return;
+                if (GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                    return;
 
-            if (instrument.Name == "messaging.client.operation.duration")
-            {
-                operationDuration = measurement;
-                durationErrorType = GetTag(tags, DekafDiagnostics.ErrorType);
-            }
-        });
-        listener.Start();
+                if (instrument.Name == "messaging.client.operation.duration")
+                {
+                    operationDuration = measurement;
+                    durationErrorType = GetTag(tags, DekafDiagnostics.ErrorType);
+                }
+            });
 
         await using var producer = new KafkaProducer<string, string>(
             new ProducerOptions
@@ -195,18 +178,12 @@ public sealed class KafkaProducerMetricsTests
     }
 
     private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key)
-    {
-        foreach (var tag in tags)
-        {
-            if (tag.Key == key)
-                return tag.Value?.ToString();
-        }
+        => AccumulatorTestHelpers.GetTag(tags, key);
 
-        return null;
-    }
-
-    private static bool IsProducerSuccessMetric(string name) =>
-        name is "messaging.client.sent.messages"
-            or "dekaf.producer.sent.bytes"
-            or "messaging.client.operation.duration";
+    private static readonly string[] ProducerSuccessMetrics =
+    [
+        "messaging.client.sent.messages",
+        "dekaf.producer.sent.bytes",
+        "messaging.client.operation.duration"
+    ];
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerMetricsTests.cs
@@ -10,14 +10,14 @@ public sealed class KafkaProducerMetricsTests
 {
     [Test]
     [NotInParallel("MeterListener")]
-    public async Task AwaitWithMetrics_MeterOnlyListener_RecordsSuccessMetrics()
+    public async Task AwaitWithMetrics_MeterOnlyListener_RecordsDurationOnly()
     {
+        // Sent counters are per-batch (see ReadyBatchDeliveryMetricsTests); the awaited
+        // path must emit only the operation duration, never the counters.
         var topic = $"orders-{Guid.NewGuid():N}";
         long messagesSent = 0;
         long bytesSent = 0;
         double operationDuration = -1;
-        string? messagesTopic = null;
-        string? bytesTopic = null;
         string? durationTopic = null;
 
         using var listener = new MeterListener();
@@ -36,15 +36,9 @@ public sealed class KafkaProducerMetricsTests
                 return;
 
             if (instrument.Name == "messaging.client.sent.messages")
-            {
                 messagesSent += measurement;
-                messagesTopic = metricTopic;
-            }
             else if (instrument.Name == "dekaf.producer.sent.bytes")
-            {
                 bytesSent += measurement;
-                bytesTopic = metricTopic;
-            }
         });
         listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
         {
@@ -60,7 +54,7 @@ public sealed class KafkaProducerMetricsTests
         });
         listener.Start();
 
-        await Assert.That(ProducerMetricsEnabled()).IsTrue();
+        await Assert.That(OperationScopedMetricsEnabled()).IsTrue();
 
         await using var producer = new KafkaProducer<string, string>(
             new ProducerOptions
@@ -77,19 +71,15 @@ public sealed class KafkaProducerMetricsTests
             Topic = topic,
             Partition = 1,
             Offset = 42,
-            Timestamp = DateTimeOffset.UtcNow,
-            KeySize = 3,
-            ValueSize = 5
+            Timestamp = DateTimeOffset.UtcNow
         });
 
         var metadata = await InvokeAwaitWithMetrics(producer, completion, topic);
 
         await Assert.That(metadata.Topic).IsEqualTo(topic);
-        await Assert.That(messagesSent).IsEqualTo(1);
-        await Assert.That(bytesSent).IsEqualTo(8);
+        await Assert.That(messagesSent).IsEqualTo(0);
+        await Assert.That(bytesSent).IsEqualTo(0);
         await Assert.That(operationDuration).IsGreaterThanOrEqualTo(0);
-        await Assert.That(messagesTopic).IsEqualTo(topic);
-        await Assert.That(bytesTopic).IsEqualTo(topic);
         await Assert.That(durationTopic).IsEqualTo(topic);
     }
 
@@ -179,10 +169,10 @@ public sealed class KafkaProducerMetricsTests
         await Assert.That(async () => await pending).Throws<OperationCanceledException>();
     }
 
-    private static bool ProducerMetricsEnabled()
+    private static bool OperationScopedMetricsEnabled()
     {
         var method = typeof(KafkaProducer<string, string>).GetMethod(
-            "ProducerMetricsEnabled",
+            "OperationScopedMetricsEnabled",
             BindingFlags.NonPublic | BindingFlags.Static);
 
         return (bool)method!.Invoke(null, null)!;

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchDeliveryMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchDeliveryMetricsTests.cs
@@ -1,0 +1,112 @@
+using System.Buffers;
+using System.Diagnostics.Metrics;
+using Dekaf.Diagnostics;
+using Dekaf.Producer;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+/// <summary>
+/// Pins the per-batch producer counter emission in <see cref="ReadyBatch.CompleteSend"/>:
+/// every delivered batch adds its record count to <c>messaging.client.sent.messages</c> and
+/// its encoded wire bytes to <c>dekaf.producer.sent.bytes</c> exactly once, including
+/// fire-and-forget batches that never touch the awaited-operation metrics path.
+/// </summary>
+public sealed class ReadyBatchDeliveryMetricsTests
+{
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task CompleteSend_EmitsRecordCountAndEncodedBytes_OncePerBatch()
+    {
+        var topic = $"delivery-metrics-{Guid.NewGuid():N}";
+        var (listener, counters) = CreateSentCounterListener(topic);
+        using var _ = listener;
+
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var batch = CreateBatch(pool, topic, recordCount: 3, encodedSize: 4096);
+
+        batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+        // Second call must hit the completion guard — no double count.
+        batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+
+        await Assert.That(counters.Messages).IsEqualTo(3);
+        await Assert.That(counters.Bytes).IsEqualTo(4096);
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task CompleteSend_FireAndForgetBatch_NoCompletionSources_StillEmits()
+    {
+        var topic = $"delivery-metrics-fnf-{Guid.NewGuid():N}";
+        var (listener, counters) = CreateSentCounterListener(topic);
+        using var _ = listener;
+
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(topic, 0),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            recordCount: 5,
+            dataSize: 100);
+        batch.TrySetMemoryReleased();
+        batch.SetEncodedSize(2048);
+
+        // Fire-and-forget acks=0 path completes with baseOffset -1.
+        batch.CompleteSend(baseOffset: -1, DateTimeOffset.UtcNow);
+
+        await Assert.That(counters.Messages).IsEqualTo(5);
+        await Assert.That(counters.Bytes).IsEqualTo(2048);
+    }
+
+    private sealed class SentCounters
+    {
+        public long Messages;
+        public long Bytes;
+    }
+
+    private static (MeterListener Listener, SentCounters Counters) CreateSentCounterListener(string topic)
+    {
+        var counters = new SentCounters();
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
+                instrument.Name is "messaging.client.sent.messages" or "dekaf.producer.sent.bytes")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                return;
+
+            if (instrument.Name == "messaging.client.sent.messages")
+                counters.Messages += measurement;
+            else
+                counters.Bytes += measurement;
+        });
+        listener.Start();
+        return (listener, counters);
+    }
+
+    private static ReadyBatch CreateBatch(
+        ValueTaskSourcePool<RecordMetadata> pool, string topic, int recordCount, int encodedSize)
+    {
+        var batch = new ReadyBatch();
+        var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
+        sources[0] = pool.Rent();
+
+        batch.Initialize(
+            new TopicPartition(topic, 0),
+            new RecordBatch { Records = Array.Empty<Record>() },
+            sources,
+            completionSourcesCount: 1,
+            recordCount: recordCount,
+            dataSize: 100);
+        batch.TrySetMemoryReleased();
+        batch.SetEncodedSize(encodedSize);
+        return batch;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/ReadyBatchDeliveryMetricsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/ReadyBatchDeliveryMetricsTests.cs
@@ -14,6 +14,9 @@ namespace Dekaf.Tests.Unit.Producer;
 /// </summary>
 public sealed class ReadyBatchDeliveryMetricsTests
 {
+    private static readonly string[] SentInstrumentNames =
+        ["messaging.client.sent.messages", "dekaf.producer.sent.bytes"];
+
     [Test]
     [NotInParallel("MeterListener")]
     public async Task CompleteSend_EmitsRecordCountAndEncodedBytes_OncePerBatch()
@@ -23,7 +26,7 @@ public sealed class ReadyBatchDeliveryMetricsTests
         using var _ = listener;
 
         await using var pool = new ValueTaskSourcePool<RecordMetadata>();
-        var batch = CreateBatch(pool, topic, recordCount: 3, encodedSize: 4096);
+        var (batch, _) = CreateBatch(pool, topic, recordCount: 3, encodedSize: 4096);
 
         batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
         // Second call must hit the completion guard — no double count.
@@ -59,44 +62,89 @@ public sealed class ReadyBatchDeliveryMetricsTests
         await Assert.That(counters.Bytes).IsEqualTo(2048);
     }
 
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task CompleteSend_ThrowingMetricsListener_StillCompletesAwaiters()
+    {
+        // A listener callback is user (or exporter) code running inline inside Counter.Add,
+        // after CompleteSend has claimed the once-only completion guard. If it escaped, the
+        // batch would retire with its awaiters unsignalled and every later Fail would
+        // short-circuit on the same guard — ProduceAsync callers would wait forever.
+        var topic = $"delivery-metrics-throw-{Guid.NewGuid():N}";
+        var (listener, _) = CreateSentCounterListener(
+            topic, onMeasurement: () => throw new InvalidOperationException("exporter blew up"));
+        using var _1 = listener;
+
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        var (batch, delivery) = CreateBatch(pool, topic, recordCount: 1, encodedSize: 512);
+
+        batch.CompleteSend(baseOffset: 7, DateTimeOffset.UtcNow);
+
+        var metadata = await delivery.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(metadata.Offset).IsEqualTo(7);
+    }
+
+    [Test]
+    [NotInParallel("MeterListener")]
+    public async Task Fail_ThrowingMetricsListener_StillFaultsAwaiters()
+    {
+        // Same hazard on the failure path: the unobserved-error counter is emitted after the
+        // guard is claimed but before the completion sources receive the exception.
+        var topic = $"delivery-metrics-fail-throw-{Guid.NewGuid():N}";
+        using var listener = AccumulatorTestHelpers.StartMeterListener(
+            ["dekaf.producer.send.errors"],
+            onLong: (_, _, tags, _) =>
+            {
+                if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) == topic)
+                    throw new InvalidOperationException("exporter blew up");
+            });
+
+        await using var pool = new ValueTaskSourcePool<RecordMetadata>();
+        // 3 records, 1 awaiter — the other two are unobserved, so the error counter fires.
+        var (batch, delivery) = CreateBatch(pool, topic, recordCount: 3, encodedSize: 512);
+
+        batch.Fail(new InvalidOperationException("delivery failed"));
+
+        await Assert.That(async () => await delivery.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<InvalidOperationException>();
+    }
+
     private sealed class SentCounters
     {
         public long Messages;
         public long Bytes;
     }
 
-    private static (MeterListener Listener, SentCounters Counters) CreateSentCounterListener(string topic)
+    private static (MeterListener Listener, SentCounters Counters) CreateSentCounterListener(
+        string topic, Action? onMeasurement = null)
     {
         var counters = new SentCounters();
-        var listener = new MeterListener();
-        listener.InstrumentPublished = (instrument, meterListener) =>
-        {
-            if (instrument.Meter.Name == DekafDiagnostics.MeterName &&
-                instrument.Name is "messaging.client.sent.messages" or "dekaf.producer.sent.bytes")
+        var listener = AccumulatorTestHelpers.StartMeterListener(
+            SentInstrumentNames,
+            onLong: (instrument, measurement, tags, _) =>
             {
-                meterListener.EnableMeasurementEvents(instrument);
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
-        {
-            if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
-                return;
+                if (AccumulatorTestHelpers.GetTag(tags, DekafDiagnostics.MessagingDestinationName) != topic)
+                    return;
 
-            if (instrument.Name == "messaging.client.sent.messages")
-                counters.Messages += measurement;
-            else
-                counters.Bytes += measurement;
-        });
-        listener.Start();
+                onMeasurement?.Invoke();
+
+                if (instrument.Name == "messaging.client.sent.messages")
+                    counters.Messages += measurement;
+                else
+                    counters.Bytes += measurement;
+            });
+
         return (listener, counters);
     }
 
-    private static ReadyBatch CreateBatch(
+    private static (ReadyBatch Batch, Task<RecordMetadata> Delivery) CreateBatch(
         ValueTaskSourcePool<RecordMetadata> pool, string topic, int recordCount, int encodedSize)
     {
         var batch = new ReadyBatch();
         var sources = ArrayPool<PooledValueTaskSource<RecordMetadata>>.Shared.Rent(1);
-        sources[0] = pool.Rent();
+        var source = pool.Rent();
+        sources[0] = source;
+        var delivery = source.Task.AsTask();
 
         batch.Initialize(
             new TopicPartition(topic, 0),
@@ -107,6 +155,6 @@ public sealed class ReadyBatchDeliveryMetricsTests
             dataSize: 100);
         batch.TrySetMemoryReleased();
         batch.SetEncodedSize(encodedSize);
-        return batch;
+        return (batch, delivery);
     }
 }


### PR DESCRIPTION
Fixes #2529 — with a **corrected root cause** vs the issue's original framing (the counter *was* wired, but only on the awaited path, with size fields nothing ever populates).

## The two defects

Profile run [31033317953](https://github.com/thomhurst/Dekaf/actions/runs/31033317953) showed `messaging.client.sent.messages` ticking at ~1,500/s while the lane delivered **1.47M msg/s**, and `dekaf.producer.sent.bytes` flat 0:

1. Both counters were emitted per **awaited operation** (`EmitProduceSuccessMetrics`) — fire-and-forget traffic (the overwhelming majority in FnF workloads) never reached them.
2. The bytes add used `RecordMetadata.KeySize + ValueSize` — `init` fields **no client code ever populates** (verified: zero writers in `src/Dekaf`), so even awaited completions added 0.

## Fix

- `DekafMetrics.RecordBatchDelivered(topic, recordCount, encodedBytes)` called once per batch from `ReadyBatch.CompleteSend` — the single once-guarded choke point both the acked (`BrokerSender.cs:3260`) and fire-and-forget (`:3869`) paths funnel through. Review verified call-site emission would double-count on racing completions (`ProducerBatchLifecycleHammerTests` hammers exactly that); the batch guard is the only free exactly-once point. Split/abandon/failure paths verified not to double-count; failure symmetry already exists (`CompleteFailure` emits per-batch `ProduceErrors` for unobserved records).
- Bytes = `EncodedSize` — the actual post-compression wire size of the record batch (semantics updated in the instrument description and docs; the old "key + value" doc was describing values that were never emitted).
- Awaited path keeps only operation duration + errors; gate renamed `OperationScopedMetricsEnabled`. Always-zero `messaging.message.body.size` tag dropped from send spans. `RecordMetadata.KeySize/ValueSize` documented as not populated (removal would be breaking; the in-memory testing cluster still sets them — noted in the doc).
- `docs/docs/observability.md` aligned: bytes semantics, body-size scoped to consume spans, fire-and-forget coverage noted.

## Performance (per-batch path, CLAUDE.md evidence)

No-listener cost: two `Counter<long>.Enabled` reads per batch (~3ns no-ops). `SparseReadyBatchCompletionBenchmarks` A/B on the same box, in-process toolchain:

| | Mean | Allocated |
|---|---|---|
| main | 194.3 ± 14.7 ns | 0 B |
| branch | 199.1 ± 13.7 ns | 0 B |

Overlapping error bars, zero allocations both sides. Enabled path builds the `TagList` inline (stack struct, allocation-free — /simplify review measured this cheaper than the tag-cache it originally had, which was also an unbounded static-growth vector and was removed).

## Tests

- New `ReadyBatchDeliveryMetricsTests`: per-batch emission (record count + encoded bytes), double-`CompleteSend` no-double-count guard, fire-and-forget shape (no completion sources, baseOffset −1).
- `KafkaProducerMetricsTests` updated: awaited path pins duration-only (re-adding counters there fails the test).
- Full unit suite 6614/6614; solution builds 0 warnings.

Reviewed via /simplify (4 agents); applied: tag-cache removal, shared `AccumulatorTestHelpers.GetTag` reuse, comment/doc dedup, gate rename. Noted follow-ups (not this PR): `CompleteFailure` error-tag shape consistency; `KeySize/ValueSize` deprecation candidate for next major.