### PR TITLE
Fix Schema Registry subject naming compatibility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,10 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="Confluent.Kafka" Version="2.15.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry" Version="2.15.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.15.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Json" Version="2.15.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.15.0" />
     <PackageVersion Include="Dekaf" Version="$(DekafPackageVersion)" />
     <PackageVersion Include="GitVersion.MsBuild" Version="6.8.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
@@ -35,6 +39,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
+    <PackageVersion Include="protobuf-net.Reflection" Version="3.2.12" />
     <PackageVersion Include="Reservoir" Version="1.4.0" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -157,6 +157,10 @@ These formats match Confluent serializers. Avro `GenericRecord` subjects use the
 record's runtime schema, JSON Schema subjects use the schema `title` when present, and Protobuf
 subjects use the message descriptor's full name.
 
+When using the generic `SchemaRegistrySerializer` with a record-based strategy, prefer its
+subject-independent `Func<Schema>` schema factory overload. The subject-aware `Func<string, Schema>`
+overload may be called again with the schema-derived subject until the callback and schema name agree.
+
 ### Migrating subjects created before this fix
 
 Older Dekaf releases appended `-key` or `-value` to `RecordName` and `TopicRecordName` subjects.

--- a/docs/docs/serialization/schema-registry.md
+++ b/docs/docs/serialization/schema-registry.md
@@ -141,14 +141,43 @@ The serializer automatically registers new schema versions and handles compatibi
 ## Subject Naming Strategies
 
 ```csharp
-var serializer = new AvroSerializer<Order>(schemaRegistry, new AvroSerializerConfig
+var serializer = new AvroSchemaRegistrySerializer<Order>(schemaRegistry, new AvroSerializerConfig
 {
-    SubjectNameStrategy = SubjectNameStrategy.TopicRecord
+    SubjectNameStrategy = SubjectNameStrategy.TopicRecordName
 });
 ```
 
-| Strategy | Subject Name |
-|----------|--------------|
-| Topic | `{topic}-value` |
-| Record | `{record-name}` |
-| TopicRecord | `{topic}-{record-name}` |
+| Strategy | Value or key subject |
+|----------|----------------------|
+| `TopicName` | `{topic}-value` or `{topic}-key` |
+| `RecordName` | `{fully-qualified-record-name}` |
+| `TopicRecordName` | `{topic}-{fully-qualified-record-name}` |
+
+These formats match Confluent serializers. Avro `GenericRecord` subjects use the fullname from the
+record's runtime schema, JSON Schema subjects use the schema `title` when present, and Protobuf
+subjects use the message descriptor's full name.
+
+### Migrating subjects created before this fix
+
+Older Dekaf releases appended `-key` or `-value` to `RecordName` and `TopicRecordName` subjects.
+Before upgrading producers, register or copy each schema version from the old suffixed subject to
+the standard subject. Keep the same compatibility mode and version order. For example:
+
+- `com.example.Order-value` becomes `com.example.Order`.
+- `orders-com.example.Order-key` becomes `orders-com.example.Order`.
+
+If consumers or deployment sequencing require a gradual migration, keep the old names temporarily:
+
+```csharp
+var config = new AvroSerializerConfig
+{
+    SubjectNameStrategy = SubjectNameStrategy.RecordName,
+    UseLegacySubjectNames = true
+};
+```
+
+`UseLegacySubjectNames` is also available on `ProtobufSerializerConfig` and as an optional
+constructor/builder-extension argument for JSON Schema and generic Schema Registry serializers.
+It affects only the enum-based `RecordName` and `TopicRecordName` strategies; `TopicName` and custom
+`ISubjectNameStrategy` implementations are unchanged. Disable the option after every producer and
+schema has moved to the standard subject.

--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
+using Avro;
 using Avro.IO;
+using Newtonsoft.Json.Linq;
 using AvroSchema = Avro.Schema;
 
 namespace Dekaf.SchemaRegistry.Avro;
@@ -15,6 +17,382 @@ internal sealed class AvroSchemaReferenceComparer : IEqualityComparer<AvroSchema
     public bool Equals(AvroSchema? x, AvroSchema? y) => ReferenceEquals(x, y);
 
     public int GetHashCode(AvroSchema obj) => RuntimeHelpers.GetHashCode(obj);
