### PR TITLE
perf(producer): eliminate disabled debug-log closures

### DIFF
--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
@@ -2993,10 +2994,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                     // Diagnostic: log response content and expected batches for mismatch diagnosis
                     if (_logger.IsEnabled(LogLevel.Debug))
                     {
-                        var batchKeys = string.Join(", ",
-                            Enumerable.Range(0, count)
-                                .Where(idx => batches[idx] is not null)
-                                .Select(idx => $"{batches[idx].TopicPartition.Topic}-{batches[idx].TopicPartition.Partition}"));
+                        var batchKeys = FormatBatchKeys(batches, count);
                         var respKeys = directResponse is not null
                             ? $"{batches[0].TopicPartition.Topic}-{directResponse.Value.Index}"
                             : responseLookup is not null
@@ -3970,10 +3968,7 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 // This traces which batches are paired with which response task.
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    var pipelinedPartitions = string.Join(", ",
-                        Enumerable.Range(0, count)
-                            .Where(i => batches[i] is not null)
-                            .Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
+                    var pipelinedPartitions = FormatBatchKeys(batches, count);
                     LogPendingResponseCreated(_instanceId, _brokerId, responseTask.Id, count, pipelinedPartitions);
                 }
 
@@ -4165,6 +4160,26 @@ internal sealed partial class BrokerSender : IAsyncDisposable
                 ArrayPool<int>.Shared.Return(generations);
             }
         }
+    }
+
+    internal static string FormatBatchKeys(ReadyBatch[] batches, int count)
+    {
+        var result = new StringBuilder();
+        for (var i = 0; i < count; i++)
+        {
+            var batch = batches[i];
+            if (batch is null)
+                continue;
+
+            if (result.Length > 0)
+                result.Append(", ");
+
+            result.Append(batch.TopicPartition.Topic)
+                .Append('-')
+                .Append(batch.TopicPartition.Partition);
+        }
+
+        return result.ToString();
     }
 
     internal static bool IsFatalAuthenticationFailure(

--- a/src/Dekaf/Producer/BrokerSender.cs
+++ b/src/Dekaf/Producer/BrokerSender.cs
@@ -1,10 +1,10 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks.Sources;
 using Dekaf.Compression;
@@ -4164,22 +4164,77 @@ internal sealed partial class BrokerSender : IAsyncDisposable
 
     internal static string FormatBatchKeys(ReadyBatch[] batches, int count)
     {
-        var result = new StringBuilder();
+        var length = 0;
         for (var i = 0; i < count; i++)
         {
             var batch = batches[i];
             if (batch is null)
                 continue;
 
-            if (result.Length > 0)
-                result.Append(", ");
+            if (length > 0)
+                length += 2;
 
-            result.Append(batch.TopicPartition.Topic)
-                .Append('-')
-                .Append(batch.TopicPartition.Partition);
+            length = checked(length + batch.TopicPartition.Topic.Length + 1);
+            length = checked(length + GetPartitionFormattedLength(batch.TopicPartition.Partition));
         }
 
-        return result.ToString();
+        if (length == 0)
+            return string.Empty;
+
+        return string.Create(
+            length,
+            (Batches: batches, Count: count),
+            static (destination, state) =>
+            {
+                var position = 0;
+                for (var i = 0; i < state.Count; i++)
+                {
+                    var batch = state.Batches[i];
+                    if (batch is null)
+                        continue;
+
+                    if (position > 0)
+                    {
+                        destination[position++] = ',';
+                        destination[position++] = ' ';
+                    }
+
+                    var topic = batch.TopicPartition.Topic;
+                    topic.AsSpan().CopyTo(destination[position..]);
+                    position += topic.Length;
+                    destination[position++] = '-';
+
+                    if (!batch.TopicPartition.Partition.TryFormat(
+                            destination[position..],
+                            out var partitionLength,
+                            provider: CultureInfo.CurrentCulture))
+                        throw new InvalidOperationException("Partition could not be formatted.");
+
+                    position += partitionLength;
+                }
+            });
+    }
+
+    private static int GetPartitionFormattedLength(int partition)
+    {
+        var magnitude = partition < 0 ? (uint)-(long)partition : (uint)partition;
+        var digitCount = magnitude switch
+        {
+            >= 1_000_000_000 => 10,
+            >= 100_000_000 => 9,
+            >= 10_000_000 => 8,
+            >= 1_000_000 => 7,
+            >= 100_000 => 6,
+            >= 10_000 => 5,
+            >= 1_000 => 4,
+            >= 100 => 3,
+            >= 10 => 2,
+            _ => 1,
+        };
+
+        return partition < 0
+            ? checked(digitCount + NumberFormatInfo.CurrentInfo.NegativeSign.Length)
+            : digitCount;
     }
 
     internal static bool IsFatalAuthenticationFailure(

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderDiagnosticFormattingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderDiagnosticFormattingTests.cs
@@ -1,0 +1,33 @@
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class BrokerSenderDiagnosticFormattingTests
+{
+    [Test]
+    public async Task FormatBatchKeys_SkipsEmptySlotsAndPreservesOrder()
+    {
+        var first = CreateBatch("orders", 2);
+        var second = CreateBatch("payments", 7);
+        ReadyBatch[] batches = [first, null!, second];
+
+        var result = BrokerSender.FormatBatchKeys(batches, batches.Length);
+
+        await Assert.That(result).IsEqualTo("orders-2, payments-7");
+    }
+
+    private static ReadyBatch CreateBatch(string topic, int partition)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = [] },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            recordCount: 0,
+            dataSize: 0);
+        return batch;
+    }
+}

