### PR TITLE
Migrate pipelined response pool to Reservoir

### DIFF
--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -1059,7 +1059,9 @@ public sealed partial class KafkaConnection :
         private const int ConsumerReady = 2;
         private const int ReturnReady = CompletionReady | ConsumerReady;
 
-        private static readonly ConcurrentStack<PooledPipelinedResponse<TRequest, TResponse>> Pool = new();
+        private static readonly Reservoir.ObjectPool<
+            PooledPipelinedResponse<TRequest, TResponse>,
+            PoolPolicy> Pool = new(MaxPoolSize);
         private static int s_poolCount;
 
         // The pending request already enters this completion from an asynchronous callback.
@@ -1098,14 +1100,8 @@ public sealed partial class KafkaConnection :
             long telemetryStartTimestamp,
             CancellationToken cancellationToken)
         {
-            if (!Pool.TryPop(out var operation))
-            {
-                operation = new PooledPipelinedResponse<TRequest, TResponse>();
-            }
-            else
-            {
-                Interlocked.Decrement(ref s_poolCount);
-            }
+            var operation = Pool.Rent();
+            Interlocked.Decrement(ref s_poolCount);
 
             operation.Initialize(
                 connection,
@@ -1306,6 +1302,14 @@ public sealed partial class KafkaConnection :
 
         private void ReturnToPool()
         {
+            Pool.Return(this);
+            // Reservoir invokes Destroy synchronously when capacity rejects this return.
+            // Increment after Return balances both retained and rejected objects.
+            Interlocked.Increment(ref s_poolCount);
+        }
+
+        private void ResetForPooling()
+        {
             _connection = null;
             _pending = null;
             _pendingTask = default;
@@ -1317,15 +1321,28 @@ public sealed partial class KafkaConnection :
             _telemetryStartTimestamp = 0;
             _returnReadiness = 0;
             _core.Reset();
+        }
 
-            if (Interlocked.Increment(ref s_poolCount) <= MaxPoolSize)
+        private readonly struct PoolPolicy
+            : Reservoir.IPooledObjectDestroyPolicy<
+                PooledPipelinedResponse<TRequest, TResponse>>
+        {
+            public PooledPipelinedResponse<TRequest, TResponse> Create()
             {
-                Pool.Push(this);
+                // Rent decrements after Reservoir returns, so count misses as transient retained
+                // entries to keep the diagnostic count at zero for newly created operations.
+                Interlocked.Increment(ref s_poolCount);
+                return new PooledPipelinedResponse<TRequest, TResponse>();
             }
-            else
+
+            public bool TryReset(PooledPipelinedResponse<TRequest, TResponse> operation)
             {
-                Interlocked.Decrement(ref s_poolCount);
+                operation.ResetForPooling();
+                return true;
             }
+
+            public void Destroy(PooledPipelinedResponse<TRequest, TResponse> operation)
+                => Interlocked.Decrement(ref s_poolCount);
         }
 
         TResponse IValueTaskSource<TResponse>.GetResult(short token)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ObjectPoolMigrationBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ObjectPoolMigrationBenchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
+using System.Collections.Concurrent;
 using Dekaf.Consumer;
 using Dekaf.Networking;
 using Dekaf.Producer;
@@ -16,24 +17,36 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 [OperationsPerSecond]
 public class ObjectPoolMigrationBenchmarks
 {
+    private ConcurrentStackPool _concurrentStack = null!;
     private ObjectPool<PooledItem, PooledItemPolicy> _reservoir = null!;
     private TrackedPool _tracked = null!;
 
-    [Params(32, 128)]
+    [Params(32, 128, 256)]
     public int Capacity { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
+        _concurrentStack = new ConcurrentStackPool(Capacity);
         _reservoir = new ObjectPool<PooledItem, PooledItemPolicy>(Capacity);
         _tracked = new TrackedPool(Capacity);
 
+        var concurrentStackItem = _concurrentStack.Rent();
+        _concurrentStack.Return(concurrentStackItem);
         var item = _reservoir.Rent();
         _reservoir.Return(item);
         _tracked.PreWarm(1);
     }
 
     [Benchmark(Baseline = true)]
+    public PooledItem ConcurrentStack()
+    {
+        var item = _concurrentStack.Rent();
+        _concurrentStack.Return(item);
+        return item;
+    }
+
+    [Benchmark]
     public PooledItem Reservoir()
     {
         var item = _reservoir.Rent();
@@ -50,6 +63,32 @@ public class ObjectPoolMigrationBenchmarks
     }
 
     public sealed class PooledItem;
+
+    private sealed class ConcurrentStackPool(int capacity)
+    {
+        private readonly ConcurrentStack<PooledItem> _items = new();
+        private int _count;
+
+        public PooledItem Rent()
+        {
+            if (!_items.TryPop(out var item))
+                return new PooledItem();
+
+            Interlocked.Decrement(ref _count);
+            return item;
+        }
+
+        public void Return(PooledItem item)
+        {
+            if (Interlocked.Increment(ref _count) <= capacity)
+            {
+                _items.Push(item);
+                return;
+            }
+
+            Interlocked.Decrement(ref _count);
+        }
+    }
 
     private sealed class TrackedPool(int capacity)
         : Dekaf.Producer.ObjectPool<PooledItem>(capacity)


### PR DESCRIPTION
## Summary

- replace the bounded `ConcurrentStack<T>` pool for pipelined responses with `Reservoir.ObjectPool<T, TPolicy>`
- preserve reset behavior, bounded retention, and approximate retained-count diagnostics
- extend object-pool benchmarks with the exact legacy algorithm and production capacity of 256

## Performance

BenchmarkDotNet 0.15.8, .NET 10.0.11, Intel Core i7-12700K:

| Pool | Capacity | Mean | Allocated | Ops/s |
| --- | ---: | ---: | ---: | ---: |
| `ConcurrentStack` | 256 | 24.63 ns | 32 B | 40.60M |
| Reservoir | 256 | 13.18 ns | 0 B | 75.88M |

Reservoir reduces warm rent/return latency by 46.5%, raises throughput by 1.87x, and eliminates the 32 B `ConcurrentStack` node allocation per cycle.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit --configuration Release --no-restore`
- `Dekaf.Tests.Unit --treenode-filter /*/*/KafkaConnectionTests/*` — 52 passed
- `dotnet build tools/Dekaf.Benchmarks --configuration Release --no-restore`
- default-duration `ObjectPoolMigrationBenchmarks` BenchmarkDotNet run
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal response object pooling with bounded capacity and more consistent resource management.
  * Added benchmarking coverage across multiple pool capacities to evaluate pooling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->