### PR TITLE
fix(health-checks): treat joined consumers with zero assignments as healthy standbys

### DIFF
--- a/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
@@ -9,11 +9,14 @@ namespace Dekaf.Extensions.HealthChecks;
 /// <see cref="HealthStatus.Degraded"/> when any partition exceeds the degraded threshold,
 /// and <see cref="HealthStatus.Unhealthy"/> when any partition exceeds the unhealthy threshold
 /// or when the consumer's group membership is not live.
+/// A heartbeat is considered stale after three missed broker-directed heartbeat intervals.
 /// </summary>
 /// <typeparam name="TKey">The consumer key type.</typeparam>
 /// <typeparam name="TValue">The consumer value type.</typeparam>
 public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
 {
+    private const int HeartbeatStaleIntervalMultiplier = 3;
+
     private readonly IKafkaConsumer<TKey, TValue> _consumer;
     private readonly DekafConsumerHealthCheckOptions _options;
 
@@ -151,14 +154,7 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
     private HealthCheckResult? CheckGroupLiveness(int assignedPartitionCount)
     {
         if (_consumer is not IConsumerGroupLiveness livenessSource)
-        {
-            if (assignedPartitionCount != 0)
-                return null;
-
-            return string.IsNullOrEmpty(_consumer.MemberId)
-                ? null
-                : CreateStandbyResult(CreateLivenessData("Standby", assignedPartitionCount));
-        }
+            return null;
 
         var liveness = livenessSource.GroupLiveness;
 
@@ -169,7 +165,7 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
                 data: CreateLivenessData("Stopped", assignedPartitionCount, liveness));
         }
 
-        if (liveness.LastHeartbeatFailure is { Length: > 0 } failure)
+        if (liveness.HasConsumerGroup && liveness.LastHeartbeatFailure is { Length: > 0 } failure)
         {
             return HealthCheckResult.Unhealthy(
                 $"Consumer coordinator heartbeat failed: {failure}",
@@ -184,14 +180,15 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
         }
 
         var heartbeatAge = liveness.TimeSinceLastHeartbeat;
+        var heartbeatStaleThreshold = GetHeartbeatStaleThreshold(liveness.HeartbeatInterval);
         if (liveness.HasConsumerGroup &&
-            (heartbeatAge is null || heartbeatAge > liveness.SessionTimeout))
+            (heartbeatAge is null || heartbeatAge > heartbeatStaleThreshold))
         {
             return HealthCheckResult.Unhealthy(
                 heartbeatAge is null
                     ? "Consumer has joined its group but has no successful heartbeat."
                     : $"Consumer heartbeat is stale ({heartbeatAge.Value.TotalSeconds:F1}s old; " +
-                      $"session timeout is {liveness.SessionTimeout.TotalSeconds:F1}s).",
+                      $"expected interval is {liveness.HeartbeatInterval.TotalSeconds:F1}s).",
                 data: CreateLivenessData("StaleHeartbeat", assignedPartitionCount, liveness));
         }
 
@@ -205,6 +202,16 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
         _options.NoAssignmentStatus,
         "Consumer is a live standby group member with no partition assignment.",
         data: data);