+}
+
+internal sealed class AvroSchemaLogicalComparer : IEqualityComparer<AvroSchema>
+{
+    internal static readonly AvroSchemaLogicalComparer Instance = new();
+
+    private static readonly JTokenEqualityComparer JTokenComparer = new();
+
+    [ThreadStatic]
+    private static AvroSchemaComparisonState? _state;
+
+    private AvroSchemaLogicalComparer() { }
+
+    public bool Equals(AvroSchema? x, AvroSchema? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null || x.Tag != y.Tag)
+            return false;
+
+        var state = _state ??= new AvroSchemaComparisonState();
+        state.EqualityPairs.Clear();
+        try
+        {
+            return EqualsCore(x, y, state);
+        }
+        finally
+        {
+            state.EqualityPairs.Clear();
+        }
+    }
+
+    public int GetHashCode(AvroSchema schema)
+    {
+        var state = _state ??= new AvroSchemaComparisonState();
+        state.HashedSchemas.Clear();
+        try
+        {
+            return GetHashCodeCore(schema, state);
+        }
+        finally
+        {
+            state.HashedSchemas.Clear();
+        }
+    }
+
+    private static bool EqualsCore(
+        AvroSchema x,
+        AvroSchema y,
+        AvroSchemaComparisonState state)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x.Tag != y.Tag)
+            return false;
+
+        if (x is NamedSchema xNamed)
+        {
+            if (y is not NamedSchema yNamed || !NamedSchemaEquals(xNamed, yNamed))
+                return false;
+
+            if (!state.EqualityPairs.Add(new AvroSchemaPair(x, y)))
+                return true;
+        }
+
+        if (!PropertiesEqual(
+                AvroSchemaLogicalAccessors.GetProperties(x),
+                AvroSchemaLogicalAccessors.GetProperties(y)))
+        {
+            return false;
+        }
+
+        return x.Tag switch
+        {
+            AvroSchema.Type.Record or AvroSchema.Type.Error =>
+                RecordSchemaEquals((RecordSchema)x, (RecordSchema)y, state),
+            AvroSchema.Type.Enumeration => EnumSchemaEquals((EnumSchema)x, (EnumSchema)y),
+            AvroSchema.Type.Array => EqualsCore(
+                ((ArraySchema)x).ItemSchema,
+                ((ArraySchema)y).ItemSchema,
+                state),
+            AvroSchema.Type.Map => EqualsCore(
+                ((MapSchema)x).ValueSchema,
+                ((MapSchema)y).ValueSchema,
+                state),
+            AvroSchema.Type.Union => UnionSchemaEquals((UnionSchema)x, (UnionSchema)y, state),
+            AvroSchema.Type.Fixed => ((FixedSchema)x).Size == ((FixedSchema)y).Size,
+            AvroSchema.Type.Logical => LogicalSchemaEquals((LogicalSchema)x, (LogicalSchema)y, state),
+            _ => true
+        };
+    }
+
+    private static bool NamedSchemaEquals(NamedSchema x, NamedSchema y) =>
+        string.Equals(x.Fullname, y.Fullname, StringComparison.Ordinal) &&
+        OptionalStringEquals(x.Documentation, y.Documentation) &&
+        SchemaNameListEquals(
+            AvroSchemaLogicalAccessors.GetAliases(x),
+            AvroSchemaLogicalAccessors.GetAliases(y));
+
+    private static bool RecordSchemaEquals(
+        RecordSchema x,
+        RecordSchema y,
+        AvroSchemaComparisonState state)
+    {
+        if (AvroSchemaLogicalAccessors.GetIsRequest(x) !=
+                AvroSchemaLogicalAccessors.GetIsRequest(y) ||
+            x.Fields.Count != y.Fields.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Fields.Count; i++)
+        {
+            if (!FieldEquals(x.Fields[i], y.Fields[i], state))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool FieldEquals(Field x, Field y, AvroSchemaComparisonState state) =>
+        string.Equals(x.Name, y.Name, StringComparison.Ordinal) &&
+        OptionalStringEquals(x.Documentation, y.Documentation) &&
+        JTokenComparer.Equals(x.DefaultValue, y.DefaultValue) &&
+        StringListEquals(x.Aliases, y.Aliases) &&
+        PropertiesEqual(
+            AvroSchemaLogicalAccessors.GetProperties(x),
+            AvroSchemaLogicalAccessors.GetProperties(y)) &&
+        EqualsCore(x.Schema, y.Schema, state);
+
+    private static bool EnumSchemaEquals(EnumSchema x, EnumSchema y) =>
+        StringListEquals(x.Symbols, y.Symbols) &&
+        string.Equals(x.Default, y.Default, StringComparison.Ordinal);
+
+    private static bool UnionSchemaEquals(
+        UnionSchema x,
+        UnionSchema y,
+        AvroSchemaComparisonState state)
+    {
+        if (x.Schemas.Count != y.Schemas.Count)
+            return false;
+
+        for (var i = 0; i < x.Schemas.Count; i++)
+        {
+            if (!EqualsCore(x.Schemas[i], y.Schemas[i], state))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool LogicalSchemaEquals(
+        LogicalSchema x,
+        LogicalSchema y,
+        AvroSchemaComparisonState state) =>
+        string.Equals(x.LogicalTypeName, y.LogicalTypeName, StringComparison.Ordinal) &&
+        EqualsCore(x.BaseSchema, y.BaseSchema, state);
+
+    private static bool PropertiesEqual(PropertyMap? x, PropertyMap? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || x.Count == 0)
+            return y is null || y.Count == 0;
+        if (y is null || y.Count == 0 || x.Count != y.Count)
+            return false;
+
+        foreach (var property in x)
+        {
+            if (!y.TryGetValue(property.Key, out var value) ||
+                !string.Equals(property.Value, value, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool SchemaNameListEquals(IList<SchemaName>? x, IList<SchemaName>? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null || x.Count != y.Count)
+            return false;
+
+        for (var i = 0; i < x.Count; i++)
+        {
+            if (!string.Equals(x[i].Fullname, y[i].Fullname, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool StringListEquals(IList<string>? x, IList<string>? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null || x.Count != y.Count)
+            return false;
+
+        for (var i = 0; i < x.Count; i++)
+        {
+            if (!string.Equals(x[i], y[i], StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int GetHashCodeCore(AvroSchema schema, AvroSchemaComparisonState state)
+    {
+        if (schema is NamedSchema named && !state.HashedSchemas.Add(schema))
+            return Combine((int)schema.Tag, GetStringHashCode(named.Fullname));
+
+        var hash = Combine(
+            (int)schema.Tag,
+            GetPropertiesHashCode(AvroSchemaLogicalAccessors.GetProperties(schema)));
+
+        if (schema is NamedSchema namedSchema)
+        {
+            hash = Combine(hash, GetStringHashCode(namedSchema.Fullname));
+            hash = Combine(hash, GetOptionalStringHashCode(namedSchema.Documentation));
+            hash = Combine(
+                hash,
+                GetSchemaNameListHashCode(AvroSchemaLogicalAccessors.GetAliases(namedSchema)));
+        }
+
+        return schema.Tag switch
+        {
+            AvroSchema.Type.Record or AvroSchema.Type.Error =>
+                GetRecordSchemaHashCode(hash, (RecordSchema)schema, state),
+            AvroSchema.Type.Enumeration => GetEnumSchemaHashCode(hash, (EnumSchema)schema),
+            AvroSchema.Type.Array => Combine(
+                hash,
+                GetHashCodeCore(((ArraySchema)schema).ItemSchema, state)),
+            AvroSchema.Type.Map => Combine(
+                hash,
+                GetHashCodeCore(((MapSchema)schema).ValueSchema, state)),
+            AvroSchema.Type.Union => GetUnionSchemaHashCode(hash, (UnionSchema)schema, state),
+            AvroSchema.Type.Fixed => Combine(hash, ((FixedSchema)schema).Size),
+            AvroSchema.Type.Logical => GetLogicalSchemaHashCode(hash, (LogicalSchema)schema, state),
+            _ => hash
+        };
+    }
+
+    private static int GetRecordSchemaHashCode(
+        int hash,
+        RecordSchema schema,
+        AvroSchemaComparisonState state)
+    {
+        hash = Combine(hash, AvroSchemaLogicalAccessors.GetIsRequest(schema) ? 1 : 0);
+        hash = Combine(hash, schema.Fields.Count);
+        for (var i = 0; i < schema.Fields.Count; i++)
+            hash = Combine(hash, GetFieldHashCode(schema.Fields[i], state));
+        return hash;
+    }
+
+    private static int GetFieldHashCode(Field field, AvroSchemaComparisonState state)
+    {
+        var hash = Combine(GetStringHashCode(field.Name), GetOptionalStringHashCode(field.Documentation));
+        hash = Combine(
+            hash,
+            field.DefaultValue is null ? 0 : JTokenComparer.GetHashCode(field.DefaultValue));
+        hash = Combine(hash, GetStringListHashCode(field.Aliases));
+        hash = Combine(
+            hash,
+            GetPropertiesHashCode(AvroSchemaLogicalAccessors.GetProperties(field)));
+        return Combine(hash, GetHashCodeCore(field.Schema, state));
+    }
+
+    private static int GetEnumSchemaHashCode(int hash, EnumSchema schema)
+    {
+        hash = Combine(hash, GetStringListHashCode(schema.Symbols));
+        return Combine(hash, GetStringHashCode(schema.Default));
+    }
+
+    private static int GetUnionSchemaHashCode(
+        int hash,
+        UnionSchema schema,
+        AvroSchemaComparisonState state)
+    {
+        hash = Combine(hash, schema.Schemas.Count);
+        for (var i = 0; i < schema.Schemas.Count; i++)
+            hash = Combine(hash, GetHashCodeCore(schema.Schemas[i], state));
+        return hash;
+    }
+
+    private static int GetLogicalSchemaHashCode(
+        int hash,
+        LogicalSchema schema,
+        AvroSchemaComparisonState state)
+    {
+        hash = Combine(hash, GetStringHashCode(schema.LogicalTypeName));
+        return Combine(hash, GetHashCodeCore(schema.BaseSchema, state));
+    }
+
+    private static int GetPropertiesHashCode(PropertyMap? properties)
+    {
+        if (properties is null)
+            return 0;
+
+        var sum = 0;
+        var xor = 0;
+        foreach (var property in properties)
+        {
+            var propertyHash = Combine(
+                GetStringHashCode(property.Key),
+                GetStringHashCode(property.Value));
+            sum = unchecked(sum + propertyHash);
+            xor ^= propertyHash;
+        }
+
+        return Combine(properties.Count, Combine(sum, xor));
+    }
+
+    private static int GetSchemaNameListHashCode(IList<SchemaName>? names)
+    {
+        if (names is null)
+            return 0;
+
+        var hash = names.Count;
+        for (var i = 0; i < names.Count; i++)
+            hash = Combine(hash, GetStringHashCode(names[i].Fullname));
+        return hash;
+    }
+
+    private static int GetStringListHashCode(IList<string>? values)
+    {
+        if (values is null)
+            return 0;
+
+        var hash = values.Count;
+        for (var i = 0; i < values.Count; i++)
+            hash = Combine(hash, GetStringHashCode(values[i]));
+        return hash;
+    }
+
+    private static int GetStringHashCode(string? value) =>
+        value is null ? 0 : StringComparer.Ordinal.GetHashCode(value);
+
+    private static bool OptionalStringEquals(string? x, string? y) =>
+        string.IsNullOrEmpty(x)
+            ? string.IsNullOrEmpty(y)
+            : string.Equals(x, y, StringComparison.Ordinal);
+
+    private static int GetOptionalStringHashCode(string? value) =>
+        string.IsNullOrEmpty(value) ? 0 : StringComparer.Ordinal.GetHashCode(value);
+
+    private static int Combine(int hash, int value) =>
+        unchecked((hash * 16777619) ^ value);
+
+    private sealed class AvroSchemaComparisonState
+    {
+        internal HashSet<AvroSchema> HashedSchemas { get; } =
+            new(AvroSchemaReferenceComparer.Instance);
+
+        internal HashSet<AvroSchemaPair> EqualityPairs { get; } =
+            new(AvroSchemaPairReferenceComparer.Instance);
+    }
+}
+
+internal static class AvroSchemaLogicalAccessors
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "<Props>k__BackingField")]
+    internal static extern ref PropertyMap? GetProperties(AvroSchema schema);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "aliases")]
+    internal static extern ref IList<SchemaName>? GetAliases(NamedSchema schema);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Props")]
+    internal static extern ref PropertyMap? GetProperties(Field field);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "request")]
+    internal static extern ref bool GetIsRequest(RecordSchema schema);
 }
 
 internal sealed class AvroSchemaPairReferenceComparer : IEqualityComparer<AvroSchemaPair>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -73,40 +73,52 @@ internal sealed class AvroSchemaLogicalComparer : IEqualityComparer<AvroSchema>
         if (x.Tag != y.Tag)
             return false;
 
+        var pair = default(AvroSchemaPair);
+        var pairAdded = false;
         if (x is NamedSchema xNamed)
         {
             if (y is not NamedSchema yNamed || !NamedSchemaEquals(xNamed, yNamed))
                 return false;
 
-            if (!state.EqualityPairs.Add(new AvroSchemaPair(x, y)))
+            pair = new AvroSchemaPair(x, y);
+            if (!state.EqualityPairs.Add(pair))
                 return true;
+            pairAdded = true;
         }
 
-        if (!PropertiesEqual(
-                AvroSchemaLogicalAccessors.GetProperties(x),
-                AvroSchemaLogicalAccessors.GetProperties(y)))
+        try
         {
-            return false;
-        }
+            if (!PropertiesEqual(
+                    AvroSchemaLogicalAccessors.GetProperties(x),
+                    AvroSchemaLogicalAccessors.GetProperties(y)))
+            {
+                return false;
+            }
 
-        return x.Tag switch
+            return x.Tag switch
+            {
+                AvroSchema.Type.Record or AvroSchema.Type.Error =>
+                    RecordSchemaEquals((RecordSchema)x, (RecordSchema)y, state),
+                AvroSchema.Type.Enumeration => EnumSchemaEquals((EnumSchema)x, (EnumSchema)y),
+                AvroSchema.Type.Array => EqualsCore(
+                    ((ArraySchema)x).ItemSchema,
+                    ((ArraySchema)y).ItemSchema,
+                    state),
+                AvroSchema.Type.Map => EqualsCore(
+                    ((MapSchema)x).ValueSchema,
+                    ((MapSchema)y).ValueSchema,
+                    state),
+                AvroSchema.Type.Union => UnionSchemaEquals((UnionSchema)x, (UnionSchema)y, state),
+                AvroSchema.Type.Fixed => ((FixedSchema)x).Size == ((FixedSchema)y).Size,
+                AvroSchema.Type.Logical => LogicalSchemaEquals((LogicalSchema)x, (LogicalSchema)y, state),
+                _ => true
+            };
+        }
+        finally
         {
-            AvroSchema.Type.Record or AvroSchema.Type.Error =>
-                RecordSchemaEquals((RecordSchema)x, (RecordSchema)y, state),
-            AvroSchema.Type.Enumeration => EnumSchemaEquals((EnumSchema)x, (EnumSchema)y),
-            AvroSchema.Type.Array => EqualsCore(
-                ((ArraySchema)x).ItemSchema,
-                ((ArraySchema)y).ItemSchema,
-                state),
-            AvroSchema.Type.Map => EqualsCore(
-                ((MapSchema)x).ValueSchema,
-                ((MapSchema)y).ValueSchema,
-                state),
-            AvroSchema.Type.Union => UnionSchemaEquals((UnionSchema)x, (UnionSchema)y, state),
-            AvroSchema.Type.Fixed => ((FixedSchema)x).Size == ((FixedSchema)y).Size,
-            AvroSchema.Type.Logical => LogicalSchemaEquals((LogicalSchema)x, (LogicalSchema)y, state),
-            _ => true
-        };
+            if (pairAdded)
+                state.EqualityPairs.Remove(pair);
+        }
     }
 
     private static bool NamedSchemaEquals(NamedSchema x, NamedSchema y) =>
@@ -230,38 +242,47 @@ internal sealed class AvroSchemaLogicalComparer : IEqualityComparer<AvroSchema>
 
     private static int GetHashCodeCore(AvroSchema schema, AvroSchemaComparisonState state)
     {
-        if (schema is NamedSchema named && !state.HashedSchemas.Add(schema))
-            return Combine((int)schema.Tag, GetStringHashCode(named.Fullname));
+        var tracksPath = schema is NamedSchema;
+        if (tracksPath && !state.HashedSchemas.Add(schema))
+            return Combine((int)schema.Tag, GetStringHashCode(((NamedSchema)schema).Fullname));
 
-        var hash = Combine(
-            (int)schema.Tag,
-            GetPropertiesHashCode(AvroSchemaLogicalAccessors.GetProperties(schema)));
-
-        if (schema is NamedSchema namedSchema)
+        try
         {
-            hash = Combine(hash, GetStringHashCode(namedSchema.Fullname));
-            hash = Combine(hash, GetOptionalStringHashCode(namedSchema.Documentation));
-            hash = Combine(
-                hash,
-                GetSchemaNameListHashCode(AvroSchemaLogicalAccessors.GetAliases(namedSchema)));
+            var hash = Combine(
+                (int)schema.Tag,
+                GetPropertiesHashCode(AvroSchemaLogicalAccessors.GetProperties(schema)));
+
+            if (schema is NamedSchema namedSchema)
+            {
+                hash = Combine(hash, GetStringHashCode(namedSchema.Fullname));
+                hash = Combine(hash, GetOptionalStringHashCode(namedSchema.Documentation));
+                hash = Combine(
+                    hash,
+                    GetSchemaNameListHashCode(AvroSchemaLogicalAccessors.GetAliases(namedSchema)));
+            }
+
+            return schema.Tag switch
+            {
+                AvroSchema.Type.Record or AvroSchema.Type.Error =>
+                    GetRecordSchemaHashCode(hash, (RecordSchema)schema, state),
+                AvroSchema.Type.Enumeration => GetEnumSchemaHashCode(hash, (EnumSchema)schema),
+                AvroSchema.Type.Array => Combine(
+                    hash,
+                    GetHashCodeCore(((ArraySchema)schema).ItemSchema, state)),
+                AvroSchema.Type.Map => Combine(
+                    hash,
+                    GetHashCodeCore(((MapSchema)schema).ValueSchema, state)),
+                AvroSchema.Type.Union => GetUnionSchemaHashCode(hash, (UnionSchema)schema, state),
+                AvroSchema.Type.Fixed => Combine(hash, ((FixedSchema)schema).Size),
+                AvroSchema.Type.Logical => GetLogicalSchemaHashCode(hash, (LogicalSchema)schema, state),
+                _ => hash
+            };
         }
-
-        return schema.Tag switch
+        finally
         {
-            AvroSchema.Type.Record or AvroSchema.Type.Error =>
-                GetRecordSchemaHashCode(hash, (RecordSchema)schema, state),
-            AvroSchema.Type.Enumeration => GetEnumSchemaHashCode(hash, (EnumSchema)schema),
-            AvroSchema.Type.Array => Combine(
-                hash,
-                GetHashCodeCore(((ArraySchema)schema).ItemSchema, state)),
-            AvroSchema.Type.Map => Combine(
-                hash,
-                GetHashCodeCore(((MapSchema)schema).ValueSchema, state)),
-            AvroSchema.Type.Union => GetUnionSchemaHashCode(hash, (UnionSchema)schema, state),
-            AvroSchema.Type.Fixed => Combine(hash, ((FixedSchema)schema).Size),
-            AvroSchema.Type.Logical => GetLogicalSchemaHashCode(hash, (LogicalSchema)schema, state),
-            _ => hash
-        };
+            if (tracksPath)
+                state.HashedSchemas.Remove(schema);
+        }
     }
 
     private static int GetRecordSchemaHashCode(

--- a/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroCodecCache.cs
@@ -153,6 +153,7 @@ internal sealed class AvroSchemaLogicalComparer : IEqualityComparer<AvroSchema>
         string.Equals(x.Name, y.Name, StringComparison.Ordinal) &&
         OptionalStringEquals(x.Documentation, y.Documentation) &&
         JTokenComparer.Equals(x.DefaultValue, y.DefaultValue) &&
+        x.Ordering == y.Ordering &&
         StringListEquals(x.Aliases, y.Aliases) &&
         PropertiesEqual(
             AvroSchemaLogicalAccessors.GetProperties(x),
@@ -303,6 +304,7 @@ internal sealed class AvroSchemaLogicalComparer : IEqualityComparer<AvroSchema>
         hash = Combine(
             hash,
             field.DefaultValue is null ? 0 : JTokenComparer.GetHashCode(field.DefaultValue));
+        hash = Combine(hash, (int?)field.Ordering ?? -1);
         hash = Combine(hash, GetStringListHashCode(field.Aliases));
         hash = Combine(
             hash,

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -46,13 +46,17 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly AvroSerializerConfig _config;
     private readonly bool _ownsClient;
-    private readonly ConcurrentDictionary<string, Lazy<Task<int>>> _schemaIdCache = new();
+    private readonly ConcurrentDictionary<SchemaIdCacheKey, Lazy<Task<int>>> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
+    private readonly ConcurrentDictionary<AvroSchema, SubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
+        new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
+    private AvroSchema? _lastDynamicSchema;
+    private SubjectSchemaIdCache? _lastDynamicSubjectSchemaIdCache;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -92,10 +96,11 @@ public sealed class AvroSchemaRegistrySerializer<
     public async Task<int> WarmupAsync(string topic, T value, bool isKey = false, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(value);
-        var subject = GetSubjectName(topic, isKey, value);
-        var schema = CreateRegistrySchema(value);
+        var avroSchema = GetSchemaForValue(value);
+        var subject = GetSubjectName(topic, isKey, avroSchema);
+        var schema = CreateRegistrySchema(avroSchema);
         var schemaId = await GetOrFetchSchemaIdAsync(subject, schema, cancellationToken).ConfigureAwait(false);
-        CacheSubjectSchemaId(topic, isKey, subject, schemaId, schema);
+        CacheSubjectSchemaId(topic, isKey, avroSchema, subject, schemaId, schema);
         return schemaId;
     }
 
@@ -110,7 +115,8 @@ public sealed class AvroSchemaRegistrySerializer<
         ArgumentNullException.ThrowIfNull(value);
 
         var isKey = context.Component == SerializationComponent.Key;
-        if (_subjectSchemaIdCache.Contains(context.Topic, isKey))
+        var avroSchema = GetSchemaForValue(value);
+        if (GetSubjectSchemaIdCache(avroSchema).Contains(context.Topic, isKey))
         {
             return ValueTask.CompletedTask;
         }
@@ -261,21 +267,35 @@ public sealed class AvroSchemaRegistrySerializer<
     }
 
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry GetSchemaForContext(string topic, bool isKey, T value)
-        => _subjectSchemaIdCache.GetOrAdd(
+    {
+        var avroSchema = GetSchemaForValue(value);
+        var state = new SubjectSchemaIdState(this, avroSchema);
+        return GetSubjectSchemaIdCache(avroSchema).GetOrAdd(
             topic,
             isKey,
-            new SubjectSchemaIdState(this, value),
-            static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey, state.Value),
-            static (state, subject) => state.Serializer.GetSchemaIdCacheValue(subject, state.Value));
+            state,
+            static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey, state.Schema),
+            static (state, subject) => state.Serializer.GetSchemaIdCacheValue(subject, state.Schema));
+    }
 
-    private int CacheSubjectSchemaId(string topic, bool isKey, string subject, int schemaId, RegistrySchema schema)
-        => _subjectSchemaIdCache.Cache(topic, isKey, subject, schemaId, schema);
+    private int CacheSubjectSchemaId(
+        string topic,
+        bool isKey,
+        AvroSchema avroSchema,
+        string subject,
+        int schemaId,
+        RegistrySchema schema) =>
+        GetSubjectSchemaIdCache(avroSchema).Cache(topic, isKey, subject, schemaId, schema);
 
-    private readonly record struct SubjectSchemaIdState(AvroSchemaRegistrySerializer<T> Serializer, T Value);
+    private readonly record struct SubjectSchemaIdState(
+        AvroSchemaRegistrySerializer<T> Serializer,
+        AvroSchema Schema);
 
-    private SubjectSchemaIdCache.SubjectSchemaIdCacheValue GetSchemaIdCacheValue(string subject, T value)
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheValue GetSchemaIdCacheValue(
+        string subject,
+        AvroSchema avroSchema)
     {
-        var schema = CreateRegistrySchema(value);
+        var schema = CreateRegistrySchema(avroSchema);
         return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(GetSchemaIdCached(subject, schema), schema);
     }
 
@@ -338,26 +358,30 @@ public sealed class AvroSchemaRegistrySerializer<
 
     private Lazy<Task<int>> GetOrAddSchemaIdLazy(string subject, RegistrySchema schema)
     {
-        if (_schemaIdCache.TryGetValue(subject, out var cached))
+        var key = new SchemaIdCacheKey(subject, schema.SchemaString);
+        if (_schemaIdCache.TryGetValue(key, out var cached))
             return cached;
 
         return _schemaIdCache.GetOrAdd(
-            subject,
+            key,
             static (key, state) => state.Serializer.CreateSchemaIdLazy(key, state.Schema),
             new SchemaIdFetchState(this, schema));
     }
 
-    private Lazy<Task<int>> CreateSchemaIdLazy(string subject, RegistrySchema schema) =>
-        new(() => FetchSchemaIdAsync(subject, schema));
+    private Lazy<Task<int>> CreateSchemaIdLazy(SchemaIdCacheKey key, RegistrySchema schema) =>
+        new(() => FetchSchemaIdAsync(key, schema));
+
+    private readonly record struct SchemaIdCacheKey(string Subject, string SchemaString);
 
     private readonly record struct SchemaIdFetchState(
         AvroSchemaRegistrySerializer<T> Serializer,
         RegistrySchema Schema);
 
     private async Task<int> FetchSchemaIdAsync(
-        string subject,
+        SchemaIdCacheKey key,
         RegistrySchema registrySchema)
     {
+        var subject = key.Subject;
         try
         {
             if (_config.UseLatestVersion)
@@ -390,14 +414,13 @@ public sealed class AvroSchemaRegistrySerializer<
         }
         catch
         {
-            _schemaIdCache.TryRemove(subject, out _);
+            _schemaIdCache.TryRemove(key, out _);
             throw;
         }
     }
 
-    private RegistrySchema CreateRegistrySchema(T value)
+    private static RegistrySchema CreateRegistrySchema(AvroSchema avroSchema)
     {
-        var avroSchema = GetSchemaFromValue(value);
         return new RegistrySchema
         {
             SchemaType = SchemaType.Avro,
@@ -416,6 +439,26 @@ public sealed class AvroSchemaRegistrySerializer<
         };
     }
 
+    private AvroSchema GetSchemaForValue(T value) =>
+        _writerSchema ?? GetSchemaFromValue(value);
+
+    private SubjectSchemaIdCache GetSubjectSchemaIdCache(AvroSchema schema)
+    {
+        if (_writerSchema is not null)
+            return _subjectSchemaIdCache;
+
+        var lastSchema = Volatile.Read(ref _lastDynamicSchema);
+        if (ReferenceEquals(lastSchema, schema))
+            return Volatile.Read(ref _lastDynamicSubjectSchemaIdCache)!;
+
+        var cache = _dynamicSubjectSchemaIdCaches.GetOrAdd(
+            schema,
+            static _ => new SubjectSchemaIdCache());
+        Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, cache);
+        Volatile.Write(ref _lastDynamicSchema, schema);
+        return cache;
+    }
+
     private static AvroSchema? GetSchemaFromType()
     {
         // Check if T implements ISpecificRecord and has a static Schema property
@@ -431,9 +474,9 @@ public sealed class AvroSchemaRegistrySerializer<
         return null;
     }
 
