### PR TITLE
Migrate performant networking pools to Reservoir

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -4875,18 +4875,23 @@ internal sealed class PooledResponseMemory : IPooledMemory
 
 /// <summary>
 /// Thread-safe bounded pool for <see cref="PooledPendingRequest"/> instances.
-/// Uses lock-free operations via <see cref="ConcurrentStack{T}"/> for high throughput.
+/// Uses Reservoir's bounded, preallocated storage for zero-allocation rent and return.
 /// </summary>
 internal sealed class PendingRequestPool
 {
     private const int DefaultMaxPoolSize = 256;
-    private readonly int _maxPoolSize;
-    private readonly ConcurrentStack<PooledPendingRequest> _pool = new();
+    private readonly Reservoir.ObjectPool<PooledPendingRequest, PoolPolicy> _pool;
     private int _poolCount;
 
     public PendingRequestPool() : this(DefaultMaxPoolSize) { }
 
-    public PendingRequestPool(int maxPoolSize) { _maxPoolSize = maxPoolSize; }
+    public PendingRequestPool(int maxPoolSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxPoolSize);
+        _pool = new Reservoir.ObjectPool<PooledPendingRequest, PoolPolicy>(
+            new PoolPolicy(this),
+            maxPoolSize);
+    }
 
     public int ApproximateCount => Volatile.Read(ref _poolCount);
 
@@ -4896,13 +4901,9 @@ internal sealed class PendingRequestPool
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public PooledPendingRequest Rent()
     {
-        if (_pool.TryPop(out var request))
-        {
-            Interlocked.Decrement(ref _poolCount);
-            return request;
-        }
-
-        return new PooledPendingRequest();
+        var request = _pool.Rent();
+        Interlocked.Decrement(ref _poolCount);
+        return request;
     }
 
     /// <summary>
@@ -4912,20 +4913,28 @@ internal sealed class PendingRequestPool
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Return(PooledPendingRequest request)
     {
-        // Reset the request for reuse
-        request.Reset();
+        _pool.Return(request);
+        // Destroy runs synchronously when retention is rejected.
+        Interlocked.Increment(ref _poolCount);
+    }
 
-        // Check if pool is full
-        var count = Interlocked.Increment(ref _poolCount);
-        if (count <= _maxPoolSize)
+    private readonly struct PoolPolicy(PendingRequestPool owner)
+        : Reservoir.IPooledObjectDestroyPolicy<PooledPendingRequest>
+    {
+        public PooledPendingRequest Create()
         {
-            _pool.Push(request);
+            Interlocked.Increment(ref owner._poolCount);
+            return new PooledPendingRequest();
         }
-        else
+
+        public bool TryReset(PooledPendingRequest request)
         {
-            // Pool is full - decrement count and let GC handle the instance
-            Interlocked.Decrement(ref _poolCount);
+            request.Reset();
+            return true;
         }
+
+        public void Destroy(PooledPendingRequest request) =>
+            Interlocked.Decrement(ref owner._poolCount);
     }
 }
 

--- a/src/Dekaf/Networking/PipeMemoryPool.cs
+++ b/src/Dekaf/Networking/PipeMemoryPool.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Collections.Concurrent;
 
 namespace Dekaf.Networking;
 
@@ -42,8 +41,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     private static readonly Queue<(int MaxArrayLength, int MaxArraysPerBucket)> s_sharedPoolOrder = [];
 
     private readonly ArrayPool<byte> _pool;
-    private readonly ConcurrentStack<PooledMemoryOwner> _ownerPool = new();
-    private int _ownerPoolCount;
+    private readonly Reservoir.ObjectPool<PooledMemoryOwner, PooledMemoryOwnerPolicy> _ownerPool;
     private int _disposed;
 
     /// <summary>
@@ -79,6 +77,9 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     public PipeMemoryPool(int maxArrayLength = 4 * 1024 * 1024, int maxArraysPerBucket = 32)
     {
         _pool = ArrayPool<byte>.Create(maxArrayLength, maxArraysPerBucket);
+        _ownerPool = new Reservoir.ObjectPool<PooledMemoryOwner, PooledMemoryOwnerPolicy>(
+            new PooledMemoryOwnerPolicy(this),
+            MaxOwnerPoolSize);
     }
 
     internal static PipeMemoryPool Create(
@@ -124,17 +125,9 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
         if (minBufferSize < 0)
             minBufferSize = 4096;
 
-        if (_ownerPool.TryPop(out var owner))
-        {
-            // Note: the decrement happens after the pop, so _ownerPoolCount can transiently
-            // overstate the actual number of pooled items. This is an acceptable approximation —
-            // the count is only used to bound pool growth, not for correctness.
-            Interlocked.Decrement(ref _ownerPoolCount);
-            owner.Initialize(minBufferSize);
-            return owner;
-        }
-
-        return new PooledMemoryOwner(this, minBufferSize);
+        var owner = _ownerPool.Rent();
+        owner.Initialize(minBufferSize);
+        return owner;
     }
 
     /// <summary>
@@ -145,40 +138,17 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
     /// sends (hundreds of Rent/Dispose cycles per second per connection).
     /// </summary>
     private void ReturnOwner(PooledMemoryOwner owner)