+
+    private static TimeSpan GetHeartbeatStaleThreshold(TimeSpan heartbeatInterval)
+    {
+        if (heartbeatInterval <= TimeSpan.Zero)
+            return TimeSpan.Zero;
+
+        return heartbeatInterval.Ticks > TimeSpan.MaxValue.Ticks / HeartbeatStaleIntervalMultiplier
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromTicks(heartbeatInterval.Ticks * HeartbeatStaleIntervalMultiplier);
+    }
 
     private static Dictionary<string, object> CreateLivenessData(
         string consumerState,
@@ -222,7 +229,9 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
             data["HasConsumerGroup"] = snapshot.HasConsumerGroup;
             data["IsJoined"] = snapshot.IsJoined;
             data["IsStopped"] = snapshot.IsStopped;
-            data["SessionTimeoutMilliseconds"] = snapshot.SessionTimeout.TotalMilliseconds;
+            data["HeartbeatIntervalMilliseconds"] = snapshot.HeartbeatInterval.TotalMilliseconds;
+            data["HeartbeatStaleThresholdMilliseconds"] =
+                GetHeartbeatStaleThreshold(snapshot.HeartbeatInterval).TotalMilliseconds;
             if (snapshot.TimeSinceLastHeartbeat is { } heartbeatAge)
                 data["HeartbeatAgeMilliseconds"] = heartbeatAge.TotalMilliseconds;
             if (snapshot.LastHeartbeatFailure is { } failure)

--- a/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheck.cs
@@ -8,7 +8,7 @@ namespace Dekaf.Extensions.HealthChecks;
 /// Reports <see cref="HealthStatus.Healthy"/> when all partitions are within the degraded threshold,
 /// <see cref="HealthStatus.Degraded"/> when any partition exceeds the degraded threshold,
 /// and <see cref="HealthStatus.Unhealthy"/> when any partition exceeds the unhealthy threshold
-/// or when the consumer has no assignment.
+/// or when the consumer's group membership is not live.
 /// </summary>
 /// <typeparam name="TKey">The consumer key type.</typeparam>
 /// <typeparam name="TValue">The consumer value type.</typeparam>
@@ -43,9 +43,15 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
             var offsets = _consumer.Offsets;
             var assignment = partitions.Assignment;
 
+            var livenessResult = CheckGroupLiveness(assignment.Count);
+            if (livenessResult is { } result)
+                return result;
+
             if (assignment.Count == 0)
             {
-                return HealthCheckResult.Unhealthy("Consumer has no partition assignment.");
+                return HealthCheckResult.Unhealthy(
+                    "Consumer has no partition assignment and no live group membership.",
+                    data: CreateLivenessData("MissingGroupMembership", assignment.Count));
             }
 
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -140,5 +146,89 @@ public sealed class DekafConsumerHealthCheck<TKey, TValue> : IHealthCheck
                 "Failed to check consumer health.",
                 exception: ex);
         }
+    }
+
+    private HealthCheckResult? CheckGroupLiveness(int assignedPartitionCount)
+    {
+        if (_consumer is not IConsumerGroupLiveness livenessSource)
+        {
+            if (assignedPartitionCount != 0)
+                return null;
+
+            return string.IsNullOrEmpty(_consumer.MemberId)
+                ? null
+                : CreateStandbyResult(CreateLivenessData("Standby", assignedPartitionCount));
+        }
+
+        var liveness = livenessSource.GroupLiveness;
+
+        if (liveness.IsStopped)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Consumer is stopped.",
+                data: CreateLivenessData("Stopped", assignedPartitionCount, liveness));
+        }
+
+        if (liveness.LastHeartbeatFailure is { Length: > 0 } failure)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Consumer coordinator heartbeat failed: {failure}",
+                data: CreateLivenessData("CoordinatorFailure", assignedPartitionCount, liveness));
+        }
+
+        if (liveness.HasConsumerGroup && !liveness.IsJoined)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Consumer is not joined to its consumer group.",
+                data: CreateLivenessData("MissingGroupMembership", assignedPartitionCount, liveness));
+        }
+
+        var heartbeatAge = liveness.TimeSinceLastHeartbeat;
+        if (liveness.HasConsumerGroup &&
+            (heartbeatAge is null || heartbeatAge > liveness.SessionTimeout))
+        {
+            return HealthCheckResult.Unhealthy(
+                heartbeatAge is null
+                    ? "Consumer has joined its group but has no successful heartbeat."
+                    : $"Consumer heartbeat is stale ({heartbeatAge.Value.TotalSeconds:F1}s old; " +
+                      $"session timeout is {liveness.SessionTimeout.TotalSeconds:F1}s).",
+                data: CreateLivenessData("StaleHeartbeat", assignedPartitionCount, liveness));
+        }
+
+        if (assignedPartitionCount == 0 && liveness.HasConsumerGroup)
+            return CreateStandbyResult(CreateLivenessData("Standby", assignedPartitionCount, liveness));
+
+        return null;
+    }
+
+    private HealthCheckResult CreateStandbyResult(Dictionary<string, object> data) => new(
+        _options.NoAssignmentStatus,
+        "Consumer is a live standby group member with no partition assignment.",
+        data: data);
+
+    private static Dictionary<string, object> CreateLivenessData(
+        string consumerState,
+        int assignedPartitionCount,
+        ConsumerGroupLiveness? liveness = null)
+    {
+        var data = new Dictionary<string, object>
+        {
+            ["ConsumerState"] = consumerState,
+            ["AssignedPartitionCount"] = assignedPartitionCount
+        };
+
+        if (liveness is { } snapshot)
+        {
+            data["HasConsumerGroup"] = snapshot.HasConsumerGroup;
+            data["IsJoined"] = snapshot.IsJoined;
+            data["IsStopped"] = snapshot.IsStopped;
+            data["SessionTimeoutMilliseconds"] = snapshot.SessionTimeout.TotalMilliseconds;
+            if (snapshot.TimeSinceLastHeartbeat is { } heartbeatAge)
+                data["HeartbeatAgeMilliseconds"] = heartbeatAge.TotalMilliseconds;
+            if (snapshot.LastHeartbeatFailure is { } failure)
+                data["LastHeartbeatFailure"] = failure;
+        }
+
+        return data;
     }
 }

