### PR TITLE
Pool async consumer timeout state

### DIFF
--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -4049,6 +4049,9 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
         return ConsumeOneWithTimeoutAsync(timeout, bufferedDrainStarted, pollRecorded, cancellationToken);
     }
 
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+#endif
     private async ValueTask<ConsumeResult<TKey, TValue>?> ConsumeOneWithTimeoutAsync(
         TimeSpan timeout,
         long? bufferedDrainStarted,

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AsyncConsumerSerdePoolingBenchmarks.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using Dekaf.Benchmarks.Infrastructure;
+using Dekaf.Consumer;
+using Dekaf.Protocol.Records;
+using Dekaf.Serialization;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the buffered ConsumeOneAsync path with an asynchronous value deserializer,
+/// including a forced-suspension case that exposes state-machine allocations.
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(AsyncConsumerSerdeJobConfig))]
+public class AsyncConsumerSerdePoolingBenchmarks
+{
+    private const int RecordsPerBatch = 1_000;
+    private const int BatchCount = 200;
+    private const int PollsPerIteration = BatchCount * RecordsPerBatch;
+    private const string Topic = "consume-one-async-serde";
+    private const int Partition = 0;
+    private static readonly TimeSpan PollTimeout = TimeSpan.FromSeconds(10);
+
+    private sealed class AsyncConsumerSerdeJobConfig : ManualConfig
+    {
+        public AsyncConsumerSerdeJobConfig()
+        {
+            AddJob(Job.Default
+                .WithStrategy(RunStrategy.Throughput)
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(10)
+                .WithInvocationCount(PollsPerIteration)
+                .WithUnrollFactor(1));
+        }
+    }
+
+    private Record[][] _batchRecords = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _completedConsumer = null!;
+    private KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> _yieldingConsumer = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var value = new byte[100];
+        _batchRecords = new Record[10][];
+        for (var b = 0; b < _batchRecords.Length; b++)
+        {
+            var records = new Record[RecordsPerBatch];
+            for (var i = 0; i < records.Length; i++)
+            {
+                records[i] = new Record
+                {
+                    OffsetDelta = i,
+                    TimestampDelta = i,
+                    Key = value,
+                    Value = value
+                };
+            }
+
+            _batchRecords[b] = records;
+        }
+
+        _completedConsumer = CreateConsumer(new CompletedDeserializer());
+        _yieldingConsumer = CreateConsumer(new YieldingDeserializer());
+    }
+
+    [IterationSetup(Target = nameof(Completed))]
+    public void CompletedSetup() => Reseed(_completedConsumer);
+
+    [IterationSetup(Target = nameof(Yielding))]
+    public void YieldingSetup() => Reseed(_yieldingConsumer);
+
+    [Benchmark]
+    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Completed()
+        => _completedConsumer.ConsumeOneAsync(PollTimeout);
+
+    [Benchmark]
+    public ValueTask<ConsumeResult<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>?> Yielding()
+        => _yieldingConsumer.ConsumeOneAsync(PollTimeout);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        BufferedConsumerHarness.DrainPendingFetches(_completedConsumer);
+        BufferedConsumerHarness.DrainPendingFetches(_yieldingConsumer);
+        _completedConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _yieldingConsumer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    private static KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> CreateConsumer(
+        IAsyncDeserializer<ReadOnlyMemory<byte>> asyncValueDeserializer)
+    {
+        var consumer = new KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>(
+            new ConsumerOptions
+            {
+                BootstrapServers = ["localhost:9092"],
+                OffsetCommitMode = OffsetCommitMode.Manual,
+                QueuedMinMessages = 1
+            },
+            Serializers.RawBytes,
+            Serializers.RawBytes,
+            asyncValueDeserializer: asyncValueDeserializer);
+        BufferedConsumerHarness.InitializeForBufferedFastPath(consumer, Topic, Partition);
+        return consumer;
+    }
+
+    private void Reseed(KafkaConsumer<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>> consumer)
+        => BufferedConsumerHarness.ReseedPendingFetches(
+            consumer, Topic, Partition, _batchRecords, BatchCount, RecordsPerBatch);
+
+    private sealed class CompletedDeserializer : IAsyncDeserializer<ReadOnlyMemory<byte>>
+    {
+        public ValueTask<ReadOnlyMemory<byte>> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(data);
+    }
+
+    private sealed class YieldingDeserializer : IAsyncDeserializer<ReadOnlyMemory<byte>>
+    {
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+        public async ValueTask<ReadOnlyMemory<byte>> DeserializeAsync(
+            ReadOnlyMemory<byte> data,
+            SerializationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- use PoolingAsyncValueTaskMethodBuilder for the outer ConsumeOneWithTimeoutAsync state machine
- add a broker-free BenchmarkDotNet gate for completed and suspending async deserializers
- leave nested consumer state machines unchanged because they did not improve the measured result

## Performance

.NET 10.0.10, BenchmarkDotNet 0.15.8:

| Scenario | Baseline | Candidate | Result |
|---|---:|---:|---:|
| yielding async deserializer | 2,055 ns / 2,213 B | 2,013 ns / 1,701 B | neutral time / -23% allocation |
| completed deserializer control | 529 ns / 0 B | 525 ns / 0 B | neutral / unchanged |

Command:
dotnet run --project tools/Dekaf.Benchmarks -c Release -- --filter "*AsyncConsumerSerdePoolingBenchmarks*" --join

## Verification

- benchmark project build: 0 warnings, 0 errors
- ConsumeOneFastPathTests: 29 passed
- AsyncSerdeTests integration: 6 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved asynchronous message consumption efficiency on supported .NET builds through pooled execution.
  * Added benchmarking coverage for completed and yielding asynchronous deserialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->