-    private string GetSubjectName(string topic, bool isKey, T value)
+    private string GetSubjectName(string topic, bool isKey, AvroSchema schema)
     {
-        var recordName = GetRecordName(value);
+        var recordName = GetRecordName(schema);
         if (_config.CustomSubjectNameStrategy is not null)
         {
             return _config.CustomSubjectNameStrategy.GetSubjectName(topic, recordName, isKey);
@@ -447,9 +490,9 @@ public sealed class AvroSchemaRegistrySerializer<
             _config.UseLegacySubjectNames);
     }
 
-    private string GetRecordName(T value)
+    private static string GetRecordName(AvroSchema schema)
     {
-        return GetSchemaFromValue(value) is global::Avro.RecordSchema recordSchema
+        return schema is global::Avro.RecordSchema recordSchema
             ? recordSchema.Fullname
             : typeof(T).FullName ?? typeof(T).Name;
     }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -49,17 +48,15 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<SchemaIdCacheKey, Lazy<Task<int>>> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly ConcurrentDictionary<string, SubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
-        new(StringComparer.Ordinal);
-    private readonly ConditionalWeakTable<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCachesByInstance = new();
-    private readonly ConditionalWeakTable<AvroSchema, DynamicSubjectSchemaIdCache>.CreateValueCallback
-        _createDynamicSubjectSchemaIdCache;
-    private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
-        new(AvroSchemaReferenceComparer.Instance);
+    private readonly ConcurrentDictionary<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
+        new(AvroSchemaLogicalComparer.Instance);
+    private readonly ConcurrentDictionary<AvroSchema, DynamicGenericWriter> _genericWriters =
+        new(AvroSchemaLogicalComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
     private DynamicSubjectSchemaIdCache? _lastDynamicSubjectSchemaIdCache;
+    private DynamicGenericWriter? _lastDynamicGenericWriter;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -75,7 +72,6 @@ public sealed class AvroSchemaRegistrySerializer<
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new AvroSerializerConfig();
         _ownsClient = ownsClient;
-        _createDynamicSubjectSchemaIdCache = CreateDynamicSubjectSchemaIdCache;
 
         // Try to get schema from type T if it's a specific record
         _writerSchema = GetSchemaFromType();
@@ -316,9 +312,7 @@ public sealed class AvroSchemaRegistrySerializer<
                 break;
 
             case GenericRecord genericRecord:
-                var genericWriter = _genericWriters.GetOrAdd(
-                    genericRecord.Schema,
-                    static schema => new GenericDatumWriter<GenericRecord>(schema));
+                var genericWriter = GetGenericWriter(genericRecord.Schema);
                 genericWriter.Write(genericRecord, encoder);
                 break;
 
@@ -456,19 +450,24 @@ public sealed class AvroSchemaRegistrySerializer<
         if (last is not null && ReferenceEquals(last.Schema, schema))
             return last.Cache;
 
-        var entry = _dynamicSubjectSchemaIdCachesByInstance.GetValue(
+        var entry = _dynamicSubjectSchemaIdCaches.GetOrAdd(
             schema,
-            _createDynamicSubjectSchemaIdCache);
+            static schema => new DynamicSubjectSchemaIdCache(schema, new SubjectSchemaIdCache()));
         Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, entry);
         return entry.Cache;
     }
 
-    private DynamicSubjectSchemaIdCache CreateDynamicSubjectSchemaIdCache(AvroSchema schema)
+    private GenericDatumWriter<GenericRecord> GetGenericWriter(AvroSchema schema)
     {
-        var cache = _dynamicSubjectSchemaIdCaches.GetOrAdd(
-            schema.ToString(),
-            static _ => new SubjectSchemaIdCache());
-        return new DynamicSubjectSchemaIdCache(schema, cache);
+        var last = Volatile.Read(ref _lastDynamicGenericWriter);
+        if (last is not null && ReferenceEquals(last.Schema, schema))
+            return last.Writer;
+
+        var entry = _genericWriters.GetOrAdd(
+            schema,
+            static schema => new DynamicGenericWriter(schema));
+        Volatile.Write(ref _lastDynamicGenericWriter, entry);
+        return entry.Writer;
     }
 
     private sealed class DynamicSubjectSchemaIdCache
@@ -481,6 +480,18 @@ public sealed class AvroSchemaRegistrySerializer<
 
         internal AvroSchema Schema { get; }
         internal SubjectSchemaIdCache Cache { get; }
+    }
+
+    private sealed class DynamicGenericWriter
+    {
+        internal DynamicGenericWriter(AvroSchema schema)
+        {
+            Schema = schema;
+            Writer = new GenericDatumWriter<GenericRecord>(schema);
+        }
+
+        internal AvroSchema Schema { get; }
+        internal GenericDatumWriter<GenericRecord> Writer { get; }
     }
 
     private static AvroSchema? GetSchemaFromType()

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -48,15 +48,14 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<SchemaIdCacheKey, Lazy<Task<int>>> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly ConcurrentDictionary<AvroSchema, SubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
+    private readonly ConcurrentDictionary<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
-    private AvroSchema? _lastDynamicSchema;
-    private SubjectSchemaIdCache? _lastDynamicSubjectSchemaIdCache;
+    private DynamicSubjectSchemaIdCache? _lastDynamicSubjectSchemaIdCache;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -447,16 +446,27 @@ public sealed class AvroSchemaRegistrySerializer<
         if (_writerSchema is not null)
             return _subjectSchemaIdCache;
 
-        var lastSchema = Volatile.Read(ref _lastDynamicSchema);
-        if (ReferenceEquals(lastSchema, schema))
-            return Volatile.Read(ref _lastDynamicSubjectSchemaIdCache)!;
+        var last = Volatile.Read(ref _lastDynamicSubjectSchemaIdCache);
+        if (last is not null && ReferenceEquals(last.Schema, schema))
+            return last.Cache;
 
-        var cache = _dynamicSubjectSchemaIdCaches.GetOrAdd(
+        var entry = _dynamicSubjectSchemaIdCaches.GetOrAdd(
             schema,
-            static _ => new SubjectSchemaIdCache());
-        Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, cache);
-        Volatile.Write(ref _lastDynamicSchema, schema);
-        return cache;
+            static schema => new DynamicSubjectSchemaIdCache(schema));
+        Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, entry);
+        return entry.Cache;
+    }
+
+    private sealed class DynamicSubjectSchemaIdCache
+    {
+        internal DynamicSubjectSchemaIdCache(AvroSchema schema)
+        {
+            Schema = schema;
+            Cache = new SubjectSchemaIdCache();
+        }
+
+        internal AvroSchema Schema { get; }
+        internal SubjectSchemaIdCache Cache { get; }
     }
 
     private static AvroSchema? GetSchemaFromType()

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Avro.Generic;
 using Avro.IO;
 using Avro.Specific;
@@ -48,8 +49,11 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<SchemaIdCacheKey, Lazy<Task<int>>> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly ConcurrentDictionary<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
-        new(AvroSchemaReferenceComparer.Instance);
+    private readonly ConcurrentDictionary<string, SubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
+        new(StringComparer.Ordinal);
+    private readonly ConditionalWeakTable<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCachesByInstance = new();
+    private readonly ConditionalWeakTable<AvroSchema, DynamicSubjectSchemaIdCache>.CreateValueCallback
+        _createDynamicSubjectSchemaIdCache;
     private readonly ConcurrentDictionary<AvroSchema, GenericDatumWriter<GenericRecord>> _genericWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
@@ -71,6 +75,7 @@ public sealed class AvroSchemaRegistrySerializer<
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _config = config ?? new AvroSerializerConfig();
         _ownsClient = ownsClient;
+        _createDynamicSubjectSchemaIdCache = CreateDynamicSubjectSchemaIdCache;
 
         // Try to get schema from type T if it's a specific record
         _writerSchema = GetSchemaFromType();
@@ -78,6 +83,7 @@ public sealed class AvroSchemaRegistrySerializer<
 
     internal int CachedGenericWriterCount => _genericWriters.Count;
     internal int CachedSpecificWriterCount => _specificWriters.Count;
+    internal int CachedDynamicSubjectSchemaCount => _dynamicSubjectSchemaIdCaches.Count;
 
     /// <summary>
     /// Pre-warms the schema cache for a specific topic.
@@ -450,19 +456,27 @@ public sealed class AvroSchemaRegistrySerializer<
         if (last is not null && ReferenceEquals(last.Schema, schema))
             return last.Cache;
 
-        var entry = _dynamicSubjectSchemaIdCaches.GetOrAdd(
+        var entry = _dynamicSubjectSchemaIdCachesByInstance.GetValue(
             schema,
-            static schema => new DynamicSubjectSchemaIdCache(schema));
+            _createDynamicSubjectSchemaIdCache);
         Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, entry);
         return entry.Cache;
     }
 
+    private DynamicSubjectSchemaIdCache CreateDynamicSubjectSchemaIdCache(AvroSchema schema)
+    {
+        var cache = _dynamicSubjectSchemaIdCaches.GetOrAdd(
+            schema.ToString(),
+            static _ => new SubjectSchemaIdCache());
+        return new DynamicSubjectSchemaIdCache(schema, cache);
+    }
+
     private sealed class DynamicSubjectSchemaIdCache
     {
-        internal DynamicSubjectSchemaIdCache(AvroSchema schema)
+        internal DynamicSubjectSchemaIdCache(AvroSchema schema, SubjectSchemaIdCache cache)
         {
             Schema = schema;
-            Cache = new SubjectSchemaIdCache();
+            Cache = cache;
         }
 
         internal AvroSchema Schema { get; }

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -92,7 +92,7 @@ public sealed class AvroSchemaRegistrySerializer<
     public async Task<int> WarmupAsync(string topic, T value, bool isKey = false, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(value);
-        var subject = GetSubjectName(topic, isKey);
+        var subject = GetSubjectName(topic, isKey, value);
         var schema = CreateRegistrySchema(value);
         var schemaId = await GetOrFetchSchemaIdAsync(subject, schema, cancellationToken).ConfigureAwait(false);
         CacheSubjectSchemaId(topic, isKey, subject, schemaId, schema);
@@ -265,7 +265,7 @@ public sealed class AvroSchemaRegistrySerializer<
             topic,
             isKey,
             new SubjectSchemaIdState(this, value),
-            static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey),
+            static (state, topic, isKey) => state.Serializer.GetSubjectName(topic, isKey, state.Value),
             static (state, subject) => state.Serializer.GetSchemaIdCacheValue(subject, state.Value));
 
     private int CacheSubjectSchemaId(string topic, bool isKey, string subject, int schemaId, RegistrySchema schema)
@@ -431,36 +431,27 @@ public sealed class AvroSchemaRegistrySerializer<
         return null;
     }
 
-    private string GetSubjectName(string topic, bool isKey)
+    private string GetSubjectName(string topic, bool isKey, T value)
     {
+        var recordName = GetRecordName(value);
         if (_config.CustomSubjectNameStrategy is not null)
         {
-            return _config.CustomSubjectNameStrategy.GetSubjectName(topic, GetRecordName(), isKey);
+            return _config.CustomSubjectNameStrategy.GetSubjectName(topic, recordName, isKey);
         }
 
-        var suffix = isKey ? "-key" : "-value";
-        return _config.SubjectNameStrategy switch
-        {
-            SubjectNameStrategy.TopicName => topic + suffix,
-            SubjectNameStrategy.RecordName => GetRecordName() + suffix,
-            SubjectNameStrategy.TopicRecordName => $"{topic}-{GetRecordName()}{suffix}",
-            _ => topic + suffix
-        };
+        return SubjectNameResolver.GetSubjectName(
+            _config.SubjectNameStrategy,
+            topic,
+            recordName,
+            isKey,
+            _config.UseLegacySubjectNames);
     }
 
