### PR TITLE
perf(producer): remove queue-byte lock contention

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1268,7 +1268,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly Action<string, int>? _onBatchComplete;
     private readonly Action<string, int, int, int>? _onRecordAppended;
-    private readonly ConcurrentDictionary<TopicPartition, long> _partitionQueueBytes = new();
 
     private int _disposed;
     private int _closed;
@@ -1458,6 +1457,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         public int AdmissionInProgress;
 
         public int SlowPathAppendCount;
+
+        /// <summary>
+        /// Bytes in sealed or in-flight batches for this partition. Access atomically because
+        /// append and sender threads update it concurrently.
+        /// </summary>
+        public long QueueBytes;
 
         /// <summary>
         /// Set when this partition cannot reserve more broker-window bytes. The linger loop
@@ -2630,10 +2635,13 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
 
     internal long GetPartitionQueueBytes(string topic, int partition)
     {
-        return _partitionQueueBytes.TryGetValue(new TopicPartition(topic, partition), out var bytes)
-            ? Math.Max(0, bytes)
+        return _partitionDeques.TryGetValue(new TopicPartition(topic, partition), out var pd)
+            ? Math.Max(0, Volatile.Read(ref pd.QueueBytes))
             : 0;
     }
+
+    internal void SetPartitionQueueBytesForTest(string topic, int partition, long bytes) =>
+        Volatile.Write(ref GetOrCreateDeque(topic, partition).QueueBytes, bytes);
 
     public RecordAccumulator(
         ProducerOptions options,
@@ -3373,7 +3381,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
-                                if (ShouldSealAppendedBatch(currentBatch, completionSource))
+                                if (ShouldSealAppendedBatch(pd, currentBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
                                     ownsRotation = true;
@@ -3416,7 +3424,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 ownsRecordResources = false;
                                 if (firstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
-                                if (ShouldSealAppendedBatch(newBatch, completionSource))
+                                if (ShouldSealAppendedBatch(pd, newBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, newBatch);
                                     ownsRotation = true;
@@ -3952,7 +3960,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                                 if (reservedFirstAwaitedProduceInBatch)
                                     TrackPendingAwaitedProduceBatch();
 
-                                if (ShouldSealAppendedBatch(reservedAppendBatch, completionSource))
+                                if (ShouldSealAppendedBatch(pd, reservedAppendBatch, completionSource))
                                 {
                                     batchToComplete = DetachCurrentBatchForSealUnderLock(pd, reservedAppendBatch);
                                     ownsRotation = true;
@@ -4307,7 +4315,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             if (result.FirstCompletionSourceInBatch)
                 TrackPendingAwaitedProduceBatch();
 
-            if (ShouldSealAppendedBatch(currentBatch, completionSource))
+            if (ShouldSealAppendedBatch(pd, currentBatch, completionSource))
             {
                 batchToComplete = DetachCurrentBatchForSealUnderLock(pd, currentBatch);
             }
@@ -4515,6 +4523,36 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return result < current ? long.MaxValue : result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void AddPartitionQueueBytes(PartitionDeque pd, int bytes)
+    {
+        var current = Volatile.Read(ref pd.QueueBytes);
+        while (true)
+        {
+            var updated = SaturatingAdd(current, bytes);
+            var observed = Interlocked.CompareExchange(ref pd.QueueBytes, updated, current);
+            if (observed == current)
+                return;
+
+            current = observed;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void RemovePartitionQueueBytes(PartitionDeque pd, int bytes)
+    {
+        var current = Volatile.Read(ref pd.QueueBytes);
+        while (true)
+        {
+            var updated = Math.Max(0, current - bytes);
+            var observed = Interlocked.CompareExchange(ref pd.QueueBytes, updated, current);
+            if (observed == current)
+                return;
+
+            current = observed;
+        }
+    }
+
     // No ShouldFlush conjunct: every call site runs on the appending thread immediately
     // after a successful append, so RecordCount >= 1 and ShouldFlush(now, 0) is true on
     // both the awaited (lingerMs == 0 => true) and fire-and-forget (elapsed >= 0) branches —
@@ -4522,17 +4560,20 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     //
     // The bypass branch checks only the mute set, not ShouldDeferPartialBatchSeal: with
     // zero undelivered batches producer-wide (a gate condition), a non-zero
-    // _partitionQueueBytes entry is bookkeeping lag from the previous delivery
+    // QueueBytes is bookkeeping lag from the previous delivery
     // (decremented in OnBatchExitsPipeline, after CompleteSend resumed the caller),
     // never a real pipeline batch.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldSealAppendedBatch(PartitionBatch batch, PooledValueTaskSource<RecordMetadata>? completionSource)
+    private bool ShouldSealAppendedBatch(
+        PartitionDeque pd,
+        PartitionBatch batch,
+        PooledValueTaskSource<RecordMetadata>? completionSource)
     {
         if (batch.IsExactlyAtSizeLimit)
             return true;
 
         if (_options.LingerMs == 0)
-            return !ShouldDeferPartialBatchSeal(batch);
+            return !ShouldDeferPartialBatchSeal(pd, batch);
 
         return IsAppLimitedAwaitedAppend(batch, completionSource)
             && !_mutedPartitions.ContainsKey(batch.TopicPartition);
@@ -4593,11 +4634,10 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldDeferPartialBatchSeal(PartitionBatch batch)
+    private bool ShouldDeferPartialBatchSeal(PartitionDeque pd, PartitionBatch batch)
     {
         var topicPartition = batch.TopicPartition;
-        var hasPipelineBatch = _partitionQueueBytes.TryGetValue(topicPartition, out var queuedBytes)
-            && queuedBytes > 0;
+        var hasPipelineBatch = Volatile.Read(ref pd.QueueBytes) > 0;
         return ShouldDeferPartialBatchSeal(
             _mutedPartitions.ContainsKey(topicPartition),
             _serializeBatchesPerPartition,
@@ -5465,7 +5505,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
                 // still seal in the append path, and FlushAsync must always seal.
                 else if (sealAll
                     || IsAdmissionFlushRequiredUnderLock(pd)
-                    || (!ShouldDeferPartialBatchSeal(pd.CurrentBatch)
+                    || (!ShouldDeferPartialBatchSeal(pd, pd.CurrentBatch)
                         && pd.CurrentBatch.ShouldFlush(now, _options.LingerMs)))
                 {
                     ProducerDebugCounters.RecordBatchFlushedFromDictionary();
@@ -5531,7 +5571,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Tracks a batch entering the pipeline: increments counter and adds to reference-tracking dictionary.
     /// Called when a batch is completed and enqueued to a partition deque.
     /// </summary>
-    private void OnBatchEntersPipeline(PartitionDeque _, ReadyBatch batch)
+    private void OnBatchEntersPipeline(PartitionDeque pd, ReadyBatch batch)
     {
         if (_unackedBudgetEnabled)
             ChargeUnackedBudget(batch);
@@ -5542,11 +5582,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             Volatile.Write(ref batch.UnackedBudgetPipelineTracked, 1);
         }
 
-        _partitionQueueBytes.AddOrUpdate(
-            batch.TopicPartition,
-            static (_, batch) => batch.DataSize,
-            static (_, current, batch) => SaturatingAdd(current, batch.DataSize),
-            batch);
+        AddPartitionQueueBytes(pd, batch.DataSize);
 
         // Counter first, list second. If a batch races between the counter increment
         // and the list add, the sweep will miss it in the snapshot — but that's acceptable
@@ -5613,14 +5649,8 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             SignalBufferSpaceAvailable();
         }
 
-        // factoryArgument overload with static lambdas: the capturing (_, current) => ... form
-        // allocated a closure + delegate per batch, which de-amortizes to per-message at the
-        // transactional 1-message-per-batch shape (issue #2471; enter-side twin fixed by #1914).
-        _partitionQueueBytes.AddOrUpdate(
-            batch.TopicPartition,
-            static (_, _) => 0,
-            static (_, current, batch) => Math.Max(0, current - batch.DataSize),
-            batch);
+        if (_partitionDeques.TryGetValue(batch.TopicPartition, out var pd))
+            RemovePartitionQueueBytes(pd, batch.DataSize);
 
         if (_options.EnableDeliveryDiagnostics)
             batch.AppendDiag('X');

--- a/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/AdaptiveScaleDownTests.cs
@@ -974,10 +974,7 @@ public sealed class AdaptiveScaleDownTests
             SetField(sender, "_totalMaxInFlight", 4);
             SetField(sender, "_totalPendingResponseCount", 1);
 
-            var partitionQueueBytes = GetField<ConcurrentDictionary<TopicPartition, long>>(
-                accumulator,
-                "_partitionQueueBytes");
-            partitionQueueBytes[topicPartition] = 100;
+            accumulator.SetPartitionQueueBytesForTest(Topic, 0, 100);
             accumulator.Reenqueue(CreateTestBatch(valueTaskSourcePool, partition: 0), 0);
 
             typeof(BrokerSender).GetMethod(
@@ -1020,10 +1017,7 @@ public sealed class AdaptiveScaleDownTests
             SetField(sender, "_totalMaxInFlight", 4);
             SetField(sender, "_totalPendingResponseCount", 1);
 
-            var partitionQueueBytes = GetField<ConcurrentDictionary<TopicPartition, long>>(
-                accumulator,
-                "_partitionQueueBytes");
-            partitionQueueBytes[topicPartition] = 100;
+            accumulator.SetPartitionQueueBytesForTest(Topic, 0, 100);
 
             typeof(BrokerSender).GetMethod(
                 "MutePartition",

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionQueueAccountingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionQueueAccountingBenchmarks.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class PartitionQueueAccountingBenchmarks
+{
+    private const int BatchBytes = 1_048_576;
+    private readonly TopicPartition _topicPartition = new("queue-accounting", 0);
+    private readonly ConcurrentDictionary<TopicPartition, long> _queueBytes = new();
+    private readonly AtomicQueueBytes _atomicQueueBytes = new();
+    private Thread _dictionaryDrainer = null!;
+    private Thread _atomicDrainer = null!;
+    private int _stopping;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _queueBytes[_topicPartition] = 0;
+        _dictionaryDrainer = StartDrainer(DrainDictionary);
+        _atomicDrainer = StartDrainer(DrainAtomicCounter);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        Volatile.Write(ref _stopping, 1);
+        _dictionaryDrainer.Join();
+        _atomicDrainer.Join();
+    }
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = 1_000)]
+    public long ConcurrentDictionaryAddOrUpdate()
+    {
+        for (var i = 0; i < 1_000; i++)
+        {
+            _queueBytes.AddOrUpdate(
+                _topicPartition,
+                static (_, bytes) => bytes,
+                static (_, current, bytes) => SaturatingAdd(current, bytes),
+                BatchBytes);
+        }
+
+        return _queueBytes[_topicPartition];
+    }
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public long AtomicPartitionCounter()
+    {
+        for (var i = 0; i < 1_000; i++)
+            _atomicQueueBytes.Add(BatchBytes);
+
+        return Volatile.Read(ref _atomicQueueBytes.Value);
+    }
+
+    private static Thread StartDrainer(ThreadStart action)
+    {
+        var thread = new Thread(action) { IsBackground = true };
+        thread.Start();
+        return thread;
+    }
+
+    private void DrainDictionary()
+    {
+        while (Volatile.Read(ref _stopping) == 0)
+        {
+            _queueBytes.AddOrUpdate(
+                _topicPartition,
+                static (_, _) => 0,
+                static (_, current, bytes) => Math.Max(0, current - bytes),
+                BatchBytes);
+        }
+    }
+
+    private void DrainAtomicCounter()
+    {
+        while (Volatile.Read(ref _stopping) == 0)
+            _atomicQueueBytes.Remove(BatchBytes);
+    }
+
+    private static long SaturatingAdd(long current, int value)
+    {
+        var result = current + value;
+        return result < current ? long.MaxValue : result;
+    }
+
+    private sealed class AtomicQueueBytes
+    {
+        public long Value;
+
+        public void Add(int bytes)
+        {
+            var current = Volatile.Read(ref Value);
+            while (true)
+            {
+                var updated = SaturatingAdd(current, bytes);
+                var observed = Interlocked.CompareExchange(ref Value, updated, current);
+                if (observed == current)
+                    return;
+
+                current = observed;
+            }
+        }
+
+        public void Remove(int bytes)
+        {
+            var current = Volatile.Read(ref Value);
+            while (true)
+            {
+                var updated = Math.Max(0, current - bytes);
+                var observed = Interlocked.CompareExchange(ref Value, updated, current);
+                if (observed == current)
+                    return;
+
+                current = observed;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace contended `ConcurrentDictionary.AddOrUpdate` queue-byte accounting with a per-partition atomic counter
- use the owning partition deque directly during append/seal checks
- add a concurrent accounting benchmark and update white-box tests

## Performance

Baseline SHA: `6d921bcf1330b6f16137f60b04319c07676f890f`
Candidate SHA: `38ac9b63`
Environment: .NET 10.0.11, BenchmarkDotNet 0.15.8, i7-12700K, Windows 11

Same-run `PartitionQueueAccountingBenchmarks` (10 iterations, 5 warmups):

| Method | Mean | Delta | Allocated |
|---|---:|---:|---:|
| ConcurrentDictionary AddOrUpdate | 216.78 ns | baseline | 0 B |
| Atomic partition counter | 80.51 ns | -62.9% | 0 B |

EventPipe `ProducerFireHotPathBenchmarks`, target 0:

- before: `OnBatchExitsPipeline` children sampled for ~3,530 ms, including ~2,949 ms in `Monitor.Enter_Slowpath` and ~581 ms in `ConcurrentDictionary.AddOrUpdate`
- after: ~7.4 ms total; `Monitor.Enter_Slowpath` and `AddOrUpdate` disappeared
- sampled bookkeeping time: -99.8%

Profiled full producer path:

| Target | Before | After | Delta | Allocated after |
|---:|---:|---:|---:|---:|
| 0 ms | 199.7 ns | 195.4 ns | -2.2% | 0 B |
| 10 ms | 213.9 ns | 212.4 ns | -0.7% | 0 B |

The non-profiled cross-run result was noisy (target 0: 208.1 -> 214.3 ns; target 10: 941.5 -> 931.7 ns). The same-run contention benchmark and before/after stack samples isolate the causal win without relabeling that noisy full-path comparison.

## Validation

- `dotnet build tests/Dekaf.Tests.Unit/Dekaf.Tests.Unit.csproj -c Release`: 0 warnings, 0 errors
- full net10 unit suite: 6,641 passed, 0 failed
- focused concurrency/ready/flush suite: 91 passed, 0 failed