### PR TITLE
Pool async Fire serialization state

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4619,6 +4619,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// delivery-error accounting stay unified. The returned ValueTask completes when the message
     /// is appended (parity with FireAsync's append semantics).
     /// </summary>
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+#endif
     private async ValueTask FireWithAsyncSerializationAsync(
         ProducerMessage<TKey, TValue> message,
         Activity? activity,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Client/AsyncProducerSerdePoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Client/AsyncProducerSerdePoolingBenchmarks.cs
@@ -1,0 +1,130 @@
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Serialization;
+using DekafProducer = Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Client;
+
+/// <summary>
+/// Measures the FireAsync wrapper that necessarily suspends for asynchronous serialization.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class AsyncProducerSerdePoolingBenchmarks
+{
+    private const string Topic = "bench-async-producer-serde";
+    private const string YieldingTopic = "bench-yielding-producer-serde";
+    private const int Operations = 100;
+
+    private static readonly string[] Keys = BenchmarkData.CreateKeys(Operations);
+
+    private KafkaTestEnvironment _kafka = null!;
+    private DekafProducer.IKafkaProducer<string, string> _producer = null!;
+    private DekafProducer.IKafkaProducer<string, string> _yieldingProducer = null!;
+    private string _value = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _kafka = await KafkaTestEnvironment.CreateAsync().ConfigureAwait(false);
+        await Task.WhenAll(
+            _kafka.CreateTopicAsync(Topic, 3),
+            _kafka.CreateTopicAsync(YieldingTopic, 3)).ConfigureAwait(false);
+
+        _value = new string('x', 100);
+        _producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(_kafka.BootstrapServers)
+            .WithClientId("bench-async-producer-serde")
+            .WithIdempotence(false)
+            .WithAcks(DekafProducer.Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithValueSerializer(new CompletedAsyncStringSerializer())
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        _yieldingProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(_kafka.BootstrapServers)
+            .WithClientId("bench-yielding-producer-serde")
+            .WithIdempotence(false)
+            .WithAcks(DekafProducer.Acks.All)
+            .WithLinger(TimeSpan.FromMilliseconds(5))
+            .WithValueSerializer(new YieldingAsyncStringSerializer())
+            .BuildAsync()
+            .ConfigureAwait(false);
+
+        for (var i = 0; i < 1_000; i++)
+        {
+            await _producer.ProduceAsync(Topic, Keys[i % Keys.Length], _value)
+                .ConfigureAwait(false);
+            await _yieldingProducer.ProduceAsync(YieldingTopic, Keys[i % Keys.Length], _value)
+                .ConfigureAwait(false);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public async Task FireAsync_CompletedSerializer()
+    {
+        for (var i = 0; i < Operations; i++)
+        {
+            await _producer.FireAsync(Topic, Keys[i], _value)
+                .ConfigureAwait(false);
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = Operations)]
+    public async Task FireAsync_YieldingSerializer()
+    {
+        for (var i = 0; i < Operations; i++)
+        {
+            await _yieldingProducer.FireAsync(YieldingTopic, Keys[i], _value)
+                .ConfigureAwait(false);
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _producer.DisposeAsync().ConfigureAwait(false);
+        await _yieldingProducer.DisposeAsync().ConfigureAwait(false);
+        await _kafka.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private sealed class CompletedAsyncStringSerializer : IAsyncSerializer<string>
+    {
+        public ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            var span = destination.GetSpan(byteCount);
+            var written = Encoding.UTF8.GetBytes(value, span);
+            destination.Advance(written);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class YieldingAsyncStringSerializer : IAsyncSerializer<string>
+    {
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+        public async ValueTask SerializeAsync(
+            string value,
+            IBufferWriter<byte> destination,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Yield();
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            var span = destination.GetSpan(byteCount);
+            var written = Encoding.UTF8.GetBytes(value, span);
+            destination.Advance(written);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- use PoolingAsyncValueTaskMethodBuilder for FireWithAsyncSerializationAsync
- add a real-Kafka BenchmarkDotNet allocation gate for completed and suspending async serializers
- keep completed-serializer behavior unchanged

## Performance

Paired baseline/candidate jobs, .NET 10.0.10, BenchmarkDotNet 0.15.8:

| Scenario | Baseline | Candidate | Delta |
|---|---:|---:|---:|
| FireAsync, yielding serializer | 1,451.7 ns / 502 B | 1,112.5 ns / 261 B | -23% time / -48% allocation |
| FireAsync, completed serializer control | 501.2 ns / 80 B | 512.9 ns / 80 B | neutral within error / unchanged |

Command:
dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter "*AsyncProducerSerdePoolingBenchmarks.FireAsync*" --join

## Verification

- benchmark project build: 0 warnings, 0 errors
- producer unit suites: 9 passed
- AsyncSerdeTests + RetryPolicyIntegrationTests: 11 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved asynchronous message production efficiency on supported .NET targets by reducing overhead during asynchronous serialization.
  - Existing producer behavior and public APIs remain unchanged.

- **Tests**
  - Added benchmark coverage for completed and yielding asynchronous serializers to measure producer performance across common serialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->