### PR TITLE
perf(producer): eliminate TopicProducer batch allocations

### DIFF
--- a/src/Dekaf/Producer/IProducerFastPath.cs
+++ b/src/Dekaf/Producer/IProducerFastPath.cs
@@ -12,4 +12,9 @@ internal interface IProducerFastPath<TKey, TValue>
         int? partition,
         DateTimeOffset? timestamp,
         CancellationToken cancellationToken);
+
+    Task<RecordMetadata[]> ProduceAllAsync(
+        string topic,
+        IEnumerable<TopicProducerMessage<TKey, TValue>> messages,
+        CancellationToken cancellationToken);
 }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1979,39 +1979,57 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return [];
         }
 
-        var completion = ProduceAllCompletion.Rent(messageBuffer.Count);
-        using var bulkScope = _accumulator.EnterBulkProduceScope();
+        ProduceAllCompletion completion;
+        RecordAccumulator.BulkProduceScope bulkScope;
         try
         {
-            for (var i = 0; i < messageBuffer.Count; i++)
+            completion = ProduceAllCompletion.Rent(messageBuffer.Count);
+            bulkScope = _accumulator.EnterBulkProduceScope();
+        }
+        catch
+        {
+            messageBuffer.Dispose();
+            throw;
+        }
+
+        try
+        {
+            try
             {
-                try
+                for (var i = 0; i < messageBuffer.Count; i++)
                 {
-                    var message = messageBuffer[i];
-                    completion.Register(i, ProduceAsync(
-                        topic,
-                        message.Key,
-                        message.Value,
-                        message.Headers,
-                        message.Partition,
-                        message.Timestamp,
-                        ProduceContinuationMode.InlineWhenDirect,
-                        cancellationToken));
-                }
-                catch (Exception ex)
-                {
-                    completion.RecordFailure(i, ex);
-                    completion.AbortRegistration(messageBuffer.Count - i);
-                    break;
+                    try
+                    {
+                        var message = messageBuffer[i];
+                        completion.Register(i, ProduceAsync(
+                            topic,
+                            message.Key,
+                            message.Value,
+                            message.Headers,
+                            message.Partition,
+                            message.Timestamp,
+                            ProduceContinuationMode.InlineWhenDirect,
+                            cancellationToken));
+                    }
+                    catch (Exception ex)
+                    {
+                        completion.RecordFailure(i, ex);
+                        completion.AbortRegistration(messageBuffer.Count - i);
+                        break;
+                    }
                 }
             }
+            finally
+            {
+                messageBuffer.Dispose();
+            }
+
+            return await completion.WaitAsync().ConfigureAwait(false);
         }
         finally
         {
-            messageBuffer.Dispose();
+            bulkScope.Dispose();
         }
