### PR TITLE
perf(consumer): remove exception-based fetch timeouts

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -9345,6 +9345,8 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             prefetched.Dispose();
         }
 
+        _prefetchBuffer.Dispose();
+
         _fetchBufferMemoryPool.Dispose();
 
         _assignmentLock.Dispose();

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -9345,7 +9345,7 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             prefetched.Dispose();
         }
 
-        _prefetchBuffer.Dispose();
+        _prefetchBuffer.Dispose(prefetchTask);
 
         _fetchBufferMemoryPool.Dispose();
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -315,6 +315,7 @@ internal sealed class MpscFetchBuffer
                 return new ValueTask<bool>(HasDataAvailable());
             }
 
+            Debug.Assert(!_readWaiterActive, "MpscFetchBuffer supports one active reader.");
             _readWaiterActive = true;
             return _readWaiter.Prepare(timeoutMs);
         }
@@ -390,6 +391,7 @@ internal sealed class MpscFetchBuffer
         private bool _queuedResult;
         private Exception? _queuedException;
         private int _cancellationRequested;
+        private bool _disposed;
 
         public ReadWaiter(MpscFetchBuffer owner)
         {
@@ -566,8 +568,30 @@ internal sealed class MpscFetchBuffer
 
         public void Dispose()
         {
-            _cancellationRegistration.Dispose();
-            _timeoutTimer?.Dispose();
+            CancellationTokenRegistration cancellationRegistration;
+            Timer? timeoutTimer;
+
+            lock (_owner._dataAvailableWaiterLock)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+
+                // Dispose may race the caller consuming the pending ValueTask. Complete it
+                // before tearing down its only wake-up sources, then detach the timer so the
+                // eventual GetResult cleanup cannot call Change on a disposed instance.
+                if (_owner._readWaiterActive)
+                    TrySetSignal();
+
+                cancellationRegistration = _cancellationRegistration;
+                _cancellationRegistration = default;
+                timeoutTimer = _timeoutTimer;
+                _timeoutTimer = null;
+            }
+
+            cancellationRegistration.Dispose();
+            timeoutTimer?.Dispose();
         }
     }
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -400,9 +400,8 @@ internal sealed class MpscFetchBuffer
 
         public void SetCancellationToken(CancellationToken cancellationToken)
         {
-            if (cancellationToken == _cancellationToken)
-                return;
-
+            // CancellationTokenSource.TryReset clears registrations without changing token
+            // identity, so equality cannot prove that the previous registration is still live.
             _cancellationRegistration.Dispose();
             _cancellationToken = cancellationToken;
             Volatile.Write(ref _cancellationRequested, cancellationToken.IsCancellationRequested ? 1 : 0);

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -518,13 +518,15 @@ internal sealed class MpscFetchBuffer
                     }
 
                     _completed = true;
+                    _queuedResult = false;
+                    _queuedException = null;
                 }
 
                 // Completing inline while holding the owner lock can deadlock: the continuation
                 // may dispose a linked CTS and wait for a cancellation callback that needs the
                 // same lock. Publish completion only after releasing it.
                 _owner._beforeConsumerTimeoutCompletionForTesting?.Invoke();
-                _core.SetResult(false);
+                QueueCompletion();
             }
             finally
             {

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -465,7 +465,7 @@ internal sealed class MpscFetchBuffer
         private void QueueCompletion()
         {
 #if NET10_0_OR_GREATER
-            if (!ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: true))
+            if (!ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false))
                 ExecuteQueuedCompletion();
 #else
             if (!ThreadPool.QueueUserWorkItem(static state => ((ReadWaiter)state!).ExecuteQueuedCompletion(), this))

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -521,6 +521,8 @@ internal sealed class MpscFetchBuffer
             if (!ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false))
                 ExecuteQueuedCompletion();
 #else
+            // The compatibility reference asset cannot access IThreadPoolWorkItem. Dekaf's
+            // supported .NET 10+ runtime selects the allocation-free net10.0 asset above.
             if (!ThreadPool.QueueUserWorkItem(static state => ((ReadWaiter)state!).ExecuteQueuedCompletion(), this))
                 ExecuteQueuedCompletion();
 #endif

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -34,9 +34,11 @@ internal sealed class MpscFetchBuffer
     private readonly Action? _beforeConsumerTimeoutForTesting;
     private readonly Action? _afterConsumerTimeoutForTesting;
     private readonly Action? _beforeConsumerTimeoutCompletionForTesting;
+    private readonly Action? _afterConsumerCancellationRegisteredForTesting;
     private bool _readWaiterActive;
     private int _producerWaiterCount;
     private int _consumerWaiting;
+    private int _producerSignalsDisposed;
     private volatile bool _completed;
     private volatile Exception? _completionError;
 
@@ -48,7 +50,8 @@ internal sealed class MpscFetchBuffer
             afterProducerSlotReservedForTesting: null,
             beforeConsumerTimeoutForTesting: null,
             afterConsumerTimeoutForTesting: null,
-            beforeConsumerTimeoutCompletionForTesting: null)
+            beforeConsumerTimeoutCompletionForTesting: null,
+            afterConsumerCancellationRegisteredForTesting: null)
     {
     }
 
@@ -59,7 +62,8 @@ internal sealed class MpscFetchBuffer
         Action<long>? afterProducerSlotReservedForTesting = null,
         Action? beforeConsumerTimeoutForTesting = null,
         Action? afterConsumerTimeoutForTesting = null,
-        Action? beforeConsumerTimeoutCompletionForTesting = null)
+        Action? beforeConsumerTimeoutCompletionForTesting = null,
+        Action? afterConsumerCancellationRegisteredForTesting = null)
     {
         if (capacity < 1)
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
@@ -80,6 +84,7 @@ internal sealed class MpscFetchBuffer
         _beforeConsumerTimeoutForTesting = beforeConsumerTimeoutForTesting;
         _afterConsumerTimeoutForTesting = afterConsumerTimeoutForTesting;
         _beforeConsumerTimeoutCompletionForTesting = beforeConsumerTimeoutCompletionForTesting;
+        _afterConsumerCancellationRegisteredForTesting = afterConsumerCancellationRegisteredForTesting;
         _readWaiter = new ReadWaiter(this);
     }
 
@@ -96,6 +101,8 @@ internal sealed class MpscFetchBuffer
     }
 
     internal int ProducerWaiterCount => Volatile.Read(ref _producerWaiterCount);
+
+    internal bool ProducerSignalsDisposedForTesting => Volatile.Read(ref _producerSignalsDisposed) != 0;
 
     /// <summary>
     /// Attempts to write an item. Safe for concurrent callers (multiple prefetch tasks).
@@ -294,7 +301,10 @@ internal sealed class MpscFetchBuffer
             spin.SpinOnce();
         }
 
-        _readWaiter.SetCancellationToken(cancellationToken);
+        if (!_readWaiter.TrySetCancellationToken(cancellationToken))
+            return new ValueTask<bool>(false);
+
+        _afterConsumerCancellationRegisteredForTesting?.Invoke();
         Volatile.Write(ref _consumerWaiting, 1);
         Interlocked.MemoryBarrier();
 
@@ -313,6 +323,12 @@ internal sealed class MpscFetchBuffer
                 if (_completionError is not null)
                     throw _completionError;
                 return new ValueTask<bool>(HasDataAvailable());
+            }
+
+            if (_readWaiter.IsDisposed)
+            {
+                Volatile.Write(ref _consumerWaiting, 0);
+                return new ValueTask<bool>(false);
             }
 
             Debug.Assert(!_readWaiterActive, "MpscFetchBuffer supports one active reader.");
@@ -361,9 +377,36 @@ internal sealed class MpscFetchBuffer
         }
     }
 
