### PR TITLE
Add Tluma AI chat widget to documentation

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,6 +13,30 @@ const config = {
   organizationName: 'thomhurst',
   projectName: 'Dekaf',
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `window.tlumaConfig = {
+  source: 'thomhurst/dekaf',
+  theme: 'auto',
+  brandColor: 'blue',
+  button: 'bottom-right',
+  welcomePulse: true,
+  edgePadding: '1rem',
+  autoOpen: false,
+  desktopFullscreenByDefault: false,
+};`,
+    },
+  ],
+
+  scripts: [
+    {
+      src: 'https://tluma.ai/widget.js',
+      async: true,
+    },
+  ],
+
   onBrokenLinks: 'throw',
 
   markdown: {


### PR DESCRIPTION
## Summary

- configure Tluma AI chat widget globally for documentation pages
- load widget script asynchronously after defining project and display settings

## Why

Give documentation visitors direct access to project-aware AI assistance.

## Impact

Adds bottom-right Tluma chat button using automatic light/dark theme selection. No library runtime code changes.

## Validation

- `npm run build` from `docs/`
- verified generated HTML contains configuration before async widget script