### PR TITLE
Accelerate CRC32C for large record batches

### DIFF
--- a/src/Dekaf/Protocol/Records/RecordBatch.cs
+++ b/src/Dekaf/Protocol/Records/RecordBatch.cs
@@ -1993,8 +1993,15 @@ internal static class Crc32C
     private const int SliceCount = 8;
     private const int PositiveIntBitCount = 31;
 #if !NETSTANDARD2_0
+    // Short inputs need small chunks to minimize the scalar tail. Larger inputs use wider
+    // chunks to amortize the GF(2) shift that recombines the three independent CRC lanes.
     private const int HardwareParallelChunkSize = 512;
     private const int HardwareParallelBlockSize = HardwareParallelChunkSize * 3;
+    private const int HardwareMediumParallelChunkSize = 4_096;
+    private const int HardwareMediumParallelBlockSize = HardwareMediumParallelChunkSize * 3;
+    private const int HardwareLargeParallelChunkSize = 16_384;
+    private const int HardwareLargeParallelBlockSize = HardwareLargeParallelChunkSize * 3;
+    private const int HardwareLargeInputThreshold = 256 * 1024;
 #endif
 
     private static readonly uint[] Table = GenerateTable();
@@ -2003,6 +2010,14 @@ internal static class Crc32C
 #if !NETSTANDARD2_0
     private static readonly uint[] HardwareShiftChunk = CreateShiftOperator(HardwareParallelChunkSize);
     private static readonly uint[] HardwareShiftTwoChunks = CreateShiftOperator(HardwareParallelChunkSize * 2);
+    private static readonly uint[] HardwareMediumShiftChunk =
+        CreateShiftOperator(HardwareMediumParallelChunkSize);
+    private static readonly uint[] HardwareMediumShiftTwoChunks =
+        CreateShiftOperator(HardwareMediumParallelChunkSize * 2);
+    private static readonly uint[] HardwareLargeShiftChunk =
+        CreateShiftOperator(HardwareLargeParallelChunkSize);
+    private static readonly uint[] HardwareLargeShiftTwoChunks =
+        CreateShiftOperator(HardwareLargeParallelChunkSize * 2);
 #endif
 
     private static uint[] GenerateTable()