--- a/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheckOptions.cs
+++ b/src/Dekaf.Extensions.HealthChecks/DekafConsumerHealthCheckOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 namespace Dekaf.Extensions.HealthChecks;
 
 /// <summary>
@@ -5,6 +7,13 @@ namespace Dekaf.Extensions.HealthChecks;
 /// </summary>
 public sealed class DekafConsumerHealthCheckOptions
 {
+    /// <summary>
+    /// The status returned for a live, joined consumer that has no assigned partitions.
+    /// Default is <see cref="HealthStatus.Healthy"/> because a consumer group may have more
+    /// members than partitions.
+    /// </summary>
+    public HealthStatus NoAssignmentStatus { get; init; } = HealthStatus.Healthy;
+
     /// <summary>
     /// The maximum acceptable consumer lag (in messages) per partition before the health check
     /// reports <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded"/>.
@@ -31,8 +40,19 @@ public sealed class DekafConsumerHealthCheckOptions
     /// <exception cref="ArgumentException">
     /// Thrown when <see cref="DegradedThreshold"/> is greater than or equal to <see cref="UnhealthyThreshold"/>.
     /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <see cref="NoAssignmentStatus"/> is not a valid <see cref="HealthStatus"/>.
+    /// </exception>
     public void Validate()
     {
+        if (!Enum.IsDefined(NoAssignmentStatus))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(NoAssignmentStatus),
+                NoAssignmentStatus,
+                "NoAssignmentStatus must be a valid health status.");
+        }
+
         if (DegradedThreshold >= UnhealthyThreshold)
         {
             throw new ArgumentException(

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -77,6 +77,8 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
 
     private volatile CoordinatorState _state = CoordinatorState.Unjoined;
     private KafkaException? _fatalHeartbeatException;
+    private long _lastSuccessfulHeartbeatTimestamp;
+    private string? _lastHeartbeatFailure;
     private int _disposed;
     private readonly Func<int> _getCoordinationConnectionIndex;
 
@@ -163,6 +165,20 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public CoordinatorState State => _state;
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
+
+    internal ConsumerGroupLiveness CaptureGroupLiveness(bool isStopped)
+    {
+        var lastHeartbeatTimestamp = Volatile.Read(ref _lastSuccessfulHeartbeatTimestamp);
+        return new ConsumerGroupLiveness(
+            HasConsumerGroup: true,
+            IsJoined: _state == CoordinatorState.Stable,
+            IsStopped: isStopped || Volatile.Read(ref _disposed) != 0,
+            TimeSinceLastHeartbeat: lastHeartbeatTimestamp == 0
+                ? null
+                : Stopwatch.GetElapsedTime(lastHeartbeatTimestamp),
+            SessionTimeout: TimeSpan.FromMilliseconds(_options.SessionTimeoutMs),
+            LastHeartbeatFailure: Volatile.Read(ref _lastHeartbeatFailure));
+    }
 
     internal ValueTask RecordPollAsync(CancellationToken cancellationToken)
     {
@@ -1596,6 +1612,9 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             HandleConsumerGroupHeartbeatError(response, subscribedTopicRegex);
         }
 
+        Volatile.Write(ref _lastSuccessfulHeartbeatTimestamp, Stopwatch.GetTimestamp());
+        Volatile.Write(ref _lastHeartbeatFailure, null);
+
         if (!isInitial && ownedTopicPartitions is not null)
             Volatile.Write(ref _sentOwnedTopicPartitionsVersion, assignmentVersion);
 
@@ -1998,6 +2017,7 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
             catch (Exception ex)
             {
                 LogHeartbeatFailed(ex);
+                Volatile.Write(ref _lastHeartbeatFailure, ex.Message);
 
                 if (ex is BrokerVersionException brokerVersionException)
                 {

--- a/src/Dekaf/Consumer/ConsumerCoordinator.cs
+++ b/src/Dekaf/Consumer/ConsumerCoordinator.cs
@@ -166,17 +166,17 @@ public sealed partial class ConsumerCoordinator : IAsyncDisposable
     public TopicPartitionSet Assignment => _assignedPartitions;
     internal int AssignmentVersion => Volatile.Read(ref _assignmentVersion);
 
-    internal ConsumerGroupLiveness CaptureGroupLiveness(bool isStopped)
+    internal ConsumerGroupLiveness CaptureGroupLiveness(bool isStopped, bool hasConsumerGroup)
     {
         var lastHeartbeatTimestamp = Volatile.Read(ref _lastSuccessfulHeartbeatTimestamp);
         return new ConsumerGroupLiveness(
-            HasConsumerGroup: true,
-            IsJoined: _state == CoordinatorState.Stable,
+            HasConsumerGroup: hasConsumerGroup,
+            IsJoined: hasConsumerGroup && _state == CoordinatorState.Stable,
             IsStopped: isStopped || Volatile.Read(ref _disposed) != 0,
             TimeSinceLastHeartbeat: lastHeartbeatTimestamp == 0
                 ? null
                 : Stopwatch.GetElapsedTime(lastHeartbeatTimestamp),
-            SessionTimeout: TimeSpan.FromMilliseconds(_options.SessionTimeoutMs),
+            HeartbeatInterval: TimeSpan.FromMilliseconds(Math.Max(_heartbeatIntervalMs, 1)),
             LastHeartbeatFailure: Volatile.Read(ref _lastHeartbeatFailure));
     }
 

--- a/src/Dekaf/Consumer/ConsumerGroupLiveness.cs
+++ b/src/Dekaf/Consumer/ConsumerGroupLiveness.cs
@@ -1,0 +1,35 @@
+namespace Dekaf.Consumer;
+
+/// <summary>
+/// Optional capability that exposes the liveness of a consumer's group membership.
+/// </summary>
+/// <remarks>
+/// Dekaf's built-in consumer implements this interface. Consumer wrappers can implement it so
+/// operational integrations can distinguish a live standby member from a consumer that has not
+/// joined its group or has stopped heartbeating.
+/// </remarks>
+public interface IConsumerGroupLiveness
+{
+    /// <summary>Gets a point-in-time snapshot of the consumer's group liveness.</summary>
+    ConsumerGroupLiveness GroupLiveness { get; }
+}
+
+/// <summary>
+/// A point-in-time snapshot of consumer group liveness.
+/// </summary>
+/// <param name="HasConsumerGroup">Whether the consumer is configured to participate in a group.</param>
+/// <param name="IsJoined">Whether the consumer currently has stable group membership.</param>
+/// <param name="IsStopped">Whether the consumer has been closed or disposed.</param>
+/// <param name="TimeSinceLastHeartbeat">
+/// Time elapsed since the most recent successful group heartbeat, or <see langword="null"/>
+/// when no heartbeat has succeeded.
+/// </param>
+/// <param name="SessionTimeout">The configured group session timeout.</param>
+/// <param name="LastHeartbeatFailure">The most recent heartbeat failure, if any.</param>
+public readonly record struct ConsumerGroupLiveness(
+    bool HasConsumerGroup,
+    bool IsJoined,
+    bool IsStopped,
+    TimeSpan? TimeSinceLastHeartbeat,
+    TimeSpan SessionTimeout,
+    string? LastHeartbeatFailure);

--- a/src/Dekaf/Consumer/ConsumerGroupLiveness.cs
+++ b/src/Dekaf/Consumer/ConsumerGroupLiveness.cs
@@ -24,12 +24,14 @@ public interface IConsumerGroupLiveness
 /// Time elapsed since the most recent successful group heartbeat, or <see langword="null"/>
 /// when no heartbeat has succeeded.
 /// </param>
-/// <param name="SessionTimeout">The configured group session timeout.</param>
+/// <param name="HeartbeatInterval">
+/// The broker-directed interval between consumer group heartbeats.
+/// </param>
 /// <param name="LastHeartbeatFailure">The most recent heartbeat failure, if any.</param>
 public readonly record struct ConsumerGroupLiveness(
     bool HasConsumerGroup,
     bool IsJoined,
     bool IsStopped,
     TimeSpan? TimeSinceLastHeartbeat,
-    TimeSpan SessionTimeout,
+    TimeSpan HeartbeatInterval,
     string? LastHeartbeatFailure);

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -861,6 +861,7 @@ internal static class ConsumerFetchPools
 /// <typeparam name="TValue">Value type.</typeparam>
 public sealed partial class KafkaConsumer<TKey, TValue> :
     IKafkaConsumer<TKey, TValue>,
+    IConsumerGroupLiveness,
     IConsumerPositions,
     IConsumerPartitions,
     IConsumerOffsets,
@@ -1721,6 +1722,17 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
     public IConsumerPositions Positions => this;
     public IConsumerPartitions Partitions => this;
     public IConsumerOffsets Offsets => this;
+
+    ConsumerGroupLiveness IConsumerGroupLiveness.GroupLiveness => _coordinator is null
+        ? new ConsumerGroupLiveness(
+            HasConsumerGroup: false,
+            IsJoined: false,
+            IsStopped: Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0,
+            TimeSinceLastHeartbeat: null,
+            SessionTimeout: TimeSpan.Zero,
+            LastHeartbeatFailure: null)
+        : _coordinator.CaptureGroupLiveness(
+            Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0);
 
     IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
     {

--- a/src/Dekaf/Consumer/KafkaConsumer.cs
+++ b/src/Dekaf/Consumer/KafkaConsumer.cs
@@ -1729,10 +1729,11 @@ public sealed partial class KafkaConsumer<TKey, TValue> :
             IsJoined: false,
             IsStopped: Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0,
             TimeSinceLastHeartbeat: null,
-            SessionTimeout: TimeSpan.Zero,
+            HeartbeatInterval: TimeSpan.Zero,
             LastHeartbeatFailure: null)
         : _coordinator.CaptureGroupLiveness(
-            Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0);
+            Volatile.Read(ref _closed) != 0 || Volatile.Read(ref _consumerDisposed) != 0,
+            _topicPattern is not null || _subscriptionSnapshot.Count != 0);
 
     IDisposable IConsumerRebalanceEventSource.RegisterRuntimeRebalanceListener(IRebalanceListener listener)
     {

--- a/tests/Dekaf.Tests.Integration/ConsumerHealthCheckIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerHealthCheckIntegrationTests.cs
@@ -26,8 +26,8 @@ public sealed class ConsumerHealthCheckIntegrationTests(KafkaTestContainer kafka
         try
         {
             await WaitForConditionAsync(
-                () => ((IConsumerGroupLiveness)first).GroupLiveness.IsJoined &&
-                      ((IConsumerGroupLiveness)second).GroupLiveness.IsJoined &&
+                () => HasConfirmedHeartbeat(first) &&
+                      HasConfirmedHeartbeat(second) &&
                       first.Assignment.Count + second.Assignment.Count == 1,
                 TimeSpan.FromSeconds(20),
                 description: "both consumers to join with one standby member");
@@ -72,5 +72,11 @@ public sealed class ConsumerHealthCheckIntegrationTests(KafkaTestContainer kafka
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
         }
+    }
+
+    private static bool HasConfirmedHeartbeat(IKafkaConsumer<string, string> consumer)
+    {
+        var liveness = ((IConsumerGroupLiveness)consumer).GroupLiveness;
+        return liveness.IsJoined && liveness.TimeSinceLastHeartbeat is not null;
     }
 }

--- a/tests/Dekaf.Tests.Integration/ConsumerHealthCheckIntegrationTests.cs
+++ b/tests/Dekaf.Tests.Integration/ConsumerHealthCheckIntegrationTests.cs
@@ -1,0 +1,76 @@
+using Dekaf.Consumer;
+using Dekaf.Extensions.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Consumer")]
+[Category("HealthChecks")]
+public sealed class ConsumerHealthCheckIntegrationTests(KafkaTestContainer kafka) : KafkaIntegrationTest(kafka)
+{
+    [Test]
+    public async Task MoreConsumersThanPartitions_UnassignedMemberRemainsHealthy()
+    {
+        var topic = await KafkaContainer.CreateTestTopicAsync(partitions: 1);
+        var groupId = $"health-check-standby-{Guid.NewGuid():N}";
+
+        await using var first = await CreateConsumerAsync("health-check-first", groupId);
+        await using var second = await CreateConsumerAsync("health-check-second", groupId);
+        first.Subscribe(topic);
+        second.Subscribe(topic);
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var firstPoll = ConsumeUntilCancelledAsync(first, cancellation.Token);
+        var secondPoll = ConsumeUntilCancelledAsync(second, cancellation.Token);
+
+        try
+        {
+            await WaitForConditionAsync(
+                () => ((IConsumerGroupLiveness)first).GroupLiveness.IsJoined &&
+                      ((IConsumerGroupLiveness)second).GroupLiveness.IsJoined &&
+                      first.Assignment.Count + second.Assignment.Count == 1,
+                TimeSpan.FromSeconds(20),
+                description: "both consumers to join with one standby member");
+
+            var standby = first.Assignment.Count == 0 ? first : second;
+            var healthCheck = new DekafConsumerHealthCheck<string, string>(
+                standby,
+                new DekafConsumerHealthCheckOptions());
+
+            var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+            await Assert.That(standby.Assignment).IsEmpty();
+            await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+            await Assert.That(result.Data["ConsumerState"]).IsEqualTo("Standby");
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            await Task.WhenAll(firstPoll, secondPoll);
+        }
+    }
+
+    private async Task<IKafkaConsumer<string, string>> CreateConsumerAsync(string clientId, string groupId) =>
+        await Kafka.CreateConsumer<string, string>()
+            .WithBootstrapServers(KafkaContainer.BootstrapServers)
+            .WithClientId(clientId)
+            .WithGroupId(groupId)
+            .WithSessionTimeout(TimeSpan.FromSeconds(10))
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync();
+
+    private static async Task ConsumeUntilCancelledAsync(
+        IKafkaConsumer<string, string> consumer,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var _ in consumer.ConsumeAsync(cancellationToken))
+            {
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+}

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.DependencyInjection\Dekaf.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Extensions.Hosting\Dekaf.Extensions.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.Extensions.HealthChecks\Dekaf.Extensions.HealthChecks.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Outbox\Dekaf.Outbox.csproj" />
     <!-- Entity Framework Core cannot compile under NativeAOT (ILC IL3002 in EF itself);
          the outbox EF store and its end-to-end test are covered by the JIT legs only. -->

--- a/tests/Dekaf.Tests.Unit/Consumer/ConsumerGroupLivenessTests.cs
+++ b/tests/Dekaf.Tests.Unit/Consumer/ConsumerGroupLivenessTests.cs
@@ -1,0 +1,41 @@
+using Dekaf.Consumer;
+using Dekaf.Serialization;
+
+namespace Dekaf.Tests.Unit.Consumer;
+
+public sealed class ConsumerGroupLivenessTests
+{
+    [Test]
+    public async Task ManualAssignmentWithConfiguredGroup_DoesNotReportGroupParticipation()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.Assign(new TopicPartition("test-topic", 0));
+
+        var liveness = ((IConsumerGroupLiveness)consumer).GroupLiveness;
+
+        await Assert.That(liveness.HasConsumerGroup).IsFalse();
+        await Assert.That(liveness.IsJoined).IsFalse();
+    }
+
+    [Test]
+    public async Task SubscriptionWithConfiguredGroup_ReportsGroupParticipation()
+    {
+        await using var consumer = CreateConsumer();
+        consumer.Subscribe("test-topic");
+
+        var liveness = ((IConsumerGroupLiveness)consumer).GroupLiveness;
+
+        await Assert.That(liveness.HasConsumerGroup).IsTrue();
+        await Assert.That(liveness.IsJoined).IsFalse();
+    }
+
+    private static KafkaConsumer<string, string> CreateConsumer() => new(
+        new ConsumerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            ClientId = "liveness-test-consumer",
+            GroupId = "liveness-test-group"
+        },
+        Serializers.String,
+        Serializers.String);
+}

--- a/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
@@ -56,6 +56,51 @@ public class HealthCheckTests
     }
 
     [Test]
+    public async Task ConsumerHealthCheck_NoLivenessWithMemberIdAndNoAssignment_ReturnsUnhealthy()
+    {
+        var consumer = CreateConsumerSubstitute(out var partitions, out _, out _);
+        consumer.MemberId.Returns("stale-member-id");
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("MissingGroupMembership");
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_ManualAssignmentWithConfiguredGroup_EvaluatesLag()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness() with
+            {
+                HasConsumerGroup = false,
+                IsJoined = false,
+                TimeSinceLastHeartbeat = null,
+                LastHeartbeatFailure = "failure from previous group subscription"
+            },
+            out var partitions,
+            out var positions,
+            out var offsets);
+        var topicPartition = new TopicPartition("test-topic", 0);
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { topicPartition });
+        positions.GetPosition(topicPartition).Returns(90L);
+        offsets.QueryWatermarkOffsetsAsync(topicPartition, Arg.Any<CancellationToken>())
+            .Returns(new WatermarkOffsets(0, 100));
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+        await Assert.That(result.Data["MaxLag"]).IsEqualTo(10L);
+    }
+
+    [Test]
     public async Task ConsumerHealthCheck_NotJoinedWithAssignment_ReturnsUnhealthy()
     {
         var consumer = CreateConsumerSubstitute(
@@ -93,6 +138,8 @@ public class HealthCheckTests
         await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
         await Assert.That(result.Description).Contains("stale");
         await Assert.That(result.Data["ConsumerState"]).IsEqualTo("StaleHeartbeat");
+        await Assert.That(result.Data["HeartbeatIntervalMilliseconds"]).IsEqualTo(3000d);
+        await Assert.That(result.Data["HeartbeatStaleThresholdMilliseconds"]).IsEqualTo(9000d);
     }
 
     [Test]
@@ -790,7 +837,7 @@ public class HealthCheckTests
         IsJoined: true,
         IsStopped: false,
         TimeSinceLastHeartbeat: TimeSpan.FromSeconds(1),
-        SessionTimeout: TimeSpan.FromSeconds(10),
+        HeartbeatInterval: TimeSpan.FromSeconds(3),
         LastHeartbeatFailure: null);
 
     private static HealthCheckContext CreateContext()