-    private static string GetRecordName()
+    private string GetRecordName(T value)
     {
-        // For Avro specific records, try to get the full name from schema
-        if (typeof(ISpecificRecord).IsAssignableFrom(typeof(T)))
-        {
-            // Avro generated classes have a static _SCHEMA field (cached lookup)
-            var schemaField = AvroSchemaFieldCache.GetSchemaField(typeof(T));
-
-            if (schemaField?.GetValue(null) is global::Avro.RecordSchema recordSchema)
-                return recordSchema.Fullname;
-        }
-
-        return typeof(T).FullName ?? typeof(T).Name;
+        return GetSchemaFromValue(value) is global::Avro.RecordSchema recordSchema
+            ? recordSchema.Fullname
+            : typeof(T).FullName ?? typeof(T).Name;
     }
 
     /// <summary>

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSchemaRegistrySerializer.cs
@@ -48,15 +48,12 @@ public sealed class AvroSchemaRegistrySerializer<
     private readonly bool _ownsClient;
     private readonly ConcurrentDictionary<SchemaIdCacheKey, Lazy<Task<int>>> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
-    private readonly ConcurrentDictionary<AvroSchema, DynamicSubjectSchemaIdCache> _dynamicSubjectSchemaIdCaches =
-        new(AvroSchemaLogicalComparer.Instance);
-    private readonly ConcurrentDictionary<AvroSchema, DynamicGenericWriter> _genericWriters =
+    private readonly ConcurrentDictionary<AvroSchema, DynamicSchemaCache> _dynamicSchemaCaches =
         new(AvroSchemaLogicalComparer.Instance);
     private readonly ConcurrentDictionary<AvroSchema, SpecificDefaultWriter> _specificWriters =
         new(AvroSchemaReferenceComparer.Instance);
     private readonly AvroSchema? _writerSchema;
-    private DynamicSubjectSchemaIdCache? _lastDynamicSubjectSchemaIdCache;
-    private DynamicGenericWriter? _lastDynamicGenericWriter;
+    private DynamicSchemaCache? _lastDynamicSchemaCache;
 
     /// <summary>
     /// Creates a new Avro Schema Registry serializer.
@@ -77,9 +74,9 @@ public sealed class AvroSchemaRegistrySerializer<
         _writerSchema = GetSchemaFromType();
     }
 
-    internal int CachedGenericWriterCount => _genericWriters.Count;
+    internal int CachedGenericWriterCount => _dynamicSchemaCaches.Count;
     internal int CachedSpecificWriterCount => _specificWriters.Count;
-    internal int CachedDynamicSubjectSchemaCount => _dynamicSubjectSchemaIdCaches.Count;
+    internal int CachedDynamicSubjectSchemaCount => _dynamicSchemaCaches.Count;
 
     /// <summary>
     /// Pre-warms the schema cache for a specific topic.
@@ -446,51 +443,37 @@ public sealed class AvroSchemaRegistrySerializer<
         if (_writerSchema is not null)
             return _subjectSchemaIdCache;
 
-        var last = Volatile.Read(ref _lastDynamicSubjectSchemaIdCache);
-        if (last is not null && ReferenceEquals(last.Schema, schema))
-            return last.Cache;
+        return GetDynamicSchemaCache(schema).SubjectSchemaIdCache;
+    }
 
-        var entry = _dynamicSubjectSchemaIdCaches.GetOrAdd(
+    private GenericDatumWriter<GenericRecord> GetGenericWriter(AvroSchema schema) =>
+        GetDynamicSchemaCache(schema).Writer;
+
+    private DynamicSchemaCache GetDynamicSchemaCache(AvroSchema schema)
+    {
+        var last = Volatile.Read(ref _lastDynamicSchemaCache);
+        if (last is not null && ReferenceEquals(Volatile.Read(ref last.LastSeenSchema), schema))
+            return last;
+
+        var entry = _dynamicSchemaCaches.GetOrAdd(
             schema,
-            static schema => new DynamicSubjectSchemaIdCache(schema, new SubjectSchemaIdCache()));
-        Volatile.Write(ref _lastDynamicSubjectSchemaIdCache, entry);
-        return entry.Cache;
+            static schema => new DynamicSchemaCache(schema));
+        Volatile.Write(ref entry.LastSeenSchema, schema);
+        Volatile.Write(ref _lastDynamicSchemaCache, entry);
+        return entry;
     }
 
-    private GenericDatumWriter<GenericRecord> GetGenericWriter(AvroSchema schema)
+    private sealed class DynamicSchemaCache
     {
-        var last = Volatile.Read(ref _lastDynamicGenericWriter);
-        if (last is not null && ReferenceEquals(last.Schema, schema))
-            return last.Writer;
-
-        var entry = _genericWriters.GetOrAdd(
-            schema,
-            static schema => new DynamicGenericWriter(schema));
-        Volatile.Write(ref _lastDynamicGenericWriter, entry);
-        return entry.Writer;
-    }
-
-    private sealed class DynamicSubjectSchemaIdCache
-    {
-        internal DynamicSubjectSchemaIdCache(AvroSchema schema, SubjectSchemaIdCache cache)
+        internal DynamicSchemaCache(AvroSchema schema)
         {
-            Schema = schema;
-            Cache = cache;
-        }
-
-        internal AvroSchema Schema { get; }
-        internal SubjectSchemaIdCache Cache { get; }
-    }
-
-    private sealed class DynamicGenericWriter
-    {
-        internal DynamicGenericWriter(AvroSchema schema)
-        {
-            Schema = schema;
+            LastSeenSchema = schema;
+            SubjectSchemaIdCache = new SubjectSchemaIdCache();
             Writer = new GenericDatumWriter<GenericRecord>(schema);
         }
 
-        internal AvroSchema Schema { get; }
+        internal AvroSchema LastSeenSchema;
+        internal SubjectSchemaIdCache SubjectSchemaIdCache { get; }
         internal GenericDatumWriter<GenericRecord> Writer { get; }
     }
 

--- a/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Avro/AvroSerializerConfig.cs
@@ -25,6 +25,14 @@ public sealed class AvroSerializerConfig
     public ISubjectNameStrategy? CustomSubjectNameStrategy { get; init; }
 
     /// <summary>
+    /// Whether <see cref="SubjectNameStrategy.RecordName"/> and
+    /// <see cref="SubjectNameStrategy.TopicRecordName"/> should retain Dekaf's legacy
+    /// -key/-value suffix. Enable this temporarily while migrating existing subjects.
+    /// Default is false.
+    /// </summary>
+    public bool UseLegacySubjectNames { get; init; }
+
+    /// <summary>
     /// Whether to use the latest schema version from the registry instead of the schema
     /// derived from the .NET type. This is useful when the writer schema should come
     /// from the registry rather than from code.

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSchemaRegistrySerializer.cs
@@ -171,17 +171,12 @@ public sealed class ProtobufSchemaRegistrySerializer<
             return _config.CustomSubjectNameStrategy.GetSubjectName(topic, _descriptor.FullName, isKey);
         }
 
-        var suffix = isKey ? "-key" : "-value";
-
-        return _config.SubjectNameStrategy switch
-        {
-            SubjectNameStrategy.TopicName => topic + suffix,
-            SubjectNameStrategy.RecordName => _config.UseDeprecatedFormat
-                ? _descriptor.FullName
-                : _descriptor.FullName + suffix,
-            SubjectNameStrategy.TopicRecordName => $"{topic}-{_descriptor.FullName}{suffix}",
-            _ => topic + suffix
-        };
+        return SubjectNameResolver.GetSubjectName(
+            _config.SubjectNameStrategy,
+            topic,
+            _descriptor.FullName,
+            isKey,
+            _config.UseLegacySubjectNames);
     }
 
     private static MessageDescriptor GetMessageDescriptor()

--- a/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
+++ b/src/Dekaf.SchemaRegistry.Protobuf/ProtobufSerializerConfig.cs
@@ -20,6 +20,14 @@ public sealed class ProtobufSerializerConfig
     public ISubjectNameStrategy? CustomSubjectNameStrategy { get; init; }
 
     /// <summary>
+    /// Whether <see cref="SubjectNameStrategy.RecordName"/> and
+    /// <see cref="SubjectNameStrategy.TopicRecordName"/> should retain Dekaf's legacy
+    /// -key/-value suffix. Enable this temporarily while migrating existing subjects.
+    /// Default is false.
+    /// </summary>
+    public bool UseLegacySubjectNames { get; init; }
+
+    /// <summary>
     /// Whether to auto-register schemas when producing messages.
     /// Default is true.
     /// </summary>
@@ -41,7 +49,6 @@ public sealed class ProtobufSerializerConfig
 
     /// <summary>
     /// Whether to use the deprecated unsigned Protobuf message-index encoding.
-    /// This also preserves the previous RecordName subject naming format without a -key/-value suffix.
     /// Default is false.
     /// </summary>
     public bool UseDeprecatedFormat { get; init; }

--- a/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
+++ b/src/Dekaf.SchemaRegistry/JsonSchemaSerializer.cs
@@ -41,12 +41,41 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
     private readonly bool _normalizeSchemas;
+    private readonly bool _useLegacySubjectNames;
     private readonly Schema _schema;
+    private readonly string _recordName;
     private readonly bool _ownsClient;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
+
+    /// <summary>
+    /// Creates a new JSON Schema Registry serializer.
+    /// </summary>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
+    public JsonSchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        JsonSerializerOptions? jsonOptions = null,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
+        : this(
+            schemaRegistry,
+            jsonSchema,
+            useLegacySubjectNames: false,
+            jsonOptions,
+            subjectNameStrategy,
+            autoRegisterSchemas,
+            ownsClient,
+            ruleExecutor,
+            normalizeSchemas)
+    {
+    }
 
     /// <summary>
     /// Creates a new JSON Schema Registry serializer.
@@ -59,11 +88,13 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
     /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
     /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
     [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<T> constructor for NativeAOT.")]
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
+        bool useLegacySubjectNames,
         JsonSerializerOptions? jsonOptions = null,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
@@ -77,6 +108,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _normalizeSchemas = normalizeSchemas;
+        _useLegacySubjectNames = useLegacySubjectNames;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -84,6 +116,32 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SchemaType = SchemaType.Json,
             SchemaString = jsonSchema
         };
+        _recordName = SubjectNameResolver.GetRecordName(_schema, typeof(T).FullName ?? typeof(T).Name);
+    }
+
+    /// <summary>
+    /// Creates a new NativeAOT-safe JSON Schema Registry serializer.
+    /// </summary>
+    public JsonSchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        JsonTypeInfo<T> jsonTypeInfo,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
+        : this(
+            schemaRegistry,
+            jsonSchema,
+            jsonTypeInfo,
+            useLegacySubjectNames: false,
+            subjectNameStrategy,
+            autoRegisterSchemas,
+            ownsClient,
+            ruleExecutor,
+            normalizeSchemas)
+    {
     }
 
     /// <summary>
@@ -97,10 +155,12 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
     /// <param name="ruleExecutor">Optional rule executor applied to JSON payload bytes.</param>
     /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
     public JsonSchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
         JsonTypeInfo<T> jsonTypeInfo,
+        bool useLegacySubjectNames,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
@@ -113,6 +173,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _normalizeSchemas = normalizeSchemas;
+        _useLegacySubjectNames = useLegacySubjectNames;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
         _schema = new Schema
@@ -120,6 +181,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SchemaType = SchemaType.Json,
             SchemaString = jsonSchema
         };
+        _recordName = SubjectNameResolver.GetRecordName(_schema, typeof(T).FullName ?? typeof(T).Name);
     }
 
     /// <summary>
@@ -158,6 +220,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SchemaType = SchemaType.Json,
             SchemaString = jsonSchema
         };
+        _recordName = SubjectNameResolver.GetRecordName(_schema, typeof(T).FullName ?? typeof(T).Name);
     }
 
     /// <summary>
@@ -194,6 +257,7 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
             SchemaType = SchemaType.Json,
             SchemaString = jsonSchema
         };
+        _recordName = SubjectNameResolver.GetRecordName(_schema, typeof(T).FullName ?? typeof(T).Name);
     }
 
     public void Serialize<TWriter>(T value, ref TWriter destination, SerializationContext context)
@@ -300,17 +364,15 @@ public sealed class JsonSchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisp
     {
         if (_customSubjectNameStrategy is not null)
         {
-            return _customSubjectNameStrategy.GetSubjectName(topic, typeof(T).FullName, isKey);
+            return _customSubjectNameStrategy.GetSubjectName(topic, _recordName, isKey);
         }
 
-        var suffix = isKey ? "-key" : "-value";
-        return _subjectNameStrategy switch
-        {
-            SubjectNameStrategy.TopicName => topic + suffix,
-            SubjectNameStrategy.RecordName => typeof(T).FullName + suffix,
-            SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
-            _ => topic + suffix
-        };
+        return SubjectNameResolver.GetSubjectName(
+            _subjectNameStrategy,
+            topic,
+            _recordName,
+            isKey,
+            _useLegacySubjectNames);
     }
 
     public ValueTask DisposeAsync()

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
@@ -148,6 +148,48 @@ public static class SchemaRegistryExtensions
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         Action<TValue, IBufferWriter<byte>> serialize,
+        Func<Schema> getSchema,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
+        => UseSchemaRegistry(
+            builder,
+            schemaRegistry,
+            serialize,
+            getSchema,
+            useLegacySubjectNames: false,
+            subjectNameStrategy: subjectNameStrategy,
+            autoRegisterSchemas: autoRegisterSchemas);
+
+    /// <summary>
+    /// Configures the producer to use a custom Schema Registry serializer for values.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        Action<TValue, IBufferWriter<byte>> serialize,
+        Func<Schema> getSchema,
+        bool useLegacySubjectNames,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
+    {
+        var serializer = new SchemaRegistrySerializer<TValue>(
+            schemaRegistry,
+            serialize,
+            getSchema,
+            useLegacySubjectNames,
+            subjectNameStrategy,
+            autoRegisterSchemas);
+
+        return builder.WithValueSerializer(serializer);
+    }
+
+    /// <summary>
+    /// Configures the producer to use a custom Schema Registry serializer for values.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        Action<TValue, IBufferWriter<byte>> serialize,
         Func<string, Schema> getSchema,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true)

