### PR TITLE
Bound transaction retries by max.block.ms

### DIFF
--- a/src/Dekaf/Networking/IKafkaConnection.cs
+++ b/src/Dekaf/Networking/IKafkaConnection.cs
@@ -127,6 +127,29 @@ internal interface IKafkaPipelinedWriteCompletionConnection
         where TResponse : IKafkaResponse;
 }
 
+/// <summary>
+/// Exposes the point at which a request may begin writing to the socket, after all
+/// pre-write waits have completed.
+/// </summary>
+internal interface IKafkaRequestWriteObserverConnection
+{
+    ValueTask<TResponse> SendWithWriteObservationAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        Action requestWriteStarted,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse;
+
+    ValueTask<PipelinedResponse<TResponse>> SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        Action requestWriteStarted,
+        CancellationToken cancellationToken = default)
+        where TRequest : IKafkaRequest<TResponse>
+        where TResponse : IKafkaResponse;
+}
+
 internal interface IPipelinedResponseSource<TResponse> : IValueTaskSource<TResponse>
 {
     void Abandon(short token);

--- a/src/Dekaf/Networking/KafkaConnection.cs
+++ b/src/Dekaf/Networking/KafkaConnection.cs
@@ -80,7 +80,8 @@ public sealed partial class KafkaConnection :
     IKafkaCapabilityProvider,
     IIdleTrackedKafkaConnection,
     IRetirableKafkaConnection,
-    IKafkaPipelinedWriteCompletionConnection
+    IKafkaPipelinedWriteCompletionConnection,
+    IKafkaRequestWriteObserverConnection
 {
     private readonly string _host;
     private readonly int _port;
@@ -603,11 +604,24 @@ public sealed partial class KafkaConnection :
         where TResponse : IKafkaResponse
         => SendAsyncCore<TRequest, TResponse>(request, apiVersion, requireReady: true, cancellationToken);
 
+    ValueTask<TResponse> IKafkaRequestWriteObserverConnection.SendWithWriteObservationAsync<TRequest, TResponse>(
+        TRequest request,
+        short apiVersion,
+        Action requestWriteStarted,
+        CancellationToken cancellationToken)
+        => SendAsyncCore<TRequest, TResponse>(
+            request,
+            apiVersion,
+            requireReady: true,
+            cancellationToken,
+            requestWriteStarted);
+
     private async ValueTask<TResponse> SendAsyncCore<TRequest, TResponse>(
         TRequest request,
         short apiVersion,
         bool requireReady,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -663,7 +677,13 @@ public sealed partial class KafkaConnection :
             // Write phase
             LogSendingRequest(KafkaMessageMetadata<TRequest, TResponse>.ApiKey, correlationId, apiVersion, _host, _port);
 
-            await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken)
+            await PreSerializeAndWriteAsync<TRequest, TResponse>(
+                    request,
+                    correlationId,
+                    apiVersion,
+                    headerVersion,
+                    cancellationToken,
+                    requestWriteStarted: requestWriteStarted)
                 .ConfigureAwait(false);
 
             LogRequestSentWaitingForResponse(correlationId);
@@ -913,6 +933,19 @@ public sealed partial class KafkaConnection :
             cancellationToken);
 
     ValueTask<PipelinedResponse<TResponse>>
+        IKafkaRequestWriteObserverConnection.SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            Action requestWriteStarted,
+            CancellationToken cancellationToken)
+        => SendPipelinedAfterWriteCoreAsync<TRequest, TResponse>(
+            request,
+            apiVersion,
+            callerOwnsTimeout: false,
+            cancellationToken,
+            requestWriteStarted);
+
+    ValueTask<PipelinedResponse<TResponse>>
         IKafkaPipelinedWriteCompletionConnection.SendPipelinedWithCallerTimeoutAfterWriteAsync<TRequest, TResponse>(
             TRequest request,
             short apiVersion,
@@ -944,7 +977,8 @@ public sealed partial class KafkaConnection :
         TRequest request,
         short apiVersion,
         bool callerOwnsTimeout,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -1000,7 +1034,14 @@ public sealed partial class KafkaConnection :
         {
             var telemetryStartTimestamp = _telemetryMetricCollector is null ? 0 : Stopwatch.GetTimestamp();
 
-            await PreSerializeAndWriteAsync<TRequest, TResponse>(request, correlationId, apiVersion, headerVersion, cancellationToken, callerOwnsTimeout)
+            await PreSerializeAndWriteAsync<TRequest, TResponse>(
+                    request,
+                    correlationId,
+                    apiVersion,
+                    headerVersion,
+                    cancellationToken,
+                    callerOwnsTimeout,
+                    requestWriteStarted)
                 .ConfigureAwait(false);
 
             return PooledPipelinedResponse<TRequest, TResponse>.Rent(
@@ -1602,7 +1643,8 @@ public sealed partial class KafkaConnection :
         short apiVersion,
         short headerVersion,
         CancellationToken cancellationToken,
-        bool callerOwnsTimeout = false)
+        bool callerOwnsTimeout = false,
+        Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -1639,7 +1681,8 @@ public sealed partial class KafkaConnection :
                 prefixLength,
                 encodedRecords,
                 suffixOffset,
-                suffixLength);
+                suffixLength,
+                requestWriteStarted);
             await AwaitBorrowedFrameWriteAsync(
                     segmentedWriteTask,
                     correlationId,
@@ -1666,7 +1709,11 @@ public sealed partial class KafkaConnection :
         // From here the frame write owns both the lock and the buffer; WriteFrameHoldingLockAsync
         // releases them itself so a timed-out caller can abandon the wait without cancelling the
         // socket write mid-frame (see AwaitFrameWriteAsync).
-        var writeTask = WriteFrameHoldingLockAsync(serializedArray, serializedLength, clearSerializedArray);
+        var writeTask = WriteFrameHoldingLockAsync(
+            serializedArray,
+            serializedLength,
+            clearSerializedArray,
+            requestWriteStarted);
         await AwaitFrameWriteAsync(writeTask, correlationId, callerOwnsTimeout, cancellationToken).ConfigureAwait(false);
     }
 
@@ -1778,7 +1825,8 @@ public sealed partial class KafkaConnection :
         int prefixLength,
         ReadOnlySequence<byte> encodedRecords,
         int suffixOffset,
-        int suffixLength)
+        int suffixLength,
+        Action? requestWriteStarted = null)
     {
         var scatterGatherSenderLockHeld = false;
         try
@@ -1812,6 +1860,7 @@ public sealed partial class KafkaConnection :
             if (suffixLength > 0)
                 pendingSegments.Add(new ArraySegment<byte>(metadataArray, suffixOffset, suffixLength));
 
+            requestWriteStarted?.Invoke();
             sender.BeginPendingSend();
             while (sender.HasPendingSegments)
             {
@@ -1851,7 +1900,11 @@ public sealed partial class KafkaConnection :
     /// close). Callers that time out abandon the await instead (<see cref="AwaitFrameWriteAsync"/>);
     /// the frame finishes in the background and the connection stays frame-aligned and usable.
     /// </summary>
-    private async Task WriteFrameHoldingLockAsync(byte[] serializedData, int length, bool clearArray)
+    private async Task WriteFrameHoldingLockAsync(
+        byte[] serializedData,
+        int length,
+        bool clearArray,
+        Action? requestWriteStarted = null)
     {
         try
         {
@@ -1864,6 +1917,7 @@ public sealed partial class KafkaConnection :
             if (Volatile.Read(ref _disposed) != 0)
                 throw new ObjectDisposedException(nameof(KafkaConnection));
 
+            requestWriteStarted?.Invoke();
             await _stream.WriteAsync(serializedData.AsMemory(0, length), CancellationToken.None).ConfigureAwait(false);
         }
         catch

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2489,8 +2489,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         TransactionRetryBudget retryBudget,
         out int retryDelayMs)
     {
-        var remainingMs = retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds();
-        if (remainingMs <= 0)
+        if (!TryGetTransactionRemainingMilliseconds(retryBudget, out var remainingMs))
         {
             retryDelayMs = 0;
             return false;
@@ -2500,18 +2499,54 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         return true;
     }
 
+    private static bool TryGetTransactionRemainingMilliseconds(
+        TransactionRetryBudget retryBudget,
+        out int remainingMs)
+    {
+        var remaining = retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds();
+        if (remaining <= 0)
+        {
+            remainingMs = 0;
+            return false;
+        }
+
+        remainingMs = (int)Math.Min(remaining, int.MaxValue);
+        return true;
+    }
+
+    private static CancellationTokenSource CreateTransactionRetryCancellationSource(
+        TransactionRetryBudget retryBudget,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var remainingMs = Math.Max(0, retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds());
+        timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(remainingMs));
+        return timeoutCts;
+    }
+
     private KafkaTimeoutException CreateTransactionTimeoutException(
         string operation,
         TransactionRetryBudget retryBudget,
-        int attempts)
+        int attempts,
+        Exception? innerException = null)
     {
         var elapsedMs = Math.Max(0, MonotonicClock.GetMilliseconds() - retryBudget.StartedAtMs);
         var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
-        return new KafkaTimeoutException(
-            TimeoutKind.Transaction,
-            TimeSpan.FromMilliseconds(elapsedMs),
-            configured,
-            $"{operation} did not complete within max.block.ms ({_options.MaxBlockMs}ms) after {attempts} attempts.");
+        var message =
+            $"{operation} did not complete within max.block.ms ({_options.MaxBlockMs}ms) after {attempts} attempts.";
+        return innerException is null
+            ? new KafkaTimeoutException(
+                TimeoutKind.Transaction,
+                TimeSpan.FromMilliseconds(elapsedMs),
+                configured,
+                message)
+            : new KafkaTimeoutException(
+                TimeoutKind.Transaction,
+                TimeSpan.FromMilliseconds(elapsedMs),
+                configured,
+                message,
+                innerException);
     }
 
     internal async ValueTask ReinitializeProducerIdAsync(
@@ -2529,96 +2564,120 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         var attempt = 0;
-        while (true)
+        if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
+            throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt);
+
+        using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
+        var retryCancellationToken = timeoutCts.Token;
+        try
         {
-            var request = new InitProducerIdRequest
+            while (true)
             {
-                TransactionalId = _options.TransactionalId,
-                TransactionTimeoutMs = _options.TransactionTimeoutMs,
-                ProducerId = _producerId,
-                ProducerEpoch = _producerEpoch,
-                EnableTwoPhaseCommit = _options.EnableTwoPhaseCommit,
-                KeepPreparedTransaction = keepPreparedTransaction
-            };
+                if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
+                    break;
 
-            var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
-                    _transactionCoordinatorId,
-                    request,
-                    cancellationToken,
-                    minimumRequiredVersion: (_options.EnableTwoPhaseCommit || keepPreparedTransaction)
-                        ? (short)6
-                        : short.MinValue,
-                    captureTransactionFeatures: true,
-                    keepPreparedTransaction: keepPreparedTransaction)
-                .ConfigureAwait(false);
-
-            if (response.ErrorCode != ErrorCode.None)
-            {
-                var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
-
-                if (classification == TransactionErrorClassification.Retriable)
+                var request = new InitProducerIdRequest
                 {
-                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                        break;
+                    TransactionalId = _options.TransactionalId,
+                    TransactionTimeoutMs = _options.TransactionTimeoutMs,
+                    ProducerId = _producerId,
+                    ProducerEpoch = _producerEpoch,
+                    EnableTwoPhaseCommit = _options.EnableTwoPhaseCommit,
+                    KeepPreparedTransaction = keepPreparedTransaction
+                };
 
-                    if (response.ErrorCode == ErrorCode.NotCoordinator)
+                var response = await SendWithConnectionLeaseAsync<InitProducerIdRequest, InitProducerIdResponse>(
+                        _transactionCoordinatorId,
+                        request,
+                        retryCancellationToken,
+                        minimumRequiredVersion: (_options.EnableTwoPhaseCommit || keepPreparedTransaction)
+                            ? (short)6
+                            : short.MinValue,
+                        captureTransactionFeatures: true,
+                        keepPreparedTransaction: keepPreparedTransaction)
+                    .ConfigureAwait(false);
+
+                if (response.ErrorCode != ErrorCode.None)
+                {
+                    var classification = TransactionErrorClassifier.Classify(response.ErrorCode, _currentTransactionUsesTV2);
+
+                    if (classification == TransactionErrorClassification.Retriable)
                     {
-                        LogInitProducerIdNotCoordinator(attempt + 1);
+                        if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                            break;
 
-                        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                        await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
+                        if (response.ErrorCode == ErrorCode.NotCoordinator)
+                        {
+                            LogInitProducerIdNotCoordinator(attempt + 1);
+
+                            await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                            await FindTransactionCoordinatorAsync(retryBudget, retryCancellationToken)
+                                .ConfigureAwait(false);
+                            attempt++;
+                            continue;
+                        }
+
+                        LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
+
+                        await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
                         attempt++;
                         continue;
                     }
 
-                    LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
+                    // InitProducerId runs before a transaction is active, so abortable errors do not
+                    // transition to AbortableError; only fatal errors mark the producer unusable.
+                    if (classification == TransactionErrorClassification.Fatal)
+                    {
+                        _transactionState = TransactionState.FatalError;
+                    }
 
-                    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                    attempt++;
-                    continue;
+                    throw CreateTransactionException(response.ErrorCode, classification,
+                        $"InitProducerId failed: {response.ErrorCode}");
                 }
 
-                // InitProducerId runs before a transaction is active, so abortable errors do not
-                // transition to AbortableError; only fatal errors mark the producer unusable.
-                if (classification == TransactionErrorClassification.Fatal)
-                {
-                    _transactionState = TransactionState.FatalError;
-                }
+                _producerId = response.ProducerId;
+                _producerEpoch = response.ProducerEpoch;
 
-                throw CreateTransactionException(response.ErrorCode, classification,
-                    $"InitProducerId failed: {response.ErrorCode}");
+                _accumulator.ProducerId = _producerId;
+                _accumulator.ProducerEpoch = _producerEpoch;
+                _accumulator.IsTransactional = true;
+
+                _accumulator.ResetSequenceNumbers();
+                _preparedTransactionState = response.OngoingTransactionProducerId >= 0
+                    && response.OngoingTransactionProducerEpoch >= 0
+                        ? new PreparedTransactionState(
+                            response.OngoingTransactionProducerId,
+                            response.OngoingTransactionProducerEpoch)
+                        : PreparedTransactionState.Empty;
+
+                LogTransactionsInitialized(_producerId, _producerEpoch);
+                return;
             }
-
-            _producerId = response.ProducerId;
-            _producerEpoch = response.ProducerEpoch;
-
-            _accumulator.ProducerId = _producerId;
-            _accumulator.ProducerEpoch = _producerEpoch;
-            _accumulator.IsTransactional = true;
-
-            _accumulator.ResetSequenceNumbers();
-            _preparedTransactionState = response.OngoingTransactionProducerId >= 0
-                && response.OngoingTransactionProducerEpoch >= 0
-                    ? new PreparedTransactionState(
-                        response.OngoingTransactionProducerId,
-                        response.OngoingTransactionProducerEpoch)
-                    : PreparedTransactionState.Empty;
-
-            LogTransactionsInitialized(_producerId, _producerEpoch);
-            return;
+        }
+        catch (OperationCanceledException) when (
+            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt + 1);
         }
 
         throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt + 1);
     }
 
-    private async ValueTask FindTransactionCoordinatorAsync(CancellationToken cancellationToken)
-        => await FindTransactionCoordinatorAsync(CreateTransactionRetryBudget(), cancellationToken)
-            .ConfigureAwait(false);
-
     private async ValueTask FindTransactionCoordinatorAsync(
         TransactionRetryBudget retryBudget,
         CancellationToken cancellationToken)
     {
+        var attempt = 0;
+        if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
+        {
+            throw CreateTransactionTimeoutException(
+                "FindCoordinator for transaction",
+                retryBudget,
+                attempt);
+        }
+
+        using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
+        var retryCancellationToken = timeoutCts.Token;
         var brokers = _metadataManager.Metadata.GetBrokers();
         if (brokers.Count == 0)
         {
@@ -2631,52 +2690,65 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             KeyType = CoordinatorType.Transaction
         };
 
-        var attempt = 0;
-        while (true)
+        try
         {
-            var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-                brokers[0].NodeId,
-                request,
-                cancellationToken).ConfigureAwait(false);
-
-            if (response.Coordinators.Count == 0)
+            while (true)
             {
-                throw new TransactionException(ErrorCode.CoordinatorNotAvailable,
-                    "FindCoordinator returned an empty Coordinators array")
-                {
-                    TransactionalId = _options.TransactionalId
-                };
-            }
-
-            var coordinator = response.Coordinators[0];
-            var errorCode = coordinator.ErrorCode;
-
-            if (errorCode is ErrorCode.CoordinatorNotAvailable or ErrorCode.NotCoordinator)
-            {
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
                     break;
 
-                LogTransactionCoordinatorNotAvailable(errorCode, attempt + 1, retryDelayMs);
+                var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                    brokers[0].NodeId,
+                    request,
+                    retryCancellationToken).ConfigureAwait(false);
 
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
-
-            if (errorCode != ErrorCode.None)
-            {
-                throw new TransactionException(errorCode,
-                    $"FindCoordinator for transaction failed: {errorCode}")
+                if (response.Coordinators.Count == 0)
                 {
-                    TransactionalId = _options.TransactionalId
-                };
+                    throw new TransactionException(ErrorCode.CoordinatorNotAvailable,
+                        "FindCoordinator returned an empty Coordinators array")
+                    {
+                        TransactionalId = _options.TransactionalId
+                    };
+                }
+
+                var coordinator = response.Coordinators[0];
+                var errorCode = coordinator.ErrorCode;
+
+                if (errorCode is ErrorCode.CoordinatorNotAvailable or ErrorCode.NotCoordinator)
+                {
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+
+                    LogTransactionCoordinatorNotAvailable(errorCode, attempt + 1, retryDelayMs);
+
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
+                if (errorCode != ErrorCode.None)
+                {
+                    throw new TransactionException(errorCode,
+                        $"FindCoordinator for transaction failed: {errorCode}")
+                    {
+                        TransactionalId = _options.TransactionalId
+                    };
+                }
+
+                _transactionCoordinatorId = coordinator.NodeId;
+                _connectionPool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
+
+                LogTransactionCoordinatorFound(_transactionCoordinatorId, _options.TransactionalId);
+                return;
             }
-
-            _transactionCoordinatorId = coordinator.NodeId;
-            _connectionPool.RegisterBroker(coordinator.NodeId, coordinator.Host, coordinator.Port);
-
-            LogTransactionCoordinatorFound(_transactionCoordinatorId, _options.TransactionalId);
-            return;
+        }
+        catch (OperationCanceledException) when (
+            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateTransactionTimeoutException(
+                "FindCoordinator for transaction",
+                retryBudget,
+                attempt + 1);
         }
 
         throw CreateTransactionTimeoutException(
@@ -2720,72 +2792,86 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         };
 
         var retryBudget = CreateTransactionRetryBudget();