--- a/tests/Dekaf.Tests.Unit/Producer/BrokerSenderDiagnosticFormattingTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/BrokerSenderDiagnosticFormattingTests.cs
@@ -18,6 +18,18 @@ public class BrokerSenderDiagnosticFormattingTests
         await Assert.That(result).IsEqualTo("orders-2, payments-7");
     }
 
+    [Test]
+    public async Task FormatBatchKeys_FormatsPartitionExtremes()
+    {
+        var minimum = CreateBatch("minimum", int.MinValue);
+        var maximum = CreateBatch("maximum", int.MaxValue);
+        ReadyBatch[] batches = [minimum, maximum];
+
+        var result = BrokerSender.FormatBatchKeys(batches, batches.Length);
+
+        await Assert.That(result).IsEqualTo($"minimum-{int.MinValue}, maximum-{int.MaxValue}");
+    }
+
     private static ReadyBatch CreateBatch(string topic, int partition)
     {
         var batch = new ReadyBatch();

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerSenderDiagnosticFormattingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerSenderDiagnosticFormattingBenchmarks.cs
@@ -3,6 +3,8 @@ using BenchmarkDotNet.Engines;
 using Dekaf.Producer;
 using Dekaf.Protocol;
 using Dekaf.Protocol.Records;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -31,6 +33,68 @@ public class BrokerSenderDiagnosticFormattingBenchmarks
 
     [Benchmark]
     public string IndexedStringCreate() => BrokerSender.FormatBatchKeys(_batches, BatchCount);
+
+    private static ReadyBatch CreateBatch(string topic, int partition)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = [] },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            recordCount: 0,
+            dataSize: 0);
+        return batch;
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class BrokerSenderDisabledDebugLoggingBenchmarks
+{
+    private readonly ILogger _logger = NullLogger.Instance;
+    private ReadyBatch[] _batches = null!;
+    private string _sink = string.Empty;
+
+    [Params(16)]
+    public int BatchCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _batches = new ReadyBatch[BatchCount];
+        for (var i = 0; i < BatchCount; i++)
+            _batches[i] = CreateBatch("benchmark-topic", i);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int DisabledOriginalCallSite()
+    {
+        var batches = _batches;
+        var count = BatchCount;
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _sink = string.Join(", ",
+                Enumerable.Range(0, count)
+                    .Where(i => batches[i] is not null)
+                    .Select(i => $"{batches[i].TopicPartition.Topic}-{batches[i].TopicPartition.Partition}"));
+        }
+
+        return batches.Length + count + _sink.Length;
+    }
+
+    [Benchmark]
+    public int DisabledCurrentCallSite()
+    {
+        var batches = _batches;
+        var count = BatchCount;
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _sink = BrokerSender.FormatBatchKeys(batches, count);
+
+        return batches.Length + count + _sink.Length;
+    }
 
     private static ReadyBatch CreateBatch(string topic, int partition)
     {

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerSenderDiagnosticFormattingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/BrokerSenderDiagnosticFormattingBenchmarks.cs
@@ -1,0 +1,47 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+using Dekaf.Protocol;
+using Dekaf.Protocol.Records;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class BrokerSenderDiagnosticFormattingBenchmarks
+{
+    private ReadyBatch[] _batches = null!;
+
+    [Params(16)]
+    public int BatchCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _batches = new ReadyBatch[BatchCount];
+        for (var i = 0; i < BatchCount; i++)
+            _batches[i] = CreateBatch("benchmark-topic", i);
+    }
+
+    [Benchmark(Baseline = true)]
+    public string CapturingLinq() => string.Join(", ",
+        Enumerable.Range(0, BatchCount)
+            .Where(i => _batches[i] is not null)
+            .Select(i => $"{_batches[i].TopicPartition.Topic}-{_batches[i].TopicPartition.Partition}"));
+
+    [Benchmark]
+    public string IndexedStringCreate() => BrokerSender.FormatBatchKeys(_batches, BatchCount);
+
+    private static ReadyBatch CreateBatch(string topic, int partition)
+    {
+        var batch = new ReadyBatch();
+        batch.Initialize(
+            new TopicPartition(topic, partition),
+            new RecordBatch { Records = [] },
+            completionSourcesArray: null,
+            completionSourcesCount: 0,
+            recordCount: 0,
+            dataSize: 0);
+        return batch;
+    }
+}