--- a/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
+++ b/tests/Dekaf.Tests.Unit/Extensions/HealthCheckTests.cs
@@ -15,9 +15,74 @@ public class HealthCheckTests
     #region Consumer Health Check Tests
 
     [Test]
-    public async Task ConsumerHealthCheck_NoAssignment_ReturnsUnhealthy()
+    public async Task ConsumerHealthCheck_LiveStandbyWithNoAssignment_ReturnsHealthy()
     {
-        var consumer = CreateConsumerSubstitute(out var partitions, out _, out _);
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness(),
+            out var partitions,
+            out _,
+            out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Healthy);
+        await Assert.That(result.Description).Contains("live standby");
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("Standby");
+        await Assert.That(result.Data["AssignedPartitionCount"]).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_LiveStandby_UsesConfiguredNoAssignmentStatus()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness(),
+            out var partitions,
+            out _,
+            out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer,
+            new DekafConsumerHealthCheckOptions { NoAssignmentStatus = HealthStatus.Degraded });
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Degraded);
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("Standby");
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_NotJoinedWithAssignment_ReturnsUnhealthy()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness() with { IsJoined = false, TimeSinceLastHeartbeat = null },
+            out var partitions,
+            out _,
+            out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition> { new("test-topic", 0) });
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+        await Assert.That(result.Description).Contains("not joined");
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("MissingGroupMembership");
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_StaleHeartbeat_ReturnsUnhealthy()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness() with { TimeSinceLastHeartbeat = TimeSpan.FromSeconds(11) },
+            out var partitions,
+            out _,
+            out _);
         partitions.Assignment.Returns(new HashSet<TopicPartition>());
 
         var healthCheck = new DekafConsumerHealthCheck<string, string>(
@@ -26,13 +91,58 @@ public class HealthCheckTests
         var result = await healthCheck.CheckHealthAsync(CreateContext());
 
         await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
-        await Assert.That(result.Description).Contains("no partition assignment");
+        await Assert.That(result.Description).Contains("stale");
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("StaleHeartbeat");
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_CoordinatorFailure_ReturnsUnhealthy()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness() with { LastHeartbeatFailure = "Coordinator unavailable" },
+            out var partitions,
+            out _,
+            out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+        await Assert.That(result.Description).Contains("Coordinator unavailable");
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("CoordinatorFailure");
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_StoppedConsumer_ReturnsUnhealthy()
+    {
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness() with { IsStopped = true },
+            out var partitions,
+            out _,
+            out _);
+        partitions.Assignment.Returns(new HashSet<TopicPartition>());
+
+        var healthCheck = new DekafConsumerHealthCheck<string, string>(
+            consumer, new DekafConsumerHealthCheckOptions());
+
+        var result = await healthCheck.CheckHealthAsync(CreateContext());
+
+        await Assert.That(result.Status).IsEqualTo(HealthStatus.Unhealthy);
+        await Assert.That(result.Description).Contains("stopped");
+        await Assert.That(result.Data["ConsumerState"]).IsEqualTo("Stopped");
     }
 
     [Test]
     public async Task ConsumerHealthCheck_LowLag_ReturnsHealthy()
     {
-        var consumer = CreateConsumerSubstitute(out var partitions, out var positions, out var offsets);
+        var consumer = CreateConsumerSubstitute(
+            LiveGroupLiveness(),
+            out var partitions,
+            out var positions,
+            out var offsets);
         var tp = new TopicPartition("test-topic", 0);
         partitions.Assignment.Returns(new HashSet<TopicPartition> { tp });
         positions.GetPosition(tp).Returns(90L);
@@ -266,6 +376,19 @@ public class HealthCheckTests
 
         await Assert.That(() => new DekafConsumerHealthCheck<string, string>(consumer, options))
             .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ConsumerHealthCheck_InvalidNoAssignmentStatus_ThrowsArgumentOutOfRangeException()
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>>();
+        var options = new DekafConsumerHealthCheckOptions
+        {
+            NoAssignmentStatus = (HealthStatus)int.MaxValue
+        };
+
+        await Assert.That(() => new DekafConsumerHealthCheck<string, string>(consumer, options))
+            .Throws<ArgumentOutOfRangeException>();
     }
 
     [Test]