-
         var attempt = 0;
-        while (true)
+        using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
+        var retryCancellationToken = timeoutCts.Token;
+
+        try
         {
-            var response = await SendWithConnectionLeaseAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
-                    _transactionCoordinatorId,
-                    request,
-                    cancellationToken,
-                    requireTransactionFeatureMatch: true)
-                .ConfigureAwait(false);
-
-            // Check for retriable errors in the response
-            var hasRetriableError = false;
-            ErrorCode? firstNonRetriableError = null;
-            string? errorContext = null;
-
-            foreach (var topicResult in response.Results)
+            while (true)
             {
-                foreach (var partitionResult in topicResult.Partitions)
-                {
-                    if (partitionResult.ErrorCode == ErrorCode.None)
-                        continue;
+                if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
+                    break;
 
-                    if (partitionResult.ErrorCode is ErrorCode.ConcurrentTransactions
-                        or ErrorCode.CoordinatorLoadInProgress
-                        or ErrorCode.CoordinatorNotAvailable)
+                var response = await SendWithConnectionLeaseAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
+                        _transactionCoordinatorId,
+                        request,
+                        retryCancellationToken,
+                        requireTransactionFeatureMatch: true)
+                    .ConfigureAwait(false);
+
+                // Check for retriable errors in the response
+                var hasRetriableError = false;
+                ErrorCode? firstNonRetriableError = null;
+                string? errorContext = null;
+
+                foreach (var topicResult in response.Results)
+                {
+                    foreach (var partitionResult in topicResult.Partitions)
                     {
-                        hasRetriableError = true;
-                    }
-                    else if (partitionResult.ErrorCode == ErrorCode.NotCoordinator)
-                    {
-                        hasRetriableError = true;
-                        // Re-discover coordinator on next retry
-                        await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        firstNonRetriableError = partitionResult.ErrorCode;
-                        errorContext = $"{topicResult.Name}-{partitionResult.PartitionIndex}";
+                        if (partitionResult.ErrorCode == ErrorCode.None)
+                            continue;
+
+                        if (partitionResult.ErrorCode is ErrorCode.ConcurrentTransactions
+                            or ErrorCode.CoordinatorLoadInProgress
+                            or ErrorCode.CoordinatorNotAvailable)
+                        {
+                            hasRetriableError = true;
+                        }
+                        else if (partitionResult.ErrorCode == ErrorCode.NotCoordinator)
+                        {
+                            hasRetriableError = true;
+                            // Re-discover coordinator on next retry
+                            await FindTransactionCoordinatorAsync(retryBudget, retryCancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            firstNonRetriableError = partitionResult.ErrorCode;
+                            errorContext = $"{topicResult.Name}-{partitionResult.PartitionIndex}";
+                        }
                     }
                 }
+
+                if (firstNonRetriableError.HasValue)
+                {
+                    // Runs on the BrokerSender background path: transitioning to AbortableError/FatalError
+                    // here is what makes subsequent ProduceAsync calls fail fast. This error is not in the
+                    // classifier's retriable set, so the call always throws (never returns).
+                    ThrowIfNonRetriableTransactionError(
+                        firstNonRetriableError.Value,
+                        $"AddPartitionsToTxn for {errorContext}",
+                        _currentTransactionUsesTV2);
+                }
+
+                if (!hasRetriableError)
+                {
+                    return; // Success
+                }
+
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                    break;
+
+                LogAddPartitionsToTxnRetriableError(attempt + 1, retryDelayMs);
+
+                await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                attempt++;
             }
-
-            if (firstNonRetriableError.HasValue)
-            {
-                // Runs on the BrokerSender background path: transitioning to AbortableError/FatalError
-                // here is what makes subsequent ProduceAsync calls fail fast. This error is not in the
-                // classifier's retriable set, so the call always throws (never returns).
-                ThrowIfNonRetriableTransactionError(
-                    firstNonRetriableError.Value,
-                    $"AddPartitionsToTxn for {errorContext}",
-                    _currentTransactionUsesTV2);
-            }
-
-            if (!hasRetriableError)
-            {
-                return; // Success
-            }
-
-            if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                break;
-
-            LogAddPartitionsToTxnRetriableError(attempt + 1, retryDelayMs);
-
-            await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-            attempt++;
+        }
+        catch (OperationCanceledException) when (
+            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateTransactionTimeoutException("AddPartitionsToTxn", retryBudget, attempt + 1);
         }
 
         throw CreateTransactionTimeoutException("AddPartitionsToTxn", retryBudget, attempt + 1);
