### PR TITLE
perf(producer): cache partition deques

### DIFF
--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3093,10 +3093,11 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     // Single thread-local cache consolidating all per-thread deque lookup state.
-    // Reduces 3 separate [ThreadStatic] lookups to 1.
-    // Per-thread one-slot cache for GetOrCreateDeque to avoid ConcurrentDictionary hash+lookup
-    // on every message. The cache stores (accumulator instance, TopicPartition, PartitionDeque).
-    // Hit rate is high in partition-affine append workers and single-partition scenarios.
+    // Direct mapping preserves partition locality without an O(n) lookup: round-robin producers
+    // otherwise miss a one-slot cache on every message and fall through to ConcurrentDictionary.
+    private const int DequeCacheSize = 16;
+    private const int DequeCacheMask = DequeCacheSize - 1;
+
     // Note: holds a strong reference to the accumulator until the thread reuses the cache slot.
     // This is acceptable because producers are typically singleton-lifetime objects.
     // IMPORTANT: This cache is only valid because _partitionDeques never removes entries.
@@ -3110,38 +3111,54 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private sealed class AccumulatorThreadCache
     {
-        public RecordAccumulator? CachedAccumulator;
-        public TopicPartition CachedTopicPartition;
-        public PartitionDeque? CachedDeque;
+        public readonly AccumulatorThreadCacheEntry[] Entries =
+            new AccumulatorThreadCacheEntry[DequeCacheSize];
+    }
+
+    private struct AccumulatorThreadCacheEntry
+    {
+        public RecordAccumulator? Accumulator;
+        public string? Topic;
+        public int Partition;
+        public PartitionDeque? Deque;
     }
 
     /// <summary>
     /// Gets or creates the PartitionDeque for a topic-partition pair.