-    {
-        if (Volatile.Read(ref _disposed) != 0)
-            return;
-
-        if (Interlocked.Increment(ref _ownerPoolCount) <= MaxOwnerPoolSize)
-        {
-            _ownerPool.Push(owner);
-
-            // Guard against dispose racing between the check above and the push.
-            // If Dispose() ran between our initial check and the Push, the drain loop
-            // in Dispose may have already completed — re-drain to avoid leaking the owner.
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                while (_ownerPool.TryPop(out _)) { }
-            }
-        }
-        else
-        {
-            Interlocked.Decrement(ref _ownerPoolCount);
-        }
-    }
+        => _ownerPool.Return(owner);
 
     protected override void Dispose(bool disposing)
     {
         // Mark as disposed. The underlying ArrayPool<byte>.Create() instance
         // has no Dispose method — it will be collected by the GC along with all
         // its retained arrays once no more IMemoryOwner references are alive.
-        Volatile.Write(ref _disposed, 1);
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
 
-        // Drain the owner pool to allow GC of wrapper objects
-        while (_ownerPool.TryPop(out _))
-        {
-            // Discard
-        }
+        _ownerPool.Dispose();
     }
 
     /// <summary>
@@ -191,11 +161,7 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
         private readonly PipeMemoryPool _parentPool;
         private byte[]? _array;
 
-        public PooledMemoryOwner(PipeMemoryPool parentPool, int minBufferSize)
-        {
-            _parentPool = parentPool;
-            _array = parentPool._pool.Rent(minBufferSize);
-        }
+        public PooledMemoryOwner(PipeMemoryPool parentPool) => _parentPool = parentPool;
 
         /// <summary>
         /// Re-initializes the owner for reuse after being returned to the wrapper pool.
@@ -224,5 +190,13 @@ internal sealed class PipeMemoryPool : MemoryPool<byte>
                 _parentPool.ReturnOwner(this);
             }
         }
+    }
+
+    private readonly struct PooledMemoryOwnerPolicy(PipeMemoryPool owner)
+        : Reservoir.IPooledObjectPolicy<PooledMemoryOwner>
+    {
+        public PooledMemoryOwner Create() => new(owner);
+
+        public bool TryReset(PooledMemoryOwner item) => true;
     }
 }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ObjectPoolMigrationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ObjectPoolMigrationBenchmarks.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using Dekaf.Consumer;
+using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol.Records;
 using Reservoir;
@@ -76,15 +77,24 @@ public class PoolHotPathBenchmarks
     private const int ArenaCapacity = 1024 * 1024;
     private static readonly IReadOnlyList<RecordBatch> EmptyBatches = Array.Empty<RecordBatch>();
     private ValueTaskSourcePool<int> _valueTaskSources = null!;
+    private PendingRequestPool _pendingRequests = null!;
+    private PipeMemoryPool _pipeMemory = null!;
 
     [GlobalSetup]
     public void Setup()
     {
         _valueTaskSources = new ValueTaskSourcePool<int>(4096);
+        _pendingRequests = new PendingRequestPool();
+        _pipeMemory = new PipeMemoryPool();
 
         var source = _valueTaskSources.Rent();
         source.SetResult(0);
         _ = source.Task.GetAwaiter().GetResult();
+
+        var pendingRequest = _pendingRequests.Rent();
+        _pendingRequests.Return(pendingRequest);
+
+        _pipeMemory.Rent(4096).Dispose();
 
         var arena = BatchArena.RentOrCreate(ArenaCapacity);
         BatchArena.ReturnToPool(arena);
@@ -117,4 +127,24 @@ public class PoolHotPathBenchmarks
         BatchArena.ReturnToPool(arena);
         return capacity;
     }
+
+    [Benchmark]
+    public int PendingRequestRentReturn()
+    {
+        var request = _pendingRequests.Rent();
+        _pendingRequests.Return(request);
+        return _pendingRequests.ApproximateCount;
+    }
+
+    [Benchmark]
+    public int PipeMemoryOwnerRentReturn()
+    {
+        var owner = _pipeMemory.Rent(4096);
+        var length = owner.Memory.Length;
+        owner.Dispose();
+        return length;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _pipeMemory.Dispose();
 }


### PR DESCRIPTION
## Summary

- migrate `PendingRequestPool` from `ConcurrentStack<T>` to a bounded Reservoir `ObjectPool<T, TPolicy>`
- migrate `PipeMemoryPool` owner retention to Reservoir and make pool disposal idempotent
- add BenchmarkDotNet coverage for both rent/return paths
- keep `PooledPipelinedResponse` on `ConcurrentStack<T>`; its Reservoir candidate was not Pareto-safe in repeated end-to-end measurements

## Benchmark evidence

Same Windows 11 machine, Intel i7-12700K, .NET 10.0.11, BenchmarkDotNet 0.15.8. Baseline `d577f843` contains only the benchmark additions; candidate `48062c9a` contains the final implementation.

### Direct pool hot paths

ShortRun: 3 warmups, 3 iterations, 1 launch, MemoryDiagnoser.

| Benchmark | Baseline | Candidate | Mean delta | Baseline alloc | Candidate alloc |
|---|---:|---:|---:|---:|---:|
| PendingRequestRentReturn | 28.52 ns | 28.04 ns | -1.7% | 32 B | 0 B |
| PipeMemoryOwnerRentReturn | 53.01 ns | 40.03 ns | -24.5% | 32 B | 0 B |

Throughput moved from 35.06M to 35.67M ops/s (+1.7%) for pending requests and 18.87M to 24.98M ops/s (+32.4%) for pipe owners.

### Pooled producer path

15 iterations, 5 warmups, 1 launch, MemoryDiagnoser.

| Measurement | Mean | StdDev | Allocated |
|---|---:|---:|---:|
| Baseline control 1 | 32.73 us | 1.495 us | 760 B |
| Final candidate | 32.51 us | 1.415 us | 728 B |
| Baseline control 2 | 31.64 us | 0.522 us | 760 B |

Candidate timing remains within observed control variance while removing the remaining `ConcurrentStack<T>` node allocation from `PendingRequestPool` (32 B/operation).

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj --configuration Release`
- full net10.0 unit suite: 6,631 passed, 0 failed
- focused networking/pool suite: 72 passed, 0 failed
- `git diff --check`