@@ -2849,106 +2935,131 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         CancellationToken cancellationToken)
     {
         var attempt = 0;
-        while (true)
+        if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
         {
-            var request = new EndTxnRequest
-            {
-                TransactionalId = _options.TransactionalId!,
-                ProducerId = producerId,
-                ProducerEpoch = producerEpoch,
-                Committed = committed
-            };
+            throw CreateTransactionTimeoutException(
+                $"EndTxn ({(committed ? "commit" : "abort")})",
+                retryBudget,
+                attempt);
+        }
 
-            EndTxnResponse response;
-            using (var connectionLease = await _connectionPool.LeaseConnectionAsync(
-                       _transactionCoordinatorId,
-                       cancellationToken).ConfigureAwait(false))
+        using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
+        var retryCancellationToken = timeoutCts.Token;
+        try
+        {
+            while (true)
             {
-                var connection = connectionLease.Connection;
-                EnsureTransactionFeatureMatch();
-                var apiVersion = _metadataManager.GetNegotiatedApiVersion(
-                    connection,
-                    ApiKey.EndTxn,
-                    EndTxnRequest.LowestSupportedVersion,
-                    EndTxnRequest.HighestSupportedVersion);
-                if (afterRequestWrittenAsync is null)
+                if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
+                    break;
+
+                var request = new EndTxnRequest
                 {
-                    response = await connection
-                        .SendAsync<EndTxnRequest, EndTxnResponse>(
-                            request, apiVersion, cancellationToken)
+                    TransactionalId = _options.TransactionalId!,
+                    ProducerId = producerId,
+                    ProducerEpoch = producerEpoch,
+                    Committed = committed
+                };
+
+                EndTxnResponse response;
+                using (var connectionLease = await _connectionPool.LeaseConnectionAsync(
+                           _transactionCoordinatorId,
+                           retryCancellationToken).ConfigureAwait(false))
+                {
+                    var connection = connectionLease.Connection;
+                    EnsureTransactionFeatureMatch();
+                    var apiVersion = _metadataManager.GetNegotiatedApiVersion(
+                        connection,
+                        ApiKey.EndTxn,
+                        EndTxnRequest.LowestSupportedVersion,
+                        EndTxnRequest.HighestSupportedVersion);
+                    if (afterRequestWrittenAsync is null)
+                    {
+                        response = await connection
+                            .SendAsync<EndTxnRequest, EndTxnResponse>(
+                                request, apiVersion, retryCancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
+                        {
+                            throw new InvalidOperationException(
+                                "The transaction coordinator connection cannot report request write completion.");
+                        }
+
+                        var responseTask = await writeCompletionConnection
+                            .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
+                                request, apiVersion, retryCancellationToken)
+                            .ConfigureAwait(false);
+                        var responseConsumptionStarted = false;
+                        try
+                        {
+                            var requestWrittenCallback = afterRequestWrittenAsync;
+                            afterRequestWrittenAsync = null;
+                            await requestWrittenCallback().ConfigureAwait(false);
+
+                            var responseValueTask = responseTask.AsValueTask();
+                            responseConsumptionStarted = true;
+                            response = await responseValueTask.ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            if (!responseConsumptionStarted)
+                                responseTask.Abandon();
+                        }
+                    }
+                }
+
+                if (response.ErrorCode == ErrorCode.None)
+                {
+                    // TV2 (v5+): broker returns bumped ProducerId/Epoch in EndTxn response.
+                    // Apply them so the next transaction uses the new identity without
+                    // a separate InitProducerId round-trip.
+                    // Safe without _epochBumpLock: EndTxn is called only after FlushAsync
+                    // drains all in-flight batches, so no BrokerSender is active.
+                    if (applyResponseProducerState && _currentTransactionUsesTV2 && response.ProducerId >= 0)
+                    {
+                        _producerId = response.ProducerId;
+                        _producerEpoch = response.ProducerEpoch;
+                        _accumulator.ProducerId = _producerId;
+                        _accumulator.ProducerEpoch = _producerEpoch;
+                        _accumulator.ResetSequenceNumbers();
+                    }
+
+                    return;
+                }
+
+                // Fatal or abortable errors transition state and throw the matching typed exception;
+                // this returns only for retriable errors, which are handled with backoff below.
+                ThrowIfNonRetriableTransactionError(response.ErrorCode,
+                    $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
+
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                    break;
+
+                if (response.ErrorCode == ErrorCode.NotCoordinator)
+                {
+                    LogEndTxnNotCoordinator(attempt + 1);
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    await FindTransactionCoordinatorAsync(retryBudget, retryCancellationToken)
                         .ConfigureAwait(false);
-                }
-                else
-                {
-                    if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
-                    {
-                        throw new InvalidOperationException(
-                            "The transaction coordinator connection cannot report request write completion.");
-                    }
-
-                    var responseTask = await writeCompletionConnection
-                        .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
-                            request, apiVersion, cancellationToken)
-                        .ConfigureAwait(false);
-                    var responseConsumptionStarted = false;
-                    try
-                    {
-                        var requestWrittenCallback = afterRequestWrittenAsync;
-                        afterRequestWrittenAsync = null;
-                        await requestWrittenCallback().ConfigureAwait(false);
-
-                        var responseValueTask = responseTask.AsValueTask();
-                        responseConsumptionStarted = true;
-                        response = await responseValueTask.ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        if (!responseConsumptionStarted)
-                            responseTask.Abandon();
-                    }
-                }
-            }
-
-            if (response.ErrorCode == ErrorCode.None)
-            {
-                // TV2 (v5+): broker returns bumped ProducerId/Epoch in EndTxn response.
-                // Apply them so the next transaction uses the new identity without
-                // a separate InitProducerId round-trip.
-                // Safe without _epochBumpLock: EndTxn is called only after FlushAsync
-                // drains all in-flight batches, so no BrokerSender is active.
-                if (applyResponseProducerState && _currentTransactionUsesTV2 && response.ProducerId >= 0)
-                {
-                    _producerId = response.ProducerId;
-                    _producerEpoch = response.ProducerEpoch;
-                    _accumulator.ProducerId = _producerId;
-                    _accumulator.ProducerEpoch = _producerEpoch;
-                    _accumulator.ResetSequenceNumbers();
+                    attempt++;
+                    continue;
                 }
 
-                return;
-            }
-
-            // Fatal or abortable errors transition state and throw the matching typed exception;
-            // this returns only for retriable errors, which are handled with backoff below.
-            ThrowIfNonRetriableTransactionError(response.ErrorCode,
-                $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
-
-            if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                break;
-
-            if (response.ErrorCode == ErrorCode.NotCoordinator)
-            {
-                LogEndTxnNotCoordinator(attempt + 1);
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
+                LogEndTxnRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
+                await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
                 attempt++;
                 continue;
             }
-
-            LogEndTxnRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
-            await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-            attempt++;
-            continue;
+        }
+        catch (OperationCanceledException) when (
+            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateTransactionTimeoutException(
+                $"EndTxn ({(committed ? "commit" : "abort")})",
+                retryBudget,
+                attempt + 1);
         }
 
         throw CreateTransactionTimeoutException(
@@ -2995,251 +3106,273 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // request-local topic IDs; a connection capped at v4 retains explicit enrollment.
         var retryBudget = CreateTransactionRetryBudget();
         var tv2 = _currentTransactionUsesTV2;
-
-        // Materialize once so a lost response can retry safely even when the caller supplied
-        // a single-use enumerable.
-        var topicOffsets = new Dictionary<string, List<TxnOffsetCommitRequestPartition>>();
-        foreach (var offset in offsets)
-        {
-            if (!topicOffsets.TryGetValue(offset.Topic, out var list))
-            {
-                list = [];
-                topicOffsets[offset.Topic] = list;
-            }
-
-            list.Add(new TxnOffsetCommitRequestPartition
-            {
-                PartitionIndex = offset.Partition,
-                CommittedOffset = offset.Offset,
-                CommittedLeaderEpoch = offset.LeaderEpoch,
-                CommittedMetadata = offset.Metadata
-            });
-        }
-
         var attempt = 0;
-        while (true)
+        Exception? lastTransportException = null;
+        using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
+        var retryCancellationToken = timeoutCts.Token;
+
+        try
         {
-            // TV1 always performs explicit offset enrollment before coordinator discovery.
-            if (!tv2)
+            // Materialize once so a lost response can retry safely even when the caller supplied
+            // a single-use enumerable.
+            var topicOffsets = new Dictionary<string, List<TxnOffsetCommitRequestPartition>>();
+            foreach (var offset in offsets)
             {
-                var addOffsetsError = await SendAddOffsetsToTransactionAsync(
-                        consumerGroupId,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (addOffsetsError != ErrorCode.None)
+                if (!topicOffsets.TryGetValue(offset.Topic, out var list))
                 {
-                    if (await PrepareAddOffsetsRetryAsync(
-                            addOffsetsError,
-                            attempt,
-                            retryBudget,
-                            tv2,
-                            cancellationToken)
-                        .ConfigureAwait(false))
-                    {
-                        attempt++;
-                        continue;
-                    }
-
-                    break;
+                    list = [];
+                    topicOffsets[offset.Topic] = list;
                 }
-            }
 
-            // Find the group coordinator. This remains uncached so NotCoordinator retries
-            // refresh only the affected group coordinator information.
-            var brokers = _metadataManager.Metadata.GetBrokers();
-            var findCoordRequest = new FindCoordinatorRequest
-            {
-                Key = consumerGroupId,
-                KeyType = CoordinatorType.Group
-            };
-
-            var findCoordResponse = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
-                    brokers[0].NodeId,
-                    findCoordRequest,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            if (findCoordResponse.Coordinators.Count == 0)
-            {
-                // Treat an empty coordinator set as transiently unavailable and retry.
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                    break;
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
-
-            var coord = findCoordResponse.Coordinators[0];
-            _connectionPool.RegisterBroker(coord.NodeId, coord.Host, coord.Port);
-
-            if (coord.ErrorCode != ErrorCode.None)
-            {
-                ThrowIfNonRetriableTransactionError(coord.ErrorCode,
-                    $"FindCoordinator for consumer group '{consumerGroupId}'", tv2);
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                    break;
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
-
-            using var coordinatorLease = await _connectionPool.LeaseConnectionAsync(
-                coord.NodeId,
-                cancellationToken).ConfigureAwait(false);
-            EnsureTransactionFeatureMatch();
-            var coordinatorConnection = coordinatorLease.Connection;
-            var highestAllowedVersion = tv2
-                ? TxnOffsetCommitRequest.HighestSupportedVersion
-                : (short)4;
-            var txnOffsetCommitVersion = _metadataManager.GetNegotiatedApiVersion(
-                coordinatorConnection,
-                ApiKey.TxnOffsetCommit,
-                TxnOffsetCommitRequest.LowestSupportedVersion,
-                highestAllowedVersion);
-
-            if (tv2 && txnOffsetCommitVersion < 5)
-            {
-                var addOffsetsError = await SendAddOffsetsToTransactionAsync(
-                        consumerGroupId,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (addOffsetsError != ErrorCode.None)
+                list.Add(new TxnOffsetCommitRequestPartition
                 {
-                    if (await PrepareAddOffsetsRetryAsync(
-                            addOffsetsError,
-                            attempt,
-                            retryBudget,
-                            tv2,
-                            cancellationToken)
-                        .ConfigureAwait(false))
-                    {
-                        attempt++;
-                        continue;
-                    }
+                    PartitionIndex = offset.Partition,
+                    CommittedOffset = offset.Offset,
+                    CommittedLeaderEpoch = offset.LeaderEpoch,
+                    CommittedMetadata = offset.Metadata
+                });
+            }
 
+            while (true)
+            {
+                if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
                     break;
-                }
-            }
 
-            OffsetTopicIdRequestMap? topicIdMap = null;
-            List<TxnOffsetCommitRequestTopic> txnTopics;
-            if (txnOffsetCommitVersion >= TxnOffsetCommitRequest.TopicIdVersion)
-            {
-                (txnTopics, topicIdMap) = await BuildTxnOffsetCommitTopicsAsync(
-                        topicOffsets,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (topicIdMap is null)
-                    txnOffsetCommitVersion = TxnOffsetCommitRequest.TopicIdVersion - 1;
-            }
-            else
-            {
-                txnTopics = BuildTxnOffsetCommitTopics(topicOffsets, topicIdMap: null);
-            }
-
-            var txnOffsetCommitRequest = new TxnOffsetCommitRequest
-            {
-                TransactionalId = _options.TransactionalId!,
-                GroupId = consumerGroupId,
-                ProducerId = _producerId,
-                ProducerEpoch = _producerEpoch,
-                GenerationIdOrMemberEpoch = generationIdOrMemberEpoch,
-                MemberId = memberId,
-                GroupInstanceId = groupInstanceId,
-                Topics = txnTopics
-            };
-
-            TxnOffsetCommitResponse txnOffsetCommitResponse;
-            try
-            {
-                txnOffsetCommitResponse = await coordinatorConnection
-                    .SendAsync<TxnOffsetCommitRequest, TxnOffsetCommitResponse>(
-                        txnOffsetCommitRequest,
-                        txnOffsetCommitVersion,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (
-                !cancellationToken.IsCancellationRequested
-                && RetryHelper.IsRetriableRequestFailure(ex))
-            {
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                    break;
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
-
-            ErrorCode? commitError = null;
-            string? commitContext = null;
-            try
-            {
-                var responseSnapshot = topicIdMap?.CaptureResponseSnapshot();
-                foreach (var topicResult in txnOffsetCommitResponse.Topics)
+                // TV1 always performs explicit offset enrollment before coordinator discovery.
+                if (!tv2)
                 {
-                    var topicName = topicIdMap is null
-                        ? topicResult.Name
-                        : topicIdMap.MatchResponseTopic(
-                            topicResult.TopicId,
-                            responseSnapshot!,
-                            "TxnOffsetCommit",
-                            responseMismatchIsRetriable: true);
-
-                    foreach (var partitionResult in topicResult.Partitions)
+                    var addOffsetsError = await SendAddOffsetsToTransactionAsync(
+                            consumerGroupId,
+                            retryCancellationToken)
+                        .ConfigureAwait(false);
+                    if (addOffsetsError != ErrorCode.None)
                     {
-                        if (partitionResult.ErrorCode != ErrorCode.None)
+                        if (await PrepareAddOffsetsRetryAsync(
+                                addOffsetsError,
+                                attempt,
+                                retryBudget,
+                                tv2,
+                                retryCancellationToken)
+                            .ConfigureAwait(false))
                         {
-                            commitError = partitionResult.ErrorCode;
-                            commitContext = $"TxnOffsetCommit for {topicName}-{partitionResult.PartitionIndex}";
-                            break;
+                            attempt++;
+                            continue;
                         }
-                    }
 
-                    if (commitError.HasValue)
                         break;
+                    }
                 }
-            }
-            catch (Exception ex) when (
-                !cancellationToken.IsCancellationRequested
-                && RetryHelper.IsRetriableRequestFailure(ex))
-            {
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                    break;
-                await _metadataManager.RefreshMetadataAsync(
-                        topicOffsets.Keys,
-                        forceRefresh: true,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
 
-            if (commitError.HasValue)
-            {
-                ThrowIfNonRetriableTransactionError(commitError.Value, commitContext!, tv2);
-                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
-                    break;
-                if (commitError.Value.RequiresMetadataRefresh())
+                // Find the group coordinator. This remains uncached so NotCoordinator retries
+                // refresh only the affected group coordinator information.
+                var brokers = _metadataManager.Metadata.GetBrokers();
+                var findCoordRequest = new FindCoordinatorRequest
                 {
+                    Key = consumerGroupId,
+                    KeyType = CoordinatorType.Group
+                };
+
+                var findCoordResponse = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
+                        brokers[0].NodeId,
+                        findCoordRequest,
+                        retryCancellationToken)
+                    .ConfigureAwait(false);
+
+                if (findCoordResponse.Coordinators.Count == 0)
+                {
+                    // Treat an empty coordinator set as transiently unavailable and retry.
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
+                var coord = findCoordResponse.Coordinators[0];
+                _connectionPool.RegisterBroker(coord.NodeId, coord.Host, coord.Port);
+
+                if (coord.ErrorCode != ErrorCode.None)
+                {
+                    ThrowIfNonRetriableTransactionError(coord.ErrorCode,
+                        $"FindCoordinator for consumer group '{consumerGroupId}'", tv2);
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
+                using var coordinatorLease = await _connectionPool.LeaseConnectionAsync(
+                    coord.NodeId,
+                    retryCancellationToken).ConfigureAwait(false);
+                EnsureTransactionFeatureMatch();
+                var coordinatorConnection = coordinatorLease.Connection;
+                var highestAllowedVersion = tv2
+                    ? TxnOffsetCommitRequest.HighestSupportedVersion
+                    : (short)4;
+                var txnOffsetCommitVersion = _metadataManager.GetNegotiatedApiVersion(
+                    coordinatorConnection,
+                    ApiKey.TxnOffsetCommit,
+                    TxnOffsetCommitRequest.LowestSupportedVersion,
+                    highestAllowedVersion);
+
+                if (tv2 && txnOffsetCommitVersion < 5)
+                {
+                    var addOffsetsError = await SendAddOffsetsToTransactionAsync(
+                            consumerGroupId,
+                            retryCancellationToken)
+                        .ConfigureAwait(false);
+                    if (addOffsetsError != ErrorCode.None)
+                    {
+                        if (await PrepareAddOffsetsRetryAsync(
+                                addOffsetsError,
+                                attempt,
+                                retryBudget,
+                                tv2,
+                                retryCancellationToken)
+                            .ConfigureAwait(false))
+                        {
+                            attempt++;
+                            continue;
+                        }
+
+                        break;
+                    }
+                }
+
+                OffsetTopicIdRequestMap? topicIdMap = null;
+                List<TxnOffsetCommitRequestTopic> txnTopics;
+                if (txnOffsetCommitVersion >= TxnOffsetCommitRequest.TopicIdVersion)
+                {
+                    (txnTopics, topicIdMap) = await BuildTxnOffsetCommitTopicsAsync(
+                            topicOffsets,
+                            retryCancellationToken)
+                        .ConfigureAwait(false);
+                    if (topicIdMap is null)
+                        txnOffsetCommitVersion = TxnOffsetCommitRequest.TopicIdVersion - 1;
+                }
+                else
+                {
+                    txnTopics = BuildTxnOffsetCommitTopics(topicOffsets, topicIdMap: null);
+                }
+
+                var txnOffsetCommitRequest = new TxnOffsetCommitRequest
+                {
+                    TransactionalId = _options.TransactionalId!,
+                    GroupId = consumerGroupId,
+                    ProducerId = _producerId,
+                    ProducerEpoch = _producerEpoch,
+                    GenerationIdOrMemberEpoch = generationIdOrMemberEpoch,
+                    MemberId = memberId,
+                    GroupInstanceId = groupInstanceId,
+                    Topics = txnTopics
+                };
+
+                TxnOffsetCommitResponse txnOffsetCommitResponse;
+                try
+                {
+                    txnOffsetCommitResponse = await coordinatorConnection
+                        .SendAsync<TxnOffsetCommitRequest, TxnOffsetCommitResponse>(
+                            txnOffsetCommitRequest,
+                            txnOffsetCommitVersion,
+                            retryCancellationToken)
+                        .ConfigureAwait(false);
+                    lastTransportException = null;
+                }
+                catch (Exception ex) when (
+                    !retryCancellationToken.IsCancellationRequested
+                    && RetryHelper.IsRetriableRequestFailure(ex))
+                {
+                    lastTransportException = ex;
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
+                ErrorCode? commitError = null;
+                string? commitContext = null;
+                try
+                {
+                    var responseSnapshot = topicIdMap?.CaptureResponseSnapshot();
+                    foreach (var topicResult in txnOffsetCommitResponse.Topics)
+                    {
+                        var topicName = topicIdMap is null
+                            ? topicResult.Name
+                            : topicIdMap.MatchResponseTopic(
+                                topicResult.TopicId,
+                                responseSnapshot!,
+                                "TxnOffsetCommit",
+                                responseMismatchIsRetriable: true);
+
+                        foreach (var partitionResult in topicResult.Partitions)
+                        {
+                            if (partitionResult.ErrorCode != ErrorCode.None)
+                            {
+                                commitError = partitionResult.ErrorCode;
+                                commitContext = $"TxnOffsetCommit for {topicName}-{partitionResult.PartitionIndex}";
+                                break;
+                            }
+                        }
+
+                        if (commitError.HasValue)
+                            break;
+                    }
+                }
+                catch (Exception ex) when (
+                    !retryCancellationToken.IsCancellationRequested
+                    && RetryHelper.IsRetriableRequestFailure(ex))
+                {
+                    lastTransportException = ex;
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
                     await _metadataManager.RefreshMetadataAsync(
                             topicOffsets.Keys,
                             forceRefresh: true,
-                            cancellationToken)
+                            retryCancellationToken)
                         .ConfigureAwait(false);
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
                 }
-                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                attempt++;
-                continue;
-            }
 
-            return;
+                if (commitError.HasValue)
+                {
+                    ThrowIfNonRetriableTransactionError(commitError.Value, commitContext!, tv2);
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+                    if (commitError.Value.RequiresMetadataRefresh())
+                    {
+                        await _metadataManager.RefreshMetadataAsync(
+                                topicOffsets.Keys,
+                                forceRefresh: true,
+                                retryCancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
+                return;
+            }
+        }
+        catch (OperationCanceledException) when (
+            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw CreateTransactionTimeoutException(
+                "SendOffsetsToTransaction",
+                retryBudget,
+                attempt + 1,
+                lastTransportException);
         }
 
         throw CreateTransactionTimeoutException(
             "SendOffsetsToTransaction",
             retryBudget,
-            attempt + 1);
+            attempt + 1,
+            lastTransportException);
     }
 
     private async ValueTask<(List<TxnOffsetCommitRequestTopic> Topics, OffsetTopicIdRequestMap? TopicIdMap)>

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -5827,13 +5827,17 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 await AbortAsync().ConfigureAwait(false);
             }
-            catch (KafkaException exception) when (
-                exception is TransactionException or KafkaTimeoutException)
+            catch (KafkaTimeoutException)
+            {
+                // Best-effort abort timed out. AbortAsync already preserved AbortableError
+                // for a pre-write timeout or FatalError for an ambiguous in-flight outcome.
+                // Keep that state so a new transaction cannot reuse the still-open broker transaction.
+            }
+            catch (TransactionException)
             {
                 // Best-effort abort during disposal — if the broker rejects it
-                // (e.g. InvalidTxnState because no messages were produced) or times out,
-                // just clean up state and move on. Fatal responses remain sticky, while
-                // abortable responses return to Ready because this transaction is disposed.
+                // (e.g. InvalidTxnState because no messages were produced), clean up state
+                // and move on. Fatal responses remain sticky.
                 _producer.FinalizeCompletedTransactionState(preserveAbortableError: false);
             }
         }

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2168,11 +2168,29 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         ThrowIfNotInitialized();
         ThrowIfFatalTransactionError("Cannot initialize transactions");
-        await SemaphoreHelper.AcquireOrThrowDisposedAsync(_transactionLock, nameof(KafkaProducer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
+        var retryBudget = CreateTransactionRetryBudget();
+        using (var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken))
+        {
+            try
+            {
+                await SemaphoreHelper.AcquireOrThrowDisposedAsync(
+                        _transactionLock,
+                        nameof(KafkaProducer<TKey, TValue>),
+                        timeoutCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw CreateTransactionTimeoutException(
+                    "InitTransactions lock acquisition",
+                    retryBudget,
+                    attempts: 0);
+            }
+        }
+
         try
         {
-            var retryBudget = CreateTransactionRetryBudget();
-
             // Step 1: Find the transaction coordinator
             await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
 
@@ -2249,7 +2267,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (!committed && !_currentTransactionUsesTV2)
             {
-                await ReinitializeProducerIdAsync(
+                await ReinitializeProducerIdAfterAbortAsync(
                         keepPreparedTransaction: false,
                         retryBudget,
                         cancellationToken)
@@ -2678,12 +2696,6 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
         var retryCancellationToken = timeoutCts.Token;
-        var brokers = _metadataManager.Metadata.GetBrokers();
-        if (brokers.Count == 0)
-        {
-            throw new InvalidOperationException("No brokers available");
-        }
-
         var request = new FindCoordinatorRequest
         {
             Key = _options.TransactionalId!,
@@ -2697,6 +2709,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
                     break;
 
+                var brokers = _metadataManager.Metadata.GetBrokers();
+                if (brokers.Count == 0)
+                {
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+
+                    await _metadataManager.RefreshMetadataAsync(retryCancellationToken).ConfigureAwait(false);
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
                 var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
                     brokers[0].NodeId,
                     request,
@@ -2704,11 +2728,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (response.Coordinators.Count == 0)
                 {
-                    throw new TransactionException(ErrorCode.CoordinatorNotAvailable,
-                        "FindCoordinator returned an empty Coordinators array")
-                    {
-                        TransactionalId = _options.TransactionalId
-                    };
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
                 }
 
                 var coordinator = response.Coordinators[0];
@@ -2812,6 +2837,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 // Check for retriable errors in the response
                 var hasRetriableError = false;
+                var needsCoordinatorRediscovery = false;
                 ErrorCode? firstNonRetriableError = null;
                 string? errorContext = null;
 
@@ -2831,9 +2857,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         else if (partitionResult.ErrorCode == ErrorCode.NotCoordinator)
                         {
                             hasRetriableError = true;
-                            // Re-discover coordinator on next retry
-                            await FindTransactionCoordinatorAsync(retryBudget, retryCancellationToken)
-                                .ConfigureAwait(false);
+                            needsCoordinatorRediscovery = true;
                         }
                         else
                         {
@@ -2841,6 +2865,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             errorContext = $"{topicResult.Name}-{partitionResult.PartitionIndex}";
                         }
                     }
+                }
+
+                if (needsCoordinatorRediscovery && !firstNonRetriableError.HasValue)
+                {
+                    await FindTransactionCoordinatorAsync(retryBudget, retryCancellationToken)
+                        .ConfigureAwait(false);
                 }
 
                 if (firstNonRetriableError.HasValue)
@@ -2887,18 +2917,39 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             CreateTransactionRetryBudget(),
             cancellationToken);
 
-    internal ValueTask EndTransactionAsync(
-        bool committed,
+    internal async ValueTask CommitTransactionAsync(
         Func<ValueTask>? afterRequestWrittenAsync,
         CancellationToken cancellationToken)
-        => EndTransactionAsync(
-            committed,
-            _producerId,
-            _producerEpoch,
-            applyResponseProducerState: true,
-            afterRequestWrittenAsync,
-            CreateTransactionRetryBudget(),
-            cancellationToken);
+    {
+        var retryBudget = CreateTransactionRetryBudget();
+        using (var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken))
+        {
+            try
+            {
+                await FlushAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (
+                timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                _lastTransactionError = ErrorCode.RequestTimedOut;
+                _transactionState = TransactionState.AbortableError;
+                throw CreateTransactionTimeoutException(
+                    "Flush before EndTxn (commit)",
+                    retryBudget,
+                    attempts: 0);
+            }
+        }
+
+        await EndTransactionAsync(
+                committed: true,
+                _producerId,
+                _producerEpoch,
+                applyResponseProducerState: true,
+                afterRequestWrittenAsync,
+                retryBudget,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     internal async ValueTask AbortTransactionAsync(CancellationToken cancellationToken)
     {
@@ -2917,11 +2968,36 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // same max.block.ms budget. TV2 already returned the bumped identity.
         if (!_currentTransactionUsesTV2)
         {
-            await ReinitializeProducerIdAsync(
+            await ReinitializeProducerIdAfterAbortAsync(
                     keepPreparedTransaction: false,
                     retryBudget,
                     cancellationToken)
                 .ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ReinitializeProducerIdAfterAbortAsync(
+        bool keepPreparedTransaction,
+        TransactionRetryBudget retryBudget,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ReinitializeProducerIdAsync(
+                    keepPreparedTransaction,
+                    retryBudget,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            if (_transactionState != TransactionState.FatalError)
+            {
+                _lastTransactionError = ErrorCode.InvalidProducerEpoch;
+                _transactionState = TransactionState.FatalError;
+            }
+
+            throw;
         }
     }
 
@@ -3166,6 +3242,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 // Find the group coordinator. This remains uncached so NotCoordinator retries
                 // refresh only the affected group coordinator information.
                 var brokers = _metadataManager.Metadata.GetBrokers();
+                if (brokers.Count == 0)
+                {
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                        break;
+
+                    await _metadataManager.RefreshMetadataAsync(retryCancellationToken).ConfigureAwait(false);
+                    await Task.Delay(retryDelayMs, retryCancellationToken).ConfigureAwait(false);
+                    attempt++;
+                    continue;
+                }
+
                 var findCoordRequest = new FindCoordinatorRequest
                 {
                     Key = consumerGroupId,
@@ -5592,11 +5679,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 
         try
         {
-            // Flush all pending messages before committing
-            await _producer.FlushAsync(cancellationToken).ConfigureAwait(false);
-
-            await _producer.EndTransactionAsync(
-                    committed: true,
+            await _producer.CommitTransactionAsync(
                     afterRequestWrittenAsync,
                     cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2171,12 +2171,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         await SemaphoreHelper.AcquireOrThrowDisposedAsync(_transactionLock, nameof(KafkaProducer<TKey, TValue>), cancellationToken).ConfigureAwait(false);
         try
         {
+            var retryBudget = CreateTransactionRetryBudget();
 
             // Step 1: Find the transaction coordinator
-            await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+            await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
 
             // Step 2: Initialize the producer ID via the coordinator
-            await ReinitializeProducerIdAsync(cancellationToken, keepPreparedTransaction).ConfigureAwait(false);
+            await ReinitializeProducerIdAsync(keepPreparedTransaction, retryBudget, cancellationToken)
+                .ConfigureAwait(false);
 
             _transactionState = _preparedTransactionState.HasTransaction
                 ? TransactionState.PreparedTransaction
@@ -2230,6 +2232,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         try
         {
+            var retryBudget = CreateTransactionRetryBudget();
             var applyResponseProducerState =
                 transactionToComplete.ProducerId == _producerId
                 && transactionToComplete.ProducerEpoch == _producerEpoch;
@@ -2240,12 +2243,17 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     transactionToComplete.ProducerEpoch,
                     applyResponseProducerState,
                     afterRequestWrittenAsync: null,
+                    retryBudget,
                     cancellationToken)
                 .ConfigureAwait(false);
 
             if (!committed && !_currentTransactionUsesTV2)
             {
-                await ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
+                await ReinitializeProducerIdAsync(
+                        keepPreparedTransaction: false,
+                        retryBudget,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
         finally
@@ -2467,13 +2475,61 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _options.RetryBackoffMaxMs,
             zeroBasedAttempt + 1);
 
+    private TransactionRetryBudget CreateTransactionRetryBudget()
+    {
+        var startedAtMs = MonotonicClock.GetMilliseconds();
+        var deadlineMs = long.MaxValue - startedAtMs > _options.MaxBlockMs
+            ? startedAtMs + _options.MaxBlockMs
+            : long.MaxValue;
+        return new TransactionRetryBudget(startedAtMs, deadlineMs);
+    }
+
+    private bool TryGetTransactionRetryDelay(
+        int zeroBasedAttempt,
+        TransactionRetryBudget retryBudget,
+        out int retryDelayMs)
+    {
+        var remainingMs = retryBudget.DeadlineMs - MonotonicClock.GetMilliseconds();
+        if (remainingMs <= 0)
+        {
+            retryDelayMs = 0;
+            return false;
+        }
+
+        retryDelayMs = (int)Math.Min(CalculateRequestRetryBackoff(zeroBasedAttempt), remainingMs);
+        return true;
+    }
+
+    private KafkaTimeoutException CreateTransactionTimeoutException(
+        string operation,
+        TransactionRetryBudget retryBudget,
+        int attempts)
+    {
+        var elapsedMs = Math.Max(0, MonotonicClock.GetMilliseconds() - retryBudget.StartedAtMs);
+        var configured = TimeSpan.FromMilliseconds(_options.MaxBlockMs);
+        return new KafkaTimeoutException(
+            TimeoutKind.Transaction,
+            TimeSpan.FromMilliseconds(elapsedMs),
+            configured,
+            $"{operation} did not complete within max.block.ms ({_options.MaxBlockMs}ms) after {attempts} attempts.");
+    }
+
     internal async ValueTask ReinitializeProducerIdAsync(
         CancellationToken cancellationToken,
         bool keepPreparedTransaction = false)
-    {
-        const int maxRetries = 10;
+        => await ReinitializeProducerIdAsync(
+                keepPreparedTransaction,
+                CreateTransactionRetryBudget(),
+                cancellationToken)
+            .ConfigureAwait(false);
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+    private async ValueTask ReinitializeProducerIdAsync(
+        bool keepPreparedTransaction,
+        TransactionRetryBudget retryBudget,
+        CancellationToken cancellationToken)
+    {
+        var attempt = 0;
+        while (true)
         {
             var request = new InitProducerIdRequest
             {
@@ -2502,22 +2558,23 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
                 if (classification == TransactionErrorClassification.Retriable)
                 {
-                    if (attempt == maxRetries - 1)
+                    if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                         break;
 
-                    var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                     if (response.ErrorCode == ErrorCode.NotCoordinator)
                     {
-                        LogInitProducerIdNotCoordinator(attempt + 1, maxRetries);
+                        LogInitProducerIdNotCoordinator(attempt + 1);
 
                         await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                        await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                        await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
+                        attempt++;
                         continue;
                     }
 
-                    LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+                    LogInitProducerIdRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
 
                     await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                    attempt++;
                     continue;
                 }
 
@@ -2551,14 +2608,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return;
         }
 
-        throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
-            $"InitProducerId failed after {maxRetries} retries")
-        {
-            TransactionalId = _options.TransactionalId
-        };
+        throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt + 1);
     }
 
     private async ValueTask FindTransactionCoordinatorAsync(CancellationToken cancellationToken)
+        => await FindTransactionCoordinatorAsync(CreateTransactionRetryBudget(), cancellationToken)
+            .ConfigureAwait(false);
+
+    private async ValueTask FindTransactionCoordinatorAsync(
+        TransactionRetryBudget retryBudget,
+        CancellationToken cancellationToken)
     {
         var brokers = _metadataManager.Metadata.GetBrokers();
         if (brokers.Count == 0)
@@ -2572,9 +2631,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             KeyType = CoordinatorType.Transaction
         };
 
-        const int maxRetries = 5;
-
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+        var attempt = 0;
+        while (true)
         {
             var response = await SendWithConnectionLeaseAsync<FindCoordinatorRequest, FindCoordinatorResponse>(
                 brokers[0].NodeId,
@@ -2595,13 +2653,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
             if (errorCode is ErrorCode.CoordinatorNotAvailable or ErrorCode.NotCoordinator)
             {
-                if (attempt == maxRetries - 1)
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                     break;
 
-                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
-                LogTransactionCoordinatorNotAvailable(errorCode, attempt + 1, maxRetries, retryDelayMs);
+                LogTransactionCoordinatorNotAvailable(errorCode, attempt + 1, retryDelayMs);
 
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
@@ -2621,11 +2679,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             return;
         }
 
-        throw new TransactionException(ErrorCode.CoordinatorNotAvailable,
-            $"FindCoordinator for transaction failed after {maxRetries} retries")
-        {
-            TransactionalId = _options.TransactionalId
-        };
+        throw CreateTransactionTimeoutException(
+            "FindCoordinator for transaction",
+            retryBudget,
+            attempt + 1);
     }
 
     internal async ValueTask AddPartitionsToTransactionAsync(
@@ -2662,9 +2719,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             Topics = topics
         };
 
-        const int maxRetries = 5;
+        var retryBudget = CreateTransactionRetryBudget();
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+        var attempt = 0;
+        while (true)
         {
             var response = await SendWithConnectionLeaseAsync<AddPartitionsToTxnRequest, AddPartitionsToTxnResponse>(
                     _transactionCoordinatorId,
@@ -2695,7 +2753,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     {
                         hasRetriableError = true;
                         // Re-discover coordinator on next retry
-                        await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                        await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -2721,20 +2779,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return; // Success
             }
 
-            if (attempt == maxRetries - 1)
+            if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                 break;
 
-            var retryDelayMs = CalculateRequestRetryBackoff(attempt);
-            LogAddPartitionsToTxnRetriableError(attempt + 1, maxRetries, retryDelayMs);
+            LogAddPartitionsToTxnRetriableError(attempt + 1, retryDelayMs);
 
             await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+            attempt++;
         }
 
-        throw new TransactionException(ErrorCode.ConcurrentTransactions,
-            $"AddPartitionsToTxn failed after {maxRetries} retries")
-        {
-            TransactionalId = _options.TransactionalId
-        };
+        throw CreateTransactionTimeoutException("AddPartitionsToTxn", retryBudget, attempt + 1);
     }
 
     internal ValueTask EndTransactionAsync(bool committed, CancellationToken cancellationToken)
@@ -2744,6 +2798,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _producerEpoch,
             applyResponseProducerState: true,
             afterRequestWrittenAsync: null,
+            CreateTransactionRetryBudget(),
             cancellationToken);
 
     internal ValueTask EndTransactionAsync(
@@ -2756,7 +2811,33 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             _producerEpoch,
             applyResponseProducerState: true,
             afterRequestWrittenAsync,
+            CreateTransactionRetryBudget(),
             cancellationToken);
+
+    internal async ValueTask AbortTransactionAsync(CancellationToken cancellationToken)
+    {
+        var retryBudget = CreateTransactionRetryBudget();
+        await EndTransactionAsync(
+                committed: false,
+                _producerId,
+                _producerEpoch,
+                applyResponseProducerState: true,
+                afterRequestWrittenAsync: null,
+                retryBudget,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        // TV1: broker doesn't return bumped epoch in EndTxn, so fetch it with the
+        // same max.block.ms budget. TV2 already returned the bumped identity.
+        if (!_currentTransactionUsesTV2)
+        {
+            await ReinitializeProducerIdAsync(
+                    keepPreparedTransaction: false,
+                    retryBudget,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
 
     private async ValueTask EndTransactionAsync(
         bool committed,
@@ -2764,11 +2845,11 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         short producerEpoch,
         bool applyResponseProducerState,
         Func<ValueTask>? afterRequestWrittenAsync,
+        TransactionRetryBudget retryBudget,
         CancellationToken cancellationToken)
     {
-        const int maxRetries = 5;
-
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+        var attempt = 0;
+        while (true)
         {
             var request = new EndTxnRequest
             {
@@ -2852,28 +2933,28 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             ThrowIfNonRetriableTransactionError(response.ErrorCode,
                 $"EndTxn ({(committed ? "commit" : "abort")})", _currentTransactionUsesTV2);
 
-            if (attempt == maxRetries - 1)
+            if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                 break;
 
-            var retryDelayMs = CalculateRequestRetryBackoff(attempt);
             if (response.ErrorCode == ErrorCode.NotCoordinator)
             {
-                LogEndTxnNotCoordinator(attempt + 1, maxRetries);
+                LogEndTxnNotCoordinator(attempt + 1);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
-                await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+                await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
-            LogEndTxnRetriableError(response.ErrorCode, attempt + 1, maxRetries, retryDelayMs);
+            LogEndTxnRetriableError(response.ErrorCode, attempt + 1, retryDelayMs);
             await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+            attempt++;
             continue;
         }
 
-        throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
-            $"EndTxn ({(committed ? "commit" : "abort")}) failed after {maxRetries} retries")
-        {
-            TransactionalId = _options.TransactionalId
-        };
+        throw CreateTransactionTimeoutException(
+            $"EndTxn ({(committed ? "commit" : "abort")})",
+            retryBudget,
+            attempt + 1);
     }
 
     internal ValueTask SendOffsetsToTransactionInternalAsync(
@@ -2912,7 +2993,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         // TxnOffsetCommit v4. TV2 discovers the group coordinator first, then uses v5 or v6
         // to enroll offsets implicitly when that exact connection supports it. V6 uses
         // request-local topic IDs; a connection capped at v4 retains explicit enrollment.
-        const int maxRetries = 5;
+        var retryBudget = CreateTransactionRetryBudget();
         var tv2 = _currentTransactionUsesTV2;
 
         // Materialize once so a lost response can retry safely even when the caller supplied
@@ -2935,7 +3016,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             });
         }
 
-        for (var attempt = 0; attempt < maxRetries; attempt++)
+        var attempt = 0;
+        while (true)
         {
             // TV1 always performs explicit offset enrollment before coordinator discovery.
             if (!tv2)
@@ -2949,11 +3031,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     if (await PrepareAddOffsetsRetryAsync(
                             addOffsetsError,
                             attempt,
-                            maxRetries,
+                            retryBudget,
                             tv2,
                             cancellationToken)
                         .ConfigureAwait(false))
                     {
+                        attempt++;
                         continue;
                     }
 
@@ -2979,10 +3062,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             if (findCoordResponse.Coordinators.Count == 0)
             {
                 // Treat an empty coordinator set as transiently unavailable and retry.
-                if (attempt == maxRetries - 1)
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                     break;
-                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
@@ -2993,10 +3076,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 ThrowIfNonRetriableTransactionError(coord.ErrorCode,
                     $"FindCoordinator for consumer group '{consumerGroupId}'", tv2);
-                if (attempt == maxRetries - 1)
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                     break;
-                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
@@ -3025,11 +3108,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     if (await PrepareAddOffsetsRetryAsync(
                             addOffsetsError,
                             attempt,
-                            maxRetries,
+                            retryBudget,
                             tv2,
                             cancellationToken)
                         .ConfigureAwait(false))
                     {
+                        attempt++;
                         continue;
                     }
 
@@ -3076,12 +3160,13 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                     .ConfigureAwait(false);
             }
             catch (Exception ex) when (
-                attempt < maxRetries - 1
-                && !cancellationToken.IsCancellationRequested
+                !cancellationToken.IsCancellationRequested
                 && RetryHelper.IsRetriableRequestFailure(ex))
             {
-                await Task.Delay(CalculateRequestRetryBackoff(attempt), cancellationToken)
-                    .ConfigureAwait(false);
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                    break;
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
@@ -3115,24 +3200,25 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 }
             }
             catch (Exception ex) when (
-                attempt < maxRetries - 1
-                && !cancellationToken.IsCancellationRequested
+                !cancellationToken.IsCancellationRequested
                 && RetryHelper.IsRetriableRequestFailure(ex))
             {
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
+                    break;
                 await _metadataManager.RefreshMetadataAsync(
                         topicOffsets.Keys,
                         forceRefresh: true,
                         cancellationToken)
                     .ConfigureAwait(false);
-                await Task.Delay(CalculateRequestRetryBackoff(attempt), cancellationToken)
-                    .ConfigureAwait(false);
+                await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
             if (commitError.HasValue)
             {
                 ThrowIfNonRetriableTransactionError(commitError.Value, commitContext!, tv2);
-                if (attempt == maxRetries - 1)
+                if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
                     break;
                 if (commitError.Value.RequiresMetadataRefresh())
                 {
@@ -3142,19 +3228,18 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             cancellationToken)
                         .ConfigureAwait(false);
                 }
-                var retryDelayMs = CalculateRequestRetryBackoff(attempt);
                 await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
+                attempt++;
                 continue;
             }
 
             return;
         }
 
-        throw new TransactionException(ErrorCode.CoordinatorLoadInProgress,
-            $"SendOffsetsToTransaction failed after {maxRetries} retries")
-        {
-            TransactionalId = _options.TransactionalId
-        };
+        throw CreateTransactionTimeoutException(
+            "SendOffsetsToTransaction",
+            retryBudget,
+            attempt + 1);
     }
 
     private async ValueTask<(List<TxnOffsetCommitRequestTopic> Topics, OffsetTopicIdRequestMap? TopicIdMap)>
@@ -3245,20 +3330,22 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     private async ValueTask<bool> PrepareAddOffsetsRetryAsync(
         ErrorCode errorCode,
         int attempt,
-        int maxRetries,
+        TransactionRetryBudget retryBudget,
         bool tv2,
         CancellationToken cancellationToken)
     {
         ThrowIfNonRetriableTransactionError(errorCode, "AddOffsetsToTxn", tv2);
-        if (attempt == maxRetries - 1)
+        if (!TryGetTransactionRetryDelay(attempt, retryBudget, out var retryDelayMs))
             return false;
 
         if (errorCode == ErrorCode.NotCoordinator)
-            await FindTransactionCoordinatorAsync(cancellationToken).ConfigureAwait(false);
+            await FindTransactionCoordinatorAsync(retryBudget, cancellationToken).ConfigureAwait(false);
 
-        await Task.Delay(CalculateRequestRetryBackoff(attempt), cancellationToken).ConfigureAwait(false);
+        await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
         return true;
     }
+
+    private readonly record struct TransactionRetryBudget(long StartedAtMs, long DeadlineMs);
 
     /// <inheritdoc />
     public ITopicProducer<TKey, TValue> ForTopic(string topic)
@@ -5144,32 +5231,32 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     [LoggerMessage(Level = LogLevel.Warning, Message = "Producer interceptor {Interceptor} OnAcknowledgement threw an exception")]
     private partial void LogInterceptorOnAcknowledgementFailed(Exception ex, string interceptor);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "InitProducerId retriable error ({ErrorCode}, attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms")]
-    private partial void LogInitProducerIdRetriableError(ErrorCode errorCode, int attempt, int maxRetries, int delay);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "InitProducerId retriable error ({ErrorCode}, attempt {Attempt}), retrying in {Delay}ms")]
+    private partial void LogInitProducerIdRetriableError(ErrorCode errorCode, int attempt, int delay);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "InitProducerId got NotCoordinator (attempt {Attempt}/{MaxRetries}), re-discovering coordinator")]
-    private partial void LogInitProducerIdNotCoordinator(int attempt, int maxRetries);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "InitProducerId got NotCoordinator (attempt {Attempt}), re-discovering coordinator")]
+    private partial void LogInitProducerIdNotCoordinator(int attempt);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Initialized transactions: ProducerId={ProducerId}, Epoch={Epoch}")]
     private partial void LogTransactionsInitialized(long producerId, short epoch);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Transaction coordinator not available ({ErrorCode}, attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms")]
-    private partial void LogTransactionCoordinatorNotAvailable(ErrorCode errorCode, int attempt, int maxRetries, int delay);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Transaction coordinator not available ({ErrorCode}, attempt {Attempt}), retrying in {Delay}ms")]
+    private partial void LogTransactionCoordinatorNotAvailable(ErrorCode errorCode, int attempt, int delay);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Found transaction coordinator {NodeId} for {TransactionalId}")]
     private partial void LogTransactionCoordinatorFound(int nodeId, string? transactionalId);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "AddPartitionsToTxn retriable error (attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms")]
-    private partial void LogAddPartitionsToTxnRetriableError(int attempt, int maxRetries, int delay);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "AddPartitionsToTxn retriable error (attempt {Attempt}), retrying in {Delay}ms")]
+    private partial void LogAddPartitionsToTxnRetriableError(int attempt, int delay);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "AddPartitionsToTxn transport failure (attempt {Attempt}), retrying in {Delay}ms")]
     private partial void LogAddPartitionsToTxnTransportRetry(int attempt, int delay);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "EndTxn retriable error ({ErrorCode}, attempt {Attempt}/{MaxRetries}), retrying in {Delay}ms")]
-    private partial void LogEndTxnRetriableError(ErrorCode errorCode, int attempt, int maxRetries, int delay);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "EndTxn retriable error ({ErrorCode}, attempt {Attempt}), retrying in {Delay}ms")]
+    private partial void LogEndTxnRetriableError(ErrorCode errorCode, int attempt, int delay);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "EndTxn got NotCoordinator (attempt {Attempt}/{MaxRetries}), re-discovering coordinator")]
-    private partial void LogEndTxnNotCoordinator(int attempt, int maxRetries);
+    [LoggerMessage(Level = LogLevel.Debug, Message = "EndTxn got NotCoordinator (attempt {Attempt}), re-discovering coordinator")]
+    private partial void LogEndTxnNotCoordinator(int attempt);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error in linger loop")]
     private partial void LogLingerLoopError(Exception ex);
@@ -5422,15 +5509,7 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
 
         try
         {
-            await _producer.EndTransactionAsync(committed: false, cancellationToken).ConfigureAwait(false);
-
-            // TV1: broker doesn't return bumped epoch in EndTxn, so we must call
-            // InitProducerId to get it (KIP-360).
-            // TV2: EndTxn v5 response already contained the bumped epoch — skip.
-            if (!_producer._currentTransactionUsesTV2)
-            {
-                await _producer.ReinitializeProducerIdAsync(cancellationToken).ConfigureAwait(false);
-            }
+            await _producer.AbortTransactionAsync(cancellationToken).ConfigureAwait(false);
 
             _aborted = true;
         }
@@ -5476,10 +5555,11 @@ internal sealed class Transaction<TKey, TValue> : ITransaction<TKey, TValue>
             {
                 await AbortAsync().ConfigureAwait(false);
             }
-            catch (TransactionException)
+            catch (KafkaException exception) when (
+                exception is TransactionException or KafkaTimeoutException)
             {
                 // Best-effort abort during disposal — if the broker rejects it
-                // (e.g. InvalidTxnState because no messages were produced),
+                // (e.g. InvalidTxnState because no messages were produced) or times out,
                 // just clean up state and move on. Fatal responses remain sticky, while
                 // abortable responses return to Ready because this transaction is disposed.
                 _producer.FinalizeCompletedTransactionState(preserveAbortableError: false);

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2405,7 +2405,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         short minimumRequiredVersion = short.MinValue,
         bool captureTransactionFeatures = false,
         bool requireTransactionFeatureMatch = false,
-        bool keepPreparedTransaction = false)
+        bool keepPreparedTransaction = false,
+        Action? beforeRequestSend = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -2430,6 +2431,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 $"v{minimumRequiredVersion} required by this operation; negotiated v{apiVersion}.");
         }
 
+        beforeRequestSend?.Invoke();
         return await connection.SendAsync<TRequest, TResponse>(
             request,
             apiVersion,
@@ -2587,6 +2589,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
         var retryCancellationToken = timeoutCts.Token;
+        var initProducerIdRequestInFlight = false;
         try
         {
             while (true)
@@ -2612,8 +2615,10 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             ? (short)6
                             : short.MinValue,
                         captureTransactionFeatures: true,
-                        keepPreparedTransaction: keepPreparedTransaction)
+                        keepPreparedTransaction: keepPreparedTransaction,
+                        beforeRequestSend: () => initProducerIdRequestInFlight = true)
                     .ConfigureAwait(false);
+                initProducerIdRequestInFlight = false;
 
                 if (response.ErrorCode != ErrorCode.None)
                 {
@@ -2675,6 +2680,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         catch (OperationCanceledException) when (
             timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
+            if (initProducerIdRequestInFlight)
+            {
+                _lastTransactionError = ErrorCode.InvalidProducerEpoch;
+                _transactionState = TransactionState.FatalError;
+            }
+
             throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt + 1);
         }
 

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2677,14 +2677,16 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 return;
             }
         }
-        catch (OperationCanceledException) when (
-            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
             if (initProducerIdRequestInFlight)
             {
                 _lastTransactionError = ErrorCode.InvalidProducerEpoch;
                 _transactionState = TransactionState.FatalError;
             }
+
+            if (cancellationToken.IsCancellationRequested || !timeoutCts.IsCancellationRequested)
+                throw;
 
             throw CreateTransactionTimeoutException("InitProducerId", retryBudget, attempt + 1);
         }
@@ -2939,11 +2941,14 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
             {
                 await FlushAsync(timeoutCts.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) when (
-                timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
                 _lastTransactionError = ErrorCode.RequestTimedOut;
                 _transactionState = TransactionState.AbortableError;
+
+                if (cancellationToken.IsCancellationRequested || !timeoutCts.IsCancellationRequested)
+                    throw;
+
                 throw CreateTransactionTimeoutException(
                     "Flush before EndTxn (commit)",
                     retryBudget,
@@ -3026,6 +3031,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         var attempt = 0;
         if (!TryGetTransactionRemainingMilliseconds(retryBudget, out _))
         {
+            PreserveEndTransactionTimeoutState(requestInFlight: false);
             throw CreateTransactionTimeoutException(
                 $"EndTxn ({(committed ? "commit" : "abort")})",
                 retryBudget,
@@ -3147,14 +3153,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 continue;
             }
         }
-        catch (OperationCanceledException) when (
-            timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            if (endTxnRequestInFlight)
-            {
-                _lastTransactionError = ErrorCode.RequestTimedOut;
-                _transactionState = TransactionState.FatalError;
-            }
+            PreserveEndTransactionTimeoutState(endTxnRequestInFlight);
+
+            if (cancellationToken.IsCancellationRequested || !timeoutCts.IsCancellationRequested)
+                throw;
 
             throw CreateTransactionTimeoutException(
                 $"EndTxn ({(committed ? "commit" : "abort")})",
@@ -3162,10 +3166,19 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 attempt + 1);
         }
 
+        PreserveEndTransactionTimeoutState(requestInFlight: false);
         throw CreateTransactionTimeoutException(
             $"EndTxn ({(committed ? "commit" : "abort")})",
             retryBudget,
             attempt + 1);
+    }
+
+    private void PreserveEndTransactionTimeoutState(bool requestInFlight)
+    {
+        _lastTransactionError = ErrorCode.RequestTimedOut;
+        _transactionState = requestInFlight
+            ? TransactionState.FatalError
+            : TransactionState.AbortableError;
     }
 
     internal ValueTask SendOffsetsToTransactionInternalAsync(

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2406,7 +2406,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         bool captureTransactionFeatures = false,
         bool requireTransactionFeatureMatch = false,
         bool keepPreparedTransaction = false,
-        Action? beforeRequestSend = null)
+        Action? requestWriteStarted = null)
         where TRequest : IKafkaRequest<TResponse>
         where TResponse : IKafkaResponse
     {
@@ -2431,11 +2431,26 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                 $"v{minimumRequiredVersion} required by this operation; negotiated v{apiVersion}.");
         }
 
-        beforeRequestSend?.Invoke();
-        return await connection.SendAsync<TRequest, TResponse>(
-            request,
-            apiVersion,
-            cancellationToken).ConfigureAwait(false);
+        if (requestWriteStarted is null)
+        {
+            return await connection.SendAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        if (connection is not IKafkaRequestWriteObserverConnection writeObserverConnection)
+        {
+            throw new InvalidOperationException(
+                "The transaction coordinator connection cannot report request write start.");
+        }
+
+        return await writeObserverConnection.SendWithWriteObservationAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                requestWriteStarted,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private void CaptureTransactionFeatures(bool keepPreparedTransaction)
@@ -2616,7 +2631,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             : short.MinValue,
                         captureTransactionFeatures: true,
                         keepPreparedTransaction: keepPreparedTransaction,
-                        beforeRequestSend: () => initProducerIdRequestInFlight = true)
+                        requestWriteStarted: () => initProducerIdRequestInFlight = true)
                     .ConfigureAwait(false);
                 initProducerIdRequestInFlight = false;
 
@@ -3068,27 +3083,31 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         ApiKey.EndTxn,
                         EndTxnRequest.LowestSupportedVersion,
                         EndTxnRequest.HighestSupportedVersion);
+                    if (connection is not IKafkaRequestWriteObserverConnection writeObserverConnection)
+                    {
+                        throw new InvalidOperationException(
+                            "The transaction coordinator connection cannot report request write start.");
+                    }
+
                     if (afterRequestWrittenAsync is null)
                     {
-                        endTxnRequestInFlight = true;
-                        response = await connection
-                            .SendAsync<EndTxnRequest, EndTxnResponse>(
-                                request, apiVersion, retryCancellationToken)
+                        response = await writeObserverConnection
+                            .SendWithWriteObservationAsync<EndTxnRequest, EndTxnResponse>(
+                                request,
+                                apiVersion,
+                                () => endTxnRequestInFlight = true,
+                                retryCancellationToken)
                             .ConfigureAwait(false);
                         endTxnRequestInFlight = false;
                     }
                     else
                     {
-                        if (connection is not IKafkaPipelinedWriteCompletionConnection writeCompletionConnection)
-                        {
-                            throw new InvalidOperationException(
-                                "The transaction coordinator connection cannot report request write completion.");
-                        }
-
-                        endTxnRequestInFlight = true;
-                        var responseTask = await writeCompletionConnection
-                            .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
-                                request, apiVersion, retryCancellationToken)
+                        var responseTask = await writeObserverConnection
+                            .SendPipelinedWithWriteObservationAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
+                                request,
+                                apiVersion,
+                                () => endTxnRequestInFlight = true,
+                                retryCancellationToken)
                             .ConfigureAwait(false);
                         var responseConsumptionStarted = false;
                         try

--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -2991,6 +2991,8 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         }
         catch (Exception)
         {
+            // EndTxn has already succeeded before this required TV1 epoch refresh starts.
+            // Caller cancellation cannot make the cached producer identity safe to reuse.
             if (_transactionState != TransactionState.FatalError)
             {
                 _lastTransactionError = ErrorCode.InvalidProducerEpoch;
@@ -3021,6 +3023,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
 
         using var timeoutCts = CreateTransactionRetryCancellationSource(retryBudget, cancellationToken);
         var retryCancellationToken = timeoutCts.Token;
+        var endTxnRequestInFlight = false;
         try
         {
             while (true)
@@ -3050,10 +3053,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                         EndTxnRequest.HighestSupportedVersion);
                     if (afterRequestWrittenAsync is null)
                     {
+                        endTxnRequestInFlight = true;
                         response = await connection
                             .SendAsync<EndTxnRequest, EndTxnResponse>(
                                 request, apiVersion, retryCancellationToken)
                             .ConfigureAwait(false);
+                        endTxnRequestInFlight = false;
                     }
                     else
                     {
@@ -3063,6 +3068,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                                 "The transaction coordinator connection cannot report request write completion.");
                         }
 
+                        endTxnRequestInFlight = true;
                         var responseTask = await writeCompletionConnection
                             .SendPipelinedAfterWriteAsync<EndTxnRequest, EndTxnResponse>(
                                 request, apiVersion, retryCancellationToken)
@@ -3077,6 +3083,7 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
                             var responseValueTask = responseTask.AsValueTask();
                             responseConsumptionStarted = true;
                             response = await responseValueTask.ConfigureAwait(false);
+                            endTxnRequestInFlight = false;
                         }
                         finally
                         {
@@ -3132,6 +3139,12 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
         catch (OperationCanceledException) when (
             timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
+            if (endTxnRequestInFlight)
+            {
+                _lastTransactionError = ErrorCode.RequestTimedOut;
+                _transactionState = TransactionState.FatalError;
+            }
+
             throw CreateTransactionTimeoutException(
                 $"EndTxn ({(committed ? "commit" : "abort")})",
                 retryBudget,

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -422,10 +422,21 @@ public sealed class ProducerOptions
     /// If the timeout expires, a <see cref="Errors.KafkaTimeoutException"/> is thrown with a descriptive message.
     /// </para>
     /// <para>
-    /// Equivalent to Kafka's <c>max.block.ms</c> configuration. Default is 60000ms (60 seconds).
+    /// Equivalent to Kafka's <c>max.block.ms</c> configuration. Must be positive.
+    /// Default is 60000ms (60 seconds).
     /// </para>
     /// </summary>
-    public int MaxBlockMs { get; init; } = 60000;
+    public int MaxBlockMs
+    {
+        get => _maxBlockMs;
+        init
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, 1);
+            _maxBlockMs = value;
+        }
+    }
+
+    private readonly int _maxBlockMs = 60000;
 
     /// <summary>
     /// Maximum request size in bytes.

--- a/src/Dekaf/Producer/ProducerOptions.cs
+++ b/src/Dekaf/Producer/ProducerOptions.cs
@@ -414,8 +414,9 @@ public sealed class ProducerOptions
     /// and <see cref="KafkaProducer{TKey,TValue}.Send"/> will block when the producer's buffer
     /// is full or metadata is unavailable.
     /// <para>
-    /// This controls how long the producer waits for buffer space (backpressure) and for
-    /// initial metadata when producing to a new topic for the first time.
+    /// This controls how long the producer waits for buffer space (backpressure), initial
+    /// metadata when producing to a new topic for the first time, and transaction coordinator
+    /// operations such as initialization, offset commits, commit, and abort.
     /// </para>
     /// <para>
     /// If the timeout expires, a <see cref="Errors.KafkaTimeoutException"/> is thrown with a descriptive message.

--- a/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionCoordinatorFaultTests.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using Dekaf.Consumer;
+using Dekaf.Errors;
 using Dekaf.Networking;
 using Dekaf.Producer;
 using Dekaf.Protocol;
@@ -15,6 +17,88 @@ namespace Dekaf.Tests.Integration;
 public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContainer kafka)
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromMinutes(2);
+
+    [Test]
+    public async Task InitTransactions_CoordinatorResponseBeyondMaxBlock_TimesOutAndRecovers()
+    {
+        using var testTimeout = new CancellationTokenSource(TestTimeout);
+        var cancellationToken = testTimeout.Token;
+        var topic = await kafka.CreateTestTopicAsync();
+        await WarmTransactionCoordinatorAsync(cancellationToken);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.ProducerBootstrapServers)
+            .WithTransactionalId($"transaction-init-deadline-{Guid.NewGuid():N}")
+            .WithMaxBlock(TimeSpan.FromSeconds(2))
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+
+        try
+        {
+            await kafka.AddCoordinatorLatencyAsync(cancellationToken, latencyMs: 8_000);
+            var stopwatch = Stopwatch.StartNew();
+
+            var exception = await Assert.That(() => producer.InitTransactionsAsync(
+                    cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>();
+
+            await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+            await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(4));
+        }
+        finally
+        {
+            await kafka.HealCoordinatorAsync(cancellationToken);
+        }
+
+        await producer.InitTransactionsAsync(cancellationToken);
+        await using var transaction = producer.BeginTransaction();
+        _ = await transaction.ProduceAsync(topic, "recovered-key", "recovered-value", cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    [Test]
+    public async Task SendOffsets_CoordinatorResponseBeyondMaxBlock_TimesOutAndRecovers()
+    {
+        using var testTimeout = new CancellationTokenSource(TestTimeout);
+        var cancellationToken = testTimeout.Token;
+        var topic = await kafka.CreateTestTopicAsync();
+        await WarmTransactionCoordinatorAsync(cancellationToken);
+
+        await using var producer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.ProducerBootstrapServers)
+            .WithTransactionalId($"transaction-offset-deadline-{Guid.NewGuid():N}")
+            .WithMaxBlock(TimeSpan.FromSeconds(2))
+            .WithAcks(Acks.All)
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+        await producer.InitTransactionsAsync(cancellationToken);
+        await using var transaction = producer.BeginTransaction();
+        var offsets = new[] { new TopicPartitionOffset(topic, 0, 0) };
+        var consumerGroupId = $"transaction-offset-deadline-group-{Guid.NewGuid():N}";
+
+        try
+        {
+            await kafka.AddCoordinatorLatencyAsync(cancellationToken, latencyMs: 8_000);
+            var stopwatch = Stopwatch.StartNew();
+
+            var exception = await Assert.That(() => transaction.SendOffsetsToTransactionAsync(
+                    offsets,
+                    consumerGroupId,
+                    cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>();
+
+            await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+            await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(4));
+        }
+        finally
+        {
+            await kafka.HealCoordinatorAsync(cancellationToken);
+        }
+
+        await transaction.SendOffsetsToTransactionAsync(offsets, consumerGroupId, cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+    }
 
     [Test]
     public async Task Abort_CoordinatorResponseDelayed_RecoversWithoutVisibility()
@@ -152,6 +236,16 @@ public sealed class TransactionCoordinatorFaultTests(TransactionFaultKafkaContai
         {
             // Expected when cleanup cancels an incomplete background operation.
         }
+    }
+
+    private async Task WarmTransactionCoordinatorAsync(CancellationToken cancellationToken)
+    {
+        await using var warmupProducer = await Kafka.CreateProducer<string, string>()
+            .WithBootstrapServers(kafka.ProducerBootstrapServers)
+            .WithTransactionalId($"transaction-warmup-{Guid.NewGuid():N}")
+            .WithLoggerFactory(GlobalTestSetup.GetLoggerFactory())
+            .BuildAsync(cancellationToken);
+        await warmupProducer.InitTransactionsAsync(cancellationToken);
     }
 
     private sealed class EndTxnRequestObserver

--- a/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
+++ b/tests/Dekaf.Tests.Integration/TransactionFaultKafkaContainer.cs
@@ -81,14 +81,16 @@ public sealed class TransactionFaultKafkaContainer : KafkaTestContainer
         await WaitForAdminReadyAsync("transaction fault proxy").ConfigureAwait(false);
     }
 
-    public async Task AddCoordinatorLatencyAsync(CancellationToken cancellationToken)
+    public async Task AddCoordinatorLatencyAsync(
+        CancellationToken cancellationToken,
+        int latencyMs = 5_000)
     {
         var toxic = new ToxiproxyLatencyConfiguration(
             CoordinatorFaultName,
             "latency",
             "downstream",
             1,
-            new ToxiproxyLatencyAttributes(5_000, 0));
+            new ToxiproxyLatencyAttributes(latencyMs, 0));
         using var response = await _toxiproxyClient.PostAsJsonAsync(
             $"proxies/{ProducerProxyName}/toxics",
             toxic,

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -686,7 +686,90 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
-    public async Task SendWithWriteObservation_CancellationWhileWaitingForWriteLock_DoesNotSignalWriteStart(
+    public async Task SendWithWriteObservation_Success_InvokesCallbackOnce(CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            var callbackCount = 0;
+
+            var sendTask = ((IKafkaRequestWriteObserverConnection)connection)
+                .SendWithWriteObservationAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    () => Interlocked.Increment(ref callbackCount),
+                    cancellationToken)
+                .AsTask();
+            var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
+            await serverClient.GetStream().WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken);
+
+            var response = await sendTask.ConfigureAwait(false);
+            await Assert.That(response.ErrorCode).IsEqualTo(ErrorCode.None);
+            await Assert.That(callbackCount).IsEqualTo(1);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
+    public async Task SendPipelinedWithWriteObservation_Success_InvokesCallbackOnce(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+            await using var connection = new KafkaConnection(IPAddress.Loopback.ToString(), port);
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            var callbackCount = 0;
+
+            var response = await ((IKafkaRequestWriteObserverConnection)connection)
+                .SendPipelinedWithWriteObservationAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                    new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                    apiVersion: 3,
+                    () => Interlocked.Increment(ref callbackCount),
+                    cancellationToken);
+            var requestFrame = await ReadRequestFrameAsync(serverClient.GetStream(), cancellationToken);
+            var correlationId = BinaryPrimitives.ReadInt32BigEndian(requestFrame.AsSpan(4, 4));
+            await serverClient.GetStream().WriteAsync(
+                BuildApiVersionsV3ResponseFrame(correlationId),
+                cancellationToken);
+
+            while (!response.IsCompleted)
+                await Task.Yield();
+            var parsed = response.GetResult();
+            await Assert.That(parsed.ErrorCode).IsEqualTo(ErrorCode.None);
+            await Assert.That(callbackCount).IsEqualTo(1);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(10_000)]
+    public async Task WriteObservation_CancellationWhileWaitingForWriteLock_DoesNotSignalWriteStart(
+        bool pipelined,
         CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
@@ -710,13 +793,27 @@ public sealed class KafkaConnectionTests
             {
                 var requestWriteStarted = false;
                 using var callerCancellation = new CancellationTokenSource();
-                var sendTask = ((IKafkaRequestWriteObserverConnection)connection)
-                    .SendWithWriteObservationAsync<ApiVersionsRequest, ApiVersionsResponse>(
-                        new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
-                        apiVersion: 3,
-                        () => requestWriteStarted = true,
-                        callerCancellation.Token)
-                    .AsTask();
+                var writeObserverConnection = (IKafkaRequestWriteObserverConnection)connection;
+                var request = new ApiVersionsRequest
+                {
+                    ClientSoftwareName = "test",
+                    ClientSoftwareVersion = "1.0"
+                };
+                Task sendTask = pipelined
+                    ? writeObserverConnection
+                        .SendPipelinedWithWriteObservationAfterWriteAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                            request,
+                            apiVersion: 3,
+                            () => requestWriteStarted = true,
+                            callerCancellation.Token)
+                        .AsTask()
+                    : writeObserverConnection
+                        .SendWithWriteObservationAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                            request,
+                            apiVersion: 3,
+                            () => requestWriteStarted = true,
+                            callerCancellation.Token)
+                        .AsTask();
 
                 var requestReachedWriteWait = SpinWait.SpinUntil(
                     () => GetPrivateField<int>(connection, "_pendingRequestCount") == 1,

--- a/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Networking/KafkaConnectionTests.cs
@@ -686,6 +686,62 @@ public sealed class KafkaConnectionTests
 
     [Test]
     [Timeout(10_000)]
+    public async Task SendWithWriteObservation_CancellationWhileWaitingForWriteLock_DoesNotSignalWriteStart(
+        CancellationToken cancellationToken)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var acceptTask = AcceptAndCompleteHandshakeAsync(listener, cancellationToken);
+            await using var connection = new KafkaConnection(
+                IPAddress.Loopback.ToString(),
+                port,
+                options: new ConnectionOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+
+            await connection.ConnectAsync(cancellationToken);
+            using var serverClient = await acceptTask.ConfigureAwait(false);
+            var writeLock = GetPrivateField<SemaphoreSlim>(connection, "_writeLock");
+            await writeLock.WaitAsync(cancellationToken);
+
+            try
+            {
+                var requestWriteStarted = false;
+                using var callerCancellation = new CancellationTokenSource();
+                var sendTask = ((IKafkaRequestWriteObserverConnection)connection)
+                    .SendWithWriteObservationAsync<ApiVersionsRequest, ApiVersionsResponse>(
+                        new ApiVersionsRequest { ClientSoftwareName = "test", ClientSoftwareVersion = "1.0" },
+                        apiVersion: 3,
+                        () => requestWriteStarted = true,
+                        callerCancellation.Token)
+                    .AsTask();
+
+                var requestReachedWriteWait = SpinWait.SpinUntil(
+                    () => GetPrivateField<int>(connection, "_pendingRequestCount") == 1,
+                    TimeSpan.FromSeconds(5));
+                await Assert.That(requestReachedWriteWait).IsTrue();
+                await Assert.That(requestWriteStarted).IsFalse();
+
+                await callerCancellation.CancelAsync();
+                await Assert.That(async () => await sendTask.ConfigureAwait(false))
+                    .Throws<OperationCanceledException>();
+                await Assert.That(requestWriteStarted).IsFalse();
+            }
+            finally
+            {
+                writeLock.Release();
+            }
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    [Timeout(10_000)]
     public async Task ReceiveLoop_IdleLongerThanRequestTimeout_RemainsConnected(CancellationToken cancellationToken)
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
@@ -1524,7 +1580,7 @@ public sealed class KafkaConnectionTests
         if (method is null)
             throw new InvalidOperationException("WriteFrameHoldingLockAsync was not found.");
 
-        var writeTask = (Task)method.Invoke(connection, [buffer, 4, false])!;
+        var writeTask = (Task)method.Invoke(connection, [buffer, 4, false, null])!;
         return (writeTask, writeLock);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/MaxBlockMsTests.cs
@@ -54,6 +54,20 @@ public sealed class MaxBlockMsTests
         await Assert.That(options.MaxBlockMs).IsEqualTo(1);
     }
 
+    [Test]
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task MaxBlockMs_NonPositiveValue_ThrowsArgumentOutOfRangeException(int maxBlockMs)
+    {
+        var act = () => new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            MaxBlockMs = maxBlockMs
+        };
+
+        await Assert.That(act).Throws<ArgumentOutOfRangeException>();
+    }
+
     #endregion
 
     #region Builder - WithMaxBlock (from Ms)

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
@@ -239,6 +239,31 @@ public sealed class TransactionOffsetCommitTests
     }
 
     [Test]
+    public async Task TV2_RetriableCommitError_RetriesBeyondPreviousAttemptLimit()
+    {
+        var outcomes = new Queue<object>(
+        [
+            ErrorCode.CoordinatorLoadInProgress,
+            ErrorCode.CoordinatorLoadInProgress,
+            ErrorCode.CoordinatorLoadInProgress,
+            ErrorCode.CoordinatorLoadInProgress,
+            ErrorCode.CoordinatorLoadInProgress,
+            ErrorCode.None
+        ]);
+        await using var harness = CreateHarness(
+            transactionVersion: 2,
+            txnOffsetCommitMaxVersion: 5,
+            commitOutcomes: outcomes);
+
+        await harness.Producer.SendOffsetsToTransactionInternalAsync(
+            [new TopicPartitionOffset("orders", 0, 42)],
+            "group-1",
+            CancellationToken.None);
+
+        await Assert.That(harness.Connection.CommitRequests).Count().IsEqualTo(6);
+    }
+
+    [Test]
     public async Task TV2_TransactionAbortable_UsesKip890Classification()
     {
         var outcomes = new Queue<object>([ErrorCode.TransactionAbortable]);

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
@@ -264,6 +264,29 @@ public sealed class TransactionOffsetCommitTests
     }
 
     [Test]
+    public async Task TV2_TransportFailuresUntilDeadline_ArePreservedAsTimeoutCause()
+    {
+        var outcomes = new Queue<object>(Enumerable.Range(0, 1000)
+            .Select(static _ => (object)new IOException("coordinator connection lost")));
+        await using var harness = CreateHarness(
+            transactionVersion: 2,
+            txnOffsetCommitMaxVersion: 5,
+            commitOutcomes: outcomes,
+            retryBackoffMs: 10,
+            maxBlockMs: 1000);
+
+        var exception = await Assert.That(() => harness.Producer.SendOffsetsToTransactionInternalAsync(
+                [new TopicPartitionOffset("orders", 0, 42)],
+                "group-1",
+                CancellationToken.None).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(exception.InnerException).IsTypeOf<IOException>();
+        await Assert.That(exception.InnerException!.Message).IsEqualTo("coordinator connection lost");
+    }
+
+    [Test]
     public async Task TV2_TransactionAbortable_UsesKip890Classification()
     {
         var outcomes = new Queue<object>([ErrorCode.TransactionAbortable]);
@@ -286,7 +309,9 @@ public sealed class TransactionOffsetCommitTests
         short transactionVersion,
         short txnOffsetCommitMaxVersion,
         Queue<object>? commitOutcomes = null,
-        Guid topicId = default)
+        Guid topicId = default,
+        int retryBackoffMs = 0,
+        int maxBlockMs = 1000)
     {
         var connection = new RecordingConnection(txnOffsetCommitMaxVersion, commitOutcomes, topicId);
         var connectionPool = new ConnectionPool(
@@ -319,10 +344,10 @@ public sealed class TransactionOffsetCommitTests
             {
                 BootstrapServers = ["localhost:9092"],
                 TransactionalId = "transaction-1",
-                RetryBackoffMs = 0,
-                RetryBackoffMaxMs = 0,
+                RetryBackoffMs = retryBackoffMs,
+                RetryBackoffMaxMs = retryBackoffMs,
                 CloseTimeoutMs = 100,
-                MaxBlockMs = 100
+                MaxBlockMs = maxBlockMs
             },
             Serializers.String,
             Serializers.String,

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionOffsetCommitTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using Dekaf.Consumer;
 using Dekaf.Errors;
@@ -272,8 +273,10 @@ public sealed class TransactionOffsetCommitTests
             transactionVersion: 2,
             txnOffsetCommitMaxVersion: 5,
             commitOutcomes: outcomes,
+            findCoordinatorDelayMs: 1200,
             retryBackoffMs: 10,
-            maxBlockMs: 1000);
+            maxBlockMs: 2000);
+        var stopwatch = Stopwatch.StartNew();
 
         var exception = await Assert.That(() => harness.Producer.SendOffsetsToTransactionInternalAsync(
                 [new TopicPartitionOffset("orders", 0, 42)],
@@ -284,6 +287,43 @@ public sealed class TransactionOffsetCommitTests
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
         await Assert.That(exception.InnerException).IsTypeOf<IOException>();
         await Assert.That(exception.InnerException!.Message).IsEqualTo("coordinator connection lost");
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2800));
+    }
+
+    [Test]
+    public async Task TV2_EmptyCoordinatorResponse_RetriesWithinDeadline()
+    {
+        await using var harness = CreateHarness(
+            transactionVersion: 2,
+            txnOffsetCommitMaxVersion: 5,
+            emptyCoordinatorResponsesBeforeSuccess: 1);
+
+        await harness.Producer.SendOffsetsToTransactionInternalAsync(
+            [new TopicPartitionOffset("orders", 0, 42)],
+            "group-1",
+            CancellationToken.None);
+
+        await Assert.That(harness.Connection.Requests.Count(static request =>
+            request.ApiKey == ApiKey.FindCoordinator)).IsEqualTo(2);
+        await Assert.That(harness.Connection.CommitRequests).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TV2_EmptyBrokerMetadata_RefreshesAndRetriesWithinDeadline()
+    {
+        await using var harness = CreateHarness(
+            transactionVersion: 2,
+            txnOffsetCommitMaxVersion: 5,
+            startWithEmptyBrokerMetadata: true);
+
+        await harness.Producer.SendOffsetsToTransactionInternalAsync(
+            [new TopicPartitionOffset("orders", 0, 42)],
+            "group-1",
+            CancellationToken.None);
+
+        await Assert.That(harness.Connection.Requests.Any(static request =>
+            request.ApiKey == ApiKey.Metadata)).IsTrue();
+        await Assert.That(harness.Connection.CommitRequests).Count().IsEqualTo(1);
     }
 
     [Test]
@@ -310,10 +350,18 @@ public sealed class TransactionOffsetCommitTests
         short txnOffsetCommitMaxVersion,
         Queue<object>? commitOutcomes = null,
         Guid topicId = default,
+        int findCoordinatorDelayMs = 0,
+        int emptyCoordinatorResponsesBeforeSuccess = 0,
+        bool startWithEmptyBrokerMetadata = false,
         int retryBackoffMs = 0,
         int maxBlockMs = 1000)
     {
-        var connection = new RecordingConnection(txnOffsetCommitMaxVersion, commitOutcomes, topicId);
+        var connection = new RecordingConnection(
+            txnOffsetCommitMaxVersion,
+            commitOutcomes,
+            topicId,
+            findCoordinatorDelayMs,
+            emptyCoordinatorResponsesBeforeSuccess);
         var connectionPool = new ConnectionPool(
             "transaction-offset-tests",
             connectionOptions: null,
@@ -322,7 +370,9 @@ public sealed class TransactionOffsetCommitTests
         connectionPool.RegisterBroker(1, "localhost", 9092);
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
-        metadataManager.Metadata.Update(CreateMetadataResponse(topicId));
+        metadataManager.Metadata.Update(startWithEmptyBrokerMetadata
+            ? new MetadataResponse { Brokers = [], Topics = [] }
+            : CreateMetadataResponse(topicId));
         metadataManager.ObserveClusterCapabilities(
             "cluster-a",
             KafkaConnectionCapabilities.Create(new ApiVersionsResponse
@@ -391,8 +441,11 @@ public sealed class TransactionOffsetCommitTests
     private sealed class RecordingConnection(
         short txnOffsetCommitMaxVersion,
         Queue<object>? commitOutcomes,
-        Guid topicId) : IKafkaConnection, IKafkaCapabilityProvider
+        Guid topicId,
+        int findCoordinatorDelayMs,
+        int emptyCoordinatorResponsesBeforeSuccess) : IKafkaConnection, IKafkaCapabilityProvider
     {
+        private int _findCoordinatorRequests;
         public int BrokerId => 1;
         public string Host => "localhost";
         public int Port => 9092;
@@ -424,29 +477,54 @@ public sealed class TransactionOffsetCommitTests
                 apiVersion,
                 request is FindCoordinatorRequest coordinatorRequest ? coordinatorRequest.Key : null));
 
+            if (request is FindCoordinatorRequest delayedFindCoordinatorRequest
+                && findCoordinatorDelayMs > 0)
+            {
+                return CreateDelayedFindCoordinatorResponseAsync<TResponse>(
+                    delayedFindCoordinatorRequest,
+                    cancellationToken);
+            }
+
             IKafkaResponse response = request switch
             {
                 AddOffsetsToTxnRequest => new AddOffsetsToTxnResponse { ErrorCode = ErrorCode.None },
-                FindCoordinatorRequest findRequest => new FindCoordinatorResponse
-                {
-                    Coordinators =
-                    [
-                        new Coordinator
-                        {
-                            Key = findRequest.Key,
-                            NodeId = 1,
-                            Host = "localhost",
-                            Port = 9092,
-                            ErrorCode = ErrorCode.None
-                        }
-                    ]
-                },
+                FindCoordinatorRequest findRequest => CreateFindCoordinatorResponse(findRequest),
                 MetadataRequest => CreateMetadataResponse(topicId),
                 TxnOffsetCommitRequest txnOffsetCommit => CreateCommitResponse(txnOffsetCommit),
                 _ => throw new NotSupportedException(typeof(TRequest).Name)
             };
 
             return ValueTask.FromResult((TResponse)response);
+        }
+
+        private async ValueTask<TResponse> CreateDelayedFindCoordinatorResponseAsync<TResponse>(
+            FindCoordinatorRequest request,
+            CancellationToken cancellationToken)
+            where TResponse : IKafkaResponse
+        {
+            await Task.Delay(findCoordinatorDelayMs, cancellationToken).ConfigureAwait(false);
+            return (TResponse)(IKafkaResponse)CreateFindCoordinatorResponse(request);
+        }
+
+        private FindCoordinatorResponse CreateFindCoordinatorResponse(FindCoordinatorRequest request)
+        {
+            var requestNumber = Interlocked.Increment(ref _findCoordinatorRequests);
+            return new FindCoordinatorResponse
+            {
+                Coordinators = requestNumber <= emptyCoordinatorResponsesBeforeSuccess
+                    ? []
+                    :
+                    [
+                        new Coordinator
+                        {
+                            Key = request.Key,
+                            NodeId = 1,
+                            Host = "localhost",
+                            Port = 9092,
+                            ErrorCode = ErrorCode.None
+                        }
+                    ]
+            };
         }
 
         private TxnOffsetCommitResponse CreateCommitResponse(TxnOffsetCommitRequest request)

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -584,15 +584,35 @@ public sealed class TransactionTests
             currentProducerEpoch: 9,
             initProducerIdRetriableFailuresBeforeSuccess: int.MaxValue,
             retryBackoffMs: 10,
-            maxBlockMs: 50);
+            maxBlockMs: 1000);
 
         var exception = await Assert.That(() => harness.Producer.ReinitializeProducerIdAsync(
                 CancellationToken.None).AsTask())
             .Throws<KafkaTimeoutException>();
 
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
-        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(50));
-        await Assert.That(exception.Message).Contains("max.block.ms (50ms)");
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
+        await Assert.That(exception.Message).Contains("max.block.ms (1000ms)");
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task ReinitializeProducerIdAsync_MaxBlockDeadline_CancelsInFlightRequest(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdWaitsForCancellation: true,
+            maxBlockMs: 1000);
+
+        var exception = await Assert.That(() => harness.Producer.ReinitializeProducerIdAsync(
+                cancellationToken).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
     }
 
     [Test]