--- a/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistryExtensions.cs
@@ -13,15 +13,6 @@ public static class SchemaRegistryExtensions
     /// <summary>
     /// Configures the producer to use JSON Schema Registry serialization for values.
     /// </summary>
-    /// <typeparam name="TKey">Key type.</typeparam>
-    /// <typeparam name="TValue">Value type.</typeparam>
-    /// <param name="builder">The producer builder.</param>
-    /// <param name="schemaRegistry">The Schema Registry client.</param>
-    /// <param name="jsonSchema">The JSON schema for the value type.</param>
-    /// <param name="jsonOptions">Optional JSON serializer options.</param>
-    /// <param name="subjectNameStrategy">Subject name strategy.</param>
-    /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
-    /// <returns>The builder for chaining.</returns>
     [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
     [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
     public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
@@ -31,16 +22,68 @@ public static class SchemaRegistryExtensions
         JsonSerializerOptions? jsonOptions = null,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true)
+        => UseJsonSchemaRegistry(
+            builder,
+            schemaRegistry,
+            jsonSchema,
+            useLegacySubjectNames: false,
+            jsonOptions: jsonOptions,
+            subjectNameStrategy: subjectNameStrategy,
+            autoRegisterSchemas: autoRegisterSchemas);
+
+    /// <summary>
+    /// Configures the producer to use JSON Schema Registry serialization for values.
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="builder">The producer builder.</param>
+    /// <param name="schemaRegistry">The Schema Registry client.</param>
+    /// <param name="jsonSchema">The JSON schema for the value type.</param>
+    /// <param name="jsonOptions">Optional JSON serializer options.</param>
+    /// <param name="subjectNameStrategy">Subject name strategy.</param>
+    /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
+    /// <returns>The builder for chaining.</returns>
+    [RequiresUnreferencedCode("JsonSerializerOptions-based JSON serialization uses reflection. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
+    [RequiresDynamicCode("JsonSerializerOptions-based JSON serialization may require runtime code generation. Use the JsonTypeInfo<TValue> overload for NativeAOT.")]
+    public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        bool useLegacySubjectNames,
+        JsonSerializerOptions? jsonOptions = null,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
     {
         var serializer = new JsonSchemaRegistrySerializer<TValue>(
             schemaRegistry,
             jsonSchema,
+            useLegacySubjectNames,
             jsonOptions,
             subjectNameStrategy,
             autoRegisterSchemas);
 
         return builder.WithValueSerializer(serializer);
     }
+
+    /// <summary>
+    /// Configures the producer to use NativeAOT-safe JSON Schema Registry serialization for values.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        string jsonSchema,
+        JsonTypeInfo<TValue> jsonTypeInfo,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
+        => UseJsonSchemaRegistry(
+            builder,
+            schemaRegistry,
+            jsonSchema,
+            jsonTypeInfo,
+            useLegacySubjectNames: false,
+            subjectNameStrategy: subjectNameStrategy,
+            autoRegisterSchemas: autoRegisterSchemas);
 
     /// <summary>
     /// Configures the producer to use NativeAOT-safe JSON Schema Registry serialization for values.
@@ -53,12 +96,14 @@ public static class SchemaRegistryExtensions
     /// <param name="jsonTypeInfo">Source-generated metadata for the value type.</param>
     /// <param name="subjectNameStrategy">Subject name strategy.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseJsonSchemaRegistry<TKey, TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         string jsonSchema,
         JsonTypeInfo<TValue> jsonTypeInfo,
+        bool useLegacySubjectNames,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true)
     {
@@ -66,6 +111,7 @@ public static class SchemaRegistryExtensions
             schemaRegistry,
             jsonSchema,
             jsonTypeInfo,
+            useLegacySubjectNames,
             subjectNameStrategy,
             autoRegisterSchemas);
 
@@ -94,6 +140,25 @@ public static class SchemaRegistryExtensions
 
         return builder.WithValueDeserializer(deserializer);
     }
+
+    /// <summary>
+    /// Configures the producer to use a custom Schema Registry serializer for values.
+    /// </summary>
+    public static ProducerBuilder<TKey, TValue> UseSchemaRegistry<TKey, TValue>(
+        this ProducerBuilder<TKey, TValue> builder,
+        ISchemaRegistryClient schemaRegistry,
+        Action<TValue, IBufferWriter<byte>> serialize,
+        Func<string, Schema> getSchema,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true)
+        => UseSchemaRegistry(
+            builder,
+            schemaRegistry,
+            serialize,
+            getSchema,
+            useLegacySubjectNames: false,
+            subjectNameStrategy: subjectNameStrategy,
+            autoRegisterSchemas: autoRegisterSchemas);
 
     /// <summary>
     /// Configures the consumer to use NativeAOT-safe JSON Schema Registry deserialization for values.
@@ -127,12 +192,14 @@ public static class SchemaRegistryExtensions
     /// <param name="getSchema">Function to get the schema for a subject.</param>
     /// <param name="subjectNameStrategy">Subject name strategy.</param>
     /// <param name="autoRegisterSchemas">Whether to auto-register schemas.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
     /// <returns>The builder for chaining.</returns>
     public static ProducerBuilder<TKey, TValue> UseSchemaRegistry<TKey, TValue>(
         this ProducerBuilder<TKey, TValue> builder,
         ISchemaRegistryClient schemaRegistry,
         Action<TValue, IBufferWriter<byte>> serialize,
         Func<string, Schema> getSchema,
+        bool useLegacySubjectNames,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true)
     {
@@ -140,6 +207,7 @@ public static class SchemaRegistryExtensions
             schemaRegistry,
             serialize,
             getSchema,
+            useLegacySubjectNames,
             subjectNameStrategy,
             autoRegisterSchemas);
 

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -34,6 +34,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly ISchemaRegistryClient _schemaRegistry;
     private readonly Action<T, IBufferWriter<byte>> _serialize;
     private readonly Func<string, Schema> _getSchema;
+    private readonly bool _schemaFactoryIgnoresSubject;
     private readonly SubjectNameStrategy _subjectNameStrategy;
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
@@ -96,6 +97,58 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
         _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
         _getSchema = getSchema ?? throw new ArgumentNullException(nameof(getSchema));
+        _subjectNameStrategy = subjectNameStrategy;
+        _autoRegisterSchemas = autoRegisterSchemas;
+        _normalizeSchemas = normalizeSchemas;
+        _useLegacySubjectNames = useLegacySubjectNames;
+        _ownsClient = ownsClient;
+        _ruleExecutor = ruleExecutor;
+    }
+
+    /// <summary>
+    /// Creates a new Schema Registry serializer whose schema factory is independent of the subject name.
+    /// </summary>
+    public SchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        Action<T, IBufferWriter<byte>> serialize,
+        Func<Schema> getSchema,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
+        : this(
+            schemaRegistry,
+            serialize,
+            getSchema,
+            useLegacySubjectNames: false,
+            subjectNameStrategy,
+            autoRegisterSchemas,
+            ownsClient,
+            ruleExecutor,
+            normalizeSchemas)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new Schema Registry serializer whose schema factory is independent of the subject name.
+    /// </summary>
+    public SchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        Action<T, IBufferWriter<byte>> serialize,
+        Func<Schema> getSchema,
+        bool useLegacySubjectNames,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
+    {
+        ArgumentNullException.ThrowIfNull(getSchema);
+        _schemaRegistry = schemaRegistry ?? throw new ArgumentNullException(nameof(schemaRegistry));
+        _serialize = serialize ?? throw new ArgumentNullException(nameof(serialize));
+        _getSchema = _ => getSchema();
+        _schemaFactoryIgnoresSubject = true;
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _normalizeSchemas = normalizeSchemas;
@@ -188,17 +241,29 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchema(string topic, bool isKey)
     {
         var fallbackRecordName = typeof(T).FullName ?? typeof(T).Name;
-        var lookupSubject = GetSubjectName(topic, fallbackRecordName, isKey);
-        var schema = _getSchema(lookupSubject);
-        var recordName = SubjectNameResolver.GetRecordName(schema, fallbackRecordName);
-        var subject = string.Equals(recordName, fallbackRecordName, StringComparison.Ordinal)
-            ? lookupSubject
-            : GetSubjectName(topic, recordName, isKey);
-        return new SubjectSchemaIdCache.SubjectSchemaIdCacheEntry(
-            new SubjectSchemaIdCache.SubjectSchemaIdCacheKey(topic, isKey),
-            subject,
-            GetSchemaIdSync(subject, schema),
-            schema);
+        var subject = GetSubjectName(topic, fallbackRecordName, isKey);
+
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            var schema = _getSchema(subject);
+            var recordName = SubjectNameResolver.GetRecordName(schema, fallbackRecordName);
+            var resolvedSubject = string.Equals(recordName, fallbackRecordName, StringComparison.Ordinal)
+                ? subject
+                : GetSubjectName(topic, recordName, isKey);
+
+            if (_schemaFactoryIgnoresSubject || string.Equals(resolvedSubject, subject, StringComparison.Ordinal))
+            {
+                return new SubjectSchemaIdCache.SubjectSchemaIdCacheEntry(
+                    new SubjectSchemaIdCache.SubjectSchemaIdCacheKey(topic, isKey),
+                    resolvedSubject,
+                    GetSchemaIdSync(resolvedSubject, schema),
+                    schema);
+            }
+
+            subject = resolvedSubject;
+        }
+
+        throw new InvalidOperationException("The schema callback did not resolve to a stable subject name.");
     }
 
     private int GetSchemaIdSync(string subject, Schema schema)

--- a/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
+++ b/src/Dekaf.SchemaRegistry/SchemaRegistrySerializer.cs
@@ -38,11 +38,37 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     private readonly ISubjectNameStrategy? _customSubjectNameStrategy;
     private readonly bool _autoRegisterSchemas;
     private readonly bool _normalizeSchemas;
+    private readonly bool _useLegacySubjectNames;
     private readonly bool _ownsClient;
     private readonly ISchemaRegistryRuleExecutor? _ruleExecutor;
 
     private readonly ConcurrentDictionary<string, int> _schemaIdCache = new();
     private readonly SubjectSchemaIdCache _subjectSchemaIdCache = new();
+
+    /// <summary>
+    /// Creates a new Schema Registry serializer.
+    /// </summary>
+    public SchemaRegistrySerializer(
+        ISchemaRegistryClient schemaRegistry,
+        Action<T, IBufferWriter<byte>> serialize,
+        Func<string, Schema> getSchema,
+        SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
+        bool autoRegisterSchemas = true,
+        bool ownsClient = false,
+        ISchemaRegistryRuleExecutor? ruleExecutor = null,
+        bool normalizeSchemas = false)
+        : this(
+            schemaRegistry,
+            serialize,
+            getSchema,
+            useLegacySubjectNames: false,
+            subjectNameStrategy,
+            autoRegisterSchemas,
+            ownsClient,
+            ruleExecutor,
+            normalizeSchemas)
+    {
+    }
 
     /// <summary>
     /// Creates a new Schema Registry serializer.
@@ -55,10 +81,12 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
     /// <param name="ownsClient">Whether this serializer owns the client and should dispose it.</param>
     /// <param name="ruleExecutor">Optional rule executor applied to payload bytes.</param>
     /// <param name="normalizeSchemas">Whether to normalize schemas during registration.</param>
+    /// <param name="useLegacySubjectNames">Whether RecordName and TopicRecordName should use Dekaf's legacy -key/-value suffixes.</param>
     public SchemaRegistrySerializer(
         ISchemaRegistryClient schemaRegistry,
         Action<T, IBufferWriter<byte>> serialize,
         Func<string, Schema> getSchema,
+        bool useLegacySubjectNames,
         SubjectNameStrategy subjectNameStrategy = SubjectNameStrategy.TopicName,
         bool autoRegisterSchemas = true,
         bool ownsClient = false,
@@ -71,6 +99,7 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         _subjectNameStrategy = subjectNameStrategy;
         _autoRegisterSchemas = autoRegisterSchemas;
         _normalizeSchemas = normalizeSchemas;
+        _useLegacySubjectNames = useLegacySubjectNames;
         _ownsClient = ownsClient;
         _ruleExecutor = ruleExecutor;
     }
@@ -154,14 +183,23 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
             topic,
             isKey,
             this,
-            static (serializer, topic, isKey) => serializer.GetSubjectName(topic, isKey),
-            static (serializer, subject) =>
-            {
-                var schema = serializer._getSchema(subject);
-                return new SubjectSchemaIdCache.SubjectSchemaIdCacheValue(
-                    serializer.GetSchemaIdSync(subject, schema),
-                    schema);
-            });
+            static (serializer, topic, isKey) => serializer.ResolveSchema(topic, isKey));
+
+    private SubjectSchemaIdCache.SubjectSchemaIdCacheEntry ResolveSchema(string topic, bool isKey)
+    {
+        var fallbackRecordName = typeof(T).FullName ?? typeof(T).Name;
+        var lookupSubject = GetSubjectName(topic, fallbackRecordName, isKey);
+        var schema = _getSchema(lookupSubject);
+        var recordName = SubjectNameResolver.GetRecordName(schema, fallbackRecordName);
+        var subject = string.Equals(recordName, fallbackRecordName, StringComparison.Ordinal)
+            ? lookupSubject
+            : GetSubjectName(topic, recordName, isKey);
+        return new SubjectSchemaIdCache.SubjectSchemaIdCacheEntry(
+            new SubjectSchemaIdCache.SubjectSchemaIdCacheKey(topic, isKey),
+            subject,
+            GetSchemaIdSync(subject, schema),
+            schema);
+    }
 
     private int GetSchemaIdSync(string subject, Schema schema)
     {
@@ -187,21 +225,19 @@ public sealed class SchemaRegistrySerializer<T> : ISerializer<T>, IAsyncDisposab
         return _schemaIdCache.GetOrAdd(subject, fetchedId);
     }
 
-    private string GetSubjectName(string topic, bool isKey)
+    private string GetSubjectName(string topic, string recordName, bool isKey)
     {
         if (_customSubjectNameStrategy is not null)
         {
-            return _customSubjectNameStrategy.GetSubjectName(topic, typeof(T).FullName, isKey);
+            return _customSubjectNameStrategy.GetSubjectName(topic, recordName, isKey);
         }
 
-        var suffix = isKey ? "-key" : "-value";
-        return _subjectNameStrategy switch
-        {
-            SubjectNameStrategy.TopicName => topic + suffix,
-            SubjectNameStrategy.RecordName => typeof(T).FullName + suffix,
-            SubjectNameStrategy.TopicRecordName => $"{topic}-{typeof(T).FullName}{suffix}",
-            _ => topic + suffix
-        };
+        return SubjectNameResolver.GetSubjectName(
+            _subjectNameStrategy,
+            topic,
+            recordName,
+            isKey,
+            _useLegacySubjectNames);
     }
 
     public ValueTask DisposeAsync()
