### PR TITLE
perf(producer): bypass single-partition hashing

### DIFF
--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -546,6 +546,9 @@ public sealed class DefaultPartitioner : IPartitioner, IBatchCompletionAwarePart
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         if (UsesStickyPartition(key, keyIsNull))
         {
             return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
@@ -625,6 +628,9 @@ public sealed class StickyPartitioner : IPartitioner, IBatchCompletionAwareParti
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         if (UsesStickyPartition(key, keyIsNull))
         {
             return _stickyPartitionTracker.GetOrAssign(topic, partitionCount);
@@ -674,6 +680,9 @@ public sealed class RoundRobinPartitioner : IPartitioner
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return (int)(++_counter % (uint)partitionCount);
     }
 }
@@ -699,6 +708,9 @@ public sealed class ConsistentPartitioner : IPartitioner
 {
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return LibrdkafkaCrc32.Partition(key, partitionCount);
     }
 }
@@ -712,6 +724,9 @@ public sealed class ConsistentRandomPartitioner : IPartitioner
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return key.Length == 0
             ? _randomPartitionSelector.NextPartition(partitionCount)
             : LibrdkafkaCrc32.Partition(key, partitionCount);
@@ -726,6 +741,9 @@ public sealed class Murmur2Partitioner : IPartitioner
 {
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return Murmur2.Partition(key, partitionCount);
     }
 }
@@ -739,6 +757,9 @@ public sealed class Murmur2RandomPartitioner : IPartitioner
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return keyIsNull
             ? _randomPartitionSelector.NextPartition(partitionCount)
             : Murmur2.Partition(key, partitionCount);
@@ -753,6 +774,9 @@ public sealed class Fnv1APartitioner : IPartitioner
 {
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return Fnv1A.Partition(key, partitionCount);
     }
 }
@@ -766,6 +790,9 @@ public sealed class Fnv1ARandomPartitioner : IPartitioner
 
     public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         return keyIsNull
             ? _randomPartitionSelector.NextPartition(partitionCount)
             : Fnv1A.Partition(key, partitionCount);
@@ -782,6 +809,9 @@ internal sealed class RandomPartitionSelector
 
     public int NextPartition(int partitionCount)
     {
+        if (partitionCount == 1)
+            return 0;
+
         var value = unchecked((uint)Interlocked.Add(ref _state, GoldenRatioIncrement));
         value ^= value >> 16;
         value *= MixMultiplier1;

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -742,3 +742,76 @@ public class LibrdkafkaPartitionerTests
         uint Fnv1A,
         int Fnv1APartition);
 }
+
+public class SinglePartitionFastPathTests
+{
+    private const string Topic = "single-partition-transition";
+    private const int MultiPartitionCount = 7;
+    private const int RandomState = 0x1234_5678;
+
+    [Test]
+    [Arguments(typeof(DefaultPartitioner), true, "")]
+    [Arguments(typeof(StickyPartitioner), true, "")]
+    [Arguments(typeof(RoundRobinPartitioner), false, "key")]
+    [Arguments(typeof(RandomPartitioner), false, "key")]
+    [Arguments(typeof(ConsistentPartitioner), false, "key")]
+    [Arguments(typeof(ConsistentRandomPartitioner), true, "")]
+    [Arguments(typeof(Murmur2Partitioner), false, "key")]
+    [Arguments(typeof(Murmur2RandomPartitioner), true, "")]
+    [Arguments(typeof(Fnv1APartitioner), false, "key")]
+    [Arguments(typeof(Fnv1ARandomPartitioner), true, "")]
+    public async Task Partition_SinglePartition_DoesNotChangeSubsequentSequence(
+        Type partitionerType,
+        bool keyIsNull,
+        string keyText)
+    {
+        var warmedPartitioner = CreatePartitioner(partitionerType);
+        var freshPartitioner = CreatePartitioner(partitionerType);
+        SetRandomStateIfPresent(warmedPartitioner, RandomState);
+        SetRandomStateIfPresent(freshPartitioner, RandomState);
+        var key = Encoding.UTF8.GetBytes(keyText);
+
+        for (var i = 0; i < 32; i++)
+        {
+            await Assert.That(warmedPartitioner.Partition(Topic, key, keyIsNull, partitionCount: 1))
+                .IsEqualTo(0)
+                .Because($"{partitionerType.Name} must return the only available partition");
+        }
+
+        for (var i = 0; i < 32; i++)
+        {
+            var actual = warmedPartitioner.Partition(Topic, key, keyIsNull, MultiPartitionCount);
+            var expected = freshPartitioner.Partition(Topic, key, keyIsNull, MultiPartitionCount);
+
+            await Assert.That(actual)
+                .IsEqualTo(expected)
+                .Because($"single-partition calls must not advance {partitionerType.Name} state");
+        }
+    }
+
+    private static IPartitioner CreatePartitioner(Type partitionerType)
+    {
+        if (partitionerType == typeof(DefaultPartitioner))
+            return new DefaultPartitioner();
+        if (partitionerType == typeof(StickyPartitioner))
+            return new StickyPartitioner();
+
+        return (IPartitioner)(Activator.CreateInstance(partitionerType)
+            ?? throw new InvalidOperationException($"Could not create {partitionerType.Name}."));
+    }
+
+    private static void SetRandomStateIfPresent(IPartitioner partitioner, int state)
+    {
+        var selectorField = partitioner.GetType().GetField(
+            "_randomPartitionSelector",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (selectorField?.GetValue(partitioner) is not { } selector)
+            return;
+
+        var stateField = selector.GetType().GetField(
+            "_state",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new MissingFieldException(selector.GetType().Name, "_state");
+        stateField.SetValue(selector, state);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class PartitionerBenchmarks
+{
+    private const string Topic = "partitioner-hot-path";
+    private const uint PositiveMask = 0x7fff_ffff;
+    private readonly IPartitioner _baselinePartitioner = new HashingDefaultPartitioner();
+    private readonly IPartitioner _partitioner = new DefaultPartitioner();
+    private readonly byte[] _key = "benchmark-partition-key"u8.ToArray();
+
+    [Params(1, 12)]
+    public int PartitionCount { get; set; }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 1_000)]
+    public int HashThenPartitionKeyedRecords()
+        => PartitionKeyedRecords(_baselinePartitioner);
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public int PartitionKeyedRecords()
+        => PartitionKeyedRecords(_partitioner);
+
+    private int PartitionKeyedRecords(IPartitioner partitioner)
+    {
+        var result = 0;
+        for (var i = 0; i < 1_000; i++)
+            result ^= partitioner.Partition(Topic, _key, keyIsNull: false, PartitionCount);
+
+        return result;
+    }
+
+    private sealed class HashingDefaultPartitioner : IPartitioner
+    {
+        public int Partition(string topic, ReadOnlySpan<byte> key, bool keyIsNull, int partitionCount)
+            => (int)((Murmur2.Hash(key) & PositiveMask) % (uint)partitionCount);
+    }
+}

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -33,6 +33,9 @@ public class ProducerFireHotPathBenchmarks
     [Params(0, 10)]
     public int DeliveryLatencyTargetMs { get; set; }
 
+    [Params(1, 12)]
+    public int PartitionCount { get; set; }
+
     [GlobalSetup]
     public async Task Setup()
     {
@@ -56,7 +59,7 @@ public class ProducerFireHotPathBenchmarks
             Serializers.String);
 
         await StopBackgroundLoopsAsync(_producer).ConfigureAwait(false);
-        SeedMetadata(_producer);
+        SeedMetadata(_producer, PartitionCount);
         SetInstanceField(_producer, "_initialized", true);
 
         _accumulator = _producer.RecordAccumulator;
@@ -112,8 +115,21 @@ public class ProducerFireHotPathBenchmarks
         }
     }
 