@@ -1047,6 +1067,7 @@ public sealed class TransactionTests
         int initProducerIdRetriableFailuresBeforeSuccess = 0,
         int addPartitionsRetriableFailuresBeforeSuccess = 0,
         int endTxnRetriableFailuresBeforeSuccess = 0,
+        bool initProducerIdWaitsForCancellation = false,
         int retryBackoffMs = 0,
         int maxBlockMs = 1000)
     {
@@ -1058,7 +1079,8 @@ public sealed class TransactionTests
             coordinatorRetriableFailuresBeforeSuccess,
             initProducerIdRetriableFailuresBeforeSuccess,
             addPartitionsRetriableFailuresBeforeSuccess,
-            endTxnRetriableFailuresBeforeSuccess);
+            endTxnRetriableFailuresBeforeSuccess,
+            initProducerIdWaitsForCancellation);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",
@@ -1194,7 +1216,8 @@ public sealed class TransactionTests
         int coordinatorRetriableFailuresBeforeSuccess,
         int initProducerIdRetriableFailuresBeforeSuccess,
         int addPartitionsRetriableFailuresBeforeSuccess,
-        int endTxnRetriableFailuresBeforeSuccess) : IKafkaConnection, IRetirableKafkaConnection,
+        int endTxnRetriableFailuresBeforeSuccess,
+        bool initProducerIdWaitsForCancellation) : IKafkaConnection, IRetirableKafkaConnection,
         IKafkaPipelinedWriteCompletionConnection
     {
         private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
@@ -1235,6 +1258,12 @@ public sealed class TransactionTests
             where TResponse : IKafkaResponse
         {
             Volatile.Write(ref _leaseCountDuringRequest, LeaseCount);
+            if (request is InitProducerIdRequest && initProducerIdWaitsForCancellation)
+            {
+                InitProducerIdRequests++;
+                return WaitForCancellationAsync<TResponse>(cancellationToken);
+            }
+
             IKafkaResponse response = request switch
             {
                 EndTxnRequest endTxnRequest => CreateEndTxnResponse(endTxnRequest),
@@ -1245,6 +1274,13 @@ public sealed class TransactionTests
             };
 
             return ValueTask.FromResult((TResponse)response);
+        }
+
+        private static async ValueTask<TResponse> WaitForCancellationAsync<TResponse>(
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            return default!;
         }
 
         private FindCoordinatorResponse CreateFindCoordinatorResponse(FindCoordinatorRequest request)

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -769,6 +769,29 @@ public sealed class TransactionTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task InitTransactionsAsync_CancellationBeforeWrite_DoesNotPoisonProducer(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdWaitsBeforeWriteForCancellation: true,
+            maxBlockMs: 4000);
+        harness.Producer._transactionState = TransactionState.Ready;
+        using var callerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var initializationTask = harness.Producer.InitTransactionsAsync(callerCancellation.Token).AsTask();
+
+        await harness.InitProducerIdStarted.WaitAsync(cancellationToken);
+        callerCancellation.Cancel();
+
+        await Assert.That(() => initializationTask).Throws<OperationCanceledException>();
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
+    }
+
+    [Test]
     public async Task EndTransactionAsync_RetriesBeyondPreviousAttemptLimit()
     {
         await using var harness = BuildPreparedCompletionHarness(
@@ -899,6 +922,39 @@ public sealed class TransactionTests
         await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
         await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
         await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [Timeout(5_000)]
+    public async Task EndTransactionAsync_CancellationBeforeWrite_PreservesAbortableState(
+        bool committed,
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            endTxnWaitsBeforeWriteForCancellation: true,
+            maxBlockMs: 4000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        var transaction = new Transaction<string, string>(harness.Producer);
+        using var callerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var completionTask = committed
+            ? transaction.CommitAsync(callerCancellation.Token).AsTask()
+            : transaction.AbortAsync(callerCancellation.Token).AsTask();
+
+        await harness.EndTxnStarted.WaitAsync(cancellationToken);
+        callerCancellation.Cancel();
+
+        await Assert.That(() => completionTask).Throws<OperationCanceledException>();
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<InvalidOperationException>();
+
+        harness.Producer._transactionState = TransactionState.Ready;
+        await transaction.DisposeAsync();
     }
 
     [Test]
@@ -1353,6 +1409,8 @@ public sealed class TransactionTests
         int endTxnRetriableFailuresBeforeSuccess = 0,
         bool endTxnWaitsForCancellation = false,
         bool initProducerIdWaitsForCancellation = false,
+        bool endTxnWaitsBeforeWriteForCancellation = false,
+        bool initProducerIdWaitsBeforeWriteForCancellation = false,
         int findCoordinatorDelayMs = 0,
         int emptyCoordinatorResponsesBeforeSuccess = 0,
         ErrorCode addPartitionsRetriableError = ErrorCode.CoordinatorLoadInProgress,
@@ -1370,6 +1428,8 @@ public sealed class TransactionTests
             endTxnRetriableFailuresBeforeSuccess,
             endTxnWaitsForCancellation,
             initProducerIdWaitsForCancellation,
+            endTxnWaitsBeforeWriteForCancellation,
+            initProducerIdWaitsBeforeWriteForCancellation,
             findCoordinatorDelayMs,
             emptyCoordinatorResponsesBeforeSuccess,
             addPartitionsRetriableError);
@@ -1513,10 +1573,12 @@ public sealed class TransactionTests
         int endTxnRetriableFailuresBeforeSuccess,
         bool endTxnWaitsForCancellation,
         bool initProducerIdWaitsForCancellation,
+        bool endTxnWaitsBeforeWriteForCancellation,
+        bool initProducerIdWaitsBeforeWriteForCancellation,
         int findCoordinatorDelayMs,
         int emptyCoordinatorResponsesBeforeSuccess,
         ErrorCode addPartitionsRetriableError) : IKafkaConnection, IRetirableKafkaConnection,