-    internal void Dispose()
+    internal void Dispose(Task? producerTask = null)
     {
         _readWaiter.Dispose();
+
+        if (producerTask is { IsCompleted: false })
+        {
+            _ = producerTask.ContinueWith(
+                static (task, state) =>
+                {
+                    _ = task.Exception;
+                    ((MpscFetchBuffer)state!).DisposeProducerSignals();
+                },
+                this,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            return;
+        }
+
+        if (producerTask?.IsFaulted is true)
+            _ = producerTask.Exception;
+
+        DisposeProducerSignals();
+    }
+
+    private void DisposeProducerSignals()
+    {
+        if (Interlocked.Exchange(ref _producerSignalsDisposed, 1) != 0)
+            return;
+
         _dataAvailable.Dispose();
         _spaceAvailable.Dispose();
     }
@@ -381,6 +424,7 @@ internal sealed class MpscFetchBuffer
 #endif
     {
         private readonly MpscFetchBuffer _owner;
+        private readonly object _registrationGate = new();
         private readonly TimerCallback _timeoutCallback;
         private ManualResetValueTaskSourceCore<bool> _core;
         private Timer? _timeoutTimer;
@@ -400,16 +444,25 @@ internal sealed class MpscFetchBuffer
             _timeoutCallback = static state => ((ReadWaiter)state!).OnTimeout();
         }
 
-        public void SetCancellationToken(CancellationToken cancellationToken)
+        public bool IsDisposed => _disposed;
+
+        public bool TrySetCancellationToken(CancellationToken cancellationToken)
         {
-            // CancellationTokenSource.TryReset clears registrations without changing token
-            // identity, so equality cannot prove that the previous registration is still live.
-            _cancellationRegistration.Dispose();
-            _cancellationToken = cancellationToken;
-            Volatile.Write(ref _cancellationRequested, cancellationToken.IsCancellationRequested ? 1 : 0);
-            _cancellationRegistration = cancellationToken.CanBeCanceled
-                ? cancellationToken.UnsafeRegister(static state => ((ReadWaiter)state!).OnCancellation(), this)
-                : default;
+            lock (_registrationGate)
+            {
+                if (_disposed)
+                    return false;
+
+                // CancellationTokenSource.TryReset clears registrations without changing token
+                // identity, so equality cannot prove that the previous registration is still live.
+                _cancellationRegistration.Dispose();
+                _cancellationToken = cancellationToken;
+                Volatile.Write(ref _cancellationRequested, cancellationToken.IsCancellationRequested ? 1 : 0);
+                _cancellationRegistration = cancellationToken.CanBeCanceled
+                    ? cancellationToken.UnsafeRegister(static state => ((ReadWaiter)state!).OnCancellation(), this)
+                    : default;
+                return true;
+            }
         }
 
         public ValueTask<bool> Prepare(int timeoutMs)
@@ -570,30 +623,33 @@ internal sealed class MpscFetchBuffer
 
         public void Dispose()
         {
-            CancellationTokenRegistration cancellationRegistration;
-            Timer? timeoutTimer;
-
-            lock (_owner._dataAvailableWaiterLock)
+            lock (_registrationGate)
             {
-                if (_disposed)
-                    return;
+                CancellationTokenRegistration cancellationRegistration;
+                Timer? timeoutTimer;
 
-                _disposed = true;
+                lock (_owner._dataAvailableWaiterLock)
+                {
+                    if (_disposed)
+                        return;
 
-                // Dispose may race the caller consuming the pending ValueTask. Complete it
-                // before tearing down its only wake-up sources, then detach the timer so the
-                // eventual GetResult cleanup cannot call Change on a disposed instance.
-                if (_owner._readWaiterActive)
-                    TrySetSignal();
+                    _disposed = true;
 
-                cancellationRegistration = _cancellationRegistration;
-                _cancellationRegistration = default;
-                timeoutTimer = _timeoutTimer;
-                _timeoutTimer = null;
+                    // Dispose may race the caller consuming the pending ValueTask. Complete it
+                    // before tearing down its only wake-up sources, then detach the timer so the
+                    // eventual GetResult cleanup cannot call Change on a disposed instance.
+                    if (_owner._readWaiterActive)
+                        TrySetSignal();
+
+                    cancellationRegistration = _cancellationRegistration;
+                    _cancellationRegistration = default;
+                    timeoutTimer = _timeoutTimer;
+                    _timeoutTimer = null;
+                }
+
+                cancellationRegistration.Dispose();
+                timeoutTimer?.Dispose();
             }
-
-            cancellationRegistration.Dispose();
-            timeoutTimer?.Dispose();
         }
     }
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks.Sources;
 
 namespace Dekaf.Consumer;
 
@@ -25,10 +27,14 @@ internal sealed class MpscFetchBuffer
     private readonly ManualResetEventSlim _dataAvailable = new(false);
     private readonly SemaphoreSlim _spaceAvailable = new(0, int.MaxValue);
     private readonly object _dataAvailableWaiterLock = new();
+    private readonly ReadWaiter _readWaiter;
     private readonly Action? _afterProducerWaiterCountIncrementedForTesting;
     private readonly Action? _beforeConsumerWaitSpinForTesting;
     private readonly Action<long>? _afterProducerSlotReservedForTesting;
-    private TaskCompletionSource<bool>? _dataAvailableWaiter;
+    private readonly Action? _beforeConsumerTimeoutForTesting;
+    private readonly Action? _afterConsumerTimeoutForTesting;
+    private readonly Action? _beforeConsumerTimeoutCompletionForTesting;
+    private bool _readWaiterActive;
     private int _producerWaiterCount;
     private int _consumerWaiting;
     private volatile bool _completed;
@@ -39,7 +45,10 @@ internal sealed class MpscFetchBuffer
             capacity,
             afterProducerWaiterCountIncrementedForTesting: null,
             beforeConsumerWaitSpinForTesting: null,
-            afterProducerSlotReservedForTesting: null)
+            afterProducerSlotReservedForTesting: null,
+            beforeConsumerTimeoutForTesting: null,
+            afterConsumerTimeoutForTesting: null,
+            beforeConsumerTimeoutCompletionForTesting: null)
     {
     }
 
@@ -47,7 +56,10 @@ internal sealed class MpscFetchBuffer
         int capacity,
         Action? afterProducerWaiterCountIncrementedForTesting,
         Action? beforeConsumerWaitSpinForTesting = null,
-        Action<long>? afterProducerSlotReservedForTesting = null)
+        Action<long>? afterProducerSlotReservedForTesting = null,
+        Action? beforeConsumerTimeoutForTesting = null,
+        Action? afterConsumerTimeoutForTesting = null,
+        Action? beforeConsumerTimeoutCompletionForTesting = null)
     {
         if (capacity < 1)
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
@@ -65,6 +77,10 @@ internal sealed class MpscFetchBuffer
         _afterProducerWaiterCountIncrementedForTesting = afterProducerWaiterCountIncrementedForTesting;
         _beforeConsumerWaitSpinForTesting = beforeConsumerWaitSpinForTesting;
         _afterProducerSlotReservedForTesting = afterProducerSlotReservedForTesting;
+        _beforeConsumerTimeoutForTesting = beforeConsumerTimeoutForTesting;
+        _afterConsumerTimeoutForTesting = afterConsumerTimeoutForTesting;
+        _beforeConsumerTimeoutCompletionForTesting = beforeConsumerTimeoutCompletionForTesting;
+        _readWaiter = new ReadWaiter(this);
     }
 
     internal int Capacity => _buffer.Length;
@@ -240,20 +256,20 @@ internal sealed class MpscFetchBuffer
     /// Waits asynchronously until data is available or the buffer is completed.
     /// Returns false if the wait times out or the buffer is completed and empty.
     /// </summary>