@@ -358,12 +394,12 @@ public enum SubjectNameStrategy
     TopicName,
 
     /// <summary>
-    /// Subject name is the fully qualified record name with -key or -value suffix.
+    /// Subject name is the fully qualified record name.
     /// </summary>
     RecordName,
 
     /// <summary>
-    /// Subject name is topic-recordname with -key or -value suffix.
+    /// Subject name is topic-recordname.
     /// </summary>
     TopicRecordName
 }

--- a/src/Dekaf.SchemaRegistry/SubjectNameResolver.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectNameResolver.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+
+namespace Dekaf.SchemaRegistry;
+
+internal static class SubjectNameResolver
+{
+    internal static string GetSubjectName(
+        SubjectNameStrategy strategy,
+        string topic,
+        string? recordName,
+        bool isKey,
+        bool useLegacySubjectNames)
+    {
+        var suffix = isKey ? "-key" : "-value";
+        return strategy switch
+        {
+            SubjectNameStrategy.TopicName => topic + suffix,
+            SubjectNameStrategy.RecordName => useLegacySubjectNames
+                ? recordName + suffix
+                : RequireRecordName(recordName, strategy),
+            SubjectNameStrategy.TopicRecordName => useLegacySubjectNames
+                ? $"{topic}-{recordName}{suffix}"
+                : $"{topic}-{RequireRecordName(recordName, strategy)}",
+            _ => topic + suffix
+        };
+    }
+
+    internal static string GetRecordName(Schema schema, string fallback)
+    {
+        if (schema.SchemaType is not (SchemaType.Avro or SchemaType.Json))
+            return fallback;
+
+        try
+        {
+            using var document = JsonDocument.Parse(schema.SchemaString);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return fallback;
+
+            if (schema.SchemaType == SchemaType.Json &&
+                root.TryGetProperty("title", out var title) &&
+                title.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(title.GetString()))
+            {
+                return title.GetString()!;
+            }
+
+            if (schema.SchemaType == SchemaType.Avro &&
+                root.TryGetProperty("name", out var name) &&
+                name.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrEmpty(name.GetString()))
+            {
+                var recordName = name.GetString()!;
+                if (recordName.Contains('.'))
+                    return recordName;
+
+                if (root.TryGetProperty("namespace", out var @namespace) &&
+                    @namespace.ValueKind == JsonValueKind.String &&
+                    !string.IsNullOrEmpty(@namespace.GetString()))
+                {
+                    return $"{@namespace.GetString()}.{recordName}";
+                }
+
+                return recordName;
+            }
+        }
+        catch (JsonException)
+        {
+            // Schema Registry will report malformed schemas during lookup or registration.
+        }
+
+        return fallback;
+    }
+
+    private static string RequireRecordName(string? recordName, SubjectNameStrategy strategy)
+    {
+        if (!string.IsNullOrEmpty(recordName))
+            return recordName;
+
+        throw new InvalidOperationException($"{strategy} requires a fully-qualified record name.");
+    }
+}

--- a/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
+++ b/src/Dekaf.SchemaRegistry/SubjectSchemaIdCache.cs
@@ -30,6 +30,20 @@ internal sealed class SubjectSchemaIdCache
         return Cache(key, subject, schema.SchemaId, schema.Schema);
     }
 
+    internal SubjectSchemaIdCacheEntry GetOrAdd<TState>(
+        string topic,
+        bool isKey,
+        TState state,
+        Func<TState, string, bool, SubjectSchemaIdCacheEntry> resolve)
+    {
+        var key = new SubjectSchemaIdCacheKey(topic, isKey);
+        if (TryGetCached(key, out var cached))
+            return cached;
+
+        var resolved = resolve(state, topic, isKey);
+        return Cache(key, resolved.Subject, resolved.SchemaId, resolved.Schema);
+    }
+
     // Cheap membership check for async preparation: true once (topic, isKey) has a resolved schema ID,
     // meaning a subsequent synchronous GetOrAdd for it will hit the cache instead of fetching/blocking.
     internal bool Contains(string topic, bool isKey) =>

--- a/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
+++ b/tests/Dekaf.Tests.Integration/Dekaf.Tests.Integration.csproj
@@ -30,15 +30,21 @@
 
   <ItemGroup Condition="'$(PublishAot)' == 'true'">
     <Compile Remove="OutboxRelayIntegrationTests.cs" />
+    <Compile Remove="SchemaRegistrySubjectCompatibilityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Apache.Avro" />
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Confluent.SchemaRegistry" Condition="'$(PublishAot)' != 'true'" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Condition="'$(PublishAot)' != 'true'" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json" Condition="'$(PublishAot)' != 'true'" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="protobuf-net.Reflection" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Condition="'$(PublishAot)' != 'true'" />
     <PackageReference Include="SSH.NET" PrivateAssets="All" />
     <PackageReference Include="TUnit" />