-        IKafkaPipelinedWriteCompletionConnection
+        IKafkaPipelinedWriteCompletionConnection, IKafkaRequestWriteObserverConnection
     {
         private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
         private int _leaseCount;
@@ -1596,6 +1658,33 @@ public sealed class TransactionTests
             };
 
             return ValueTask.FromResult((TResponse)response);
+        }
+
+        public ValueTask<TResponse> SendWithWriteObservationAsync<TRequest, TResponse>(
+            TRequest request,
+            short apiVersion,
+            Action requestWriteStarted,
+            CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            if (request is InitProducerIdRequest && initProducerIdWaitsBeforeWriteForCancellation)
+            {
+                InitProducerIdRequests++;
+                _initProducerIdStarted.TrySetResult();
+                return WaitForCancellationAsync<TResponse>(cancellationToken);
+            }
+
+            if (request is EndTxnRequest endTxnRequest && endTxnWaitsBeforeWriteForCancellation)
+            {
+                EndTxnRequests++;
+                CapturedEndTxnRequest = endTxnRequest;
+                _endTxnStarted.TrySetResult();
+                return WaitForCancellationAsync<TResponse>(cancellationToken);
+            }
+
+            requestWriteStarted();
+            return SendAsync<TRequest, TResponse>(request, apiVersion, cancellationToken);
         }
 
         private static async ValueTask<TResponse> WaitForCancellationAsync<TResponse>(
@@ -1732,6 +1821,22 @@ public sealed class TransactionTests
             return ValueTask.FromResult(new PipelinedResponse<TResponse>(
                 (IPipelinedResponseSource<TResponse>)(object)_pipelinedResponseSource,
                 token: 0));
+        }
+
+        public ValueTask<PipelinedResponse<TResponse>>
+            SendPipelinedWithWriteObservationAfterWriteAsync<TRequest, TResponse>(
+                TRequest request,
+                short apiVersion,
+                Action requestWriteStarted,
+                CancellationToken cancellationToken = default)
+            where TRequest : IKafkaRequest<TResponse>
+            where TResponse : IKafkaResponse
+        {
+            requestWriteStarted();
+            return SendPipelinedAfterWriteAsync<TRequest, TResponse>(
+                request,
+                apiVersion,
+                cancellationToken);
         }
 
         public ValueTask<PipelinedResponse<TResponse>>

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -661,6 +661,7 @@ public sealed class TransactionTests
         var accumulator = GetInstanceField<RecordAccumulator>(harness.Producer, "_accumulator");
         SetInstanceField(accumulator, "_inFlightBatchCount", 1L);
         await using var transaction = new Transaction<string, string>(harness.Producer);
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
@@ -668,6 +669,8 @@ public sealed class TransactionTests
                 .Throws<KafkaTimeoutException>();
 
             await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+            await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
