### PR TITLE
Pool producer backpressure completion state

### DIFF
--- a/src/Dekaf/Producer/KafkaProducer.cs
+++ b/src/Dekaf/Producer/KafkaProducer.cs
@@ -4589,6 +4589,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// <summary>
     /// Awaits an in-flight append and disposes the activity on completion.
     /// </summary>
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+#endif
     private async ValueTask FinishProduceAsync(ValueTask<bool> appendResult, Activity? activity, string topic)
     {
         try
@@ -4617,6 +4620,9 @@ public sealed partial class KafkaProducer<TKey, TValue> : IKafkaProducer<TKey, T
     /// Cold-path finish for the callback fire-and-forget overload.
     /// All exceptions are delivered to the callback rather than thrown.
     /// </summary>
+#if NET
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+#endif
     private async ValueTask FinishProduceAsyncWithCallback(
         ValueTask<bool> appendResult,
         Action<RecordMetadata, Exception?> deliveryHandler)

--- a/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerSlowPathPoolingBenchmarks.cs
+++ b/tools/Dekaf.Benchmarks/Benchmarks/Unit/ProducerSlowPathPoolingBenchmarks.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Dekaf.Producer;
+
+namespace Dekaf.Benchmarks.Benchmarks.Unit;
+
+/// <summary>
+/// Measures the suspended FireAsync append tails used when BufferMemory backpressure makes
+/// accumulator append incomplete.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ProducerSlowPathPoolingBenchmarks
+{
+    private const string Topic = "producer-slow-path-pooling";
+
+    private static readonly Action<RecordMetadata, Exception?> DeliveryHandler = static (_, _) => { };
+
+    private readonly DeferredBoolSource _source = new();
+    private FinishDelegate _finish = null!;
+    private FinishWithCallbackDelegate _finishWithCallback = null!;
+
+    private delegate ValueTask FinishDelegate(ValueTask<bool> appendResult, Activity? activity, string topic);
+    private delegate ValueTask FinishWithCallbackDelegate(
+        ValueTask<bool> appendResult,
+        Action<RecordMetadata, Exception?> deliveryHandler);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var producerType = typeof(KafkaProducer<string, string>);
+        var producer = (KafkaProducer<string, string>)RuntimeHelpers.GetUninitializedObject(producerType);
+
+        _finish = producerType
+            .GetMethod("FinishProduceAsync", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<FinishDelegate>(producer);
+        _finishWithCallback = producerType
+            .GetMethod("FinishProduceAsyncWithCallback", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .CreateDelegate<FinishWithCallbackDelegate>(producer);
+    }
+
+    [Benchmark]
+    public ValueTask FinishProduceAsync() =>
+        _finish(_source.QueueResult(), activity: null, Topic);
+
+    [Benchmark]
+    public ValueTask FinishProduceAsyncWithCallback() =>
+        _finishWithCallback(_source.QueueResult(), DeliveryHandler);
+
+    private sealed class DeferredBoolSource : IValueTaskSource<bool>, IThreadPoolWorkItem
+    {
+        private ManualResetValueTaskSourceCore<bool> _core;
+
+        public ValueTask<bool> QueueResult()
+        {
+            _core.Reset();
+            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: true);
+            return new ValueTask<bool>(this, _core.Version);
+        }
+
+        void IThreadPoolWorkItem.Execute() => _core.SetResult(true);
+
+        public bool GetResult(short token) => _core.GetResult(token);
+
+        public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+
+        public void OnCompleted(
+            Action<object?> continuation,
+            object? state,
+            short token,
+            ValueTaskSourceOnCompletedFlags flags) =>
+            _core.OnCompleted(continuation, state, token, flags);
+    }
+}


### PR DESCRIPTION
## What changed

- Use `PoolingAsyncValueTaskMethodBuilder` for the two suspended FireAsync append tails.
- Add a focused BenchmarkDotNet benchmark that invokes the real private finish methods through cached delegates and forces asynchronous completion with a reusable `IValueTaskSource<bool>`.

## Why

When BufferMemory backpressure makes accumulator append incomplete, both FireAsync tails suspended using the default async ValueTask builder. CPU/GC profiling attributed `AsyncStateMachineBox` allocations to this path.

The synchronous per-message path is unchanged.

## Benchmark

Baseline: `456167f68d555d24e8ce2a7ae3a204e554f7ea29`

| Method | Baseline | Candidate | Candidate repeat | Allocated |
|---|---:|---:|---:|---:|
| FinishProduceAsync | 647.2 ns | 660.0 ns | 605.6 ns | 119 B → 0 B |
| FinishProduceAsyncWithCallback | 626.0 ns | 603.2 ns | 599.5 ns | 110 B → 0 B |

The first candidate run was timing-ambiguous, so it was repeated once per the performance gate. The repeat improved both methods while preserving zero allocation.

## Validation

- `dotnet build tools/Dekaf.Benchmarks --configuration Release`
- `dotnet build tests/Dekaf.Tests.Unit --configuration Release`
- `KafkaProducerFastPathTests`: 10 passed
- BenchmarkDotNet MemoryDiagnoser: 0 B for both candidate methods