-    public async ValueTask<bool> WaitToReadAsync(int timeoutMs, CancellationToken cancellationToken)
+    public ValueTask<bool> WaitToReadAsync(int timeoutMs, CancellationToken cancellationToken)
     {
         if (timeoutMs < Timeout.Infinite)
             throw new ArgumentOutOfRangeException(nameof(timeoutMs), "Timeout must be non-negative or Timeout.Infinite.");
 
         // Fast check: data already available?
         if (HasDataAvailable())
-            return true;
+            return new ValueTask<bool>(true);
 
         if (_completed)
         {
             if (_completionError is not null)
                 throw _completionError;
-            return HasDataAvailable();
+            return new ValueTask<bool>(HasDataAvailable());
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -262,7 +278,7 @@ internal sealed class MpscFetchBuffer
         {
             if (_completionError is not null)
                 throw _completionError;
-            return HasDataAvailable();
+            return new ValueTask<bool>(HasDataAvailable());
         }
 
         // Catch near-simultaneous producer arrivals without publishing a TCS and forcing its
@@ -273,75 +289,34 @@ internal sealed class MpscFetchBuffer
         while (!spin.NextSpinWillYield)
         {
             if (HasDataAvailable())
-                return true;
+                return new ValueTask<bool>(true);
 
             spin.SpinOnce();
         }
 
-        TaskCompletionSource<bool>? waiter = null;
+        _readWaiter.SetCancellationToken(cancellationToken);
         Volatile.Write(ref _consumerWaiting, 1);
+        Interlocked.MemoryBarrier();
 
-        try
+        lock (_dataAvailableWaiterLock)
         {
-            Interlocked.MemoryBarrier();
-
-            lock (_dataAvailableWaiterLock)
+            // Re-check after publishing the waiter flag to avoid missed signals.
+            if (HasDataAvailable())
             {
-                // Re-check after publishing the waiter flag to avoid missed signals.
-                if (HasDataAvailable())
-                    return true;
-
-                if (_completed)
-                {
-                    if (_completionError is not null)
-                        throw _completionError;
-                    return HasDataAvailable();
-                }
-
-                if (_dataAvailableWaiter is null || _dataAvailableWaiter.Task.IsCompleted)
-                {
-                    _dataAvailableWaiter =
-                        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                }
-
-                waiter = _dataAvailableWaiter;
+                Volatile.Write(ref _consumerWaiting, 0);
+                return new ValueTask<bool>(true);
             }
 
-            bool signaled;
-            if (timeoutMs == Timeout.Infinite)
+            if (_completed)
             {
-                signaled = await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                using var timeoutTimer = new Timer(
-                    static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false),
-                    waiter,
-                    timeoutMs,
-                    Timeout.Infinite);
-                signaled = await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                Volatile.Write(ref _consumerWaiting, 0);
+                if (_completionError is not null)
+                    throw _completionError;
+                return new ValueTask<bool>(HasDataAvailable());
             }
 
-            if (!signaled)
-                return false;
-
-            if (_completionError is not null)
-                throw _completionError;
-
-            return HasDataAvailable();
-        }
-        finally
-        {
-            if (waiter is not null)
-            {
-                lock (_dataAvailableWaiterLock)
-                {
-                    if (ReferenceEquals(_dataAvailableWaiter, waiter))
-                        _dataAvailableWaiter = null;
-                }
-            }
-
-            Volatile.Write(ref _consumerWaiting, 0);
+            _readWaiterActive = true;
+            return _readWaiter.Prepare(timeoutMs);
         }
     }
 
@@ -378,19 +353,222 @@ internal sealed class MpscFetchBuffer
     {
         _dataAvailable.Set();
 
-        TaskCompletionSource<bool>? waiter;
         lock (_dataAvailableWaiterLock)
         {
-            waiter = _dataAvailableWaiter;
+            if (_readWaiterActive)
+                _readWaiter.TrySetSignal();
         }
+    }
 
-        waiter?.TrySetResult(true);
+    internal void Dispose()
+    {
+        _readWaiter.Dispose();
+        _dataAvailable.Dispose();
+        _spaceAvailable.Dispose();
     }
 
     private void DrainAvailableSpaceSignals()
     {
         while (_spaceAvailable.Wait(0, CancellationToken.None))
         {
+        }
+    }
+
+    private sealed class ReadWaiter : IValueTaskSource<bool>, IDisposable
+#if NET10_0_OR_GREATER
+        , IThreadPoolWorkItem
+#endif
+    {
+        private readonly MpscFetchBuffer _owner;
+        private readonly TimerCallback _timeoutCallback;
+        private ManualResetValueTaskSourceCore<bool> _core;
+        private Timer? _timeoutTimer;
+        private CancellationTokenRegistration _cancellationRegistration;
+        private CancellationToken _cancellationToken;
+        private long _timeoutDeadline;
+        private bool _completed;
+        private bool _queuedResult;
+        private Exception? _queuedException;
+        private int _cancellationRequested;
+
+        public ReadWaiter(MpscFetchBuffer owner)
+        {
+            _owner = owner;
+            _core.RunContinuationsAsynchronously = false;
+            _timeoutCallback = static state => ((ReadWaiter)state!).OnTimeout();
+        }
+
+        public void SetCancellationToken(CancellationToken cancellationToken)
+        {
+            if (cancellationToken == _cancellationToken)
+                return;
+
+            _cancellationRegistration.Dispose();
+            _cancellationToken = cancellationToken;
+            Volatile.Write(ref _cancellationRequested, cancellationToken.IsCancellationRequested ? 1 : 0);
+            _cancellationRegistration = cancellationToken.CanBeCanceled
+                ? cancellationToken.UnsafeRegister(static state => ((ReadWaiter)state!).OnCancellation(), this)
+                : default;
+        }
+
+        public ValueTask<bool> Prepare(int timeoutMs)
+        {
+            _core.Reset();
+            _completed = false;
+
+            if (Volatile.Read(ref _cancellationRequested) != 0)
+            {
+                TrySetException(new OperationCanceledException(_cancellationToken));
+                return new ValueTask<bool>(this, _core.Version);
+            }
+
+            if (timeoutMs != Timeout.Infinite)
+            {
+                _timeoutDeadline = Stopwatch.GetTimestamp()
+                    + timeoutMs * Stopwatch.Frequency / 1_000;
+                if (_timeoutTimer is null)
+                    _timeoutTimer = new Timer(_timeoutCallback, this, timeoutMs, Timeout.Infinite);
+                else
+                    _timeoutTimer.Change(timeoutMs, Timeout.Infinite);
+            }
+            else
+            {
+                _timeoutDeadline = long.MaxValue;
+            }
+
+            return new ValueTask<bool>(this, _core.Version);
+        }
+
+        public void TrySetSignal()
+        {
+            if (_completed)
+                return;
+
+            _completed = true;
+            _queuedResult = true;
+            _queuedException = null;
+            QueueCompletion();
+        }
+
+        private void TrySetException(Exception exception)
+        {
+            if (_completed)
+                return;
+
+            _completed = true;
+            _queuedResult = false;
+            _queuedException = exception;
+            QueueCompletion();
+        }
+
+        private void QueueCompletion()
+        {
+#if NET10_0_OR_GREATER
+            if (!ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: true))
+                ExecuteQueuedCompletion();
+#else
+            if (!ThreadPool.QueueUserWorkItem(static state => ((ReadWaiter)state!).ExecuteQueuedCompletion(), this))
+                ExecuteQueuedCompletion();
+#endif
+        }
+
+        private void ExecuteQueuedCompletion()
+        {
+            var exception = _queuedException;
+            _queuedException = null;
+            if (exception is not null)
+                _core.SetException(exception);
+            else
+                _core.SetResult(_queuedResult);
+        }
+
+#if NET10_0_OR_GREATER
+        void IThreadPoolWorkItem.Execute() => ExecuteQueuedCompletion();
+#endif
+
+        private void OnCancellation()
+        {
+            Volatile.Write(ref _cancellationRequested, 1);
+            lock (_owner._dataAvailableWaiterLock)
+            {
+                if (_owner._readWaiterActive)
+                    TrySetException(new OperationCanceledException(_cancellationToken));
+            }
+        }
+
+        private void OnTimeout()
+        {
+            _owner._beforeConsumerTimeoutForTesting?.Invoke();
+            try
+            {
+                lock (_owner._dataAvailableWaiterLock)
+                {
+                    if (!_owner._readWaiterActive || _completed || _timeoutDeadline == long.MaxValue)
+                        return;
+
+                    var remainingTicks = _timeoutDeadline - Stopwatch.GetTimestamp();
+                    if (remainingTicks > 0)
+                    {
+                        var remainingMs = Math.Max(
+                            1,
+                            (int)((remainingTicks * 1_000 + Stopwatch.Frequency - 1) / Stopwatch.Frequency));
+                        _timeoutTimer!.Change(remainingMs, Timeout.Infinite);
+                        return;
+                    }
+
+                    _completed = true;
+                }
+
+                // Completing inline while holding the owner lock can deadlock: the continuation
+                // may dispose a linked CTS and wait for a cancellation callback that needs the
+                // same lock. Publish completion only after releasing it.
+                _owner._beforeConsumerTimeoutCompletionForTesting?.Invoke();
+                _core.SetResult(false);
+            }
+            finally
+            {
+                _owner._afterConsumerTimeoutForTesting?.Invoke();
+            }
+        }
+
+        bool IValueTaskSource<bool>.GetResult(short token)
+        {
+            try
+            {
+                var signaled = _core.GetResult(token);
+                if (!signaled)
+                    return false;
+
+                if (_owner._completionError is not null)
+                    throw _owner._completionError;
+
+                return _owner.HasDataAvailable();
+            }
+            finally
+            {
+                lock (_owner._dataAvailableWaiterLock)
+                {
+                    _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                    _owner._readWaiterActive = false;
+                }
+
+                Volatile.Write(ref _owner._consumerWaiting, 0);
+            }
+        }
+
+        ValueTaskSourceStatus IValueTaskSource<bool>.GetStatus(short token) => _core.GetStatus(token);
+
+        void IValueTaskSource<bool>.OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) =>
+            _core.OnCompleted(continuation, state, token, flags);
+
+        public void Dispose()
+        {
+            _cancellationRegistration.Dispose();
+            _timeoutTimer?.Dispose();
         }
     }
 