-
-        return await completion.WaitAsync().ConfigureAwait(false);
     }
 
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1939,12 +1939,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         if (messages is IList<TopicProducerMessage<TKey, TValue>> messageList)
         {
-            if (messageList.Count == 0)
+            var messageCount = messageList.Count;
+            if (messageCount == 0)
                 return [];
 
-            var listCompletion = ProduceAllCompletion.Rent(messageList.Count);
+            var listCompletion = ProduceAllCompletion.Rent(messageCount);
             using var listBulkScope = _accumulator.EnterBulkProduceScope();
-            for (var i = 0; i < messageList.Count; i++)
+            for (var i = 0; i < messageCount; i++)
             {
                 try
                 {
@@ -1962,7 +1963,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 catch (Exception ex)
                 {
                     listCompletion.RecordFailure(i, ex);
-                    listCompletion.AbortRegistration(messageList.Count - i);
+                    listCompletion.AbortRegistration(messageCount - i);
                     break;
                 }
             }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1929,6 +1929,46 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return await completion.WaitAsync().ConfigureAwait(false);
     }
 
+    async Task<RecordMetadata[]> IProducerFastPath<TKey, TValue>.ProduceAllAsync(
+        string topic,
+        IEnumerable<TopicProducerMessage<TKey, TValue>> messages,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(topic);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var messageList = messages as IList<TopicProducerMessage<TKey, TValue>> ?? messages.ToList();
+        if (messageList.Count == 0)
+            return [];
+
+        var completion = ProduceAllCompletion.Rent(messageList.Count);
+        using var bulkScope = _accumulator.EnterBulkProduceScope();
+        for (var i = 0; i < messageList.Count; i++)
+        {
+            try
+            {
+                var message = messageList[i];
+                completion.Register(i, ProduceAsync(
+                    topic,
+                    message.Key,
+                    message.Value,
+                    message.Headers,
+                    message.Partition,
+                    message.Timestamp,
+                    ProduceContinuationMode.InlineWhenDirect,
+                    cancellationToken));
+            }
+            catch (Exception ex)
+            {
+                completion.RecordFailure(i, ex);
+                completion.AbortRegistration(messageList.Count - i);
+                break;
+            }
+        }
+
+        return await completion.WaitAsync().ConfigureAwait(false);
+    }
+
     public ValueTask FlushAsync(CancellationToken cancellationToken = default)
     {
         if (ProducerCallbackContext.IsInDeliveryCallback)

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1937,24 +1937,57 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ArgumentNullException.ThrowIfNull(topic);
         ArgumentNullException.ThrowIfNull(messages);
 
-        // Materialize before entering the bulk scope so arbitrary caller enumeration cannot
-        // suppress the accumulator's app-limited seal gate for an unbounded duration.
-        var messageList = PooledReadOnlyList<TopicProducerMessage<TKey, TValue>>.Rent(messages);
-        if (messageList.Count == 0)
+        if (messages is IList<TopicProducerMessage<TKey, TValue>> messageList)
         {
-            messageList.Dispose();
-            return [];
-        }
+            if (messageList.Count == 0)
+                return [];
 
-        var completion = ProduceAllCompletion.Rent(messageList.Count);
-        using var bulkScope = _accumulator.EnterBulkProduceScope();
-        try
-        {
+            var listCompletion = ProduceAllCompletion.Rent(messageList.Count);
+            using var listBulkScope = _accumulator.EnterBulkProduceScope();
             for (var i = 0; i < messageList.Count; i++)
             {
                 try
                 {
                     var message = messageList[i];
+                    listCompletion.Register(i, ProduceAsync(
+                        topic,
+                        message.Key,
+                        message.Value,
+                        message.Headers,
+                        message.Partition,
+                        message.Timestamp,
+                        ProduceContinuationMode.InlineWhenDirect,
+                        cancellationToken));
+                }
+                catch (Exception ex)
+                {
+                    listCompletion.RecordFailure(i, ex);
+                    listCompletion.AbortRegistration(messageList.Count - i);
+                    break;
+                }
+            }
+
+            return await listCompletion.WaitAsync().ConfigureAwait(false);
+        }
+
+        // Materialize before entering the bulk scope so arbitrary caller enumeration cannot
+        // suppress the accumulator's app-limited seal gate for an unbounded duration.
+        var messageBuffer = PooledReadOnlyList<TopicProducerMessage<TKey, TValue>>.Rent(messages);
+        if (messageBuffer.Count == 0)
+        {
+            messageBuffer.Dispose();
+            return [];
+        }
+
+        var completion = ProduceAllCompletion.Rent(messageBuffer.Count);
+        using var bulkScope = _accumulator.EnterBulkProduceScope();
+        try
+        {
+            for (var i = 0; i < messageBuffer.Count; i++)
+            {
+                try
+                {
+                    var message = messageBuffer[i];
                     completion.Register(i, ProduceAsync(
                         topic,
                         message.Key,
@@ -1968,14 +2001,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 catch (Exception ex)
                 {
                     completion.RecordFailure(i, ex);
-                    completion.AbortRegistration(messageList.Count - i);
+                    completion.AbortRegistration(messageBuffer.Count - i);
                     break;
                 }
             }
         }
         finally
         {
-            messageList.Dispose();
+            messageBuffer.Dispose();
         }
 
         return await completion.WaitAsync().ConfigureAwait(false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -1937,33 +1937,45 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         ArgumentNullException.ThrowIfNull(topic);
         ArgumentNullException.ThrowIfNull(messages);
 
-        var messageList = messages as IList<TopicProducerMessage<TKey, TValue>> ?? messages.ToList();
+        // Materialize before entering the bulk scope so arbitrary caller enumeration cannot
+        // suppress the accumulator's app-limited seal gate for an unbounded duration.
+        var messageList = PooledReadOnlyList<TopicProducerMessage<TKey, TValue>>.Rent(messages);
         if (messageList.Count == 0)
+        {
+            messageList.Dispose();
             return [];
+        }
 
         var completion = ProduceAllCompletion.Rent(messageList.Count);
         using var bulkScope = _accumulator.EnterBulkProduceScope();
-        for (var i = 0; i < messageList.Count; i++)
+        try
         {
-            try
+            for (var i = 0; i < messageList.Count; i++)
             {
-                var message = messageList[i];
-                completion.Register(i, ProduceAsync(
-                    topic,
-                    message.Key,
-                    message.Value,
-                    message.Headers,
-                    message.Partition,
-                    message.Timestamp,
-                    ProduceContinuationMode.InlineWhenDirect,
-                    cancellationToken));
+                try
+                {
+                    var message = messageList[i];
+                    completion.Register(i, ProduceAsync(
+                        topic,
+                        message.Key,
+                        message.Value,
+                        message.Headers,
+                        message.Partition,
+                        message.Timestamp,
+                        ProduceContinuationMode.InlineWhenDirect,
+                        cancellationToken));
+                }
+                catch (Exception ex)
+                {
+                    completion.RecordFailure(i, ex);
+                    completion.AbortRegistration(messageList.Count - i);
+                    break;
+                }
             }
-            catch (Exception ex)
-            {
-                completion.RecordFailure(i, ex);
-                completion.AbortRegistration(messageList.Count - i);
-                break;
-            }
+        }
+        finally
+        {
+            messageList.Dispose();
         }
 
         return await completion.WaitAsync().ConfigureAwait(false);

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -29,6 +29,7 @@ internal ref struct PooledReadOnlyList<T>
         Queue<T> { Count: 1 } queue => new PooledReadOnlyList<T>(queue.Peek(), null, 1),
         Queue<T> queue => RentQueue(queue),
         Stack<T> { Count: 1 } stack => new PooledReadOnlyList<T>(stack.Peek(), null, 1),
+        Stack<T> stack => RentStack(stack),
         LinkedList<T> { Count: 1 } linkedList => new PooledReadOnlyList<T>(linkedList.First!.Value, null, 1),
         HashSet<T> { Count: 1 } hashSet => RentEnumerator(hashSet.GetEnumerator()),
         SortedSet<T> { Count: 1 } sortedSet => RentEnumerator(sortedSet.GetEnumerator()),
@@ -65,6 +66,25 @@ internal ref struct PooledReadOnlyList<T>
         {
             collection.CopyTo(rentedArray, 0);
             return new PooledReadOnlyList<T>(default, rentedArray, collection.Count);
+        }
+        catch
+        {
+            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentStack(Stack<T> stack)
+    {
+        if (stack.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        // Keep the concrete CopyTo call: dispatch through IEnumerable<T> boxes Stack<T>.Enumerator.
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, stack.Count));
+        try
+        {
+            stack.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, stack.Count);
         }
         catch
         {

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -24,7 +24,57 @@ internal ref struct PooledReadOnlyList<T>
 
     public T this[int index] => _rentedArray is not null ? _rentedArray[index] : _firstItem!;
 
-    public static PooledReadOnlyList<T> Rent(IEnumerable<T> source)
+    public static PooledReadOnlyList<T> Rent(IEnumerable<T> source) => source switch
+    {
+        Queue<T> { Count: 1 } queue => new PooledReadOnlyList<T>(queue.Peek(), null, 1),
+        Queue<T> queue => RentQueue(queue),
+        Stack<T> { Count: 1 } stack => new PooledReadOnlyList<T>(stack.Peek(), null, 1),
+        LinkedList<T> { Count: 1 } linkedList => new PooledReadOnlyList<T>(linkedList.First!.Value, null, 1),
+        HashSet<T> { Count: 1 } hashSet => RentEnumerator(hashSet.GetEnumerator()),
+        SortedSet<T> { Count: 1 } sortedSet => RentEnumerator(sortedSet.GetEnumerator()),
+        ICollection<T> collection => RentCollection(collection),
+        _ => RentEnumerator(source.GetEnumerator()),
+    };
+
+    private static PooledReadOnlyList<T> RentQueue(Queue<T> queue)
+    {
+        if (queue.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        // Keep the concrete CopyTo call: dispatch through ICollection<T> measured 40 B/op.
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, queue.Count));
+        try
+        {
+            queue.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, queue.Count);
+        }
+        catch
+        {
+            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentCollection(ICollection<T> collection)
+    {
+        if (collection.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, collection.Count));
+        try
+        {
+            collection.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, collection.Count);
+        }
+        catch
+        {
+            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentEnumerator<TEnumerator>(TEnumerator enumerator)
+        where TEnumerator : IEnumerator<T>
     {
         T[]? rentedArray = null;
         T? firstItem = default;
@@ -32,8 +82,9 @@ internal ref struct PooledReadOnlyList<T>
 
         try
         {
-            foreach (var item in source)
+            while (enumerator.MoveNext())
             {
+                var item = enumerator.Current;
                 if (count == 0)
                 {
                     firstItem = item;
@@ -64,6 +115,10 @@ internal ref struct PooledReadOnlyList<T>
             if (rentedArray is not null)
                 ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
             throw;
+        }
+        finally
+        {
+            enumerator.Dispose();
         }
     }
 

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
@@ -8,60 +9,66 @@ namespace Dekaf.Producer;
 /// </summary>
 internal ref struct PooledReadOnlyList<T>
 {
-    private readonly IList<T>? _list;
+#if NET10_0_OR_GREATER
+    private const int InlineCapacity = 16;
+#else
+    private const int InlineCapacity = 8;
+#endif
+    private const int InitialPooledCapacity = 128;
+
+    private InlineBuffer _inlineBuffer;
     private T[]? _rentedArray;
 
-    private PooledReadOnlyList(IList<T> list)
+    private PooledReadOnlyList(InlineBuffer inlineBuffer, T[]? rentedArray, int count)
     {
-        _list = list;
-        _rentedArray = null;
-        Count = list.Count;
-    }
-
-    private PooledReadOnlyList(T[]? rentedArray, int count)
-    {
-        _list = null;
+        _inlineBuffer = inlineBuffer;
         _rentedArray = rentedArray;
         Count = count;
     }
 
     public int Count { get; }
 
-    public T this[int index] => _list is not null ? _list[index] : _rentedArray![index];
+    public T this[int index] => _rentedArray is not null ? _rentedArray[index] : _inlineBuffer[index];
 
     public static PooledReadOnlyList<T> Rent(IEnumerable<T> source)
     {
-        if (source is IList<T> list)
-            return new PooledReadOnlyList<T>(list);
-
-        T[]? buffer = null;
+        InlineBuffer inlineBuffer = default;
+        T[]? rentedArray = null;
         var count = 0;
 
         try
         {
             foreach (var item in source)
             {
-                if (buffer is null)
+                if (rentedArray is null && count < InlineCapacity)
                 {
-                    buffer = ArrayPool<T>.Shared.Rent(16);
-                }
-                else if (count == buffer.Length)
-                {
-                    var expanded = ArrayPool<T>.Shared.Rent(checked(buffer.Length * 2));
-                    buffer.AsSpan(0, count).CopyTo(expanded);
-                    ArrayPool<T>.Shared.Return(buffer, clearArray: true);
-                    buffer = expanded;
+                    inlineBuffer[count++] = item;
+                    continue;
                 }
 
-                buffer[count++] = item;
+                if (rentedArray is null)
+                {
+                    rentedArray = ArrayPool<T>.Shared.Rent(InitialPooledCapacity);
+                    for (var i = 0; i < InlineCapacity; i++)
+                        rentedArray[i] = inlineBuffer[i];
+                }
+                else if (count == rentedArray.Length)
+                {
+                    var expanded = ArrayPool<T>.Shared.Rent(checked(rentedArray.Length * 2));
+                    rentedArray.AsSpan(0, count).CopyTo(expanded);
+                    ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+                    rentedArray = expanded;
+                }
+
+                rentedArray[count++] = item;
             }
 
-            return new PooledReadOnlyList<T>(buffer, count);
+            return new PooledReadOnlyList<T>(inlineBuffer, rentedArray, count);
         }
         catch
         {
-            if (buffer is not null)
-                ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+            if (rentedArray is not null)
+                ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
             throw;
         }
     }
@@ -75,4 +82,55 @@ internal ref struct PooledReadOnlyList<T>
         _rentedArray = null;
         ArrayPool<T>.Shared.Return(buffer, clearArray: true);
     }
+
+#if NET10_0_OR_GREATER
+    [InlineArray(InlineCapacity)]
+    private struct InlineBuffer
+    {
+        private T _element0;
+    }
+#else
+    private struct InlineBuffer
+    {
+        private T _element0;
+        private T _element1;
+        private T _element2;
+        private T _element3;
+        private T _element4;
+        private T _element5;
+        private T _element6;
+        private T _element7;
+
+        public T this[int index]
+        {
+            readonly get => index switch
+            {
+                0 => _element0,
+                1 => _element1,
+                2 => _element2,
+                3 => _element3,
+                4 => _element4,
+                5 => _element5,
+                6 => _element6,
+                7 => _element7,
+                _ => throw new ArgumentOutOfRangeException(nameof(index)),
+            };
+            set
+            {
+                switch (index)
+                {
+                    case 0: _element0 = value; break;
+                    case 1: _element1 = value; break;
+                    case 2: _element2 = value; break;
+                    case 3: _element3 = value; break;
+                    case 4: _element4 = value; break;
+                    case 5: _element5 = value; break;
+                    case 6: _element6 = value; break;
+                    case 7: _element7 = value; break;
+                    default: throw new ArgumentOutOfRangeException(nameof(index));
+                }
+            }
+        }
+    }
+#endif
 }

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -1,0 +1,78 @@
+using System.Buffers;
+
+namespace Dekaf.Producer;
+
+/// <summary>
+/// Provides indexed access to an <see cref="IEnumerable{T}"/> without allocating a
+/// heap-backed list when the source does not already support indexing.
+/// </summary>
+internal ref struct PooledReadOnlyList<T>
+{
+    private readonly IList<T>? _list;
+    private T[]? _rentedArray;
+
+    private PooledReadOnlyList(IList<T> list)
+    {
+        _list = list;
+        _rentedArray = null;
+        Count = list.Count;
+    }
+
+    private PooledReadOnlyList(T[]? rentedArray, int count)
+    {
+        _list = null;
+        _rentedArray = rentedArray;
+        Count = count;
+    }
+
+    public int Count { get; }
+
+    public T this[int index] => _list is not null ? _list[index] : _rentedArray![index];
+
+    public static PooledReadOnlyList<T> Rent(IEnumerable<T> source)
+    {
+        if (source is IList<T> list)
+            return new PooledReadOnlyList<T>(list);
+
+        T[]? buffer = null;
+        var count = 0;
+
+        try
+        {
+            foreach (var item in source)
+            {
+                if (buffer is null)
+                {
+                    buffer = ArrayPool<T>.Shared.Rent(16);
+                }
+                else if (count == buffer.Length)
+                {
+                    var expanded = ArrayPool<T>.Shared.Rent(checked(buffer.Length * 2));
+                    buffer.AsSpan(0, count).CopyTo(expanded);
+                    ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+                    buffer = expanded;
+                }
+
+                buffer[count++] = item;
+            }
+
+            return new PooledReadOnlyList<T>(buffer, count);
+        }
+        catch
+        {
+            if (buffer is not null)
+                ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        var buffer = _rentedArray;
+        if (buffer is null)
+            return;
+
+        _rentedArray = null;
+        ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+    }
+}

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
@@ -31,9 +32,11 @@ internal ref struct PooledReadOnlyList<T>
         Stack<T> { Count: 1 } stack => new PooledReadOnlyList<T>(stack.Peek(), null, 1),
         Stack<T> stack => RentStack(stack),
         LinkedList<T> { Count: 1 } linkedList => new PooledReadOnlyList<T>(linkedList.First!.Value, null, 1),
+        LinkedList<T> linkedList => RentLinkedList(linkedList),
         HashSet<T> { Count: 1 } hashSet => RentEnumerator(hashSet.GetEnumerator()),
-        SortedSet<T> { Count: 1 } sortedSet => RentEnumerator(sortedSet.GetEnumerator()),
-        ICollection<T> collection => RentCollection(collection),
+        HashSet<T> hashSet => RentHashSet(hashSet),
+        SortedSet<T> { Count: 1 } sortedSet => new PooledReadOnlyList<T>(sortedSet.Min, null, 1),
+        SortedSet<T> sortedSet => RentSortedSet(sortedSet),
         _ => RentEnumerator(source.GetEnumerator()),
     };
 
@@ -43,33 +46,16 @@ internal ref struct PooledReadOnlyList<T>
             return new PooledReadOnlyList<T>(default, null, 0);
 
         // Keep the concrete CopyTo call: dispatch through ICollection<T> measured 40 B/op.
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, queue.Count));
+        var count = queue.Count;
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
         try
         {
             queue.CopyTo(rentedArray, 0);
-            return new PooledReadOnlyList<T>(default, rentedArray, queue.Count);
+            return new PooledReadOnlyList<T>(default, rentedArray, count);
         }
         catch
         {
-            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
-            throw;
-        }
-    }
-
-    private static PooledReadOnlyList<T> RentCollection(ICollection<T> collection)
-    {
-        if (collection.Count == 0)
-            return new PooledReadOnlyList<T>(default, null, 0);
-
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, collection.Count));
-        try
-        {
-            collection.CopyTo(rentedArray, 0);
-            return new PooledReadOnlyList<T>(default, rentedArray, collection.Count);
-        }
-        catch
-        {
-            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            Return(rentedArray, count);
             throw;
         }
     }
@@ -80,15 +66,73 @@ internal ref struct PooledReadOnlyList<T>
             return new PooledReadOnlyList<T>(default, null, 0);
 
         // Keep the concrete CopyTo call: dispatch through IEnumerable<T> boxes Stack<T>.Enumerator.
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, stack.Count));
+        var count = stack.Count;
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
         try
         {
             stack.CopyTo(rentedArray, 0);
-            return new PooledReadOnlyList<T>(default, rentedArray, stack.Count);
+            return new PooledReadOnlyList<T>(default, rentedArray, count);
         }
         catch
         {
-            ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            Return(rentedArray, count);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentLinkedList(LinkedList<T> linkedList)
+    {
+        if (linkedList.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        var count = linkedList.Count;
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        try
+        {
+            linkedList.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, count);
+        }
+        catch
+        {
+            Return(rentedArray, count);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentHashSet(HashSet<T> hashSet)
+    {
+        if (hashSet.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        var count = hashSet.Count;
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        try
+        {
+            hashSet.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, count);
+        }
+        catch
+        {
+            Return(rentedArray, count);
+            throw;
+        }
+    }
+
+    private static PooledReadOnlyList<T> RentSortedSet(SortedSet<T> sortedSet)
+    {
+        if (sortedSet.Count == 0)
+            return new PooledReadOnlyList<T>(default, null, 0);
+
+        var count = sortedSet.Count;
+        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        try
+        {
+            sortedSet.CopyTo(rentedArray, 0);
+            return new PooledReadOnlyList<T>(default, rentedArray, count);
+        }
+        catch
+        {
+            Return(rentedArray, count);
             throw;
         }
     }
@@ -102,44 +146,54 @@ internal ref struct PooledReadOnlyList<T>
 
         try
         {
-            while (enumerator.MoveNext())
+            if (enumerator.MoveNext())
             {
-                var item = enumerator.Current;
-                if (count == 0)
+                firstItem = enumerator.Current;
+                count = 1;
+                while (enumerator.MoveNext())
                 {
-                    firstItem = item;
-                    count = 1;
-                    continue;
-                }
+                    var item = enumerator.Current;
+                    if (rentedArray is null)
+                    {
+                        rentedArray = ArrayPool<T>.Shared.Rent(InitialPooledCapacity);
+                        rentedArray[0] = firstItem!;
+                    }
+                    else if (count == rentedArray.Length)
+                    {
+                        var expanded = ArrayPool<T>.Shared.Rent(checked(rentedArray.Length * 2));
+                        rentedArray.AsSpan(0, count).CopyTo(expanded);
+                        Return(rentedArray, count);
+                        rentedArray = expanded;
+                    }
 
-                if (rentedArray is null)
-                {
-                    rentedArray = ArrayPool<T>.Shared.Rent(InitialPooledCapacity);
-                    rentedArray[0] = firstItem!;
+                    rentedArray[count++] = item;
                 }
-                else if (count == rentedArray.Length)
-                {
-                    var expanded = ArrayPool<T>.Shared.Rent(checked(rentedArray.Length * 2));
-                    rentedArray.AsSpan(0, count).CopyTo(expanded);
-                    ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
-                    rentedArray = expanded;
-                }
-
-                rentedArray[count++] = item;
             }
-
-            return new PooledReadOnlyList<T>(firstItem, rentedArray, count);
         }
         catch
         {
             if (rentedArray is not null)
-                ArrayPool<T>.Shared.Return(rentedArray, clearArray: true);
+            {
+                Return(rentedArray, count);
+                rentedArray = null;
+            }
+
+            enumerator.Dispose();
             throw;
         }
-        finally
+
+        try
         {
             enumerator.Dispose();
         }
+        catch
+        {
+            if (rentedArray is not null)
+                Return(rentedArray, count);
+            throw;
+        }
+
+        return new PooledReadOnlyList<T>(firstItem, rentedArray, count);
     }
 
     public void Dispose()
@@ -150,6 +204,20 @@ internal ref struct PooledReadOnlyList<T>
             return;
 
         _rentedArray = null;
-        ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+        Return(buffer, Count);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void Return(T[] buffer, int count)
+    {
+        // Sparse buckets clear live slots only; dense buckets use ArrayPool's optimized full clear.
+        if (count >= buffer.Length / 2)
+        {
+            ArrayPool<T>.Shared.Return(buffer, clearArray: true);
+            return;
+        }
+
+        buffer.AsSpan(0, count).Clear();
+        ArrayPool<T>.Shared.Return(buffer);
     }
 }

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -46,7 +46,7 @@ internal ref struct PooledReadOnlyList<T>
 
         // Keep the concrete CopyTo call: dispatch through ICollection<T> measured 40 B/op.
         var count = queue.Count;
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        var rentedArray = ArrayPool<T>.Shared.Rent(count);
         try
         {
             queue.CopyTo(rentedArray, 0);
@@ -66,7 +66,7 @@ internal ref struct PooledReadOnlyList<T>
 
         // Keep the concrete CopyTo call: dispatch through IEnumerable<T> boxes Stack<T>.Enumerator.
         var count = stack.Count;
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        var rentedArray = ArrayPool<T>.Shared.Rent(count);
         try
         {
             stack.CopyTo(rentedArray, 0);
@@ -85,7 +85,7 @@ internal ref struct PooledReadOnlyList<T>
             return new PooledReadOnlyList<T>(default, null, 0);
 
         var count = linkedList.Count;
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        var rentedArray = ArrayPool<T>.Shared.Rent(count);
         try
         {
             linkedList.CopyTo(rentedArray, 0);
@@ -104,7 +104,7 @@ internal ref struct PooledReadOnlyList<T>
             return new PooledReadOnlyList<T>(default, null, 0);
 
         var count = hashSet.Count;
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        var rentedArray = ArrayPool<T>.Shared.Rent(count);
         try
         {
             hashSet.CopyTo(rentedArray, 0);
@@ -123,7 +123,7 @@ internal ref struct PooledReadOnlyList<T>
             return new PooledReadOnlyList<T>(default, null, 0);
 
         var count = sortedSet.Count;
-        var rentedArray = ArrayPool<T>.Shared.Rent(Math.Max(InitialPooledCapacity, count));
+        var rentedArray = ArrayPool<T>.Shared.Rent(count);
         try
         {
             sortedSet.CopyTo(rentedArray, 0);
@@ -177,7 +177,14 @@ internal ref struct PooledReadOnlyList<T>
                 rentedArray = null;
             }
 
-            enumerator.Dispose();
+            // Preserve the enumeration failure if cleanup also fails.
+            try
+            {
+                enumerator.Dispose();
+            }
+            catch
+            {
+            }
             throw;
         }
 

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -1,56 +1,50 @@
 using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
 /// <summary>
-/// Provides indexed access to an <see cref="IEnumerable{T}"/> without allocating a
-/// heap-backed list when the source does not already support indexing.
+/// Buffers a non-indexed <see cref="IEnumerable{T}"/> for indexed access without
+/// allocating a heap-backed list.
 /// </summary>
 internal ref struct PooledReadOnlyList<T>
 {
-#if NET10_0_OR_GREATER
-    private const int InlineCapacity = 16;
-#else
-    private const int InlineCapacity = 8;
-#endif
     private const int InitialPooledCapacity = 128;
 
-    private InlineBuffer _inlineBuffer;
+    private T? _firstItem;
     private T[]? _rentedArray;
 
-    private PooledReadOnlyList(InlineBuffer inlineBuffer, T[]? rentedArray, int count)
+    private PooledReadOnlyList(T? firstItem, T[]? rentedArray, int count)
     {
-        _inlineBuffer = inlineBuffer;
+        _firstItem = firstItem;
         _rentedArray = rentedArray;
         Count = count;
     }
 
     public int Count { get; }
 
-    public T this[int index] => _rentedArray is not null ? _rentedArray[index] : _inlineBuffer[index];
+    public T this[int index] => _rentedArray is not null ? _rentedArray[index] : _firstItem!;
 
     public static PooledReadOnlyList<T> Rent(IEnumerable<T> source)
     {
-        InlineBuffer inlineBuffer = default;
         T[]? rentedArray = null;
+        T? firstItem = default;
         var count = 0;
 
         try
         {
             foreach (var item in source)
             {
-                if (rentedArray is null && count < InlineCapacity)
+                if (count == 0)
                 {
-                    inlineBuffer[count++] = item;
+                    firstItem = item;
+                    count = 1;
                     continue;
                 }
 
                 if (rentedArray is null)
                 {
                     rentedArray = ArrayPool<T>.Shared.Rent(InitialPooledCapacity);
-                    for (var i = 0; i < InlineCapacity; i++)
-                        rentedArray[i] = inlineBuffer[i];
+                    rentedArray[0] = firstItem!;
                 }
                 else if (count == rentedArray.Length)
                 {
@@ -63,7 +57,7 @@ internal ref struct PooledReadOnlyList<T>
                 rentedArray[count++] = item;
             }
 
-            return new PooledReadOnlyList<T>(inlineBuffer, rentedArray, count);
+            return new PooledReadOnlyList<T>(firstItem, rentedArray, count);
         }
         catch
         {
@@ -76,61 +70,11 @@ internal ref struct PooledReadOnlyList<T>
     public void Dispose()
     {
         var buffer = _rentedArray;
+        _firstItem = default;
         if (buffer is null)
             return;
 
         _rentedArray = null;
         ArrayPool<T>.Shared.Return(buffer, clearArray: true);
     }
-
-#if NET10_0_OR_GREATER
-    [InlineArray(InlineCapacity)]
-    private struct InlineBuffer
-    {
-        private T _element0;
-    }
-#else
-    private struct InlineBuffer
-    {
-        private T _element0;
-        private T _element1;
-        private T _element2;
-        private T _element3;
-        private T _element4;
-        private T _element5;
-        private T _element6;
-        private T _element7;
-
-        public T this[int index]
-        {
-            readonly get => index switch
-            {
-                0 => _element0,
-                1 => _element1,
-                2 => _element2,
-                3 => _element3,
-                4 => _element4,
-                5 => _element5,
-                6 => _element6,
-                7 => _element7,
-                _ => throw new ArgumentOutOfRangeException(nameof(index)),
-            };
-            set
-            {
-                switch (index)
-                {
-                    case 0: _element0 = value; break;
-                    case 1: _element1 = value; break;
-                    case 2: _element2 = value; break;
-                    case 3: _element3 = value; break;
-                    case 4: _element4 = value; break;
-                    case 5: _element5 = value; break;
-                    case 6: _element6 = value; break;
-                    case 7: _element7 = value; break;
-                    default: throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-        }
-    }
-#endif
 }

--- a/src/Dekaf/Producer/PooledReadOnlyList.cs
+++ b/src/Dekaf/Producer/PooledReadOnlyList.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
@@ -207,16 +206,8 @@ internal ref struct PooledReadOnlyList<T>
         Return(buffer, Count);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void Return(T[] buffer, int count)
     {
-        // Sparse buckets clear live slots only; dense buckets use ArrayPool's optimized full clear.
-        if (count >= buffer.Length / 2)
-        {
-            ArrayPool<T>.Shared.Return(buffer, clearArray: true);
-            return;
-        }
-
         buffer.AsSpan(0, count).Clear();
         ArrayPool<T>.Shared.Return(buffer);
     }

--- a/src/Dekaf/Producer/TopicProducer.cs
+++ b/src/Dekaf/Producer/TopicProducer.cs
@@ -158,12 +158,15 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
     }
 
     /// <inheritdoc />
-    public async Task<RecordMetadata[]> ProduceAllAsync(
+    public Task<RecordMetadata[]> ProduceAllAsync(
         IEnumerable<TopicProducerMessage<TKey, TValue>> messages,
         CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
         ArgumentNullException.ThrowIfNull(messages);
+
+        if (_producer is IProducerFastPath<TKey, TValue> fastPath)
+            return fastPath.ProduceAllAsync(Topic, messages, cancellationToken);
 
         // Convert TopicProducerMessage to ProducerMessage with embedded topic
         var producerMessages = messages.Select(m => new ProducerMessage<TKey, TValue>
@@ -176,7 +179,7 @@ internal sealed class TopicProducer<TKey, TValue> : ITopicProducer<TKey, TValue>
             Timestamp = m.Timestamp
         });
 
-        return await _producer.ProduceAllAsync(producerMessages, cancellationToken).ConfigureAwait(false);
+        return _producer.ProduceAllAsync(producerMessages, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -16,6 +16,7 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
     public int? CapturedPartition { get; private set; }
     public DateTimeOffset? CapturedTimestamp { get; private set; }
     public CancellationToken CapturedCancellationToken { get; private set; }
+    public List<TKey?> CapturedBatchKeys { get; } = [];
 
     public RecordMetadata Result { get; set; } = new()
     {
@@ -87,7 +88,8 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
                 message.Partition,
                 message.Timestamp,
                 cancellationToken);
-            results.Add(Result);
+            CapturedBatchKeys.Add(message.Key);
+            results.Add(Result with { Offset = results.Count });
         }
 
         return Task.FromResult(results.ToArray());

--- a/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/FastPathProducerSpy.cs
@@ -7,6 +7,7 @@ namespace Dekaf.Tests.Unit.Producer;
 internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, TValue>, IProducerFastPath<TKey, TValue>
 {
     public int FastPathCalls { get; private set; }
+    public int BatchFastPathCalls { get; private set; }
     public int MessageCalls { get; private set; }
     public string? CapturedTopic { get; private set; }
     public TKey? CapturedKey { get; private set; }
@@ -67,6 +68,29 @@ internal sealed class FastPathProducerSpy<TKey, TValue> : IKafkaProducer<TKey, T
         CapturedTimestamp = timestamp;
         CapturedCancellationToken = cancellationToken;
         return ValueTask.FromResult(Result);
+    }
+
+    Task<RecordMetadata[]> IProducerFastPath<TKey, TValue>.ProduceAllAsync(
+        string topic,
+        IEnumerable<TopicProducerMessage<TKey, TValue>> messages,
+        CancellationToken cancellationToken)
+    {
+        BatchFastPathCalls++;
+        var results = new List<RecordMetadata>();
+        foreach (var message in messages)
+        {
+            _ = ((IProducerFastPath<TKey, TValue>)this).ProduceAsync(
+                topic,
+                message.Key,
+                message.Value,
+                message.Headers,
+                message.Partition,
+                message.Timestamp,
+                cancellationToken);
+            results.Add(Result);
+        }
+
+        return Task.FromResult(results.ToArray());
     }
 
     public ValueTask FireAsync(ProducerMessage<TKey, TValue> message) => ValueTask.CompletedTask;

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
@@ -85,10 +85,39 @@ public class KafkaProducerProduceAllTests
         }
     }
 
+    [Test]
+    public async Task TopicProducer_ProduceAllAsync_EmptyInputs_ReturnsEmptyResults()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        try
+        {
+            var topicProducer = producer.ForTopic("test-topic");
+
+            var listResult = await topicProducer.ProduceAllAsync(
+                Array.Empty<TopicProducerMessage<string, string>>());
+            var enumerableResult = await topicProducer.ProduceAllAsync(EnumerateNoMessages());
+
+            await Assert.That(listResult).IsEmpty();
+            await Assert.That(enumerableResult).IsEmpty();
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+
     private static IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
     {
         yield return new TopicProducerMessage<string, string> { Key = "k0", Value = "v0" };
         yield return new TopicProducerMessage<string, string> { Key = "k1", Value = "v1" };
         yield return new TopicProducerMessage<string, string> { Key = "k2", Value = "v2" };
+    }
+
+    private static IEnumerable<TopicProducerMessage<string, string>> EnumerateNoMessages()
+    {
+        yield break;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
@@ -109,6 +109,31 @@ public class KafkaProducerProduceAllTests
         }
     }
 
+    [Test]
+    public async Task TopicProducer_ProduceAllAsync_MutatingListCount_DoesNotHang()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        try
+        {
+            var topicProducer = producer.ForTopic("test-topic");
+            var messages = new ChangingCountList();
+
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await topicProducer.ProduceAllAsync(messages)
+                    .WaitAsync(TimeSpan.FromSeconds(10)));
+
+            await Assert.That(thrown!.Message).Contains("InitializeAsync");
+            await Assert.That(messages.CountReads).IsEqualTo(1);
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+
     private static IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
     {
         yield return new TopicProducerMessage<string, string> { Key = "k0", Value = "v0" };
@@ -119,5 +144,44 @@ public class KafkaProducerProduceAllTests
     private static IEnumerable<TopicProducerMessage<string, string>> EnumerateNoMessages()
     {
         yield break;
+    }
+
+    private sealed class ChangingCountList : IList<TopicProducerMessage<string, string>>
+    {
+        private int _countReads;
+
+        public int CountReads => _countReads;
+
+        public int Count => Interlocked.Increment(ref _countReads) <= 2 ? 2 : 0;
+
+        public bool IsReadOnly => true;
+
+        public TopicProducerMessage<string, string> this[int index]
+        {
+            get => new() { Key = $"k{index}", Value = $"v{index}" };
+            set => throw new NotSupportedException();
+        }
+
+        public IEnumerator<TopicProducerMessage<string, string>> GetEnumerator() =>
+            throw new NotSupportedException();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public int IndexOf(TopicProducerMessage<string, string> item) => throw new NotSupportedException();
+
+        public void Insert(int index, TopicProducerMessage<string, string> item) => throw new NotSupportedException();
+
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public void Add(TopicProducerMessage<string, string> item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(TopicProducerMessage<string, string> item) => throw new NotSupportedException();
+
+        public void CopyTo(TopicProducerMessage<string, string>[] array, int arrayIndex) =>
+            throw new NotSupportedException();
+
+        public bool Remove(TopicProducerMessage<string, string> item) => throw new NotSupportedException();
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/KafkaProducerProduceAllTests.cs
@@ -61,4 +61,34 @@ public class KafkaProducerProduceAllTests
             await producer.DisposeAsync();
         }
     }
+
+    [Test]
+    public async Task TopicProducer_ProduceAllAsync_NonListSyncThrow_FaultsAggregateWithoutHanging()
+    {
+        var producer = Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers("localhost:9092")
+            .Build();
+
+        try
+        {
+            var topicProducer = producer.ForTopic("test-topic");
+
+            var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await topicProducer.ProduceAllAsync(EnumerateMessages())
+                    .WaitAsync(TimeSpan.FromSeconds(10)));
+
+            await Assert.That(thrown!.Message).Contains("InitializeAsync");
+        }
+        finally
+        {
+            await producer.DisposeAsync();
+        }
+    }
+
+    private static IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
+    {
+        yield return new TopicProducerMessage<string, string> { Key = "k0", Value = "v0" };
+        yield return new TopicProducerMessage<string, string> { Key = "k1", Value = "v1" };
+        yield return new TopicProducerMessage<string, string> { Key = "k2", Value = "v2" };
+    }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -1,0 +1,29 @@
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class PooledReadOnlyListTests
+{
+    [Test]
+    public async Task Rent_EnumerableBeyondInlineCapacity_PreservesCountAndOrder()
+    {
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(Enumerate(100));
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(preservesOrder).IsTrue();
+    }
+
+    private static IEnumerable<int> Enumerate(int count)
+    {
+        for (var i = 0; i < count; i++)
+            yield return i;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -4,6 +4,8 @@ namespace Dekaf.Tests.Unit.Producer;
 
 public class PooledReadOnlyListTests
 {
+    private const int MultipleItemCount = 256;
+
     [Test]
     public async Task Rent_EnumerableBeyondInlineCapacity_PreservesCountAndOrder()
     {
@@ -11,13 +13,13 @@ public class PooledReadOnlyListTests
         var preservesOrder = true;
 
         {
-            using var messages = PooledReadOnlyList<int>.Rent(Enumerate(100));
+            using var messages = PooledReadOnlyList<int>.Rent(Enumerate(MultipleItemCount));
             count = messages.Count;
             for (var i = 0; i < messages.Count; i++)
                 preservesOrder &= messages[i] == i;
         }
 
-        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
         await Assert.That(preservesOrder).IsTrue();
     }
 
@@ -28,13 +30,13 @@ public class PooledReadOnlyListTests
         var preservesOrder = true;
 
         {
-            using var messages = PooledReadOnlyList<int>.Rent(new Queue<int>(Enumerable.Range(0, 100)));
+            using var messages = PooledReadOnlyList<int>.Rent(new Queue<int>(Enumerable.Range(0, MultipleItemCount)));
             count = messages.Count;
             for (var i = 0; i < messages.Count; i++)
                 preservesOrder &= messages[i] == i;
         }
 
-        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
         await Assert.That(preservesOrder).IsTrue();
     }
 
@@ -45,14 +47,14 @@ public class PooledReadOnlyListTests
         var preservesOrder = true;
 
         {
-            var stack = new Stack<int>(Enumerable.Range(0, 100).Reverse());
+            var stack = new Stack<int>(Enumerable.Range(0, MultipleItemCount).Reverse());
             using var messages = PooledReadOnlyList<int>.Rent(stack);
             count = messages.Count;
             for (var i = 0; i < messages.Count; i++)
                 preservesOrder &= messages[i] == i;
         }
 
-        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
         await Assert.That(preservesOrder).IsTrue();
     }
 
@@ -63,14 +65,14 @@ public class PooledReadOnlyListTests
         var preservesOrder = true;
 
         {
-            var linkedList = new LinkedList<int>(Enumerable.Range(0, 100));
+            var linkedList = new LinkedList<int>(Enumerable.Range(0, MultipleItemCount));
             using var messages = PooledReadOnlyList<int>.Rent(linkedList);
             count = messages.Count;
             for (var i = 0; i < messages.Count; i++)
                 preservesOrder &= messages[i] == i;
         }
 
-        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
         await Assert.That(preservesOrder).IsTrue();
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -59,6 +59,25 @@ public class PooledReadOnlyListTests
     }
 
     [Test]
+    public async Task Rent_HashSetMultiple_PreservesCountAndOrder()
+    {
+        var source = new HashSet<int>(Enumerable.Range(0, MultipleItemCount));
+        var expected = source.ToArray();
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(source);
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == expected[i];
+        }
+
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
+        await Assert.That(preservesOrder).IsTrue();
+    }
+
+    [Test]
     public async Task Rent_Collection_PreservesCountAndOrder()
     {
         var count = 0;
@@ -103,6 +122,24 @@ public class PooledReadOnlyListTests
         }
 
         await Assert.That(value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Rent_SortedSetMultiple_PreservesCountAndOrder()
+    {
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            var source = new SortedSet<int>(Enumerable.Range(0, MultipleItemCount).Reverse());
+            using var messages = PooledReadOnlyList<int>.Rent(source);
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(count).IsEqualTo(MultipleItemCount);
+        await Assert.That(preservesOrder).IsTrue();
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -21,6 +21,23 @@ public class PooledReadOnlyListTests
         await Assert.That(preservesOrder).IsTrue();
     }
 
+    [Test]
+    public async Task Rent_Queue_PreservesCountAndOrder()
+    {
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(new Queue<int>(Enumerable.Range(0, 100)));
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(preservesOrder).IsTrue();
+    }
+
     private static IEnumerable<int> Enumerate(int count)
     {
         for (var i = 0; i < count; i++)

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -76,9 +76,102 @@ public class PooledReadOnlyListTests
         await Assert.That(preservesOrder).IsTrue();
     }
 
+    [Test]
+    public async Task Rent_ArbitraryCollection_PreservesEnumerationOrder()
+    {
+        var source = new ReverseCopyCollection(Enumerable.Range(0, MultipleItemCount));
+        var preservesOrder = true;
+
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(source);
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(preservesOrder).IsTrue();
+        await Assert.That(source.CopyToCalled).IsFalse();
+    }
+
+    [Test]
+    public async Task Rent_SortedSetSingleton_PreservesValue()
+    {
+        var value = 0;
+
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(new SortedSet<int> { 42 });
+            value = messages[0];
+        }
+
+        await Assert.That(value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Rent_EnumeratorDisposeThrows_PropagatesException()
+    {
+        Action act = static () =>
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(new DisposeThrowingEnumerable());
+        };
+
+        await Assert.That(act).Throws<InvalidOperationException>()
+            .WithMessage("dispose failed");
+    }
+
     private static IEnumerable<int> Enumerate(int count)
     {
         for (var i = 0; i < count; i++)
             yield return i;
+    }
+
+    private sealed class ReverseCopyCollection(IEnumerable<int> items) : ICollection<int>
+    {
+        private readonly List<int> _items = [.. items];
+
+        public bool CopyToCalled { get; private set; }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => true;
+
+        public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void CopyTo(int[] array, int arrayIndex)
+        {
+            CopyToCalled = true;
+            for (var i = 0; i < _items.Count; i++)
+                array[arrayIndex + i] = _items[_items.Count - i - 1];
+        }
+
+        public bool Contains(int item) => _items.Contains(item);
+
+        public void Add(int item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Remove(int item) => throw new NotSupportedException();
+    }
+
+    private sealed class DisposeThrowingEnumerable : IEnumerable<int>
+    {
+        public IEnumerator<int> GetEnumerator() => new Enumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private sealed class Enumerator : IEnumerator<int>
+        {
+            private int _current = -1;
+
+            public int Current => _current;
+
+            object System.Collections.IEnumerator.Current => Current;
+
+            public bool MoveNext() => ++_current < 2;
+
+            public void Reset() => throw new NotSupportedException();
+
+            public void Dispose() => throw new InvalidOperationException("dispose failed");
+        }
     }
 }

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -38,6 +38,24 @@ public class PooledReadOnlyListTests
         await Assert.That(preservesOrder).IsTrue();
     }
 
+    [Test]
+    public async Task Rent_Stack_PreservesCountAndOrder()
+    {
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            var stack = new Stack<int>(Enumerable.Range(0, 100).Reverse());
+            using var messages = PooledReadOnlyList<int>.Rent(stack);
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(preservesOrder).IsTrue();
+    }
+
     private static IEnumerable<int> Enumerate(int count)
     {
         for (var i = 0; i < count; i++)

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -117,6 +117,18 @@ public class PooledReadOnlyListTests
             .WithMessage("dispose failed");
     }
 
+    [Test]
+    public async Task Rent_EnumerationAndDisposeThrow_PreservesEnumerationException()
+    {
+        Action act = static () =>
+        {
+            using var messages = PooledReadOnlyList<int>.Rent(new EnumerationAndDisposeThrowingEnumerable());
+        };
+
+        await Assert.That(act).Throws<ArgumentException>()
+            .WithMessage("enumeration failed");
+    }
+
     private static IEnumerable<int> Enumerate(int count)
     {
         for (var i = 0; i < count; i++)
@@ -168,6 +180,34 @@ public class PooledReadOnlyListTests
             object System.Collections.IEnumerator.Current => Current;
 
             public bool MoveNext() => ++_current < 2;
+
+            public void Reset() => throw new NotSupportedException();
+
+            public void Dispose() => throw new InvalidOperationException("dispose failed");
+        }
+    }
+
+    private sealed class EnumerationAndDisposeThrowingEnumerable : IEnumerable<int>
+    {
+        public IEnumerator<int> GetEnumerator() => new Enumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private sealed class Enumerator : IEnumerator<int>
+        {
+            private int _current = -1;
+
+            public int Current => _current;
+
+            object System.Collections.IEnumerator.Current => Current;
+
+            public bool MoveNext()
+            {
+                if (++_current < 2)
+                    return true;
+
+                throw new ArgumentException("enumeration failed");
+            }
 
             public void Reset() => throw new NotSupportedException();
 

--- a/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PooledReadOnlyListTests.cs
@@ -56,6 +56,24 @@ public class PooledReadOnlyListTests
         await Assert.That(preservesOrder).IsTrue();
     }
 
+    [Test]
+    public async Task Rent_Collection_PreservesCountAndOrder()
+    {
+        var count = 0;
+        var preservesOrder = true;
+
+        {
+            var linkedList = new LinkedList<int>(Enumerable.Range(0, 100));
+            using var messages = PooledReadOnlyList<int>.Rent(linkedList);
+            count = messages.Count;
+            for (var i = 0; i < messages.Count; i++)
+                preservesOrder &= messages[i] == i;
+        }
+
+        await Assert.That(count).IsEqualTo(100);
+        await Assert.That(preservesOrder).IsTrue();
+    }
+
     private static IEnumerable<int> Enumerate(int count)
     {
         for (var i = 0; i < count; i++)

--- a/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
@@ -360,6 +360,10 @@ public class TopicProducerTests
         var results = await topicProducer.ProduceAllAsync(messages, cts.Token);
 
         await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(results[0].Offset).IsEqualTo(0);
+        await Assert.That(results[1].Offset).IsEqualTo(1);
+        await Assert.That(innerProducer.CapturedBatchKeys[0]).IsEqualTo("key1");
+        await Assert.That(innerProducer.CapturedBatchKeys[1]).IsEqualTo("key2");
         await Assert.That(innerProducer.BatchFastPathCalls).IsEqualTo(1);
         await Assert.That(innerProducer.FastPathCalls).IsEqualTo(2);
         await Assert.That(innerProducer.MessageCalls).IsEqualTo(0);

--- a/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TopicProducerTests.cs
@@ -337,6 +337,42 @@ public class TopicProducerTests
     }
 
     [Test]
+    public async Task ProduceAllAsync_Messages_UsesBatchFastPathWhenAvailable()
+    {
+        var innerProducer = new FastPathProducerSpy<string, string>();
+        var topicProducer = new TopicProducer<string, string>(innerProducer, "my-topic", ownsProducer: false);
+        var timestamp = DateTimeOffset.UtcNow;
+        var headers = new Headers { { "header", [1, 2, 3] } };
+        using var cts = new CancellationTokenSource();
+        var messages = new[]
+        {
+            new TopicProducerMessage<string, string> { Key = "key1", Value = "value1" },
+            new TopicProducerMessage<string, string>
+            {
+                Key = "key2",
+                Value = "value2",
+                Headers = headers,
+                Partition = 2,
+                Timestamp = timestamp,
+            },
+        };
+
+        var results = await topicProducer.ProduceAllAsync(messages, cts.Token);
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        await Assert.That(innerProducer.BatchFastPathCalls).IsEqualTo(1);
+        await Assert.That(innerProducer.FastPathCalls).IsEqualTo(2);
+        await Assert.That(innerProducer.MessageCalls).IsEqualTo(0);
+        await Assert.That(innerProducer.CapturedTopic).IsEqualTo("my-topic");
+        await Assert.That(innerProducer.CapturedKey).IsEqualTo("key2");
+        await Assert.That(innerProducer.CapturedValue).IsEqualTo("value2");
+        await Assert.That(innerProducer.CapturedHeaders).IsSameReferenceAs(headers);
+        await Assert.That(innerProducer.CapturedPartition).IsEqualTo(2);
+        await Assert.That(innerProducer.CapturedTimestamp).IsEqualTo(timestamp);
+        await Assert.That(innerProducer.CapturedCancellationToken).IsEqualTo(cts.Token);
+    }
+
+    [Test]
     public async Task FlushAsync_DelegatesToInnerProducer()
     {
         // Arrange

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -1,0 +1,132 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Serialization;
+using Dekaf.Telemetry;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class TopicProducerProduceAllBenchmarks
+{
+    private ITopicProducer<string, string> _producer = null!;
+    private TopicProducerMessage<string, string>[] _messages = null!;
+
+    [Params(1, 100)]
+    public int MessageCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _producer = new BenchmarkProducer().ForTopic("benchmark-topic");
+        _messages = Enumerable.Range(0, MessageCount)
+            .Select(static i => new TopicProducerMessage<string, string>
+            {
+                Key = i.ToString(),
+                Value = "value",
+                Partition = i % 3,
+                Timestamp = DateTimeOffset.UnixEpoch,
+            })
+            .ToArray();
+    }
+
+    [Benchmark]
+    public Task<RecordMetadata[]> ProduceAllAsync() => _producer.ProduceAllAsync(_messages);
+
+    private sealed class BenchmarkProducer : IKafkaProducer<string, string>, IProducerFastPath<string, string>
+    {
+        private static readonly RecordMetadata[] Results = [];
+        private static readonly Task<RecordMetadata[]> CompletedResults = Task.FromResult(Results);
+        private int _checksum;
+
+        public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            ProducerMessage<string, string> message,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public ValueTask<RecordMetadata> ProduceAsync(
+            string topic,
+            string? key,
+            string value,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        ValueTask<RecordMetadata> IProducerFastPath<string, string>.ProduceAsync(
+            string topic,
+            string? key,
+            string value,
+            Headers? headers,
+            int? partition,
+            DateTimeOffset? timestamp,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public ValueTask FireAsync(ProducerMessage<string, string> message) => throw new NotSupportedException();
+
+        public ValueTask FireAsync(string topic, string? key, string value) => throw new NotSupportedException();
+
+        public ValueTask FireAsync(
+            ProducerMessage<string, string> message,
+            Action<RecordMetadata, Exception?> deliveryHandler) => throw new NotSupportedException();
+
+        public Task<RecordMetadata[]> ProduceAllAsync(
+            IEnumerable<ProducerMessage<string, string>> messages,
+            CancellationToken cancellationToken = default)
+        {
+            var checksum = 0;
+            foreach (var message in messages)
+                checksum += message.Value.Length;
+
+            Volatile.Write(ref _checksum, checksum);
+            return CompletedResults;
+        }
+
+        public Task<RecordMetadata[]> ProduceAllAsync(
+            string topic,
+            IEnumerable<(string? Key, string Value)> messages,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<RecordMetadata[]> ProduceAllAsync(
+            string topic,
+            IEnumerable<TopicProducerMessage<string, string>> messages,
+            CancellationToken cancellationToken = default)
+        {
+            var checksum = 0;
+            foreach (var message in messages)
+                checksum += message.Value.Length;
+
+            Volatile.Write(ref _checksum, checksum);
+            return CompletedResults;
+        }
+
+        public ValueTask FlushAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask PurgeAsync(PurgeOptions options, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public void RegisterMetricForSubscription(ApplicationTelemetryMetric metric)
+        {
+        }
+
+        public void UnregisterMetricFromSubscription(string name)
+        {
+        }
+
+        public ITransaction<string, string> BeginTransaction() => throw new NotSupportedException();
+
+        public ValueTask InitTransactionsAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask InitTransactionsAsync(
+            bool keepPreparedTransaction,
+            CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask CompletePreparedTransactionAsync(
+            PreparedTransactionState preparedState,
+            bool committed,
+            CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ITopicProducer<string, string> ForTopic(string topic) =>
+            new TopicProducer<string, string>(this, topic, ownsProducer: false);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -180,18 +180,23 @@ public class TopicProducerProduceAllBenchmarks
 [SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
 public class TopicProducerMessageMaterializationBenchmarks
 {
+    private static readonly IComparer<TopicProducerMessage<string, string>> MessageComparer =
+        Comparer<TopicProducerMessage<string, string>>.Create(
+            static (left, right) => string.CompareOrdinal(left.Key, right.Key));
     private TopicProducerMessage<string, string>[] _messages = null!;
     private Queue<TopicProducerMessage<string, string>> _queue = null!;
     private Stack<TopicProducerMessage<string, string>> _stack = null!;
+    private SortedSet<TopicProducerMessage<string, string>> _sortedSet = null!;
 
     public enum EnumerableSource
     {
         Iterator,
         Queue,
         Stack,
+        SortedSet,
     }
 
-    [Params(1, 100)]
+    [Params(1, 2, 100)]
     public int MessageCount { get; set; }
 
     [ParamsAllValues]
@@ -205,6 +210,7 @@ public class TopicProducerMessageMaterializationBenchmarks
             .ToArray();
         _queue = new Queue<TopicProducerMessage<string, string>>(_messages);
         _stack = new Stack<TopicProducerMessage<string, string>>(_messages.Reverse());
+        _sortedSet = new SortedSet<TopicProducerMessage<string, string>>(_messages, MessageComparer);
     }
 
     [Benchmark]
@@ -222,6 +228,7 @@ public class TopicProducerMessageMaterializationBenchmarks
         EnumerableSource.Iterator => EnumerateMessages(),
         EnumerableSource.Queue => _queue,
         EnumerableSource.Stack => _stack,
+        EnumerableSource.SortedSet => _sortedSet,
         _ => throw new ArgumentOutOfRangeException(),
     };
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -43,6 +43,25 @@ public class TopicProducerProduceAllBenchmarks
     [Benchmark]
     public Task<RecordMetadata[]> ProduceAllAsync() => _producer.ProduceAllAsync(GetMessages());
 
+    [Benchmark]
+    public int MaterializeForIndexedRegistration()
+    {
+        var source = GetMessages();
+        if (source is IList<TopicProducerMessage<string, string>> messageList)
+        {
+            var listChecksum = 0;
+            for (var i = 0; i < messageList.Count; i++)
+                listChecksum += messageList[i].Value.Length;
+            return listChecksum;
+        }
+
+        using var messages = PooledReadOnlyList<TopicProducerMessage<string, string>>.Rent(source);
+        var checksum = 0;
+        for (var i = 0; i < messages.Count; i++)
+            checksum += messages[i].Value.Length;
+        return checksum;
+    }
+
     private IEnumerable<TopicProducerMessage<string, string>> GetMessages() =>
         Source is MessageSource.Array ? _messages : EnumerateMessages();
 

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -43,25 +43,6 @@ public class TopicProducerProduceAllBenchmarks
     [Benchmark]
     public Task<RecordMetadata[]> ProduceAllAsync() => _producer.ProduceAllAsync(GetMessages());
 
-    [Benchmark]
-    public int MaterializeForIndexedRegistration()
-    {
-        var source = GetMessages();
-        if (source is IList<TopicProducerMessage<string, string>> messageList)
-        {
-            var listChecksum = 0;
-            for (var i = 0; i < messageList.Count; i++)
-                listChecksum += messageList[i].Value.Length;
-            return listChecksum;
-        }
-
-        using var messages = PooledReadOnlyList<TopicProducerMessage<string, string>>.Rent(source);
-        var checksum = 0;
-        for (var i = 0; i < messages.Count; i++)
-            checksum += messages[i].Value.Length;
-        return checksum;
-    }
-
     private IEnumerable<TopicProducerMessage<string, string>> GetMessages() =>
         Source is MessageSource.Array ? _messages : EnumerateMessages();
 
@@ -192,5 +173,36 @@ public class TopicProducerProduceAllBenchmarks
             new TopicProducer<string, string>(this, topic, ownsProducer: false);
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class TopicProducerMessageMaterializationBenchmarks
+{
+    private TopicProducerMessage<string, string>[] _messages = null!;
+
+    [Params(1, 100)]
+    public int MessageCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _messages = Enumerable.Range(0, MessageCount)
+        .Select(static i => new TopicProducerMessage<string, string> { Key = i.ToString(), Value = "value" })
+        .ToArray();
+
+    [Benchmark]
+    public int MaterializeForIndexedRegistration()
+    {
+        using var messages = PooledReadOnlyList<TopicProducerMessage<string, string>>.Rent(EnumerateMessages());
+        var checksum = 0;
+        for (var i = 0; i < messages.Count; i++)
+            checksum += messages[i].Value.Length;
+        return checksum;
+    }
+
+    private IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
+    {
+        for (var i = 0; i < _messages.Length; i++)
+            yield return _messages[i];
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -181,24 +181,41 @@ public class TopicProducerProduceAllBenchmarks
 public class TopicProducerMessageMaterializationBenchmarks
 {
     private TopicProducerMessage<string, string>[] _messages = null!;
+    private Queue<TopicProducerMessage<string, string>> _queue = null!;
+
+    public enum EnumerableSource
+    {
+        Iterator,
+        Queue,
+    }
 
     [Params(1, 100)]
     public int MessageCount { get; set; }
 
+    [ParamsAllValues]
+    public EnumerableSource Source { get; set; }
+
     [GlobalSetup]
-    public void Setup() => _messages = Enumerable.Range(0, MessageCount)
-        .Select(static i => new TopicProducerMessage<string, string> { Key = i.ToString(), Value = "value" })
-        .ToArray();
+    public void Setup()
+    {
+        _messages = Enumerable.Range(0, MessageCount)
+            .Select(static i => new TopicProducerMessage<string, string> { Key = i.ToString(), Value = "value" })
+            .ToArray();
+        _queue = new Queue<TopicProducerMessage<string, string>>(_messages);
+    }
 
     [Benchmark]
     public int MaterializeForIndexedRegistration()
     {
-        using var messages = PooledReadOnlyList<TopicProducerMessage<string, string>>.Rent(EnumerateMessages());
+        using var messages = PooledReadOnlyList<TopicProducerMessage<string, string>>.Rent(GetMessages());
         var checksum = 0;
         for (var i = 0; i < messages.Count; i++)
             checksum += messages[i].Value.Length;
         return checksum;
     }
+
+    private IEnumerable<TopicProducerMessage<string, string>> GetMessages() =>
+        Source is EnumerableSource.Iterator ? EnumerateMessages() : _queue;
 
     private IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -182,11 +182,13 @@ public class TopicProducerMessageMaterializationBenchmarks
 {
     private TopicProducerMessage<string, string>[] _messages = null!;
     private Queue<TopicProducerMessage<string, string>> _queue = null!;
+    private Stack<TopicProducerMessage<string, string>> _stack = null!;
 
     public enum EnumerableSource
     {
         Iterator,
         Queue,
+        Stack,
     }
 
     [Params(1, 100)]
@@ -202,6 +204,7 @@ public class TopicProducerMessageMaterializationBenchmarks
             .Select(static i => new TopicProducerMessage<string, string> { Key = i.ToString(), Value = "value" })
             .ToArray();
         _queue = new Queue<TopicProducerMessage<string, string>>(_messages);
+        _stack = new Stack<TopicProducerMessage<string, string>>(_messages.Reverse());
     }
 
     [Benchmark]
@@ -214,8 +217,13 @@ public class TopicProducerMessageMaterializationBenchmarks
         return checksum;
     }
 
-    private IEnumerable<TopicProducerMessage<string, string>> GetMessages() =>
-        Source is EnumerableSource.Iterator ? EnumerateMessages() : _queue;
+    private IEnumerable<TopicProducerMessage<string, string>> GetMessages() => Source switch
+    {
+        EnumerableSource.Iterator => EnumerateMessages(),
+        EnumerableSource.Queue => _queue,
+        EnumerableSource.Stack => _stack,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
 
     private IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/TopicProducerProduceAllBenchmarks.cs
@@ -13,13 +13,22 @@ public class TopicProducerProduceAllBenchmarks
     private ITopicProducer<string, string> _producer = null!;
     private TopicProducerMessage<string, string>[] _messages = null!;
 
+    public enum MessageSource
+    {
+        Array,
+        Enumerable,
+    }
+
     [Params(1, 100)]
     public int MessageCount { get; set; }
+
+    [ParamsAllValues]
+    public MessageSource Source { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
-        _producer = new BenchmarkProducer().ForTopic("benchmark-topic");
+        _producer = new BenchmarkProducer(MessageCount).ForTopic("benchmark-topic");
         _messages = Enumerable.Range(0, MessageCount)
             .Select(static i => new TopicProducerMessage<string, string>
             {
@@ -32,13 +41,23 @@ public class TopicProducerProduceAllBenchmarks
     }
 
     [Benchmark]
-    public Task<RecordMetadata[]> ProduceAllAsync() => _producer.ProduceAllAsync(_messages);
+    public Task<RecordMetadata[]> ProduceAllAsync() => _producer.ProduceAllAsync(GetMessages());
+
+    private IEnumerable<TopicProducerMessage<string, string>> GetMessages() =>
+        Source is MessageSource.Array ? _messages : EnumerateMessages();
+
+    private IEnumerable<TopicProducerMessage<string, string>> EnumerateMessages()
+    {
+        for (var i = 0; i < _messages.Length; i++)
+            yield return _messages[i];
+    }
 
     private sealed class BenchmarkProducer : IKafkaProducer<string, string>, IProducerFastPath<string, string>
     {
-        private static readonly RecordMetadata[] Results = [];
-        private static readonly Task<RecordMetadata[]> CompletedResults = Task.FromResult(Results);
+        private readonly int _expectedCount;
         private int _checksum;
+
+        public BenchmarkProducer(int expectedCount) => _expectedCount = expectedCount;
 
         public ValueTask InitializeAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
@@ -73,12 +92,18 @@ public class TopicProducerProduceAllBenchmarks
             IEnumerable<ProducerMessage<string, string>> messages,
             CancellationToken cancellationToken = default)
         {
+            var results = new RecordMetadata[_expectedCount];
             var checksum = 0;
+            var index = 0;
             foreach (var message in messages)
+            {
                 checksum += message.Value.Length;
+                results[index] = CreateMetadata(index++);
+            }
 
+            ValidateCount(index);
             Volatile.Write(ref _checksum, checksum);
-            return CompletedResults;
+            return Task.FromResult(results);
         }
 
         public Task<RecordMetadata[]> ProduceAllAsync(
@@ -91,12 +116,32 @@ public class TopicProducerProduceAllBenchmarks
             IEnumerable<TopicProducerMessage<string, string>> messages,
             CancellationToken cancellationToken = default)
         {
+            var results = new RecordMetadata[_expectedCount];
             var checksum = 0;
+            var index = 0;
             foreach (var message in messages)
+            {
                 checksum += message.Value.Length;
+                results[index] = CreateMetadata(index++);
+            }
 
+            ValidateCount(index);
             Volatile.Write(ref _checksum, checksum);
-            return CompletedResults;
+            return Task.FromResult(results);
+        }
+
+        private static RecordMetadata CreateMetadata(int index) => new()
+        {
+            Topic = "benchmark-topic",
+            Partition = index % 3,
+            Offset = index,
+            Timestamp = DateTimeOffset.UnixEpoch,
+        };
+
+        private void ValidateCount(int count)
+        {
+            if (count != _expectedCount)
+                throw new InvalidOperationException($"Expected {_expectedCount} messages but received {count}.");
         }
 
         public ValueTask FlushAsync(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;


### PR DESCRIPTION
## Problem  `TopicProducer.ProduceAllAsync(IEnumerable<TopicProducerMessage<TKey,TValue>>)` projected every item through LINQ into a new `ProducerMessage`. That added an iterator, an async wrapper, and one heap object per message before the producer hot path.  ## Change  - Add an internal topic-bound batch fast path that consumes `TopicProducerMessage` directly. - Preserve headers, partition, timestamp, input ordering, cancellation, bulk-produce scope, and `ProduceAllCompletion` behavior. - Keep `IList<T>` inputs on the direct indexed path. - Replace the non-indexed `ToList()` fallback with pooled storage: the first enumerated item stays inline; larger iterators rent one array; `ICollection<T>` sources use `Count` + `CopyTo`; Queue uses a measured concrete zero-allocation path. - Return pooled storage if aggregate-completion or bulk-scope setup throws. - Avoid boxing BCL struct enumerators for Queue, Stack, LinkedList, HashSet, and SortedSet shapes. - Add real-`KafkaProducer` synchronous-registration failure coverage, pooled growth/Queue ordering coverage, and per-message spy result/order assertions. - Make the benchmark producer return one ordered `RecordMetadata` per input, so result creation and the API contract are included.  Non-Dekaf `IKafkaProducer` implementations retain the existing compatibility fallback.  ## Benchmark  BenchmarkDotNet 0.15.8, .NET 10.0.10, i7-12700K, 1 launch / 3 warmups / 5 measured iterations. Baseline `e0cb0e67`; candidate `7f540f2c`.  ### Public TopicProducer batch API  Identical benchmark source on baseline and candidate. The synchronous producer stub consumes every message, builds an ordered result array with one metadata value per input, and keeps a checksum observable.  | Messages | Source | Baseline | Candidate | Time delta | Baseline alloc | Candidate alloc | Alloc delta | |---:|---|---:|---:|---:|---:|---:|---:| | 1 | array | 50.74 ns | 22.04 ns | -56.6% | 408 B | 144 B | -64.7% | | 1 | non-`IList` enumerable | 59.09 ns | 26.89 ns | -54.5% | 464 B | 192 B | -58.6% | | 100 | array | 2,006.73 ns | 1,291.89 ns | -35.6% | 13,080 B | 4,896 B | -62.6% | | 100 | non-`IList` enumerable | 2,146.70 ns | 1,370.70 ns | -36.2% | 13,136 B | 4,944 B | -62.4% |  Remaining allocation is contract-required result-array/`Task` creation; enumerable rows also include the caller-owned iterator.  ### Non-indexed registration storage  This isolates the reviewed non-`IList` fallback: baseline uses the original `ToList()` behavior; candidate uses the production pooled buffer. Iterator covers a reference-type yield enumerator. Queue covers a BCL struct enumerator that would box through `IEnumerable<T>`.  | Messages | Source | Baseline | Candidate | Time delta | Baseline alloc | Candidate alloc | Alloc delta | |---:|---|---:|---:|---:|---:|---:|---:| | 1 | iterator | 19.505 ns | 15.272 ns | -21.7% | 136 B | 48 B | -64.7% | | 1 | Queue | 12.229 ns | 1.630 ns | -86.7% | 88 B | 0 B | -100% | | 100 | iterator | 410.066 ns | 331.851 ns | -19.1% | 2,240 B | 48 B | -97.9% | | 100 | Queue | 330.172 ns | 66.694 ns | -79.8% | 2,192 B | 0 B | -100% |  The iterator candidate's 48 B is solely the benchmark's caller-owned yield iterator. Client storage is 0 B after warmup; Queue is 0 B end-to-end for this materialization step.  ### Stack specialization  This compares the immediately preceding candidate `57c59ec3` with `7f540f2c` after review found multi-item `Stack<T>` still boxed its struct enumerator.  | Messages | Before | After | Time delta | Before alloc | After alloc | |---:|---:|---:|---:|---:|---:| | 1 | 3.623 ns | 3.738 ns | confidence intervals overlap | 0 B | 0 B | | 100 | 348.157 ns | 231.527 ns | -33.5% | 40 B | 0 B | ## Review hardening (commit `438bbd00`)

The review audit found five correctness/performance edges and they are now covered:

- Cache mutable `IList<T>.Count` once so registration cannot strand aggregate completion.
- Preserve arbitrary `ICollection<T>` enumeration order instead of assuming `CopyTo` order.
- Return rented arrays when enumerator disposal throws.
- Use `SortedSet<T>.Min` for allocation-free singleton materialization.
- Clear only occupied pooled slots; never clear the unused tail of a 128+ element bucket.

Exact benchmark shape on predecessor `71ed13f9` and candidate `438bbd00`; candidate → baseline → candidate control, same machine/runtime/configuration.

| Count | Source | Before | After | Time delta | Before alloc | After alloc |
|---:|---|---:|---:|---:|---:|---:|
| 1 | Iterator | 14.520 ns | 13.528 ns | -6.8% | 48 B | 48 B |
| 1 | Queue | 2.534 ns | 2.625 ns | CI overlaps | 0 B | 0 B |
| 1 | Stack | 3.834 ns | 3.632 ns | -5.3% | 0 B | 0 B |
| 1 | SortedSet | 26.459 ns | 6.680 ns | -74.8% | 72 B | 0 B |
| 2 | Iterator | 38.513 ns | 27.619 ns | -28.3% | 48 B | 48 B |
| 2 | Queue | 26.876 ns | 13.270 ns | -50.6% | 0 B | 0 B |
| 2 | Stack | 27.935 ns | 16.960 ns | -39.3% | 0 B | 0 B |
| 2 | SortedSet | 51.795 ns | 37.639 ns | -27.3% | 168 B | 168 B |
| 100 | Iterator | 383.275 ns | 346.158 ns | -9.7% | 48 B | 48 B |
| 100 | Queue | 62.475 ns | 60.537 ns | -3.1% | 0 B | 0 B |
| 100 | Stack | 225.285 ns | 224.559 ns | CI overlaps | 0 B | 0 B |
| 100 | SortedSet | 618.005 ns | 543.143 ns | -12.1% | 248 B | 248 B |

Iterator's 48 B and multi-item SortedSet allocations are source/runtime traversal allocations, unchanged by pooled client storage.

`SortedSet<T>` follow-up audit: .NET's public `CopyTo` uses a per-walk delegate plus tree stack. A concrete struct-enumerator candidate reduced 2/100-item allocation from `168→72 B` / `248→152 B`, but regressed 100-item time from `543→1,135 ns` (+109%), so it was rejected under the Pareto gate. The remaining allocation is once per input batch (not per message); .NET exposes no span/indexed traversal API. Runtime source: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs An intermediate forced-inline/whole-bucket-clear candidate was rejected after the paired control showed collection timing regressions; the final clear-live-slots implementation restores or improves every protected row.
## Validation  - Release build, `net10.0` + `netstandard2.0`: 0 warnings/errors - full net10 unit suite: 6,628/6,628 passed - Kafka 4.3.1 `TopicProducerTests`: 15/15 passed - synchronous failure/abort tests: 3/3 passed - pooled iterator + Queue + Stack + ICollection count/order tests: 4/4 passed - empty IList + non-IList fast-path tests: 2/2 passed
- `/simplify`: reviewed; direct loops and concrete Queue `CopyTo` remain because generic interface dispatch measured 40 B/op  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added efficient asynchronous batch message production with cancellation support.
  * Batch operations return metadata for all produced records and complete immediately for empty batches.
  * Added support for producing messages from enumerable sources.

* **Bug Fixes**
  * Batch production now uses the optimized path when available.
  * Preserved message metadata, topic information, and cancellation handling.
  * Improved handling of synchronous production failures and completion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final review follow-up (`35be03b9`)

- Exact-count BCL sources now call `ArrayPool<T>.Shared.Rent(count)` instead of requesting at least 128 slots. For a two-item source this changes the request `128 → 2` (the current shared-pool bucket is 16).
- If enumeration and `IEnumerator<T>.Dispose()` both throw, the original enumeration failure now remains observable and the occupied pooled span is returned first.
- Added a deterministic two-item enumeration+dispose failure test; focused suite passes `8/8`.
- `/simplify` retained the duplicated list/pooled registration loops intentionally: a delegate or interface abstraction would add dispatch/allocation risk to the producer hot path.

Same-machine BenchmarkDotNet comparison, predecessor `438bbd00` → `35be03b9`, .NET 10.0.10, 1 launch / 3 warmups / 5 measured iterations:

| Count | Source | Before | After | Delta | Allocation |
|---:|---|---:|---:|---:|---:|
| 1 | Iterator | 14.699 ns | 14.734 ns | +0.2% | 48 B → 48 B |
| 1 | Queue | 2.669 ns | 2.605 ns | -2.4% | 0 B → 0 B |
| 1 | Stack | 3.697 ns | 3.594 ns | -2.8% | 0 B → 0 B |
| 1 | SortedSet | 6.772 ns | 6.793 ns | +0.3% | 0 B → 0 B |
| 2 | Iterator | 26.802 ns | 28.789 ns | CI overlaps | 48 B → 48 B |
| 2 | Queue | 13.374 ns | 12.885 ns | -3.7% | 0 B → 0 B |
| 2 | Stack | 17.400 ns | 17.275 ns | -0.7% | 0 B → 0 B |
| 2 | SortedSet | 41.118 ns | 40.960 ns | -0.4% | 168 B → 168 B |
| 100 | Iterator | 347.850 ns | 353.292 ns | CI overlaps | 48 B → 48 B |
| 100 | Queue | 61.726 ns | 61.299 ns | -0.7% | 0 B → 0 B |
| 100 | Stack | 225.872 ns | 227.117 ns | CI overlaps | 0 B → 0 B |
| 100 | SortedSet | 614.628 ns | 610.280 ns | -0.7% | 248 B → 248 B |

No material protected-metric regression; all exact-count two-item source rows improve while retaining their allocation results.
## Exact-head validation after main sync (`70b48dcd`)

Merged current `main` (including #2551) and revalidated on Windows 11 / i7-12700K / .NET 10.0.10. Release build: 0 warnings/errors; focused producer tests: 37/37 passed.

Public API benchmark:

| Messages | Source | Mean | Allocated |
|---:|---|---:|---:|
| 1 | Array | 22.97 ns | 144 B |
| 1 | Enumerable | 26.28 ns | 192 B |
| 100 | Array | 1,345.85 ns | 4,896 B |
| 100 | Enumerable | 1,474.21 ns | 4,944 B |

Compared with pre-sync candidate `35be03b9`, allocations are identical and all timing confidence intervals overlap.

Materialization allocation audit on the exact head:

| Count | Iterator | Queue | Stack | SortedSet |
|---:|---:|---:|---:|---:|
| 1 | 48 B | 0 B | 0 B | 0 B |
| 2 | 48 B | 0 B | 0 B | 168 B |
| 100 | 48 B | 0 B | 0 B | 248 B |

The iterator bytes are caller-owned yield-enumerator allocation. The multi-item `SortedSet<T>` bytes are its BCL traversal storage, unchanged from the predecessor and already disclosed above; Dekaf's pooled destination remains allocation-free. Fresh exact-head CI is running.
### Exact-head review follow-up (`a2e2404d`)

Added deterministic multi-item count/order coverage for the specialized `HashSet<T>` and `SortedSet<T>` materialization branches requested by exact-head review. This is test-only; the `70b48dcd` exact-head benchmark remains valid. Release build: 0 warnings/errors; `PooledReadOnlyListTests`: 10/10 passed.
Final exact-head validation: [CI run 31511274615](https://github.com/thomhurst/Dekaf/actions/runs/31511274615) fully passed, including producer, consume, faults, messaging, TLS, security, NativeAOT, leak gates, unit tests, code quality, and the final `CI Passed` aggregate. Exact-head automated review is `CLEAR`.