### PR DESCRIPTION
## Problem  Two Debug-only diagnostic formatters used capturing LINQ lambdas inside hot `BrokerSender` methods. The compiler allocated `BrokerSender+<>c__DisplayClass183_0` before the Debug-level guard, so normal Warning-level production traffic paid for a closure that was never used.  ## Change  Move batch-key formatting to one indexed helper and remove both capturing LINQ pipelines. The helper runs only after `ILogger.IsEnabled(LogLevel.Debug)` succeeds. Log text and batch order remain unchanged; null pooled-array slots are still skipped.  ## Profile  `dotnet-trace --profile gc-verbose`, 15.1 seconds, producer stress, Dekaf, 1 broker, 1 KB messages, Debug logging disabled. Baseline and candidate both use main SHA `6e9e017a` plus only this patch.  | Allocation type | Baseline sampled | Candidate sampled | Sampled rate | |---|---:|---:|---:| | `BrokerSender+<>c__DisplayClass183_0` | 622.17 KB / 6 ticks | 0 B / 0 ticks | 41.11 KB/s → 0 |  `GCAllocationTick` samples at roughly 100 KB. Candidate reflection also confirms the compiled `BrokerSender` contains no `DisplayClass183` type, so the removed closure cannot allocate below the sampling threshold.  ## Benchmark

BenchmarkDotNet 0.15.8, .NET 10.0.10, i7-12700K, `[MemoryDiagnoser]`, 1 launch / 3 warmups / 5 measured iterations. One run compares the removed capturing-LINQ formatter with candidate `cc143873`'s production `FormatBatchKeys` for 16 batches.

| Formatter | Mean | Allocated | Time delta | Alloc delta |
|---|---:|---:|---:|---:|
| capturing LINQ (before) | 455.6 ns | 1,872 B | — | — |
| indexed `string.Create` (after) | 108.7 ns | 640 B | -76.1% | -65.8% |


### Disabled Debug call site (review proof)

Candidate `6a0791c7` adds a second `[MemoryDiagnoser]` benchmark that mirrors the real `IsEnabled(LogLevel.Debug)` guard and keeps method-local `batches`/`count` live outside the guard. That reproduces the original compiler-generated display class instead of capturing a benchmark field.

| Disabled call shape | Mean | Allocated | Time delta | Alloc delta |
|---|---:|---:|---:|---:|
| original method-local capturing LINQ | 2.516 ns | 24 B | — | — |
| current guarded indexed helper | 0.026 ns* | 0 B | -99.0% | -100% |

`*` BenchmarkDotNet reports the candidate as indistinguishable from empty-method overhead. The required hot-path result is exact: disabled Debug logging falls from `24 B/op` to `0 B/op`.
The remaining 640 B is the required formatted result string. An intermediate `StringBuilder` candidate was rejected because it improved time but increased Debug-enabled allocation to 2.05 KB.
## Validation  - `BrokerSenderDiagnosticFormattingTests` + `BrokerSenderSendLoopTests`: 76/76 passed - Unit Release build: 0 warnings/errors - `/simplify`: reviewed; indexed diagnostic helper retained to keep LINQ and closures out of hot methods  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic messages for batch processing and pipelined sends.
  * Batch keys now preserve their original order while ignoring empty entries.
  * Improved formatting for partition values, including minimum and maximum values.
* **Tests**
  * Added coverage for batch-key diagnostic formatting, including null and empty batch slots.
* **Performance**
  * Reduced overhead when generating diagnostic batch-key information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->