--- a/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
+++ b/tests/Dekaf.Tests.Integration/SchemaRegistrySubjectCompatibilityTests.cs
@@ -1,0 +1,184 @@
+using System.Buffers;
+using Avro.Generic;
+using Confluent.Kafka;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.SchemaRegistry.Protobuf;
+using Dekaf.Serialization;
+using Dekaf.Tests.Integration.Protos;
+using AvroSchema = Avro.Schema;
+using ConfluentSubjectNameStrategy = Confluent.SchemaRegistry.SubjectNameStrategy;
+using DekafSubjectNameStrategy = Dekaf.SchemaRegistry.SubjectNameStrategy;
+
+namespace Dekaf.Tests.Integration;
+
+[Category("Serialization")]
+[ClassDataSource<KafkaWithSchemaRegistryContainer>(Shared = SharedType.PerTestSession)]
+public sealed class SchemaRegistrySubjectCompatibilityTests(KafkaWithSchemaRegistryContainer testInfra)
+{
+    private const string AvroRecordSchema = """
+        {
+            "type": "record",
+            "name": "CompatibilityRecord",
+            "namespace": "dekaf.compatibility",
+            "fields": [
+                { "name": "id", "type": "int" }
+            ]
+        }
+        """;
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Avro_ConfluentRegisteredSubject_CanBeLookedUpByDekaf(bool topicRecord)
+    {
+        var topic = $"avro-subject-compat-{Guid.NewGuid():N}";
+        using var confluentRegistry = CreateConfluentClient();
+        var confluentSerializer = new Confluent.SchemaRegistry.Serdes.AvroSerializer<GenericRecord>(
+            confluentRegistry,
+            new Confluent.SchemaRegistry.Serdes.AvroSerializerConfig
+            {
+                SubjectNameStrategy = topicRecord
+                    ? ConfluentSubjectNameStrategy.TopicRecord
+                    : ConfluentSubjectNameStrategy.Record
+            });
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(AvroRecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", 42);
+
+        await confluentSerializer.SerializeAsync(
+            record,
+            new Confluent.Kafka.SerializationContext(MessageComponentType.Value, topic));
+
+        using var dekafRegistry = CreateDekafClient();
+        var expectedSubject = topicRecord
+            ? $"{topic}-dekaf.compatibility.CompatibilityRecord"
+            : "dekaf.compatibility.CompatibilityRecord";
+        var registered = await dekafRegistry.GetSchemaBySubjectAsync(expectedSubject);
+        await Assert.That(registered.Subject).IsEqualTo(expectedSubject);
+
+        await using var dekafSerializer = new AvroSchemaRegistrySerializer<GenericRecord>(
+            dekafRegistry,
+            new AvroSerializerConfig
+            {
+                SubjectNameStrategy = topicRecord
+                    ? DekafSubjectNameStrategy.TopicRecordName
+                    : DekafSubjectNameStrategy.RecordName,
+                AutoRegisterSchemas = false
+            });
+        var destination = new ArrayBufferWriter<byte>();
+        dekafSerializer.Serialize(record, ref destination, CreateDekafContext(topic));
+    }
+
+    [Test]
+    public async Task Protobuf_ConfluentRegisteredSubject_CanBeLookedUpByDekaf()
+    {
+        var topic = $"protobuf-subject-compat-{Guid.NewGuid():N}";
+        using var confluentRegistry = CreateConfluentClient();
+        var confluentSerializer = new Confluent.SchemaRegistry.Serdes.ProtobufSerializer<TestPerson>(
+            confluentRegistry,
+            new Confluent.SchemaRegistry.Serdes.ProtobufSerializerConfig
+            {
+                SubjectNameStrategy = ConfluentSubjectNameStrategy.Record
+            });
+        var value = new TestPerson { Id = 42, Name = "Compatibility", Email = "compat@example.com" };
+
+        await confluentSerializer.SerializeAsync(
+            value,
+            new Confluent.Kafka.SerializationContext(MessageComponentType.Value, topic));
+
+        using var dekafRegistry = CreateDekafClient();
+        var expectedSubject = TestPerson.Descriptor.FullName;
+        var registered = await dekafRegistry.GetSchemaBySubjectAsync(expectedSubject);
+        await Assert.That(registered.Subject).IsEqualTo(expectedSubject);
+
+        await using var dekafSerializer = new ProtobufSchemaRegistrySerializer<TestPerson>(
+            dekafRegistry,
+            new ProtobufSerializerConfig
+            {
+                SubjectNameStrategy = DekafSubjectNameStrategy.RecordName,
+                AutoRegisterSchemas = false
+            });
+        var destination = new ArrayBufferWriter<byte>();
+        dekafSerializer.Serialize(value, ref destination, CreateDekafContext(topic));
+    }
+
+    [Test]
+    public async Task Json_ConfluentRegisteredSubject_CanBeLookedUpByDekaf()
+    {
+        var topic = $"json-subject-compat-{Guid.NewGuid():N}";
+        using var confluentRegistry = CreateConfluentClient();
+        var confluentSerializer = new Confluent.SchemaRegistry.Serdes.JsonSerializer<CompatibilityJsonRecord>(
+            confluentRegistry,
+            new Confluent.SchemaRegistry.Serdes.JsonSerializerConfig
+            {
+                SubjectNameStrategy = ConfluentSubjectNameStrategy.Record
+            });
+        var value = new CompatibilityJsonRecord { Id = 42 };
+
+        await confluentSerializer.SerializeAsync(
+            value,
+            new Confluent.Kafka.SerializationContext(MessageComponentType.Value, topic));
+
+        using var dekafRegistry = CreateDekafClient();
+        var subjects = await dekafRegistry.GetAllSubjectsAsync();
+        var subject = subjects.Single(static candidate => candidate.Contains(nameof(CompatibilityJsonRecord), StringComparison.Ordinal));
+        var registered = await dekafRegistry.GetSchemaBySubjectAsync(subject);
+
+        await using var dekafSerializer = new JsonSchemaRegistrySerializer<CompatibilityJsonRecord>(
+            dekafRegistry,
+            registered.Schema.SchemaString,
+            subjectNameStrategy: DekafSubjectNameStrategy.RecordName,
+            autoRegisterSchemas: false);
+        var destination = new ArrayBufferWriter<byte>();
+        dekafSerializer.Serialize(value, ref destination, CreateDekafContext(topic));
+    }
+
+    [Test]
+    public async Task GenericSerializer_UsesConfluentAvroRuntimeSchemaSubject()
+    {
+        var topic = $"generic-subject-compat-{Guid.NewGuid():N}";
+        using var confluentRegistry = CreateConfluentClient();
+        var confluentSerializer = new Confluent.SchemaRegistry.Serdes.AvroSerializer<GenericRecord>(
+            confluentRegistry,
+            new Confluent.SchemaRegistry.Serdes.AvroSerializerConfig
+            {
+                SubjectNameStrategy = ConfluentSubjectNameStrategy.Record
+            });
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(AvroRecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", 42);
+        await confluentSerializer.SerializeAsync(
+            record,
+            new Confluent.Kafka.SerializationContext(MessageComponentType.Value, topic));
+
+        using var dekafRegistry = CreateDekafClient();
+        var registered = await dekafRegistry.GetSchemaBySubjectAsync("dekaf.compatibility.CompatibilityRecord");
+        await using var dekafSerializer = new SchemaRegistrySerializer<GenericRecord>(
+            dekafRegistry,
+            static (_, writer) => writer.Advance(0),
+            _ => registered.Schema,
+            DekafSubjectNameStrategy.RecordName,
+            autoRegisterSchemas: false);
+        var destination = new ArrayBufferWriter<byte>();
+        dekafSerializer.Serialize(record, ref destination, CreateDekafContext(topic));
+    }
+
+    private Confluent.SchemaRegistry.CachedSchemaRegistryClient CreateConfluentClient() =>
+        new(new Confluent.SchemaRegistry.SchemaRegistryConfig { Url = testInfra.RegistryUrl });
+
+    private SchemaRegistryClient CreateDekafClient() =>
+        new(new SchemaRegistryConfig { Url = testInfra.RegistryUrl });
+
+    private static Dekaf.Serialization.SerializationContext CreateDekafContext(string topic) =>
+        new()
+        {
+            Topic = topic,
+            Component = SerializationComponent.Value
+        };
+
+    private sealed class CompatibilityJsonRecord
+    {
+        public int Id { get; init; }
+    }
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSchemaLogicalComparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSchemaLogicalComparerTests.cs
@@ -1,0 +1,58 @@
+using Avro;
+using Dekaf.SchemaRegistry.Avro;
+using AvroSchema = Avro.Schema;
+
+namespace Dekaf.Tests.Unit.SchemaRegistry;
+
+public class AvroSchemaLogicalComparerTests
+{
+    [Test]
+    public async Task SharedAndDuplicatedNamedSchemas_HaveEqualHashes()
+    {
+        var sharedChild = CreateChildSchema();
+        var shared = CreateRootSchema(sharedChild, sharedChild);
+        var duplicated = CreateRootSchema(CreateChildSchema(), CreateChildSchema());
+        var comparer = AvroSchemaLogicalComparer.Instance;
+
+        await Assert.That(comparer.Equals(shared, duplicated)).IsTrue();
+        await Assert.That(comparer.GetHashCode(shared)).IsEqualTo(comparer.GetHashCode(duplicated));
+
+        var schemas = new Dictionary<AvroSchema, int>(comparer)
+        {
+            [shared] = 1,
+            [duplicated] = 2
+        };
+        await Assert.That(schemas.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task LogicalTypeParameters_ArePartOfSchemaIdentity()
+    {
+        var scaleTwo = AvroSchema.Parse(
+            "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":8,\"scale\":2}");
+        var scaleThree = AvroSchema.Parse(
+            "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":8,\"scale\":3}");
+        var comparer = AvroSchemaLogicalComparer.Instance;
+
+        await Assert.That(comparer.Equals(scaleTwo, scaleThree)).IsFalse();
+
+        var schemas = new Dictionary<AvroSchema, int>(comparer)
+        {
+            [scaleTwo] = 1,
+            [scaleThree] = 2
+        };
+        await Assert.That(schemas.Count).IsEqualTo(2);
+    }
+
+    private static RecordSchema CreateChildSchema() =>
+        RecordSchema.Create(
+            "Child",
+            [new Field(AvroSchema.Parse("\"int\""), "value", 0)],
+            "Dekaf.Tests");
+
+    private static RecordSchema CreateRootSchema(AvroSchema first, AvroSchema second) =>
+        RecordSchema.Create(
+            "Root",
+            [new Field(first, "first", 0), new Field(second, "second", 1)],
+            "Dekaf.Tests");
+}

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSchemaLogicalComparerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/AvroSchemaLogicalComparerTests.cs
@@ -44,6 +44,26 @@ public class AvroSchemaLogicalComparerTests
         await Assert.That(schemas.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task FieldOrdering_IsPartOfSchemaIdentity()
+    {
+        var ascending = AvroSchema.Parse(
+            """{"type":"record","name":"Ordered","fields":[{"name":"value","type":"int","order":"ascending"}]}""");
+        var descending = AvroSchema.Parse(
+            """{"type":"record","name":"Ordered","fields":[{"name":"value","type":"int","order":"descending"}]}""");
+        var comparer = AvroSchemaLogicalComparer.Instance;
+
+        await Assert.That(comparer.Equals(ascending, descending)).IsFalse();
+        await Assert.That(comparer.GetHashCode(ascending)).IsNotEqualTo(comparer.GetHashCode(descending));
+
+        var schemas = new Dictionary<AvroSchema, int>(comparer)
+        {
+            [ascending] = 1,
+            [descending] = 2
+        };
+        await Assert.That(schemas.Count).IsEqualTo(2);
+    }
+
     private static RecordSchema CreateChildSchema() =>
         RecordSchema.Create(
             "Child",

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/ProtobufSchemaRegistrySerializerTests.cs
@@ -169,7 +169,80 @@ public class ProtobufSchemaRegistrySerializerTests
         serializer.Serialize(message, ref buffer, CreateContext("my-topic"));
 
         // Assert - should use full message name
-        await Assert.That(capturedSubject).IsEqualTo("dekaf.tests.TestMessage-value");
+        await Assert.That(capturedSubject).IsEqualTo("dekaf.tests.TestMessage");
+    }
+
+    [Test]
+    public async Task Serialize_UsesTopicRecordNameSubjectStrategy()
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        string? capturedSubject = null;
+        schemaRegistry.GetOrRegisterSchemaAsync(Arg.Any<string>(), Arg.Any<Schema>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedSubject = callInfo.Arg<string>()!;
+                return Task.FromResult(1);
+            });
+
+        var config = new ProtobufSerializerConfig { SubjectNameStrategy = SubjectNameStrategy.TopicRecordName };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new TestMessage(), ref buffer, CreateContext("my-topic", isKey: true));
+
+        await Assert.That(capturedSubject).IsEqualTo("my-topic-dekaf.tests.TestMessage");
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Serialize_UseDeprecatedFormat_DoesNotAffectRecordNameSubject(bool useDeprecatedFormat)
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        string? capturedSubject = null;
+        schemaRegistry.GetOrRegisterSchemaAsync(Arg.Any<string>(), Arg.Any<Schema>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedSubject = callInfo.Arg<string>()!;
+                return Task.FromResult(1);
+            });
+
+        var config = new ProtobufSerializerConfig
+        {
+            SubjectNameStrategy = SubjectNameStrategy.RecordName,
+            UseDeprecatedFormat = useDeprecatedFormat
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new TestMessage(), ref buffer, CreateContext("my-topic"));
+
+        await Assert.That(capturedSubject).IsEqualTo("dekaf.tests.TestMessage");
+    }
+
+    [Test]
+    public async Task Serialize_LegacyRecordNameSubjectStrategy_RetainsSuffix()
+    {
+        var schemaRegistry = Substitute.For<ISchemaRegistryClient>();
+        string? capturedSubject = null;
+        schemaRegistry.GetOrRegisterSchemaAsync(Arg.Any<string>(), Arg.Any<Schema>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedSubject = callInfo.Arg<string>()!;
+                return Task.FromResult(1);
+            });
+
+        var config = new ProtobufSerializerConfig
+        {
+            SubjectNameStrategy = SubjectNameStrategy.RecordName,
+            UseLegacySubjectNames = true
+        };
+        await using var serializer = new ProtobufSchemaRegistrySerializer<TestMessage>(schemaRegistry, config);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(new TestMessage(), ref buffer, CreateContext("my-topic", isKey: true));
+
+        await Assert.That(capturedSubject).IsEqualTo("dekaf.tests.TestMessage-key");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -186,6 +186,13 @@ public sealed class SubjectNameStrategyTests
     }
 
     [Test]
+    public async Task AvroSerializerConfig_UseLegacySubjectNames_DefaultsToFalse()
+    {
+        var config = new AvroSerializerConfig();
+        await Assert.That(config.UseLegacySubjectNames).IsFalse();
+    }
+
+    [Test]
     public async Task ProtobufSerializerConfig_SubjectNameStrategy_DefaultsToTopicName()
     {
         var config = new ProtobufSerializerConfig();
@@ -211,6 +218,13 @@ public sealed class SubjectNameStrategyTests
     {
         var config = new ProtobufSerializerConfig();
         await Assert.That(config.UseLatestVersion).IsFalse();
+    }
+
+    [Test]
+    public async Task ProtobufSerializerConfig_UseLegacySubjectNames_DefaultsToFalse()
+    {
+        var config = new ProtobufSerializerConfig();
+        await Assert.That(config.UseLegacySubjectNames).IsFalse();
     }
 
     // --- Integration with AvroSchemaRegistrySerializer ---
@@ -256,11 +270,8 @@ public sealed class SubjectNameStrategyTests
         // Act
         serializer.Serialize(record, ref buffer, context);
 
-        // Assert - for GenericRecord (not ISpecificRecord), the record name falls back
-        // to the .NET FullName of GenericRecord since the static _SCHEMA field is not available.
-        // For ISpecificRecord types, the Avro schema fullname would be used instead.
         var subjects = await schemaRegistry.GetAllSubjectsAsync();
-        await Assert.That(subjects).Contains("Avro.Generic.GenericRecord-value");
+        await Assert.That(subjects).Contains("test.SimpleRecord");
     }
 
     [Test]
@@ -285,19 +296,146 @@ public sealed class SubjectNameStrategyTests
         // Act
         serializer.Serialize(record, ref buffer, context);
 
-        // Assert
         var subjects = await schemaRegistry.GetAllSubjectsAsync();
-        // GenericRecord uses .FullName from the schema, so this should be the
-        // Avro record fullname (not the .NET type name)
-        var hasTopicRecordSubject = false;
-        foreach (var subject in subjects)
+        await Assert.That(subjects).Contains("my-topic-test.SimpleRecord");
+    }
+
+    [Test]
+    public async Task AvroSerializer_LegacyRecordNameStrategy_RetainsSuffix()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var config = new AvroSerializerConfig
         {
-            if (subject.StartsWith("my-topic-", StringComparison.Ordinal) && subject != "my-topic-value" && subject != "my-topic-key")
+            SubjectNameStrategy = SubjectNameStrategy.RecordName,
+            UseLegacySubjectNames = true
+        };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry, config);
+
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", 1);
+        record.Add("name", "test");
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(record, ref buffer, CreateContext("my-topic"));
+
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("test.SimpleRecord-value");
+    }
+
+    [Test]
+    public async Task JsonSerializer_RecordNameStrategy_UsesSchemaTitle()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new JsonSchemaRegistrySerializer<string>(
+            schemaRegistry,
+            """{ "title": "com.example.JsonRecord", "type": "string" }""",
+            subjectNameStrategy: SubjectNameStrategy.RecordName);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("value", ref buffer, CreateContext("my-topic"));
+
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("com.example.JsonRecord");
+    }
+
+    [Test]
+    public async Task JsonSerializer_LegacyTopicRecordNameStrategy_RetainsSuffix()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new JsonSchemaRegistrySerializer<string>(
+            schemaRegistry,
+            """{ "title": "com.example.JsonRecord", "type": "string" }""",
+            subjectNameStrategy: SubjectNameStrategy.TopicRecordName,
+            useLegacySubjectNames: true);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("value", ref buffer, CreateContext("my-topic", isKey: true));
+
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("my-topic-com.example.JsonRecord-key");
+    }
+
+    [Test]
+    public async Task GenericSerializer_RecordNameStrategy_UsesRuntimeSchemaName()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            schemaRegistry,
+            static (value, writer) =>
             {
-                hasTopicRecordSubject = true;
-            }
-        }
-        await Assert.That(hasTopicRecordSubject).IsTrue();
+                var span = writer.GetSpan(value.Length);
+                for (var i = 0; i < value.Length; i++)
+                    span[i] = (byte)value[i];
+                writer.Advance(value.Length);
+            },
+            _ => schema,
+            SubjectNameStrategy.RecordName);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("value", ref buffer, CreateContext("my-topic"));
+
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("test.SimpleRecord");
+    }
+
+    [Test]
+    public async Task GenericSerializer_LegacyRecordNameStrategy_RetainsSuffix()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            schemaRegistry,
+            static (value, writer) =>
+            {
+                writer.GetSpan(1)[0] = (byte)value[0];
+                writer.Advance(1);
+            },
+            _ => schema,
+            useLegacySubjectNames: true,
+            subjectNameStrategy: SubjectNameStrategy.RecordName);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("value", ref buffer, CreateContext("my-topic", isKey: true));
+
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("test.SimpleRecord-key");
+    }
+
+    [Test]
+    public async Task UnknownEnumStrategy_PreservesTopicNameFallback()
+    {
+        var subject = SubjectNameResolver.GetSubjectName(
+            (SubjectNameStrategy)int.MaxValue,
+            "my-topic",
+            "com.example.Record",
+            isKey: false,
+            useLegacySubjectNames: false);
+
+        await Assert.That(subject).IsEqualTo("my-topic-value");
+    }
+
+    [Test]
+    public async Task JsonBooleanSchema_RecordNameFallsBackToClrType()
+    {
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Json,
+            SchemaString = "true"
+        };
+
+        var recordName = SubjectNameResolver.GetRecordName(schema, "com.example.Record");
+
+        await Assert.That(recordName).IsEqualTo("com.example.Record");
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Buffers.Binary;
 using Avro.Generic;
 using Dekaf.SchemaRegistry;
 using Dekaf.SchemaRegistry.Avro;
@@ -241,6 +242,17 @@ public sealed class SubjectNameStrategyTests
         }
         """;
 
+    private const string AlternateRecordSchema = """
+        {
+            "type": "record",
+            "name": "AlternateRecord",
+            "namespace": "test",
+            "fields": [
+                { "name": "id", "type": "int" }
+            ]
+        }
+        """;
+
     private static SerializationContext CreateContext(string topic = "test-topic", bool isKey = false) =>
         new()
         {
@@ -324,6 +336,37 @@ public sealed class SubjectNameStrategyTests
     }
 
     [Test]
+    [Arguments(SubjectNameStrategy.TopicName)]
+    [Arguments(SubjectNameStrategy.RecordName)]
+    [Arguments(SubjectNameStrategy.TopicRecordName)]
+    public async Task AvroSerializer_RuntimeSchemasOnSameTopic_UseDistinctSchemaIds(
+        SubjectNameStrategy subjectNameStrategy)
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var config = new AvroSerializerConfig { SubjectNameStrategy = subjectNameStrategy };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry, config);
+
+        var firstSchema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
+        var firstRecord = new GenericRecord(firstSchema);
+        firstRecord.Add("id", 1);
+        firstRecord.Add("name", "first");
+
+        var secondSchema = (Avro.RecordSchema)AvroSchema.Parse(AlternateRecordSchema);
+        var secondRecord = new GenericRecord(secondSchema);
+        secondRecord.Add("id", 2);
+
+        var firstBuffer = new ArrayBufferWriter<byte>();
+        var secondBuffer = new ArrayBufferWriter<byte>();
+        var context = CreateContext("shared-topic");
+        serializer.Serialize(firstRecord, ref firstBuffer, context);
+        serializer.Serialize(secondRecord, ref secondBuffer, context);
+
+        var firstId = BinaryPrimitives.ReadInt32BigEndian(firstBuffer.WrittenSpan.Slice(1, 4));
+        var secondId = BinaryPrimitives.ReadInt32BigEndian(secondBuffer.WrittenSpan.Slice(1, 4));
+        await Assert.That(secondId).IsNotEqualTo(firstId);
+    }
+
+    [Test]
     public async Task JsonSerializer_RecordNameStrategy_UsesSchemaTitle()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
@@ -360,6 +403,7 @@ public sealed class SubjectNameStrategyTests
     public async Task GenericSerializer_RecordNameStrategy_UsesRuntimeSchemaName()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();
+        var requestedSubjects = new List<string>();
         var schema = new Schema
         {
             SchemaType = SchemaType.Avro,
@@ -374,12 +418,46 @@ public sealed class SubjectNameStrategyTests
                     span[i] = (byte)value[i];
                 writer.Advance(value.Length);
             },
-            _ => schema,
+            subject =>
+            {
+                requestedSubjects.Add(subject);
+                return schema;
+            },
             SubjectNameStrategy.RecordName);
 
         var buffer = new ArrayBufferWriter<byte>();
         serializer.Serialize("value", ref buffer, CreateContext("my-topic"));
 
+        var subjects = await schemaRegistry.GetAllSubjectsAsync();
+        await Assert.That(subjects).Contains("test.SimpleRecord");
+        await Assert.That(requestedSubjects).Count().IsEqualTo(2);
+        await Assert.That(requestedSubjects).IsEquivalentTo(["System.String", "test.SimpleRecord"]);
+    }
+
+    [Test]
+    public async Task GenericSerializer_SubjectIndependentSchemaFactory_ResolvesSchemaOnce()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var calls = 0;
+        var schema = new Schema
+        {
+            SchemaType = SchemaType.Avro,
+            SchemaString = SimpleRecordSchema
+        };
+        await using var serializer = new SchemaRegistrySerializer<string>(
+            schemaRegistry,
+            static (_, writer) => writer.Advance(0),
+            () =>
+            {
+                calls++;
+                return schema;
+            },
+            SubjectNameStrategy.RecordName);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize("value", ref buffer, CreateContext("my-topic"));
+
+        await Assert.That(calls).IsEqualTo(1);
         var subjects = await schemaRegistry.GetAllSubjectsAsync();
         await Assert.That(subjects).Contains("test.SimpleRecord");
     }

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -253,6 +253,18 @@ public sealed class SubjectNameStrategyTests
         }
         """;
 
