### PR TITLE
Use Reservoir for inflight entry pooling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
     <PackageVersion Include="Polyfill" Version="11.0.2" />
+    <PackageVersion Include="Reservoir" Version="1.2.3" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Reservoir" Version="1.2.3" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />
     <PackageVersion Include="System.IO.Pipelines" Version="10.0.11" />

--- a/src/Dekaf/Dekaf.csproj
+++ b/src/Dekaf/Dekaf.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Reservoir" />
     <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 

--- a/src/Dekaf/Producer/PartitionInflightTracker.cs
+++ b/src/Dekaf/Producer/PartitionInflightTracker.cs
@@ -125,8 +125,8 @@ internal sealed class PartitionState
 }
 
 /// <summary>
-/// Lock-free pool for InflightEntry objects.
-/// Extends <see cref="ObjectPool{T}"/> for pre-warm support and miss tracking.
+/// Reservoir-backed pool for InflightEntry objects.
+/// Uses manual Rent/Return because entries remain owned across asynchronous send completion.
 /// Default size 1024: with MaxInFlightRequestsPerConnection=5 and coalesced batches
 /// containing 10-50 partitions each, the steady-state in-flight count can reach
 /// 5 * 50 = 250 entries per connection. Multiple BrokerSenders multiply this further.
@@ -134,11 +134,52 @@ internal sealed class PartitionState
 /// workloads, creating mid-lived InflightEntry objects that survived Gen0 and got
 /// promoted to Gen2 before dying — contributing to pathological Gen2 GC pressure.
 /// </summary>
-internal sealed class InflightEntryPool(int maxPoolSize = 1024)
-    : ObjectPool<InflightEntry>(maxPoolSize)
+internal sealed class InflightEntryPool
 {
-    protected override InflightEntry Create() => new();
-    protected override void Reset(InflightEntry item) => item.Reset();
+    private readonly Reservoir.ObjectPool<InflightEntry, InflightEntryPolicy> _pool;
+    private long _misses;
+
+    public InflightEntryPool(int maxPoolSize = 1024)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        MaxPoolSize = maxPoolSize;
+        _pool = new Reservoir.ObjectPool<InflightEntry, InflightEntryPolicy>(
+            new InflightEntryPolicy(this),
+            maxPoolSize);
+    }
+
+    public int MaxPoolSize { get; }
+
+    public long Misses => Volatile.Read(ref _misses);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public InflightEntry Rent() => _pool.Rent();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Return(InflightEntry item) => _pool.Return(item);
+
+    public void PreWarm(int count)
+    {
+        count = Math.Min(count, MaxPoolSize);
+        for (var i = 0; i < count; i++)
+            _pool.Return(new InflightEntry());
+    }
+
+    private readonly struct InflightEntryPolicy(InflightEntryPool owner)
+        : Reservoir.IPooledObjectPolicy<InflightEntry>
+    {
+        public InflightEntry Create()
+        {
+            Interlocked.Increment(ref owner._misses);
+            return new InflightEntry();
+        }
+
+        public bool TryReset(InflightEntry item)
+        {
+            item.Reset();
+            return true;
+        }
+    }
 }
 
 /// <summary>

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(PublishAot)' != 'true'" />
+    <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="TUnit.Logging.Microsoft" />
     <PackageReference Include="Testcontainers.Kafka" />

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="Testcontainers.Kafka" />
   </ItemGroup>
 

--- a/tools/Dekaf.Profiling/Dekaf.Profiling.csproj
+++ b/tools/Dekaf.Profiling/Dekaf.Profiling.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="Testcontainers.Kafka" />
   </ItemGroup>
 

--- a/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
+++ b/tools/Dekaf.StressTests/Dekaf.StressTests.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="Testcontainers.Kafka" />
     <PackageReference Include="Testcontainers.Toxiproxy" />


### PR DESCRIPTION
## Summary

- replace `InflightEntryPool`'s hand-rolled `ObjectPool<T>` backing with Reservoir 1.2.3
- preserve maximum capacity, miss diagnostics, prewarming, and reset behavior
- keep manual `Rent`/`Return` because entries remain owned across asynchronous send completion
- pin Testcontainers consumers to `SSH.NET 2026.0.0` to resolve CVE-2026-48798 and restore warnings-as-errors CI

Testcontainers already merged its upstream dependency bump in [testcontainers/testcontainers-dotnet#1739](https://github.com/testcontainers/testcontainers-dotnet/pull/1739).

## Performance

BenchmarkDotNet ShortRun, .NET 10.0.11, Intel Core i7-12700K:

| Partition count | Before | After | Delta | Allocated |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 93.20 ns | 67.21 ns | -27.9% | 0 B |
| 10 | 92.54 ns | 67.55 ns | -27.0% | 0 B |

A pool-only same-run comparison also measured Reservoir's manual rent/return path 61–76% faster across 1, 4, and 16 workers, with 0 B allocated.

## Validation

- `dotnet restore Dekaf.sln` — succeeds with NuGet audit enabled
- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release --no-restore`
- `Dekaf.Tests.Unit.exe --treenode-filter "/*/*/PartitionInflightTrackerTests/*"` — 28 passed
- verified all four Testcontainers consumers resolve `SSH.NET 2026.0.0`
- `git diff --check`
- NativeAOT managed compilation completed; final native link could not run locally because Visual C++ linker prerequisites are unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved management and reuse of in-flight processing resources with configurable capacity.
  * Added pre-warming to help reduce allocation delays during workload spikes.
  * Improved reuse tracking to provide greater insight into resource availability.
  * Reset resources safely after use, supporting more consistent processing behavior.
  * Added clearer capacity controls to help tune performance for different workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->