-    private static void SeedMetadata(KafkaProducer<string, string> producer)
+    private static void SeedMetadata(KafkaProducer<string, string> producer, int partitionCount)
     {
+        var partitions = new PartitionMetadata[partitionCount];
+        for (var partition = 0; partition < partitionCount; partition++)
+        {
+            partitions[partition] = new PartitionMetadata
+            {
+                ErrorCode = ErrorCode.None,
+                PartitionIndex = partition,
+                LeaderId = 0,
+                ReplicaNodes = [0],
+                IsrNodes = [0],
+            };
+        }
+
         var metadataManager = GetInstanceField<MetadataManager>(producer, "_metadataManager");
         metadataManager.Metadata.Update(new MetadataResponse
         {
@@ -129,17 +145,7 @@ public class ProducerFireHotPathBenchmarks
                 {
                     ErrorCode = ErrorCode.None,
                     Name = Topic,
-                    Partitions =
-                    [
-                        new PartitionMetadata
-                        {
-                            ErrorCode = ErrorCode.None,
-                            PartitionIndex = 0,
-                            LeaderId = 0,
-                            ReplicaNodes = [0],
-                            IsrNodes = [0],
-                        },
-                    ],
+                    Partitions = partitions,
                 },
             ],
         });


### PR DESCRIPTION
## Summary

- return partition 0 before hashing, sticky-state lookup, or random selection when a topic has one partition
- cover every built-in partitioner while preserving custom partitioner behavior
- add same-run partitioner and 1-vs-12-partition producer benchmarks

## Performance

Baseline SHA: `6d921bcf1330b6f16137f60b04319c07676f890f`
Candidate SHA: `e08f209d`
Environment: .NET 10.0.11, BenchmarkDotNet 0.15.8, i7-12700K, Windows 11

Same-run `PartitionerBenchmarks` (10 iterations, 5 warmups):

| Partitions | Before | After | Delta | Allocated |
|---:|---:|---:|---:|---:|
| 1 | 5.7134 ns | 0.3298 ns | -94.2% | 0 B |
| 12 | 5.6543 ns | 5.7841 ns | +0.13 ns | 0 B |

Expanded `ProducerFireHotPathBenchmarks` control:

| Target | Partitions | Before | After | Delta |
|---:|---:|---:|---:|---:|
| 0 ms | 1 | 209.1 ns | 214.6 ns | +2.6% |
| 0 ms | 12 control | 227.8 ns | 234.1 ns | +2.8% |
| 10 ms | 1 | 934.3 ns | 931.9 ns | -0.3% |
| 10 ms | 12 control | 1478.3 ns | 1471.5 ns | -0.5% |

The target-0 shift is common to candidate and 12-partition control (+5-6 ns), so it is run-level drift, not a single-partition regression. Control-adjusted delta is -0.2 percentage points. A separate full-path repeat reported 0 B for both targets. The expanded run saw one 29 B single-partition sample from the stochastic background drainer; the other three cells and the direct hot-path benchmark remained 0 B.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release`: 0 warnings, 0 errors
- full net10 unit suite: 6,651 passed, 0 failed
- focused partitioner suite: 61 passed, 0 failed