+            await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2500));
             await Assert.That(harness.EndTxnRequests).IsEqualTo(0);
             await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
         }
@@ -736,6 +739,30 @@ public sealed class TransactionTests
             .Throws<KafkaTimeoutException>();
 
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task InitTransactionsAsync_CallerCancellationInFlight_PreservesFatalState(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdWaitsForCancellation: true,
+            maxBlockMs: 4000);
+        harness.Producer._transactionState = TransactionState.Ready;
+        using var callerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var initializationTask = harness.Producer.InitTransactionsAsync(callerCancellation.Token).AsTask();
+
+        await harness.InitProducerIdStarted.WaitAsync(cancellationToken);
+        callerCancellation.Cancel();
+
+        await Assert.That(() => initializationTask).Throws<OperationCanceledException>();
         await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
         await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
         await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
@@ -839,6 +866,36 @@ public sealed class TransactionTests
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
         await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
         await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2500));
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [Timeout(5_000)]
+    public async Task EndTransactionAsync_CallerCancellationInFlight_PreservesFatalState(
+        bool committed,
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            endTxnWaitsForCancellation: true,
+            maxBlockMs: 4000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+        using var callerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var completionTask = committed
+            ? transaction.CommitAsync(callerCancellation.Token).AsTask()
+            : transaction.AbortAsync(callerCancellation.Token).AsTask();
+
+        await harness.EndTxnStarted.WaitAsync(cancellationToken);
+        callerCancellation.Cancel();
+
+        await Assert.That(() => completionTask).Throws<OperationCanceledException>();
         await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
         await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
         await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
@@ -1436,6 +1493,7 @@ public sealed class TransactionTests
         public int AddPartitionsRequests => connection.AddPartitionsRequests;
         public int EndTxnRequests => connection.EndTxnRequests;
         public Task InitProducerIdStarted => connection.InitProducerIdStarted;
+        public Task EndTxnStarted => connection.EndTxnStarted;
 
         public async ValueTask DisposeAsync()
         {
@@ -1478,8 +1536,11 @@ public sealed class TransactionTests
         public int AddPartitionsRequests { get; private set; }
         public int EndTxnRequests { get; private set; }
         public Task InitProducerIdStarted => _initProducerIdStarted.Task;
+        public Task EndTxnStarted => _endTxnStarted.Task;
 
         private readonly TaskCompletionSource _initProducerIdStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _endTxnStarted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public bool TryAcquireLease()
@@ -1513,6 +1574,7 @@ public sealed class TransactionTests
             {
                 EndTxnRequests++;
                 CapturedEndTxnRequest = waitingEndTxnRequest;
+                _endTxnStarted.TrySetResult();
                 return WaitForCancellationAsync<TResponse>(cancellationToken);
             }
 

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -163,6 +163,27 @@ public sealed class TransactionTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task DisposeAsync_WhenAbortTimesOutBeforeWrite_PreservesAbortableError(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 42,
+            currentProducerEpoch: 5,
+            endTxnWaitsBeforeWriteForCancellation: true,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        var transaction = new Transaction<string, string>(harness.Producer);
+
+        await transaction.DisposeAsync().AsTask().WaitAsync(cancellationToken);
+
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<InvalidOperationException>();
+    }
+
+    [Test]
     public async Task InitTransactionsAsync_WithoutTransactionalId_Throws()
     {
         await using var producer = Kafka.CreateProducer<string, string>()
@@ -566,7 +587,8 @@ public sealed class TransactionTests
             currentProducerId: 2002,
             currentProducerEpoch: 9,
             coordinatorRetriableFailuresBeforeSuccess: 5,
-            initProducerIdRetriableFailuresBeforeSuccess: 10);
+            initProducerIdRetriableFailuresBeforeSuccess: 10,
+            maxBlockMs: 60_000);
         harness.Producer._transactionState = TransactionState.Uninitialized;
 
         await harness.Producer.InitTransactionsAsync();
@@ -583,7 +605,8 @@ public sealed class TransactionTests
             PreparedTransactionState.Empty,
             currentProducerId: 2002,
             currentProducerEpoch: 9,
-            emptyCoordinatorResponsesBeforeSuccess: 1);
+            emptyCoordinatorResponsesBeforeSuccess: 1,
+            maxBlockMs: 60_000);
         harness.Producer._transactionState = TransactionState.Uninitialized;
 
         await harness.Producer.InitTransactionsAsync();