+    private const string RecursiveRecordSchema = """
+        {
+            "type": "record",
+            "name": "Node",
+            "namespace": "test",
+            "fields": [
+                { "name": "value", "type": "int" },
+                { "name": "next", "type": ["null", "test.Node"], "default": null }
+            ]
+        }
+        """;
+
     private static SerializationContext CreateContext(string topic = "test-topic", bool isKey = false) =>
         new()
         {
@@ -416,19 +428,69 @@ public sealed class SubjectNameStrategyTests
         using var schemaRegistry = new MockSchemaRegistryClient();
         await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
         var context = CreateContext("shared-topic");
+        var records = new GenericRecord[100];
 
-        for (var i = 0; i < 100; i++)
+        for (var i = 0; i < records.Length; i++)
         {
             var schema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
             var record = new GenericRecord(schema);
             record.Add("id", i);
             record.Add("name", "equivalent");
-            var buffer = new ArrayBufferWriter<byte>();
+            records[i] = record;
+        }
 
+        var buffer = new ArrayBufferWriter<byte>();
+        serializer.Serialize(records[0], ref buffer, context);
+        buffer.ResetWrittenCount();
+        serializer.Serialize(records[1], ref buffer, context);
+
+        var prepareBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 2; i < records.Length; i++)
+            serializer.PrepareAsync(records[i], context).GetAwaiter().GetResult();
+        var prepareAllocated = GC.GetAllocatedBytesForCurrentThread() - prepareBefore;
+
+        var stableBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 2; i < records.Length; i++)
+        {
+            buffer.ResetWrittenCount();
+            serializer.Serialize(records[0], ref buffer, context);
+        }
+        var stableAllocated = GC.GetAllocatedBytesForCurrentThread() - stableBefore;
+
+        var equivalentBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 2; i < records.Length; i++)
+        {
+            buffer.ResetWrittenCount();
+            serializer.Serialize(records[i], ref buffer, context);
+        }
+        var equivalentAllocated = GC.GetAllocatedBytesForCurrentThread() - equivalentBefore;
+
+        await Assert.That(serializer.CachedDynamicSubjectSchemaCount).IsEqualTo(1);
+        await Assert.That(serializer.CachedGenericWriterCount).IsEqualTo(1);
+        await Assert.That(prepareAllocated).IsEqualTo(0);
+        await Assert.That(equivalentAllocated).IsEqualTo(stableAllocated);
+    }
+
+    [Test]
+    public async Task AvroSerializer_EquivalentRecursiveSchemas_ReuseSubjectCache()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var context = CreateContext("recursive-topic");
+        var buffer = new ArrayBufferWriter<byte>();
+
+        for (var i = 0; i < 2; i++)
+        {
+            var schema = (Avro.RecordSchema)AvroSchema.Parse(RecursiveRecordSchema);
+            var record = new GenericRecord(schema);
+            record.Add("value", i);
+            record.Add("next", null);
+            buffer.ResetWrittenCount();
             serializer.Serialize(record, ref buffer, context);
         }
 
         await Assert.That(serializer.CachedDynamicSubjectSchemaCount).IsEqualTo(1);
+        await Assert.That(serializer.CachedGenericWriterCount).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -367,6 +367,49 @@ public sealed class SubjectNameStrategyTests
     }
 
     [Test]
+    public async Task AvroSerializer_ConcurrentRuntimeSchemas_KeepSchemaAndCachePaired()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        var config = new AvroSerializerConfig { SubjectNameStrategy = SubjectNameStrategy.RecordName };
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry, config);
+
+        var firstSchema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
+        var firstRecord = new GenericRecord(firstSchema);
+        firstRecord.Add("id", 1);
+        firstRecord.Add("name", "first");
+
+        var secondSchema = (Avro.RecordSchema)AvroSchema.Parse(AlternateRecordSchema);
+        var secondRecord = new GenericRecord(secondSchema);
+        secondRecord.Add("id", 2);
+
+        var context = CreateContext("shared-topic");
+        var firstId = await serializer.WarmupAsync(context.Topic, firstRecord);
+        var secondId = await serializer.WarmupAsync(context.Topic, secondRecord);
+        var mismatches = 0;
+        using var start = new Barrier(2);
+
+        Task RunAsync(GenericRecord record, int expectedId) => Task.Factory.StartNew(() =>
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            start.SignalAndWait();
+            for (var i = 0; i < 10_000; i++)
+            {
+                buffer.ResetWrittenCount();
+                serializer.Serialize(record, ref buffer, context);
+                var actualId = BinaryPrimitives.ReadInt32BigEndian(buffer.WrittenSpan.Slice(1, 4));
+                if (actualId != expectedId)
+                    Interlocked.Increment(ref mismatches);
+            }
+        }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+        await Task.WhenAll(
+            RunAsync(firstRecord, firstId),
+            RunAsync(secondRecord, secondId));
+
+        await Assert.That(mismatches).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task JsonSerializer_RecordNameStrategy_UsesSchemaTitle()
     {
         using var schemaRegistry = new MockSchemaRegistryClient();

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -467,6 +467,7 @@ public sealed class SubjectNameStrategyTests
 
         await Assert.That(serializer.CachedDynamicSubjectSchemaCount).IsEqualTo(1);
         await Assert.That(serializer.CachedGenericWriterCount).IsEqualTo(1);
+        await Assert.That(schemaRegistry.GetOrRegisterSchemaCallCount).IsEqualTo(1);
         await Assert.That(prepareAllocated).IsEqualTo(0);
         await Assert.That(equivalentAllocated).IsEqualTo(stableAllocated);
     }
@@ -491,6 +492,7 @@ public sealed class SubjectNameStrategyTests
 
         await Assert.That(serializer.CachedDynamicSubjectSchemaCount).IsEqualTo(1);
         await Assert.That(serializer.CachedGenericWriterCount).IsEqualTo(1);
+        await Assert.That(schemaRegistry.GetOrRegisterSchemaCallCount).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
+++ b/tests/Dekaf.Tests.Unit/SchemaRegistry/SubjectNameStrategyTests.cs
@@ -385,6 +385,7 @@ public sealed class SubjectNameStrategyTests
         var context = CreateContext("shared-topic");
         var firstId = await serializer.WarmupAsync(context.Topic, firstRecord);
         var secondId = await serializer.WarmupAsync(context.Topic, secondRecord);
+        await Assert.That(secondId).IsNotEqualTo(firstId);
         var mismatches = 0;
         using var start = new Barrier(2);
 
@@ -407,6 +408,27 @@ public sealed class SubjectNameStrategyTests
             RunAsync(secondRecord, secondId));
 
         await Assert.That(mismatches).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AvroSerializer_EquivalentRuntimeSchemaInstances_ReuseSubjectCache()
+    {
+        using var schemaRegistry = new MockSchemaRegistryClient();
+        await using var serializer = new AvroSchemaRegistrySerializer<GenericRecord>(schemaRegistry);
+        var context = CreateContext("shared-topic");
+
+        for (var i = 0; i < 100; i++)
+        {
+            var schema = (Avro.RecordSchema)AvroSchema.Parse(SimpleRecordSchema);
+            var record = new GenericRecord(schema);
+            record.Add("id", i);
+            record.Add("name", "equivalent");
+            var buffer = new ArrayBufferWriter<byte>();
+
+            serializer.Serialize(record, ref buffer, context);
+        }
+
+        await Assert.That(serializer.CachedDynamicSubjectSchemaCount).IsEqualTo(1);
     }
 
     [Test]

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/AvroSchemaRegistrySerializerBenchmarks.cs
@@ -1,0 +1,118 @@
+using System.Buffers;
+using Avro.Generic;
+using BenchmarkDotNet.Attributes;
+using Dekaf.SchemaRegistry;
+using Dekaf.SchemaRegistry.Avro;
+using Dekaf.Serialization;
+using AvroSchema = Avro.Schema;
+using RegistrySchema = Dekaf.SchemaRegistry.Schema;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the producer's generic Avro preparation path for stable and equivalent schema instances.
+/// </summary>
+[MemoryDiagnoser(displayGenColumns: false)]
+public class AvroSchemaRegistrySerializerBenchmarks
+{
+    private const string RecordSchema =
+        """
+        {
+          "type": "record",
+          "name": "BenchmarkRecord",
+          "namespace": "Dekaf.Benchmarks",
+          "fields": [
+            { "name": "id", "type": "int" },
+            { "name": "name", "type": "string" }
+          ]
+        }
+        """;
+
+    private AvroSchemaRegistrySerializer<GenericRecord> _serializer = null!;
+    private GenericRecord[] _equivalentRecords = null!;
+    private GenericRecord _stableRecord = null!;
+    private SerializationContext _context;
+    private int _recordIndex;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _serializer = new AvroSchemaRegistrySerializer<GenericRecord>(new BenchmarkSchemaRegistryClient());
+        _context = new SerializationContext
+        {
+            Topic = "avro-benchmark",
+            Component = SerializationComponent.Value
+        };
+
+        _equivalentRecords = new GenericRecord[256];
+        for (var i = 0; i < _equivalentRecords.Length; i++)
+            _equivalentRecords[i] = CreateRecord(i);
+
+        _stableRecord = _equivalentRecords[0];
+        var buffer = new ArrayBufferWriter<byte>();
+        _serializer.Serialize(_stableRecord, ref buffer, _context);
+    }
+
+    [GlobalCleanup]
+    public ValueTask Cleanup() => _serializer.DisposeAsync();
+
+    [Benchmark(Baseline = true, Description = "Prepare stable generic Avro schema")]
+    public ValueTask PrepareStableSchema() => _serializer.PrepareAsync(_stableRecord, _context);
+
+    [Benchmark(Description = "Prepare equivalent generic Avro schema instance")]
+    public ValueTask PrepareEquivalentSchema()
+    {
+        _recordIndex = (_recordIndex + 1) & (_equivalentRecords.Length - 1);
+        return _serializer.PrepareAsync(_equivalentRecords[_recordIndex], _context);
+    }
+
+    private static GenericRecord CreateRecord(int id)
+    {
+        var schema = (Avro.RecordSchema)AvroSchema.Parse(RecordSchema);
+        var record = new GenericRecord(schema);
+        record.Add("id", id);
+        record.Add("name", "benchmark");
+        return record;
+    }
+
+    private sealed class BenchmarkSchemaRegistryClient : ISchemaRegistryClient
+    {
+        public Task<int> RegisterSchemaAsync(
+            string subject,
+            RegistrySchema schema,
+            CancellationToken cancellationToken = default) => Task.FromResult(1);
+
+        public Task<RegistrySchema> GetSchemaAsync(int id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<RegisteredSchema> GetSchemaBySubjectAsync(
+            string subject,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<int> GetOrRegisterSchemaAsync(
+            string subject,
+            RegistrySchema schema,
+            CancellationToken cancellationToken = default) => Task.FromResult(1);
+
+        public Task<IReadOnlyList<string>> GetAllSubjectsAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> GetVersionsAsync(
+            string subject,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<bool> IsCompatibleAsync(
+            string subject,
+            RegistrySchema schema,
+            string version = "latest",
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<int>> DeleteSubjectAsync(
+            string subject,
+            bool permanent = false,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public void Dispose() { }
+    }
+}

--- a/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
+++ b/tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Dekaf.Compression.Lz4\Dekaf.Compression.Lz4.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Compression.Zstd\Dekaf.Compression.Zstd.csproj" />
     <ProjectReference Include="..\..\src\Dekaf.Serialization.Json\Dekaf.Serialization.Json.csproj" />
+    <ProjectReference Include="..\..\src\Dekaf.SchemaRegistry.Avro\Dekaf.SchemaRegistry.Avro.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- align `TopicName`, `RecordName`, and `TopicRecordName` subjects with Confluent across Avro, Protobuf, JSON Schema, and the generic serializer
- derive subjects from runtime Avro schemas, JSON Schema titles, and Protobuf descriptors without adding work to statically-schema'd steady-state paths
- key dynamic Avro subjects and writers through one allocation-free logical schema cache, preserving same-instance fast paths and distinguishing schema versions registered under the same subject
- make subject-aware generic schema callbacks converge on the final schema-derived subject, with a subject-independent schema factory overload
- decouple Protobuf subject naming from `UseDeprecatedFormat`
- add `UseLegacySubjectNames` migration support while preserving the existing public overloads
- document the subject migration and add compatibility tests that register with Confluent serializers before looking up with Dekaf

## Validation

- Release unit and integration projects build cleanly on .NET SDK 10.0.400
- 6,706 unit tests pass
- 5 Confluent compatibility integration tests pass against Kafka and Schema Registry
- dynamic generic Avro preparation benchmarks report 0 B/op for both stable and freshly equivalent schema instances
- integration project builds with `PublishAot=true`
- `git diff --check` passes

### Cached serialization benchmark

BenchmarkDotNet 0.15.8 with MemoryDiagnoser, 10 measurement iterations and 5 warmups, comparing the exact pre-fix code commit `76e99b4b` with this branch:

| Version | Mean | Median | Max | Throughput | Allocated |
|---|---:|---:|---:|---:|---:|
| `76e99b4b` | 27.21 ns | 27.64 ns | 29.42 ns | 36.75 M ops/s | 0 B/op |
| candidate | 19.31 ns | 18.91 ns | 22.00 ns | 51.80 M ops/s | 0 B/op |

BenchmarkDotNet's Mann-Whitney comparison reports the two jobs as statistically equivalent. Across six interleaved 100M-operation process samples, median CPU time was 28.75 ns/op before and 28.28 ns/op after.

Fixes #2568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Confluent-compatible subject naming for Avro, JSON Schema, and Protobuf serializers.
  * Added schema-derived record and topic-record naming strategies.
  * Added `UseLegacySubjectNames` options for preserving legacy suffixes during migration.
  * Improved support for multiple runtime schemas on the same topic.
  * Added compatibility with subjects registered by Confluent serializers.

* **Documentation**
  * Updated subject naming, migration, and legacy compatibility guidance.

* **Tests**
  * Added coverage for naming strategies, runtime schemas, legacy behavior, and cross-serializer compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