@@ -603,6 +726,7 @@ public class HealthCheckTests
         await Assert.That(options.DegradedThreshold).IsEqualTo(1000L);
         await Assert.That(options.UnhealthyThreshold).IsEqualTo(10000L);
         await Assert.That(options.Timeout).IsEqualTo(TimeSpan.FromSeconds(5));
+        await Assert.That(options.NoAssignmentStatus).IsEqualTo(HealthStatus.Healthy);
     }
 
     [Test]
@@ -641,6 +765,33 @@ public class HealthCheckTests
 
         return consumer;
     }
+
+    private static IKafkaConsumer<string, string> CreateConsumerSubstitute(
+        ConsumerGroupLiveness groupLiveness,
+        out IConsumerPartitions partitions,
+        out IConsumerPositions positions,
+        out IConsumerOffsets offsets)
+    {
+        var consumer = Substitute.For<IKafkaConsumer<string, string>, IConsumerGroupLiveness>();
+        ((IConsumerGroupLiveness)consumer).GroupLiveness.Returns(groupLiveness);
+        partitions = Substitute.For<IConsumerPartitions>();
+        positions = Substitute.For<IConsumerPositions>();
+        offsets = Substitute.For<IConsumerOffsets>();
+
+        consumer.Partitions.Returns(partitions);
+        consumer.Positions.Returns(positions);
+        consumer.Offsets.Returns(offsets);
+
+        return consumer;
+    }
+
+    private static ConsumerGroupLiveness LiveGroupLiveness() => new(
+        HasConsumerGroup: true,
+        IsJoined: true,
+        IsStopped: false,
+        TimeSinceLastHeartbeat: TimeSpan.FromSeconds(1),
+        SessionTimeout: TimeSpan.FromSeconds(10),
+        LastHeartbeatFailure: null);
 
     private static HealthCheckContext CreateContext()
     {


### PR DESCRIPTION
## Summary

- expose an additive consumer-group liveness snapshot for operational integrations
- treat live joined consumers with zero assignments as healthy standbys by default
- add configurable `NoAssignmentStatus` and state-specific diagnostics
- keep stopped, unjoined, stale-heartbeat, and coordinator-failure states unhealthy

## Root cause

`DekafConsumerHealthCheck` used assignment count as a proxy for consumer health. A stable group can legitimately have more members than partitions, so standby members were incorrectly reported unhealthy despite current heartbeats and valid group membership.

## Impact

Readiness checks no longer fail for healthy standby consumers. Applications that require every consumer to own a partition can retain stricter behavior by setting `NoAssignmentStatus` to `Degraded` or `Unhealthy`.

The liveness bookkeeping runs on the periodic coordinator-heartbeat path and does not add work or allocations to per-message consume paths.

## Validation

- `dotnet build src/Dekaf.Extensions.HealthChecks/Dekaf.Extensions.HealthChecks.csproj --configuration Release --no-restore -p:RunAnalyzers=false`
- focused health-check unit tests: 41 passed
- focused Testcontainers integration test against Podman: 1 passed (two consumers, one partition)

Fixes #2555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Consumer health checks now monitor group membership, heartbeat freshness, coordinator connectivity, and stopped consumers.
  - Health results include consumer group liveness details for easier diagnosis.
  - No-assignment status can be configured, allowing live standby consumers to remain healthy or report another configured status.
  - Messages now distinguish missing group membership from other no-assignment conditions.

- **Bug Fixes**
  - Detects unhealthy consumers with stale heartbeats, coordinator failures, or unexpected stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->