--- a/src/Dekaf/Consumer/MpscFetchBuffer.cs
+++ b/src/Dekaf/Consumer/MpscFetchBuffer.cs
@@ -307,22 +307,23 @@ internal sealed class MpscFetchBuffer
                 waiter = _dataAvailableWaiter;
             }
 
-            try
+            bool signaled;
+            if (timeoutMs == Timeout.Infinite)
             {
-                if (timeoutMs == Timeout.Infinite)
-                {
-                    await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await waiter.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs), cancellationToken)
-                        .ConfigureAwait(false);
-                }
+                signaled = await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (TimeoutException)
+            else
             {
+                using var timeoutTimer = new Timer(
+                    static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false),
+                    waiter,
+                    timeoutMs,
+                    Timeout.Infinite);
+                signaled = await waiter.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!signaled)
                 return false;
-            }
 
             if (_completionError is not null)
                 throw _completionError;

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -283,7 +283,7 @@ public class MpscFetchBufferTests
 
             await Assert.That(result).IsTrue();
             await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
-            await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+            await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
             await Assert.That(buffer.TryRead(out var read)).IsTrue();
             await Assert.That(read).IsSameReferenceAs(item);
         }
@@ -305,7 +305,7 @@ public class MpscFetchBufferTests
 
         await Assert.That(timedOut).IsFalse();
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
-        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+        await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
 
         var waitTask = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
         await Assert.That(waitTask.IsCompleted).IsFalse();