@@ -798,7 +821,8 @@ public sealed class TransactionTests
             PreparedTransactionState.Empty,
             currentProducerId: 2002,
             currentProducerEpoch: 9,
-            endTxnRetriableFailuresBeforeSuccess: 5);
+            endTxnRetriableFailuresBeforeSuccess: 5,
+            maxBlockMs: 60_000);
 
         await harness.Producer.EndTransactionAsync(committed: true, CancellationToken.None);
 
@@ -812,7 +836,8 @@ public sealed class TransactionTests
             PreparedTransactionState.Empty,
             currentProducerId: 2002,
             currentProducerEpoch: 9,
-            addPartitionsRetriableFailuresBeforeSuccess: 5);
+            addPartitionsRetriableFailuresBeforeSuccess: 5,
+            maxBlockMs: 60_000);
 
         await harness.Producer.AddPartitionsToTransactionAsync(
             [new TopicPartition("orders", 0)],
@@ -829,7 +854,8 @@ public sealed class TransactionTests
             currentProducerId: 2002,
             currentProducerEpoch: 9,
             addPartitionsRetriableFailuresBeforeSuccess: 1,
-            addPartitionsRetriableError: ErrorCode.NotCoordinator);
+            addPartitionsRetriableError: ErrorCode.NotCoordinator,
+            maxBlockMs: 60_000);
 
         await harness.Producer.AddPartitionsToTransactionAsync(
             [new TopicPartition("orders", 0), new TopicPartition("orders", 1)],
@@ -1419,20 +1445,20 @@ public sealed class TransactionTests
     {
         var connection = new LeaseTrackingConnection(
             preparedState,
-            currentProducerId,
-            currentProducerEpoch,
-            endTxnError,
-            coordinatorRetriableFailuresBeforeSuccess,
-            initProducerIdRetriableFailuresBeforeSuccess,
-            addPartitionsRetriableFailuresBeforeSuccess,
-            endTxnRetriableFailuresBeforeSuccess,
-            endTxnWaitsForCancellation,
-            initProducerIdWaitsForCancellation,
-            endTxnWaitsBeforeWriteForCancellation,
-            initProducerIdWaitsBeforeWriteForCancellation,
-            findCoordinatorDelayMs,
-            emptyCoordinatorResponsesBeforeSuccess,
-            addPartitionsRetriableError);
+            producerId: currentProducerId,
+            producerEpoch: currentProducerEpoch,
+            endTxnError: endTxnError,
+            coordinatorRetriableFailuresBeforeSuccess: coordinatorRetriableFailuresBeforeSuccess,
+            initProducerIdRetriableFailuresBeforeSuccess: initProducerIdRetriableFailuresBeforeSuccess,
+            addPartitionsRetriableFailuresBeforeSuccess: addPartitionsRetriableFailuresBeforeSuccess,
+            endTxnRetriableFailuresBeforeSuccess: endTxnRetriableFailuresBeforeSuccess,
+            endTxnWaitsForCancellation: endTxnWaitsForCancellation,
+            initProducerIdWaitsForCancellation: initProducerIdWaitsForCancellation,
+            endTxnWaitsBeforeWriteForCancellation: endTxnWaitsBeforeWriteForCancellation,
+            initProducerIdWaitsBeforeWriteForCancellation: initProducerIdWaitsBeforeWriteForCancellation,
+            findCoordinatorDelayMs: findCoordinatorDelayMs,
+            emptyCoordinatorResponsesBeforeSuccess: emptyCoordinatorResponsesBeforeSuccess,
+            addPartitionsRetriableError: addPartitionsRetriableError);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -719,6 +719,29 @@ public sealed class TransactionTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task InitTransactionsAsync_ReadyProducerInFlightInitTimeout_PreservesFatalState(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdWaitsForCancellation: true,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.Ready;
+
+        var exception = await Assert.That(() => harness.Producer.InitTransactionsAsync(
+                cancellationToken).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
     public async Task EndTransactionAsync_RetriesBeyondPreviousAttemptLimit()
     {
         await using var harness = BuildPreparedCompletionHarness(
@@ -805,6 +828,7 @@ public sealed class TransactionTests
             maxBlockMs: 1000);
         harness.Producer._transactionState = TransactionState.InTransaction;
         await using var transaction = new Transaction<string, string>(harness.Producer);
+        var stopwatch = Stopwatch.StartNew();
 
         var exception = committed
             ? await Assert.That(() => transaction.CommitAsync(cancellationToken).AsTask())
@@ -813,6 +837,8 @@ public sealed class TransactionTests
                 .Throws<KafkaTimeoutException>();
 
         await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(1000));
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2500));
         await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
         await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
         await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -558,6 +558,74 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task InitTransactionsAsync_RetriesBeyondPreviousAttemptLimits()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            coordinatorRetriableFailuresBeforeSuccess: 5,
+            initProducerIdRetriableFailuresBeforeSuccess: 10);
+        harness.Producer._transactionState = TransactionState.Uninitialized;
+
+        await harness.Producer.InitTransactionsAsync();
+
+        await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(6);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(11);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
+    }
+
+    [Test]
+    public async Task ReinitializeProducerIdAsync_MaxBlockDeadline_ThrowsTransactionTimeout()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdRetriableFailuresBeforeSuccess: int.MaxValue,
+            retryBackoffMs: 10,
+            maxBlockMs: 50);
+
+        var exception = await Assert.That(() => harness.Producer.ReinitializeProducerIdAsync(
+                CancellationToken.None).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(exception.Configured).IsEqualTo(TimeSpan.FromMilliseconds(50));
+        await Assert.That(exception.Message).Contains("max.block.ms (50ms)");
+    }
+
+    [Test]
+    public async Task EndTransactionAsync_RetriesBeyondPreviousAttemptLimit()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            endTxnRetriableFailuresBeforeSuccess: 5);
+
+        await harness.Producer.EndTransactionAsync(committed: true, CancellationToken.None);
+
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task AddPartitionsToTransactionAsync_RetriesBeyondPreviousAttemptLimit()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            addPartitionsRetriableFailuresBeforeSuccess: 5);
+
+        await harness.Producer.AddPartitionsToTransactionAsync(
+            [new TopicPartition("orders", 0)],
+            CancellationToken.None);
+
+        await Assert.That(harness.AddPartitionsRequests).IsEqualTo(6);
+    }
+
+    [Test]
     public async Task CompletePreparedTransactionAsync_Abort_UsesPreparedTransactionProducerIdentity()
     {
         var preparedState = new PreparedTransactionState(1001, 4);
@@ -974,13 +1042,23 @@ public sealed class TransactionTests
         long currentProducerId,
         short currentProducerEpoch,
         ErrorCode endTxnError = ErrorCode.None,
-        short transactionFeatureVersion = 3)
+        short transactionFeatureVersion = 3,
+        int coordinatorRetriableFailuresBeforeSuccess = 0,
+        int initProducerIdRetriableFailuresBeforeSuccess = 0,
+        int addPartitionsRetriableFailuresBeforeSuccess = 0,
+        int endTxnRetriableFailuresBeforeSuccess = 0,
+        int retryBackoffMs = 0,
+        int maxBlockMs = 1000)
     {
         var connection = new LeaseTrackingConnection(
             preparedState,
             currentProducerId,
             currentProducerEpoch,
-            endTxnError);
+            endTxnError,
+            coordinatorRetriableFailuresBeforeSuccess,
+            initProducerIdRetriableFailuresBeforeSuccess,
+            addPartitionsRetriableFailuresBeforeSuccess,
+            endTxnRetriableFailuresBeforeSuccess);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",
@@ -990,6 +1068,19 @@ public sealed class TransactionTests
         connectionPool.RegisterBroker(1, "localhost", 9092);
 
         var metadataManager = new MetadataManager(connectionPool, ["localhost:9092"]);
+        metadataManager.Metadata.Update(new MetadataResponse
+        {
+            Brokers = [new BrokerMetadata { NodeId = 1, Host = "localhost", Port = 9092 }],
+            Topics = []
+        });
+        metadataManager.SetApiVersion(
+            ApiKey.FindCoordinator,
+            FindCoordinatorRequest.LowestSupportedVersion,
+            FindCoordinatorRequest.HighestSupportedVersion);
+        metadataManager.SetApiVersion(
+            ApiKey.AddPartitionsToTxn,
+            AddPartitionsToTxnRequest.LowestSupportedVersion,
+            AddPartitionsToTxnRequest.HighestSupportedVersion);
         metadataManager.SetApiVersion(
             ApiKey.EndTxn,
             EndTxnRequest.LowestSupportedVersion,
@@ -1006,6 +1097,9 @@ public sealed class TransactionTests
                 BootstrapServers = ["localhost:9092"],
                 TransactionalId = "test-txn-id",
                 EnableTwoPhaseCommit = true,
+                RetryBackoffMs = retryBackoffMs,
+                RetryBackoffMaxMs = retryBackoffMs,
+                MaxBlockMs = maxBlockMs,
                 CloseTimeoutMs = 100
             },
             Serializers.String,
@@ -1080,6 +1174,10 @@ public sealed class TransactionTests
         public int LeaseCountDuringRequest => connection.LeaseCountDuringRequest;
         public int LeaseCount => connection.LeaseCount;
         public int PipelinedResponseAbandonCalls => connection.PipelinedResponseAbandonCalls;
