### PR TITLE
perf(producer): cache sticky partition state

### DIFF
--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Hashing;
+using System.Runtime.CompilerServices;
 
 namespace Dekaf.Producer;
 
@@ -34,6 +35,12 @@ internal interface IUniformStickyPartitioner
 internal sealed class StickyPartitionTracker
 {
     private readonly ConcurrentDictionary<string, StickyPartitionState> _partitions = new();
+    // One-entry lock-free hint for the overwhelmingly common single-topic producer. Writers
+    // use an odd/even seqlock version so readers never observe a topic from one publication
+    // paired with a state from another.
+    private string? _cachedTopic;
+    private StickyPartitionState? _cachedState;
+    private int _cacheVersion;
     private readonly bool _adaptivePartitioning;
     private readonly int _availabilityTimeoutMs;
     private readonly bool _rackAwarePartitioning;
@@ -438,20 +445,75 @@ internal sealed class StickyPartitionTracker
 
     private StickyPartitionState GetOrCreateAssignedState(string topic, int partitionCount)
     {
+        if (TryGetCachedState(topic) is { } cached)
+            return cached;
+
         if (_partitions.TryGetValue(topic, out var state))
+        {
+            CacheState(topic, state);
             return state;
+        }
 
         var created = new StickyPartitionState(NextPartition(topic, partitionCount, currentPartition: null));
-        return _partitions.GetOrAdd(topic, created);
+        state = _partitions.GetOrAdd(topic, created);
+        CacheState(topic, state);
+        return state;
     }
 
     private StickyPartitionState GetOrCreateStateWithPartition(string topic, int initialPartition)
     {
+        if (TryGetCachedState(topic) is { } cached)
+            return cached;
+
         if (_partitions.TryGetValue(topic, out var state))
+        {
+            CacheState(topic, state);
             return state;
+        }
 
         var created = new StickyPartitionState(initialPartition);
-        return _partitions.GetOrAdd(topic, created);
+        state = _partitions.GetOrAdd(topic, created);
+        CacheState(topic, state);
+        return state;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private StickyPartitionState? TryGetCachedState(string topic)
+    {
+        var version = Volatile.Read(ref _cacheVersion);
+        if ((version & 1) != 0)
+            return null;
+
+        var cachedTopic = _cachedTopic;
+        var cachedState = _cachedState;
+        return version == Volatile.Read(ref _cacheVersion)
+            && string.Equals(cachedTopic, topic, StringComparison.Ordinal)
+                ? cachedState
+                : null;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void CacheState(string topic, StickyPartitionState state)
+    {
+        var spinner = new SpinWait();
+        while (true)
+        {
+            var version = Volatile.Read(ref _cacheVersion);
+            if ((version & 1) != 0
+                || Interlocked.CompareExchange(
+                    ref _cacheVersion,
+                    unchecked(version + 1),
+                    version) != version)
+            {
+                spinner.SpinOnce();
+                continue;
+            }
+
+            _cachedTopic = topic;
+            _cachedState = state;
+            Volatile.Write(ref _cacheVersion, unchecked(version + 2));
+            return;
+        }
     }
 
     private bool IsUnavailable(string topic, int partition, long queueSize)

--- a/src/Dekaf/Producer/Partitioner.cs
+++ b/src/Dekaf/Producer/Partitioner.cs
@@ -34,13 +34,13 @@ internal interface IUniformStickyPartitioner
 
 internal sealed class StickyPartitionTracker
 {
+    private const int StateCacheSize = 16;
+    private const int StateCacheMask = StateCacheSize - 1;
+
     private readonly ConcurrentDictionary<string, StickyPartitionState> _partitions = new();
-    // One-entry lock-free hint for the overwhelmingly common single-topic producer. Writers
-    // use an odd/even seqlock version so readers never observe a topic from one publication
-    // paired with a state from another.
-    private string? _cachedTopic;
-    private StickyPartitionState? _cachedState;
-    private int _cacheVersion;
+    // A state contains its topic, so each cache slot is published with one atomic reference
+    // write. Multi-topic misses never serialize on a writer lock.
+    private readonly StickyPartitionState?[] _stateCache = new StickyPartitionState?[StateCacheSize];
     private readonly bool _adaptivePartitioning;
     private readonly int _availabilityTimeoutMs;
     private readonly bool _rackAwarePartitioning;
@@ -454,7 +454,7 @@ internal sealed class StickyPartitionTracker
             return state;
         }
 
-        var created = new StickyPartitionState(NextPartition(topic, partitionCount, currentPartition: null));
+        var created = new StickyPartitionState(topic, NextPartition(topic, partitionCount, currentPartition: null));
         state = _partitions.GetOrAdd(topic, created);
         CacheState(topic, state);
         return state;
@@ -471,7 +471,7 @@ internal sealed class StickyPartitionTracker
             return state;
         }
 
-        var created = new StickyPartitionState(initialPartition);
+        var created = new StickyPartitionState(topic, initialPartition);
         state = _partitions.GetOrAdd(topic, created);
         CacheState(topic, state);
         return state;
@@ -480,41 +480,20 @@ internal sealed class StickyPartitionTracker
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private StickyPartitionState? TryGetCachedState(string topic)
     {
-        var version = Volatile.Read(ref _cacheVersion);
-        if ((version & 1) != 0)
-            return null;
-
-        var cachedTopic = _cachedTopic;
-        var cachedState = _cachedState;
-        return version == Volatile.Read(ref _cacheVersion)
-            && string.Equals(cachedTopic, topic, StringComparison.Ordinal)
+        var cachedState = Volatile.Read(ref _stateCache[GetStateCacheIndex(topic)]);
+        return cachedState is not null
+            && string.Equals(cachedState.Topic, topic, StringComparison.Ordinal)
                 ? cachedState
                 : null;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CacheState(string topic, StickyPartitionState state)
-    {
-        var spinner = new SpinWait();
-        while (true)
-        {
-            var version = Volatile.Read(ref _cacheVersion);
-            if ((version & 1) != 0
-                || Interlocked.CompareExchange(
-                    ref _cacheVersion,
-                    unchecked(version + 1),
-                    version) != version)
-            {
-                spinner.SpinOnce();
-                continue;
-            }
+        => Volatile.Write(ref _stateCache[GetStateCacheIndex(topic)], state);
 
-            _cachedTopic = topic;
-            _cachedState = state;
-            Volatile.Write(ref _cacheVersion, unchecked(version + 2));
-            return;
-        }
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetStateCacheIndex(string topic)
+        => RuntimeHelpers.GetHashCode(topic) & StateCacheMask;
 
     private bool IsUnavailable(string topic, int partition, long queueSize)
     {
@@ -557,8 +536,9 @@ internal sealed class StickyPartitionTracker
         return result < left ? long.MaxValue : result;
     }
 
-    private sealed class StickyPartitionState(int partition)
+    private sealed class StickyPartitionState(string topic, int partition)
     {
+        public readonly string Topic = topic;
         public long PackedState = PackState(partition, producedBytes: 0);
     }
 

--- a/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
+++ b/tests/Dekaf.Tests.Unit/Producer/PartitionerTests.cs
@@ -363,6 +363,62 @@ public class DefaultPartitionerTests
         await Assert.That(partition).IsGreaterThanOrEqualTo(0);
         await Assert.That(partition).IsLessThan(partitionCount);
     }
+
+    [Test]
+    public async Task Partition_ConcurrentTopics_PreserveIndependentStickyState()
+    {
+        var partitioner = new DefaultPartitioner();
+        var uniform = (IUniformStickyPartitioner)partitioner;
+        const string firstTopic = "first-topic";
+        const string secondTopic = "second-topic";
+        const int partitionCount = 17;
+
+        var firstPartition = partitioner.Partition(
+            firstTopic,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            partitionCount);
+        var secondPartition = partitioner.Partition(
+            secondTopic,
+            ReadOnlySpan<byte>.Empty,
+            keyIsNull: true,
+            partitionCount);
+        while (secondPartition == firstPartition)
+        {
+            partitioner.OnBatchComplete(secondTopic, partitionCount);
+            secondPartition = partitioner.Partition(
+                secondTopic,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                partitionCount);
+        }
+
+        var statePreserved = 1;
+        var tasks = new Task[8];
+        for (var taskIndex = 0; taskIndex < tasks.Length; taskIndex++)
+        {
+            tasks[taskIndex] = Task.Run(() =>
+            {
+                for (var i = 0; i < 10_000; i++)
+                {
+                    var topic = (i & 1) == 0 ? firstTopic : secondTopic;
+                    var expected = (i & 1) == 0 ? firstPartition : secondPartition;
+                    var actual = partitioner.Partition(
+                        topic,
+                        ReadOnlySpan<byte>.Empty,
+                        keyIsNull: true,
+                        partitionCount);
+                    if (actual != expected)
+                        Interlocked.Exchange(ref statePreserved, 0);
+
+                    uniform.OnRecordAppended(topic, actual, bytes: 1, partitionCount);
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks);
+        await Assert.That(statePreserved).IsEqualTo(1);
+    }
 }
 
 public class StickyPartitionerTests

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
@@ -10,6 +10,21 @@ public class PartitionerBenchmarks
 {
     private const string Topic = "partitioner-hot-path";
     private const uint PositiveMask = 0x7fff_ffff;
+    private static readonly string[] Topics =
+    [
+        "partitioner-hot-path-0",
+        "partitioner-hot-path-1",
+        "partitioner-hot-path-2",
+        "partitioner-hot-path-3",
+        "partitioner-hot-path-4",
+        "partitioner-hot-path-5",
+        "partitioner-hot-path-6",
+        "partitioner-hot-path-7",
+        "partitioner-hot-path-8",
+        "partitioner-hot-path-9",
+        "partitioner-hot-path-10",
+        "partitioner-hot-path-11"
+    ];
     private readonly IPartitioner _baselinePartitioner = new HashingDefaultPartitioner();
     private readonly IPartitioner _partitioner = new DefaultPartitioner();
     private readonly IUniformStickyPartitioner _uniformPartitioner;
@@ -44,6 +59,29 @@ public class PartitionerBenchmarks
                 PartitionCount);
             _uniformPartitioner.OnRecordAppended(
                 Topic,
+                partition,
+                bytes: 1_000,
+                PartitionCount);
+            result ^= partition;
+        }
+
+        return result;
+    }
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public int PartitionAndRecordNullKeysAcrossTopics()
+    {
+        var result = 0;
+        for (var i = 0; i < 1_000; i++)
+        {
+            var topic = Topics[i % Topics.Length];
+            var partition = _partitioner.Partition(
+                topic,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                PartitionCount);
+            _uniformPartitioner.OnRecordAppended(
+                topic,
                 partition,
                 bytes: 1_000,
                 PartitionCount);

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/PartitionerBenchmarks.cs
@@ -12,7 +12,13 @@ public class PartitionerBenchmarks
     private const uint PositiveMask = 0x7fff_ffff;
     private readonly IPartitioner _baselinePartitioner = new HashingDefaultPartitioner();
     private readonly IPartitioner _partitioner = new DefaultPartitioner();
+    private readonly IUniformStickyPartitioner _uniformPartitioner;
     private readonly byte[] _key = "benchmark-partition-key"u8.ToArray();
+
+    public PartitionerBenchmarks()
+    {
+        _uniformPartitioner = (IUniformStickyPartitioner)_partitioner;
+    }
 
     [Params(1, 12)]
     public int PartitionCount { get; set; }
@@ -24,6 +30,28 @@ public class PartitionerBenchmarks
     [Benchmark(OperationsPerInvoke = 1_000)]
     public int PartitionKeyedRecords()
         => PartitionKeyedRecords(_partitioner);
+
+    [Benchmark(OperationsPerInvoke = 1_000)]
+    public int PartitionAndRecordNullKeys()
+    {
+        var result = 0;
+        for (var i = 0; i < 1_000; i++)
+        {
+            var partition = _partitioner.Partition(
+                Topic,
+                ReadOnlySpan<byte>.Empty,
+                keyIsNull: true,
+                PartitionCount);
+            _uniformPartitioner.OnRecordAppended(
+                Topic,
+                partition,
+                bytes: 1_000,
+                PartitionCount);
+            result ^= partition;
+        }
+
+        return result;
+    }
 
     private int PartitionKeyedRecords(IPartitioner partitioner)
     {


### PR DESCRIPTION
## What

- add an allocation-free 16-entry direct-mapped state cache to `StickyPartitionTracker`
- publish each topic/state pair with one atomic reference write; no writer lock or spin loop
- add concurrent alternating-topic correctness coverage
- add single-topic and 12-topic null-key producer-shape benchmarks

## Why

Null-key production looked up the same topic twice per message through `ConcurrentDictionary`: once to choose the sticky partition and again to record appended bytes. The fixed cache turns common topic-local paths into lock-free volatile reads while dictionary fallback preserves correctness. Atomic whole-state publication prevents mismatched pairs and avoids serializing multi-topic misses.

Base: `0def34248990d206fc4702d295ae3e6a421e4afe`
Candidate: `755ccd55640a6186adabf9eceeeb0510fdfb3246`

## BenchmarkDotNet

Windows 11, i7-12700K, .NET 10.0.11, `MemoryDiagnoser`, 1,000 operations/invoke. Baseline and final post-review candidate ran sequentially on the same machine.

| Case | Before | After | Delta |
|---|---:|---:|---:|
| Null-key partition + append, 12 partitions | 12.1267 ns | 8.8933 ns | **-26.7%** |
| Null-key partition + append, 12 topics × 12 partitions | 14.0292 ns | 10.5301 ns | **-24.9%** |
| Keyed partition control, 12 partitions | 5.8178 ns | 5.7981 ns | neutral |
| Rack-aware rotation, 10 partitions | 22.00 ns | 19.78 ns | **-10.1%** |
| Rack-aware rotation, 10,000 partitions | 21.95 ns | 20.02 ns | **-8.8%** |

All benchmark cases: **0 B allocated**. The one-partition null-key case bypasses tracker lookup and remained effectively unchanged (0.6519 vs 0.6610 ns).

## Kafka stress

Same one-broker producer configuration as the baseline controls, with delivery diagnostics:

- average 214,080 msg/s vs 215,146 / 215,695 controls (-0.5% / -0.7%)
- median 220,315 msg/s vs 215,935 / 221,124 controls (+2.0% / -0.4%)
- p50/p95/p99: 43.15 / 201.45 / 248.25 ms, below both controls
- CPU 1.224 us/message, inside the 1.120-1.293 control spread
- 2.604 B/message, zero errors

The broker-bound stress result is neutral; the isolated null-key CPU win is deterministic.

## Checks

- concurrent alternating-topic test: 80,000 operations preserve independent sticky state
- post-review focused default-partitioner tests: **20 passed**
- initial full unit suite: **6,684 passed**
- post-review full suite: 6,683 passed; one unrelated `BrokerSender` cancellation/script timing test failed. Exact baseline control passed, and this PR does not touch `BrokerSender`.
- Release builds: clean, zero warnings