-    /// Uses a per-thread one-slot cache to avoid ConcurrentDictionary lookup when the
-    /// same thread repeatedly accesses the same partition (common in append workers).
+    /// Uses a per-thread direct-mapped cache to avoid ConcurrentDictionary lookup for
+    /// partition-affine and round-robin append workers.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private PartitionDeque GetOrCreateDeque(string topic, int partition)
     {
-        var tp = new TopicPartition(topic, partition);
-
-        // Fast path: check thread-local cache (skip if disposed to avoid serving stale data)
         var cache = t_cache ??= new AccumulatorThreadCache();
-        if (cache.CachedAccumulator == this && Volatile.Read(ref _disposed) == 0 && cache.CachedTopicPartition == tp && cache.CachedDeque is { } cached)
+        var cacheIndex = partition & DequeCacheMask;
+        ref var entry = ref cache.Entries[cacheIndex];
+        if (entry.Accumulator == this
+            && Volatile.Read(ref _disposed) == 0
+            && entry.Partition == partition
+            && string.Equals(entry.Topic, topic, StringComparison.Ordinal)
+            && entry.Deque is { } cached)
+        {
             return cached;
+        }
 
-        return GetOrCreateDequeSlow(tp, cache);
+        return GetOrCreateDequeSlow(topic, partition, ref entry);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private PartitionDeque GetOrCreateDequeSlow(TopicPartition tp, AccumulatorThreadCache cache)
+    private PartitionDeque GetOrCreateDequeSlow(
+        string topic,
+        int partition,
+        ref AccumulatorThreadCacheEntry entry)
     {
+        var tp = new TopicPartition(topic, partition);
         var deque = _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
 
-        // Update thread-local cache
-        cache.CachedAccumulator = this;
-        cache.CachedTopicPartition = tp;
-        cache.CachedDeque = deque;
+        entry.Accumulator = this;
+        entry.Topic = topic;
+        entry.Partition = partition;
+        entry.Deque = deque;
 
         return deque;
     }

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3096,24 +3096,35 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     // Direct mapping preserves partition locality without an O(n) lookup: round-robin producers
-    // otherwise fall through to ConcurrentDictionary on every message. Keeping the cache on the
-    // accumulator makes producer switches O(1) and ties cache lifetime to accumulator lifetime.
-    private const int DequeCacheSize = 16;
-    private const int DequeCacheMask = DequeCacheSize - 1;
+    // otherwise fall through to ConcurrentDictionary on every message. The shared array belongs
+    // to one RecordAccumulator and is split into 64 thread-assigned shards, giving partition-affine
+    // producer threads independent hot entries under normal producer concurrency. Thread-local state
+    // stores only a shard number, so it cannot extend the accumulator's lifetime.
+    private const int DequeCacheSlotsPerShard = 16;
+    private const int DequeCacheSlotMask = DequeCacheSlotsPerShard - 1;
+    private const int DequeCacheShardCount = 64;
+    private const int DequeCacheShardMask = DequeCacheShardCount - 1;
+    private const int DequeCacheShardShift = 4;
 
-    // IMPORTANT: This cache is only valid because _partitionDeques never removes entries.
-    // If partition eviction is ever added, the cache must be invalidated on removal.
-    private readonly PartitionDeque?[] _partitionDequeCache = new PartitionDeque?[DequeCacheSize];
+    private static int s_nextDequeCacheShard;
+
+    [ThreadStatic]
+    private static int t_dequeCacheShardPlusOne;
+
+    // IMPORTANT: This per-RecordAccumulator cache is only valid because _partitionDeques never
+    // removes entries. If partition eviction is ever added, all shards must be invalidated.
+    private readonly PartitionDeque?[] _partitionDequeCache =
+        new PartitionDeque?[DequeCacheSlotsPerShard * DequeCacheShardCount];
 
     /// <summary>
     /// Gets or creates the PartitionDeque for a topic-partition pair.
-    /// Uses a per-thread direct-mapped cache to avoid ConcurrentDictionary lookup for
-    /// partition-affine and round-robin append workers.
+    /// Uses a thread-sharded direct-mapped cache owned by this RecordAccumulator to avoid
+    /// ConcurrentDictionary lookup for partition-affine and round-robin append workers.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private PartitionDeque GetOrCreateDeque(string topic, int partition)
     {
-        var cacheIndex = partition & DequeCacheMask;
+        var cacheIndex = GetDequeCacheIndex(partition);
         var cached = Volatile.Read(ref _partitionDequeCache[cacheIndex]);
         if (Volatile.Read(ref _disposed) == 0
             && cached is not null
@@ -3124,6 +3135,25 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         }
 
         return GetOrCreateDequeSlow(topic, partition, cacheIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetDequeCacheIndex(int partition)
+    {
+        var shardPlusOne = t_dequeCacheShardPlusOne;
+        if (shardPlusOne == 0)
+            shardPlusOne = InitializeDequeCacheShard();
+
+        return ((shardPlusOne - 1) << DequeCacheShardShift) | (partition & DequeCacheSlotMask);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int InitializeDequeCacheShard()
+    {
+        var shard = (Interlocked.Increment(ref s_nextDequeCacheShard) - 1) & DequeCacheShardMask;
+        var shardPlusOne = shard + 1;
+        t_dequeCacheShardPlusOne = shardPlusOne;
+        return shardPlusOne;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -3111,13 +3111,14 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// </summary>
     private sealed class AccumulatorThreadCache
     {
+        public RecordAccumulator? Owner;
+
         public readonly AccumulatorThreadCacheEntry[] Entries =
             new AccumulatorThreadCacheEntry[DequeCacheSize];
     }
 
     private struct AccumulatorThreadCacheEntry
     {
-        public RecordAccumulator? Accumulator;
         public string? Topic;
         public int Partition;
         public PartitionDeque? Deque;
@@ -3132,10 +3133,12 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     private PartitionDeque GetOrCreateDeque(string topic, int partition)
     {
         var cache = t_cache ??= new AccumulatorThreadCache();
+        if (cache.Owner != this)
+            return GetOrCreateDequeForNewOwner(topic, partition, cache);
+
         var cacheIndex = partition & DequeCacheMask;
         ref var entry = ref cache.Entries[cacheIndex];
-        if (entry.Accumulator == this
-            && Volatile.Read(ref _disposed) == 0
+        if (Volatile.Read(ref _disposed) == 0
             && entry.Partition == partition
             && string.Equals(entry.Topic, topic, StringComparison.Ordinal)
             && entry.Deque is { } cached)
@@ -3143,6 +3146,18 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
             return cached;
         }
 
+        return GetOrCreateDequeSlow(topic, partition, ref entry);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private PartitionDeque GetOrCreateDequeForNewOwner(
+        string topic,
+        int partition,
+        AccumulatorThreadCache cache)
+    {
+        Array.Clear(cache.Entries, 0, cache.Entries.Length);
+        cache.Owner = this;
+        ref var entry = ref cache.Entries[partition & DequeCacheMask];
         return GetOrCreateDequeSlow(topic, partition, ref entry);
     }
 
@@ -3155,7 +3170,6 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         var tp = new TopicPartition(topic, partition);
         var deque = _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
 
-        entry.Accumulator = this;
         entry.Topic = topic;
         entry.Partition = partition;
         entry.Deque = deque;

--- a/src/Dekaf/Producer/RecordAccumulator.cs
+++ b/src/Dekaf/Producer/RecordAccumulator.cs
@@ -1421,12 +1421,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     /// Uses a ring-buffer backing array instead of LinkedList to eliminate per-batch
     /// LinkedListNode and HashSet allocations. Typical deques hold 1-3 batches.
     /// </summary>
-    private sealed class PartitionDeque(RecordAccumulator owner)
+    private sealed class PartitionDeque(TopicPartition topicPartition, RecordAccumulator owner)
     {
         private readonly RecordAccumulator _owner = owner;
         private ReadyBatch?[] _items = new ReadyBatch?[4];
         private int _head;
         private int _count;
+
+        public readonly string Topic = topicPartition.Topic;
+        public readonly int Partition = topicPartition.Partition;
 
         /// <summary>Per-partition lock for deque access (matches Java's synchronized(deque)).
         /// SpinLock avoids kernel transitions for the brief critical sections in append/drain paths.</summary>
@@ -1617,7 +1620,7 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     }
 
     private PartitionDeque GetOrCreateDeque(TopicPartition tp)
-        => _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
+        => _partitionDeques.GetOrAdd(tp, static (key, owner) => new PartitionDeque(key, owner), this);
 
     /// <summary>
     /// Drains the push-based notification queue to find partitions with sendable data.
@@ -3092,37 +3095,15 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
         return batch;
     }
 
-    // Single thread-local cache consolidating all per-thread deque lookup state.
     // Direct mapping preserves partition locality without an O(n) lookup: round-robin producers
-    // otherwise miss a one-slot cache on every message and fall through to ConcurrentDictionary.
+    // otherwise fall through to ConcurrentDictionary on every message. Keeping the cache on the
+    // accumulator makes producer switches O(1) and ties cache lifetime to accumulator lifetime.
     private const int DequeCacheSize = 16;
     private const int DequeCacheMask = DequeCacheSize - 1;
 
-    // Note: holds a strong reference to the accumulator until the thread reuses the cache slot.
-    // This is acceptable because producers are typically singleton-lifetime objects.
     // IMPORTANT: This cache is only valid because _partitionDeques never removes entries.
     // If partition eviction is ever added, the cache must be invalidated on removal.
-    [ThreadStatic]
-    private static AccumulatorThreadCache? t_cache;
-
-    /// <summary>
-    /// Holds per-thread cached state for partition deque lookups.
-    /// Consolidating into a single class reduces thread-static lookup overhead from 3 to 1.
-    /// </summary>
-    private sealed class AccumulatorThreadCache
-    {
-        public RecordAccumulator? Owner;
-
-        public readonly AccumulatorThreadCacheEntry[] Entries =
-            new AccumulatorThreadCacheEntry[DequeCacheSize];
-    }
-
-    private struct AccumulatorThreadCacheEntry
-    {
-        public string? Topic;
-        public int Partition;
-        public PartitionDeque? Deque;
-    }
+    private readonly PartitionDeque?[] _partitionDequeCache = new PartitionDeque?[DequeCacheSize];
 
     /// <summary>
     /// Gets or creates the PartitionDeque for a topic-partition pair.
@@ -3132,47 +3113,31 @@ public sealed partial class RecordAccumulator : IAsyncDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private PartitionDeque GetOrCreateDeque(string topic, int partition)
     {
-        var cache = t_cache ??= new AccumulatorThreadCache();
-        if (cache.Owner != this)
-            return GetOrCreateDequeForNewOwner(topic, partition, cache);
-
         var cacheIndex = partition & DequeCacheMask;
-        ref var entry = ref cache.Entries[cacheIndex];
+        var cached = Volatile.Read(ref _partitionDequeCache[cacheIndex]);
         if (Volatile.Read(ref _disposed) == 0
-            && entry.Partition == partition
-            && string.Equals(entry.Topic, topic, StringComparison.Ordinal)
-            && entry.Deque is { } cached)
+            && cached is not null
+            && cached.Partition == partition
+            && string.Equals(cached.Topic, topic, StringComparison.Ordinal))
         {
             return cached;
         }
 
-        return GetOrCreateDequeSlow(topic, partition, ref entry);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private PartitionDeque GetOrCreateDequeForNewOwner(
-        string topic,
-        int partition,
-        AccumulatorThreadCache cache)
-    {
-        Array.Clear(cache.Entries, 0, cache.Entries.Length);
-        cache.Owner = this;
-        ref var entry = ref cache.Entries[partition & DequeCacheMask];
-        return GetOrCreateDequeSlow(topic, partition, ref entry);
+        return GetOrCreateDequeSlow(topic, partition, cacheIndex);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private PartitionDeque GetOrCreateDequeSlow(
         string topic,
         int partition,
-        ref AccumulatorThreadCacheEntry entry)
+        int cacheIndex)
     {
         var tp = new TopicPartition(topic, partition);
-        var deque = _partitionDeques.GetOrAdd(tp, static (_, owner) => new PartitionDeque(owner), this);
-
-        entry.Topic = topic;
-        entry.Partition = partition;
-        entry.Deque = deque;
+        var deque = _partitionDeques.GetOrAdd(
+            tp,
+            static (key, owner) => new PartitionDeque(key, owner),
+            this);
+        Volatile.Write(ref _partitionDequeCache[cacheIndex], deque);
 
         return deque;
     }

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorDequeCacheTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorDequeCacheTests.cs
@@ -1,0 +1,125 @@
+using System.Reflection;
+using Dekaf.Producer;
+
+namespace Dekaf.Tests.Unit.Producer;
+
+public class RecordAccumulatorDequeCacheTests
+{
+    private static readonly MethodInfo GetOrCreateDequeMethod = typeof(RecordAccumulator).GetMethod(
+        "GetOrCreateDeque",
+        BindingFlags.NonPublic | BindingFlags.Instance,
+        [typeof(string), typeof(int)])!;
+
+    [Test]
+    [Timeout(30_000)]
+    public async Task GetOrCreateDeque_ConcurrentCollidingPartitions_KeepBothThreadShardsHot(
+        CancellationToken cancellationToken)
+    {
+        await using var accumulator = CreateAccumulator();
+        using var start = new ManualResetEventSlim();
+        object? partition0Deque = null;
+        object? partition16Deque = null;
+
+        var partition0Thread = StartLookupThread(
+            accumulator,
+            partition: 0,
+            start,
+            deque => partition0Deque = deque);
+        var partition16Thread = StartLookupThread(
+            accumulator,
+            partition: 16,
+            start,
+            deque => partition16Deque = deque);
+
+        start.Set();
+        JoinThread(partition0Thread, cancellationToken);
+        JoinThread(partition16Thread, cancellationToken);
+
+        await Assert.That(partition0Deque).IsNotNull();
+        await Assert.That(partition16Deque).IsNotNull();
+        await Assert.That(partition0Deque).IsNotSameReferenceAs(partition16Deque);
+        await Assert.That(GetPartition(partition0Deque!)).IsEqualTo(0);
+        await Assert.That(GetPartition(partition16Deque!)).IsEqualTo(16);
+
+        var cache = AccumulatorTestHelpers.GetPrivateField<object?[]>(accumulator, "_partitionDequeCache");
+        await Assert.That(Array.IndexOf(cache, partition0Deque)).IsGreaterThanOrEqualTo(0);
+        await Assert.That(Array.IndexOf(cache, partition16Deque)).IsGreaterThanOrEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_SamePartitionAcrossTopics_ReturnsTopicSpecificDeque()
+    {
+        await using var accumulator = CreateAccumulator();
+
+        var orders = GetOrCreateDeque(accumulator, "orders", partition: 3);
+        var payments = GetOrCreateDeque(accumulator, "payments", partition: 3);
+        var ordersAgain = GetOrCreateDeque(accumulator, "orders", partition: 3);
+
+        await Assert.That(ordersAgain).IsSameReferenceAs(orders);
+        await Assert.That(payments).IsNotSameReferenceAs(orders);
+        await Assert.That(GetTopic(orders)).IsEqualTo("orders");
+        await Assert.That(GetTopic(payments)).IsEqualTo("payments");
+    }
+
+    [Test]
+    public async Task GetOrCreateDeque_AlternatingAccumulators_PreservesInstanceOwnership()
+    {
+        await using var firstAccumulator = CreateAccumulator();
+        await using var secondAccumulator = CreateAccumulator();
+
+        var first = GetOrCreateDeque(firstAccumulator, "orders", partition: 5);
+        var second = GetOrCreateDeque(secondAccumulator, "orders", partition: 5);
+        var firstAgain = GetOrCreateDeque(firstAccumulator, "orders", partition: 5);
+        var secondAgain = GetOrCreateDeque(secondAccumulator, "orders", partition: 5);
+
+        await Assert.That(firstAgain).IsSameReferenceAs(first);
+        await Assert.That(secondAgain).IsSameReferenceAs(second);
+        await Assert.That(first).IsNotSameReferenceAs(second);
+    }
+
+    private static RecordAccumulator CreateAccumulator()
+        => new(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1_048_576,
+            LingerMs = 0
+        });
+
+    private static Thread StartLookupThread(
+        RecordAccumulator accumulator,
+        int partition,
+        ManualResetEventSlim start,
+        Action<object> setResult)
+    {
+        var thread = new Thread(() =>
+        {
+            start.Wait();
+            object? deque = null;
+            for (var i = 0; i < 1_000; i++)
+                deque = GetOrCreateDeque(accumulator, "orders", partition);
+
+            setResult(deque!);
+        })
+        {
+            IsBackground = true
+        };
+        thread.Start();
+        return thread;
+    }
+
+    private static object GetOrCreateDeque(RecordAccumulator accumulator, string topic, int partition)
+        => GetOrCreateDequeMethod.Invoke(accumulator, [topic, partition])!;
+
+    private static void JoinThread(Thread thread, CancellationToken cancellationToken)
+    {
+        while (!thread.Join(millisecondsTimeout: 50))
+            cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private static int GetPartition(object deque)
+        => (int)deque.GetType().GetField("Partition")!.GetValue(deque)!;
+
+    private static string GetTopic(object deque)
+        => (string)deque.GetType().GetField("Topic")!.GetValue(deque)!;
+}

--- a/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/RecordAccumulatorTests.cs
@@ -3252,7 +3252,7 @@ public class RecordAccumulatorTests
     {
         var pdType = typeof(RecordAccumulator).GetNestedType("PartitionDeque",
             System.Reflection.BindingFlags.NonPublic)!;
-        var pd = Activator.CreateInstance(pdType, accumulator)!;
+        var pd = Activator.CreateInstance(pdType, batch.TopicPartition, accumulator)!;
         var method = typeof(RecordAccumulator).GetMethod("OnBatchEntersPipeline",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         method!.Invoke(accumulator, [pd, batch]);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AccumulatorAppendBenchmarks.cs
@@ -17,6 +17,7 @@ namespace Dekaf.Benchmarks.Benchmarks.Unit;
 public class AccumulatorAppendBenchmarks
 {
     private RecordAccumulator _accumulator = null!;
+    private RecordAccumulator _secondAccumulator = null!;
     private byte[] _keyBytes = null!;
     private byte[] _valueBytes = null!;
     private CancellationTokenSource _drainerCts = null!;
@@ -37,6 +38,7 @@ public class AccumulatorAppendBenchmarks
         };
 
         _accumulator = new RecordAccumulator(options);
+        _secondAccumulator = new RecordAccumulator(options);
         _keyBytes = Encoding.UTF8.GetBytes("benchmark-key-0");
         _valueBytes = new byte[MessageSize];
 
@@ -48,11 +50,15 @@ public class AccumulatorAppendBenchmarks
         var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         // Warm single-partition pools by filling and draining 4 complete batches
-        FillAndDrain(partition: 0, batchCount: 4, msgsPerBatch, ts);
+        FillAndDrain(_accumulator, partition: 0, batchCount: 4, msgsPerBatch, ts);
+        FillAndDrain(_secondAccumulator, partition: 0, batchCount: 4, msgsPerBatch, ts);
 
         // Warm multi-partition deques used by AppendMultiPartition
         for (var p = 0; p < 10; p++)
-            FillAndDrain(partition: p, batchCount: 1, msgsPerBatch, ts);
+        {
+            FillAndDrain(_accumulator, partition: p, batchCount: 1, msgsPerBatch, ts);
+            FillAndDrain(_secondAccumulator, partition: p, batchCount: 1, msgsPerBatch, ts);
+        }
 
         // Start background drainer to prevent buffer from filling
         _drainerCts = new CancellationTokenSource();
@@ -65,6 +71,7 @@ public class AccumulatorAppendBenchmarks
         _drainerCts.Cancel();
         try { await _drainerTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
         await _accumulator.DisposeAsync().ConfigureAwait(false);
+        await _secondAccumulator.DisposeAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -102,6 +109,24 @@ public class AccumulatorAppendBenchmarks
     }
 
     /// <summary>
+    /// Alternates between producer accumulators on one thread. Guards against cache
+    /// invalidation work becoming an O(cache-size) per-message operation.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = 100)]
+    public void AppendAlternatingAccumulators()
+    {
+        var ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        for (var i = 0; i < 100; i++)
+        {
+            var accumulator = (i & 1) == 0 ? _accumulator : _secondAccumulator;
+            AwaitSync(accumulator.AppendFromSpansAsync(
+                "bench-topic", i % 10, ts,
+                _keyBytes, false, _valueBytes, false,
+                null, 0, null, CancellationToken.None));
+        }
+    }
+
+    /// <summary>
     /// Blocks on an append ValueTask. On the hot path the task is already completed and this
     /// is allocation-free. On the cold path (buffer full → pooled PendingAppend source) the
     /// task is not yet completed — GetAwaiter().GetResult() on an incomplete IValueTaskSource
@@ -119,29 +144,34 @@ public class AccumulatorAppendBenchmarks
         valueTask.AsTask().GetAwaiter().GetResult();
     }
 
-    private void FillAndDrain(int partition, int batchCount, int msgsPerBatch, long ts)
+    private void FillAndDrain(
+        RecordAccumulator accumulator,
+        int partition,
+        int batchCount,
+        int msgsPerBatch,
+        long ts)
     {
         var totalMessages = msgsPerBatch * batchCount;
         for (var i = 0; i < totalMessages; i++)
         {
-            AwaitSync(_accumulator.AppendFromSpansAsync(
+            AwaitSync(accumulator.AppendFromSpansAsync(
                 "bench-topic", partition, ts,
                 _keyBytes, false, _valueBytes, false,
                 null, 0, null, CancellationToken.None));
 
             // Drain periodically to release memory and return arenas/arrays to pools
             if (i % msgsPerBatch == msgsPerBatch - 1)
-                DrainAll();
+                DrainAll(accumulator);
         }
-        DrainAll();
+        DrainAll(accumulator);
     }
 
-    private void DrainAll()
+    private static void DrainAll(RecordAccumulator accumulator)
     {
-        while (_accumulator.TryDrainBatch(out var batch))
+        while (accumulator.TryDrainBatch(out var batch))
         {
-            _accumulator.ReleaseMemory(batch.DataSize);
-            _accumulator.ReturnReadyBatch(batch);
+            accumulator.ReleaseMemory(batch.DataSize);
+            accumulator.ReturnReadyBatch(batch);
         }
     }
 
@@ -156,6 +186,12 @@ public class AccumulatorAppendBenchmarks
             {
                 _accumulator.ReleaseMemory(batch.DataSize);
                 _accumulator.ReturnReadyBatch(batch);
+                sw.Reset();
+            }
+            else if (_secondAccumulator.TryDrainBatch(out batch))
+            {
+                _secondAccumulator.ReleaseMemory(batch.DataSize);
+                _secondAccumulator.ReturnReadyBatch(batch);
                 sw.Reset();
             }
             else

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionDequeCacheBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionDequeCacheBenchmarks.cs
@@ -1,0 +1,132 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures one partition-deque cache resolution per produced message. The dictionary is warmed
+/// before measurement, isolating direct-cache hits, collision misses, and thread contention.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 3, iterationCount: 3)]
+public class PartitionDequeCacheBenchmarks
+{
+    private const int ResolutionsPerWorker = 100;
+
+    private RecordAccumulator _accumulator = null!;
+    private AutoResetEvent _partition0Start = null!;
+    private AutoResetEvent _partition16Start = null!;
+    private AutoResetEvent _partition0Done = null!;
+    private AutoResetEvent _partition16Done = null!;
+    private Thread _partition0Worker = null!;
+    private Thread _partition16Worker = null!;
+    private volatile bool _stopWorkers;
+    private Exception? _workerException;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _accumulator = new RecordAccumulator(new ProducerOptions
+        {
+            BootstrapServers = ["localhost:9092"],
+            BufferMemory = ulong.MaxValue,
+            BatchSize = 1_048_576,
+            LingerMs = 0
+        });
+
+        _accumulator.SetPartitionQueueBytesForTest("bench-topic", partition: 0, bytes: 0);
+        _accumulator.SetPartitionQueueBytesForTest("bench-topic", partition: 16, bytes: 0);
+
+        _partition0Start = new AutoResetEvent(false);
+        _partition16Start = new AutoResetEvent(false);
+        _partition0Done = new AutoResetEvent(false);
+        _partition16Done = new AutoResetEvent(false);
+        _partition0Worker = StartWorker(partition: 0, _partition0Start, _partition0Done);
+        _partition16Worker = StartWorker(partition: 16, _partition16Start, _partition16Done);
+
+        RunWorkers();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        _stopWorkers = true;
+        _partition0Start.Set();
+        _partition16Start.Set();
+        _partition0Worker.Join();
+        _partition16Worker.Join();
+        _partition0Start.Dispose();
+        _partition16Start.Dispose();
+        _partition0Done.Dispose();
+        _partition16Done.Dispose();
+        await _accumulator.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Alternates warmed partitions 0 and 16, which map to the same direct-cache slot.
+    /// Every resolution is a cache miss and allocation must remain 0 B/message.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = ResolutionsPerWorker)]
+    public void ResolveColdCacheCollision()
+    {
+        for (var i = 0; i < ResolutionsPerWorker; i++)
+            _accumulator.SetPartitionQueueBytesForTest("bench-topic", (i & 1) << 4, bytes: 0);
+    }
+
+    /// <summary>
+    /// Resolves colliding slots concurrently from two partition-affine producer threads.
+    /// Worker creation and synchronization objects are outside measurement allocations.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = ResolutionsPerWorker * 2)]
+    public void ResolveConcurrentCacheCollision()
+    {
+        RunWorkers();
+
+        if (_workerException is { } exception)
+            throw new InvalidOperationException("Partition-deque cache worker failed.", exception);
+    }
+
+    private Thread StartWorker(int partition, AutoResetEvent start, AutoResetEvent done)
+    {
+        var thread = new Thread(() => WorkerLoop(partition, start, done))
+        {
+            IsBackground = true,
+            Name = $"PartitionDequeCacheBenchmark-p{partition}"
+        };
+        thread.Start();
+        return thread;
+    }
+
+    private void WorkerLoop(int partition, AutoResetEvent start, AutoResetEvent done)
+    {
+        while (true)
+        {
+            start.WaitOne();
+            if (_stopWorkers)
+                return;
+
+            try
+            {
+                for (var i = 0; i < ResolutionsPerWorker; i++)
+                    _accumulator.SetPartitionQueueBytesForTest("bench-topic", partition, bytes: 0);
+            }
+            catch (Exception exception)
+            {
+                Interlocked.CompareExchange(ref _workerException, exception, null);
+            }
+            finally
+            {
+                done.Set();
+            }
+        }
+    }
+
+    private void RunWorkers()
+    {
+        _partition0Start.Set();
+        _partition16Start.Set();
+        _partition0Done.WaitOne();
+        _partition16Done.WaitOne();
+    }
+}


### PR DESCRIPTION
## What

- replace the accumulator's one-slot thread cache with an instance-owned 16-entry direct-mapped cache
- publish whole `PartitionDeque` references atomically; producer switches require no invalidation or scan
- construct `TopicPartition` only on cache miss
- add an alternating-accumulator regression benchmark

## Why

Round-robin production invalidated the one-slot cache on every partition switch, forcing a `ConcurrentDictionary` lookup per message. Instance ownership preserves O(1) lookup across partitions and producers, avoids per-message allocation, and prevents thread-static retention after producer disposal.

Base: `0def34248990d206fc4702d295ae3e6a421e4afe`
Candidate: `0e76f1e6fda39bad7e7d40b4d5e56568eb842bf0`

## BenchmarkDotNet

Windows 11, i7-12700K, .NET 10.0.11, `MemoryDiagnoser`. Review-fix before/after used identical benchmark harnesses sequentially on the same machine.

| Case | Before | After | Delta |
|---|---:|---:|---:|
| Producer Fire, target off, 1 partition | 214.1 ns | 201.7 ns | **-5.8%** |
| Producer Fire, target off, 12 partitions | 241.2 ns | 209.5 ns | **-13.1%** |
| Producer Fire, target 10 ms, 1 partition | 928.9 ns | 936.8 ns | neutral within variance |
| Producer Fire, target 10 ms, 12 partitions | 1,478.1 ns | 1,488.2 ns | neutral within variance |
| Accumulator, 100 B, 1 partition | 72.52 ns | 72.24 ns | neutral |
| Accumulator, 100 B, multi-partition | 78.41 ns | 71.66 ns | **-8.6%** |
| Accumulator, 1 KB, multi-partition | 164.87 ns | 162.36 ns | -1.5% |

Review regression case, prior PR head → final candidate:

| Alternating accumulators | Before | After | Delta |
|---|---:|---:|---:|
| 100 B | 93.21 ns | 73.77 ns | **-20.9%** |
| 1 KB | 171.52 ns | 165.88 ns | -3.3% |

Complete runs preserve 0 B steady-state allocation. Occasional 2-36 B samples are the benchmark's documented stochastic drainer-behind cold path; paired repeat cases returned to 0 B.

## Kafka stress

One broker, 6 partitions, 1 KB, acks=leader, linger=5 ms, batch=1 MiB, target=10 ms, delivery diagnostics, 1 minute.

Two baseline controls:
- average 215,146 / 215,695 msg/s
- median 215,935 / 221,124 msg/s

Candidate repeat:
- average 217,583 msg/s (**+0.9% to +1.1%**)
- median 224,227 msg/s (**+1.4% to +3.8%**)
- p50/p95/p99/max: 42.95 / 195.85 / 241.95 / 351.28 ms (all below both controls)
- CPU 1.156 us/message, 2.593 B/message, zero errors

An earlier candidate run measured 210,560 average / 207,865 median, exposing local broker variance. The repeat and both controls are recorded here; formal duration acceptance should use the repository's same-VM baseline-candidate-baseline lane.

## Checks

- focused accumulator tests: **342 passed**
- full unit suite after final review fix: **6,683 passed**
- Release builds: clean, zero warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved record accumulation efficiency when appending records across multiple topics and partitions.
  * Optimized partition handling for faster lookups, including concurrent and colliding partition workloads.
  * Added benchmark coverage for alternating writes between multiple accumulators.
* **Bug Fixes**
  * Improved isolation of partition processing across topics and accumulator instances.
* **Tests**
  * Expanded coverage for concurrent partition handling and accumulator ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->