### PR TITLE
Fix produce profiling and benchmark acknowledgements

### DIFF
--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerFireHotPathBenchmarks.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
@@ -103,6 +104,19 @@ public class ProducerFireHotPathBenchmarks
         {
             if (_accumulator.TryDrainBatch(out var batch))
             {
+                if (batch.UnackedBudget is { } budget)
+                {
+                    var acknowledgedAt = Stopwatch.GetTimestamp();
+                    var sentAt = acknowledgedAt - Stopwatch.Frequency / 1_000;
+                    var snapshot = budget.SnapshotDelivery(
+                        sentAt,
+                        appLimited: false,
+                        batch.StopwatchCreatedTicks,
+                        batch.AdmissionGeneration);
+                    budget.OnAcked(batch.DataSize, snapshot, acknowledgedAt);
+                    budget.CompleteAckedPass(acknowledgedAt);
+                }
+
                 _accumulator.OnBatchExitsPipeline(batch);
                 _accumulator.ReleaseMemory(batch.DataSize);
                 _accumulator.ReturnReadyBatch(batch);

--- a/tools/Dekaf.Profiling/Program.cs
+++ b/tools/Dekaf.Profiling/Program.cs
@@ -154,7 +154,7 @@ public static class Program
     {
         var messageValue = new string('x', messageSize);
 
-        await using var producer = Kafka.CreateProducer<string, string>()
+        await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("profiling-producer")
             .WithIdempotence(false)
@@ -163,7 +163,8 @@ public static class Program
             .WithBatchSize(16384)
             .WithBufferMemory(ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(connectionsPerBroker)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         // Warmup
         await producer.ProduceAsync(Topic, "warmup", "warmup").ConfigureAwait(false);
@@ -206,14 +207,15 @@ public static class Program
     {
         var messageValue = new string('x', messageSize);
 
-        await using var producer = Kafka.CreateProducer<string, string>()
+        await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("profiling-producer-acked")
             .WithAcks(Acks.All)
             .WithLinger(TimeSpan.FromMilliseconds(1))
             .WithBatchSize(16384)
             .WithConnectionsPerBroker(connectionsPerBroker)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         // Warmup
         for (var i = 0; i < 10; i++)
@@ -269,14 +271,15 @@ public static class Program
     {
         var messageValue = new string('x', messageSize);
 
-        await using var producer = Kafka.CreateProducer<string, string>()
+        await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("profiling-producer-batch")
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(5))
             .WithBatchSize(16384)
             .WithConnectionsPerBroker(connectionsPerBroker)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         // Warmup
         for (var i = 0; i < 100; i++)
@@ -386,7 +389,7 @@ public static class Program
         Console.WriteLine($"  Producer batch size: {producerBatchSize:N0} bytes");
         Console.WriteLine($"  Connections per broker: {connectionsPerBroker}");
 
-        await using var producer = Kafka.CreateProducer<string, string>()
+        await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId(clientId)
             .WithIdempotence(idempotence)
@@ -395,7 +398,8 @@ public static class Program
             .WithBatchSize(producerBatchSize)
             .WithBufferMemory(ProducerBufferMemoryBytes)
             .WithConnectionsPerBroker(connectionsPerBroker)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         await producer.ProduceAsync(Topic, "warmup", "warmup").ConfigureAwait(false);
         for (var i = 0; i < 999; i++)
@@ -457,12 +461,13 @@ public static class Program
         var messageValue = new string('x', messageSize);
         var messagesToSeed = batchSize * 100; // Seed plenty of messages
 
-        await using (var producer = Kafka.CreateProducer<string, string>()
+        await using (var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("profiling-seeder")
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(1))
-            .Build())
+            .BuildAsync()
+            .ConfigureAwait(false))
         {
             for (var i = 0; i < messagesToSeed; i++)
             {
@@ -473,12 +478,13 @@ public static class Program
         Console.WriteLine($"  Seeded {messagesToSeed:N0} messages");
 
         // Now consume
-        await using var consumer = Kafka.CreateConsumer<string, string>()
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(bootstrapServers)
             .WithClientId("profiling-consumer")
             .WithGroupId($"profiling-group-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         consumer.Subscribe(Topic);
 
@@ -517,19 +523,21 @@ public static class Program
 
         await kafka.CreateTopicAsync(roundtripTopic, partitions: 1).ConfigureAwait(false);
 
-        await using var producer = Kafka.CreateProducer<string, string>()
+        await using var producer = await Kafka.CreateProducer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)
             .WithClientId("profiling-roundtrip-producer")
             .WithAcks(Acks.Leader)
             .WithLinger(TimeSpan.FromMilliseconds(1))
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
-        await using var consumer = Kafka.CreateConsumer<string, string>()
+        await using var consumer = await Kafka.CreateConsumer<string, string>()
             .WithBootstrapServers(kafka.BootstrapServers)
             .WithClientId("profiling-roundtrip-consumer")
             .WithGroupId($"profiling-roundtrip-{Guid.NewGuid():N}")
             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-            .Build();
+            .BuildAsync()
+            .ConfigureAwait(false);
 
         consumer.Subscribe(roundtripTopic);
 
@@ -630,11 +638,12 @@ public static class Program
             try
             {
                 // Try to create a producer and send a test message
-                await using var producer = Kafka.CreateProducer<string, string>()
+                await using var producer = await Kafka.CreateProducer<string, string>()
                     .WithBootstrapServers(bootstrapServers)
                     .WithClientId("kafka-ready-check")
                     .WithAcks(Acks.Leader)
-                    .Build();
+                    .BuildAsync()
+                    .ConfigureAwait(false);
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                 await producer.ProduceAsync(new ProducerMessage<string, string>
@@ -806,33 +815,8 @@ public static class Program
             _container = container;
         }
 
-        public async Task CreateTopicAsync(string topic, int partitions)
-        {
-            if (_container is null)
-            {
-                await AdminCreateTopicAsync(BootstrapServers, topic, partitions).ConfigureAwait(false);
-                return;
-            }
-
-            var result = await _container.ExecAsync([
-                "kafka-topics",
-                "--bootstrap-server", "localhost:9092",
-                "--create",
-                "--topic", topic,
-                "--partitions", partitions.ToString(),
-                "--replication-factor", "1",
-                "--if-not-exists"
-            ]).ConfigureAwait(false);
-
-            if (result.ExitCode == 0)
-            {
-                Console.WriteLine($"Created topic: {topic}");
-            }
-            else
-            {
-                Console.WriteLine($"Warning: Topic creation returned exit code {result.ExitCode}: {result.Stderr}");
-            }
-        }
+        public Task CreateTopicAsync(string topic, int partitions) =>
+            AdminCreateTopicAsync(BootstrapServers, topic, partitions);
 
         private static async Task AdminCreateTopicAsync(string bootstrapServers, string topic, int partitions)
         {


### PR DESCRIPTION
## What changed

- Initialize every profiling producer and consumer with `BuildAsync()`.
- Create topics through Dekaf's admin API using the externally advertised bootstrap address.
- Feed successful acknowledgement samples into the broker-window controller in `ProducerFireHotPathBenchmarks`.

## Why

The profiling app failed before workloads started because clients built with `Build()` were never initialized. Container topic creation also targeted `localhost:9092` from inside a broker advertising a random external host port.

The broker-free fire-path benchmark released batch bytes without recording acknowledgements, leaving the delivery-latency admission controller in an unrealistic permanent initial-window state.

## Validation

- `dotnet build tools/Dekaf.Profiling/Dekaf.Profiling.csproj --configuration Release`
- `dotnet build tools/Dekaf.Benchmarks/Dekaf.Benchmarks.csproj --configuration Release`
- Real Kafka smoke: `producer-fire-forget 1 1000 1000 1` completed at 65,303 msg/s.
- Exact benchmark before/after remained allocation-free and showed no product-code shift:
  - DLT 0, 1 partition: 203.0 ns → 231.1 ns
  - DLT 0, 12 partitions: 217.2 ns → 214.8 ns
  - DLT 10, 1 partition: 920.0 ns → 918.4 ns
  - DLT 10, 12 partitions: 1,500.7 ns → 1,504.1 ns

Timing intervals overlap; this PR changes harness fidelity, not producer implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved benchmark timing and batch acknowledgement tracking for more consistent performance measurements.
  - Updated profiling scenarios to use reliable asynchronous setup and execution flows.

- **Reliability**
  - Streamlined test-environment topic setup to provide more consistent readiness across profiling runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->