@@ -314,7 +314,87 @@ public class MpscFetchBufferTests
 
         await Assert.That(await waitTask).IsFalse();
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
-        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+        await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_StaleTimeoutCannotCompleteNextWait()
+    {
+        using var timeoutEntered = new ManualResetEventSlim();
+        using var releaseTimeout = new ManualResetEventSlim();
+        using var timeoutExited = new ManualResetEventSlim();
+        var buffer = new MpscFetchBuffer(
+            capacity: 4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerTimeoutForTesting: () =>
+            {
+                timeoutEntered.Set();
+                releaseTimeout.Wait();
+            },
+            afterConsumerTimeoutForTesting: timeoutExited.Set);
+        var item = CreateDummy();
+
+        try
+        {
+            var firstWait = buffer.WaitToReadAsync(1, CancellationToken.None).AsTask();
+            await Assert.That(timeoutEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(buffer.TryWrite(item)).IsTrue();
+            await Assert.That(await firstWait).IsTrue();
+            await Assert.That(buffer.TryRead(out var read)).IsTrue();
+            await Assert.That(read).IsSameReferenceAs(item);
+
+            var nextWait = buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None).AsTask();
+            releaseTimeout.Set();
+            await Assert.That(timeoutExited.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(nextWait.IsCompleted).IsFalse();
+
+            buffer.Complete();
+            await Assert.That(await nextWait).IsFalse();
+        }
+        finally
+        {
+            releaseTimeout.Set();
+            item.Dispose();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task WaitToReadAsync_TimeoutCompletionDoesNotHoldWaiterLock()
+    {
+        using var cancellationStarted = new ManualResetEventSlim();
+        using var cancellationFinished = new ManualResetEventSlim();
+        using var cts = new CancellationTokenSource();
+        Thread? cancellationThread = null;
+        var cancellationFinishedBeforeCompletion = false;
+        var buffer = new MpscFetchBuffer(
+            capacity: 4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerTimeoutCompletionForTesting: () =>
+            {
+                cancellationThread = new Thread(() =>
+                {
+                    cancellationStarted.Set();
+                    cts.Cancel();
+                    cancellationFinished.Set();
+                });
+                cancellationThread.Start();
+                cancellationStarted.Wait();
+                cancellationFinishedBeforeCompletion = cancellationFinished.Wait(TimeSpan.FromSeconds(5));
+            });
+
+        try
+        {
+            var result = await buffer.WaitToReadAsync(1, cts.Token);
+
+            await Assert.That(result).IsFalse();
+            await Assert.That(cancellationFinishedBeforeCompletion).IsTrue();
+        }
+        finally
+        {
+            cancellationThread?.Join();
+            buffer.Dispose();
+        }
     }
 
     [Test]
@@ -346,7 +426,7 @@ public class MpscFetchBufferTests
             .Throws<InvalidOperationException>()
             .WithMessage("test error");
         await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
-        await Assert.That(GetDataAvailableWaiter(buffer)).IsNull();
+        await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
     }
 
     [Test]
@@ -580,13 +660,12 @@ public class MpscFetchBufferTests
             await Assert.That(firstReserved.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             waitForReadable = buffer.WaitToReadAsync(30_000, CancellationToken.None).AsTask();
             await TestWait.UntilAsync(
-                () => GetConsumerWaiting(buffer) == 1 && GetDataAvailableWaiter(buffer) is not null,
+                () => GetConsumerWaiting(buffer) == 1 && IsReadWaiterActive(buffer),
                 TimeSpan.FromSeconds(5));
 
             var secondWrite = Task.Run(() => buffer.TryWrite(second));
             await Assert.That(await secondWrite.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
             await Assert.That(buffer.Count).IsEqualTo(2);
-            await Assert.That(GetDataAvailableWaiter(buffer)!.Task.IsCompleted).IsFalse();
             await Assert.That(waitForReadable.IsCompleted).IsFalse();
         }
         finally
@@ -655,11 +734,11 @@ public class MpscFetchBufferTests
         return (int)field.GetValue(buffer)!;
     }
 
-    private static TaskCompletionSource<bool>? GetDataAvailableWaiter(MpscFetchBuffer buffer)
+    private static bool IsReadWaiterActive(MpscFetchBuffer buffer)
     {
         var field = typeof(MpscFetchBuffer).GetField(
-            "_dataAvailableWaiter",
+            "_readWaiterActive",
             BindingFlags.NonPublic | BindingFlags.Instance)!;
-        return (TaskCompletionSource<bool>?)field.GetValue(buffer);
+        return (bool)field.GetValue(buffer)!;
     }
 }

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -502,6 +502,93 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_DisposeAfterCancellationRegistration_DoesNotReactivateWaiter()
+    {
+        using var registrationCompleted = new ManualResetEventSlim();
+        using var releaseWaiter = new ManualResetEventSlim();
+        using var cts = new CancellationTokenSource();
+        var buffer = new MpscFetchBuffer(
+            capacity: 4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            afterConsumerCancellationRegisteredForTesting: () =>
+            {
+                registrationCompleted.Set();
+                releaseWaiter.Wait();
+            });
+
+        var waitTask = Task.Run(() =>
+            buffer.WaitToReadAsync(Timeout.Infinite, cts.Token).AsTask());
+
+        try
+        {
+            await Assert.That(registrationCompleted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            buffer.Dispose();
+            releaseWaiter.Set();
+
+            await Assert.That(await waitTask).IsFalse();
+            await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+            await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
+        }
+        finally
+        {
+            releaseWaiter.Set();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task Dispose_PrefetchProducerCanCompleteAfterBestEffortShutdown()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var producerCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        buffer.Dispose(producerCompletion.Task);
+        buffer.Complete();
+
+        await Assert.That(buffer.IsCompleted).IsTrue();
+        await Assert.That(buffer.ProducerSignalsDisposedForTesting).IsFalse();
+
+        producerCompletion.SetResult();
+        await TestWait.UntilAsync(
+            () => buffer.ProducerSignalsDisposedForTesting,
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Dispose_PrefetchProducerCanObserveReleasedSpaceAfterBestEffortShutdown()
+    {
+        var buffer = new MpscFetchBuffer(1);
+        var item = CreateDummy();
+        var producerCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            await Assert.That(buffer.TryWrite(item)).IsTrue();
+            var producerWait = buffer.WaitToWriteAsync(CancellationToken.None).AsTask();
+            await TestWait.UntilAsync(() => buffer.ProducerWaiterCount == 1, TimeSpan.FromSeconds(5));
+
+            buffer.Dispose(producerCompletion.Task);
+            await Assert.That(buffer.TryRead(out var read)).IsTrue();
+            await producerWait;
+
+            await Assert.That(read).IsSameReferenceAs(item);
+            await Assert.That(buffer.ProducerSignalsDisposedForTesting).IsFalse();
+
+            producerCompletion.SetResult();
+            await TestWait.UntilAsync(
+                () => buffer.ProducerSignalsDisposedForTesting,
+                TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            producerCompletion.TrySetResult();
+            item.Dispose();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
     public async Task WaitToReadAsync_AlreadyCompletedWithError_ThrowsError()
     {
         var buffer = new MpscFetchBuffer(4);

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -426,6 +426,22 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_Dispose_CompletesActiveWait()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        using var cts = new CancellationTokenSource();
+        var waitTask = buffer.WaitToReadAsync(30_000, cts.Token).AsTask();
+
+        await Assert.That(waitTask.IsCompleted).IsFalse();
+
+        buffer.Dispose();
+
+        await Assert.That(await waitTask).IsFalse();
+        await Assert.That(GetConsumerWaiting(buffer)).IsEqualTo(0);
+        await Assert.That(IsReadWaiterActive(buffer)).IsFalse();
+    }
+
+    [Test]
     public async Task WaitToReadAsync_AlreadyCompletedWithError_ThrowsError()
     {
         var buffer = new MpscFetchBuffer(4);

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -400,6 +400,8 @@ public class MpscFetchBufferTests
     [Test]
     public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationOnTimerThread()
     {
+        using var timeoutEntered = new ManualResetEventSlim();
+        using var releaseTimeout = new ManualResetEventSlim();
         using var continuationEntered = new ManualResetEventSlim();
         using var releaseContinuation = new ManualResetEventSlim();
         using var continuationFinished = new ManualResetEventSlim();
@@ -407,6 +409,11 @@ public class MpscFetchBufferTests
         var buffer = new MpscFetchBuffer(
             capacity: 4,
             afterProducerWaiterCountIncrementedForTesting: null,
+            beforeConsumerTimeoutForTesting: () =>
+            {
+                timeoutEntered.Set();
+                releaseTimeout.Wait();
+            },
             afterConsumerTimeoutForTesting: timeoutCallbackExited.Set);
         var result = true;
         Exception? continuationException = null;
@@ -432,6 +439,8 @@ public class MpscFetchBufferTests
                 }
             });
 
+            await Assert.That(timeoutEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            releaseTimeout.Set();
             await Assert.That(continuationEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             await Assert.That(timeoutCallbackExited.Wait(TimeSpan.FromSeconds(5))).IsTrue();
 
@@ -442,6 +451,7 @@ public class MpscFetchBufferTests
         }
         finally
         {
+            releaseTimeout.Set();
             releaseContinuation.Set();
             buffer.Dispose();
         }

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -398,6 +398,34 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_ResetCancellationSource_ReRegistersCallback()
+    {
+        var buffer = new MpscFetchBuffer(4);
+        var item = CreateDummy();
+        using var cts = new CancellationTokenSource();
+
+        try
+        {
+            var firstWait = buffer.WaitToReadAsync(Timeout.Infinite, cts.Token).AsTask();
+            await Assert.That(buffer.TryWrite(item)).IsTrue();
+            await Assert.That(await firstWait).IsTrue();
+            await Assert.That(buffer.TryRead(out var read)).IsTrue();
+            await Assert.That(read).IsSameReferenceAs(item);
+
+            await Assert.That(cts.TryReset()).IsTrue();
+            var nextWait = buffer.WaitToReadAsync(Timeout.Infinite, cts.Token).AsTask();
+            await cts.CancelAsync();
+
+            await Assert.That(async () => await nextWait).Throws<OperationCanceledException>();
+        }
+        finally
+        {
+            item.Dispose();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
     public async Task WaitToReadAsync_AlreadyCompletedWithError_ThrowsError()
     {
         var buffer = new MpscFetchBuffer(4);

--- a/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/MpscFetchBufferTests.cs
@@ -398,6 +398,56 @@ public class MpscFetchBufferTests
     }
 
     [Test]
+    public async Task WaitToReadAsync_TimeoutDoesNotRunContinuationOnTimerThread()
+    {
+        using var continuationEntered = new ManualResetEventSlim();
+        using var releaseContinuation = new ManualResetEventSlim();
+        using var continuationFinished = new ManualResetEventSlim();
+        using var timeoutCallbackExited = new ManualResetEventSlim();
+        var buffer = new MpscFetchBuffer(
+            capacity: 4,
+            afterProducerWaiterCountIncrementedForTesting: null,
+            afterConsumerTimeoutForTesting: timeoutCallbackExited.Set);
+        var result = true;
+        Exception? continuationException = null;
+
+        try
+        {
+            var awaiter = buffer.WaitToReadAsync(1, CancellationToken.None).GetAwaiter();
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                continuationEntered.Set();
+                releaseContinuation.Wait();
+                try
+                {
+                    result = awaiter.GetResult();
+                }
+                catch (Exception exception)
+                {
+                    continuationException = exception;
+                }
+                finally
+                {
+                    continuationFinished.Set();
+                }
+            });
+
+            await Assert.That(continuationEntered.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(timeoutCallbackExited.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            releaseContinuation.Set();
+            await Assert.That(continuationFinished.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(continuationException).IsNull();
+            await Assert.That(result).IsFalse();
+        }
+        finally
+        {
+            releaseContinuation.Set();
+            buffer.Dispose();
+        }
+    }
+
+    [Test]
     public async Task WaitToReadAsync_ResetCancellationSource_ReRegistersCallback()
     {
         var buffer = new MpscFetchBuffer(4);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -5,12 +5,37 @@ using Dekaf.Consumer;
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
 [MemoryDiagnoser]
-[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 2, iterationCount: 3)]
+[IterationTime(5000)]
 public class MpscFetchBufferTimeoutBenchmarks
 {
     private readonly MpscFetchBuffer _buffer = new(4);
+    private CancellationTokenSource? _cancellationSource;
+    private CancellationToken _cancellationToken;
+
+    [Params(false, true)]
+    public bool Cancellable { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        if (Cancellable)
+        {
+            _cancellationSource = new CancellationTokenSource();
+            _cancellationToken = _cancellationSource.Token;
+        }
+
+        await _buffer.WaitToReadAsync(timeoutMs: 1, _cancellationToken).ConfigureAwait(false);
+    }
 
     [Benchmark]
     public ValueTask<bool> TimeoutAsync() =>
-        _buffer.WaitToReadAsync(timeoutMs: 1, CancellationToken.None);
+        _buffer.WaitToReadAsync(timeoutMs: 1, _cancellationToken);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _buffer.Dispose();
+        _cancellationSource?.Dispose();
+    }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dekaf.Consumer;
@@ -67,6 +68,16 @@ public class MpscFetchBufferSignalBenchmarks
         "benchmark-topic",
         partitionIndex: 0,
         Array.Empty<RecordBatch>());
+    private readonly Action _continuation;
+    private ValueTask<bool> _pendingWait;
+    private Exception? _completionException;
+    private bool _signaled;
+    private int _completionVersion;
+
+    public MpscFetchBufferSignalBenchmarks()
+    {
+        _continuation = CompletePendingWait;
+    }
 
     [GlobalSetup]
     public void Setup() => SignalPendingWait();
@@ -74,22 +85,49 @@ public class MpscFetchBufferSignalBenchmarks
     [Benchmark]
     public bool SignalPendingWait()
     {
-        var wait = _buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
-        if (wait.IsCompleted)
+        var expectedVersion = Volatile.Read(ref _completionVersion) + 1;
+        _completionException = null;
+        _pendingWait = _buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+        if (_pendingWait.IsCompleted)
             throw new InvalidOperationException("Read wait did not park.");
+
+        _pendingWait.GetAwaiter().UnsafeOnCompleted(_continuation);
 
         if (!_buffer.TryWrite(_item))
             throw new InvalidOperationException("Benchmark item could not be written.");
 
+        var deadline = Stopwatch.GetTimestamp() + 5 * Stopwatch.Frequency;
         var spin = new SpinWait();
-        while (!wait.IsCompleted)
+        while (Volatile.Read(ref _completionVersion) != expectedVersion)
+        {
+            if (Stopwatch.GetTimestamp() >= deadline)
+                throw new InvalidOperationException("Read wait did not complete within five seconds.");
             spin.SpinOnce();
+        }
 
-        var signaled = wait.GetAwaiter().GetResult();
+        if (_completionException is not null)
+            throw new InvalidOperationException("Read wait failed.", _completionException);
+
         if (!_buffer.TryRead(out var item) || !ReferenceEquals(item, _item))
             throw new InvalidOperationException("Benchmark item could not be read.");
 
-        return signaled;
+        return _signaled;
+    }
+
+    private void CompletePendingWait()
+    {
+        try
+        {
+            _signaled = _pendingWait.GetAwaiter().GetResult();
+        }
+        catch (Exception exception)
+        {
+            _completionException = exception;
+        }
+        finally
+        {
+            Interlocked.Increment(ref _completionVersion);
+        }
     }
 
     [GlobalCleanup]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
 
 namespace Dekaf.Benchmarks.Benchmarks.Unit;
 
@@ -53,5 +54,48 @@ public class MpscFetchBufferTimeoutBenchmarks
     {
         _buffer.Dispose();
         _cancellationSource?.Dispose();
+    }
+}
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 15)]
+[IterationTime(1000)]
+public class MpscFetchBufferSignalBenchmarks
+{
+    private readonly MpscFetchBuffer _buffer = new(4);
+    private readonly PendingFetchData _item = PendingFetchData.Create(
+        "benchmark-topic",
+        partitionIndex: 0,
+        Array.Empty<RecordBatch>());
+
+    [GlobalSetup]
+    public void Setup() => SignalPendingWait();
+
+    [Benchmark]
+    public bool SignalPendingWait()
+    {
+        var wait = _buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
+        if (wait.IsCompleted)
+            throw new InvalidOperationException("Read wait did not park.");
+
+        if (!_buffer.TryWrite(_item))
+            throw new InvalidOperationException("Benchmark item could not be written.");
+
+        var spin = new SpinWait();
+        while (!wait.IsCompleted)
+            spin.SpinOnce();
+
+        var signaled = wait.GetAwaiter().GetResult();
+        if (!_buffer.TryRead(out var item) || !ReferenceEquals(item, _item))
+            throw new InvalidOperationException("Benchmark item could not be read.");
+
+        return signaled;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _buffer.Dispose();
+        _item.Dispose();
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -1,0 +1,16 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Consumer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 5)]
+public class MpscFetchBufferTimeoutBenchmarks
+{
+    private readonly MpscFetchBuffer _buffer = new(4);
+
+    [Benchmark]
+    public ValueTask<bool> TimeoutAsync() =>
+        _buffer.WaitToReadAsync(timeoutMs: 1, CancellationToken.None);
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -13,13 +13,20 @@ public class MpscFetchBufferTimeoutBenchmarks
     private CancellationTokenSource? _cancellationSource;
     private CancellationToken _cancellationToken;
 
-    [Params(false, true)]
-    public bool Cancellable { get; set; }
+    public enum CancellationMode
+    {
+        None,
+        Stable,
+        ResetBetweenWaits,
+    }
+
+    [ParamsAllValues]
+    public CancellationMode Mode { get; set; }
 
     [GlobalSetup]
     public async Task Setup()
     {
-        if (Cancellable)
+        if (Mode is not CancellationMode.None)
         {
             _cancellationSource = new CancellationTokenSource();
             _cancellationToken = _cancellationSource.Token;
@@ -29,8 +36,17 @@ public class MpscFetchBufferTimeoutBenchmarks
     }
 
     [Benchmark]
-    public ValueTask<bool> TimeoutAsync() =>
-        _buffer.WaitToReadAsync(timeoutMs: 1, _cancellationToken);
+    public ValueTask<bool> TimeoutAsync()
+    {
+        if (Mode is CancellationMode.ResetBetweenWaits)
+        {
+            if (!_cancellationSource!.TryReset())
+                throw new InvalidOperationException("Cancellation source could not be reset.");
+            _cancellationToken = _cancellationSource.Token;
+        }
+
+        return _buffer.WaitToReadAsync(timeoutMs: 1, _cancellationToken);
+    }
 
     [GlobalCleanup]
     public void Cleanup()

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/MpscFetchBufferTimeoutBenchmarks.cs
@@ -87,6 +87,7 @@ public class MpscFetchBufferSignalBenchmarks
     {
         var expectedVersion = Volatile.Read(ref _completionVersion) + 1;
         _completionException = null;
+        _signaled = false;
         _pendingWait = _buffer.WaitToReadAsync(Timeout.Infinite, CancellationToken.None);
         if (_pendingWait.IsCompleted)
             throw new InvalidOperationException("Read wait did not park.");
@@ -107,6 +108,9 @@ public class MpscFetchBufferSignalBenchmarks
 
         if (_completionException is not null)
             throw new InvalidOperationException("Read wait failed.", _completionException);
+
+        if (!_signaled)
+            throw new InvalidOperationException("Read wait completed without a data signal.");
 
         if (!_buffer.TryRead(out var item) || !ReferenceEquals(item, _item))
             throw new InvalidOperationException("Benchmark item could not be read.");


### PR DESCRIPTION
## Problem

`MpscFetchBuffer.WaitToReadAsync` created timeout/cancellation machinery and caught `TimeoutException` for every normal empty-poll timeout. A 15-second consumer trace recorded 49 `System.TimeoutException` throws from this path. The original benchmark allocated 1.17 KB per timeout.

## Change

Replace the per-wait `TaskCompletionSource`, `Task.WaitAsync`, and timeout object graph with one reusable `IValueTaskSource<bool>` waiter per buffer:

- reuse one `Timer` and one cancellation registration
- use `ManualResetValueTaskSourceCore<bool>` for allocation-free timeout completion
- queue data/cancellation completion through the reusable waiter so producer/cancellation threads never run the consumer continuation inline
- reject stale timer callbacks with the current deadline
- release the waiter lock before publishing timeout completion; otherwise a continuation disposing a linked CTS can deadlock with its cancellation callback
- dispose waiter resources with the consumer

Deterministic tests cover stale timer callbacks and the lock/cancellation deadlock.

## Benchmark

BenchmarkDotNet 0.15.8, `[MemoryDiagnoser]`, .NET 10.0.10, i7-12700K, 1 ms requested timeout (Windows timer resolution makes observed waits about 15.5 ms). Exact job: 1 launch, 2 warmups, 3 measured 5-second iterations, 336 operations per iteration. Baseline `0c751571`; final candidate `db844d10`.

| Cancellation token | Baseline mean | Candidate mean | Delta | Baseline allocated | Candidate allocated |
|---|---:|---:|---:|---:|---:|
| `CancellationToken.None` | 15.499 ms | 15.458 ms | -0.26% | 1.17 KB/op | 0 B/op |
| Cancellable, not cancelled | 15.478 ms | 15.498 ms | +0.13% | 1.17 KB/op | 0 B/op |

Both timing confidence intervals overlap; the ±0.3% deltas are OS timer scheduling noise. The allocation improvement is 100%, and both hot-path cases are 0 B/op.

Allocation-noise audit: one combined candidate launch sampled a fixed 1,024 bytes across 336 non-cancellable operations and displayed 3 B/op; the exact isolated repeat reported raw `GC: 0 0 0 0 336`. The cancellable case reported the same raw zero. An earlier 64-operation run likewise exposed a fixed 1 KB sampling quantum; increasing to 336 operations made clear that it does not scale per wait.

### Rejected intermediate

The first candidate (`641a01e7`) replaced exception control flow with a new one-shot `Timer` per wait:

| Mean | Allocated | Exceptions |
|---:|---:|---:|
| 15.539 ms | 384 B/op | 0/op |

That removed exceptions and 68% of allocation but still violated the zero-allocation hot-path gate, so it was replaced by the reusable waiter.

## Profile and correctness evidence

- Before trace: 49 timeout exceptions / 15 seconds
- Final candidate: no exception-based timeout control flow
- Exact three-broker failover integration initially exposed a linked-token cancellation deadlock in an experimental inline-completion revision
- `dotnet-stack` showed timeout continuation disposing a linked CTS while holding `_dataAvailableWaiterLock`, with the cancellation callback waiting for that lock
- Final revision completes timeout after releasing the lock; deterministic regression test and the formerly hanging integration test pass

CPU per message, throughput, and message latency percentiles are not exercised by this idle-timeout microbenchmark; no data-plane behavior changed. The benchmark protects timeout latency and allocations, while integration coverage protects cancellation, failover, and stability.

## Pooled CTS reset correction (`625944fd`)

Review found that `CancellationTokenSource.TryReset()` clears registrations without changing token identity. The waiter previously treated equal tokens as proof its callback remained registered, so a reused consume-timeout CTS could overrun until data or `FetchMaxWaitMs` woke the buffer. The waiter now re-registers every wait; a deterministic test performs successful wait → `TryReset()` → cancelled wait and proves prompt `OperationCanceledException`.

The benchmark now includes the exact reset lifecycle. Pre-correction `db844d10` and candidate `625944fd`, same BDN job:

| Mode | Before | After | Delta | Before alloc | After alloc |
|---|---:|---:|---:|---:|---:|
| None | 15.446 ms | 15.488 ms | CI overlaps | 0 B | 0 B |
| Stable cancellable token | 15.474 ms | 15.502 ms | CI overlaps | 0 B | 0 B |
| `TryReset()` between waits | 15.471 ms | 15.480 ms | CI overlaps | 0 B | 0 B |

The reset baseline was fast only because cancellation was disconnected; candidate restores correctness while retaining exact `0 B/op` and unchanged timeout latency.
## Validation

- Release solution build: 0 warnings, 0 errors
- full net10 unit suite: 6,622/6,622 passed
- `MpscFetchBufferTests`: 30/30 passed
- exact `CoordinatorFailover_DuringMemberJoin_Converges` integration test: passed in 18.5 s after the deadlock fix
- prior consumer + empty-topic integration selection on this branch: 38/38 passed
- `/simplify`: reviewed; reusable waiter, explicit completion branches, and lock-release boundary retained because they enforce zero allocation and prevent inline-continuation deadlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timed and cancellable asynchronous reads for more reliable timeout, cancellation, and completion behavior.
  - Prevented stale timeouts from affecting subsequent reads and ensured active waits complete safely during disposal.
  - Ensured consumer shutdown properly releases buffered resources.

- **Performance**
  - Reduced overhead for repeated asynchronous read waits.

- **Tests**
  - Added coverage for timeout handling, cancellation reuse, disposal, continuation scheduling, and producer/consumer race conditions.
  - Added benchmarks for timeout and signal-processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Disposal-race correction (`4461079d`)

Review found `ReadWaiter.Dispose()` could race an active `ValueTask`: disposing its timer/registration could either strand the waiter or make eventual `GetResult()` call `Timer.Change` on a disposed timer. Disposal now force-completes an active waiter and detaches both resources under `_dataAvailableWaiterLock`, then disposes them outside the lock. A deterministic test proves a pending finite, cancellable wait completes `false` and clears waiter state during disposal. A Debug-only assertion also catches violation of the single-reader contract.

Pre-correction `625944fd` versus candidate `4461079d`, same `[MemoryDiagnoser]` job:

| Mode | Before | After | Delta | Before alloc | After alloc |
|---|---:|---:|---:|---:|---:|
| None | 15.488 ms | 15.46 ms | CI overlaps | 0 B | 0 B |
| Stable cancellable token | 15.502 ms | 15.49 ms | CI overlaps | 0 B | 0 B |
| `TryReset()` between waits | 15.480 ms | 15.49 ms | CI overlaps | 0 B | 0 B |

The correction is cold-path disposal work. All timeout modes retain exact `0 B/op`; timing confidence intervals overlap. Release build remains at 0 warnings/errors, full net10 unit suite passes 6,622/6,622, and focused `MpscFetchBufferTests` pass 30/30.
## Timer-thread continuation correction (`28e69f42`)

Review found timeout completion called `ManualResetValueTaskSourceCore.SetResult(false)` directly with `RunContinuationsAsynchronously = false`, allowing user continuation work to block the shared timer thread. Timeout now records its queued result under `_dataAvailableWaiterLock`, releases the lock, and publishes through the same reusable `IThreadPoolWorkItem` path as signal/cancellation. A deterministic test blocks the consumer continuation and proves the timer callback exits independently.

Pre-correction `4461079d` versus candidate `28e69f42`, same `[MemoryDiagnoser]` job:

| Mode | Before | After | Delta | Before alloc | After alloc |
|---|---:|---:|---:|---:|---:|
| None | 15.46 ms | 15.46 ms | CI overlaps | 0 B | 0 B |
| Stable cancellable token | 15.49 ms | 15.46 ms | CI overlaps | 0 B | 0 B |
| `TryReset()` between waits | 15.49 ms | 15.51 ms | CI overlaps | 0 B | 0 B |

All modes retain exact `0 B/op`; timing confidence intervals overlap. Release build: 0 warnings/errors. Full net10 unit suite: 6,622/6,622. Focused `MpscFetchBufferTests`: 30/30.
## Data-arrival wake benchmark and global queue (`5e4c2c45`)

Final review required measurement of the actual parked-consumer wake path (`WaitToReadAsync` → `TryWrite` → `SignalConsumerWaitingForData` → completion). The new `[MemoryDiagnoser]` benchmark parks the reader, writes one reusable `PendingFetchData`, spin-observes completion without `AsTask`/an async state machine, consumes the same item, and repeats. Exact job: one launch, three warmups, fifteen measured one-second iterations, same machine/runtime as the timeout benchmark.

Paired sequence baseline → candidate → baseline control:

| Revision | Mean wake | Allocated |
|---|---:|---:|
| Original `0c751571` | 20.33 µs | 232 B/op |
| Final `5e4c2c45` | 12.67 µs | 0 B/op |
| Original control `0c751571` | 22.68 µs | 232 B/op |

Candidate improves mean wake latency by 37.7% versus the preceding baseline and 44.2% versus the following control while removing 100% of per-wake allocation. Raw candidate GC counts were `0 0 0 0` across 72,032 operations. OS/ThreadPool scheduling produces broad distributions, but candidate beats both same-machine controls and cannot hide an allocation trade.

### Rejected queue placement

The first measured `preferLocal:true` revision reported 73.21 µs and 0 B/op: allocation improved, but wake latency regressed materially versus the 24.27 µs initial baseline measurement. It was rejected. `preferLocal:false` uses the global ThreadPool queue so a consumer wake is not stranded behind producer-local work.

Timeout-path control, `28e69f42` → `5e4c2c45`:

| Mode | Before | After | Before alloc | After alloc |
|---|---:|---:|---:|---:|
| None | 15.46 ms | 15.49 ms | 0 B | 0 B |
| Stable cancellable token | 15.46 ms | 15.48 ms | 0 B | 0 B |
| `TryReset()` between waits | 15.51 ms | 15.49 ms | 0 B | 0 B |

All timeout confidence intervals overlap. The deterministic timer-thread test now blocks the timeout callback before continuation registration, removing its prior vacuous-pass race. Final validation: Release solution build 0 warnings/errors; full net10 unit suite 6,622/6,622; focused `MpscFetchBufferTests` 30/30.

## Final review audit (`76a97c29`)

### Corrected data-arrival benchmark

The earlier data-arrival benchmark polled `ValueTask.IsCompleted` and therefore did not register the caller continuation that production executes. This section supersedes its wake-latency comparison. The corrected benchmark registers one cached continuation with `UnsafeOnCompleted`, uses a bounded five-second wait, consumes the result in that continuation, and retains `[MemoryDiagnoser]`.

Same-machine BenchmarkDotNet comparison, original `0c751571` → final `76a97c29`, .NET 10.0.10, one launch / three warmups / fifteen measured one-second iterations:

| Revision | Mean wake | Error | Allocated |
|---|---:|---:|---:|
| Original `0c751571` | 18.60 µs | 5.921 µs | 232 B/op |
| Final `76a97c29` | 16.61 µs | 4.281 µs | 0 B/op |

Mean improves 10.7%, confidence intervals overlap, and allocation falls 100%. The supported `net10.0` hot path remains exactly `0 B/op`.

Final timeout control after all disposal changes:

| Mode | Mean | Allocated |
|---|---:|---:|
| None | 15.54 ms | 0 B/op |
| Stable cancellable token | 15.54 ms | 0 B/op |
| `TryReset()` between waits | 15.55 ms | 0 B/op |

### Disposal correctness

- Serialize cancellation registration with waiter disposal, then re-check disposal under `_dataAvailableWaiterLock`; a deterministic test pauses exactly after registration and proves disposal cannot reactivate an infinite waiter.
- `KafkaConsumer.DisposeAsync` now passes the actual prefetch task into buffer disposal. If the best-effort five-second join did not establish producer quiescence, signal disposal is attached to eventual task completion with `ExecuteSynchronously`; producer `Complete`, `TryWrite`, and released-space paths cannot touch disposed synchronization primitives.
- The cleanup continuation observes a faulted producer task before disposing signals. Signal disposal is idempotent.
- Focused `MpscFetchBufferTests`: `33/33`; Release unit build: 0 warnings/errors.

### Compatibility-asset audit

Forcing the `netstandard2.0` asset under .NET 8 confirmed the compatibility fallback costs `32 B/wake` (`16.43 µs`). This does not execute on Dekaf's supported .NET 10+ runtime: NuGet selects the allocation-free `net10.0` asset, and the project explicitly requires .NET 10+. Adding a `net8.0` asset was tested and rejected because Dekaf uses runtime-required .NET 10 features (`allows ref struct` generics and `System.Threading.Lock`). Two portable dispatch experiments were also rejected under the Pareto gate:

| Experiment | Mean wake | Allocated | Decision |
|---|---:|---:|---|
| `ManualResetValueTaskSourceCore.RunContinuationsAsynchronously` | 16.774 µs | 32 B/op | reject: allocation |
| reusable registered-wait dispatcher | 129.4 µs | 32 B/op | reject: allocation + latency |

The `netstandard2.0` branch remains a compatibility reference fallback; the supported runtime path uses the reusable `IThreadPoolWorkItem` and is measured at `0 B/op`.

`/simplify` retained the registration gate, explicit lock order, reusable queued completion, and delayed signal cleanup because each closes a measured race without adding supported hot-path allocation.


## Benchmark result validation (`85d4e363`)

CodeRabbit correctly found that the benchmark's cached `_signaled` field could retain `true` from the previous operation. The final harness now resets `_signaled=false` before every wait and throws unless the registered continuation observes `true`. This section supersedes the `18.60 → 16.61 µs` row immediately above; both revisions were rerun with the identical stricter harness.

| Revision | Mean wake | Error | Allocated |
|---|---:|---:|---:|
| Original `0c751571` | 22.31 µs | 7.009 µs | 232 B/op |
| Final `85d4e363` | 12.86 µs | 4.432 µs | 0 B/op |

The final mean is 42.4% lower and allocation falls 100%. Distributions remain scheduler-wide and confidence intervals overlap narrowly, so the protected conclusion is: no demonstrated wake-latency regression and an exact `232 B/op → 0 B/op` improvement. The stricter benchmark completed every operation with a true data signal; any false/stale completion now fails the run.
## Exact-head validation after main sync (`e0f17d00`)

Merged current `main` into the branch after #2551 and later accepted commits landed, then revalidated the resulting merge candidate on the same Windows 11 / i7-12700K / .NET 10.0.10 machine:

| Benchmark | Mean | Allocated |
|---|---:|---:|
| `TimeoutAsync(None)` | 15.53 ms | 0 B/op |
| `TimeoutAsync(Stable)` | 15.53 ms | 0 B/op |
| `TimeoutAsync(ResetBetweenWaits)` | 15.52 ms | 0 B/op |
| `SignalPendingWait` | 17.80 us | 0 B/op |

The signal benchmark remained noisy (`99.9% CI 13.06-22.54 us`), so the causal performance decision remains the strict paired comparison already reported above (`22.31 us / 232 B` baseline -> `12.86 us / 0 B` candidate). This exact-head run confirms the hard allocation gate still holds after the main sync.

Validation:
- Release unit build: 0 warnings, 0 errors
- `MpscFetchBufferTests`: 33/33 passed
- `ClassicCoordinatorFailover_CommitsResumeWithoutLossOrDuplicates`: 1/1 passed on exact head; 7/7 local diagnostic runs total

### CI failure audit

[CI run 31505306356](https://github.com/thomhurst/Dekaf/actions/runs/31505306356) failed only because `ClassicCoordinatorFailover_CommitsResumeWithoutLossOrDuplicates` timed out before its first failover (`consumed 0 of 30 expected records`); the faults lane was then cancelled by fail-fast. That test uses two `Confluent.Kafka.IConsumer` control consumers, not Dekaf or `MpscFetchBuffer`. The uploaded trace showed all initial Dekaf producer sends completed. Five fresh three-broker diagnostic repetitions plus the two earlier/current focused runs passed (7/7, 16-32 s). No speculative source or test change was made; the new head is a real current-main merge candidate and CI is validating it afresh.
Fresh exact-head CI: [run 31507827983](https://github.com/thomhurst/Dekaf/actions/runs/31507827983) fully passed, including consume (11m25s), faults (11m13s), all other integration lanes, leak gates, NativeAOT, unit tests, code quality, and the final `CI Passed` aggregate.