@@ -2077,6 +2092,16 @@ internal static class Crc32C
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ComputeHardwareX86(ReadOnlySpan<byte> data)
     {
+        if (Sse42.X64.IsSupported && data.Length >= HardwareLargeInputThreshold)
+        {
+            return ComputeHardwareX86Large(data);
+        }
+
+        if (Sse42.X64.IsSupported && data.Length >= HardwareMediumParallelBlockSize)
+        {
+            return ComputeHardwareX86Medium(data);
+        }
+
         if (Sse42.X64.IsSupported && data.Length >= HardwareParallelBlockSize)
         {
             return ComputeHardwareX86Optimized(data);
@@ -2123,6 +2148,78 @@ internal static class Crc32C
             // shifting each raw CRC state as though its following chunks were zero bytes.
             crc = ShiftCrc32C(crc0, HardwareShiftTwoChunks) ^ ShiftCrc32C(crc1, HardwareShiftChunk) ^ crc2;
             offset += HardwareParallelBlockSize;
+        }
+
+        return UpdateHardwareX86(data[offset..], crc) ^ 0xFFFFFFFFu;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint ComputeHardwareX86Medium(ReadOnlySpan<byte> data)
+    {
+        var crc = 0xFFFFFFFFu;
+        var offset = 0;
+
+        while (offset + HardwareMediumParallelBlockSize <= data.Length)
+        {
+            var crc0 = crc;
+            var crc1 = 0u;
+            var crc2 = 0u;
+
+            for (var i = 0; i < HardwareMediumParallelChunkSize; i += 8)
+            {
+                crc0 = (uint)Sse42.X64.Crc32(
+                    crc0,
+                    BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(offset + i, 8)));
+                crc1 = (uint)Sse42.X64.Crc32(
+                    crc1,
+                    BinaryPrimitives.ReadUInt64LittleEndian(
+                        data.Slice(offset + HardwareMediumParallelChunkSize + i, 8)));
+                crc2 = (uint)Sse42.X64.Crc32(
+                    crc2,
+                    BinaryPrimitives.ReadUInt64LittleEndian(
+                        data.Slice(offset + (HardwareMediumParallelChunkSize * 2) + i, 8)));
+            }
+
+            crc = ShiftCrc32C(crc0, HardwareMediumShiftTwoChunks)
+                ^ ShiftCrc32C(crc1, HardwareMediumShiftChunk)
+                ^ crc2;
+            offset += HardwareMediumParallelBlockSize;
+        }
+
+        return UpdateHardwareX86(data[offset..], crc) ^ 0xFFFFFFFFu;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint ComputeHardwareX86Large(ReadOnlySpan<byte> data)
+    {
+        var crc = 0xFFFFFFFFu;
+        var offset = 0;
+
+        while (offset + HardwareLargeParallelBlockSize <= data.Length)
+        {
+            var crc0 = crc;
+            var crc1 = 0u;
+            var crc2 = 0u;
+
+            for (var i = 0; i < HardwareLargeParallelChunkSize; i += 8)
+            {
+                crc0 = (uint)Sse42.X64.Crc32(
+                    crc0,
+                    BinaryPrimitives.ReadUInt64LittleEndian(data.Slice(offset + i, 8)));
+                crc1 = (uint)Sse42.X64.Crc32(
+                    crc1,
+                    BinaryPrimitives.ReadUInt64LittleEndian(
+                        data.Slice(offset + HardwareLargeParallelChunkSize + i, 8)));
+                crc2 = (uint)Sse42.X64.Crc32(
+                    crc2,
+                    BinaryPrimitives.ReadUInt64LittleEndian(
+                        data.Slice(offset + (HardwareLargeParallelChunkSize * 2) + i, 8)));
+            }
+
+            crc = ShiftCrc32C(crc0, HardwareLargeShiftTwoChunks)
+                ^ ShiftCrc32C(crc1, HardwareLargeShiftChunk)
+                ^ crc2;
+            offset += HardwareLargeParallelBlockSize;
         }
 
         return UpdateHardwareX86(data[offset..], crc) ^ 0xFFFFFFFFu;

--- a/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
+++ b/tests/Dekaf.Tests.Unit/Protocol/Crc32CTests.cs
@@ -177,7 +177,12 @@ public class Crc32CTests
             yield return length;
         }
 
-        foreach (var length in new[] { 513, 777, 1024, 1535, 1536, 1537, 2048, 4096, 8191, 8192, 16384, 65536 })
+        foreach (var length in new[]
+                 {
+                     513, 777, 1024, 1535, 1536, 1537, 2048, 4096, 8191, 8192,
+                     12_287, 12_288, 12_289, 16_384, 65_536, 262_143, 262_144,
+                     262_145, 1_048_576
+                 })
         {
             yield return length;
         }

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/Crc32CBenchmarks.cs
@@ -13,7 +13,7 @@ public class Crc32CBenchmarks
 {
     private byte[] _data = null!;
 
-    [Params(128, 512, 1024, 1536, 4096, 16384, 65536)]
+    [Params(128, 512, 1024, 1536, 4096, 16384, 65536, 262_144, 524_288, 1_048_576)]
     public int Size { get; set; }
 
     [GlobalSetup]


### PR DESCRIPTION
## Summary

- add 4 KiB and 16 KiB three-lane CRC32C chunks for medium and large x86 inputs
- reduce repeated GF(2) lane recombination while preserving the tuned 512-byte path for small payloads
- cover default 1 MiB record batches and both dispatch boundaries in benchmarks/tests

## Benchmark evidence

Exact base: `000a309583edfc3e0da79e86d964d02cff1dbaec`
Candidate: `8e18bd5e`
Runtime: .NET 10.0.11, i7-12700K, BDN ShortRun, MemoryDiagnoser

| CRC32C input | Base | Candidate | Delta | Allocated |
|---:|---:|---:|---:|---:|
| 64 KiB | 3,662.137 ns | 3,113.770 ns | -15.0% | 0 B |
| 256 KiB | 15,488.110 ns | 11,628.583 ns | -24.9% | 0 B |
| 512 KiB | 48,076.300 ns | 23,426.303 ns | -51.3% | 0 B |
| 1 MiB | 113,994.637 ns | 43,918.860 ns | -61.5% | 0 B |

Small-input code is unchanged. Cross-process results remain within its observed noise band.

`ProducerFireHotPathBenchmarks`, 1 KiB message:

| Delivery target | Base | Candidate | Delta | Allocated |
|---:|---:|---:|---:|---:|
| 0 ms | 316.684 ns | 233.5 ns | -26.3% | 0 B |
| 10 ms | 930.142 ns | 927.2 ns | -0.3% | 0 B |

## Local producer stress

One broker, one connection, 1 KiB messages, one minute, separate local Testcontainers runs:

| Metric | Base | Candidate | Delta |
|---|---:|---:|---:|
| Throughput | 200,145 msg/s | 210,234 msg/s | +5.0% |
| Median interval | 200,286 msg/s | 212,842 msg/s | +6.3% |
| CPU | 1.28 us/msg | 1.25 us/msg | -2.3% |
| p50 | 45.95 ms | 45.25 ms | -1.5% |
| p95 | 198.35 ms | 203.25 ms | +2.5% |
| p99 | 246.45 ms | 253.55 ms | +2.9% |
| max | 347.52 ms | 369.39 ms | +6.3% |
| Errors | 0 | 0 | unchanged |
| Allocations | 3 B/msg | 3 B/msg | unchanged |

The short, separate-container latency comparison is ambiguous and remains within observed one-connection variance. The paired baseline-candidate-baseline producer lane is the duration acceptance gate.

## Validation

- `Dekaf.Tests.Unit`: 6,641 passed
- `ProducerTests` integration class: 29 passed against Kafka/Testcontainers
- `Crc32CTests`: dispatch-boundary and 1 MiB bitwise-reference checks passed
- Release builds: 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CRC32C processing for medium and large payloads, providing faster checksum calculation for inputs up to 1 MiB.
  * Retained existing processing paths for smaller inputs.

* **Tests**
  * Expanded coverage for large and boundary-sized payloads.

* **Benchmarks**
  * Added larger payload sizes to CRC32C performance benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->