+        public int FindCoordinatorRequests => connection.FindCoordinatorRequests;
+        public int InitProducerIdRequests => connection.InitProducerIdRequests;
+        public int AddPartitionsRequests => connection.AddPartitionsRequests;
+        public int EndTxnRequests => connection.EndTxnRequests;
 
         public async ValueTask DisposeAsync()
         {
@@ -1092,7 +1190,11 @@ public sealed class TransactionTests
         PreparedTransactionState preparedState,
         long producerId,
         short producerEpoch,
-        ErrorCode endTxnError) : IKafkaConnection, IRetirableKafkaConnection,
+        ErrorCode endTxnError,
+        int coordinatorRetriableFailuresBeforeSuccess,
+        int initProducerIdRetriableFailuresBeforeSuccess,
+        int addPartitionsRetriableFailuresBeforeSuccess,
+        int endTxnRetriableFailuresBeforeSuccess) : IKafkaConnection, IRetirableKafkaConnection,
         IKafkaPipelinedWriteCompletionConnection
     {
         private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
@@ -1108,6 +1210,10 @@ public sealed class TransactionTests
         public int LeaseCountDuringRequest => Volatile.Read(ref _leaseCountDuringRequest);
         public int ActiveOperationCount => 0;
         public int PipelinedResponseAbandonCalls => _pipelinedResponseSource.AbandonCalls;
+        public int FindCoordinatorRequests { get; private set; }
+        public int InitProducerIdRequests { get; private set; }
+        public int AddPartitionsRequests { get; private set; }
+        public int EndTxnRequests { get; private set; }
 
         public bool TryAcquireLease()
         {
@@ -1132,24 +1238,78 @@ public sealed class TransactionTests
             IKafkaResponse response = request switch
             {
                 EndTxnRequest endTxnRequest => CreateEndTxnResponse(endTxnRequest),
-                InitProducerIdRequest => new InitProducerIdResponse
-                {
-                    ErrorCode = ErrorCode.None,
-                    ProducerId = producerId,
-                    ProducerEpoch = producerEpoch
-                },
+                InitProducerIdRequest => CreateInitProducerIdResponse(),
+                FindCoordinatorRequest findCoordinatorRequest => CreateFindCoordinatorResponse(findCoordinatorRequest),
+                AddPartitionsToTxnRequest addPartitionsRequest => CreateAddPartitionsResponse(addPartitionsRequest),
                 _ => throw new NotSupportedException()
             };
 
             return ValueTask.FromResult((TResponse)response);
         }
 
+        private FindCoordinatorResponse CreateFindCoordinatorResponse(FindCoordinatorRequest request)
+        {
+            FindCoordinatorRequests++;
+            return new FindCoordinatorResponse
+            {
+                Coordinators =
+                [
+                    new Coordinator
+                    {
+                        Key = request.Key,
+                        NodeId = 1,
+                        Host = "localhost",
+                        Port = 9092,
+                        ErrorCode = FindCoordinatorRequests <= coordinatorRetriableFailuresBeforeSuccess
+                            ? ErrorCode.CoordinatorNotAvailable
+                            : ErrorCode.None
+                    }
+                ]
+            };
+        }
+
+        private InitProducerIdResponse CreateInitProducerIdResponse()
+        {
+            InitProducerIdRequests++;
+            return new InitProducerIdResponse
+            {
+                ErrorCode = InitProducerIdRequests <= initProducerIdRetriableFailuresBeforeSuccess
+                    ? ErrorCode.CoordinatorLoadInProgress
+                    : ErrorCode.None,
+                ProducerId = producerId,
+                ProducerEpoch = producerEpoch
+            };
+        }
+
+        private AddPartitionsToTxnResponse CreateAddPartitionsResponse(AddPartitionsToTxnRequest request)
+        {
+            AddPartitionsRequests++;
+            var errorCode = AddPartitionsRequests <= addPartitionsRetriableFailuresBeforeSuccess
+                ? ErrorCode.CoordinatorLoadInProgress
+                : ErrorCode.None;
+            return new AddPartitionsToTxnResponse
+            {
+                Results = request.Topics.Select(topic => new AddPartitionsToTxnTopicResult
+                {
+                    Name = topic.Name,
+                    Partitions = topic.Partitions.Select(partition => new AddPartitionsToTxnPartitionResult
+                    {
+                        PartitionIndex = partition,
+                        ErrorCode = errorCode
+                    }).ToArray()
+                }).ToArray()
+            };
+        }
+
         private EndTxnResponse CreateEndTxnResponse(EndTxnRequest request)
         {
+            EndTxnRequests++;
             CapturedEndTxnRequest = request;
             return new EndTxnResponse
             {
-                ErrorCode = endTxnError,
+                ErrorCode = EndTxnRequests <= endTxnRetriableFailuresBeforeSuccess
+                    ? ErrorCode.CoordinatorLoadInProgress
+                    : endTxnError,
                 ProducerId = preparedState.ProducerId,
                 ProducerEpoch = (short)(preparedState.ProducerEpoch + 1)
             };

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -790,6 +790,62 @@ public sealed class TransactionTests
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    [Timeout(5_000)]
+    public async Task EndTransactionAsync_InFlightDeadline_PreservesFatalState(
+        bool committed,
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            endTxnWaitsForCancellation: true,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+
+        var exception = committed
+            ? await Assert.That(() => transaction.CommitAsync(cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>()
+            : await Assert.That(() => transaction.AbortAsync(cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task AbortAsync_TV1CallerCancellationAfterEndTxn_PreservesFatalState(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            transactionFeatureVersion: 1,
+            enableTwoPhaseCommit: false,
+            initProducerIdWaitsForCancellation: true,
+            maxBlockMs: 4000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+        using var callerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var abortTask = transaction.AbortAsync(callerCancellation.Token).AsTask();
+
+        await harness.InitProducerIdStarted.WaitAsync(cancellationToken);
+        callerCancellation.Cancel();
+
+        await Assert.That(() => abortTask).Throws<OperationCanceledException>();
+        await Assert.That(harness.EndTxnRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
+    }
+
+    [Test]
     public async Task CompletePreparedTransactionAsync_Abort_UsesPreparedTransactionProducerIdentity()
     {
         var preparedState = new PreparedTransactionState(1001, 4);
@@ -1212,6 +1268,7 @@ public sealed class TransactionTests
         int initProducerIdRetriableFailuresBeforeSuccess = 0,
         int addPartitionsRetriableFailuresBeforeSuccess = 0,
         int endTxnRetriableFailuresBeforeSuccess = 0,
+        bool endTxnWaitsForCancellation = false,
         bool initProducerIdWaitsForCancellation = false,
         int findCoordinatorDelayMs = 0,
         int emptyCoordinatorResponsesBeforeSuccess = 0,
@@ -1228,6 +1285,7 @@ public sealed class TransactionTests
             initProducerIdRetriableFailuresBeforeSuccess,
             addPartitionsRetriableFailuresBeforeSuccess,
             endTxnRetriableFailuresBeforeSuccess,
+            endTxnWaitsForCancellation,
             initProducerIdWaitsForCancellation,
             findCoordinatorDelayMs,
             emptyCoordinatorResponsesBeforeSuccess,
@@ -1351,6 +1409,7 @@ public sealed class TransactionTests
         public int InitProducerIdRequests => connection.InitProducerIdRequests;
         public int AddPartitionsRequests => connection.AddPartitionsRequests;
         public int EndTxnRequests => connection.EndTxnRequests;
+        public Task InitProducerIdStarted => connection.InitProducerIdStarted;
 
         public async ValueTask DisposeAsync()
         {
@@ -1368,6 +1427,7 @@ public sealed class TransactionTests
         int initProducerIdRetriableFailuresBeforeSuccess,
         int addPartitionsRetriableFailuresBeforeSuccess,
         int endTxnRetriableFailuresBeforeSuccess,
+        bool endTxnWaitsForCancellation,
         bool initProducerIdWaitsForCancellation,
         int findCoordinatorDelayMs,
         int emptyCoordinatorResponsesBeforeSuccess,
@@ -1391,6 +1451,10 @@ public sealed class TransactionTests
         public int InitProducerIdRequests { get; private set; }
         public int AddPartitionsRequests { get; private set; }
         public int EndTxnRequests { get; private set; }
+        public Task InitProducerIdStarted => _initProducerIdStarted.Task;
+
+        private readonly TaskCompletionSource _initProducerIdStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public bool TryAcquireLease()
         {
@@ -1415,6 +1479,14 @@ public sealed class TransactionTests
             if (request is InitProducerIdRequest && initProducerIdWaitsForCancellation)
             {
                 InitProducerIdRequests++;
+                _initProducerIdStarted.TrySetResult();
+                return WaitForCancellationAsync<TResponse>(cancellationToken);
+            }
+
+            if (request is EndTxnRequest waitingEndTxnRequest && endTxnWaitsForCancellation)
+            {
+                EndTxnRequests++;
+                CapturedEndTxnRequest = waitingEndTxnRequest;
                 return WaitForCancellationAsync<TResponse>(cancellationToken);
             }
 

--- a/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/TransactionTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks.Sources;
 using Dekaf.Errors;
@@ -576,6 +577,108 @@ public sealed class TransactionTests
     }
 
     [Test]
+    public async Task InitTransactionsAsync_EmptyCoordinatorResponse_RetriesWithinDeadline()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            emptyCoordinatorResponsesBeforeSuccess: 1);
+        harness.Producer._transactionState = TransactionState.Uninitialized;
+
+        await harness.Producer.InitTransactionsAsync();
+
+        await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(2);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.Ready);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task InitTransactionsAsync_SharedDeadlineSpansCoordinatorAndProducerId(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            initProducerIdWaitsForCancellation: true,
+            findCoordinatorDelayMs: 1200,
+            maxBlockMs: 2000);
+        harness.Producer._transactionState = TransactionState.Uninitialized;
+        var stopwatch = Stopwatch.StartNew();
+
+        var exception = await Assert.That(() => harness.Producer.InitTransactionsAsync(
+                cancellationToken).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+        await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(2800));
+        await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(1);
+        await Assert.That(harness.InitProducerIdRequests).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task InitTransactionsAsync_MaxBlockDeadline_IncludesLockAcquisition(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.Uninitialized;
+        var transactionLock = GetInstanceField<SemaphoreSlim>(harness.Producer, "_transactionLock");
+        await transactionLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            var exception = await Assert.That(() => harness.Producer.InitTransactionsAsync(
+                    cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>();
+
+            await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+            await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(0);
+        }
+        finally
+        {
+            transactionLock.Release();
+        }
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task CommitAsync_MaxBlockDeadline_IncludesFlush(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        var accumulator = GetInstanceField<RecordAccumulator>(harness.Producer, "_accumulator");
+        SetInstanceField(accumulator, "_inFlightBatchCount", 1L);
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+
+        try
+        {
+            var exception = await Assert.That(() => transaction.CommitAsync(cancellationToken).AsTask())
+                .Throws<KafkaTimeoutException>();
+
+            await Assert.That(exception!.TimeoutKind).IsEqualTo(TimeoutKind.Transaction);
+            await Assert.That(harness.EndTxnRequests).IsEqualTo(0);
+            await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.AbortableError);
+        }
+        finally
+        {
+            SetInstanceField(accumulator, "_inFlightBatchCount", 0L);
+            GetInstanceField<TaskCompletionSource<bool>?>(accumulator, "_flushTcs")?.TrySetResult(true);
+        }
+    }
+
+    [Test]
     public async Task ReinitializeProducerIdAsync_MaxBlockDeadline_ThrowsTransactionTimeout()
     {
         await using var harness = BuildPreparedCompletionHarness(
@@ -643,6 +746,47 @@ public sealed class TransactionTests
             CancellationToken.None);
 
         await Assert.That(harness.AddPartitionsRequests).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task AddPartitionsToTransactionAsync_MultipleNotCoordinatorErrors_RediscoversOnce()
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            addPartitionsRetriableFailuresBeforeSuccess: 1,
+            addPartitionsRetriableError: ErrorCode.NotCoordinator);
+
+        await harness.Producer.AddPartitionsToTransactionAsync(
+            [new TopicPartition("orders", 0), new TopicPartition("orders", 1)],
+            CancellationToken.None);
+
+        await Assert.That(harness.AddPartitionsRequests).IsEqualTo(2);
+        await Assert.That(harness.FindCoordinatorRequests).IsEqualTo(1);
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task AbortAsync_TV1ProducerIdReinitializationTimeout_PreservesFatalState(
+        CancellationToken cancellationToken)
+    {
+        await using var harness = BuildPreparedCompletionHarness(
+            PreparedTransactionState.Empty,
+            currentProducerId: 2002,
+            currentProducerEpoch: 9,
+            transactionFeatureVersion: 1,
+            enableTwoPhaseCommit: false,
+            initProducerIdWaitsForCancellation: true,
+            maxBlockMs: 1000);
+        harness.Producer._transactionState = TransactionState.InTransaction;
+        await using var transaction = new Transaction<string, string>(harness.Producer);
+
+        await Assert.That(() => transaction.AbortAsync(cancellationToken).AsTask())
+            .Throws<KafkaTimeoutException>();
+
+        await Assert.That(harness.Producer._transactionState).IsEqualTo(TransactionState.FatalError);
+        await Assert.That(() => harness.Producer.BeginTransaction()).Throws<FatalTransactionException>();
     }
 
     [Test]
@@ -1063,11 +1207,15 @@ public sealed class TransactionTests
         short currentProducerEpoch,
         ErrorCode endTxnError = ErrorCode.None,
         short transactionFeatureVersion = 3,
+        bool enableTwoPhaseCommit = true,
         int coordinatorRetriableFailuresBeforeSuccess = 0,
         int initProducerIdRetriableFailuresBeforeSuccess = 0,
         int addPartitionsRetriableFailuresBeforeSuccess = 0,
         int endTxnRetriableFailuresBeforeSuccess = 0,
         bool initProducerIdWaitsForCancellation = false,
+        int findCoordinatorDelayMs = 0,
+        int emptyCoordinatorResponsesBeforeSuccess = 0,
+        ErrorCode addPartitionsRetriableError = ErrorCode.CoordinatorLoadInProgress,
         int retryBackoffMs = 0,
         int maxBlockMs = 1000)
     {
@@ -1080,7 +1228,10 @@ public sealed class TransactionTests
             initProducerIdRetriableFailuresBeforeSuccess,
             addPartitionsRetriableFailuresBeforeSuccess,
             endTxnRetriableFailuresBeforeSuccess,
-            initProducerIdWaitsForCancellation);
+            initProducerIdWaitsForCancellation,
+            findCoordinatorDelayMs,
+            emptyCoordinatorResponsesBeforeSuccess,
+            addPartitionsRetriableError);
 
         var connectionPool = new ConnectionPool(
             clientId: "test-producer",
@@ -1118,7 +1269,7 @@ public sealed class TransactionTests
             {
                 BootstrapServers = ["localhost:9092"],
                 TransactionalId = "test-txn-id",
-                EnableTwoPhaseCommit = true,
+                EnableTwoPhaseCommit = enableTwoPhaseCommit,
                 RetryBackoffMs = retryBackoffMs,
                 RetryBackoffMaxMs = retryBackoffMs,
                 MaxBlockMs = maxBlockMs,
@@ -1134,7 +1285,7 @@ public sealed class TransactionTests
         SetInstanceField(producer, "_producerId", currentProducerId);
         SetInstanceField(producer, "_producerEpoch", currentProducerEpoch);
         SetInstanceField(producer, "_transactionCoordinatorId", 1);
-        SetInstanceField(producer, "_currentTransactionUsesTV2", true);
+        SetInstanceField(producer, "_currentTransactionUsesTV2", transactionFeatureVersion >= 2);
         SetInstanceField(producer, "_currentTransactionFeatureVersion", transactionFeatureVersion);
         producer._preparedTransactionState = preparedState;
         producer._transactionState = TransactionState.PreparedTransaction;
@@ -1217,7 +1368,10 @@ public sealed class TransactionTests
         int initProducerIdRetriableFailuresBeforeSuccess,
         int addPartitionsRetriableFailuresBeforeSuccess,
         int endTxnRetriableFailuresBeforeSuccess,
-        bool initProducerIdWaitsForCancellation) : IKafkaConnection, IRetirableKafkaConnection,
+        bool initProducerIdWaitsForCancellation,
+        int findCoordinatorDelayMs,
+        int emptyCoordinatorResponsesBeforeSuccess,
+        ErrorCode addPartitionsRetriableError) : IKafkaConnection, IRetirableKafkaConnection,
         IKafkaPipelinedWriteCompletionConnection
     {
         private readonly TrackingResponseSource<EndTxnResponse> _pipelinedResponseSource = new();
@@ -1264,6 +1418,14 @@ public sealed class TransactionTests
                 return WaitForCancellationAsync<TResponse>(cancellationToken);
             }
 
+            if (request is FindCoordinatorRequest delayedFindCoordinatorRequest
+                && findCoordinatorDelayMs > 0)
+            {
+                return CreateDelayedFindCoordinatorResponseAsync<TResponse>(
+                    delayedFindCoordinatorRequest,
+                    cancellationToken);
+            }
+
             IKafkaResponse response = request switch
             {
                 EndTxnRequest endTxnRequest => CreateEndTxnResponse(endTxnRequest),
@@ -1283,9 +1445,21 @@ public sealed class TransactionTests
             return default!;
         }
 
+        private async ValueTask<TResponse> CreateDelayedFindCoordinatorResponseAsync<TResponse>(
+            FindCoordinatorRequest request,
+            CancellationToken cancellationToken)
+            where TResponse : IKafkaResponse
+        {
+            await Task.Delay(findCoordinatorDelayMs, cancellationToken).ConfigureAwait(false);
+            return (TResponse)(IKafkaResponse)CreateFindCoordinatorResponse(request);
+        }
+
         private FindCoordinatorResponse CreateFindCoordinatorResponse(FindCoordinatorRequest request)
         {
             FindCoordinatorRequests++;
+            if (FindCoordinatorRequests <= emptyCoordinatorResponsesBeforeSuccess)
+                return new FindCoordinatorResponse { Coordinators = [] };
+
             return new FindCoordinatorResponse
             {
                 Coordinators =
@@ -1321,7 +1495,7 @@ public sealed class TransactionTests
         {
             AddPartitionsRequests++;
             var errorCode = AddPartitionsRequests <= addPartitionsRetriableFailuresBeforeSuccess
-                ? ErrorCode.CoordinatorLoadInProgress
+                ? addPartitionsRetriableError
                 : ErrorCode.None;
             return new AddPartitionsToTxnResponse
             {


### PR DESCRIPTION
## Summary

- replace fixed-attempt transaction coordinator retries with a shared `MaxBlockMs` deadline
- apply the deadline to transaction lock acquisition, commit flushes, coordinator discovery, producer initialization, partition enrollment, completion, abort, offset commits, in-flight requests, and metadata refreshes
- preserve exponential backoff, caller cancellation, coordinator rediscovery, TV1 abort reinitialization safety, and the last transport failure as timeout context
- keep producers unusable when in-flight `InitProducerId` or `EndTxn` cancellation leaves the broker-side producer identity ambiguous, while preserving abortable state when completion expires before a request is sent or a best-effort disposal abort times out
- retry empty broker/coordinator discovery results and avoid redundant rediscovery for multi-partition responses
- report deadline exhaustion as a structured `KafkaTimeoutException` with `TimeoutKind.Transaction`
- distinguish pre-write cancellation from ambiguous in-flight cancellation at the actual socket-write boundary
- enforce positive `MaxBlockMs` values for both builder and direct `ProducerOptions` construction
- document that `MaxBlockMs` governs transaction coordinator operations

## Root cause

Transactional request loops stopped after five or ten attempts. With the default retry backoff, `InitProducerId` could therefore fail after roughly 6.5 seconds while a cold transaction coordinator was still creating/loading `__transaction_state`, despite the producer's 60-second `max.block.ms` budget.

## Behavior note

Best-effort abort during producer disposal now follows the same `MaxBlockMs` budget and can wait up to that configured duration when the transaction coordinator is unavailable.

## Validation

- analyzer-enabled SDK 10.0.400 Release builds for unit and integration projects: passed with zero warnings/errors
- transaction unit suites: 84 passed
- regressions cover shared deadlines across lock/flush/coordinator/request phases, internal-deadline and caller-cancelled ambiguous `InitProducerId`/`EndTxn` outcomes, configured and elapsed flush/request deadlines, pre-send abortable-state preservation, post-abort caller cancellation, empty discovery responses, one-time coordinator rediscovery, TV1 post-abort safety, and preservation of transport failures
- direct `MaxBlockMs` option validation: 19 passed
- Kafka connection write-boundary tests: 56 passed
- added Kafka/Toxiproxy integration coverage for initialization and transactional offset-commit deadline expiry and recovery; compiled locally, execution deferred to CI because Docker Desktop is unavailable
- full unit suite before the review updates: 6,635 passed; one unrelated existing concurrency test failed with one failed ack: `AdaptiveScaleDownTests.ScaleDown_UnderContinuousIdempotentTraffic_LosesNoBatches`

This is transaction coordinator cold-path code; no per-message hot path is changed.

Fixes #2507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reliability by retrying coordinator discovery, initialization, partition enrollment, commits, offset commits, and aborts until the configured timeout.
  * Added deadline-aware delays, cancellation, and metadata refreshes to keep operations within `MaxBlockMs`.
  * Empty coordinator or broker responses now retry within the timeout window.
  * Transaction timeouts provide clearer failure details while preserving underlying transport errors.

* **Documentation**
  * Clarified that `MaxBlockMs` applies to transaction coordinator operations and is validated to require a positive value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->